### PR TITLE
fix: allow agent JWTs to access plugin tool endpoints

### DIFF
--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -7,6 +7,12 @@ export function assertBoard(req: Request) {
   }
 }
 
+export function assertBoardOrAgent(req: Request) {
+  if (req.actor.type !== "board" && req.actor.type !== "agent") {
+    throw forbidden("Board or agent access required");
+  }
+}
+
 export function assertInstanceAdmin(req: Request) {
   assertBoard(req);
   if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) {

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -11,7 +11,8 @@
  * - Retrieving UI slot contributions for frontend rendering
  * - Discovering and executing plugin-contributed agent tools
  *
- * All routes require board-level authentication (assertBoard middleware).
+ * Most routes require board-level authentication (assertBoard middleware).
+ * Plugin tool discovery and execution routes allow both board and agent access.
  *
  * @module server/routes/plugins
  * @see doc/plugins/PLUGIN_SPEC.md for the full plugin specification
@@ -47,7 +48,7 @@ import type { PluginStreamBus } from "../services/plugin-stream-bus.js";
 import type { PluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
 import type { ToolRunContext } from "@paperclipai/plugin-sdk";
 import { JsonRpcCallError, PLUGIN_RPC_ERROR_CODES } from "@paperclipai/plugin-sdk";
-import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assertBoard, assertBoardOrAgent, assertCompanyAccess, getActorInfo } from "./authz.js";
 import { validateInstanceConfig } from "../services/plugin-config-validator.js";
 
 /** UI slot declaration extracted from plugin manifest */
@@ -483,7 +484,7 @@ export function pluginRoutes(
    * Errors: 501 if tool dispatcher is not configured
    */
   router.get("/plugins/tools", async (req, res) => {
-    assertBoard(req);
+    assertBoardOrAgent(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
@@ -517,7 +518,7 @@ export function pluginRoutes(
    * - 502 if the plugin worker is unavailable or the RPC call fails
    */
   router.post("/plugins/tools/execute", async (req, res) => {
-    assertBoard(req);
+    assertBoardOrAgent(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });


### PR DESCRIPTION
Fixes #3271

## Summary

- Adds `assertBoardOrAgent()` helper to `authz.ts` that accepts both board users and agent JWTs
- Uses it on `GET /plugins/tools` and `POST /plugins/tools/execute` so agents can discover and call plugin-contributed tools
- All other plugin management routes remain board-only
- Agent company scoping is unchanged — `assertCompanyAccess` still enforces agent-to-company boundaries on execute

## Test plan

- [ ] Agent JWT can call `GET /api/plugins/tools` and receive tool list
- [ ] Agent JWT can call `POST /api/plugins/tools/execute` with valid runContext
- [ ] Agent JWT is still rejected on other plugin routes (install, enable, disable, etc.)
- [ ] Board token continues to work on all plugin routes
- [ ] Agent from company A cannot execute tools with company B's companyId in runContext

🤖 Generated with [Claude Code](https://claude.com/claude-code)