### PR TITLE
Load companion instruction files for Gemini agents

### DIFF
--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -38,6 +38,7 @@ import {
 import { firstNonEmptyLine } from "./utils.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const GEMINI_COMPANION_INSTRUCTION_FILES = ["HEARTBEAT.md", "SOUL.md", "TOOLS.md"] as const;
 
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];
@@ -76,6 +77,14 @@ function renderApiAccessNote(env: Record<string, string>): string {
     "",
     "",
   ].join("\n");
+}
+
+async function readInstructionFileIfPresent(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
 }
 
 function geminiSkillsHome(): string {
@@ -258,13 +267,33 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   let instructionsPrefix = "";
+  const loadedInstructionFiles: string[] = [];
   if (instructionsFilePath) {
     try {
       const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
-      instructionsPrefix =
+      loadedInstructionFiles.push(instructionsFilePath);
+      const sections = [
         `${instructionsContents}\n\n` +
-        `The above agent instructions were loaded from ${instructionsFilePath}. ` +
-        `Resolve any relative file references from ${instructionsDir}.\n\n`;
+          `The above agent instructions were loaded from ${instructionsFilePath}. ` +
+          `Resolve any relative file references from ${instructionsDir}.\n`,
+      ];
+
+      if (path.basename(instructionsFilePath) === "AGENTS.md") {
+        for (const relativeName of GEMINI_COMPANION_INSTRUCTION_FILES) {
+          const companionPath = path.join(path.dirname(instructionsFilePath), relativeName);
+          const companionContents = await readInstructionFileIfPresent(companionPath);
+          if (!companionContents) continue;
+          loadedInstructionFiles.push(companionPath);
+          sections.push(
+            `## Companion instructions: ${relativeName}\n\n` +
+              `${companionContents}\n\n` +
+              `The above companion instructions were loaded from ${companionPath}. ` +
+              `Resolve any relative file references from ${instructionsDir}.\n`,
+          );
+        }
+      }
+
+      instructionsPrefix = sections.join("\n\n");
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(
@@ -280,6 +309,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (instructionsPrefix.length > 0) {
       notes.push(
         `Loaded agent instructions from ${instructionsFilePath}`,
+        loadedInstructionFiles.length > 1
+          ? `Loaded companion instruction files: ${loadedInstructionFiles.slice(1).join(", ")}`
+          : "No companion instruction files were loaded.",
         `Prepended instructions + path directive to prompt (relative references from ${instructionsDir}).`,
       );
       return notes;

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -82,8 +82,16 @@ function renderApiAccessNote(env: Record<string, string>): string {
 async function readInstructionFileIfPresent(filePath: string): Promise<string | null> {
   try {
     return await fs.readFile(filePath, "utf8");
-  } catch {
-    return null;
+  } catch (err) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw err;
   }
 }
 
@@ -266,6 +274,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  const instructionsEntryFile = instructionsFilePath ? path.basename(instructionsFilePath) : "";
   let instructionsPrefix = "";
   const loadedInstructionFiles: string[] = [];
   if (instructionsFilePath) {
@@ -278,7 +287,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           `Resolve any relative file references from ${instructionsDir}.\n`,
       ];
 
-      if (path.basename(instructionsFilePath) === "AGENTS.md") {
+      if (instructionsEntryFile === "AGENTS.md") {
         for (const relativeName of GEMINI_COMPANION_INSTRUCTION_FILES) {
           const companionPath = path.join(path.dirname(instructionsFilePath), relativeName);
           const companionContents = await readInstructionFileIfPresent(companionPath);
@@ -311,7 +320,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `Loaded agent instructions from ${instructionsFilePath}`,
         loadedInstructionFiles.length > 1
           ? `Loaded companion instruction files: ${loadedInstructionFiles.slice(1).join(", ")}`
-          : "No companion instruction files were loaded.",
+          : instructionsEntryFile === "AGENTS.md"
+            ? "No companion instruction files were found."
+            : `Loaded entry instruction file ${instructionsEntryFile} without companion files.`,
         `Prepended instructions + path directive to prompt (relative references from ${instructionsDir}).`,
       );
       return notes;

--- a/server/src/__tests__/gemini-local-execute.test.ts
+++ b/server/src/__tests__/gemini-local-execute.test.ts
@@ -127,6 +127,88 @@ describe("gemini execute", () => {
     }
   });
 
+  it("loads companion agent instruction files next to AGENTS.md", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-instructions-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "gemini");
+    const capturePath = path.join(root, "capture.json");
+    const instructionsRoot = path.join(root, "instructions");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(instructionsRoot, { recursive: true });
+    await writeFakeGeminiCommand(commandPath);
+    await fs.writeFile(
+      path.join(instructionsRoot, "AGENTS.md"),
+      "# AGENTS\n\nPrimary guidance.\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(instructionsRoot, "SOUL.md"),
+      "# SOUL\n\nDeveloper voice and positioning.\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(instructionsRoot, "HEARTBEAT.md"),
+      "# HEARTBEAT\n\nHeartbeat checklist.\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(instructionsRoot, "TOOLS.md"),
+      "# TOOLS\n\nUse Composio MCP first.\n",
+      "utf8",
+    );
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      await execute({
+        runId: "run-instructions",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Gemini Coder",
+          adapterType: "gemini_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          instructionsFilePath: path.join(instructionsRoot, "AGENTS.md"),
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      const promptFlagIndex = capture.argv.indexOf("--prompt");
+      const promptArg = promptFlagIndex >= 0 ? capture.argv[promptFlagIndex + 1] : "";
+      expect(promptArg).toContain("Primary guidance.");
+      expect(promptArg).toContain("Developer voice and positioning.");
+      expect(promptArg).toContain("Heartbeat checklist.");
+      expect(promptArg).toContain("Use Composio MCP first.");
+      expect(promptArg).toContain("The above agent instructions were loaded from");
+      expect(promptArg.toLowerCase()).toContain("loaded from");
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("always passes --approval-mode yolo", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-yolo-"));
     const workspace = path.join(root, "workspace");

--- a/server/src/__tests__/gemini-local-execute.test.ts
+++ b/server/src/__tests__/gemini-local-execute.test.ts
@@ -209,6 +209,65 @@ describe("gemini execute", () => {
     }
   });
 
+  it("notes non-AGENTS instruction files without claiming companions were missing", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-instructions-note-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "gemini");
+    const instructionsRoot = path.join(root, "instructions");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(instructionsRoot, { recursive: true });
+    await writeFakeGeminiCommand(commandPath);
+    const instructionsFilePath = path.join(instructionsRoot, "SOUL.md");
+    await fs.writeFile(instructionsFilePath, "# SOUL\n\nPrimary guidance.\n", "utf8");
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      let commandNotes: string[] = [];
+      await execute({
+        runId: "run-instructions-note",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Gemini Coder",
+          adapterType: "gemini_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {},
+          instructionsFilePath,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+        onMeta: async (meta) => {
+          commandNotes = meta.commandNotes ?? [];
+        },
+      });
+
+      expect(commandNotes).toContain(`Loaded agent instructions from ${instructionsFilePath}`);
+      expect(commandNotes).toContain("Loaded entry instruction file SOUL.md without companion files.");
+      expect(commandNotes).not.toContain("No companion instruction files were loaded.");
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("always passes --approval-mode yolo", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-yolo-"));
     const workspace = path.join(root, "workspace");


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs AI agents through adapter-specific runtime paths.
> - `gemini_local` was already loading the entry instructions file, but not the companion agent docs.
> - For Eve-style bundles, the actual tool-use rule lives in `TOOLS.md`, while role and heartbeat guidance live in `SOUL.md` and `HEARTBEAT.md`.
> - That meant Gemini could receive `AGENTS.md` and still miss the Composio-first instruction.
> - This pull request makes Gemini-local stitch in the companion instruction files when the bundle entry file is `AGENTS.md`.
> - The benefit is that Gemini agents now see the full runtime instruction set and can follow connected MCP tool guidance.

## What Changed

- Gemini-local now loads `HEARTBEAT.md`, `SOUL.md`, and `TOOLS.md` alongside `AGENTS.md` when those files exist in the same bundle root.
- The runtime prompt now includes explicit companion-file path notes so relative references still resolve correctly.
- Added a regression test proving Gemini receives the companion instruction content, including the Composio-first rule from `TOOLS.md`.

## Verification

- `pnpm -C server exec vitest run src/__tests__/gemini-local-execute.test.ts`
- `pnpm -r typecheck`
- `pnpm build`

## Risks

- Low risk for bundles that do not have companion files; behavior stays the same there.
- Bundles with very large companion files will now inject more prompt text, but only for `AGENTS.md`-based bundles that already expect the companion docs.
- This is a runtime behavior change, so the main regression risk is prompt bloat or duplicated guidance if an agent deliberately encoded everything in `AGENTS.md` already.

## Model Used

GPT-5 (Codex CLI, tool-using code execution)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
