### PR TITLE
fix(hermes-local): inject authToken as PAPERCLIP_API_KEY for authenti…

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
   "packageManager": "pnpm@9.15.4",
   "pnpm": {
     "patchedDependencies": {
-      "embedded-postgres@18.1.0-beta.16": "patches/embedded-postgres@18.1.0-beta.16.patch"
+      "embedded-postgres@18.1.0-beta.16": "patches/embedded-postgres@18.1.0-beta.16.patch",
+      "hermes-paperclip-adapter@0.2.0": "patches/hermes-paperclip-adapter@0.2.0.patch"
     },
     "overrides": {
       "rollup": ">=4.59.0"

--- a/patches/hermes-paperclip-adapter@0.2.0.patch
+++ b/patches/hermes-paperclip-adapter@0.2.0.patch
@@ -1,0 +1,83 @@
+diff --git a/dist/server/execute.js b/dist/server/execute.js
+index 93cddf8243271f5fb3ab101617f9114257e41328..4b2fc790115eb7a246dae529dac65309784f0217 100644
+--- a/dist/server/execute.js
++++ b/dist/server/execute.js
+@@ -58,18 +58,18 @@ Title: {{taskTitle}}
+ 
+ 1. Work on the task using your tools
+ 2. When done, mark the issue as completed:
+-   \`curl -s -X PATCH "{{paperclipApiUrl}}/issues/{{taskId}}" -H "Content-Type: application/json" -d '{"status":"done"}'\`
++   \`curl -s -X PATCH "{{paperclipApiUrl}}/issues/{{taskId}}" {{authHeader}} -H "Content-Type: application/json" -d '{"status":"done"}'\`
+ 3. Post a completion comment on the issue summarizing what you did:
+-   \`curl -s -X POST "{{paperclipApiUrl}}/issues/{{taskId}}/comments" -H "Content-Type: application/json" -d '{"body":"DONE: <your summary here>"}'\`
++   \`curl -s -X POST "{{paperclipApiUrl}}/issues/{{taskId}}/comments" {{authHeader}} -H "Content-Type: application/json" -d '{"body":"DONE: <your summary here>"}'\`
+ 4. If this issue has a parent (check the issue body or comments for references like TRA-XX), post a brief notification on the parent issue so the parent owner knows:
+-   \`curl -s -X POST "{{paperclipApiUrl}}/issues/PARENT_ISSUE_ID/comments" -H "Content-Type: application/json" -d '{"body":"{{agentName}} completed {{taskId}}. Summary: <brief>"}'\`
++   \`curl -s -X POST "{{paperclipApiUrl}}/issues/PARENT_ISSUE_ID/comments" {{authHeader}} -H "Content-Type: application/json" -d '{"body":"{{agentName}} completed {{taskId}}. Summary: <brief>"}'\`
+ {{/taskId}}
+ 
+ {{#commentId}}
+ ## Comment on This Issue
+ 
+ Someone commented. Read it:
+-   \`curl -s "{{paperclipApiUrl}}/issues/{{taskId}}/comments/{{commentId}}" | python3 -m json.tool\`
++   \`curl -s "{{paperclipApiUrl}}/issues/{{taskId}}/comments/{{commentId}}" {{authHeader}} | python3 -m json.tool\`
+ 
+ Address the comment, POST a reply if needed, then continue working.
+ {{/commentId}}
+@@ -78,17 +78,17 @@ Address the comment, POST a reply if needed, then continue working.
+ ## Heartbeat Wake — Check for Work
+ 
+ 1. List ALL open issues assigned to you (todo, backlog, in_progress):
+-   \`curl -s "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"status\"]:>12} {i[\"priority\"]:>6} {i[\"title\"]}') for i in issues if i['status'] not in ('done','cancelled')]" \`
++   \`curl -s "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}" {{authHeader}} | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"status\"]:>12} {i[\"priority\"]:>6} {i[\"title\"]}') for i in issues if i['status'] not in ('done','cancelled')]" \`
+ 
+ 2. If issues found, pick the highest priority one that is not done/cancelled and work on it:
+-   - Read the issue details: \`curl -s "{{paperclipApiUrl}}/issues/ISSUE_ID"\`
++   - Read the issue details: \`curl -s "{{paperclipApiUrl}}/issues/ISSUE_ID" {{authHeader}}\`
+    - Do the work in the project directory: {{projectName}}
+    - When done, mark complete and post a comment (see Workflow steps 2-4 above)
+ 
+ 3. If no issues assigned to you, check for unassigned issues:
+-   \`curl -s "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"title\"]}') for i in issues if not i.get('assigneeAgentId')]" \`
++   \`curl -s "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" {{authHeader}} | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"title\"]}') for i in issues if not i.get('assigneeAgentId')]" \`
+    If you find a relevant issue, assign it to yourself:
+-   \`curl -s -X PATCH "{{paperclipApiUrl}}/issues/ISSUE_ID" -H "Content-Type: application/json" -d '{"assigneeAgentId":"{{agentId}}","status":"todo"}'\`
++   \`curl -s -X PATCH "{{paperclipApiUrl}}/issues/ISSUE_ID" {{authHeader}} -H "Content-Type: application/json" -d '{"assigneeAgentId":"{{agentId}}","status":"todo"}'\`
+ 
+ 4. If truly nothing to do, report briefly what you checked.
+ {{/noTask}}`;
+@@ -110,6 +110,12 @@ function buildPrompt(ctx, config) {
+     if (!paperclipApiUrl.endsWith("/api")) {
+         paperclipApiUrl = paperclipApiUrl.replace(/\/+$/, "") + "/api";
+     }
++    // Build auth header for curl commands — uses PAPERCLIP_API_KEY env var
++    // which is injected from ctx.authToken during execute()
++    const authToken = ctx.authToken || process.env.PAPERCLIP_API_KEY || "";
++    const authHeader = authToken
++        ? `-H "Authorization: Bearer ${authToken}"`
++        : "";
+     const vars = {
+         agentId: ctx.agent?.id || "",
+         agentName,
+@@ -123,6 +129,7 @@ function buildPrompt(ctx, config) {
+         wakeReason,
+         projectName,
+         paperclipApiUrl,
++        authHeader,
+     };
+     // Handle conditional sections: {{#key}}...{{/key}}
+     let rendered = template;
+@@ -298,6 +305,12 @@ export async function execute(ctx) {
+     const taskId = cfgString(ctx.config?.taskId);
+     if (taskId)
+         env.PAPERCLIP_TASK_ID = taskId;
++    // Inject auth token as PAPERCLIP_API_KEY so the agent can authenticate
++    // with the Paperclip API in authenticated deployment mode.
++    // Follows the same pattern as claude-local adapter.
++    if (ctx.authToken) {
++        env.PAPERCLIP_API_KEY = ctx.authToken;
++    }
+     const userEnv = config.env;
+     if (userEnv && typeof userEnv === "object") {
+         Object.assign(env, userEnv);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ patchedDependencies:
   embedded-postgres@18.1.0-beta.16:
     hash: 55uhvnotpqyiy37rn3pqpukhei
     path: patches/embedded-postgres@18.1.0-beta.16.patch
+  hermes-paperclip-adapter@0.2.0:
+    hash: y6g3tpzt6xghlwfzuy7na2d7ji
+    path: patches/hermes-paperclip-adapter@0.2.0.patch
 
 importers:
 
@@ -530,7 +533,7 @@ importers:
         version: 5.2.1
       hermes-paperclip-adapter:
         specifier: ^0.2.0
-        version: 0.2.0
+        version: 0.2.0(patch_hash=y6g3tpzt6xghlwfzuy7na2d7ji)
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0(@noble/hashes@2.0.1)
@@ -669,7 +672,7 @@ importers:
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       hermes-paperclip-adapter:
         specifier: ^0.2.0
-        version: 0.2.0
+        version: 0.2.0(patch_hash=y6g3tpzt6xghlwfzuy7na2d7ji)
       lexical:
         specifier: 0.35.0
         version: 0.35.0
@@ -10679,7 +10682,7 @@ snapshots:
 
   help-me@5.0.0: {}
 
-  hermes-paperclip-adapter@0.2.0:
+  hermes-paperclip-adapter@0.2.0(patch_hash=y6g3tpzt6xghlwfzuy7na2d7ji):
     dependencies:
       '@paperclipai/adapter-utils': 2026.325.0
       picocolors: 1.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ patchedDependencies:
   embedded-postgres@18.1.0-beta.16:
     hash: 55uhvnotpqyiy37rn3pqpukhei
     path: patches/embedded-postgres@18.1.0-beta.16.patch
-  hermes-paperclip-adapter@0.2.0:
-    hash: y6g3tpzt6xghlwfzuy7na2d7ji
-    path: patches/hermes-paperclip-adapter@0.2.0.patch
 
 importers:
 
@@ -533,7 +530,7 @@ importers:
         version: 5.2.1
       hermes-paperclip-adapter:
         specifier: ^0.2.0
-        version: 0.2.0(patch_hash=y6g3tpzt6xghlwfzuy7na2d7ji)
+        version: 0.2.0
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0(@noble/hashes@2.0.1)
@@ -672,7 +669,7 @@ importers:
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       hermes-paperclip-adapter:
         specifier: ^0.2.0
-        version: 0.2.0(patch_hash=y6g3tpzt6xghlwfzuy7na2d7ji)
+        version: 0.2.0
       lexical:
         specifier: 0.35.0
         version: 0.35.0
@@ -10682,7 +10679,7 @@ snapshots:
 
   help-me@5.0.0: {}
 
-  hermes-paperclip-adapter@0.2.0(patch_hash=y6g3tpzt6xghlwfzuy7na2d7ji):
+  hermes-paperclip-adapter@0.2.0:
     dependencies:
       '@paperclipai/adapter-utils': 2026.325.0
       picocolors: 1.1.1

--- a/server/src/__tests__/hermes-local-execute.test.ts
+++ b/server/src/__tests__/hermes-local-execute.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "hermes-paperclip-adapter/server";
+
+/**
+ * Write a fake hermes CLI that captures its environment and argv,
+ * then exits cleanly with a session_id line (quiet-mode output).
+ */
+async function writeFakeHermesCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const payload = {
+  argv: process.argv.slice(2),
+  env: {
+    PAPERCLIP_AGENT_ID: process.env.PAPERCLIP_AGENT_ID || null,
+    PAPERCLIP_COMPANY_ID: process.env.PAPERCLIP_COMPANY_ID || null,
+    PAPERCLIP_API_URL: process.env.PAPERCLIP_API_URL || null,
+    PAPERCLIP_API_KEY: process.env.PAPERCLIP_API_KEY || null,
+    PAPERCLIP_RUN_ID: process.env.PAPERCLIP_RUN_ID || null,
+  },
+};
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+
+// Hermes quiet-mode output: response text then session_id line
+console.log("I checked for work.");
+console.log("");
+console.log("session_id: test-session-001");
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+function makeContext(overrides: Record<string, unknown> = {}) {
+  const logs: Array<{ stream: string; chunk: string }> = [];
+  return {
+    ctx: {
+      runId: "run-123",
+      agent: {
+        id: "agent-aaa",
+        companyId: "company-bbb",
+        name: "TestAgent",
+        adapterType: "hermes_local",
+        adapterConfig: {
+          hermesCommand: overrides.hermesCommand ?? "hermes",
+          model: "test-model",
+          timeoutSec: 10,
+          ...(overrides.adapterConfig as Record<string, unknown> ?? {}),
+        },
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        workspaceDir: overrides.cwd ?? "/tmp",
+        ...(overrides.config as Record<string, unknown> ?? {}),
+      },
+      context: {},
+      onLog: async (stream: string, chunk: string) => {
+        logs.push({ stream, chunk });
+      },
+      authToken: overrides.authToken ?? undefined,
+    },
+    logs,
+  };
+}
+
+describe("hermes_local adapter execute", () => {
+  it("injects authToken as PAPERCLIP_API_KEY into the child process env", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "hermes-test-"));
+    const hermesPath = path.join(tmpDir, "hermes");
+    const capturePath = path.join(tmpDir, "capture.json");
+    await writeFakeHermesCommand(hermesPath);
+
+    const { ctx } = makeContext({
+      hermesCommand: hermesPath,
+      authToken: "jwt-token-for-test",
+      cwd: tmpDir,
+    });
+
+    // Set env var so the fake hermes knows where to write
+    const origCapture = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+    process.env.PAPERCLIP_TEST_CAPTURE_PATH = capturePath;
+
+    try {
+      const result = await execute(ctx as any);
+      expect(result.exitCode).toBe(0);
+
+      const captured = JSON.parse(await fs.readFile(capturePath, "utf8"));
+
+      // Core assertion: PAPERCLIP_API_KEY must be the JWT auth token
+      expect(captured.env.PAPERCLIP_API_KEY).toBe("jwt-token-for-test");
+
+      // Other env vars should also be set
+      expect(captured.env.PAPERCLIP_AGENT_ID).toBe("agent-aaa");
+      expect(captured.env.PAPERCLIP_COMPANY_ID).toBe("company-bbb");
+      expect(captured.env.PAPERCLIP_RUN_ID).toBe("run-123");
+    } finally {
+      if (origCapture !== undefined) {
+        process.env.PAPERCLIP_TEST_CAPTURE_PATH = origCapture;
+      } else {
+        delete process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+      }
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not set PAPERCLIP_API_KEY when authToken is not provided", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "hermes-test-"));
+    const hermesPath = path.join(tmpDir, "hermes");
+    const capturePath = path.join(tmpDir, "capture.json");
+    await writeFakeHermesCommand(hermesPath);
+
+    const { ctx } = makeContext({
+      hermesCommand: hermesPath,
+      // No authToken
+      cwd: tmpDir,
+    });
+
+    const origCapture = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+    process.env.PAPERCLIP_TEST_CAPTURE_PATH = capturePath;
+
+    try {
+      const result = await execute(ctx as any);
+      expect(result.exitCode).toBe(0);
+
+      const captured = JSON.parse(await fs.readFile(capturePath, "utf8"));
+
+      // PAPERCLIP_API_KEY should not be set (or null)
+      expect(captured.env.PAPERCLIP_API_KEY).toBeNull();
+    } finally {
+      if (origCapture !== undefined) {
+        process.env.PAPERCLIP_TEST_CAPTURE_PATH = origCapture;
+      } else {
+        delete process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+      }
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("includes auth header in the prompt when authToken is provided", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "hermes-test-"));
+    const hermesPath = path.join(tmpDir, "hermes");
+    const capturePath = path.join(tmpDir, "capture.json");
+
+    // Modified fake that captures the -q prompt argument
+    const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const qIndex = process.argv.indexOf("-q");
+const prompt = qIndex >= 0 ? process.argv[qIndex + 1] : null;
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify({ prompt }), "utf8");
+}
+console.log("Done.");
+console.log("");
+console.log("session_id: test-session-002");
+`;
+    await fs.writeFile(hermesPath, script, "utf8");
+    await fs.chmod(hermesPath, 0o755);
+
+    const { ctx } = makeContext({
+      hermesCommand: hermesPath,
+      authToken: "my-jwt-token",
+      cwd: tmpDir,
+    });
+
+    const origCapture = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+    process.env.PAPERCLIP_TEST_CAPTURE_PATH = capturePath;
+
+    try {
+      const result = await execute(ctx as any);
+      expect(result.exitCode).toBe(0);
+
+      const captured = JSON.parse(await fs.readFile(capturePath, "utf8"));
+
+      // The prompt should contain the Authorization header in curl commands
+      expect(captured.prompt).toContain('-H "Authorization: Bearer my-jwt-token"');
+      // Auth headers should appear in the heartbeat curl commands
+      expect(captured.prompt).toContain('curl -s "http://127.0.0.1:3100/api/companies/company-bbb/issues?assigneeAgentId=agent-aaa" -H "Authorization: Bearer my-jwt-token"');
+    } finally {
+      if (origCapture !== undefined) {
+        process.env.PAPERCLIP_TEST_CAPTURE_PATH = origCapture;
+      } else {
+        delete process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+      }
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
The hermes-paperclip-adapter's execute() function ignored ctx.authToken, leaving Hermes agents unable to authenticate with the Paperclip API when running in authenticated deployment mode. The heartbeat service creates a JWT via createLocalAgentJwt() and passes it as ctx.authToken, but the hermes adapter never injected it into the child process environment or the prompt template's curl commands.

This patch (applied via pnpm patchedDependencies):
- Injects ctx.authToken as PAPERCLIP_API_KEY env var (matching claude-local pattern)
- Adds {{authHeader}} template variable with Bearer token to all curl commands
- Adds authHeader to the prompt template vars so it resolves in rendered prompts

Without this fix, all Hermes agents on authenticated Paperclip instances get {"error":"Unauthorized"} on every API call and cannot check for or work on issues.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
