### PR TITLE
fix(docker): always fix /paperclip volume ownership on start

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -6,20 +6,15 @@ PUID=${USER_UID:-1000}
 PGID=${USER_GID:-1000}
 
 # Adjust the node user's UID/GID if they differ from the runtime request
-# and fix volume ownership only when a remap is needed
-changed=0
-
 if [ "$(id -u node)" -ne "$PUID" ]; then
     echo "Updating node UID to $PUID"
     usermod -o -u "$PUID" node
-    changed=1
 fi
 
 if [ "$(id -g node)" -ne "$PGID" ]; then
     echo "Updating node GID to $PGID"
     groupmod -o -g "$PGID" node
     usermod -g "$PGID" node
-    changed=1
 fi
 
 # Always fix ownership — volume dirs may have been created as root

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -22,8 +22,7 @@ if [ "$(id -g node)" -ne "$PGID" ]; then
     changed=1
 fi
 
-if [ "$changed" = "1" ]; then
-    chown -R node:node /paperclip
-fi
+# Always fix ownership — volume dirs may have been created as root
+chown -R node:node /paperclip
 
 exec gosu node "$@"


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Docker deployment uses a volume at `/paperclip` for instance data
> - Subdirs like `data/run-logs`, `data/storage`, `data/secrets` are created at runtime by module init or onboard — sometimes as root before `gosu` switches to `node`
> - Agent runs fail with `EACCES: permission denied, mkdir '/paperclip/instances/default/data/run-logs'`
> - The entrypoint only ran `chown` when UID/GID changed, missing the fresh-volume case
> - This PR makes entrypoint always fix ownership before starting the app

## What Changed

`scripts/docker-entrypoint.sh`: removed the `changed` guard around `chown -R node:node /paperclip` so it runs unconditionally on every container start.

## Verification

Reproduced locally: fresh `docker compose up`, created CEO agent, confirmed run-logs EACCES. After fix, agent runs succeed.

## Risks

Slight startup overhead from recursive chown on large data dirs. Negligible for typical deployments.

## Model Used

- Claude Opus 4.6 (1M context) via Claude Code CLI

## Checklist

- [x] Minimal, scoped fix
- [x] No security regression
- [x] Tested locally with fresh Docker volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)