### PR TITLE
feat(plugins): add aws-file-store plugin with MinIO compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
 COPY packages/plugins/sdk/package.json packages/plugins/sdk/
+COPY packages/plugins/aws-file-store/package.json packages/plugins/aws-file-store/
 COPY patches/ patches/
 
 RUN pnpm install --frozen-lockfile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,6 +15,43 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
 
+  # MinIO is an S3-compatible object store. It backs the `aws-file-store`
+  # reference plugin (packages/plugins/examples/aws-file-store) so the shared
+  # corporate knowledge base works out of the box in dev environments.
+  minio:
+    image: minio/minio:RELEASE.2025-04-08T15-41-24Z
+    command: server /data --console-address ":9001"
+    restart: unless-stopped
+    ports:
+      - "${MINIO_API_PORT:-9000}:9000"
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+    environment:
+      MINIO_ROOT_USER: "${MINIO_ROOT_USER:-paperclip}"
+      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set}"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # One-shot init container that ensures the shared bucket exists.
+  minio-init:
+    image: minio/mc:latest
+    environment:
+      MINIO_ROOT_USER: "${MINIO_ROOT_USER:-paperclip}"
+      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set}"
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 $${MINIO_ROOT_USER:-paperclip} $${MINIO_ROOT_PASSWORD} &&
+      mc mb --ignore-existing local/${FILE_STORE_BUCKET:-paperclip} &&
+      echo 'Bucket ${FILE_STORE_BUCKET:-paperclip} created successfully'
+      "
+
   server:
     build:
       context: ..
@@ -29,12 +66,25 @@ services:
       PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
       PAPERCLIP_PUBLIC_URL: "${PAPERCLIP_PUBLIC_URL:-http://localhost:3100}"
       BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
+      # MinIO / S3-compatible file store credentials consumed by the
+      # aws-file-store plugin (and any other code that talks to the bucket).
+      AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL:-http://minio:9000}"
+      AWS_ACCESS_KEY_ID: "${MINIO_ROOT_USER:-paperclip}"
+      AWS_SECRET_ACCESS_KEY: "${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set}"
+      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION:-us-east-1}"
+      FILE_STORE_BUCKET: "${FILE_STORE_BUCKET:-paperclip}"
+      FILE_STORE_PREFIX: "${FILE_STORE_PREFIX:-file-store}"
     volumes:
       - paperclip-data:/paperclip
     depends_on:
       db:
         condition: service_healthy
+      minio:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
 
 volumes:
   pgdata:
   paperclip-data:
+  minio-data:

--- a/packages/plugins/aws-file-store/README.md
+++ b/packages/plugins/aws-file-store/README.md
@@ -1,0 +1,119 @@
+# @paperclipai/plugin-aws-file-store
+
+S3-backed shared file store for Paperclip agents and users.
+
+This plugin gives every organization a hierarchical knowledge base that lives
+in an S3 bucket. It works against AWS S3, MinIO, or any S3-compatible backend
+through the official `@aws-sdk/client-s3` client. Agents and humans share the
+same view of the bucket, so anything one party writes is immediately available
+to the other.
+
+> Inspired by [paperclipai/paperclip#3230](https://github.com/paperclipai/paperclip/pull/3230),
+> which proposed the same capability as a shell-based skill. This plugin
+> packages the same idea as a first-class Paperclip plugin so the host owns
+> capability scoping, configuration, lifecycle, and metrics instead of relying
+> on agents to chain raw `aws` CLI commands.
+
+## Layout
+
+Every organization gets two top-level directories under the configured prefix:
+
+```
+<bucket>/<prefix>/
+├── knowledge-base/        # curated documents agents use for their work
+│   ├── originals/         # native files (PDF, DOCX, images, etc.)
+│   └── markdown/          # markdown-converted versions
+└── income/                # incoming files that still need triage
+```
+
+The recommended workflow:
+
+1. New material lands in `income/`.
+2. An agent reads it, converts it to markdown, files it under
+   `knowledge-base/markdown/<topic>/`, and removes the original from `income/`.
+3. Agents prefer reading from `knowledge-base/markdown/` because the content is
+   already plain text and cheap to feed into a model.
+
+The plugin keeps a small JSON file index in plugin state that records each
+file's tags, description, author, and timestamps. Search queries hit this
+index instead of scanning the bucket, so they stay fast even with thousands of
+files.
+
+## Tools the plugin contributes
+
+| Tool | Purpose |
+|---|---|
+| `fs-write` | Write a file (text or base64) at a path, with optional tags and description. |
+| `fs-read` | Read a file. Text files come back as UTF-8; binaries come back as base64. |
+| `fs-list` | List a directory's immediate children, or recursively when asked. |
+| `fs-tree` | Render a visual tree of a subtree, capped by a configurable max depth. |
+| `fs-mkdir` | Create a directory (and any missing parents). |
+| `fs-move` | Move or rename a file or directory and update the file index in lockstep. |
+| `fs-remove` | Remove a file, or a directory with `recursive: true`. |
+| `fs-stat` | Return size, type, timestamps, tags, and description for a path. |
+| `fs-search` | Search files by name pattern, tags, free-text query, or path subtree. |
+
+All tools are scoped through the standard plugin context, so audit logging,
+metrics, and capability checks happen on the host side.
+
+## Configuration
+
+Configured per plugin instance via `instanceConfigSchema`:
+
+| Field | Default | Notes |
+|---|---|---|
+| `s3Bucket` | `paperclip` | Required. S3 bucket name. |
+| `s3Region` | `us-east-1` | AWS region (or any region the backend accepts). |
+| `s3Endpoint` | `http://localhost:9000` | Override for MinIO / S3-compatible backends. Leave empty for AWS S3. |
+| `s3Prefix` | `file-store` | Key prefix in the bucket — lets you share a bucket with other services. |
+| `s3ForcePathStyle` | `true` | Required for MinIO. Set to `false` for AWS S3 virtual-hosted style. |
+| `s3AccessKeyId` | _empty_ | Falls back to the AWS default credential chain when empty. |
+| `s3SecretAccessKey` | _empty_ | Falls back to the AWS default credential chain when empty. |
+| `maxFileSizeMb` | `50` | Files larger than this are rejected on write. |
+| `maxTreeDepth` | `10` | Max depth the `fs-tree` tool will descend by default. |
+
+## Running locally with MinIO
+
+The repository's `docker/docker-compose.yml` ships a `minio` service plus a
+one-shot `minio-init` container that creates the bucket. With it, the plugin
+works out of the box:
+
+```bash
+export MINIO_ROOT_PASSWORD=devsecret  # required by docker-compose.yml
+export BETTER_AUTH_SECRET=devsecret
+docker compose -f docker/docker-compose.yml up
+```
+
+The `server` service receives the matching `AWS_*` and `FILE_STORE_*` env vars,
+so when you create an instance of this plugin from the marketplace, the
+defaults above will Just Work.
+
+The MinIO console is on `http://localhost:9001` (default credentials
+`paperclip` / `$MINIO_ROOT_PASSWORD`).
+
+## Tests
+
+```bash
+pnpm --filter @paperclipai/plugin-aws-file-store test
+```
+
+The test suite uses a mocked `@aws-sdk/client-s3`, so it does not require a
+running MinIO container or any network access. It covers:
+
+- Key prefixing and leading-slash normalization
+- Path traversal protection
+- `HeadObject` / `ListObjectsV2` fallback in `stat()` to detect directories
+- `listDir` filtering of nested entries
+- `listRecursive` pagination across `ContinuationToken`
+- `move` (copy + delete pair) and the safety check `remove` performs against
+  non-empty directories
+- The `healthy()` probe used by the plugin's health diagnostics
+
+## Building
+
+```bash
+pnpm --filter @paperclipai/plugin-aws-file-store build
+```
+
+The build outputs `dist/manifest.js` and `dist/worker.js`, which the Paperclip
+plugin loader picks up via the `paperclipPlugin` field in `package.json`.

--- a/packages/plugins/aws-file-store/package.json
+++ b/packages/plugins/aws-file-store/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@paperclipai/plugin-aws-file-store",
+  "version": "0.1.0",
+  "description": "S3-backed shared file store for Paperclip agents (AWS S3, MinIO, or any S3-compatible backend)",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js"
+  },
+  "scripts": {
+    "prebuild": "node ../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.888.0",
+    "@paperclipai/plugin-sdk": "workspace:*",
+    "@paperclipai/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/packages/plugins/aws-file-store/src/constants.ts
+++ b/packages/plugins/aws-file-store/src/constants.ts
@@ -1,0 +1,38 @@
+export const PLUGIN_ID = "paperclip-aws-file-store";
+export const PLUGIN_VERSION = "0.1.0";
+
+export const TOOL_NAMES = {
+  writeFile: "fs-write",
+  readFile: "fs-read",
+  listDir: "fs-list",
+  treeDir: "fs-tree",
+  mkdir: "fs-mkdir",
+  move: "fs-move",
+  remove: "fs-remove",
+  stat: "fs-stat",
+  search: "fs-search",
+} as const;
+
+export const STATE_KEYS = {
+  fileIndex: "file-index",
+} as const;
+
+export const DEFAULT_CONFIG = {
+  s3Bucket: "paperclip",
+  s3Region: "us-east-1",
+  s3Endpoint: "http://localhost:9000",
+  s3Prefix: "file-store",
+  s3ForcePathStyle: true,
+  maxFileSizeMb: 50,
+  maxTreeDepth: 10,
+} as const;
+
+/**
+ * Standard directory structure created per organization.
+ * - knowledge-base: curated documents agents use for work (originals + markdown versions)
+ * - income: incoming files agents triage, convert to markdown, and move into knowledge-base
+ */
+export const ORG_DIRS = {
+  knowledgeBase: "knowledge-base",
+  income: "income",
+} as const;

--- a/packages/plugins/aws-file-store/src/index.ts
+++ b/packages/plugins/aws-file-store/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/aws-file-store/src/manifest.ts
+++ b/packages/plugins/aws-file-store/src/manifest.ts
@@ -1,0 +1,302 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import { DEFAULT_CONFIG, PLUGIN_ID, PLUGIN_VERSION, TOOL_NAMES } from "./constants.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "AWS File Store",
+  description:
+    "S3-backed hierarchical file storage for agents and users, powered by the AWS SDK. " +
+    "Each organization gets two root directories: knowledge-base (curated docs agents use) " +
+    "and income (incoming files to triage and convert). " +
+    "Supports AWS S3, MinIO, and any S3-compatible backend.",
+  author: "Paperclip",
+  categories: ["automation", "connector"],
+  capabilities: [
+    "companies.read",
+    "projects.read",
+    "issues.read",
+    "agents.read",
+    "activity.log.write",
+    "metrics.write",
+    "plugin.state.read",
+    "plugin.state.write",
+    "events.emit",
+    "agent.tools.register",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      s3Bucket: {
+        type: "string",
+        title: "S3 Bucket",
+        description: "S3 bucket name.",
+        default: DEFAULT_CONFIG.s3Bucket,
+      },
+      s3Region: {
+        type: "string",
+        title: "S3 Region",
+        description: "AWS region or MinIO region.",
+        default: DEFAULT_CONFIG.s3Region,
+      },
+      s3Endpoint: {
+        type: "string",
+        title: "S3 Endpoint URL",
+        description:
+          "Custom endpoint for S3-compatible services (e.g. http://localhost:9000 for MinIO). " +
+          "Leave empty for AWS S3.",
+        default: DEFAULT_CONFIG.s3Endpoint,
+      },
+      s3Prefix: {
+        type: "string",
+        title: "S3 Key Prefix",
+        description:
+          "Prefix for all object keys in the bucket (e.g. 'file-store'). " +
+          "Allows sharing a bucket with other services.",
+        default: DEFAULT_CONFIG.s3Prefix,
+      },
+      s3ForcePathStyle: {
+        type: "boolean",
+        title: "S3 Force Path Style",
+        description:
+          "Use path-style URLs (required for MinIO). Set to false for AWS S3 virtual-hosted style.",
+        default: DEFAULT_CONFIG.s3ForcePathStyle,
+      },
+      s3AccessKeyId: {
+        type: "string",
+        title: "S3 Access Key ID",
+        description:
+          "Access key for S3/MinIO. If empty, uses AWS default credential chain " +
+          "(AWS_ACCESS_KEY_ID env var, IAM role, etc.).",
+      },
+      s3SecretAccessKey: {
+        type: "string",
+        title: "S3 Secret Access Key",
+        description:
+          "Secret key for S3/MinIO. If empty, uses AWS default credential chain.",
+      },
+      maxFileSizeMb: {
+        type: "number",
+        title: "Max File Size (MB)",
+        description: "Maximum allowed file size in megabytes.",
+        default: DEFAULT_CONFIG.maxFileSizeMb,
+      },
+      maxTreeDepth: {
+        type: "number",
+        title: "Max Tree Depth",
+        description: "Maximum directory depth shown by the fs-tree tool.",
+        default: DEFAULT_CONFIG.maxTreeDepth,
+      },
+    },
+  },
+  tools: [
+    {
+      name: TOOL_NAMES.writeFile,
+      displayName: "Write File to Shared Store",
+      description:
+        "Writes content to a file in the shared S3 store. " +
+        "Creates parent directories automatically. " +
+        "Paths are scoped to the organization: '<org>/knowledge-base/...' or '<org>/income/...'. " +
+        "Supports text content and base64-encoded binary.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description:
+              "Destination path within the store (e.g. 'acme/knowledge-base/specs/auth.md'). " +
+              "Forward slashes only. Parent directories are created automatically.",
+          },
+          content: {
+            type: "string",
+            description: "File content. Plain text for text files, base64 for binary.",
+          },
+          encoding: {
+            type: "string",
+            enum: ["utf-8", "base64"],
+            description: "Content encoding. Defaults to 'utf-8'.",
+          },
+          tags: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Optional tags for categorization (e.g. ['report', 'q1-2026', 'finance']).",
+          },
+          description: {
+            type: "string",
+            description: "Optional human-readable description of the file.",
+          },
+          overwrite: {
+            type: "boolean",
+            description: "If false, fails when file already exists. Defaults to true.",
+          },
+        },
+        required: ["path", "content"],
+      },
+    },
+    {
+      name: TOOL_NAMES.readFile,
+      displayName: "Read File from Shared Store",
+      description:
+        "Reads a file from the shared store. Returns text content for text files " +
+        "or base64 for binary files.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Path to the file within the store.",
+          },
+        },
+        required: ["path"],
+      },
+    },
+    {
+      name: TOOL_NAMES.listDir,
+      displayName: "List Directory Contents",
+      description:
+        "Lists files and subdirectories at a given path in the shared store. " +
+        "Returns names, types, sizes, and metadata.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Directory path within the store. Use '/' or '' for root.",
+          },
+          recursive: {
+            type: "boolean",
+            description: "If true, lists all descendants recursively. Defaults to false.",
+          },
+        },
+        required: ["path"],
+      },
+    },
+    {
+      name: TOOL_NAMES.treeDir,
+      displayName: "Show Directory Tree",
+      description:
+        "Displays a visual tree of the shared store hierarchy. " +
+        "Useful for understanding the current folder structure.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Root path for the tree. Use '/' or '' for the entire store.",
+          },
+          maxDepth: {
+            type: "number",
+            description: "Maximum depth to display. Defaults to config value.",
+          },
+        },
+      },
+    },
+    {
+      name: TOOL_NAMES.mkdir,
+      displayName: "Create Directory",
+      description:
+        "Creates a directory (and any missing parents) in the shared store. " +
+        "Use to pre-create folder structures.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Directory path to create (e.g. 'acme/knowledge-base/specs').",
+          },
+        },
+        required: ["path"],
+      },
+    },
+    {
+      name: TOOL_NAMES.move,
+      displayName: "Move / Rename File or Directory",
+      description: "Moves or renames a file or directory within the shared store.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          from: {
+            type: "string",
+            description: "Current path of the file or directory.",
+          },
+          to: {
+            type: "string",
+            description: "New path for the file or directory.",
+          },
+        },
+        required: ["from", "to"],
+      },
+    },
+    {
+      name: TOOL_NAMES.remove,
+      displayName: "Remove File or Directory",
+      description:
+        "Removes a file or empty directory from the shared store. " +
+        "Use 'recursive: true' to remove non-empty directories.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Path to remove.",
+          },
+          recursive: {
+            type: "boolean",
+            description: "If true, removes directories with contents. Defaults to false.",
+          },
+        },
+        required: ["path"],
+      },
+    },
+    {
+      name: TOOL_NAMES.stat,
+      displayName: "Get File / Directory Info",
+      description:
+        "Returns metadata about a file or directory: size, type, timestamps, tags, description.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Path to inspect.",
+          },
+        },
+        required: ["path"],
+      },
+    },
+    {
+      name: TOOL_NAMES.search,
+      displayName: "Search Files in Store",
+      description: "Searches for files by name pattern, tags, or content substring.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Search query — matched against file names and descriptions.",
+          },
+          tags: {
+            type: "array",
+            items: { type: "string" },
+            description: "Filter by tags (files must have ALL specified tags).",
+          },
+          path: {
+            type: "string",
+            description: "Limit search to this directory subtree.",
+          },
+          namePattern: {
+            type: "string",
+            description: "Glob pattern for file names (e.g. '*.md', 'report-*').",
+          },
+        },
+      },
+    },
+  ],
+};
+
+export default manifest;

--- a/packages/plugins/aws-file-store/src/storage-backend.test.ts
+++ b/packages/plugins/aws-file-store/src/storage-backend.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for the aws-file-store plugin's S3 storage backend.
+ *
+ * The S3 client is mocked, so no real network or MinIO container is needed.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMock = vi.fn();
+
+vi.mock("@aws-sdk/client-s3", () => {
+  class FakeS3Client {
+    public readonly config: unknown;
+    constructor(config: unknown) {
+      this.config = config;
+    }
+    send(command: unknown): Promise<unknown> {
+      return sendMock(command);
+    }
+  }
+
+  // Each command class records its constructor input on the instance so the
+  // test can assert what was sent without depending on AWS SDK internals.
+  function makeCommand(name: string) {
+    return class {
+      static commandName = name;
+      public readonly input: unknown;
+      constructor(input: unknown) {
+        this.input = input;
+      }
+    };
+  }
+
+  return {
+    S3Client: FakeS3Client,
+    PutObjectCommand: makeCommand("PutObjectCommand"),
+    GetObjectCommand: makeCommand("GetObjectCommand"),
+    DeleteObjectCommand: makeCommand("DeleteObjectCommand"),
+    ListObjectsV2Command: makeCommand("ListObjectsV2Command"),
+    CopyObjectCommand: makeCommand("CopyObjectCommand"),
+    HeadObjectCommand: makeCommand("HeadObjectCommand"),
+  };
+});
+
+// Import after the mock is registered.
+import { S3StorageBackend, type S3BackendConfig } from "./storage-backend.js";
+
+type CommandLike = {
+  constructor: { commandName?: string };
+  input: Record<string, unknown>;
+};
+
+function lastCommand(): CommandLike {
+  const calls = sendMock.mock.calls;
+  if (calls.length === 0) throw new Error("expected at least one S3 command");
+  return calls[calls.length - 1]?.[0] as CommandLike;
+}
+
+function commandsByName(name: string): CommandLike[] {
+  return sendMock.mock.calls
+    .map((call) => call[0] as CommandLike)
+    .filter((cmd) => cmd?.constructor?.commandName === name);
+}
+
+const baseConfig: S3BackendConfig = {
+  bucket: "test-bucket",
+  region: "us-east-1",
+  prefix: "file-store",
+};
+
+beforeEach(() => {
+  sendMock.mockReset();
+});
+
+describe("S3StorageBackend key handling", () => {
+  it("prefixes keys with the configured prefix", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    sendMock.mockResolvedValueOnce({});
+
+    await backend.writeFile("knowledge-base/notes/intro.md", Buffer.from("hi"));
+
+    const cmd = lastCommand();
+    expect(cmd.constructor.commandName).toBe("PutObjectCommand");
+    expect(cmd.input).toMatchObject({
+      Bucket: "test-bucket",
+      Key: "file-store/knowledge-base/notes/intro.md",
+    });
+    expect(cmd.input.Body).toBeInstanceOf(Buffer);
+  });
+
+  it("normalizes leading slashes in input paths", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    sendMock.mockResolvedValueOnce({});
+
+    await backend.writeFile("/knowledge-base/foo.txt", Buffer.from("x"));
+
+    expect(lastCommand().input).toMatchObject({
+      Key: "file-store/knowledge-base/foo.txt",
+    });
+  });
+
+  it("rejects path traversal", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+
+    await expect(
+      backend.writeFile("knowledge-base/../../etc/passwd", Buffer.from("nope")),
+    ).rejects.toThrow(/path traversal/i);
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("supports an empty prefix", async () => {
+    const backend = new S3StorageBackend({ ...baseConfig, prefix: "" });
+    sendMock.mockResolvedValueOnce({});
+
+    await backend.writeFile("acme/income/file.bin", Buffer.from("y"));
+
+    expect(lastCommand().input).toMatchObject({
+      Key: "acme/income/file.bin",
+    });
+  });
+});
+
+describe("S3StorageBackend.exists / stat", () => {
+  it("returns true when HeadObject succeeds", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    sendMock.mockResolvedValueOnce({ ContentLength: 12 });
+
+    expect(await backend.exists("knowledge-base/x.md")).toBe(true);
+    expect(lastCommand().constructor.commandName).toBe("HeadObjectCommand");
+  });
+
+  it("returns false when HeadObject throws", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    sendMock.mockRejectedValueOnce(new Error("404"));
+
+    expect(await backend.exists("missing.md")).toBe(false);
+  });
+
+  it("treats a path with descendants as a directory in stat()", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    // First call: HeadObject for the file — fails (it's a dir).
+    sendMock.mockRejectedValueOnce(new Error("not a file"));
+    // Second call: ListObjectsV2 — finds children.
+    sendMock.mockResolvedValueOnce({
+      Contents: [{ Key: "file-store/dir/child.md", Size: 3 }],
+      CommonPrefixes: [],
+    });
+
+    const result = await backend.stat("dir");
+    expect(result).not.toBeNull();
+    expect(result?.isDir).toBe(true);
+    expect(result?.size).toBe(0);
+  });
+
+  it("returns null when stat() finds neither object nor descendants", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    sendMock.mockRejectedValueOnce(new Error("nope"));
+    sendMock.mockResolvedValueOnce({ Contents: [], CommonPrefixes: [] });
+
+    expect(await backend.stat("missing")).toBeNull();
+  });
+});
+
+describe("S3StorageBackend.listDir", () => {
+  it("returns subdirectories from CommonPrefixes and files from Contents", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    sendMock.mockResolvedValueOnce({
+      CommonPrefixes: [
+        { Prefix: "file-store/knowledge-base/originals/" },
+        { Prefix: "file-store/knowledge-base/markdown/" },
+      ],
+      Contents: [
+        { Key: "file-store/knowledge-base/README.md", Size: 42 },
+      ],
+    });
+
+    const entries = await backend.listDir("knowledge-base");
+
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        { name: "originals", isDir: true, size: 0 },
+        { name: "markdown", isDir: true, size: 0 },
+        { name: "README.md", isDir: false, size: 42 },
+      ]),
+    );
+  });
+
+  it("filters out nested files that should belong to a subdirectory", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    sendMock.mockResolvedValueOnce({
+      CommonPrefixes: [],
+      Contents: [
+        // Should be ignored at this level — belongs to a deeper dir.
+        { Key: "file-store/knowledge-base/sub/deep.md", Size: 1 },
+        { Key: "file-store/knowledge-base/top.md", Size: 5 },
+      ],
+    });
+
+    const entries = await backend.listDir("knowledge-base");
+
+    expect(entries).toEqual([{ name: "top.md", isDir: false, size: 5 }]);
+  });
+});
+
+describe("S3StorageBackend.listRecursive", () => {
+  it("paginates ListObjectsV2 calls until IsTruncated is false", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    sendMock
+      .mockResolvedValueOnce({
+        Contents: [{ Key: "file-store/dir/a.md" }],
+        IsTruncated: true,
+        NextContinuationToken: "token-1",
+      })
+      .mockResolvedValueOnce({
+        Contents: [{ Key: "file-store/dir/sub/b.md" }],
+        IsTruncated: false,
+      });
+
+    const result = await backend.listRecursive("dir");
+
+    expect(result).toEqual([
+      { relative: "a.md", isDir: false },
+      { relative: "sub/b.md", isDir: false },
+    ]);
+    expect(commandsByName("ListObjectsV2Command")).toHaveLength(2);
+  });
+});
+
+describe("S3StorageBackend.move", () => {
+  it("copies and deletes for a single file", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    // stat() — HeadObject succeeds (it's a file)
+    sendMock.mockResolvedValueOnce({ ContentLength: 7, LastModified: new Date() });
+    // CopyObject
+    sendMock.mockResolvedValueOnce({});
+    // DeleteObject
+    sendMock.mockResolvedValueOnce({});
+
+    await backend.move("a.md", "b.md");
+
+    const copies = commandsByName("CopyObjectCommand");
+    const deletes = commandsByName("DeleteObjectCommand");
+    expect(copies).toHaveLength(1);
+    expect(deletes).toHaveLength(1);
+    expect(copies[0]?.input).toMatchObject({
+      Bucket: "test-bucket",
+      CopySource: "test-bucket/file-store/a.md",
+      Key: "file-store/b.md",
+    });
+    expect(deletes[0]?.input).toMatchObject({ Key: "file-store/a.md" });
+  });
+});
+
+describe("S3StorageBackend.remove", () => {
+  it("refuses to recursively delete a non-empty directory without recursive flag", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    // stat() — HeadObject fails, then List shows children → it's a dir
+    sendMock.mockRejectedValueOnce(new Error("not a file"));
+    sendMock.mockResolvedValueOnce({
+      Contents: [{ Key: "file-store/dir/child.md", Size: 1 }],
+      CommonPrefixes: [],
+    });
+    // listDir() inside the non-recursive branch
+    sendMock.mockResolvedValueOnce({
+      CommonPrefixes: [],
+      Contents: [{ Key: "file-store/dir/child.md", Size: 1 }],
+    });
+
+    await expect(backend.remove("dir", false)).rejects.toThrow(/not empty/i);
+    // The DeleteObject command must NOT have been issued.
+    expect(commandsByName("DeleteObjectCommand")).toHaveLength(0);
+  });
+
+  it("deletes a single file without listing", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    // stat() — HeadObject succeeds
+    sendMock.mockResolvedValueOnce({ ContentLength: 3, LastModified: new Date() });
+    // DeleteObject
+    sendMock.mockResolvedValueOnce({});
+
+    await backend.remove("file.md", false);
+
+    const deletes = commandsByName("DeleteObjectCommand");
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0]?.input).toMatchObject({ Key: "file-store/file.md" });
+  });
+});
+
+describe("S3StorageBackend.healthy", () => {
+  it("returns true when ListObjectsV2 succeeds", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    sendMock.mockResolvedValueOnce({ Contents: [] });
+
+    expect(await backend.healthy()).toBe(true);
+  });
+
+  it("returns false when ListObjectsV2 throws", async () => {
+    const backend = new S3StorageBackend(baseConfig);
+    sendMock.mockRejectedValueOnce(new Error("network down"));
+
+    expect(await backend.healthy()).toBe(false);
+  });
+});

--- a/packages/plugins/aws-file-store/src/storage-backend.ts
+++ b/packages/plugins/aws-file-store/src/storage-backend.ts
@@ -1,0 +1,308 @@
+/**
+ * S3/MinIO storage backend for the file-store plugin.
+ * Local filesystem is NOT supported — all storage goes through S3-compatible APIs.
+ */
+
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+  ListObjectsV2Command,
+  CopyObjectCommand,
+  HeadObjectCommand,
+  type S3ClientConfig,
+} from "@aws-sdk/client-s3";
+
+// ---------------------------------------------------------------------------
+// Common types
+// ---------------------------------------------------------------------------
+
+export interface FileEntry {
+  name: string;
+  isDir: boolean;
+  size: number;
+}
+
+export interface StorageBackend {
+  writeFile(filePath: string, content: Buffer): Promise<void>;
+  readFile(filePath: string): Promise<Buffer>;
+  exists(filePath: string): Promise<boolean>;
+  stat(filePath: string): Promise<{ size: number; isDir: boolean; mtime: Date } | null>;
+  listDir(dirPath: string): Promise<FileEntry[]>;
+  listRecursive(dirPath: string): Promise<Array<{ relative: string; isDir: boolean }>>;
+  mkdir(dirPath: string): Promise<void>;
+  move(from: string, to: string): Promise<void>;
+  remove(filePath: string, recursive: boolean): Promise<void>;
+  healthy(): Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// S3 / MinIO backend
+// ---------------------------------------------------------------------------
+
+export interface S3BackendConfig {
+  bucket: string;
+  region: string;
+  endpoint?: string;
+  prefix?: string;
+  forcePathStyle?: boolean;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+}
+
+export class S3StorageBackend implements StorageBackend {
+  private client: S3Client;
+  private bucket: string;
+  private prefix: string;
+
+  constructor(config: S3BackendConfig) {
+    this.bucket = config.bucket;
+    this.prefix = (config.prefix ?? "file-store").replace(/\/+$/, "");
+
+    const s3Config: S3ClientConfig = {
+      region: config.region,
+      forcePathStyle: config.forcePathStyle ?? true,
+    };
+
+    if (config.endpoint) {
+      s3Config.endpoint = config.endpoint;
+    }
+
+    if (config.accessKeyId && config.secretAccessKey) {
+      s3Config.credentials = {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+      };
+    }
+
+    this.client = new S3Client(s3Config);
+  }
+
+  private key(filePath: string): string {
+    const cleaned = filePath.replace(/\\/g, "/").replace(/^\/+/, "");
+    if (cleaned.includes("..")) {
+      throw new Error("Path traversal detected — path must stay within the store root");
+    }
+    return this.prefix ? `${this.prefix}/${cleaned}` : cleaned;
+  }
+
+  private dirKey(dirPath: string): string {
+    const k = this.key(dirPath);
+    return k.endsWith("/") ? k : k + "/";
+  }
+
+  async writeFile(filePath: string, content: Buffer): Promise<void> {
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: this.key(filePath),
+        Body: content,
+      }),
+    );
+  }
+
+  async readFile(filePath: string): Promise<Buffer> {
+    const resp = await this.client.send(
+      new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: this.key(filePath),
+      }),
+    );
+    if (!resp.Body) throw new Error(`Empty response for ${filePath}`);
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of resp.Body as AsyncIterable<Uint8Array>) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+
+  async exists(filePath: string): Promise<boolean> {
+    try {
+      await this.client.send(
+        new HeadObjectCommand({ Bucket: this.bucket, Key: this.key(filePath) }),
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async stat(filePath: string): Promise<{ size: number; isDir: boolean; mtime: Date } | null> {
+    try {
+      const head = await this.client.send(
+        new HeadObjectCommand({ Bucket: this.bucket, Key: this.key(filePath) }),
+      );
+      return {
+        size: head.ContentLength ?? 0,
+        isDir: false,
+        mtime: head.LastModified ?? new Date(),
+      };
+    } catch {
+      const prefix = this.dirKey(filePath);
+      const list = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          MaxKeys: 1,
+        }),
+      );
+      if ((list.Contents?.length ?? 0) > 0 || (list.CommonPrefixes?.length ?? 0) > 0) {
+        return { size: 0, isDir: true, mtime: new Date() };
+      }
+      return null;
+    }
+  }
+
+  async listDir(dirPath: string): Promise<FileEntry[]> {
+    const prefix = dirPath ? this.dirKey(dirPath) : (this.prefix ? this.prefix + "/" : "");
+
+    const resp = await this.client.send(
+      new ListObjectsV2Command({
+        Bucket: this.bucket,
+        Prefix: prefix,
+        Delimiter: "/",
+      }),
+    );
+
+    const entries: FileEntry[] = [];
+
+    for (const cp of resp.CommonPrefixes ?? []) {
+      if (cp.Prefix) {
+        const name = cp.Prefix.slice(prefix.length).replace(/\/+$/, "");
+        if (name) entries.push({ name, isDir: true, size: 0 });
+      }
+    }
+
+    for (const obj of resp.Contents ?? []) {
+      if (obj.Key) {
+        const name = obj.Key.slice(prefix.length);
+        if (name && !name.includes("/")) {
+          entries.push({ name, isDir: false, size: obj.Size ?? 0 });
+        }
+      }
+    }
+
+    return entries;
+  }
+
+  async listRecursive(dirPath: string): Promise<Array<{ relative: string; isDir: boolean }>> {
+    const prefix = dirPath ? this.dirKey(dirPath) : (this.prefix ? this.prefix + "/" : "");
+    const results: Array<{ relative: string; isDir: boolean }> = [];
+    let continuationToken: string | undefined;
+
+    do {
+      const resp = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+        }),
+      );
+
+      for (const obj of resp.Contents ?? []) {
+        if (obj.Key) {
+          const rel = obj.Key.slice(prefix.length);
+          if (rel) results.push({ relative: rel, isDir: false });
+        }
+      }
+
+      continuationToken = resp.IsTruncated ? resp.NextContinuationToken : undefined;
+    } while (continuationToken);
+
+    return results;
+  }
+
+  async mkdir(_dirPath: string): Promise<void> {
+    // S3 prefixes are implicit — no-op
+  }
+
+  async move(from: string, to: string): Promise<void> {
+    const fromKey = this.key(from);
+    const toKey = this.key(to);
+
+    const headResult = await this.stat(from);
+    if (!headResult) throw new Error(`Source not found: ${from}`);
+
+    if (headResult.isDir) {
+      const children = await this.listRecursive(from);
+      for (const child of children) {
+        const srcKey = this.key(from + "/" + child.relative);
+        const dstKey = this.key(to + "/" + child.relative);
+        await this.client.send(
+          new CopyObjectCommand({
+            Bucket: this.bucket,
+            CopySource: `${this.bucket}/${srcKey}`,
+            Key: dstKey,
+          }),
+        );
+        await this.client.send(
+          new DeleteObjectCommand({ Bucket: this.bucket, Key: srcKey }),
+        );
+      }
+    } else {
+      await this.client.send(
+        new CopyObjectCommand({
+          Bucket: this.bucket,
+          CopySource: `${this.bucket}/${fromKey}`,
+          Key: toKey,
+        }),
+      );
+      await this.client.send(
+        new DeleteObjectCommand({ Bucket: this.bucket, Key: fromKey }),
+      );
+    }
+  }
+
+  async remove(filePath: string, recursive: boolean): Promise<void> {
+    const headResult = await this.stat(filePath);
+    if (!headResult) throw new Error(`Not found: ${filePath}`);
+
+    if (headResult.isDir) {
+      if (!recursive) {
+        const children = await this.listDir(filePath);
+        if (children.length > 0) {
+          throw new Error(
+            `Directory is not empty (${children.length} items). Set recursive=true to remove with contents.`,
+          );
+        }
+      }
+      const all = await this.listRecursive(filePath);
+      for (const child of all) {
+        await this.client.send(
+          new DeleteObjectCommand({
+            Bucket: this.bucket,
+            Key: this.key(filePath + "/" + child.relative),
+          }),
+        );
+      }
+    } else {
+      await this.client.send(
+        new DeleteObjectCommand({ Bucket: this.bucket, Key: this.key(filePath) }),
+      );
+    }
+  }
+
+  async healthy(): Promise<boolean> {
+    try {
+      await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: this.prefix,
+          MaxKeys: 1,
+        }),
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createStorageBackend(config: S3BackendConfig): StorageBackend {
+  return new S3StorageBackend(config);
+}

--- a/packages/plugins/aws-file-store/src/worker.ts
+++ b/packages/plugins/aws-file-store/src/worker.ts
@@ -1,0 +1,845 @@
+import path from "node:path";
+import {
+  definePlugin,
+  runWorker,
+  type PaperclipPlugin,
+  type PluginContext,
+  type PluginHealthDiagnostics,
+  type ToolResult,
+  type ToolRunContext,
+} from "@paperclipai/plugin-sdk";
+import { DEFAULT_CONFIG, ORG_DIRS, PLUGIN_ID, STATE_KEYS, TOOL_NAMES } from "./constants.js";
+import {
+  createStorageBackend,
+  type S3BackendConfig,
+  type StorageBackend,
+} from "./storage-backend.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type PluginConfig = {
+  s3Bucket?: string;
+  s3Region?: string;
+  s3Endpoint?: string;
+  s3Prefix?: string;
+  s3ForcePathStyle?: boolean;
+  s3AccessKeyId?: string;
+  s3SecretAccessKey?: string;
+  maxFileSizeMb?: number;
+  maxTreeDepth?: number;
+};
+
+type FileMeta = {
+  path: string;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  updatedBy: string;
+  size: number;
+  tags: string[];
+  description: string;
+  isDirectory: boolean;
+};
+
+type FileIndex = Record<string, FileMeta>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let currentContext: PluginContext | null = null;
+let currentBackend: StorageBackend | null = null;
+
+function resolveConfig(raw: Record<string, unknown>): {
+  pluginConfig: Required<PluginConfig>;
+  s3Config: S3BackendConfig;
+} {
+  const c = raw as PluginConfig;
+
+  const pluginConfig: Required<PluginConfig> = {
+    s3Bucket: c.s3Bucket || DEFAULT_CONFIG.s3Bucket,
+    s3Region: c.s3Region || DEFAULT_CONFIG.s3Region,
+    s3Endpoint: c.s3Endpoint || DEFAULT_CONFIG.s3Endpoint,
+    s3Prefix: c.s3Prefix ?? DEFAULT_CONFIG.s3Prefix,
+    s3ForcePathStyle: c.s3ForcePathStyle ?? DEFAULT_CONFIG.s3ForcePathStyle,
+    s3AccessKeyId: c.s3AccessKeyId ?? "",
+    s3SecretAccessKey: c.s3SecretAccessKey ?? "",
+    maxFileSizeMb: c.maxFileSizeMb ?? DEFAULT_CONFIG.maxFileSizeMb,
+    maxTreeDepth: c.maxTreeDepth ?? DEFAULT_CONFIG.maxTreeDepth,
+  };
+
+  const s3Config: S3BackendConfig = {
+    bucket: pluginConfig.s3Bucket,
+    region: pluginConfig.s3Region,
+    endpoint: pluginConfig.s3Endpoint || undefined,
+    prefix: pluginConfig.s3Prefix,
+    forcePathStyle: pluginConfig.s3ForcePathStyle,
+    accessKeyId: pluginConfig.s3AccessKeyId || undefined,
+    secretAccessKey: pluginConfig.s3SecretAccessKey || undefined,
+  };
+
+  return { pluginConfig, s3Config };
+}
+
+async function getConfigAndBackend(ctx: PluginContext): Promise<{
+  config: Required<PluginConfig>;
+  backend: StorageBackend;
+}> {
+  const raw = await ctx.config.get();
+  const { pluginConfig, s3Config } = resolveConfig(raw);
+
+  if (!currentBackend) {
+    currentBackend = createStorageBackend(s3Config);
+  }
+
+  return { config: pluginConfig, backend: currentBackend };
+}
+
+const TEXT_EXTENSIONS = new Set([
+  ".txt", ".md", ".markdown", ".json", ".yaml", ".yml", ".xml",
+  ".csv", ".tsv", ".html", ".htm", ".css", ".js", ".ts", ".jsx",
+  ".tsx", ".py", ".rb", ".go", ".rs", ".java", ".c", ".cpp", ".h",
+  ".sh", ".bash", ".zsh", ".fish", ".sql", ".toml", ".ini", ".cfg",
+  ".conf", ".log", ".gitignore", ".dockerfile", ".makefile",
+  ".rst", ".tex", ".bib", ".r", ".m", ".swift", ".kt", ".scala",
+  ".lua", ".pl", ".pm", ".php", ".vue", ".svelte",
+]);
+
+function isTextFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return ext === "" || TEXT_EXTENSIONS.has(ext);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, i);
+  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function actorLabel(runCtx: ToolRunContext): string {
+  return `agent:${runCtx.agentId}`;
+}
+
+function matchGlob(name: string, pattern: string): boolean {
+  const regex = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${regex}$`, "i").test(name);
+}
+
+// ---------------------------------------------------------------------------
+// File index (metadata stored in plugin state)
+// ---------------------------------------------------------------------------
+
+async function loadIndex(ctx: PluginContext): Promise<FileIndex> {
+  const data = await ctx.state.get({
+    scopeKind: "instance",
+    stateKey: STATE_KEYS.fileIndex,
+  });
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    return data as FileIndex;
+  }
+  return {};
+}
+
+async function saveIndex(ctx: PluginContext, index: FileIndex): Promise<void> {
+  await ctx.state.set(
+    { scopeKind: "instance", stateKey: STATE_KEYS.fileIndex },
+    index,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tree rendering
+// ---------------------------------------------------------------------------
+
+async function buildTree(
+  backend: StorageBackend,
+  dirPath: string,
+  prefix: string,
+  depth: number,
+  maxDepth: number,
+): Promise<string> {
+  if (depth > maxDepth) return `${prefix}...\n`;
+
+  let entries: Array<{ name: string; isDir: boolean; size: number }>;
+  try {
+    entries = await backend.listDir(dirPath);
+  } catch {
+    return "";
+  }
+
+  entries.sort((a, b) => {
+    if (a.isDir && !b.isDir) return -1;
+    if (!a.isDir && b.isDir) return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  let result = "";
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const isLast = i === entries.length - 1;
+    const connector = isLast ? "└── " : "├── ";
+    const childPrefix = isLast ? "    " : "│   ";
+
+    if (entry.isDir) {
+      result += `${prefix}${connector}${entry.name}/\n`;
+      const childPath = dirPath ? `${dirPath}/${entry.name}` : entry.name;
+      result += await buildTree(backend, childPath, prefix + childPrefix, depth + 1, maxDepth);
+    } else {
+      const sizeStr = entry.size > 0 ? ` (${formatBytes(entry.size)})` : "";
+      result += `${prefix}${connector}${entry.name}${sizeStr}\n`;
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tool handlers
+// ---------------------------------------------------------------------------
+
+async function registerToolHandlers(ctx: PluginContext): Promise<void> {
+
+  // ---- fs-write ----
+  ctx.tools.register(
+    TOOL_NAMES.writeFile,
+    {
+      displayName: "Write File to Shared Store",
+      description: "Writes content to a file in the shared S3 store.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          content: { type: "string" },
+          encoding: { type: "string", enum: ["utf-8", "base64"] },
+          tags: { type: "array", items: { type: "string" } },
+          description: { type: "string" },
+          overwrite: { type: "boolean" },
+        },
+        required: ["path", "content"],
+      },
+    },
+    async (params, runCtx: ToolRunContext): Promise<ToolResult> => {
+      const input = params as {
+        path?: string;
+        content?: string;
+        encoding?: "utf-8" | "base64";
+        tags?: string[];
+        description?: string;
+        overwrite?: boolean;
+      };
+
+      if (!input.path) return { error: "path is required" };
+      if (input.content === undefined) return { error: "content is required" };
+
+      const { config, backend } = await getConfigAndBackend(ctx);
+
+      const encoding = input.encoding ?? "utf-8";
+      const buf = encoding === "base64"
+        ? Buffer.from(input.content, "base64")
+        : Buffer.from(input.content, "utf-8");
+
+      const maxBytes = config.maxFileSizeMb * 1024 * 1024;
+      if (buf.length > maxBytes) {
+        return { error: `File exceeds maximum size of ${config.maxFileSizeMb} MB` };
+      }
+
+      const overwrite = input.overwrite !== false;
+      if (!overwrite) {
+        const fileExists = await backend.exists(input.path);
+        if (fileExists) {
+          return { error: `File already exists: ${input.path}. Set overwrite=true to replace.` };
+        }
+      }
+
+      try {
+        await backend.writeFile(input.path, buf);
+      } catch (err) {
+        return { error: `Write failed: ${err instanceof Error ? err.message : String(err)}` };
+      }
+
+      const index = await loadIndex(ctx);
+      const now = new Date().toISOString();
+      const existing = index[input.path];
+
+      index[input.path] = {
+        path: input.path,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+        createdBy: existing?.createdBy ?? actorLabel(runCtx),
+        updatedBy: actorLabel(runCtx),
+        size: buf.length,
+        tags: input.tags ?? existing?.tags ?? [],
+        description: input.description ?? existing?.description ?? "",
+        isDirectory: false,
+      };
+      await saveIndex(ctx, index);
+
+      await ctx.metrics.write("filestore.write", 1, { ext: path.extname(input.path) || "none" });
+      ctx.logger.info("File written", { path: input.path, size: buf.length });
+
+      return {
+        content:
+          `File written successfully.\n` +
+          `- **Path:** ${input.path}\n` +
+          `- **Size:** ${formatBytes(buf.length)}\n` +
+          `- **Backend:** S3`,
+        data: { path: input.path, size: buf.length },
+      };
+    },
+  );
+
+  // ---- fs-read ----
+  ctx.tools.register(
+    TOOL_NAMES.readFile,
+    {
+      displayName: "Read File from Shared Store",
+      description: "Reads a file from the shared store.",
+      parametersSchema: {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      },
+    },
+    async (params): Promise<ToolResult> => {
+      const input = params as { path?: string };
+      if (!input.path) return { error: "path is required" };
+
+      const { backend } = await getConfigAndBackend(ctx);
+
+      let buf: Buffer;
+      try {
+        buf = await backend.readFile(input.path);
+      } catch (err) {
+        return { error: `Cannot read file: ${err instanceof Error ? err.message : String(err)}` };
+      }
+
+      await ctx.metrics.write("filestore.read", 1, {});
+
+      if (isTextFile(input.path)) {
+        return {
+          content: buf.toString("utf-8"),
+          data: { path: input.path, size: buf.length, encoding: "utf-8" },
+        };
+      }
+
+      return {
+        content: `Binary file (${formatBytes(buf.length)}). Content returned as base64 in data.content.`,
+        data: {
+          path: input.path,
+          size: buf.length,
+          encoding: "base64",
+          content: buf.toString("base64"),
+        },
+      };
+    },
+  );
+
+  // ---- fs-list ----
+  ctx.tools.register(
+    TOOL_NAMES.listDir,
+    {
+      displayName: "List Directory Contents",
+      description: "Lists files and subdirectories at a given path.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          recursive: { type: "boolean" },
+        },
+        required: ["path"],
+      },
+    },
+    async (params): Promise<ToolResult> => {
+      const input = params as { path?: string; recursive?: boolean };
+      const dirPath = (input.path || "").replace(/^\/+/, "");
+
+      const { backend } = await getConfigAndBackend(ctx);
+
+      if (input.recursive) {
+        try {
+          const all = await backend.listRecursive(dirPath);
+          const lines = all.map((f) => `${f.isDir ? "📁" : "📄"} ${f.relative}`);
+          return {
+            content: lines.length > 0
+              ? lines.join("\n")
+              : `Directory is empty: ${dirPath || "/"}`,
+            data: { count: all.length, entries: all },
+          };
+        } catch (err) {
+          return { error: `Cannot list: ${err instanceof Error ? err.message : String(err)}` };
+        }
+      }
+
+      let entries: Array<{ name: string; isDir: boolean; size: number }>;
+      try {
+        entries = await backend.listDir(dirPath);
+      } catch (err) {
+        return { error: `Cannot list directory: ${err instanceof Error ? err.message : String(err)}` };
+      }
+
+      entries.sort((a, b) => {
+        if (a.isDir && !b.isDir) return -1;
+        if (!a.isDir && b.isDir) return 1;
+        return a.name.localeCompare(b.name);
+      });
+
+      const index = await loadIndex(ctx);
+      const lines: string[] = [];
+      const items: Array<{ name: string; type: string; size?: number; tags?: string[] }> = [];
+
+      for (const entry of entries) {
+        const rel = dirPath ? `${dirPath}/${entry.name}` : entry.name;
+        const meta = index[rel];
+
+        if (entry.isDir) {
+          lines.push(`📁 ${entry.name}/`);
+          items.push({ name: entry.name, type: "directory" });
+        } else {
+          const tagsStr = meta?.tags?.length ? ` [${meta.tags.join(", ")}]` : "";
+          lines.push(`📄 ${entry.name} (${formatBytes(entry.size)})${tagsStr}`);
+          items.push({ name: entry.name, type: "file", size: entry.size, tags: meta?.tags });
+        }
+      }
+
+      return {
+        content: lines.length > 0
+          ? `Contents of **${dirPath || "/"}**:\n\n${lines.join("\n")}`
+          : `Directory is empty: ${dirPath || "/"}`,
+        data: { path: dirPath || "/", count: items.length, entries: items },
+      };
+    },
+  );
+
+  // ---- fs-tree ----
+  ctx.tools.register(
+    TOOL_NAMES.treeDir,
+    {
+      displayName: "Show Directory Tree",
+      description: "Displays a visual tree of the store hierarchy.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          maxDepth: { type: "number" },
+        },
+      },
+    },
+    async (params): Promise<ToolResult> => {
+      const input = params as { path?: string; maxDepth?: number };
+      const dirPath = (input.path || "").replace(/^\/+/, "");
+
+      const { config, backend } = await getConfigAndBackend(ctx);
+      const maxDepth = input.maxDepth ?? config.maxTreeDepth;
+
+      const tree = await buildTree(backend, dirPath, "", 0, maxDepth);
+      const label = dirPath || ".";
+
+      if (!tree) {
+        return { content: `${label}/ (empty)` };
+      }
+
+      return {
+        content: `${label}/\n${tree}`,
+        data: { path: dirPath || "/" },
+      };
+    },
+  );
+
+  // ---- fs-mkdir ----
+  ctx.tools.register(
+    TOOL_NAMES.mkdir,
+    {
+      displayName: "Create Directory",
+      description: "Creates a directory (and any missing parents) in the shared store.",
+      parametersSchema: {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      },
+    },
+    async (params, runCtx: ToolRunContext): Promise<ToolResult> => {
+      const input = params as { path?: string };
+      if (!input.path) return { error: "path is required" };
+
+      const { backend } = await getConfigAndBackend(ctx);
+
+      try {
+        await backend.mkdir(input.path);
+      } catch (err) {
+        return { error: `mkdir failed: ${err instanceof Error ? err.message : String(err)}` };
+      }
+
+      const index = await loadIndex(ctx);
+      const now = new Date().toISOString();
+
+      if (!index[input.path]) {
+        index[input.path] = {
+          path: input.path,
+          createdAt: now,
+          updatedAt: now,
+          createdBy: actorLabel(runCtx),
+          updatedBy: actorLabel(runCtx),
+          size: 0,
+          tags: [],
+          description: "",
+          isDirectory: true,
+        };
+        await saveIndex(ctx, index);
+      }
+
+      ctx.logger.info("Directory created", { path: input.path });
+      return { content: `Directory created: **${input.path}**`, data: { path: input.path } };
+    },
+  );
+
+  // ---- fs-move ----
+  ctx.tools.register(
+    TOOL_NAMES.move,
+    {
+      displayName: "Move / Rename",
+      description: "Moves or renames a file or directory within the shared store.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          from: { type: "string" },
+          to: { type: "string" },
+        },
+        required: ["from", "to"],
+      },
+    },
+    async (params, runCtx: ToolRunContext): Promise<ToolResult> => {
+      const input = params as { from?: string; to?: string };
+      if (!input.from || !input.to) return { error: "from and to are required" };
+
+      const { backend } = await getConfigAndBackend(ctx);
+
+      try {
+        await backend.move(input.from, input.to);
+      } catch (err) {
+        return { error: `Move failed: ${err instanceof Error ? err.message : String(err)}` };
+      }
+
+      const index = await loadIndex(ctx);
+      const now = new Date().toISOString();
+
+      const keysToMove = Object.keys(index).filter(
+        (k) => k === input.from || k.startsWith(input.from + "/"),
+      );
+
+      for (const oldKey of keysToMove) {
+        const newKey = input.to + oldKey.slice(input.from!.length);
+        const meta = index[oldKey];
+        delete index[oldKey];
+        index[newKey] = {
+          ...meta,
+          path: newKey,
+          updatedAt: now,
+          updatedBy: actorLabel(runCtx),
+        };
+      }
+
+      await saveIndex(ctx, index);
+      ctx.logger.info("Moved", { from: input.from, to: input.to });
+
+      return {
+        content: `Moved **${input.from}** → **${input.to}**`,
+        data: { from: input.from, to: input.to },
+      };
+    },
+  );
+
+  // ---- fs-remove ----
+  ctx.tools.register(
+    TOOL_NAMES.remove,
+    {
+      displayName: "Remove File or Directory",
+      description: "Removes a file or directory from the shared store.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          recursive: { type: "boolean" },
+        },
+        required: ["path"],
+      },
+    },
+    async (params, runCtx: ToolRunContext): Promise<ToolResult> => {
+      const input = params as { path?: string; recursive?: boolean };
+      if (!input.path) return { error: "path is required" };
+
+      const { backend } = await getConfigAndBackend(ctx);
+
+      try {
+        await backend.remove(input.path, !!input.recursive);
+      } catch (err) {
+        return { error: err instanceof Error ? err.message : String(err) };
+      }
+
+      const index = await loadIndex(ctx);
+      const keysToRemove = Object.keys(index).filter(
+        (k) => k === input.path || k.startsWith(input.path + "/"),
+      );
+      for (const key of keysToRemove) {
+        delete index[key];
+      }
+      await saveIndex(ctx, index);
+
+      await ctx.activity.log({
+        companyId: runCtx.companyId,
+        entityType: "file-store",
+        message: `Removed "${input.path}" from shared file store`,
+        metadata: { plugin: PLUGIN_ID, actor: actorLabel(runCtx) },
+      });
+
+      ctx.logger.info("Removed", { path: input.path });
+      return { content: `Removed: **${input.path}**`, data: { path: input.path, removed: keysToRemove.length } };
+    },
+  );
+
+  // ---- fs-stat ----
+  ctx.tools.register(
+    TOOL_NAMES.stat,
+    {
+      displayName: "Get File / Directory Info",
+      description: "Returns metadata about a file or directory.",
+      parametersSchema: {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      },
+    },
+    async (params): Promise<ToolResult> => {
+      const input = params as { path?: string };
+      if (!input.path) return { error: "path is required" };
+
+      const { backend } = await getConfigAndBackend(ctx);
+
+      const fsStat = await backend.stat(input.path);
+      if (!fsStat) return { error: `Not found: ${input.path}` };
+
+      const index = await loadIndex(ctx);
+      const meta = index[input.path];
+
+      const info = {
+        path: input.path,
+        type: fsStat.isDir ? "directory" : "file",
+        size: fsStat.size,
+        sizeHuman: formatBytes(fsStat.size),
+        createdAt: meta?.createdAt ?? fsStat.mtime.toISOString(),
+        updatedAt: meta?.updatedAt ?? fsStat.mtime.toISOString(),
+        createdBy: meta?.createdBy ?? "unknown",
+        updatedBy: meta?.updatedBy ?? "unknown",
+        tags: meta?.tags ?? [],
+        description: meta?.description ?? "",
+      };
+
+      const lines = [
+        `**Path:** ${info.path}`,
+        `**Type:** ${info.type}`,
+        `**Size:** ${info.sizeHuman}`,
+        `**Created:** ${info.createdAt} by ${info.createdBy}`,
+        `**Updated:** ${info.updatedAt} by ${info.updatedBy}`,
+      ];
+      if (info.tags.length > 0) lines.push(`**Tags:** ${info.tags.join(", ")}`);
+      if (info.description) lines.push(`**Description:** ${info.description}`);
+
+      return { content: lines.join("\n"), data: info };
+    },
+  );
+
+  // ---- fs-search ----
+  ctx.tools.register(
+    TOOL_NAMES.search,
+    {
+      displayName: "Search Files in Store",
+      description: "Searches for files by name pattern, tags, or query.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          tags: { type: "array", items: { type: "string" } },
+          path: { type: "string" },
+          namePattern: { type: "string" },
+        },
+      },
+    },
+    async (params): Promise<ToolResult> => {
+      const input = params as {
+        query?: string;
+        tags?: string[];
+        path?: string;
+        namePattern?: string;
+      };
+
+      const index = await loadIndex(ctx);
+      let results = Object.values(index);
+
+      if (input.path) {
+        const prefix = input.path.replace(/^\/+/, "").replace(/\/+$/, "");
+        results = results.filter((m) => m.path.startsWith(prefix + "/") || m.path === prefix);
+      }
+
+      if (input.tags && input.tags.length > 0) {
+        const requiredTags = input.tags.map((t) => t.toLowerCase());
+        results = results.filter((m) =>
+          requiredTags.every((t) => m.tags.some((mt) => mt.toLowerCase() === t)),
+        );
+      }
+
+      if (input.namePattern) {
+        results = results.filter((m) => matchGlob(path.basename(m.path), input.namePattern!));
+      }
+
+      if (input.query) {
+        const q = input.query.toLowerCase();
+        results = results.filter(
+          (m) =>
+            m.path.toLowerCase().includes(q) ||
+            m.description.toLowerCase().includes(q) ||
+            m.tags.some((t) => t.toLowerCase().includes(q)),
+        );
+      }
+
+      results.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+      const limited = results.slice(0, 50);
+
+      if (limited.length === 0) {
+        return { content: "No files found matching the search criteria.", data: { count: 0, results: [] } };
+      }
+
+      const lines = limited.map((m) => {
+        const tagsStr = m.tags.length > 0 ? ` [${m.tags.join(", ")}]` : "";
+        const icon = m.isDirectory ? "📁" : "📄";
+        return `${icon} **${m.path}** (${formatBytes(m.size)})${tagsStr}`;
+      });
+
+      return {
+        content:
+          `Found **${results.length}** result(s)` +
+          (results.length > 50 ? " (showing first 50)" : "") +
+          `:\n\n${lines.join("\n")}`,
+        data: { count: results.length, results: limited },
+      };
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Plugin definition
+// ---------------------------------------------------------------------------
+
+const plugin: PaperclipPlugin = definePlugin({
+  async setup(ctx) {
+    currentContext = ctx;
+    ctx.logger.info("Shared File Store plugin initializing (S3-only mode)");
+
+    const raw = await ctx.config.get();
+    const { pluginConfig, s3Config } = resolveConfig(raw);
+
+    currentBackend = createStorageBackend(s3Config);
+
+    ctx.logger.info("S3 backend configured", {
+      bucket: pluginConfig.s3Bucket,
+      endpoint: pluginConfig.s3Endpoint,
+      prefix: pluginConfig.s3Prefix,
+    });
+
+    await registerToolHandlers(ctx);
+    ctx.logger.info("Shared File Store plugin ready");
+  },
+
+  async onHealth(): Promise<PluginHealthDiagnostics> {
+    const ctx = currentContext;
+    if (!ctx) {
+      return { status: "degraded", message: "Plugin context not initialized" };
+    }
+
+    const raw = await ctx.config.get();
+    const { pluginConfig } = resolveConfig(raw);
+    const backend = currentBackend;
+
+    if (!backend) {
+      return { status: "degraded", message: "Storage backend not initialized" };
+    }
+
+    const healthy = await backend.healthy();
+    const index = await loadIndex(ctx);
+    const fileCount = Object.values(index).filter((m) => !m.isDirectory).length;
+    const dirCount = Object.values(index).filter((m) => m.isDirectory).length;
+
+    return {
+      status: healthy ? "ok" : "degraded",
+      message: healthy
+        ? `S3 store active: ${fileCount} file(s), ${dirCount} folder(s)`
+        : `S3 backend not accessible (bucket: ${pluginConfig.s3Bucket})`,
+      details: {
+        bucket: pluginConfig.s3Bucket,
+        endpoint: pluginConfig.s3Endpoint,
+        prefix: pluginConfig.s3Prefix,
+        fileCount,
+        dirCount,
+        healthy,
+      },
+    };
+  },
+
+  async onConfigChanged(newConfig) {
+    const ctx = currentContext;
+    if (!ctx) return;
+
+    const { pluginConfig, s3Config } = resolveConfig(newConfig as Record<string, unknown>);
+    currentBackend = createStorageBackend(s3Config);
+
+    ctx.logger.info("File Store config updated — S3 backend recreated", {
+      bucket: pluginConfig.s3Bucket,
+      endpoint: pluginConfig.s3Endpoint,
+    });
+  },
+
+  async onValidateConfig(config) {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const typed = config as PluginConfig;
+
+    if (!typed.s3Bucket) {
+      errors.push("s3Bucket is required");
+    }
+    if (!typed.s3Region) {
+      warnings.push("s3Region not set — defaulting to us-east-1");
+    }
+
+    if (typed.maxFileSizeMb !== undefined) {
+      if (typeof typed.maxFileSizeMb !== "number" || typed.maxFileSizeMb < 1) {
+        errors.push("maxFileSizeMb must be a positive number");
+      }
+      if (typed.maxFileSizeMb > 500) {
+        warnings.push("maxFileSizeMb > 500 allows very large files");
+      }
+    }
+
+    if (typed.maxTreeDepth !== undefined) {
+      if (typeof typed.maxTreeDepth !== "number" || typed.maxTreeDepth < 1) {
+        errors.push("maxTreeDepth must be a positive number");
+      }
+    }
+
+    return { ok: errors.length === 0, warnings, errors };
+  },
+
+  async onShutdown() {
+    const ctx = currentContext;
+    if (ctx) {
+      ctx.logger.info("Shared File Store plugin shutting down");
+    }
+    currentBackend = null;
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/aws-file-store/tsconfig.json
+++ b/packages/plugins/aws-file-store/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023"]
+  },
+  "include": ["src"]
+}

--- a/packages/plugins/aws-file-store/vitest.config.ts
+++ b/packages/plugins/aws-file-store/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,28 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
+  packages/plugins/aws-file-store:
+    dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.888.0
+        version: 3.994.0
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      '@paperclipai/shared':
+        specifier: workspace:*
+        version: link:../../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/plugins/create-paperclip-plugin:
     dependencies:
       '@paperclipai/plugin-sdk':

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       "packages/db",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",
+      "packages/plugins/aws-file-store",
       "server",
       "ui",
       "cli",


### PR DESCRIPTION
Adds an S3-backed shared file store as a first-party Paperclip plugin
  (`@paperclipai/plugin-aws-file-store`) plus a MinIO service in
  `docker/docker-compose.yml` so it works out of the box in dev.

  Inspired by #3230 — same idea, packaged as a real plugin so the host owns
  capability scoping, configuration, lifecycle, metrics, and audit logging
  instead of relying on agents to chain raw `aws` CLI commands.

  ## What's in the plugin

  - **9 tools** registered with the agent runtime: `fs-write`, `fs-read`,
    `fs-list`, `fs-tree`, `fs-mkdir`, `fs-move`, `fs-remove`, `fs-stat`, `fs-search`.
  - **Standard layout** per organization: `knowledge-base/{originals,markdown}/`
    for curated documents and `income/` for files awaiting triage.
  - **S3-compatible backend** built on `@aws-sdk/client-s3` — works against AWS
    S3, MinIO, or any other S3-compatible provider via the `s3Endpoint` /
    `s3ForcePathStyle` config fields.
  - **File index in plugin state** so search by tag / name / description stays
    fast without scanning the bucket.
  - **Lifecycle hooks** wired up: `setup`, `onHealth` (returns file/dir counts
    and bucket reachability), `onConfigChanged`, `onValidateConfig`, `onShutdown`.

  ## Compose changes

  `docker/docker-compose.yml` now ships:
  - a `minio` service with a healthcheck,
  - a one-shot `minio-init` container that creates the bucket,
  - the matching `AWS_*` and `FILE_STORE_*` env vars on `server` so the plugin
    picks up the local MinIO automatically.

  I deliberately did **not** include the unrelated Dockerfile sha256 hash bump
  from #3230 — it's a separate concern.

  ## Tests

  - 16 unit tests in `packages/plugins/aws-file-store/src/storage-backend.test.ts`
    cover key prefixing, path traversal protection, `listDir` filtering,
    `listRecursive` pagination, `move` (copy + delete), the safety check `remove`
    performs against non-empty directories, and the `healthy()` probe.
  - The S3 client is mocked via `vi.mock`, so CI does not need a running MinIO
    container.
  - Added `packages/plugins/aws-file-store` to root `vitest.config.ts` so
    `pnpm test:run` picks the suite up automatically.