### PR TITLE
feat: Company Files — scoped knowledge base with UI, API, and agent integration

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -463,6 +463,43 @@ export function renderPaperclipWakePrompt(
   return lines.join("\n").trim();
 }
 
+export function renderPaperclipKnowledgePrompt(value: unknown): string {
+  if (!value || !Array.isArray(value) || value.length === 0) return "";
+
+  const entries = value as Array<{
+    id?: string;
+    name?: string;
+    type?: string;
+    scope?: string;
+    description?: string | null;
+  }>;
+
+  if (entries.length === 0) return "";
+
+  const scopeLabel = (scope?: string) =>
+    scope === "company" ? "Company" : scope === "department" ? "Department" : "Agent";
+
+  const lines = [
+    "## Company Knowledge Base",
+    "",
+    "The following knowledge entries are available. Fetch full content when relevant using the Paperclip API:",
+    "- Document body: `GET /api/companies/{companyId}/knowledge/{id}` (returns `documentBody` field)",
+    "- File content: `GET /api/assets/{assetId}/content` (binary download)",
+    "Use `$PAPERCLIP_API_KEY` for authentication.",
+    "",
+  ];
+
+  for (const entry of entries) {
+    const scope = scopeLabel(entry.scope);
+    const desc = entry.description ? ` — ${entry.description}` : "";
+    const icon = entry.type === "document" ? "📄" : "📎";
+    lines.push(`- ${icon} **${entry.name ?? "Untitled"}** (${scope}, ${entry.type}, id: \`${entry.id}\`)${desc}`);
+  }
+
+  lines.push("");
+  return lines.join("\n").trim();
+}
+
 export function redactEnvForLogs(env: Record<string, string>): Record<string, string> {
   const redacted: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -21,6 +21,7 @@ import {
   resolveCommandForLogs,
   renderTemplate,
   renderPaperclipWakePrompt,
+  renderPaperclipKnowledgePrompt,
   stringifyPaperclipWakePayload,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -420,8 +421,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const knowledgePrompt = renderPaperclipKnowledgePrompt(context.paperclipKnowledgeEntries);
   const prompt = joinPromptSections([
     renderedBootstrapPrompt,
+    knowledgePrompt,
     wakePrompt,
     sessionHandoffNote,
     renderedPrompt,

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -18,6 +18,7 @@ import {
   resolveCommandForLogs,
   resolvePaperclipDesiredSkillNames,
   renderTemplate,
+  renderPaperclipKnowledgePrompt,
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
   joinPromptSections,
@@ -483,9 +484,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   })();
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const knowledgePrompt = renderPaperclipKnowledgePrompt(context.paperclipKnowledgeEntries);
   const prompt = joinPromptSections([
     promptInstructionsPrefix,
     renderedBootstrapPrompt,
+    knowledgePrompt,
     wakePrompt,
     sessionHandoffNote,
     renderedPrompt,

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -19,6 +19,7 @@ import {
   resolvePaperclipDesiredSkillNames,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
+  renderPaperclipKnowledgePrompt,
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
   joinPromptSections,
@@ -367,9 +368,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const paperclipEnvNote = renderPaperclipEnvNote(env);
+  const knowledgePrompt = renderPaperclipKnowledgePrompt(context.paperclipKnowledgeEntries);
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
+    knowledgePrompt,
     wakePrompt,
     sessionHandoffNote,
     paperclipEnvNote,

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -22,6 +22,7 @@ import {
   removeMaintainerOnlySkillSymlinks,
   parseObject,
   renderTemplate,
+  renderPaperclipKnowledgePrompt,
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
   runChildProcess,
@@ -309,9 +310,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const paperclipEnvNote = renderPaperclipEnvNote(env);
   const apiAccessNote = renderApiAccessNote(env);
+  const knowledgePrompt = renderPaperclipKnowledgePrompt(context.paperclipKnowledgeEntries);
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
+    knowledgePrompt,
     wakePrompt,
     sessionHandoffNote,
     paperclipEnvNote,

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -17,6 +17,7 @@ import {
   ensurePathInEnv,
   resolveCommandForLogs,
   renderTemplate,
+  renderPaperclipKnowledgePrompt,
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
   runChildProcess,
@@ -282,9 +283,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
     const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
     const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+    const knowledgePrompt = renderPaperclipKnowledgePrompt(context.paperclipKnowledgeEntries);
     const prompt = joinPromptSections([
       instructionsPrefix,
       renderedBootstrapPrompt,
+      knowledgePrompt,
       wakePrompt,
       sessionHandoffNote,
       renderedPrompt,

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -20,6 +20,7 @@ import {
   resolvePaperclipDesiredSkillNames,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
+  renderPaperclipKnowledgePrompt,
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
   runChildProcess,
@@ -310,8 +311,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const shouldUseResumeDeltaPrompt = canResumeSession && wakePrompt.length > 0;
   const renderedHeartbeatPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const knowledgePrompt = renderPaperclipKnowledgePrompt(context.paperclipKnowledgeEntries);
   const userPrompt = joinPromptSections([
     renderedBootstrapPrompt,
+    knowledgePrompt,
     wakePrompt,
     sessionHandoffNote,
     renderedHeartbeatPrompt,

--- a/packages/db/src/migrations/0055_knowledge_entries.sql
+++ b/packages/db/src/migrations/0055_knowledge_entries.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "knowledge_entries" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "company_id" uuid NOT NULL REFERENCES "companies"("id"),
+  "parent_id" uuid REFERENCES "knowledge_entries"("id"),
+  "type" text NOT NULL,
+  "name" text NOT NULL,
+  "scope" text NOT NULL,
+  "scope_agent_id" uuid REFERENCES "agents"("id") ON DELETE CASCADE,
+  "document_id" uuid REFERENCES "documents"("id") ON DELETE CASCADE,
+  "asset_id" uuid REFERENCES "assets"("id") ON DELETE CASCADE,
+  "description" text,
+  "sort_order" integer NOT NULL DEFAULT 0,
+  "created_by_user_id" text,
+  "created_by_agent_id" uuid REFERENCES "agents"("id") ON DELETE SET NULL,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "knowledge_entries_company_scope_idx" ON "knowledge_entries" ("company_id", "scope");
+CREATE INDEX IF NOT EXISTS "knowledge_entries_company_parent_idx" ON "knowledge_entries" ("company_id", "parent_id");
+CREATE INDEX IF NOT EXISTS "knowledge_entries_company_scope_agent_idx" ON "knowledge_entries" ("company_id", "scope", "scope_agent_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "knowledge_entries_document_uq" ON "knowledge_entries" ("document_id") WHERE "document_id" IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS "knowledge_entries_asset_uq" ON "knowledge_entries" ("asset_id") WHERE "asset_id" IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1775750400000,
       "tag": "0054_draft_routines",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1775955600000,
+      "tag": "0055_knowledge_entries",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -61,3 +61,4 @@ export { pluginEntities } from "./plugin_entities.js";
 export { pluginJobs, pluginJobRuns } from "./plugin_jobs.js";
 export { pluginWebhookDeliveries } from "./plugin_webhooks.js";
 export { pluginLogs } from "./plugin_logs.js";
+export { knowledgeEntries } from "./knowledge_entries.js";

--- a/packages/db/src/schema/knowledge_entries.ts
+++ b/packages/db/src/schema/knowledge_entries.ts
@@ -1,0 +1,46 @@
+import {
+  type AnyPgColumn,
+  pgTable,
+  uuid,
+  text,
+  integer,
+  timestamp,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { agents } from "./agents.js";
+import { documents } from "./documents.js";
+import { assets } from "./assets.js";
+
+export const knowledgeEntries = pgTable(
+  "knowledge_entries",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id),
+    parentId: uuid("parent_id").references((): AnyPgColumn => knowledgeEntries.id),
+    type: text("type").notNull(), // 'folder' | 'document' | 'file'
+    name: text("name").notNull(),
+    scope: text("scope").notNull(), // 'company' | 'department' | 'agent'
+    scopeAgentId: uuid("scope_agent_id").references(() => agents.id, { onDelete: "cascade" }),
+    documentId: uuid("document_id").references(() => documents.id, { onDelete: "cascade" }),
+    assetId: uuid("asset_id").references(() => assets.id, { onDelete: "cascade" }),
+    description: text("description"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdByUserId: text("created_by_user_id"),
+    createdByAgentId: uuid("created_by_agent_id").references(() => agents.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyScopeIdx: index("knowledge_entries_company_scope_idx").on(table.companyId, table.scope),
+    companyParentIdx: index("knowledge_entries_company_parent_idx").on(table.companyId, table.parentId),
+    companyScopeAgentIdx: index("knowledge_entries_company_scope_agent_idx").on(
+      table.companyId,
+      table.scope,
+      table.scopeAgentId,
+    ),
+    documentUq: uniqueIndex("knowledge_entries_document_uq").on(table.documentId),
+    assetUq: uniqueIndex("knowledge_entries_asset_uq").on(table.assetId),
+  }),
+);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -359,6 +359,17 @@ export type {
   PluginWebhookDeliveryRecord,
   QuotaWindow,
   ProviderQuotaResult,
+  KnowledgeEntryType,
+  KnowledgeEntryScope,
+  KnowledgeEntry,
+  KnowledgeEntryWithContent,
+  KnowledgeAssetInfo,
+  KnowledgeDepartment,
+  KnowledgeDocumentRevision,
+  CreateKnowledgeFolderInput,
+  CreateKnowledgeDocumentInput,
+  UpdateKnowledgeEntryInput,
+  UpdateKnowledgeDocumentBodyInput,
 } from "./types/index.js";
 
 export {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -205,6 +205,19 @@ export type {
   CompanyPortabilityExportRequest,
 } from "./company-portability.js";
 export type {
+  KnowledgeEntryType,
+  KnowledgeEntryScope,
+  KnowledgeEntry,
+  KnowledgeEntryWithContent,
+  KnowledgeAssetInfo,
+  KnowledgeDepartment,
+  KnowledgeDocumentRevision,
+  CreateKnowledgeFolderInput,
+  CreateKnowledgeDocumentInput,
+  UpdateKnowledgeEntryInput,
+  UpdateKnowledgeDocumentBodyInput,
+} from "./knowledge.js";
+export type {
   JsonSchema,
   PluginJobDeclaration,
   PluginWebhookDeclaration,

--- a/packages/shared/src/types/knowledge.ts
+++ b/packages/shared/src/types/knowledge.ts
@@ -1,0 +1,95 @@
+export type KnowledgeEntryType = "folder" | "document" | "file";
+
+export type KnowledgeEntryScope = "company" | "department" | "agent";
+
+export interface KnowledgeEntry {
+  id: string;
+  companyId: string;
+  parentId: string | null;
+  type: KnowledgeEntryType;
+  name: string;
+  scope: KnowledgeEntryScope;
+  scopeAgentId: string | null;
+  documentId: string | null;
+  assetId: string | null;
+  description: string | null;
+  sortOrder: number;
+  createdByUserId: string | null;
+  createdByAgentId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface KnowledgeEntryWithContent extends KnowledgeEntry {
+  /** Markdown body when type='document' */
+  documentBody: string | null;
+  /** Latest revision ID when type='document' */
+  latestRevisionId: string | null;
+  /** Latest revision number when type='document' */
+  latestRevisionNumber: number | null;
+  /** Asset metadata when type='file' */
+  asset: KnowledgeAssetInfo | null;
+}
+
+export interface KnowledgeAssetInfo {
+  assetId: string;
+  provider: string;
+  objectKey: string;
+  contentType: string;
+  byteSize: number;
+  sha256: string;
+  originalFilename: string | null;
+  contentPath: string;
+}
+
+export interface KnowledgeDepartment {
+  agentId: string;
+  agentName: string;
+  agentTitle: string | null;
+  agentRole: string;
+  agentIcon: string | null;
+}
+
+export interface KnowledgeDocumentRevision {
+  id: string;
+  companyId: string;
+  documentId: string;
+  revisionNumber: number;
+  title: string | null;
+  format: string;
+  body: string;
+  changeSummary: string | null;
+  createdByAgentId: string | null;
+  createdByUserId: string | null;
+  createdAt: Date;
+}
+
+export interface CreateKnowledgeFolderInput {
+  parentId?: string | null;
+  name: string;
+  scope: KnowledgeEntryScope;
+  scopeAgentId?: string | null;
+  description?: string | null;
+}
+
+export interface CreateKnowledgeDocumentInput {
+  parentId?: string | null;
+  name: string;
+  scope: KnowledgeEntryScope;
+  scopeAgentId?: string | null;
+  description?: string | null;
+  body: string;
+}
+
+export interface UpdateKnowledgeEntryInput {
+  name?: string;
+  parentId?: string | null;
+  description?: string | null;
+  sortOrder?: number;
+}
+
+export interface UpdateKnowledgeDocumentBodyInput {
+  body: string;
+  baseRevisionId?: string | null;
+  changeSummary?: string | null;
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -29,6 +29,7 @@ import { instanceSettingsRoutes } from "./routes/instance-settings.js";
 import { llmRoutes } from "./routes/llms.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
+import { knowledgeRoutes } from "./routes/knowledge.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
@@ -152,6 +153,7 @@ export async function createApp(
   );
   api.use("/companies", companyRoutes(db, opts.storageService));
   api.use(companySkillRoutes(db));
+  api.use(knowledgeRoutes(db, opts.storageService));
   api.use(agentRoutes(db));
   api.use(assetRoutes(db, opts.storageService));
   api.use(projectRoutes(db));

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -16,3 +16,4 @@ export { inboxDismissalRoutes } from "./inbox-dismissals.js";
 export { llmRoutes } from "./llms.js";
 export { accessRoutes } from "./access.js";
 export { instanceSettingsRoutes } from "./instance-settings.js";
+export { knowledgeRoutes } from "./knowledge.js";

--- a/server/src/routes/knowledge.ts
+++ b/server/src/routes/knowledge.ts
@@ -1,0 +1,376 @@
+import { Router, type Request, type Response } from "express";
+import multer from "multer";
+import type { Db } from "@paperclipai/db";
+import type { KnowledgeEntryScope } from "@paperclipai/shared";
+import type { StorageService } from "../storage/types.js";
+import { assetService, knowledgeService, logActivity } from "../services/index.js";
+import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
+import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { unprocessable } from "../errors.js";
+
+const VALID_SCOPES = new Set(["company", "department", "agent"]);
+const VALID_TYPES = new Set(["folder", "document"]);
+
+function assertValidScope(scope: string): asserts scope is KnowledgeEntryScope {
+  if (!VALID_SCOPES.has(scope)) {
+    throw unprocessable(`Invalid scope: ${scope}. Must be one of: company, department, agent`);
+  }
+}
+
+export function knowledgeRoutes(db: Db, storage: StorageService) {
+  const router = Router();
+  const svc = knowledgeService(db);
+  const assetSvc = assetService(db);
+  const upload = multer({
+    storage: multer.memoryStorage(),
+    limits: { fileSize: MAX_ATTACHMENT_BYTES, files: 1 },
+  });
+
+  async function runSingleFileUpload(req: Request, res: Response) {
+    await new Promise<void>((resolve, reject) => {
+      upload.single("file")(req, res, (err: unknown) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+
+  // List entries
+  router.get("/companies/:companyId/knowledge", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    const scope = req.query.scope as string | undefined;
+    const scopeAgentId = req.query.scopeAgentId as string | undefined;
+    const parentId = req.query.parentId as string | undefined;
+
+    const filters: Parameters<typeof svc.list>[1] = {};
+    if (scope) {
+      assertValidScope(scope);
+      filters.scope = scope;
+    }
+    if (scopeAgentId) filters.scopeAgentId = scopeAgentId;
+    if (parentId !== undefined) {
+      filters.parentId = parentId === "null" || parentId === "" ? null : parentId;
+    }
+
+    const result = await svc.list(companyId, filters);
+    res.json(result);
+  });
+
+  // List departments (derived from org tree)
+  router.get("/companies/:companyId/knowledge/departments", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const result = await svc.listDepartments(companyId);
+    res.json(result);
+  });
+
+  // Full tree
+  router.get("/companies/:companyId/knowledge/tree", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    const scope = req.query.scope as string | undefined;
+    const scopeAgentId = req.query.scopeAgentId as string | undefined;
+
+    const filters: Parameters<typeof svc.listTree>[1] = {};
+    if (scope) {
+      assertValidScope(scope);
+      filters.scope = scope;
+    }
+    if (scopeAgentId) filters.scopeAgentId = scopeAgentId;
+
+    const result = await svc.listTree(companyId, filters);
+    res.json(result);
+  });
+
+  // Get entry with content
+  router.get("/companies/:companyId/knowledge/:entryId", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const entryId = req.params.entryId as string;
+    assertCompanyAccess(req, companyId);
+
+    const result = await svc.getById(companyId, entryId);
+    if (!result) {
+      res.status(404).json({ error: "Knowledge entry not found" });
+      return;
+    }
+    res.json(result);
+  });
+
+  // Create folder or document
+  router.post("/companies/:companyId/knowledge", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    const actor = getActorInfo(req);
+    const { type, name, scope, scopeAgentId, parentId, description, body } = req.body;
+
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      throw unprocessable("name is required");
+    }
+    if (!type || !VALID_TYPES.has(type)) {
+      throw unprocessable("type must be 'folder' or 'document'");
+    }
+    if (!scope) {
+      throw unprocessable("scope is required");
+    }
+    assertValidScope(scope);
+
+    const commonInput = {
+      parentId: parentId ?? null,
+      name: name.trim(),
+      scope,
+      scopeAgentId: scopeAgentId ?? null,
+      description: description ?? null,
+      createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+      createdByAgentId: actor.agentId,
+    };
+
+    let result;
+    if (type === "folder") {
+      result = await svc.createFolder(companyId, commonInput);
+    } else {
+      if (typeof body !== "string") {
+        throw unprocessable("body is required for document type");
+      }
+      result = await svc.createDocument(companyId, { ...commonInput, body });
+    }
+
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: `knowledge.${type}_created`,
+      entityType: "knowledge_entry",
+      entityId: result.id,
+      details: { name: result.name, scope: result.scope, type },
+    });
+
+    res.status(201).json(result);
+  });
+
+  // Upload binary file
+  router.post("/companies/:companyId/knowledge/upload", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    try {
+      await runSingleFileUpload(req, res);
+    } catch (err) {
+      if (err instanceof multer.MulterError) {
+        if (err.code === "LIMIT_FILE_SIZE") {
+          res.status(422).json({ error: `File exceeds ${MAX_ATTACHMENT_BYTES} bytes` });
+          return;
+        }
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
+
+    const file = (req as Request & { file?: { mimetype: string; buffer: Buffer; originalname: string } }).file;
+    if (!file) {
+      res.status(400).json({ error: "Missing file field 'file'" });
+      return;
+    }
+
+    const contentType = (file.mimetype || "").toLowerCase();
+    if (!isAllowedContentType(contentType)) {
+      res.status(422).json({ error: `Unsupported file type: ${contentType || "unknown"}` });
+      return;
+    }
+
+    if (file.buffer.length <= 0) {
+      res.status(422).json({ error: "File is empty" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    const scope = (req.body.scope || "company") as string;
+    assertValidScope(scope);
+    const scopeAgentId = req.body.scopeAgentId || null;
+    const parentId = req.body.parentId || null;
+    const description = req.body.description || null;
+    const name = req.body.name || file.originalname || "Untitled";
+
+    // Store file via storage service
+    const stored = await storage.putFile({
+      companyId,
+      namespace: "knowledge",
+      originalFilename: file.originalname || null,
+      contentType,
+      body: file.buffer,
+    });
+
+    // Create asset record
+    const asset = await assetSvc.create(companyId, {
+      provider: stored.provider,
+      objectKey: stored.objectKey,
+      contentType: stored.contentType,
+      byteSize: stored.byteSize,
+      sha256: stored.sha256,
+      originalFilename: stored.originalFilename,
+      createdByAgentId: actor.agentId,
+      createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+    });
+
+    // Create knowledge entry
+    const result = await svc.createFile(
+      companyId,
+      {
+        parentId,
+        name: name.trim(),
+        scope,
+        scopeAgentId,
+        description,
+        createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+        createdByAgentId: actor.agentId,
+      },
+      asset,
+    );
+
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "knowledge.file_uploaded",
+      entityType: "knowledge_entry",
+      entityId: result.id,
+      details: {
+        name: result.name,
+        scope: result.scope,
+        contentType,
+        byteSize: stored.byteSize,
+      },
+    });
+
+    res.status(201).json(result);
+  });
+
+  // Update entry metadata (rename, move, description)
+  router.patch("/companies/:companyId/knowledge/:entryId", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const entryId = req.params.entryId as string;
+    assertCompanyAccess(req, companyId);
+
+    const { name, parentId, description, sortOrder } = req.body;
+    const result = await svc.updateEntry(companyId, entryId, {
+      name,
+      ...(parentId !== undefined ? { parentId } : {}),
+      ...(description !== undefined ? { description } : {}),
+      ...(sortOrder !== undefined ? { sortOrder } : {}),
+    });
+
+    if (!result) {
+      res.status(404).json({ error: "Knowledge entry not found" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "knowledge.entry_updated",
+      entityType: "knowledge_entry",
+      entityId: result.id,
+      details: { name: result.name },
+    });
+
+    res.json(result);
+  });
+
+  // Update document body
+  router.put("/companies/:companyId/knowledge/:entryId/body", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const entryId = req.params.entryId as string;
+    assertCompanyAccess(req, companyId);
+
+    const actor = getActorInfo(req);
+    const { body, baseRevisionId, changeSummary } = req.body;
+
+    if (typeof body !== "string") {
+      throw unprocessable("body is required");
+    }
+
+    const result = await svc.updateDocumentBody(companyId, entryId, {
+      body,
+      baseRevisionId: baseRevisionId ?? null,
+      changeSummary: changeSummary ?? null,
+      createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+      createdByAgentId: actor.agentId,
+    });
+
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "knowledge.document_updated",
+      entityType: "knowledge_entry",
+      entityId: entryId,
+      details: { changeSummary },
+    });
+
+    res.json(result);
+  });
+
+  // List document revisions
+  router.get("/companies/:companyId/knowledge/:entryId/revisions", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const entryId = req.params.entryId as string;
+    assertCompanyAccess(req, companyId);
+
+    const result = await svc.listRevisions(companyId, entryId);
+    res.json(result);
+  });
+
+  // Delete entry
+  router.delete("/companies/:companyId/knowledge/:entryId", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const entryId = req.params.entryId as string;
+    assertCompanyAccess(req, companyId);
+
+    const result = await svc.deleteEntry(companyId, entryId);
+    if (!result) {
+      res.status(404).json({ error: "Knowledge entry not found" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "knowledge.entry_deleted",
+      entityType: "knowledge_entry",
+      entityId: result.id,
+      details: { name: result.name, type: result.type },
+    });
+
+    res.json(result);
+  });
+
+  // All entries visible to a specific agent
+  router.get("/companies/:companyId/knowledge/agent/:agentId", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const agentId = req.params.agentId as string;
+    assertCompanyAccess(req, companyId);
+
+    const result = await svc.resolveAgentVisibleEntries(companyId, agentId);
+    res.json(result);
+  });
+
+  return router;
+}

--- a/server/src/routes/knowledge.ts
+++ b/server/src/routes/knowledge.ts
@@ -260,8 +260,11 @@ export function knowledgeRoutes(db: Db, storage: StorageService) {
     assertCompanyAccess(req, companyId);
 
     const { name, parentId, description, sortOrder } = req.body;
+    if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
+      throw unprocessable("name must be a non-empty string");
+    }
     const result = await svc.updateEntry(companyId, entryId, {
-      name,
+      name: name !== undefined ? name.trim() : undefined,
       ...(parentId !== undefined ? { parentId } : {}),
       ...(description !== undefined ? { description } : {}),
       ...(sortOrder !== undefined ? { sortOrder } : {}),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2725,8 +2725,12 @@ export function heartbeatService(db: Db) {
     const agentKnowledgeEntries = await knowledgeSvc.resolveAgentVisibleEntries(agent.companyId, agent.id);
     // Deliver a lightweight manifest — names, scopes, descriptions, and IDs only.
     // Agents fetch full content on demand via the knowledge API.
+    // Cap at 50 most-recently-updated entries to avoid unbounded prompt bloat.
+    const MAX_KNOWLEDGE_MANIFEST_ENTRIES = 50;
     const knowledgeManifest = agentKnowledgeEntries
       .filter((e) => e.type !== "folder")
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+      .slice(0, MAX_KNOWLEDGE_MANIFEST_ENTRIES)
       .map((entry) => ({
         id: entry.id,
         name: entry.name,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -29,6 +29,7 @@ import { costService } from "./costs.js";
 import { trackAgentFirstHeartbeat } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
 import { companySkillService } from "./company-skills.js";
+import { knowledgeService } from "./knowledge.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
@@ -2720,6 +2721,22 @@ export function heartbeatService(db: Db) {
       secretsSvc,
     });
     const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId);
+    const knowledgeSvc = knowledgeService(db);
+    const agentKnowledgeEntries = await knowledgeSvc.resolveAgentVisibleEntries(agent.companyId, agent.id);
+    // Deliver a lightweight manifest — names, scopes, descriptions, and IDs only.
+    // Agents fetch full content on demand via the knowledge API.
+    const knowledgeManifest = agentKnowledgeEntries
+      .filter((e) => e.type !== "folder")
+      .map((entry) => ({
+        id: entry.id,
+        name: entry.name,
+        type: entry.type,
+        scope: entry.scope,
+        description: entry.description,
+      }));
+    if (knowledgeManifest.length > 0) {
+      context.paperclipKnowledgeEntries = knowledgeManifest;
+    }
     const runtimeConfig = {
       ...resolvedConfig,
       paperclipRuntimeSkills: runtimeSkillEntries,

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -27,6 +27,7 @@ export { companyPortabilityService } from "./company-portability.js";
 export { executionWorkspaceService } from "./execution-workspaces.js";
 export { workspaceOperationService } from "./workspace-operations.js";
 export { workProductService } from "./work-products.js";
+export { knowledgeService } from "./knowledge.js";
 export { logActivity, type LogActivityInput } from "./activity-log.js";
 export { notifyHireApproved, type NotifyHireApprovedInput } from "./hire-hook.js";
 export { publishLiveEvent, subscribeCompanyLiveEvents } from "./live-events.js";

--- a/server/src/services/knowledge.ts
+++ b/server/src/services/knowledge.ts
@@ -614,8 +614,9 @@ export function knowledgeService(db: Db) {
           await tx.delete(documents).where(inArray(documents.id, documentIds));
         }
 
-        // Note: we don't delete asset files from storage here — that would need
-        // a separate cleanup job. We only remove the DB rows.
+        // TODO: Storage objects are orphaned here — DB rows are removed but the
+        // underlying blobs (local disk / S3) are not. A background reconciliation
+        // job should be added to clean up unreferenced storage objects.
         if (assetIds.length > 0) {
           await tx.delete(assets).where(inArray(assets.id, assetIds));
         }

--- a/server/src/services/knowledge.ts
+++ b/server/src/services/knowledge.ts
@@ -1,0 +1,689 @@
+import { and, asc, desc, eq, isNull, sql, inArray } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { knowledgeEntries, documents, documentRevisions, assets, agents } from "@paperclipai/db";
+import type {
+  KnowledgeEntry,
+  KnowledgeEntryWithContent,
+  KnowledgeAssetInfo,
+  KnowledgeDepartment,
+  KnowledgeDocumentRevision,
+  KnowledgeEntryScope,
+} from "@paperclipai/shared";
+import { notFound, conflict, unprocessable } from "../errors.js";
+
+function mapEntry(row: typeof knowledgeEntries.$inferSelect): KnowledgeEntry {
+  return {
+    id: row.id,
+    companyId: row.companyId,
+    parentId: row.parentId,
+    type: row.type as KnowledgeEntry["type"],
+    name: row.name,
+    scope: row.scope as KnowledgeEntryScope,
+    scopeAgentId: row.scopeAgentId,
+    documentId: row.documentId,
+    assetId: row.assetId,
+    description: row.description,
+    sortOrder: row.sortOrder,
+    createdByUserId: row.createdByUserId,
+    createdByAgentId: row.createdByAgentId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ── Department helpers ──────────────────────────────────────────────
+
+async function findCeo(db: Db, companyId: string) {
+  const rows = await db
+    .select({ id: agents.id, name: agents.name, title: agents.title, role: agents.role, icon: agents.icon })
+    .from(agents)
+    .where(and(eq(agents.companyId, companyId), isNull(agents.reportsTo)));
+  return rows[0] ?? null;
+}
+
+async function listDepartmentHeads(db: Db, companyId: string): Promise<KnowledgeDepartment[]> {
+  const ceo = await findCeo(db, companyId);
+  if (!ceo) return [];
+
+  const heads = await db
+    .select({
+      id: agents.id,
+      name: agents.name,
+      title: agents.title,
+      role: agents.role,
+      icon: agents.icon,
+    })
+    .from(agents)
+    .where(and(eq(agents.companyId, companyId), eq(agents.reportsTo, ceo.id)))
+    .orderBy(asc(agents.name));
+
+  return heads.map((h) => ({
+    agentId: h.id,
+    agentName: h.name,
+    agentTitle: h.title,
+    agentRole: h.role,
+    agentIcon: h.icon,
+  }));
+}
+
+async function getSubtreeAgentIds(db: Db, companyId: string, rootAgentId: string): Promise<string[]> {
+  const result = await db.execute<{ id: string }>(sql`
+    WITH RECURSIVE subtree AS (
+      SELECT id FROM agents WHERE id = ${rootAgentId} AND company_id = ${companyId}
+      UNION ALL
+      SELECT a.id FROM agents a INNER JOIN subtree s ON a.reports_to = s.id WHERE a.company_id = ${companyId}
+    )
+    SELECT id FROM subtree
+  `);
+  return Array.from(result).map((r) => r.id);
+}
+
+async function getAgentDepartmentHead(
+  db: Db,
+  companyId: string,
+  agentId: string,
+): Promise<string | null> {
+  const result = await db.execute<{ id: string }>(sql`
+    WITH RECURSIVE chain AS (
+      SELECT id, reports_to FROM agents WHERE id = ${agentId} AND company_id = ${companyId}
+      UNION ALL
+      SELECT a.id, a.reports_to FROM agents a INNER JOIN chain c ON a.id = c.reports_to WHERE a.company_id = ${companyId}
+    )
+    SELECT c.id FROM chain c
+    INNER JOIN agents ceo ON c.reports_to = ceo.id AND ceo.reports_to IS NULL AND ceo.company_id = ${companyId}
+    LIMIT 1
+  `);
+  const rows = Array.from(result);
+  return rows[0]?.id ?? null;
+}
+
+// ── Descendant helper ───────────────────────────────────────────────
+
+async function getDescendantIds(db: Db, companyId: string, entryId: string): Promise<string[]> {
+  const result = await db.execute<{ id: string }>(sql`
+    WITH RECURSIVE descendants AS (
+      SELECT id FROM knowledge_entries WHERE id = ${entryId} AND company_id = ${companyId}
+      UNION ALL
+      SELECT ke.id FROM knowledge_entries ke INNER JOIN descendants d ON ke.parent_id = d.id WHERE ke.company_id = ${companyId}
+    )
+    SELECT id FROM descendants
+  `);
+  return Array.from(result).map((r) => r.id);
+}
+
+// ── Service ─────────────────────────────────────────────────────────
+
+export function knowledgeService(db: Db) {
+  return {
+    listDepartments: (companyId: string) => listDepartmentHeads(db, companyId),
+
+    list: async (
+      companyId: string,
+      filters: {
+        scope?: KnowledgeEntryScope;
+        scopeAgentId?: string;
+        parentId?: string | null;
+      } = {},
+    ): Promise<KnowledgeEntry[]> => {
+      const conditions = [eq(knowledgeEntries.companyId, companyId)];
+
+      if (filters.scope) {
+        conditions.push(eq(knowledgeEntries.scope, filters.scope));
+      }
+      if (filters.scopeAgentId) {
+        conditions.push(eq(knowledgeEntries.scopeAgentId, filters.scopeAgentId));
+      }
+      if (filters.parentId === null || filters.parentId === undefined) {
+        // If parentId not specified, only return root-level entries
+        if ("parentId" in filters) {
+          conditions.push(isNull(knowledgeEntries.parentId));
+        }
+      } else {
+        conditions.push(eq(knowledgeEntries.parentId, filters.parentId));
+      }
+
+      const rows = await db
+        .select()
+        .from(knowledgeEntries)
+        .where(and(...conditions))
+        .orderBy(
+          // folders first, then by sortOrder, then by name
+          sql`CASE WHEN ${knowledgeEntries.type} = 'folder' THEN 0 ELSE 1 END`,
+          asc(knowledgeEntries.sortOrder),
+          asc(knowledgeEntries.name),
+        );
+
+      return rows.map(mapEntry);
+    },
+
+    listTree: async (
+      companyId: string,
+      filters: { scope?: KnowledgeEntryScope; scopeAgentId?: string } = {},
+    ): Promise<KnowledgeEntry[]> => {
+      const conditions = [eq(knowledgeEntries.companyId, companyId)];
+      if (filters.scope) {
+        conditions.push(eq(knowledgeEntries.scope, filters.scope));
+      }
+      if (filters.scopeAgentId) {
+        conditions.push(eq(knowledgeEntries.scopeAgentId, filters.scopeAgentId));
+      }
+
+      const rows = await db
+        .select()
+        .from(knowledgeEntries)
+        .where(and(...conditions))
+        .orderBy(
+          sql`CASE WHEN ${knowledgeEntries.type} = 'folder' THEN 0 ELSE 1 END`,
+          asc(knowledgeEntries.sortOrder),
+          asc(knowledgeEntries.name),
+        );
+
+      return rows.map(mapEntry);
+    },
+
+    getById: async (companyId: string, entryId: string): Promise<KnowledgeEntryWithContent | null> => {
+      const entry = await db
+        .select()
+        .from(knowledgeEntries)
+        .where(and(eq(knowledgeEntries.id, entryId), eq(knowledgeEntries.companyId, companyId)))
+        .then((rows) => rows[0] ?? null);
+
+      if (!entry) return null;
+
+      let documentBody: string | null = null;
+      let latestRevisionId: string | null = null;
+      let latestRevisionNumber: number | null = null;
+      let asset: KnowledgeAssetInfo | null = null;
+
+      if (entry.type === "document" && entry.documentId) {
+        const doc = await db
+          .select()
+          .from(documents)
+          .where(eq(documents.id, entry.documentId))
+          .then((rows) => rows[0] ?? null);
+        if (doc) {
+          documentBody = doc.latestBody;
+          latestRevisionId = doc.latestRevisionId;
+          latestRevisionNumber = doc.latestRevisionNumber;
+        }
+      }
+
+      if (entry.type === "file" && entry.assetId) {
+        const a = await db
+          .select()
+          .from(assets)
+          .where(eq(assets.id, entry.assetId))
+          .then((rows) => rows[0] ?? null);
+        if (a) {
+          asset = {
+            assetId: a.id,
+            provider: a.provider,
+            objectKey: a.objectKey,
+            contentType: a.contentType,
+            byteSize: a.byteSize,
+            sha256: a.sha256,
+            originalFilename: a.originalFilename,
+            contentPath: `/api/assets/${a.id}/content`,
+          };
+        }
+      }
+
+      return {
+        ...mapEntry(entry),
+        documentBody,
+        latestRevisionId,
+        latestRevisionNumber,
+        asset,
+      };
+    },
+
+    createFolder: async (
+      companyId: string,
+      input: {
+        parentId?: string | null;
+        name: string;
+        scope: KnowledgeEntryScope;
+        scopeAgentId?: string | null;
+        description?: string | null;
+        createdByUserId?: string | null;
+        createdByAgentId?: string | null;
+      },
+    ): Promise<KnowledgeEntry> => {
+      if ((input.scope === "department" || input.scope === "agent") && !input.scopeAgentId) {
+        throw unprocessable("scopeAgentId is required for department and agent scopes");
+      }
+      const now = new Date();
+      const [row] = await db
+        .insert(knowledgeEntries)
+        .values({
+          companyId,
+          parentId: input.parentId ?? null,
+          type: "folder",
+          name: input.name,
+          scope: input.scope,
+          scopeAgentId: input.scopeAgentId ?? null,
+          description: input.description ?? null,
+          createdByUserId: input.createdByUserId ?? null,
+          createdByAgentId: input.createdByAgentId ?? null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+      return mapEntry(row);
+    },
+
+    createDocument: async (
+      companyId: string,
+      input: {
+        parentId?: string | null;
+        name: string;
+        scope: KnowledgeEntryScope;
+        scopeAgentId?: string | null;
+        description?: string | null;
+        body: string;
+        createdByUserId?: string | null;
+        createdByAgentId?: string | null;
+      },
+    ): Promise<KnowledgeEntryWithContent> => {
+      if ((input.scope === "department" || input.scope === "agent") && !input.scopeAgentId) {
+        throw unprocessable("scopeAgentId is required for department and agent scopes");
+      }
+      const now = new Date();
+
+      return db.transaction(async (tx) => {
+        // Create the document row
+        const [doc] = await tx
+          .insert(documents)
+          .values({
+            companyId,
+            title: input.name,
+            format: "markdown",
+            latestBody: input.body,
+            latestRevisionId: null,
+            latestRevisionNumber: 1,
+            createdByAgentId: input.createdByAgentId ?? null,
+            createdByUserId: input.createdByUserId ?? null,
+            updatedByAgentId: input.createdByAgentId ?? null,
+            updatedByUserId: input.createdByUserId ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning();
+
+        // Create initial revision
+        const [revision] = await tx
+          .insert(documentRevisions)
+          .values({
+            companyId,
+            documentId: doc.id,
+            revisionNumber: 1,
+            title: input.name,
+            format: "markdown",
+            body: input.body,
+            changeSummary: "Initial version",
+            createdByAgentId: input.createdByAgentId ?? null,
+            createdByUserId: input.createdByUserId ?? null,
+            createdAt: now,
+          })
+          .returning();
+
+        // Update document with revision ID
+        await tx
+          .update(documents)
+          .set({ latestRevisionId: revision.id })
+          .where(eq(documents.id, doc.id));
+
+        // Create knowledge entry
+        const [entry] = await tx
+          .insert(knowledgeEntries)
+          .values({
+            companyId,
+            parentId: input.parentId ?? null,
+            type: "document",
+            name: input.name,
+            scope: input.scope,
+            scopeAgentId: input.scopeAgentId ?? null,
+            documentId: doc.id,
+            description: input.description ?? null,
+            createdByUserId: input.createdByUserId ?? null,
+            createdByAgentId: input.createdByAgentId ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning();
+
+        return {
+          ...mapEntry(entry),
+          documentBody: input.body,
+          latestRevisionId: revision.id,
+          latestRevisionNumber: 1,
+          asset: null,
+        };
+      });
+    },
+
+    createFile: async (
+      companyId: string,
+      input: {
+        parentId?: string | null;
+        name: string;
+        scope: KnowledgeEntryScope;
+        scopeAgentId?: string | null;
+        description?: string | null;
+        createdByUserId?: string | null;
+        createdByAgentId?: string | null;
+      },
+      assetRow: {
+        id: string;
+        provider: string;
+        objectKey: string;
+        contentType: string;
+        byteSize: number;
+        sha256: string;
+        originalFilename: string | null;
+      },
+    ): Promise<KnowledgeEntryWithContent> => {
+      if ((input.scope === "department" || input.scope === "agent") && !input.scopeAgentId) {
+        throw unprocessable("scopeAgentId is required for department and agent scopes");
+      }
+      const now = new Date();
+
+      const [entry] = await db
+        .insert(knowledgeEntries)
+        .values({
+          companyId,
+          parentId: input.parentId ?? null,
+          type: "file",
+          name: input.name,
+          scope: input.scope,
+          scopeAgentId: input.scopeAgentId ?? null,
+          assetId: assetRow.id,
+          description: input.description ?? null,
+          createdByUserId: input.createdByUserId ?? null,
+          createdByAgentId: input.createdByAgentId ?? null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+
+      return {
+        ...mapEntry(entry),
+        documentBody: null,
+        latestRevisionId: null,
+        latestRevisionNumber: null,
+        asset: {
+          assetId: assetRow.id,
+          provider: assetRow.provider,
+          objectKey: assetRow.objectKey,
+          contentType: assetRow.contentType,
+          byteSize: assetRow.byteSize,
+          sha256: assetRow.sha256,
+          originalFilename: assetRow.originalFilename,
+          contentPath: `/api/assets/${assetRow.id}/content`,
+        },
+      };
+    },
+
+    updateEntry: async (
+      companyId: string,
+      entryId: string,
+      input: {
+        name?: string;
+        parentId?: string | null;
+        description?: string | null;
+        sortOrder?: number;
+      },
+    ): Promise<KnowledgeEntry | null> => {
+      const existing = await db
+        .select()
+        .from(knowledgeEntries)
+        .where(and(eq(knowledgeEntries.id, entryId), eq(knowledgeEntries.companyId, companyId)))
+        .then((rows) => rows[0] ?? null);
+      if (!existing) return null;
+
+      const updates: Partial<typeof knowledgeEntries.$inferInsert> = { updatedAt: new Date() };
+      if (input.name !== undefined) updates.name = input.name;
+      if ("parentId" in input) updates.parentId = input.parentId ?? null;
+      if ("description" in input) updates.description = input.description ?? null;
+      if (input.sortOrder !== undefined) updates.sortOrder = input.sortOrder;
+
+      // If it's a document, also update the document title
+      if (input.name !== undefined && existing.type === "document" && existing.documentId) {
+        await db
+          .update(documents)
+          .set({ title: input.name, updatedAt: new Date() })
+          .where(eq(documents.id, existing.documentId));
+      }
+
+      const [updated] = await db
+        .update(knowledgeEntries)
+        .set(updates)
+        .where(eq(knowledgeEntries.id, entryId))
+        .returning();
+
+      return mapEntry(updated);
+    },
+
+    updateDocumentBody: async (
+      companyId: string,
+      entryId: string,
+      input: {
+        body: string;
+        baseRevisionId?: string | null;
+        changeSummary?: string | null;
+        createdByUserId?: string | null;
+        createdByAgentId?: string | null;
+      },
+    ) => {
+      const entry = await db
+        .select()
+        .from(knowledgeEntries)
+        .where(and(eq(knowledgeEntries.id, entryId), eq(knowledgeEntries.companyId, companyId)))
+        .then((rows) => rows[0] ?? null);
+
+      if (!entry) throw notFound("Knowledge entry not found");
+      if (entry.type !== "document" || !entry.documentId) {
+        throw unprocessable("Entry is not a document");
+      }
+
+      return db.transaction(async (tx) => {
+        const doc = await tx
+          .select()
+          .from(documents)
+          .where(eq(documents.id, entry.documentId!))
+          .then((rows) => rows[0] ?? null);
+
+        if (!doc) throw notFound("Document not found");
+
+        // Conflict detection
+        if (input.baseRevisionId && input.baseRevisionId !== doc.latestRevisionId) {
+          throw conflict("Document was updated by someone else", {
+            currentRevisionId: doc.latestRevisionId,
+          });
+        }
+
+        const now = new Date();
+        const nextRevisionNumber = doc.latestRevisionNumber + 1;
+
+        const [revision] = await tx
+          .insert(documentRevisions)
+          .values({
+            companyId,
+            documentId: doc.id,
+            revisionNumber: nextRevisionNumber,
+            title: doc.title,
+            format: doc.format,
+            body: input.body,
+            changeSummary: input.changeSummary ?? null,
+            createdByAgentId: input.createdByAgentId ?? null,
+            createdByUserId: input.createdByUserId ?? null,
+            createdAt: now,
+          })
+          .returning();
+
+        await tx
+          .update(documents)
+          .set({
+            latestBody: input.body,
+            latestRevisionId: revision.id,
+            latestRevisionNumber: nextRevisionNumber,
+            updatedByAgentId: input.createdByAgentId ?? null,
+            updatedByUserId: input.createdByUserId ?? null,
+            updatedAt: now,
+          })
+          .where(eq(documents.id, doc.id));
+
+        await tx
+          .update(knowledgeEntries)
+          .set({ updatedAt: now })
+          .where(eq(knowledgeEntries.id, entryId));
+
+        return {
+          ...mapEntry({ ...entry, updatedAt: now }),
+          documentBody: input.body,
+          latestRevisionId: revision.id,
+          latestRevisionNumber: nextRevisionNumber,
+          asset: null,
+        };
+      });
+    },
+
+    listRevisions: async (companyId: string, entryId: string): Promise<KnowledgeDocumentRevision[]> => {
+      const entry = await db
+        .select()
+        .from(knowledgeEntries)
+        .where(and(eq(knowledgeEntries.id, entryId), eq(knowledgeEntries.companyId, companyId)))
+        .then((rows) => rows[0] ?? null);
+
+      if (!entry || entry.type !== "document" || !entry.documentId) return [];
+
+      return db
+        .select({
+          id: documentRevisions.id,
+          companyId: documentRevisions.companyId,
+          documentId: documentRevisions.documentId,
+          revisionNumber: documentRevisions.revisionNumber,
+          title: documentRevisions.title,
+          format: documentRevisions.format,
+          body: documentRevisions.body,
+          changeSummary: documentRevisions.changeSummary,
+          createdByAgentId: documentRevisions.createdByAgentId,
+          createdByUserId: documentRevisions.createdByUserId,
+          createdAt: documentRevisions.createdAt,
+        })
+        .from(documentRevisions)
+        .where(eq(documentRevisions.documentId, entry.documentId))
+        .orderBy(desc(documentRevisions.revisionNumber));
+    },
+
+    deleteEntry: async (companyId: string, entryId: string): Promise<KnowledgeEntry | null> => {
+      const entry = await db
+        .select()
+        .from(knowledgeEntries)
+        .where(and(eq(knowledgeEntries.id, entryId), eq(knowledgeEntries.companyId, companyId)))
+        .then((rows) => rows[0] ?? null);
+
+      if (!entry) return null;
+
+      return db.transaction(async (tx) => {
+        // Get all descendant IDs (for folder cascade)
+        const allIds = await getDescendantIds(tx as unknown as Db, companyId, entryId);
+
+        // Collect all document and asset IDs to clean up
+        const entriesToDelete = await tx
+          .select({
+            id: knowledgeEntries.id,
+            documentId: knowledgeEntries.documentId,
+            assetId: knowledgeEntries.assetId,
+          })
+          .from(knowledgeEntries)
+          .where(inArray(knowledgeEntries.id, allIds));
+
+        const documentIds = entriesToDelete.filter((e) => e.documentId).map((e) => e.documentId!);
+        const assetIds = entriesToDelete.filter((e) => e.assetId).map((e) => e.assetId!);
+
+        // Delete knowledge entries (children first via FK cascade on parentId)
+        // Delete from leaves up by reversing the list
+        const reversedIds = [...allIds].reverse();
+        for (const id of reversedIds) {
+          await tx.delete(knowledgeEntries).where(eq(knowledgeEntries.id, id));
+        }
+
+        // Clean up orphaned documents (cascade will handle revisions)
+        if (documentIds.length > 0) {
+          await tx.delete(documents).where(inArray(documents.id, documentIds));
+        }
+
+        // Note: we don't delete asset files from storage here — that would need
+        // a separate cleanup job. We only remove the DB rows.
+        if (assetIds.length > 0) {
+          await tx.delete(assets).where(inArray(assets.id, assetIds));
+        }
+
+        return mapEntry(entry);
+      });
+    },
+
+    resolveAgentVisibleEntries: async (
+      companyId: string,
+      agentId: string,
+    ): Promise<KnowledgeEntry[]> => {
+      // 1. Company-scoped entries (visible to all)
+      const companyEntries = await db
+        .select()
+        .from(knowledgeEntries)
+        .where(and(eq(knowledgeEntries.companyId, companyId), eq(knowledgeEntries.scope, "company")));
+
+      // 2. Agent's own entries
+      const agentEntries = await db
+        .select()
+        .from(knowledgeEntries)
+        .where(
+          and(
+            eq(knowledgeEntries.companyId, companyId),
+            eq(knowledgeEntries.scope, "agent"),
+            eq(knowledgeEntries.scopeAgentId, agentId),
+          ),
+        );
+
+      // 3. Department entries — find which department this agent belongs to
+      const deptHeadId = await getAgentDepartmentHead(db, companyId, agentId);
+      let deptEntries: (typeof knowledgeEntries.$inferSelect)[] = [];
+      if (deptHeadId) {
+        deptEntries = await db
+          .select()
+          .from(knowledgeEntries)
+          .where(
+            and(
+              eq(knowledgeEntries.companyId, companyId),
+              eq(knowledgeEntries.scope, "department"),
+              eq(knowledgeEntries.scopeAgentId, deptHeadId),
+            ),
+          );
+      }
+
+      // Also check if the agent IS a department head
+      const ownDeptEntries = await db
+        .select()
+        .from(knowledgeEntries)
+        .where(
+          and(
+            eq(knowledgeEntries.companyId, companyId),
+            eq(knowledgeEntries.scope, "department"),
+            eq(knowledgeEntries.scopeAgentId, agentId),
+          ),
+        );
+
+      const allEntries = [...companyEntries, ...agentEntries, ...deptEntries, ...ownDeptEntries];
+      // Deduplicate by ID
+      const seen = new Set<string>();
+      return allEntries
+        .filter((e) => {
+          if (seen.has(e.id)) return false;
+          seen.add(e.id);
+          return true;
+        })
+        .map(mapEntry);
+    },
+  };
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -26,6 +26,7 @@ import { Activity } from "./pages/Activity";
 import { Inbox } from "./pages/Inbox";
 import { CompanySettings } from "./pages/CompanySettings";
 import { CompanySkills } from "./pages/CompanySkills";
+import { CompanyFiles } from "./pages/CompanyFiles";
 import { CompanyExport } from "./pages/CompanyExport";
 import { CompanyImport } from "./pages/CompanyImport";
 import { DesignGuide } from "./pages/DesignGuide";
@@ -129,6 +130,7 @@ function boardRoutes() {
       <Route path="company/export/*" element={<CompanyExport />} />
       <Route path="company/import" element={<CompanyImport />} />
       <Route path="skills/*" element={<CompanySkills />} />
+      <Route path="files/*" element={<CompanyFiles />} />
       <Route path="settings" element={<LegacySettingsRedirect />} />
       <Route path="settings/*" element={<LegacySettingsRedirect />} />
       <Route path="plugins/:pluginId" element={<PluginPage />} />

--- a/ui/src/api/knowledge.ts
+++ b/ui/src/api/knowledge.ts
@@ -1,0 +1,89 @@
+import type {
+  KnowledgeEntry,
+  KnowledgeEntryWithContent,
+  KnowledgeDepartment,
+  KnowledgeDocumentRevision,
+  KnowledgeEntryScope,
+} from "@paperclipai/shared";
+import { api } from "./client";
+
+function enc(s: string) {
+  return encodeURIComponent(s);
+}
+
+export const knowledgeApi = {
+  list: (companyId: string, params?: { scope?: KnowledgeEntryScope; scopeAgentId?: string; parentId?: string | null }) => {
+    const qs = new URLSearchParams();
+    if (params?.scope) qs.set("scope", params.scope);
+    if (params?.scopeAgentId) qs.set("scopeAgentId", params.scopeAgentId);
+    if (params?.parentId !== undefined) qs.set("parentId", params.parentId ?? "null");
+    const query = qs.toString();
+    return api.get<KnowledgeEntry[]>(`/companies/${enc(companyId)}/knowledge${query ? `?${query}` : ""}`);
+  },
+
+  departments: (companyId: string) =>
+    api.get<KnowledgeDepartment[]>(`/companies/${enc(companyId)}/knowledge/departments`),
+
+  tree: (companyId: string, params?: { scope?: KnowledgeEntryScope; scopeAgentId?: string }) => {
+    const qs = new URLSearchParams();
+    if (params?.scope) qs.set("scope", params.scope);
+    if (params?.scopeAgentId) qs.set("scopeAgentId", params.scopeAgentId);
+    const query = qs.toString();
+    return api.get<KnowledgeEntry[]>(`/companies/${enc(companyId)}/knowledge/tree${query ? `?${query}` : ""}`);
+  },
+
+  detail: (companyId: string, entryId: string) =>
+    api.get<KnowledgeEntryWithContent>(`/companies/${enc(companyId)}/knowledge/${enc(entryId)}`),
+
+  createFolder: (companyId: string, data: {
+    name: string;
+    scope: KnowledgeEntryScope;
+    scopeAgentId?: string | null;
+    parentId?: string | null;
+    description?: string | null;
+  }) =>
+    api.post<KnowledgeEntry>(`/companies/${enc(companyId)}/knowledge`, {
+      type: "folder",
+      ...data,
+    }),
+
+  createDocument: (companyId: string, data: {
+    name: string;
+    scope: KnowledgeEntryScope;
+    scopeAgentId?: string | null;
+    parentId?: string | null;
+    description?: string | null;
+    body: string;
+  }) =>
+    api.post<KnowledgeEntryWithContent>(`/companies/${enc(companyId)}/knowledge`, {
+      type: "document",
+      ...data,
+    }),
+
+  uploadFile: (companyId: string, formData: FormData) =>
+    api.postForm<KnowledgeEntryWithContent>(`/companies/${enc(companyId)}/knowledge/upload`, formData),
+
+  update: (companyId: string, entryId: string, data: {
+    name?: string;
+    parentId?: string | null;
+    description?: string | null;
+    sortOrder?: number;
+  }) =>
+    api.patch<KnowledgeEntry>(`/companies/${enc(companyId)}/knowledge/${enc(entryId)}`, data),
+
+  updateBody: (companyId: string, entryId: string, data: {
+    body: string;
+    baseRevisionId?: string | null;
+    changeSummary?: string | null;
+  }) =>
+    api.put<KnowledgeEntryWithContent>(`/companies/${enc(companyId)}/knowledge/${enc(entryId)}/body`, data),
+
+  revisions: (companyId: string, entryId: string) =>
+    api.get<KnowledgeDocumentRevision[]>(`/companies/${enc(companyId)}/knowledge/${enc(entryId)}/revisions`),
+
+  delete: (companyId: string, entryId: string) =>
+    api.delete<KnowledgeEntry>(`/companies/${enc(companyId)}/knowledge/${enc(entryId)}`),
+
+  agentView: (companyId: string, agentId: string) =>
+    api.get<KnowledgeEntry[]>(`/companies/${enc(companyId)}/knowledge/agent/${enc(agentId)}`),
+};

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   Target,
   LayoutDashboard,
   DollarSign,
+  FolderOpen,
   History,
   Search,
   SquarePen,
@@ -110,6 +111,7 @@ export function Sidebar() {
         <SidebarSection label="Company">
           <SidebarNavItem to="/org" label="Org" icon={Network} />
           <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
+          <SidebarNavItem to="/files" label="Files" icon={FolderOpen} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />
           <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />

--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -3,6 +3,7 @@ const BOARD_ROUTE_ROOTS = new Set([
   "companies",
   "company",
   "skills",
+  "files",
   "org",
   "agents",
   "projects",

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -4,6 +4,19 @@ export const queryKeys = {
     detail: (id: string) => ["companies", id] as const,
     stats: ["companies", "stats"] as const,
   },
+  knowledge: {
+    list: (companyId: string, scope?: string, parentId?: string) =>
+      ["knowledge", companyId, scope ?? "all", parentId ?? "root"] as const,
+    departments: (companyId: string) => ["knowledge", companyId, "departments"] as const,
+    tree: (companyId: string, scope?: string, scopeAgentId?: string) =>
+      ["knowledge", companyId, "tree", scope ?? "all", scopeAgentId ?? "all"] as const,
+    detail: (companyId: string, entryId: string) =>
+      ["knowledge", companyId, "detail", entryId] as const,
+    revisions: (companyId: string, entryId: string) =>
+      ["knowledge", companyId, "revisions", entryId] as const,
+    agentView: (companyId: string, agentId: string) =>
+      ["knowledge", companyId, "agent", agentId] as const,
+  },
   companySkills: {
     list: (companyId: string) => ["company-skills", companyId] as const,
     detail: (companyId: string, skillId: string) => ["company-skills", companyId, skillId] as const,

--- a/ui/src/pages/CompanyFiles.tsx
+++ b/ui/src/pages/CompanyFiles.tsx
@@ -1,0 +1,874 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useParams } from "@/lib/router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  KnowledgeEntry,
+  KnowledgeEntryWithContent,
+  KnowledgeDepartment,
+  KnowledgeEntryScope,
+} from "@paperclipai/shared";
+import { knowledgeApi } from "../api/knowledge";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useToast } from "../context/ToastContext";
+import { queryKeys } from "../lib/queryKeys";
+import { EmptyState } from "../components/EmptyState";
+import { MarkdownBody } from "../components/MarkdownBody";
+import { MarkdownEditor } from "../components/MarkdownEditor";
+import { PageSkeleton } from "../components/PageSkeleton";
+import { PageTabBar } from "../components/PageTabBar";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "../lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  ChevronDown,
+  ChevronRight,
+  Download,
+  File,
+  FileText,
+  Folder,
+  FolderOpen,
+  FolderPlus,
+  FilePlus,
+  Pencil,
+  Plus,
+  Save,
+  Trash2,
+  Upload,
+} from "lucide-react";
+
+// ── Types ───────────────────────────────────────────────────────────
+
+type TreeNode = KnowledgeEntry & { children: TreeNode[] };
+
+// ── Tree helpers ────────────────────────────────────────────────────
+
+function buildTree(entries: KnowledgeEntry[]): TreeNode[] {
+  const map = new Map<string, TreeNode>();
+  const roots: TreeNode[] = [];
+
+  for (const entry of entries) {
+    map.set(entry.id, { ...entry, children: [] });
+  }
+  for (const node of map.values()) {
+    if (node.parentId && map.has(node.parentId)) {
+      map.get(node.parentId)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  return roots;
+}
+
+// ── Tree item component ─────────────────────────────────────────────
+
+function TreeItem({
+  node,
+  depth,
+  selectedId,
+  onSelect,
+  expandedIds,
+  onToggle,
+}: {
+  node: TreeNode;
+  depth: number;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  expandedIds: Set<string>;
+  onToggle: (id: string) => void;
+}) {
+  const isFolder = node.type === "folder";
+  const isExpanded = expandedIds.has(node.id);
+  const isSelected = node.id === selectedId;
+  const hasChildren = node.children.length > 0;
+
+  const Icon = isFolder
+    ? isExpanded
+      ? FolderOpen
+      : Folder
+    : node.type === "document"
+      ? FileText
+      : File;
+
+  return (
+    <>
+      <button
+        type="button"
+        className={cn(
+          "flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent",
+          isSelected && "bg-accent font-medium",
+        )}
+        style={{ paddingLeft: `${8 + depth * 20}px` }}
+        onClick={() => {
+          if (isFolder && hasChildren) onToggle(node.id);
+          onSelect(node.id);
+        }}
+      >
+        {isFolder ? (
+          <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+            {hasChildren ? (
+              isExpanded ? (
+                <ChevronDown className="h-3 w-3 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-3 w-3 text-muted-foreground" />
+              )
+            ) : null}
+          </span>
+        ) : (
+          <span className="h-4 w-4" />
+        )}
+        <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="truncate">{node.name}</span>
+      </button>
+      {isFolder && isExpanded &&
+        node.children.map((child) => (
+          <TreeItem
+            key={child.id}
+            node={child}
+            depth={depth + 1}
+            selectedId={selectedId}
+            onSelect={onSelect}
+            expandedIds={expandedIds}
+            onToggle={onToggle}
+          />
+        ))}
+    </>
+  );
+}
+
+// ── Create dialogs ──────────────────────────────────────────────────
+
+function CreateFolderDialog({
+  open,
+  onOpenChange,
+  companyId,
+  scope,
+  scopeAgentId,
+  parentId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  companyId: string;
+  scope: KnowledgeEntryScope;
+  scopeAgentId: string | null;
+  parentId: string | null;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      knowledgeApi.createFolder(companyId, {
+        name,
+        scope,
+        scopeAgentId,
+        parentId,
+        description: description.trim() || null,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["knowledge", companyId] });
+      pushToast({ title: "Folder created", tone: "success" });
+      setName("");
+      setDescription("");
+      onOpenChange(false);
+    },
+    onError: (err: Error) => {
+      pushToast({ title: "Error", body: err.message, tone: "error" });
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>New Folder</DialogTitle>
+        </DialogHeader>
+        <Input
+          placeholder="Folder name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          autoFocus
+        />
+        <Textarea
+          placeholder="Description (optional) — helps agents understand what's inside"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={2}
+          className="resize-none"
+        />
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => mutation.mutate()} disabled={!name.trim() || mutation.isPending}>
+            Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CreateDocumentDialog({
+  open,
+  onOpenChange,
+  companyId,
+  scope,
+  scopeAgentId,
+  parentId,
+  onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  companyId: string;
+  scope: KnowledgeEntryScope;
+  scopeAgentId: string | null;
+  parentId: string | null;
+  onCreated: (entry: KnowledgeEntryWithContent) => void;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      knowledgeApi.createDocument(companyId, {
+        name,
+        scope,
+        scopeAgentId,
+        parentId,
+        description: description.trim() || null,
+        body: "",
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["knowledge", companyId] });
+      pushToast({ title: "Document created", tone: "success" });
+      setName("");
+      setDescription("");
+      onOpenChange(false);
+      onCreated(result);
+    },
+    onError: (err: Error) => {
+      pushToast({ title: "Error", body: err.message, tone: "error" });
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>New Document</DialogTitle>
+        </DialogHeader>
+        <Input
+          placeholder="Document name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          autoFocus
+        />
+        <Textarea
+          placeholder="Description (optional) — helps agents understand what this document covers"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={2}
+          className="resize-none"
+        />
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => mutation.mutate()} disabled={!name.trim() || mutation.isPending}>
+            Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Content pane ────────────────────────────────────────────────────
+
+function ContentPane({
+  companyId,
+  entryId,
+}: {
+  companyId: string;
+  entryId: string | null;
+}) {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+  const [editBody, setEditBody] = useState<string | null>(null);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { data: entry, isLoading } = useQuery({
+    queryKey: queryKeys.knowledge.detail(companyId, entryId ?? ""),
+    queryFn: () => knowledgeApi.detail(companyId, entryId!),
+    enabled: !!entryId,
+  });
+
+  // Sync edit body when entry changes
+  useEffect(() => {
+    if (entry?.type === "document" && entry.documentBody !== null) {
+      setEditBody(entry.documentBody);
+    } else {
+      setEditBody(null);
+    }
+  }, [entry?.id, entry?.documentBody]);
+
+  const bodyMutation = useMutation({
+    mutationFn: (body: string) =>
+      knowledgeApi.updateBody(companyId, entryId!, {
+        body,
+        baseRevisionId: entry?.latestRevisionId,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.knowledge.detail(companyId, entryId!) });
+    },
+    onError: (err: Error) => {
+      pushToast({ title: "Save failed", body: err.message, tone: "error" });
+    },
+  });
+
+  const handleBodyChange = useCallback(
+    (value: string) => {
+      setEditBody(value);
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => {
+        bodyMutation.mutate(value);
+      }, 1500);
+    },
+    [bodyMutation],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, []);
+
+  if (!entryId) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-muted-foreground">
+        Select a file or folder to view its contents
+      </div>
+    );
+  }
+
+  if (isLoading) return <PageSkeleton />;
+  if (!entry) return <EmptyState icon={FileText} message="Entry not found" />;
+
+  // Folder view
+  if (entry.type === "folder") {
+    return (
+      <div className="p-6">
+        <h2 className="text-lg font-semibold">{entry.name}</h2>
+        {entry.description && (
+          <p className="mt-1 text-sm text-muted-foreground">{entry.description}</p>
+        )}
+        <p className="mt-4 text-sm text-muted-foreground">
+          Select a file from the tree to view its contents.
+        </p>
+      </div>
+    );
+  }
+
+  // Document view
+  if (entry.type === "document") {
+    return (
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="flex items-center gap-2 border-b px-4 py-2">
+          <FileText className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-medium">{entry.name}</h2>
+          {bodyMutation.isPending && (
+            <span className="text-xs text-muted-foreground">Saving...</span>
+          )}
+        </div>
+        <div className="flex-1 overflow-auto">
+          <MarkdownEditor
+            value={editBody ?? ""}
+            onChange={handleBodyChange}
+            placeholder="Start writing..."
+            bordered={false}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // File view
+  if (entry.type === "file" && entry.asset) {
+    const isImage = entry.asset.contentType.startsWith("image/");
+    return (
+      <div className="p-6 space-y-4">
+        <div className="flex items-center gap-2">
+          <File className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-medium">{entry.name}</h2>
+        </div>
+        {entry.description && (
+          <p className="text-sm text-muted-foreground">{entry.description}</p>
+        )}
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <p>Type: {entry.asset.contentType}</p>
+          <p>Size: {(entry.asset.byteSize / 1024).toFixed(1)} KB</p>
+          {entry.asset.originalFilename && <p>Original: {entry.asset.originalFilename}</p>}
+        </div>
+        {isImage && (
+          <img
+            src={entry.asset.contentPath}
+            alt={entry.name}
+            className="max-w-full rounded border"
+          />
+        )}
+        <a
+          href={entry.asset.contentPath}
+          download={entry.asset.originalFilename ?? entry.name}
+          className="inline-flex items-center gap-2"
+        >
+          <Button variant="ghost" size="sm">
+            <Download className="mr-1 h-4 w-4" />
+            Download
+          </Button>
+        </a>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+// ── File upload handler ─────────────────────────────────────────────
+
+function UploadFileDialog({
+  open,
+  onOpenChange,
+  companyId,
+  scope,
+  scopeAgentId,
+  parentId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  companyId: string;
+  scope: KnowledgeEntryScope;
+  scopeAgentId: string | null;
+  parentId: string | null;
+}) {
+  const [file, setFile] = useState<globalThis.File | null>(null);
+  const [description, setDescription] = useState("");
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!file) throw new Error("No file selected");
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("name", file.name);
+      formData.append("scope", scope);
+      if (scopeAgentId) formData.append("scopeAgentId", scopeAgentId);
+      if (parentId) formData.append("parentId", parentId);
+      if (description.trim()) formData.append("description", description.trim());
+      return knowledgeApi.uploadFile(companyId, formData);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["knowledge", companyId] });
+      pushToast({ title: "File uploaded", tone: "success" });
+      setFile(null);
+      setDescription("");
+      onOpenChange(false);
+    },
+    onError: (err: Error) => {
+      pushToast({ title: "Upload failed", body: err.message, tone: "error" });
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Upload File</DialogTitle>
+        </DialogHeader>
+        <input
+          type="file"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+          className="text-sm"
+        />
+        <Textarea
+          placeholder="Description (optional) — what's in this file?"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={2}
+          className="resize-none"
+        />
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => mutation.mutate()} disabled={!file || mutation.isPending}>
+            {mutation.isPending ? "Uploading..." : "Upload"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Scope panel (left side within a tab) ────────────────────────────
+
+function ScopePanel({
+  companyId,
+  scope,
+  scopeAgentId,
+  selectedId,
+  onSelect,
+}: {
+  companyId: string;
+  scope: KnowledgeEntryScope;
+  scopeAgentId: string | null;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [showCreateFolder, setShowCreateFolder] = useState(false);
+  const [showCreateDoc, setShowCreateDoc] = useState(false);
+  const [showUpload, setShowUpload] = useState(false);
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+
+  const treeParams = useMemo(
+    () => ({ scope, ...(scopeAgentId ? { scopeAgentId } : {}) }),
+    [scope, scopeAgentId],
+  );
+
+  const { data: entries, isLoading } = useQuery({
+    queryKey: queryKeys.knowledge.tree(companyId, scope, scopeAgentId ?? undefined),
+    queryFn: () => knowledgeApi.tree(companyId, treeParams),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (entryId: string) => knowledgeApi.delete(companyId, entryId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["knowledge", companyId] });
+      pushToast({ title: "Deleted", tone: "success" });
+    },
+    onError: (err: Error) => {
+      pushToast({ title: "Error", body: err.message, tone: "error" });
+    },
+  });
+
+  const tree = useMemo(() => buildTree(entries ?? []), [entries]);
+
+  const handleToggle = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  // Selected entry's parent folder for creating siblings
+  const selectedEntry = entries?.find((e) => e.id === selectedId);
+  const parentIdForCreate = selectedEntry?.type === "folder" ? selectedEntry.id : (selectedEntry?.parentId ?? null);
+
+  if (isLoading) return <PageSkeleton />;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-auto p-2">
+        {tree.length === 0 ? (
+          <div className="px-2 py-8 text-center text-sm text-muted-foreground">
+            No files yet. Create a folder or document to get started.
+          </div>
+        ) : (
+          tree.map((node) => (
+            <TreeItem
+              key={node.id}
+              node={node}
+              depth={0}
+              selectedId={selectedId}
+              onSelect={onSelect}
+              expandedIds={expandedIds}
+              onToggle={handleToggle}
+            />
+          ))
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1 border-t p-2">
+        <Button variant="ghost" size="sm" onClick={() => setShowCreateFolder(true)}>
+          <FolderPlus className="mr-1 h-3.5 w-3.5" />
+          Folder
+        </Button>
+        <Button variant="ghost" size="sm" onClick={() => setShowCreateDoc(true)}>
+          <FilePlus className="mr-1 h-3.5 w-3.5" />
+          Document
+        </Button>
+        <Button variant="ghost" size="sm" onClick={() => setShowUpload(true)}>
+          <Upload className="mr-1 h-3.5 w-3.5" />
+          Upload
+        </Button>
+        {selectedId && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto text-destructive hover:text-destructive"
+            onClick={() => {
+              if (confirm("Delete this entry and all its children?")) {
+                deleteMutation.mutate(selectedId);
+              }
+            }}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+
+      <CreateFolderDialog
+        open={showCreateFolder}
+        onOpenChange={setShowCreateFolder}
+        companyId={companyId}
+        scope={scope}
+        scopeAgentId={scopeAgentId}
+        parentId={parentIdForCreate}
+      />
+      <CreateDocumentDialog
+        open={showCreateDoc}
+        onOpenChange={setShowCreateDoc}
+        companyId={companyId}
+        scope={scope}
+        scopeAgentId={scopeAgentId}
+        parentId={parentIdForCreate}
+        onCreated={(entry) => onSelect(entry.id)}
+      />
+      <UploadFileDialog
+        open={showUpload}
+        onOpenChange={setShowUpload}
+        companyId={companyId}
+        scope={scope}
+        scopeAgentId={scopeAgentId}
+        parentId={parentIdForCreate}
+      />
+    </div>
+  );
+}
+
+// ── Department tab ──────────────────────────────────────────────────
+
+function DepartmentsTab({
+  companyId,
+  selectedId,
+  onSelect,
+}: {
+  companyId: string;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const [selectedDept, setSelectedDept] = useState<string | null>(null);
+
+  const { data: departments, isLoading } = useQuery({
+    queryKey: queryKeys.knowledge.departments(companyId),
+    queryFn: () => knowledgeApi.departments(companyId),
+  });
+
+  if (isLoading) return <PageSkeleton />;
+  if (!departments?.length) {
+    return (
+      <EmptyState
+        icon={Folder}
+        message="No departments found. Departments are derived from your org chart — agents who report directly to the CEO form department heads."
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full">
+      {/* Department list */}
+      <div className="w-48 shrink-0 border-r overflow-auto">
+        {departments.map((dept) => (
+          <button
+            key={dept.agentId}
+            type="button"
+            className={cn(
+              "flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent",
+              selectedDept === dept.agentId && "bg-accent font-medium",
+            )}
+            onClick={() => setSelectedDept(dept.agentId)}
+          >
+            <Folder className="h-4 w-4 text-muted-foreground" />
+            <div className="truncate">
+              <div className="truncate">{dept.agentName}</div>
+              <div className="truncate text-xs text-muted-foreground">{dept.agentTitle ?? dept.agentRole}</div>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* Department files */}
+      <div className="flex-1">
+        {selectedDept ? (
+          <ScopePanel
+            companyId={companyId}
+            scope="department"
+            scopeAgentId={selectedDept}
+            selectedId={selectedId}
+            onSelect={onSelect}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Select a department
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Agents tab ──────────────────────────────────────────────────────
+
+function AgentsTab({
+  companyId,
+  selectedId,
+  onSelect,
+}: {
+  companyId: string;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+
+  // Reuse agents list from existing query key
+  const { data: agentsList, isLoading } = useQuery({
+    queryKey: queryKeys.agents.list(companyId),
+    queryFn: async () => {
+      const { api } = await import("../api/client");
+      return api.get<Array<{ id: string; name: string; title: string | null; role: string; status: string }>>(
+        `/agents?companyId=${encodeURIComponent(companyId)}`,
+      );
+    },
+  });
+
+  const activeAgents = useMemo(
+    () => (agentsList ?? []).filter((a) => a.status !== "terminated"),
+    [agentsList],
+  );
+
+  if (isLoading) return <PageSkeleton />;
+
+  return (
+    <div className="flex h-full">
+      {/* Agent list */}
+      <div className="w-48 shrink-0 border-r overflow-auto">
+        {activeAgents.map((agent) => (
+          <button
+            key={agent.id}
+            type="button"
+            className={cn(
+              "flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent",
+              selectedAgent === agent.id && "bg-accent font-medium",
+            )}
+            onClick={() => setSelectedAgent(agent.id)}
+          >
+            <div className="truncate">
+              <div className="truncate">{agent.name}</div>
+              <div className="truncate text-xs text-muted-foreground">{agent.title ?? agent.role}</div>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* Agent files */}
+      <div className="flex-1">
+        {selectedAgent ? (
+          <ScopePanel
+            companyId={companyId}
+            scope="agent"
+            scopeAgentId={selectedAgent}
+            selectedId={selectedId}
+            onSelect={onSelect}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Select an agent
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Main page ───────────────────────────────────────────────────────
+
+export function CompanyFiles() {
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const [activeTab, setActiveTab] = useState("company");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "Files" }]);
+  }, [setBreadcrumbs]);
+
+  if (!selectedCompanyId) return <PageSkeleton />;
+
+  const tabs = [
+    { value: "company", label: "Company" },
+    { value: "departments", label: "Departments" },
+    { value: "agents", label: "Agents" },
+  ];
+
+  return (
+    <Tabs value={activeTab} onValueChange={(v) => { setActiveTab(v); setSelectedId(null); }}>
+      <div className="flex h-full flex-col">
+        <div className="border-b px-4 pt-2">
+          <PageTabBar items={tabs} value={activeTab} onValueChange={(v) => { setActiveTab(v); setSelectedId(null); }} align="start" />
+        </div>
+
+        <div className="flex flex-1 overflow-hidden">
+          {/* Left panel: tree */}
+          <div className="w-72 shrink-0 border-r overflow-hidden flex flex-col">
+            <TabsContent value="company" className="flex-1 overflow-hidden mt-0">
+              <ScopePanel
+                companyId={selectedCompanyId}
+                scope="company"
+                scopeAgentId={null}
+                selectedId={selectedId}
+                onSelect={setSelectedId}
+              />
+            </TabsContent>
+            <TabsContent value="departments" className="flex-1 overflow-hidden mt-0">
+              <DepartmentsTab
+                companyId={selectedCompanyId}
+                selectedId={selectedId}
+                onSelect={setSelectedId}
+              />
+            </TabsContent>
+            <TabsContent value="agents" className="flex-1 overflow-hidden mt-0">
+              <AgentsTab
+                companyId={selectedCompanyId}
+                selectedId={selectedId}
+                onSelect={setSelectedId}
+              />
+            </TabsContent>
+          </div>
+
+          {/* Right panel: content */}
+          <div className="flex flex-1 flex-col overflow-hidden">
+            <ContentPane companyId={selectedCompanyId} entryId={selectedId} />
+          </div>
+        </div>
+      </div>
+    </Tabs>
+  );
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents into zero-human companies
> - Agents operate with instructions, memory, and skills — but company-wide reference material (brand guidelines, SOPs, playbooks, templates) has no structured home
> - This knowledge currently lives implicitly on disk or in agent memory files, invisible in the UI and inaccessible to other agents
> - Real organizations need shared knowledge scoped to company, department, and individual levels
> - This pull request adds a "Files" section to the UI with a browseable, scoped knowledge base backed by existing storage infrastructure
> - A lightweight manifest is injected into agent heartbeat context so agents know what knowledge exists and can fetch it on demand
> - The benefit is that company knowledge becomes a first-class, visible, organized part of the product — accessible to both humans and agents with proper scoping

## What Changed

- **New `knowledge_entries` table** (migration 0055) as unified catalog linking folders, documents (reuses existing `documents` table with revision tracking), and binary files (reuses existing `assets` table and storage service)
- **10 REST API endpoints** (`/companies/:companyId/knowledge/*`) following existing route/auth patterns — list, tree, CRUD, file upload, revision history, agent visibility resolution
- **Knowledge service** with recursive CTE-based department derivation (departments = subtrees under CEO's direct reports), cascade deletion, and scope-aware visibility
- **React UI page** (`CompanyFiles.tsx`) with three-tab layout (Company / Departments / Agents), recursive folder tree, inline markdown editor with 1.5s autosave, binary file preview/download, and description fields on all create dialogs
- **Sidebar + routing**: "Files" nav item between Skills and Costs, `/files/*` route, `BOARD_ROUTE_ROOTS` registration
- **Agent integration**: lightweight manifest (titles + descriptions only, capped at 50 entries) injected into heartbeat context across all 6 adapters — agents fetch full content on demand via API
- **`renderPaperclipKnowledgePrompt`** utility in adapter-utils renders the manifest with API fetch instructions

## Verification

- Run migration 0055: `psql -d paperclip -f packages/db/src/migrations/0055_knowledge_entries.sql`
- Navigate to `/:companyPrefix/files` — verify three tabs render (Company / Departments / Agents)
- Create a folder + document under Company scope — verify persistence, edit with autosave
- Upload a binary file — verify download and preview (images render inline)
- Click sidebar items (Issues, Goals, etc.) — verify URLs resolve with correct company prefix
- Verify existing features unaffected: issue documents, skills page, org chart
- Trigger agent heartbeat — verify `paperclipKnowledgeEntries` appears in context snapshot

**Screenshots:** (UI changes are visible)

<img width="1248" height="831" alt="Screenshot 2026-04-10 at 04 56 17" src="https://github.com/user-attachments/assets/a355a6c3-05a0-447a-aca8-095540c94fb9" />
<img width="1303" height="829" alt="Screenshot 2026-04-10 at 04 55 53" src="https://github.com/user-attachments/assets/5c2b0a8b-0dba-4021-a947-c98b0af0afba" />
<img width="865" height="360" alt="Screenshot 2026-04-10 at 04 55 18" src="https://github.com/user-attachments/assets/5c1baf47-c8d8-4393-be29-bae62800c26b" />


## Risks

- **Migration**: Additive only — new table `knowledge_entries` with FK references to existing tables. No modifications to existing schemas. Rollback = drop table.
- **Heartbeat overhead**: Manifest capped at 50 entries, titles/descriptions only (no document bodies). Adds 3-4 DB queries per heartbeat. Negligible for typical company sizes.
- **Storage cleanup**: Deleting knowledge entries removes DB rows but not underlying storage blobs. Documented as TODO — needs a background reconciliation job in a follow-up.
- **`tx as unknown as Db` cast**: Used in delete cascade for recursive CTE within a transaction. Acknowledged as fragile — works because only `execute` is called. Follow-up to extract a `DbLike` interface.

## Model Used

Claude Opus 4.6 (1M context) via Claude Code CLI — with tool use, multi-agent exploration, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge