### PR TITLE
fix: make projectId optional in plugin tool execute runContext

### DIFF
--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -543,9 +543,9 @@ export function pluginRoutes(
       return;
     }
 
-    if (!runContext.agentId || !runContext.runId || !runContext.companyId || !runContext.projectId) {
+    if (!runContext.agentId || !runContext.runId || !runContext.companyId) {
       res.status(400).json({
-        error: '"runContext" must include agentId, runId, companyId, and projectId',
+        error: '"runContext" must include agentId, runId, and companyId',
       });
       return;
     }


### PR DESCRIPTION
Fixes #3273

## Summary

- Removes `projectId` from required fields in `POST /plugins/tools/execute` runContext validation
- `agentId`, `runId`, and `companyId` remain required
- `projectId` is still accepted and passed through when present

## Test plan

- [ ] Agent can execute plugin tools with `projectId: null` in runContext
- [ ] Agent can execute plugin tools with a valid `projectId` in runContext
- [ ] Request without `agentId`, `runId`, or `companyId` still returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)