### PR TITLE
html-report as default skill

### DIFF
--- a/skills/html-report/SKILL.md
+++ b/skills/html-report/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: html-report
+description: >
+  Generate polished, self-contained HTML reports (single file, inline CSS,
+  zero JavaScript, zero external resources) and attach them to a Paperclip
+  issue. Use when the user asks for a report, writeup, analysis, executive
+  summary, or anything that benefits from typography, sections, tables and
+  figures beyond plain markdown. Do NOT use for short issue comments — those
+  must stay markdown.
+---
+
+# html-report Skill
+
+Turn a structured JSON description into a beautiful, print-ready HTML file
+and attach it to the current issue. The output is a single self-contained
+`.html` document with inline CSS, no JavaScript, no external resources —
+open it in any browser, print it to PDF, archive it, email it. It works the
+same six months from now on an air-gapped machine.
+
+## When to use
+
+- The user asks for a "report", "отчёт", "writeup", "ресёрч", "analysis",
+  "executive summary", "brief", "дашборд", "справка", "документ".
+- The result has enough structure that a markdown comment would not do it
+  justice: multiple sections, tables, figures, callouts.
+- The result is an archival artifact the user wants to forward outside
+  Paperclip (print to PDF, send to a colleague, attach to an email).
+
+## When NOT to use
+
+- **Short updates or replies.** Leave those in the issue comment as
+  markdown — do not make a comment where every reply is a downloadable file.
+- **Interactive dashboards** (sortable tables, live charts, date pickers).
+  These require JavaScript, which the skill does not allow. Tell the user
+  you can give them a static snapshot instead.
+- **Slide decks.** Out of scope for v1 — recommend a dedicated tool.
+- **PDF.** You produce HTML, not PDF. The print CSS is tuned so the user
+  gets a clean PDF by hitting `Print → Save as PDF` in their browser. If the
+  user *really* wants a pre-rendered PDF, say so — a different skill will
+  handle that.
+
+## Absolute rules
+
+The skill scripts enforce every rule here. Violations return non-zero exit
+codes, print the error to stderr, and produce no file. You then fix the
+**JSON input** and retry.
+
+1. **Never hand-write HTML.** Always go through `build_report.py` with a
+   JSON spec. The JSON is the only supported interface.
+2. **Never edit `templates/base.html`.** If the template produces something
+   ugly, file it as feedback — do not patch in place.
+3. **No `<script>`.** No JavaScript under any circumstances.
+4. **No external resources.** No CDN fonts, no CDN CSS, no external images,
+   no preconnect hints, no `<link>` to anything.
+5. **Only `https://` URLs.** Plus `mailto:`, `#anchor`, or `/relative`. No
+   `http://`, no `javascript:`, no `data:` in anchors.
+6. **Images only as base64 data URIs.** `data:image/(png|jpeg|gif|webp|svg+xml);base64,...`
+   Pre-render charts to PNG if you need graphics.
+7. **No `style=` attributes.** The design system lives in the template.
+   Trust it.
+8. **No `on*=` event handlers.** Ever.
+9. **Hard size cap: 8 MiB** (self-imposed; paperclip server limit is 10 MiB).
+   If the report is too big, drop or downsample figures.
+
+## Workflow — end to end
+
+Run this from inside any container that has Python 3 (e.g., the paperclip
+container). All paperclip env vars are auto-injected during agent runs.
+
+```bash
+# 1. Compose the report spec as JSON
+cat > /tmp/report.json <<'JSON'
+{
+  "title": "Q1 2026 Infrastructure Review",
+  "subtitle": "Reliability and cost posture",
+  "lang": "en",
+  "author": "Infra Team",
+  "date": "2026-04-10",
+  "executive_summary": {
+    "text": "Latency down 24%, storage cost down $4.2k/mo, three incidents closed."
+  },
+  "sections": [
+    { "type": "heading", "level": 2, "text": "Overview", "anchor": true },
+    { "type": "text", "text": "Quarter started with a regional failover drill..." },
+    { "type": "heading", "level": 2, "text": "Metrics", "anchor": true },
+    {
+      "type": "table",
+      "caption": "Regional latency, ms",
+      "head": [["Region", "p50", "p99"]],
+      "rows": [
+        ["us-east", "30", "142"],
+        ["eu-west", "42", "188"]
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "warn",
+      "title": "Heads up",
+      "body": "Backup window overlaps peak traffic in ap-south."
+    }
+  ],
+  "references": [
+    { "label": "PostgreSQL 16 release notes", "url": "https://www.postgresql.org/docs/16/release-16.html" }
+  ]
+}
+JSON
+
+# 2. Build + validate (one step)
+python3 /app/skills/html-report/scripts/build_report.py \
+  --input /tmp/report.json \
+  --out   /tmp/report.html
+# exit 0  → /tmp/report.html ready
+# exit 1  → IO / JSON parse error — read stderr
+# exit 2  → structural / validator error — read stderr, fix JSON, retry
+# exit 3  → output > 8 MiB — shrink images
+
+# 3. Upload to the current issue as an attachment
+ATTACH_JSON=$(curl -fsS -X POST \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -F "file=@/tmp/report.html;type=text/html" \
+  "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues/$PAPERCLIP_TASK_ID/attachments")
+
+ATTACH_PATH=$(printf '%s' "$ATTACH_JSON" | python3 -c 'import sys,json;print(json.load(sys.stdin)["contentPath"])')
+
+# 4. Post a comment with the download link
+curl -fsS -X POST \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H "Content-Type: application/json" \
+  -d "{\"body\":\"HTML report ready — [скачать]($ATTACH_PATH)\"}" \
+  "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/comments"
+```
+
+Key facts for the agent reading this:
+
+- `$PAPERCLIP_API_URL`, `$PAPERCLIP_API_KEY`, `$PAPERCLIP_COMPANY_ID`,
+  `$PAPERCLIP_RUN_ID`, `$PAPERCLIP_TASK_ID` are auto-injected during
+  heartbeat runs. Never hard-code them.
+- The attachments endpoint returns an `IssueAttachment` object that
+  **already includes `contentPath`** (e.g. `/api/attachments/<id>/content`).
+  Use it directly — do not construct the URL by hand.
+- When the user clicks the link in the paperclip UI, the browser downloads
+  the file and opens it in a new tab as a standalone document. This is a
+  feature, not a limitation — the report is isolated from the paperclip UI
+  and can be saved, printed, forwarded.
+
+## Block types (quick reference)
+
+| `type`       | What it is                                     |
+|--------------|------------------------------------------------|
+| `heading`    | `<h2>`–`<h6>`, optionally anchored for the TOC |
+| `text`       | Paragraph (plain string or inline spans)       |
+| `list`       | `<ul>` or `<ol>`                               |
+| `table`      | Data table with optional caption               |
+| `figure`     | Image (base64 data URI only) + caption         |
+| `callout`    | Info / good / warn / bad aside                 |
+| `code_block` | `<pre><code>`                                  |
+| `details`    | Native collapsible section                     |
+| `divider`    | `<hr>`                                         |
+
+Full field-by-field spec in `references/input-schema.md`.
+
+## Troubleshooting — top 5 errors
+
+If the builder exits non-zero, the first line of stderr starts with an
+error code. The fixes below cover most cases. Full catalog in
+`references/troubleshooting.md`.
+
+- **`E303 href '...' must be https://, mailto:, #fragment or /relative`**
+  You have an `http://` link or `javascript:` in a span's `href`. Rewrite
+  it as `https://` or drop it.
+- **`E001 string contains reserved slot token '@@PAPERCLIP_SLOT:'`**
+  Your JSON contains the literal substring `@@PAPERCLIP_SLOT:` somewhere.
+  Remove it — you almost certainly didn't mean to include it.
+- **`E021 unknown block type 'X'`**
+  You used a block `type` that doesn't exist. Allowed: `heading, text, list,
+  table, figure, callout, code_block, details, divider`.
+- **`E029 figure.image.data_uri must be data:image/...`**
+  You linked an external image or used a wrong MIME type. Pre-render to PNG
+  and embed as `data:image/png;base64,...`.
+- **`E030 output is X MiB, exceeds 8 MiB self-cap`**
+  The produced HTML is too big. Almost always because of a huge base64
+  image — downsample it or drop it entirely.
+
+## Bundled files
+
+```
+skills/html-report/
+├── SKILL.md                     # this file
+├── templates/base.html          # the locked template (do not edit)
+├── scripts/
+│   ├── build_report.py          # JSON → HTML + validate (main entry)
+│   └── validate_html.py         # standalone validator
+├── examples/
+│   ├── minimal.json             # smallest happy path
+│   ├── rich.json                # kitchen sink (ru + en, table, figure, code, details)
+│   ├── bad-external-css.json    # should fail with E303
+│   └── bad-script.json          # should fail with E303
+└── references/
+    ├── input-schema.md          # full JSON spec
+    ├── content-whitelist.md     # allowed/forbidden tags and attributes
+    ├── design-tokens.md         # CSS variable rationale
+    └── troubleshooting.md       # full E-code catalog
+```
+
+## Smoke test (manual, not for agents to run in a live issue)
+
+```bash
+# inside the paperclip container or on any host with python3
+python3 /app/skills/html-report/scripts/build_report.py \
+  --input /app/skills/html-report/examples/rich.json \
+  --out   /tmp/rich.html
+# exit 0, 13 KB of HTML, cyrillic + english, tables, callouts, figure, details
+```
+
+## What this skill deliberately does NOT do
+
+- No Chromium / headless browser rendering.
+- No native PDF output — user presses `Print → Save as PDF`.
+- No JavaScript-powered charts (Chart.js, D3, Plotly, Mermaid). Pre-render
+  to PNG instead.
+- No inline SVG. Use `<img src="data:image/svg+xml;base64,...">` via the
+  `figure` block.
+- No theme overrides from JSON — the palette is locked. If you need a
+  different look, file feedback.
+- No custom templates. Only `templates/base.html`.
+- No upload from inside `build_report.py` — the script never touches your
+  `$PAPERCLIP_API_KEY`. Upload is a separate `curl` step, shown above.

--- a/skills/html-report/examples/bad-external-css.json
+++ b/skills/html-report/examples/bad-external-css.json
@@ -1,0 +1,23 @@
+{
+  "title": "Should fail",
+  "sections": [
+    {
+      "type": "heading",
+      "level": 2,
+      "text": "Trying to sneak in a CDN link",
+      "anchor": true
+    },
+    {
+      "type": "text",
+      "spans": [
+        { "kind": "text", "text": "Click " },
+        {
+          "kind": "link",
+          "text": "here",
+          "href": "http://fonts.googleapis.com/css?family=Roboto"
+        },
+        { "kind": "text", "text": " for nothing." }
+      ]
+    }
+  ]
+}

--- a/skills/html-report/examples/bad-script.json
+++ b/skills/html-report/examples/bad-script.json
@@ -1,0 +1,27 @@
+{
+  "title": "Should fail",
+  "sections": [
+    {
+      "type": "code_block",
+      "language": "javascript",
+      "code": "alert('this is only text — ok')"
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "text": "Trying to sneak a javascript: href",
+      "anchor": true
+    },
+    {
+      "type": "text",
+      "spans": [
+        { "kind": "text", "text": "Bad link: " },
+        {
+          "kind": "link",
+          "text": "click me",
+          "href": "javascript:alert(1)"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/html-report/examples/minimal.json
+++ b/skills/html-report/examples/minimal.json
@@ -1,0 +1,43 @@
+{
+  "title": "Minimal Report",
+  "subtitle": "Smallest valid input",
+  "lang": "en",
+  "author": "smoke test",
+  "date": "2026-04-10",
+  "executive_summary": {
+    "text": "A one-paragraph summary that renders as a single <p> inside the summary card."
+  },
+  "sections": [
+    {
+      "type": "heading",
+      "level": 2,
+      "text": "Overview",
+      "anchor": true
+    },
+    {
+      "type": "text",
+      "text": "Plain paragraph of prose. Nothing fancy. No spans, no styling, no images."
+    },
+    {
+      "type": "text",
+      "spans": [
+        { "kind": "text",   "text": "A span-based paragraph with " },
+        { "kind": "strong", "text": "bold" },
+        { "kind": "text",   "text": ", " },
+        { "kind": "em",     "text": "italic" },
+        { "kind": "text",   "text": " and " },
+        { "kind": "code",   "text": "inline_code()" },
+        { "kind": "text",   "text": " pieces." }
+      ]
+    },
+    {
+      "type": "list",
+      "style": "ul",
+      "items": [
+        "First bullet",
+        "Second bullet",
+        "Third bullet"
+      ]
+    }
+  ]
+}

--- a/skills/html-report/examples/rich.json
+++ b/skills/html-report/examples/rich.json
@@ -1,0 +1,155 @@
+{
+  "title": "Q1 2026 Платформенный обзор",
+  "subtitle": "Надёжность, стоимость и направления на следующий квартал",
+  "lang": "ru",
+  "author": "Infra Team",
+  "date": "2026-04-10",
+  "issue_ref": "INF-318",
+  "executive_summary": {
+    "blocks": [
+      {
+        "type": "text",
+        "text": "За Q1 2026 команда платформы стабилизировала p99 API-латентность, сократила месячные расходы на хранилище и закрыла три инцидента с базой данных. Ниже — конкретные цифры и план на Q2."
+      },
+      {
+        "type": "list",
+        "style": "ul",
+        "items": [
+          [
+            { "kind": "strong", "text": "p99 latency" },
+            { "kind": "text",   "text": ": 188 → 142 ms (−24%)" }
+          ],
+          [
+            { "kind": "strong", "text": "Storage spend" },
+            { "kind": "text",   "text": ": $12 400 → $8 200 / mo" }
+          ],
+          [
+            { "kind": "strong", "text": "Incidents" },
+            { "kind": "text",   "text": ": 5 → 2 (−60%)" }
+          ]
+        ]
+      }
+    ]
+  },
+  "sections": [
+    {
+      "type": "heading",
+      "level": 2,
+      "text": "Обзор",
+      "anchor": true
+    },
+    {
+      "type": "text",
+      "text": "Quarter started with a regional failover drill and ended with a successful PostgreSQL 16 upgrade. Мы выдержали два пиковых дня без деградации SLA."
+    },
+    {
+      "type": "text",
+      "spans": [
+        { "kind": "text",   "text": "Главный прогресс — p99 упал до " },
+        { "kind": "code",   "text": "142ms" },
+        { "kind": "text",   "text": " после миграции реплики. См. " },
+        { "kind": "link",   "text": "runbook", "href": "https://example.com/runbooks/failover" },
+        { "kind": "text",   "text": " для деталей." }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "text": "Metrics",
+      "anchor": true
+    },
+    {
+      "type": "table",
+      "caption": "Региональная задержка API, p50 / p99 (ms)",
+      "head": [["Регион", "p50", "p99", "Δ p99"]],
+      "rows": [
+        ["us-east", "30",  "142", "−24%"],
+        ["eu-west", "42",  "188", "−18%"],
+        ["ap-south","68",  "264", "−9%"]
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "warn",
+      "title": "Heads up",
+      "body": [
+        {
+          "type": "text",
+          "text": "Окно бэкапа БД (02:00–04:00 UTC) пересекается с пиковым трафиком в ap-south. В Q2 необходимо сдвинуть его на 00:00 UTC."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "good",
+      "title": "Win",
+      "body": "PostgreSQL 16 upgrade прошёл без simpатического downtime благодаря logical replication."
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "text": "Deployment playbook",
+      "anchor": true
+    },
+    {
+      "type": "text",
+      "text": "Стандартный сценарий деплоя для новой версии сервиса:"
+    },
+    {
+      "type": "code_block",
+      "language": "bash",
+      "code": "docker compose build api\ndocker compose up -d --no-deps api\ncurl -fsS http://localhost:3100/health"
+    },
+    {
+      "type": "details",
+      "summary": "Сырые цифры p99 по дням (раскрыть)",
+      "body": [
+        {
+          "type": "table",
+          "head": [["Дата", "p99 ms"]],
+          "rows": [
+            ["2026-01-01", "188"],
+            ["2026-01-15", "176"],
+            ["2026-02-01", "162"],
+            ["2026-02-15", "155"],
+            ["2026-03-01", "149"],
+            ["2026-03-15", "144"],
+            ["2026-04-01", "142"]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "text": "Diagram",
+      "anchor": true
+    },
+    {
+      "type": "figure",
+      "image": {
+        "data_uri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII=",
+        "alt": "1x1 transparent pixel placeholder",
+        "width": 64
+      },
+      "caption": "Placeholder diagram — в реальном отчёте заменить на pre-rendered PNG трендов."
+    }
+  ],
+  "references": [
+    {
+      "label": "PostgreSQL 16 release notes",
+      "url": "https://www.postgresql.org/docs/16/release-16.html"
+    },
+    {
+      "label": "Internal runbook: Regional failover",
+      "text": "ops/runbooks/regional-failover.md"
+    }
+  ],
+  "metadata": {
+    "generated_by": "smoke-test",
+    "report_version": "rich-v1"
+  }
+}

--- a/skills/html-report/references/content-whitelist.md
+++ b/skills/html-report/references/content-whitelist.md
@@ -1,0 +1,124 @@
+# html-report content whitelist
+
+Exhaustive list of what is allowed and what is forbidden in a rendered
+html-report document. The validator (`scripts/validate_html.py`) enforces
+every rule here on the final HTML; the builder (`scripts/build_report.py`)
+enforces most of them earlier, on the JSON input.
+
+## Allowed tags
+
+### Document shell (emitted by the template, not by user content)
+
+`html, head, title, meta, style, body`
+
+### Landmarks / structural
+
+`header, footer, main, nav, section, article, aside, div, span`
+
+### Text flow
+
+`h1, h2, h3, h4, h5, h6, p, ul, ol, li, strong, em, code, pre, blockquote, a, hr, br`
+
+### Tables
+
+`table, thead, tbody, tfoot, tr, th, td, caption`
+
+### Media / semantic
+
+`figure, figcaption, img`
+
+### Native interactivity (no JavaScript)
+
+`details, summary`
+
+## Allowed attributes
+
+| Tag | Attributes |
+|-----|------------|
+| `html` | `lang` |
+| `meta` | `charset`, `name`, `content` — **not** `http-equiv` |
+| `a` | `href` (scheme restricted, see below), `title`, `rel` |
+| `img` | `src` (data URI only), `alt`, `width`, `height` |
+| `table`, `th`, `td` | `colspan`, `rowspan`, `scope` |
+| any | `id`, `class` |
+
+## Forbidden tags — validator will reject
+
+- `script` — **unconditionally**, including self-closing `<script/>`
+- `iframe`, `object`, `embed`, `frame`, `frameset`, `applet` — no sandboxing surface
+- `form`, `input`, `textarea`, `select` — no interactive forms
+- `button` with `type="submit"` — no form submission
+- `link` — the template emits none and none are allowed in content (external resources banned)
+- `base` — could redirect relative URLs
+- `svg`, `math` — inline vector graphics are not allowed in v1 (use `<img src="data:image/svg+xml;base64,...">` instead)
+
+## Forbidden attributes — validator will reject
+
+- **Any attribute named `on*`** — `onclick`, `onerror`, `onload`, `onmouseover`, etc.
+- **`style`** — no inline styles; the design system in `templates/base.html` is the only source of truth
+- `http-equiv="refresh"` on `<meta>` — no redirects
+
+## URL scheme rules
+
+### `<a href>`
+
+Allowed:
+
+- `https://...` — external links, must be TLS
+- `mailto:...` — email
+- `#anchor` — same-document anchor (TOC entries)
+- `/path` or `./path` — relative, non-absolute
+
+Forbidden:
+
+- `http://...` — plain HTTP not allowed (mixed-content risk, MITM)
+- `javascript:...` — XSS
+- `data:...` — only allowed in `<img src>`, not in `<a href>`
+- `ftp://`, `file://`, `gopher://`, etc.
+
+### `<img src>`
+
+Only `data:image/(png|jpe?g|gif|webp|svg+xml);base64,<base64 payload>` is
+allowed. External `https://` images are **not** allowed because:
+
+1. They break on locked-down corporate networks.
+2. They leak reader-browser IPs to third parties.
+3. The report is supposed to be a single-file archival artifact.
+
+For charts/graphs, pre-render them to PNG in the agent's environment and
+embed the base64.
+
+### `<link href>`
+
+The validator rejects any `<link>` whose `href` is not a `data:` URI or `#`
+fragment. In practice, no `<link>` should appear in a produced report — the
+template has none and the block model never emits one.
+
+## Structural rules enforced by the validator
+
+- Every opening tag must close, nested correctly (`E100`, `E101`, `E102`).
+- `<p>` may not contain `<p>` (`E103`).
+- Block-level elements (including `<div>`, `<p>`, `<h1>`–`<h6>`, `<table>`,
+  `<ul>`, `<ol>`, `<figure>`, `<pre>`, etc.) may not appear inside inline
+  ancestors (`<span>`, `<a>`, `<strong>`, `<em>`, `<code>`) (`E104`).
+- `<li>` must be inside `<ul>` or `<ol>` (`E105`).
+- `<tr>`, `<td>`, `<th>` must be inside `<table>` (`E106`).
+- Exactly one `<style>` tag is allowed, and only inside `<head>` (`E204`).
+- `<!doctype html>`, `<html>`, `<head>`, `<body>` must all be present
+  (`E501`).
+
+## Data URI format for images
+
+Regex: `^data:image/(png|jpe?g|gif|webp|svg+xml);base64,[A-Za-z0-9+/=\s]+$`
+
+- Whitespace inside the base64 payload is allowed (fine for wrapping).
+- Types other than PNG/JPEG/GIF/WebP/SVG are rejected.
+- **Do not** use `data:image/x-icon` or `data:image/avif` — not on the list.
+
+## Summary: the five rules that catch 90% of agent mistakes
+
+1. **No `http://`** — always `https://`, or relative, or `mailto:`.
+2. **No external resources** — no CDN fonts, no CDN CSS, no external images.
+3. **No scripts** — ever.
+4. **No `style=` attributes** — trust the template, use block `type`s instead.
+5. **Images as base64 data URIs only** — pre-render if needed.

--- a/skills/html-report/references/design-tokens.md
+++ b/skills/html-report/references/design-tokens.md
@@ -1,0 +1,108 @@
+# html-report design tokens
+
+The single source of truth for how an html-report looks lives in
+`templates/base.html`, inside the `:root` block of the inline `<style>`.
+This document explains each token and **why it is locked in v1**.
+
+Do not override these via `style=` attributes in block content — the
+validator will reject such attempts with `E301`. If a palette change is
+ever needed, it happens here, not in agent output.
+
+## Palette (slate + teal, light print-friendly)
+
+| Token           | Value     | Used for                                         |
+|-----------------|-----------|--------------------------------------------------|
+| `--bg`          | `#fbfaf7` | Page background — warm off-white, easier on eyes than pure white, prints clean |
+| `--surface`     | `#ffffff` | Cards / details / summary box                    |
+| `--surface-elev`| `#f7f6f1` | Opened details background                        |
+| `--ink`         | `#1f2937` | Primary text — dark slate, high contrast without being harsh black |
+| `--muted`       | `#64748b` | Secondary text, captions, metadata, TOC          |
+| `--border`      | `#e5e7eb` | Hairlines, table rules, section dividers         |
+| `--accent`      | `#0f766e` | Links, h1 eyebrow, info callouts, blockquote rule |
+| `--accent-soft` | `#ccfbf1` | Info callout background                          |
+| `--good`        | `#15803d` | Positive callout accent                          |
+| `--good-soft`   | `#dcfce7` | Positive callout background                      |
+| `--warn`        | `#b45309` | Warning callout accent                           |
+| `--warn-soft`   | `#fef3c7` | Warning callout background                       |
+| `--bad`         | `#b91c1c` | Error callout accent                             |
+| `--bad-soft`    | `#fee2e2` | Error callout background                         |
+| `--code-bg`     | `#f1f5f4` | `<pre>` / `<code>` background                    |
+
+### Why slate + teal
+
+- **Neutral enough for any domain** — biomed research, infra postmortem,
+  sales dashboard, financial brief. No cultural or product-category bias.
+- **Prints cleanly** — no gradients, no semi-transparent backdrops, no
+  dark-mode ambiguity.
+- **Restrained accent** — a single teal anchors the document. More than one
+  accent color is "AI-aesthetic" territory and looks amateurish.
+- **Cyrillic-safe** — system font stack fallbacks cover both Latin and
+  Cyrillic letterforms consistently across macOS/Windows/Linux clients.
+
+## Typography
+
+| Token          | Stack                                                          | Used for                  |
+|----------------|----------------------------------------------------------------|---------------------------|
+| `--font-sans`  | `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif` | Body text, callouts, nav |
+| `--font-serif` | `"Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Times New Roman", Times, serif` | Headings h1–h6           |
+| `--font-mono`  | `ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace` | `<code>`, `<pre>`        |
+
+### Why system fonts only
+
+- **Zero external requests.** No Google Fonts, no Adobe Typekit, no preconnect
+  hints. Reports open on air-gapped machines and locked-down corporate
+  networks.
+- **Instant first paint.** System fonts are already resident in memory.
+- **Cyrillic coverage.** Segoe UI (Windows), SF/Apple system fonts (macOS),
+  Roboto (Android/Chrome), Noto Sans / Liberation Sans (Linux) all ship with
+  Cyrillic glyphs. No "tofu" boxes.
+- **No licensing ambiguity.** Reports can be archived and distributed without
+  tracking font licences.
+
+## Layout
+
+| Property           | Value       | Rationale                                        |
+|--------------------|-------------|--------------------------------------------------|
+| `max-width`        | `820px`     | Classic reading-width for ~75-character lines; still big enough for tables and figures |
+| Horizontal padding | `28px`      | Breathing room without eating into the column    |
+| `--radius`         | `8px`       | Single corner radius — more would be decorative  |
+| `--shadow`         | 2-stop soft | Hint of depth on the summary card, invisible on print |
+
+No sticky sidebar, no two-column layouts. Single linear column because:
+
+1. `Print → Save as PDF` from any browser produces a clean A4/Letter result
+   out of the box.
+2. Mobile renders it without media queries.
+3. Readers don't have to scan a navigation that isn't really useful in a
+   one-shot document.
+
+## Print rules
+
+`@media print` rules in `templates/base.html`:
+
+- Body background removed, text forced to pure black.
+- Container paddings collapsed so browser margins take over.
+- Links get `a::after { content: " (" attr(href) ")" }` — only for external
+  links; anchor links (`href^="#"`) stay clean.
+- `page-break-inside: avoid` on `figure`, `table`, `.callout`, `pre`,
+  `blockquote`, `h2`, `h3` — stops a heading orphaning itself at the bottom
+  of a page.
+- `details:not([open])` content is forced visible so nothing is hidden in a
+  printed PDF.
+- Summary card loses its elevation shadow and becomes a plain outlined box.
+- `@page { margin: 18mm 16mm }` — safe A4 margins; browsers override with
+  their own for US Letter if the user prints that way.
+
+## If something genuinely does not look right
+
+Do not patch it with `style=` in block content. Do not add another
+CSS variable from the agent side. Instead:
+
+1. File the feedback with a concrete reproducer (minimal JSON + what looked
+   wrong + which browser).
+2. A human editor updates `templates/base.html`.
+3. Smoke tests (`examples/minimal.json`, `examples/rich.json`) are re-run.
+4. The change ships.
+
+The whole point of locking design tokens is that reports from six months ago
+look identical to reports from tomorrow. Do not break that invariant.

--- a/skills/html-report/references/input-schema.md
+++ b/skills/html-report/references/input-schema.md
@@ -1,0 +1,270 @@
+# html-report input JSON schema
+
+This is the full specification of the JSON you pass to `build_report.py`.
+It is the **only** interface for authoring reports — never write HTML by hand,
+never edit `templates/base.html`.
+
+## Top-level object
+
+```jsonc
+{
+  "title":              "string, required",
+  "subtitle":           "string, optional",
+  "lang":               "string, optional — ISO 639-1 (e.g. 'en', 'ru', 'en-US'), default 'en'",
+  "author":             "string, optional — plain text, rendered in footer + eyebrow",
+  "date":               "string, optional — ISO date 'YYYY-MM-DD', rendered alongside author",
+  "issue_ref":          "string, optional — e.g. 'INF-318', rendered in footer",
+  "executive_summary":  "string | object, optional — see below",
+  "sections":           "array, required — list of block objects (may be empty)",
+  "references":         "array, optional — list of reference objects",
+  "metadata":           "object, optional — flat string→string map, rendered in footer"
+}
+```
+
+Unknown top-level keys → warning on stderr, not a hard error.
+
+## `lang`
+
+Must match the regex `^[a-z]{2}(-[A-Z]{2})?$`. Examples: `en`, `ru`, `en-US`,
+`ru-RU`. Sets `<html lang="...">`. Does NOT affect fonts — the system font
+stack covers Latin and Cyrillic.
+
+## `executive_summary`
+
+Three accepted shapes:
+
+```jsonc
+// 1. Plain string — wrapped in <p>
+"executive_summary": "Three sentences that a busy CTO reads in 30s."
+
+// 2. Object with text
+"executive_summary": { "text": "Three sentences..." }
+
+// 3. Object with spans (for inline emphasis)
+"executive_summary": {
+  "spans": [
+    { "kind": "text",   "text": "Latency dropped to " },
+    { "kind": "strong", "text": "142ms" },
+    { "kind": "text",   "text": "." }
+  ]
+}
+
+// 4. Object with blocks (for multi-paragraph / mixed content)
+"executive_summary": {
+  "blocks": [
+    { "type": "text", "text": "First paragraph..." },
+    { "type": "list", "style": "ul", "items": ["a", "b", "c"] }
+  ]
+}
+```
+
+## `sections` — list of blocks
+
+A section is an array of block objects. Each block has a mandatory `type`.
+Allowed types:
+
+| `type`       | Purpose |
+|--------------|---------|
+| `heading`    | `<h2>`–`<h6>`, optionally anchored for TOC |
+| `text`       | A paragraph (plain or with inline spans) |
+| `list`       | `<ul>` or `<ol>` |
+| `table`      | Data table with optional caption |
+| `figure`     | `<img>` (data URI only) + caption |
+| `callout`    | Info/good/warn/bad aside |
+| `code_block` | Preformatted code |
+| `details`    | Collapsible section |
+| `divider`    | Horizontal rule |
+
+### Block: `heading`
+
+```jsonc
+{
+  "type": "heading",
+  "level": 2,              // int, 2..6. h1 is reserved for the report title.
+  "text":  "Section name",
+  "anchor": true,          // optional; if true, include in TOC
+  "id": "custom-id"        // optional; defaults to slug of text if anchor=true
+}
+```
+
+If `anchor` is `true`, the heading also lands in the table of contents at the
+top of the report. IDs are slugified (`text.lower()` with non-word chars
+replaced by `-`) with a monotonic suffix on collisions.
+
+### Block: `text`
+
+```jsonc
+// Plain
+{ "type": "text", "text": "A normal paragraph." }
+
+// With inline emphasis — use when you need strong/em/code/link inline
+{
+  "type": "text",
+  "spans": [
+    { "kind": "text",   "text": "Hit " },
+    { "kind": "code",   "text": "/health" },
+    { "kind": "text",   "text": " — see the " },
+    { "kind": "link",   "text": "runbook", "href": "https://example.com" }
+  ]
+}
+```
+
+#### Span kinds
+
+| `kind`  | Rendered | Required fields |
+|---------|----------|-----------------|
+| `text`  | plain text, escaped | `text` |
+| `strong`| `<strong>` | `text` |
+| `em`    | `<em>` | `text` |
+| `code`  | `<code>` | `text` |
+| `link`  | `<a href>` | `text`, `href` (must be https:// / mailto: / # / /) |
+
+### Block: `list`
+
+```jsonc
+{
+  "type": "list",
+  "style": "ul",           // or "ol"
+  "items": [
+    "A plain string",
+    [
+      { "kind": "text",   "text": "Or a " },
+      { "kind": "strong", "text": "spans array" },
+      { "kind": "text",   "text": " for inline emphasis." }
+    ]
+  ]
+}
+```
+
+### Block: `table`
+
+```jsonc
+{
+  "type": "table",
+  "caption": "Optional caption above the table",
+  "head": [["Column A", "Column B", "Column C"]],
+  "rows": [
+    ["cell 1a", "cell 1b", "cell 1c"],
+    ["cell 2a", "cell 2b", "cell 2c"]
+  ]
+}
+```
+
+Cells may be plain strings or spans arrays (same shape as inline spans above).
+`head` is a `list[list]` so you can have multi-row headers if needed.
+
+### Block: `figure`
+
+```jsonc
+{
+  "type": "figure",
+  "image": {
+    "data_uri": "data:image/png;base64,iVBORw0KGgo...",
+    "alt":   "Description for screen readers and print",
+    "width": 720           // optional, int pixels, 1..4096
+  },
+  "caption": "Optional caption below the figure"
+}
+```
+
+**Only data URIs are allowed.** The regex is
+`^data:image/(png|jpe?g|gif|webp|svg+xml);base64,[A-Za-z0-9+/=]+$`.
+For charts, pre-render them to PNG outside and embed as base64.
+
+### Block: `callout`
+
+```jsonc
+{
+  "type": "callout",
+  "variant": "warn",       // "info" (default) | "good" | "warn" | "bad"
+  "title": "Heads up",     // optional
+  "body": "A plain string OR a block / list of blocks (like sections)."
+}
+```
+
+`body` is recursive — you can put tables, lists, whatever inside.
+
+### Block: `code_block`
+
+```jsonc
+{
+  "type": "code_block",
+  "language": "bash",      // optional; [a-z0-9+-]{1,20}, used only as a class hint
+  "code": "docker compose up -d\ncurl -fsS http://localhost:3100/health"
+}
+```
+
+No syntax highlighting is applied (no JS). The `language` is just a class name
+for potential future use or for user-side print styling.
+
+### Block: `details`
+
+```jsonc
+{
+  "type": "details",
+  "summary": "Click to expand",
+  "body": [
+    { "type": "text", "text": "Hidden content, rendered only when expanded." },
+    { "type": "table", "head": [["k", "v"]], "rows": [["x", "1"]] }
+  ]
+}
+```
+
+Uses the native HTML `<details>/<summary>` — no JavaScript required. When
+printed, the `@media print` rules in the template force all `details` content
+visible regardless of state.
+
+### Block: `divider`
+
+```jsonc
+{ "type": "divider" }
+```
+
+Renders as `<hr>`.
+
+## `references`
+
+```jsonc
+"references": [
+  {
+    "label": "PostgreSQL 16 release notes",
+    "url":   "https://www.postgresql.org/docs/16/release-16.html"
+  },
+  {
+    "label": "Internal runbook",
+    "text":  "ops/runbooks/regional-failover.md"
+  }
+]
+```
+
+- `label` — required, plain text.
+- `url` — optional; must pass the same href scheme check as links.
+- `text` — optional; rendered muted next to the label, e.g. for non-URL sources.
+
+References are rendered as a numbered list at the bottom of the report, inside
+`<section class="references">`.
+
+## `metadata`
+
+Flat string→string map. Rendered in the footer as `<p><strong>key:</strong> value</p>`
+pairs. Use for things like `run_id`, `report_version`, `agent_id`, etc.
+
+## Exit codes from `build_report.py`
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Success, HTML on stdout or at `--out` |
+| `1`  | CLI or IO error, or JSON parse error |
+| `2`  | Structural validation error (bad block, bad span, bad href, slot collision, or validator rejected produced HTML) |
+| `3`  | Produced HTML is larger than 8 MiB (paperclip hard limit is 10 MiB) |
+
+## Error codes summary
+
+Full catalog in `references/troubleshooting.md`. Most common ones:
+
+- `E001` — JSON contains the reserved substring `@@PAPERCLIP_SLOT:`
+- `E021` — unknown block `type`
+- `E030` — output too large
+- `E200`/`E201` — external resource / script leaked into produced HTML
+- `E303` — bad href scheme (must be https, mailto, #, /)
+- `E400` — tag outside whitelist

--- a/skills/html-report/references/troubleshooting.md
+++ b/skills/html-report/references/troubleshooting.md
@@ -1,0 +1,142 @@
+# html-report troubleshooting
+
+Catalog of error codes emitted by `build_report.py` and `validate_html.py`,
+with symptoms and fixes. Each message has the shape:
+
+```
+CODE:LINE:COL: message
+```
+
+The `LINE`/`COL` are positions in the produced HTML when the validator
+rejects rendered output; for input-schema errors the position is a JSON
+path like `$.sections[3].body.items[0]`.
+
+## Input / build errors (from `build_report.py`)
+
+| Code | Symptom | Cause | Fix |
+|------|---------|-------|-----|
+| `E001` | `$.<path>: string contains reserved slot token '@@PAPERCLIP_SLOT:'` | Some string in the JSON contains the literal substring `@@PAPERCLIP_SLOT:`, which is the template slot marker | Remove the substring from your content — you almost certainly did not mean to include it |
+| `E002` | `top-level JSON must be an object` | Top-level value is not a JSON object | Wrap your content in `{ }` |
+| `E003` | `$.sections must be a list` | `sections` missing or not an array | Provide `"sections": [ ... ]` (may be empty) |
+| `E004` | `$.lang <value> must match ...` | `lang` does not match `[a-z]{2}(-[A-Z]{2})?` | Use `"en"`, `"ru"`, `"en-US"`, etc. |
+| `E005` | `template missing slot @@PAPERCLIP_SLOT:...@@` | Template was hand-edited and a slot was removed | Do not edit `templates/base.html` |
+| `E006` | `template has unknown leftover slot` | Custom template introduced an unknown slot | Same as above — use the bundled template |
+| `E007` | `validator rejected produced HTML: ...` | The rendered HTML did not pass the policy validator. The nested lines give the actual `E1xx–E5xx` codes | Read the nested errors and fix the offending block |
+| `E008` | `cannot read input / template: ...` | Filesystem error | Check paths and permissions |
+| `E009` | `invalid JSON: ...` | Malformed JSON (trailing comma, unquoted key, etc.) | Fix the JSON; `python3 -m json.tool < file.json` helps |
+| `E010` / `E011` | `field X must be a string` | Required string missing or wrong type | Provide the field as a non-empty string |
+| `E012`–`E017` | `spans ...` | Inline span list is malformed | Each span must be either a plain string or `{kind, text, [href]}` with a valid `kind` |
+| `E020` / `E021` | `block must be an object / unknown block type` | Section block is not an object, or has an unknown `type` | Use one of: `heading, text, list, table, figure, callout, code_block, details, divider` |
+| `E022` | `heading.level must be an int 2..6` | Bad heading level | Only `h2`–`h6` are available; `h1` is reserved for the report title |
+| `E023` | `heading.id must be a string` | Non-string id | Remove the `id` to auto-slug, or provide a string |
+| `E024` | `list.style must be 'ul' or 'ol'` | Bad list style | Use exactly `"ul"` or `"ol"` |
+| `E025` | `list.items must be a non-empty list` | Empty list | Add at least one item, or drop the block |
+| `E026` / `E027` | `table.head / table.rows must be list[list]` | Table structure wrong | Both must be arrays of arrays |
+| `E028` | `figure.image must be an object` | Missing or wrong-type image | Provide `{data_uri, alt, [width]}` |
+| `E029` | `figure.image.data_uri must be data:image/...` | URL is not a data URI, or wrong MIME type | Pre-render to PNG/JPEG/WebP and base64-encode |
+| `E031` | `figure.image.alt must be a string` | Missing / wrong type | Always provide `alt` text, even an empty string is better than missing |
+| `E032` | `figure.image.width must be int 1..4096` | Bad width | Integer pixels, 1..4096 |
+| `E033` | `callout.variant must be one of ...` | Unknown variant | Use `info`, `good`, `warn`, or `bad` |
+| `E034` | `code_block.code must be a string` | Missing code | Provide the code text |
+| `E035` | `code_block.language must match ...` | Bad language string | Use lowercase letters, digits, `+`, `-`, max 20 chars (e.g. `bash`, `python`, `c++`) |
+| `E036` | `body must be string, object, or list` | Callout/details body has wrong shape | Pass a single block, a list of blocks, or a plain string |
+| `E040` | `executive_summary must be string or object with 'text' \| 'spans' \| 'blocks'` | Summary has wrong shape | Use one of the four allowed shapes |
+| `E050` / `E051` | `references ...` | References list is malformed | Each entry must be `{label, [url], [text]}` |
+| `E030` | `output is N MiB, exceeds 8 MiB self-cap` | Produced HTML > 8 MiB (usually giant base64 images) | Downsample or drop images; text is rarely the problem |
+| `E303` | `href '<value>' must be https://, mailto:, #fragment or /relative` | Unsafe link scheme | Rewrite the URL — `http://` is not allowed (use `https://` or drop the link) |
+
+## Rendered-HTML validation errors (from `validate_html.py`)
+
+These are only reached if the builder successfully rendered the HTML but
+the validator then noticed a policy violation. Almost all of these indicate
+a bug in the builder or a hand-edited template — they should be
+unreachable from pure JSON input. Report them.
+
+### Well-formedness (E100s)
+
+| Code | Symptom | Fix |
+|------|---------|-----|
+| `E100` | `<tag> opened but never closed` | Builder bug — report it |
+| `E101` | `</x> does not match currently open <y>` | Builder bug — report it |
+| `E102` | `</x> with no matching opening tag` | Builder bug — report it |
+| `E103` | `<p> may not contain another <p>` | You put a `text` block inside another `text` block's spans, or a heading inside a paragraph. Split into siblings |
+| `E104` | `<block> inside <inline> not allowed` | You nested a block-level element (table/list/etc.) inside an inline context. Split into siblings |
+| `E105` | `<li> outside <ul>/<ol>` | Builder bug — report it |
+| `E106` | `<tr>/<td>/<th> outside <table>` | Builder bug — report it |
+
+### External resources (E200s)
+
+| Code | Symptom | Fix |
+|------|---------|-----|
+| `E200` | `<link href=... > external resource forbidden` | Template was hand-edited with a CDN `<link>`. Revert the template |
+| `E201` | `<script> is forbidden` | A `<script>` slipped into output. Usually means the template was tampered with, or the slot token was bypassed |
+| `E202` | `<img src> must be data:image/...;base64,...` | Figure image URI is wrong. See `E029` |
+| `E203` | `<iframe/object/embed/frame/frameset/applet> forbidden` | Template was tampered with |
+| `E204` | `<style> outside <head>` or duplicated | Template has extra `<style>`. Revert the template |
+| `E205` | `<base> is forbidden` | Template was tampered with |
+| `E206` | `<meta http-equiv='refresh'>` | Template was tampered with |
+
+### Event handlers & dangerous attributes (E300s)
+
+| Code | Symptom | Fix |
+|------|---------|-----|
+| `E300` | `<tag> has event handler attribute 'onX'` | Some attribute starting with `on` slipped through. Builder bug — report it |
+| `E301` | `<tag> has inline style attribute` | Someone put `style=` into a block. Use design tokens instead, never inline styles |
+| `E302` | `<tag attr=...> uses javascript: URL` | A `javascript:` URL was found in an attribute. Should have been caught by `E303` first |
+| `E303` | See input-errors table above | Fix the `href` |
+| `E304` | `<form/input/textarea/select/button type='submit'> forbidden` | No forms allowed in reports |
+
+### Whitelist & shell (E400s / E500s)
+
+| Code | Symptom | Fix |
+|------|---------|-----|
+| `E400` | `<tag> not in allowed tag whitelist` | Tag outside the whitelist in `content-whitelist.md`. Switch to an allowed tag |
+| `E500` | `input HTML is empty` | Builder bug — report it |
+| `E501` | `missing <!doctype html> / <html> / <head> / <body>` | Template was hand-edited |
+
+## The five problems that account for 90% of rejected reports
+
+1. **`E303` bad href.** You typed `http://` instead of `https://`, or you
+   put a URL with no scheme expecting it to resolve. Always use `https://`,
+   `mailto:`, `#anchor`, or `/relative`.
+2. **`E029` bad image data URI.** You embedded an image URL instead of a
+   base64 data URI, or you used a MIME type other than PNG/JPEG/GIF/WebP/SVG.
+3. **`E030` file too large.** You embedded a high-resolution figure without
+   downsampling. Aim for PNGs under 500 KB before base64; base64 adds ~33%
+   overhead.
+4. **`E021` unknown block type.** You typed `paragraph` instead of `text`,
+   `image` instead of `figure`, `note` instead of `callout`. See the list in
+   `input-schema.md`.
+5. **`E001` accidental slot token.** The literal substring `@@PAPERCLIP_SLOT:`
+   is reserved. If you see this, remove that substring from your content.
+
+## How to debug a rejected report
+
+```bash
+# 1. Save your JSON input
+cat > /tmp/report.json <<'JSON'
+{ "title": ... }
+JSON
+
+# 2. Run the builder and read stderr carefully
+python3 /app/skills/html-report/scripts/build_report.py \
+  --input /tmp/report.json --out /tmp/report.html 2>&1
+
+# 3. If it got as far as producing HTML but validator rejected it,
+#    run the standalone validator to get line/column numbers:
+python3 /app/skills/html-report/scripts/validate_html.py /tmp/report.html
+
+# 4. For input-schema errors, the message includes the JSON path like
+#    $.sections[3].body.items[0] — navigate there in your JSON and fix.
+```
+
+## When to escalate
+
+Report a bug (not user error) if you see any of:
+
+- Any `E100`–`E106` while using structured blocks only (no hand-edited template).
+- Any `E200`–`E206`, `E500`, or `E501`.
+- `E030` with a report that has **no** images and is still > 8 MiB.
+- `E400` from a tag that the block model should not emit.
+
+These indicate either a builder bug or a tampered template.

--- a/skills/html-report/scripts/build_report.py
+++ b/skills/html-report/scripts/build_report.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env python3
+"""
+build_report.py — JSON → self-contained HTML report (html-report skill).
+
+Usage:
+
+    python3 build_report.py --input report.json --out report.html
+    python3 build_report.py < report.json > report.html
+
+Exit codes:
+    0 — success, HTML written
+    1 — CLI / IO / JSON-parse error
+    2 — structural validation error (bad input or bad produced HTML)
+    3 — produced HTML exceeds the 8 MiB self-cap
+
+No third-party dependencies. Python standard library only.
+The produced HTML is fully self-contained: inline CSS, no scripts,
+no external resources, images only as data: URIs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import sys
+from pathlib import Path
+
+# Allow `from validate_html import validate` when running as a script.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+import validate_html  # noqa: E402
+
+
+SLOT_TOKEN = "@@PAPERCLIP_SLOT:"
+SIZE_CAP_BYTES = 8 * 1024 * 1024  # 8 MiB — gives headroom under paperclip's 10 MiB
+
+DEFAULT_TEMPLATE = _SCRIPT_DIR.parent / "templates" / "base.html"
+
+_SLUG_RE = re.compile(r"[^\w\u00c0-\uffff]+", re.UNICODE)
+_LANG_RE = re.compile(r"^[a-z]{2}(-[A-Z]{2})?$")
+_HREF_SAFE_RE = re.compile(r"^(https:|mailto:|#|/)")
+_DATA_IMAGE_RE = re.compile(
+    r"^data:image/(png|jpe?g|gif|webp|svg\+xml);base64,[A-Za-z0-9+/=\s]+$"
+)
+_LANGUAGE_RE = re.compile(r"^[a-z0-9+\-]{1,20}$")
+_CALLOUT_VARIANTS = {"info", "good", "warn", "bad"}
+_LIST_STYLES = {"ul", "ol"}
+_SPAN_KINDS = {"text", "strong", "em", "code", "link"}
+
+_ALL_BLOCK_TYPES = {
+    "heading", "text", "list", "table", "figure",
+    "callout", "code_block", "details", "divider",
+}
+
+
+# ---------------------------------------------------------------------------
+# Input errors
+# ---------------------------------------------------------------------------
+
+
+class InputError(Exception):
+    """Structural problem in the JSON input."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.msg = message
+
+
+def _err(code: str, message: str) -> InputError:
+    return InputError(code, message)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _esc(value: str) -> str:
+    """HTML-escape a string. Everything user-provided goes through this."""
+    return html.escape(value if value is not None else "", quote=True)
+
+
+def _require_str(obj: dict, key: str, ctx: str) -> str:
+    val = obj.get(key)
+    if not isinstance(val, str) or not val:
+        raise _err("E010", f"{ctx}: field {key!r} must be a non-empty string")
+    return val
+
+
+def _optional_str(obj: dict, key: str, ctx: str) -> str | None:
+    val = obj.get(key)
+    if val is None:
+        return None
+    if not isinstance(val, str):
+        raise _err("E011", f"{ctx}: field {key!r} must be a string or null")
+    return val
+
+
+def _scan_for_slot_tokens(value, path: str = "$") -> None:
+    """Recursively refuse any string that contains the slot token."""
+    if isinstance(value, str):
+        if SLOT_TOKEN in value:
+            raise _err(
+                "E001",
+                f"{path}: string contains reserved slot token "
+                f"{SLOT_TOKEN!r} — refusing to substitute",
+            )
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            _scan_for_slot_tokens(v, f"{path}.{k}")
+    elif isinstance(value, list):
+        for i, v in enumerate(value):
+            _scan_for_slot_tokens(v, f"{path}[{i}]")
+
+
+def _check_href(href: str, ctx: str) -> str:
+    stripped = href.strip()
+    if not _HREF_SAFE_RE.match(stripped):
+        raise _err(
+            "E303",
+            f"{ctx}: href {stripped!r} must be https://, mailto:, "
+            f"#fragment or /relative",
+        )
+    return stripped
+
+
+# ---------------------------------------------------------------------------
+# Inline spans → HTML
+# ---------------------------------------------------------------------------
+
+
+def _render_spans(spans: object, ctx: str) -> str:
+    if not isinstance(spans, list):
+        raise _err("E012", f"{ctx}: spans must be a list")
+    parts: list[str] = []
+    for i, span in enumerate(spans):
+        span_ctx = f"{ctx}[{i}]"
+        if isinstance(span, str):
+            parts.append(_esc(span))
+            continue
+        if not isinstance(span, dict):
+            raise _err("E013", f"{span_ctx}: span must be string or object")
+        kind = span.get("kind")
+        if kind not in _SPAN_KINDS:
+            raise _err("E014", f"{span_ctx}: span.kind must be one of {_SPAN_KINDS}")
+        text = span.get("text", "")
+        if not isinstance(text, str):
+            raise _err("E015", f"{span_ctx}: span.text must be a string")
+        if kind == "text":
+            parts.append(_esc(text))
+        elif kind == "strong":
+            parts.append(f"<strong>{_esc(text)}</strong>")
+        elif kind == "em":
+            parts.append(f"<em>{_esc(text)}</em>")
+        elif kind == "code":
+            parts.append(f"<code>{_esc(text)}</code>")
+        elif kind == "link":
+            href = span.get("href")
+            if not isinstance(href, str):
+                raise _err("E016", f"{span_ctx}: link span missing href")
+            safe = _check_href(href, span_ctx)
+            parts.append(f'<a href="{_esc(safe)}">{_esc(text)}</a>')
+    return "".join(parts)
+
+
+def _render_inline(content, ctx: str) -> str:
+    """Accept either a plain string or a spans list → inline HTML."""
+    if isinstance(content, str):
+        return _esc(content)
+    if isinstance(content, list):
+        return _render_spans(content, ctx)
+    raise _err("E017", f"{ctx}: expected string or spans list")
+
+
+# ---------------------------------------------------------------------------
+# Slug / TOC
+# ---------------------------------------------------------------------------
+
+
+class _SlugGenerator:
+    def __init__(self) -> None:
+        self._seen: dict[str, int] = {}
+
+    def make(self, text: str) -> str:
+        base = _SLUG_RE.sub("-", text.lower()).strip("-") or "section"
+        n = self._seen.get(base, 0) + 1
+        self._seen[base] = n
+        return base if n == 1 else f"{base}-{n}"
+
+
+# ---------------------------------------------------------------------------
+# Block rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_block(block, slugger: _SlugGenerator, toc: list[tuple[str, str]],
+                  ctx: str) -> str:
+    if not isinstance(block, dict):
+        raise _err("E020", f"{ctx}: block must be an object")
+    btype = block.get("type")
+    if btype not in _ALL_BLOCK_TYPES:
+        raise _err(
+            "E021",
+            f"{ctx}: unknown block type {btype!r}; allowed: "
+            f"{sorted(_ALL_BLOCK_TYPES)}",
+        )
+
+    if btype == "heading":
+        level = block.get("level", 2)
+        if not isinstance(level, int) or not 2 <= level <= 6:
+            raise _err("E022", f"{ctx}: heading.level must be an int 2..6")
+        text = _require_str(block, "text", ctx)
+        anchor = bool(block.get("anchor", False))
+        hid = block.get("id")
+        if anchor:
+            if hid is None:
+                hid = slugger.make(text)
+            elif not isinstance(hid, str):
+                raise _err("E023", f"{ctx}: heading.id must be a string")
+            toc.append((hid, text))
+            return f'<h{level} id="{_esc(hid)}">{_esc(text)}</h{level}>'
+        return f"<h{level}>{_esc(text)}</h{level}>"
+
+    if btype == "text":
+        if "spans" in block:
+            inner = _render_spans(block["spans"], f"{ctx}.spans")
+        else:
+            inner = _esc(_require_str(block, "text", ctx))
+        return f"<p>{inner}</p>"
+
+    if btype == "list":
+        style = block.get("style", "ul")
+        if style not in _LIST_STYLES:
+            raise _err("E024", f"{ctx}: list.style must be 'ul' or 'ol'")
+        items = block.get("items")
+        if not isinstance(items, list) or not items:
+            raise _err("E025", f"{ctx}: list.items must be a non-empty list")
+        lis: list[str] = []
+        for i, item in enumerate(items):
+            inner = _render_inline(item, f"{ctx}.items[{i}]")
+            lis.append(f"<li>{inner}</li>")
+        return f"<{style}>{''.join(lis)}</{style}>"
+
+    if btype == "table":
+        head = block.get("head") or []
+        rows = block.get("rows") or []
+        if not isinstance(head, list) or not all(isinstance(r, list) for r in head):
+            raise _err("E026", f"{ctx}: table.head must be list[list]")
+        if not isinstance(rows, list) or not all(isinstance(r, list) for r in rows):
+            raise _err("E027", f"{ctx}: table.rows must be list[list]")
+        parts: list[str] = ["<table>"]
+        caption = _optional_str(block, "caption", ctx)
+        if caption:
+            parts.append(f"<caption>{_esc(caption)}</caption>")
+        if head:
+            parts.append("<thead>")
+            for hrow in head:
+                parts.append("<tr>")
+                for cell in hrow:
+                    parts.append(f"<th>{_render_inline(cell, ctx)}</th>")
+                parts.append("</tr>")
+            parts.append("</thead>")
+        parts.append("<tbody>")
+        for row in rows:
+            parts.append("<tr>")
+            for cell in row:
+                parts.append(f"<td>{_render_inline(cell, ctx)}</td>")
+            parts.append("</tr>")
+        parts.append("</tbody></table>")
+        return "".join(parts)
+
+    if btype == "figure":
+        image = block.get("image")
+        if not isinstance(image, dict):
+            raise _err("E028", f"{ctx}: figure.image must be an object")
+        data_uri = image.get("data_uri", "")
+        if not isinstance(data_uri, str) or not _DATA_IMAGE_RE.match(data_uri.strip()):
+            raise _err(
+                "E029",
+                f"{ctx}: figure.image.data_uri must be "
+                f"data:image/(png|jpe?g|gif|webp|svg+xml);base64,...",
+            )
+        alt = image.get("alt", "")
+        if not isinstance(alt, str):
+            raise _err("E031", f"{ctx}: figure.image.alt must be a string")
+        width = image.get("width")
+        width_attr = ""
+        if width is not None:
+            if not isinstance(width, int) or width <= 0 or width > 4096:
+                raise _err("E032", f"{ctx}: figure.image.width must be int 1..4096")
+            width_attr = f' width="{width}"'
+        caption = _optional_str(block, "caption", ctx)
+        figcap = f"<figcaption>{_esc(caption)}</figcaption>" if caption else ""
+        return (
+            f'<figure><img src="{_esc(data_uri.strip())}" '
+            f'alt="{_esc(alt)}"{width_attr}>{figcap}</figure>'
+        )
+
+    if btype == "callout":
+        variant = block.get("variant", "info")
+        if variant not in _CALLOUT_VARIANTS:
+            raise _err("E033", f"{ctx}: callout.variant must be one of {_CALLOUT_VARIANTS}")
+        title = _optional_str(block, "title", ctx)
+        body = block.get("body")
+        body_html = _render_body(body, slugger, toc, f"{ctx}.body")
+        title_html = (
+            f'<p class="callout-title">{_esc(title)}</p>' if title else ""
+        )
+        return (
+            f'<aside class="callout callout--{variant}">'
+            f"{title_html}{body_html}</aside>"
+        )
+
+    if btype == "code_block":
+        code_text = block.get("code", "")
+        if not isinstance(code_text, str):
+            raise _err("E034", f"{ctx}: code_block.code must be a string")
+        language = block.get("language")
+        lang_attr = ""
+        if language is not None:
+            if not isinstance(language, str) or not _LANGUAGE_RE.match(language):
+                raise _err(
+                    "E035",
+                    f"{ctx}: code_block.language must match {_LANGUAGE_RE.pattern}",
+                )
+            lang_attr = f' class="lang-{language}"'
+        return f"<pre><code{lang_attr}>{_esc(code_text)}</code></pre>"
+
+    if btype == "details":
+        summary = _require_str(block, "summary", ctx)
+        body = block.get("body")
+        body_html = _render_body(body, slugger, toc, f"{ctx}.body")
+        return (
+            f"<details><summary>{_esc(summary)}</summary>"
+            f"{body_html}</details>"
+        )
+
+    if btype == "divider":
+        return "<hr>"
+
+    # unreachable — caught above
+    raise _err("E021", f"{ctx}: unknown block type {btype!r}")
+
+
+def _render_body(body, slugger: _SlugGenerator,
+                 toc: list[tuple[str, str]], ctx: str) -> str:
+    """Body may be a single block, a list of blocks, or a plain string."""
+    if body is None:
+        return ""
+    if isinstance(body, str):
+        return f"<p>{_esc(body)}</p>"
+    if isinstance(body, dict):
+        return _render_block(body, slugger, toc, ctx)
+    if isinstance(body, list):
+        return "".join(
+            _render_block(b, slugger, toc, f"{ctx}[{i}]")
+            for i, b in enumerate(body)
+        )
+    raise _err("E036", f"{ctx}: body must be string, object, or list")
+
+
+# ---------------------------------------------------------------------------
+# Top-level rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_executive_summary(summary, slugger, toc, ctx: str) -> str:
+    if summary is None:
+        return ""
+    if isinstance(summary, str):
+        return f"<p>{_esc(summary)}</p>"
+    if isinstance(summary, dict):
+        if "text" in summary:
+            return f"<p>{_esc(str(summary['text']))}</p>"
+        if "spans" in summary:
+            return f"<p>{_render_spans(summary['spans'], f'{ctx}.spans')}</p>"
+        if "blocks" in summary:
+            return _render_body(summary["blocks"], slugger, toc, f"{ctx}.blocks")
+    raise _err(
+        "E040",
+        f"{ctx}: executive_summary must be string or object with "
+        f"'text' | 'spans' | 'blocks'",
+    )
+
+
+def _render_references(refs, ctx: str) -> str:
+    if not refs:
+        return ""
+    if not isinstance(refs, list):
+        raise _err("E050", f"{ctx}: references must be a list")
+    items: list[str] = []
+    for i, ref in enumerate(refs):
+        ref_ctx = f"{ctx}[{i}]"
+        if not isinstance(ref, dict):
+            raise _err("E051", f"{ref_ctx}: reference must be an object")
+        label = _require_str(ref, "label", ref_ctx)
+        url = _optional_str(ref, "url", ref_ctx)
+        text = _optional_str(ref, "text", ref_ctx)
+        if url:
+            safe = _check_href(url, ref_ctx)
+            line = f'<a href="{_esc(safe)}">{_esc(label)}</a>'
+        else:
+            line = f"<strong>{_esc(label)}</strong>"
+        if text:
+            line += f' <span class="ref-text">— {_esc(text)}</span>'
+        items.append(f"<li>{line}</li>")
+    return f'<h2 id="references">References</h2><ol class="refs">{"".join(items)}</ol>'
+
+
+def _render_toc(toc: list[tuple[str, str]]) -> str:
+    if not toc:
+        return ""
+    items = "".join(
+        f'<li><a href="#{_esc(hid)}">{_esc(text)}</a></li>'
+        for hid, text in toc
+    )
+    return f'<ol class="toc-list">{items}</ol>'
+
+
+def _render_footer(data: dict, ctx: str) -> str:
+    parts: list[str] = []
+    author = _optional_str(data, "author", ctx)
+    date = _optional_str(data, "date", ctx)
+    issue_ref = _optional_str(data, "issue_ref", ctx)
+    bits: list[str] = []
+    if author:
+        bits.append(_esc(author))
+    if date:
+        bits.append(_esc(date))
+    if issue_ref:
+        bits.append(f"Issue {_esc(issue_ref)}")
+    if bits:
+        parts.append(f"<p>{' · '.join(bits)}</p>")
+    metadata = data.get("metadata") or {}
+    if isinstance(metadata, dict) and metadata:
+        for k, v in metadata.items():
+            if not isinstance(k, str):
+                continue
+            parts.append(f"<p><strong>{_esc(k)}:</strong> {_esc(str(v))}</p>")
+    parts.append("<p>Generated by paperclip/html-report</p>")
+    return "".join(parts)
+
+
+def _render_meta_line(data: dict) -> str:
+    """Small eyebrow line above the h1."""
+    bits: list[str] = []
+    author = data.get("author")
+    date = data.get("date")
+    if isinstance(author, str) and author:
+        bits.append(_esc(author))
+    if isinstance(date, str) and date:
+        bits.append(_esc(date))
+    return " · ".join(bits) if bits else "Report"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def build(data: object, template_text: str) -> str:
+    """Full pipeline: validate → render → substitute → validate HTML."""
+    if not isinstance(data, dict):
+        raise _err("E002", "top-level JSON must be an object")
+    _scan_for_slot_tokens(data)
+
+    # Required
+    title = _require_str(data, "title", "$")
+    sections = data.get("sections")
+    if not isinstance(sections, list):
+        raise _err("E003", "$.sections must be a list")
+
+    # Optional
+    subtitle = _optional_str(data, "subtitle", "$") or ""
+    lang = _optional_str(data, "lang", "$") or "en"
+    if not _LANG_RE.match(lang):
+        raise _err("E004", f"$.lang {lang!r} must match [a-z]{{2}}(-[A-Z]{{2}})?")
+
+    slugger = _SlugGenerator()
+    toc: list[tuple[str, str]] = []
+
+    body_parts: list[str] = []
+    for i, block in enumerate(sections):
+        body_parts.append(_render_block(block, slugger, toc, f"$.sections[{i}]"))
+    body_html = "".join(body_parts)
+
+    summary_html = _render_executive_summary(
+        data.get("executive_summary"), slugger, toc, "$.executive_summary"
+    )
+    refs_html = _render_references(data.get("references"), "$.references")
+    toc_html = _render_toc(toc)
+    footer_html = _render_footer(data, "$")
+    meta_line = _render_meta_line(data)
+
+    # Substitute
+    slots = {
+        "lang": _esc(lang),
+        "title": _esc(title),
+        "subtitle": _esc(subtitle),
+        "meta": meta_line,
+        "toc": toc_html,
+        "executive_summary": summary_html,
+        "body": body_html,
+        "references": refs_html,
+        "footer": footer_html,
+    }
+    result = template_text
+    for slot_name, slot_value in slots.items():
+        token = f"{SLOT_TOKEN}{slot_name}@@"
+        if token not in result:
+            raise _err("E005", f"template missing slot {token}")
+        result = result.replace(token, slot_value)
+
+    # Sanity: no leftover slot tokens
+    if SLOT_TOKEN in result:
+        leftover = result.split(SLOT_TOKEN, 1)[1].split("@@", 1)[0]
+        raise _err("E006", f"template has unknown leftover slot {leftover!r}")
+
+    # Final policy validation on the rendered HTML.
+    errors = validate_html.validate(result)
+    if errors:
+        rendered = "\n".join(
+            f"{e.code}:{e.line}:{e.col}: {e.message}" for e in errors
+        )
+        raise _err("E007", "validator rejected produced HTML:\n" + rendered)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _read_input(path: str | None) -> dict:
+    try:
+        if path:
+            raw = Path(path).read_text(encoding="utf-8")
+        else:
+            raw = sys.stdin.read()
+    except OSError as exc:
+        raise _err("E008", f"cannot read input: {exc}") from exc
+    if not raw.strip():
+        raise _err("E009", "input is empty")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise _err("E009", f"invalid JSON: {exc.msg} at line {exc.lineno}") from exc
+
+
+def _read_template(path: str | None) -> str:
+    template_path = Path(path) if path else DEFAULT_TEMPLATE
+    try:
+        return template_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise _err("E008", f"cannot read template {template_path}: {exc}") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Build a self-contained HTML report from a JSON spec.",
+    )
+    ap.add_argument("--input", help="JSON input file (default: stdin)")
+    ap.add_argument("--out", help="HTML output file (default: stdout)")
+    ap.add_argument("--template", help=f"Template override (default: {DEFAULT_TEMPLATE})")
+    ap.add_argument("--quiet", action="store_true", help="Suppress progress on stderr")
+    args = ap.parse_args(argv)
+
+    quiet = args.quiet
+
+    def log(*items: object, **kwargs: object) -> None:
+        if quiet:
+            return
+        print(*items, file=sys.stderr, **kwargs)  # type: ignore[arg-type]
+
+    try:
+        data = _read_input(args.input)
+        template = _read_template(args.template)
+    except InputError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    try:
+        html_text = build(data, template)
+    except InputError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    size = len(html_text.encode("utf-8"))
+    if size > SIZE_CAP_BYTES:
+        mib = size / (1024 * 1024)
+        print(
+            f"E030:0:0: output is {mib:.2f} MiB, exceeds 8 MiB self-cap "
+            f"(paperclip hard limit is 10 MiB)",
+            file=sys.stderr,
+        )
+        return 3
+
+    log(f"html-report: rendered {size} bytes, validator clean")
+
+    if args.out:
+        Path(args.out).write_text(html_text, encoding="utf-8")
+    else:
+        sys.stdout.write(html_text)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/html-report/scripts/validate_html.py
+++ b/skills/html-report/scripts/validate_html.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""
+validate_html.py — stdlib-only HTML validator for the html-report skill.
+
+Two usage modes:
+
+    # 1. Standalone CLI — validate a file on disk:
+    python3 validate_html.py /path/to/report.html
+    # exit 0 on clean, exit 2 on any error, errors printed to stderr.
+
+    # 2. Importable API — used by build_report.py after slot substitution:
+    from validate_html import validate
+    errors = validate(html_text)
+    if errors:
+        ...
+
+The validator enforces the html-report security and correctness contract:
+no scripts, no external resources, no event handlers, no style attributes,
+no raw inline <svg>, only whitelisted tags, well-formed nesting.
+
+No third-party dependencies — Python standard library only (html.parser, re,
+sys, pathlib, argparse, collections).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import namedtuple
+from html.parser import HTMLParser
+from pathlib import Path
+
+ValidationError = namedtuple("ValidationError", "line col code message")
+
+
+# ---------------------------------------------------------------------------
+# Policy constants
+# ---------------------------------------------------------------------------
+
+# Tags that may appear anywhere in a valid report. Anything outside this set
+# triggers E400.
+ALLOWED_TAGS: frozenset[str] = frozenset({
+    # document shell
+    "html", "head", "title", "meta", "style", "body",
+    # landmark / structural
+    "header", "footer", "main", "nav", "section", "article", "aside",
+    "div", "span",
+    # headings and text flow
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "p", "ul", "ol", "li",
+    "strong", "em", "code", "pre", "blockquote",
+    "a", "hr", "br",
+    # tables
+    "table", "thead", "tbody", "tfoot", "tr", "th", "td", "caption",
+    # media / semantic
+    "figure", "figcaption", "img",
+    # native interactivity (no JS)
+    "details", "summary",
+})
+
+# Tags that are block-level for nesting purposes. A <p> cannot contain any of
+# these; an inline ancestor (see INLINE_ANCESTORS) cannot either.
+BLOCK_TAGS: frozenset[str] = frozenset({
+    "div", "p", "section", "article", "header", "footer", "nav", "aside",
+    "main", "table", "thead", "tbody", "tfoot", "tr", "ul", "ol", "li",
+    "figure", "figcaption", "pre", "blockquote",
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "details", "summary", "hr",
+})
+
+# Inline elements that must not contain block-level descendants.
+INLINE_ANCESTORS: frozenset[str] = frozenset({
+    "span", "a", "strong", "em", "code",
+})
+
+# Tags that are hard-forbidden even though html.parser will parse them.
+FORBIDDEN_TAGS: frozenset[str] = frozenset({
+    "script", "iframe", "object", "embed", "frame", "frameset", "applet",
+    "form", "input", "textarea", "select", "base",
+    # svg is only allowed via <img src="data:image/svg+xml;base64,..."> —
+    # inline <svg> is not permitted in v1.
+    "svg", "math",
+})
+
+# Void elements that do not need a closing tag.
+VOID_TAGS: frozenset[str] = frozenset({
+    "br", "hr", "img", "meta", "link", "input", "source", "area", "col",
+    "embed", "param", "track", "wbr", "base",
+})
+
+# Allowed URL schemes for <a href="...">. Empty string means relative/fragment.
+_ANCHOR_SAFE_SCHEMES: frozenset[str] = frozenset({"https", "mailto"})
+
+_DATA_IMAGE_RE = re.compile(
+    r"^data:image/(png|jpe?g|gif|webp|svg\+xml);base64,[A-Za-z0-9+/=\s]+$"
+)
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+class _ReportValidator(HTMLParser):
+    def __init__(self) -> None:
+        # convert_charrefs=False so we see raw entities if we ever need them.
+        super().__init__(convert_charrefs=True)
+        self.errors: list[ValidationError] = []
+        self.stack: list[tuple[str, int, int]] = []  # (tag, line, col)
+        self._style_count = 0
+        self._in_head = False
+        self._seen_doctype = False
+        self._seen_html = False
+        self._seen_head = False
+        self._seen_body = False
+
+    # --- helpers ----------------------------------------------------------
+
+    def _err(self, code: str, msg: str) -> None:
+        line, col = self.getpos()
+        self.errors.append(ValidationError(line, col, code, msg))
+
+    def _check_attrs(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        for name, value in attrs:
+            low = name.lower()
+
+            # E300 — any on* event handler
+            if low.startswith("on"):
+                self._err("E300", f"<{tag}> has event handler attribute {name!r}")
+
+            # E301 — inline style attribute
+            if low == "style":
+                self._err("E301", f"<{tag}> has inline style attribute")
+
+            # E302 — javascript: in URL-bearing attributes
+            if low in ("href", "src", "action", "formaction", "xlink:href") and value:
+                stripped = value.strip().lower()
+                if stripped.startswith("javascript:"):
+                    self._err("E302", f"<{tag} {name}=...> uses javascript: URL")
+
+            # E206 — meta http-equiv=refresh
+            if tag == "meta" and low == "http-equiv" and value and value.lower() == "refresh":
+                self._err("E206", "<meta http-equiv='refresh'> is forbidden")
+
+        # E303 — <a href> scheme check (https / mailto / # / / are ok)
+        if tag == "a":
+            for name, value in attrs:
+                if name.lower() == "href" and value is not None:
+                    v = value.strip()
+                    if v.startswith("#") or v.startswith("/"):
+                        continue
+                    if ":" in v:
+                        scheme = v.split(":", 1)[0].lower()
+                        if scheme not in _ANCHOR_SAFE_SCHEMES:
+                            self._err(
+                                "E303",
+                                f"<a href={v!r}> scheme {scheme!r} not allowed "
+                                f"(only https, mailto, #fragment, /relative)",
+                            )
+                    else:
+                        # no scheme, no fragment, no leading slash — treat as
+                        # relative; that is fine for same-document anchors.
+                        continue
+
+        # E200 — <link href=...> external
+        if tag == "link":
+            for name, value in attrs:
+                if name.lower() == "href" and value is not None:
+                    v = value.strip()
+                    if v.startswith("#") or v.startswith("data:"):
+                        continue
+                    if v:
+                        self._err(
+                            "E200",
+                            f"<link href={v!r}> external resource forbidden",
+                        )
+
+        # E202 — <img src> must be data:image/...;base64,...
+        if tag == "img":
+            src_val: str | None = None
+            for name, value in attrs:
+                if name.lower() == "src":
+                    src_val = value
+                    break
+            if src_val is None:
+                self._err("E202", "<img> missing src attribute")
+            else:
+                if not _DATA_IMAGE_RE.match(src_val.strip()):
+                    self._err(
+                        "E202",
+                        "<img src> must be data:image/(png|jpeg|gif|webp|svg+xml);base64,...",
+                    )
+
+    # --- handlers ---------------------------------------------------------
+
+    def handle_decl(self, decl: str) -> None:
+        if decl.lower().startswith("doctype"):
+            self._seen_doctype = True
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        line, col = self.getpos()
+
+        if tag == "html":
+            self._seen_html = True
+        elif tag == "head":
+            self._seen_head = True
+            self._in_head = True
+        elif tag == "body":
+            self._seen_body = True
+            self._in_head = False
+
+        # E201 — <script>
+        if tag == "script":
+            self._err("E201", "<script> is forbidden")
+
+        # E203 — iframes and friends
+        if tag in ("iframe", "object", "embed", "frame", "frameset", "applet"):
+            self._err("E203", f"<{tag}> is forbidden")
+
+        # E205 — <base>
+        if tag == "base":
+            self._err("E205", "<base> is forbidden")
+
+        # E304 — forms and inputs
+        if tag in ("form", "input", "textarea", "select"):
+            self._err("E304", f"<{tag}> is forbidden (no forms)")
+        if tag == "button":
+            for name, value in attrs:
+                if name.lower() == "type" and value and value.lower() == "submit":
+                    self._err("E304", "<button type='submit'> is forbidden")
+
+        # E204 — <style> only allowed once, only in <head>
+        if tag == "style":
+            self._style_count += 1
+            if self._style_count > 1:
+                self._err("E204", "<style> may only appear once (in <head>)")
+            if not self._in_head:
+                self._err("E204", "<style> outside <head> is forbidden")
+
+        # E400 — whitelist conformance (but forbidden tags already logged)
+        if tag not in ALLOWED_TAGS and tag not in FORBIDDEN_TAGS:
+            self._err("E400", f"<{tag}> not in allowed tag whitelist")
+
+        # E103 — <p> inside <p>
+        if tag == "p":
+            for t, _, _ in self.stack:
+                if t == "p":
+                    self._err("E103", "<p> may not contain another <p>")
+                    break
+
+        # E104 — block element inside an inline ancestor (scan outer-most
+        # inline ancestor, not whole stack)
+        if tag in BLOCK_TAGS:
+            for t, _, _ in self.stack:
+                if t in INLINE_ANCESTORS:
+                    self._err(
+                        "E104",
+                        f"<{tag}> (block) inside <{t}> (inline) is not allowed",
+                    )
+                    break
+
+        # E105 — <li> must be inside <ul>/<ol>
+        if tag == "li":
+            parent = self.stack[-1][0] if self.stack else None
+            if parent not in ("ul", "ol"):
+                self._err("E105", "<li> outside <ul>/<ol>")
+
+        # E106 — <tr>, <td>, <th> must be inside <table>
+        if tag in ("tr", "td", "th"):
+            if not any(t == "table" for t, _, _ in self.stack):
+                self._err("E106", f"<{tag}> outside <table>")
+
+        # Attribute scan
+        self._check_attrs(tag, attrs)
+
+        # Push on stack unless void
+        if tag not in VOID_TAGS:
+            self.stack.append((tag, line, col))
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        # Self-closing tag — run all start-tag checks but do not push.
+        tag = tag.lower()
+        if tag == "script":
+            self._err("E201", "<script/> is forbidden")
+        if tag in ("iframe", "object", "embed", "frame", "frameset", "applet"):
+            self._err("E203", f"<{tag}/> is forbidden")
+        if tag == "base":
+            self._err("E205", "<base/> is forbidden")
+        if tag not in ALLOWED_TAGS and tag not in FORBIDDEN_TAGS:
+            self._err("E400", f"<{tag}/> not in allowed tag whitelist")
+        self._check_attrs(tag, attrs)
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag == "head":
+            self._in_head = False
+        if tag in VOID_TAGS:
+            # Void tags should not have end tags; silently ignore.
+            return
+        if not self.stack:
+            self._err("E102", f"</{tag}> with no matching opening tag")
+            return
+        top, _, _ = self.stack[-1]
+        if top != tag:
+            self._err(
+                "E101",
+                f"</{tag}> does not match currently open <{top}>",
+            )
+            # Unwind until we find a match or empty the stack — makes
+            # subsequent errors meaningful instead of cascading.
+            while self.stack and self.stack[-1][0] != tag:
+                self.stack.pop()
+            if self.stack:
+                self.stack.pop()
+        else:
+            self.stack.pop()
+
+    def finish(self) -> None:
+        # E100 — any unclosed tags at EOF
+        for tag, line, _ in self.stack:
+            self.errors.append(
+                ValidationError(line, 0, "E100", f"<{tag}> opened but never closed")
+            )
+        # E501 — shell sanity
+        if not self._seen_doctype:
+            self.errors.insert(0, ValidationError(1, 0, "E501", "missing <!doctype html>"))
+        if not self._seen_html:
+            self.errors.insert(0, ValidationError(1, 0, "E501", "missing <html> element"))
+        if not self._seen_head:
+            self.errors.insert(0, ValidationError(1, 0, "E501", "missing <head> element"))
+        if not self._seen_body:
+            self.errors.insert(0, ValidationError(1, 0, "E501", "missing <body> element"))
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def validate(html_text: str, *, strict: bool = False) -> list[ValidationError]:
+    """
+    Validate an HTML document against the html-report policy.
+
+    Parameters
+    ----------
+    html_text : str
+        Full HTML document as a single string.
+    strict : bool
+        Reserved for future use; currently a no-op (all checks are strict).
+
+    Returns
+    -------
+    list[ValidationError]
+        Empty list on a clean document; one entry per violation otherwise.
+    """
+    del strict  # currently unused; every check is mandatory in v1
+
+    if not html_text or not html_text.strip():
+        return [ValidationError(1, 0, "E500", "input HTML is empty")]
+
+    parser = _ReportValidator()
+    try:
+        parser.feed(html_text)
+        parser.close()
+    except Exception as exc:  # noqa: BLE001 — html.parser rarely raises
+        parser.errors.append(
+            ValidationError(1, 0, "E102", f"parser error: {exc}")
+        )
+    parser.finish()
+    return parser.errors
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _format_error(err: ValidationError) -> str:
+    return f"{err.code}:{err.line}:{err.col}: {err.message}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Validate an HTML file against the html-report policy."
+    )
+    ap.add_argument(
+        "path",
+        nargs="?",
+        help="Path to HTML file. Omit to read from stdin.",
+    )
+    args = ap.parse_args(argv)
+
+    if args.path:
+        try:
+            html_text = Path(args.path).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"E000:0:0: cannot read {args.path}: {exc}", file=sys.stderr)
+            return 1
+    else:
+        html_text = sys.stdin.read()
+
+    errors = validate(html_text)
+    for err in errors:
+        print(_format_error(err), file=sys.stderr)
+    return 2 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/html-report/templates/base.html
+++ b/skills/html-report/templates/base.html
@@ -1,0 +1,323 @@
+<!doctype html>
+<html lang="@@PAPERCLIP_SLOT:lang@@">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="generator" content="paperclip/html-report/1.0">
+    <title>@@PAPERCLIP_SLOT:title@@</title>
+    <style>
+      :root {
+        --bg: #fbfaf7;
+        --surface: #ffffff;
+        --surface-elev: #f7f6f1;
+        --ink: #1f2937;
+        --muted: #64748b;
+        --border: #e5e7eb;
+        --accent: #0f766e;
+        --accent-soft: #ccfbf1;
+        --good: #15803d;
+        --good-soft: #dcfce7;
+        --warn: #b45309;
+        --warn-soft: #fef3c7;
+        --bad: #b91c1c;
+        --bad-soft: #fee2e2;
+        --code-bg: #f1f5f4;
+        --radius: 8px;
+        --shadow: 0 1px 2px rgba(15, 23, 42, 0.06), 0 4px 12px rgba(15, 23, 42, 0.04);
+
+        --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
+        --font-serif: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Times New Roman", Times, serif;
+        --font-mono: ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+      }
+
+      * { box-sizing: border-box; }
+
+      html { -webkit-text-size-adjust: 100%; }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family: var(--font-sans);
+        font-size: 16px;
+        line-height: 1.6;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+
+      main, header.report-header, nav.toc, footer {
+        max-width: 820px;
+        margin-left: auto;
+        margin-right: auto;
+        padding-left: 28px;
+        padding-right: 28px;
+      }
+
+      header.report-header {
+        padding-top: 56px;
+        padding-bottom: 32px;
+        border-bottom: 1px solid var(--border);
+      }
+
+      header.report-header .eyebrow {
+        margin: 0 0 12px;
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--accent);
+      }
+
+      h1, h2, h3, h4, h5, h6 {
+        font-family: var(--font-serif);
+        color: var(--ink);
+        line-height: 1.25;
+        margin-top: 1.8em;
+        margin-bottom: 0.5em;
+      }
+
+      header.report-header h1 {
+        margin: 0;
+        font-size: 36px;
+        letter-spacing: -0.01em;
+      }
+
+      header.report-header .lede {
+        margin: 8px 0 0;
+        color: var(--muted);
+        font-size: 18px;
+      }
+
+      h2 { font-size: 26px; border-bottom: 1px solid var(--border); padding-bottom: 6px; }
+      h3 { font-size: 21px; }
+      h4 { font-size: 18px; }
+      h5 { font-size: 16px; }
+      h6 { font-size: 14px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+
+      p { margin: 0 0 1em; }
+
+      a {
+        color: var(--accent);
+        text-decoration: underline;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 2px;
+      }
+      a:hover { text-decoration-thickness: 2px; }
+
+      strong { font-weight: 600; color: var(--ink); }
+      em { font-style: italic; }
+
+      code {
+        font-family: var(--font-mono);
+        font-size: 0.92em;
+        background: var(--code-bg);
+        padding: 0.1em 0.35em;
+        border-radius: 4px;
+        color: #0b4f48;
+      }
+
+      pre {
+        font-family: var(--font-mono);
+        background: var(--code-bg);
+        color: var(--ink);
+        padding: 16px 18px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        overflow-x: auto;
+        font-size: 14px;
+        line-height: 1.55;
+      }
+      pre code {
+        background: none;
+        padding: 0;
+        color: inherit;
+        font-size: inherit;
+      }
+
+      blockquote {
+        margin: 1em 0;
+        padding: 4px 18px;
+        border-left: 3px solid var(--accent);
+        color: var(--ink);
+        font-style: italic;
+      }
+      blockquote p:last-child { margin-bottom: 0; }
+
+      hr {
+        border: 0;
+        height: 1px;
+        background: var(--border);
+        margin: 2.2em 0;
+      }
+
+      ul, ol { padding-left: 1.4em; margin: 0 0 1em; }
+      li { margin-bottom: 0.35em; }
+      li > ul, li > ol { margin-top: 0.35em; margin-bottom: 0.35em; }
+
+      figure {
+        margin: 1.4em 0;
+      }
+      figure img {
+        display: block;
+        max-width: 100%;
+        height: auto;
+        border-radius: var(--radius);
+        border: 1px solid var(--border);
+      }
+      figcaption {
+        margin-top: 8px;
+        font-size: 14px;
+        color: var(--muted);
+        text-align: center;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1.2em 0;
+        font-size: 15px;
+      }
+      caption {
+        caption-side: top;
+        text-align: left;
+        padding-bottom: 8px;
+        font-size: 13px;
+        color: var(--muted);
+        font-weight: 600;
+      }
+      th, td {
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--border);
+        text-align: left;
+        vertical-align: top;
+      }
+      thead th {
+        font-weight: 600;
+        color: var(--muted);
+        border-bottom: 2px solid var(--border);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        font-size: 12px;
+      }
+      tbody tr:last-child td { border-bottom: 0; }
+
+      .callout {
+        margin: 1.4em 0;
+        padding: 14px 18px;
+        border-left: 3px solid var(--accent);
+        background: var(--accent-soft);
+        border-radius: 0 var(--radius) var(--radius) 0;
+      }
+      .callout-title {
+        margin: 0 0 6px;
+        font-weight: 600;
+        color: var(--ink);
+      }
+      .callout p:last-child { margin-bottom: 0; }
+      .callout--info { border-left-color: var(--accent); background: var(--accent-soft); }
+      .callout--good { border-left-color: var(--good);   background: var(--good-soft); }
+      .callout--warn { border-left-color: var(--warn);   background: var(--warn-soft); }
+      .callout--bad  { border-left-color: var(--bad);    background: var(--bad-soft); }
+
+      details {
+        margin: 1em 0;
+        padding: 12px 16px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        background: var(--surface);
+      }
+      details[open] { background: var(--surface-elev); }
+      summary {
+        cursor: pointer;
+        font-weight: 600;
+        color: var(--ink);
+      }
+      details > *:not(summary) { margin-top: 0.8em; }
+
+      nav.toc {
+        padding-top: 24px;
+        padding-bottom: 8px;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      nav.toc ol.toc-list {
+        list-style: decimal inside;
+        padding: 0;
+        margin: 0;
+      }
+      nav.toc ol.toc-list li { margin-bottom: 0.2em; }
+      nav.toc a { color: var(--ink); text-decoration: none; }
+      nav.toc a:hover { color: var(--accent); text-decoration: underline; }
+
+      section.summary {
+        margin-top: 2em;
+        padding: 22px 24px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+      }
+      section.summary > *:first-child { margin-top: 0; }
+      section.summary > *:last-child  { margin-bottom: 0; }
+
+      section.references ol.refs {
+        padding-left: 1.4em;
+        font-size: 14px;
+        color: var(--ink);
+      }
+      section.references ol.refs li { margin-bottom: 0.4em; }
+      section.references ol.refs li .ref-text { color: var(--muted); }
+
+      footer {
+        margin-top: 48px;
+        padding-top: 20px;
+        padding-bottom: 56px;
+        border-top: 1px solid var(--border);
+        color: var(--muted);
+        font-size: 13px;
+      }
+      footer p { margin: 0 0 4px; }
+
+      /* Print — first-class, since the whole point is that users print to PDF. */
+      @page { margin: 18mm 16mm; }
+
+      @media print {
+        body {
+          background: none;
+          color: #000;
+          font-size: 11pt;
+          line-height: 1.5;
+        }
+        main, header.report-header, nav.toc, footer { padding: 0; max-width: none; }
+        header.report-header { border-bottom-color: #000; padding-top: 0; padding-bottom: 16px; }
+        header.report-header h1 { font-size: 22pt; }
+        header.report-header .eyebrow { color: #000; }
+        h2 { border-bottom-color: #000; }
+        a { color: #000; text-decoration: underline; }
+        a::after { content: " (" attr(href) ")"; font-size: 0.85em; color: #555; }
+        /* ...but not for anchor links inside the TOC or in-document refs */
+        nav.toc a::after,
+        a[href^="#"]::after { content: ""; }
+        figure, table, .callout, pre, blockquote, h2, h3 { page-break-inside: avoid; }
+        details:not([open]) > *:not(summary) { display: block !important; }
+        details { page-break-inside: avoid; border-color: #000; background: none; }
+        section.summary { background: none; box-shadow: none; border-color: #000; }
+        footer { border-top-color: #000; }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="report-header">
+      <p class="eyebrow">@@PAPERCLIP_SLOT:meta@@</p>
+      <h1>@@PAPERCLIP_SLOT:title@@</h1>
+      <p class="lede">@@PAPERCLIP_SLOT:subtitle@@</p>
+    </header>
+    <nav class="toc" aria-label="Contents">@@PAPERCLIP_SLOT:toc@@</nav>
+    <main>
+      <section class="summary">@@PAPERCLIP_SLOT:executive_summary@@</section>
+      @@PAPERCLIP_SLOT:body@@
+      <section class="references">@@PAPERCLIP_SLOT:references@@</section>
+    </main>
+    <footer>@@PAPERCLIP_SLOT:footer@@</footer>
+  </body>
+</html>


### PR DESCRIPTION
Agents need to produce structured deliverables beyond plain markdown — reports, analyses, summaries
This PR adds the html-report skill for self-contained HTML reports
The benefit is beautiful, print-ready documents that work offline and archive perfectly

## What Changed

- Added skills/html-report/ — complete skill for generating self-contained HTML reports from JSON
- Python scripts: build_report.py (JSON→HTML) and validate_html.py (security enforcement)
- Locked template with inline CSS, print-optimized styles, no JS, no external resources
- Reference docs: input schema, content whitelist, design tokens, troubleshooting
- Examples for testing valid and invalid inputs

