### PR TITLE
fix(agents): unblock opencode model dropdown during onboarding

### DIFF
--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -178,3 +178,98 @@ describe("agent routes adapter validation", () => {
     expect(String(res.body.error ?? res.body.message ?? "")).toContain("Unknown adapter type: missing_adapter");
   });
 });
+
+// Adapter model listing endpoints intentionally use `assertBoard` (not
+// `assertCompanyAccess`) because `listAdapterModels(type)` and
+// `detectAdapterModel(type)` ignore companyId — the model list is global per
+// adapter type. This lets the onboarding UI populate the model dropdown for a
+// company the user has not been added to yet. The companion `/test-environment`
+// endpoint is intentionally NOT loosened, because it resolves per-company
+// secrets via secretService.{normalizeAdapterConfigForPersistence,resolveAdapterConfigForRuntime}.
+describe("adapter model listing endpoints", () => {
+  beforeEach(() => {
+    unregisterServerAdapter("external_test");
+    registerServerAdapter(externalAdapter);
+    mockAccessService.canUser.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    unregisterServerAdapter("external_test");
+  });
+
+  // The default createApp() above uses `source: "local_implicit"`, which is a
+  // god-mode bypass in assertCompanyAccess. To actually exercise the cross-
+  // company access path we need a realistic remote-session actor with the
+  // company list explicitly scoped.
+  function createSessionBoardApp() {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "user-1",
+        companyIds: ["company-1"],
+        source: "session",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", agentRoutes({} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  function createAgentActorApp() {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "agent",
+        agentId: "agent-1",
+        companyId: "company-1",
+        runId: "run-1",
+      };
+      next();
+    });
+    app.use("/api", agentRoutes({} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  it("lets a board user list adapter models for a company they don't belong to", async () => {
+    const res = await request(createSessionBoardApp()).get(
+      "/api/companies/other-company/adapters/external_test/models",
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it("lets a board user run model detection for a company they don't belong to", async () => {
+    const res = await request(createSessionBoardApp()).get(
+      "/api/companies/other-company/adapters/external_test/detect-model",
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    // external_test has no detectModel implementation, so the route returns null.
+    expect(res.body).toBeNull();
+  });
+
+  it("still rejects /test-environment for a company the board user doesn't belong to", async () => {
+    // Regression guard: this endpoint touches per-company secrets and must
+    // remain company-scoped even when the model listing endpoints don't.
+    const res = await request(createSessionBoardApp())
+      .post("/api/companies/other-company/adapters/external_test/test-environment")
+      .send({ adapterConfig: {} });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+  });
+
+  it("rejects non-board actors (e.g. agents) from listing adapter models", async () => {
+    const res = await request(createAgentActorApp()).get(
+      "/api/companies/company-1/adapters/external_test/models",
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -778,16 +778,18 @@ export function agentRoutes(db: Db) {
   });
 
   router.get("/companies/:companyId/adapters/:type/models", async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
+    // Adapter models are global per type — listAdapterModels(type) ignores
+    // companyId. Require board access only so the onboarding UI can populate
+    // the model dropdown for a company the user has not been added to yet.
+    assertBoard(req);
     const type = assertKnownAdapterType(req.params.type as string);
     const models = await listAdapterModels(type);
     res.json(models);
   });
 
   router.get("/companies/:companyId/adapters/:type/detect-model", async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
+    // Same rationale as /models — detection runs against the adapter type only.
+    assertBoard(req);
     const type = assertKnownAdapterType(req.params.type as string);
 
     const detected = await detectAdapterModel(type);


### PR DESCRIPTION
## The bug

  During onboarding (most visibly when configuring an `opencode_local`
  adapter), the "pick a model" dropdown shows up empty.

  The UI calls `GET /companies/:companyId/adapters/:type/models` to fill it,
  but for a freshly-signed-up user who hasn't been added to the requested
  company yet, the server replies `403 Forbidden` and the dropdown stays
  blank. Onboarding can't complete cleanly without manually working around
  this.

  `opencode_local` is the adapter where this hurts the most — its model
  list is the one users typically need to pick from during first-time
  setup, and `/detect-model` is what its UI calls right after the user
  points it at a binary. Other adapters technically hit the same gate, but
  opencode is what made the breakage obvious in practice.

  ## Why it happens

  Both `/companies/:companyId/adapters/:type/models` and
  `/companies/:companyId/adapters/:type/detect-model` are gated behind
  `assertCompanyAccess(req, companyId)`. But the handlers they protect
  (`listAdapterModels(type)` and `detectAdapterModel(type)` in
  `server/src/adapters/registry.ts:320` and `:347`) take **only the adapter
  type**. They never read `companyId`. The `companyId` in the URL is
  decorative for these two endpoints — it's used by the auth check and
  nothing else. Model lists are global per adapter type; there's nothing
  company-specific to protect.

  So the gate doesn't defend any data, but it does break the dropdown.

  ## The fix

  Replace `assertCompanyAccess` with `assertBoard` on the two model-listing
  endpoints. Any board actor can now list models for any company, which is
  fine because the response is identical regardless of company. This
  unblocks the opencode onboarding flow without changing what data is
  exposed.

  `POST /companies/:companyId/adapters/:type/test-environment` is
  **intentionally left strict**. Unlike the model endpoints, it actually
  uses `companyId` — it resolves per-company secrets via
  `secretService.normalizeAdapterConfigForPersistence` and
  `resolveAdapterConfigForRuntime` (`server/src/routes/agents.ts:809–817`).
  Loosening that one would let a board user from company A resolve company
  B's secrets. So it keeps `assertCanReadConfigurations`.