### PR TITLE
fix: OpenClaw gateway schema, Claude probe rate limits, UI token + embedded PG root

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -379,6 +379,8 @@ export interface CreateConfigValues {
   envVars: string;
   envBindings: Record<string, unknown>;
   url: string;
+  /** OpenClaw gateway shared token (create flow → adapterConfig.headers.x-openclaw-token). */
+  openclawGatewayToken?: string;
   bootstrapPrompt: string;
   payloadTemplateJson?: string;
   workspaceStrategyType?: string;

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -21,7 +21,7 @@ Core fields:
 - chrome (boolean, optional): pass --chrome when running Claude
 - promptTemplate (string, optional): run prompt template
 - maxTurnsPerRun (number, optional): max turns for one run
-- dangerouslySkipPermissions (boolean, optional, default true): pass --dangerously-skip-permissions to claude; defaults to true because Paperclip runs Claude in headless --print mode where interactive permission prompts cannot be answered
+- dangerouslySkipPermissions (boolean, optional, default true on non-root): pass --dangerously-skip-permissions to claude; ignored (treated as false) when the Paperclip process runs as root, because Claude CLI forbids this flag for uid 0. On root, Paperclip injects --allowed-tools with a built-in list so headless runs (curl/Bash to the Paperclip API, skills, subagents) work without interactive approval; override or extend with extraArgs --allowed-tools if you need MCP tools by name
 - command (string, optional): defaults to "claude"
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -33,6 +33,11 @@ import {
 } from "./parse.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
+import {
+  CLAUDE_ROOT_HEADLESS_ALLOWED_TOOLS,
+  resolveDangerouslySkipPermissions,
+  shouldInjectRootHeadlessAllowedTools,
+} from "./process-defaults.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -332,7 +337,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effort = asString(config.effort, "");
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
-  const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+  const dangerouslySkipPermissions = resolveDangerouslySkipPermissions(config.dangerouslySkipPermissions);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   const runtimeConfig = await buildClaudeRuntimeConfig({
@@ -439,6 +444,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     attemptInstructionsFilePath: string | undefined,
   ) => {
     const args = ["--print", "-", "--output-format", "stream-json", "--verbose"];
+    if (shouldInjectRootHeadlessAllowedTools(dangerouslySkipPermissions, extraArgs)) {
+      args.push("--allowed-tools", CLAUDE_ROOT_HEADLESS_ALLOWED_TOOLS);
+    }
     if (resumeSessionId) args.push("--resume", resumeSessionId);
     if (dangerouslySkipPermissions) args.push("--dangerously-skip-permissions");
     if (chrome) args.push("--chrome");

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -7,6 +7,7 @@ export {
   describeClaudeFailure,
   isClaudeMaxTurnsResult,
   isClaudeUnknownSessionError,
+  isClaudeRateLimitedOutput,
 } from "./parse.js";
 export {
   getQuotaWindows,

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -1,5 +1,5 @@
 import type { UsageSummary } from "@paperclipai/adapter-utils";
-import { asString, asNumber, parseObject, parseJson } from "@paperclipai/adapter-utils/server-utils";
+import { asString, asNumber, asBoolean, parseObject, parseJson } from "@paperclipai/adapter-utils/server-utils";
 
 const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?|login\s+required|requires\s+login|unauthorized|authentication\s+required)/i;
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
@@ -176,4 +176,18 @@ export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): bo
   return allMessages.some((msg) =>
     /no conversation found with session id|unknown session|session .* not found/i.test(msg),
   );
+}
+
+/** True when stream-json shows a rate/quota limit (Claude often exits 1 with is_error despite valid output). */
+export function isClaudeRateLimitedOutput(stdout: string, resultJson: Record<string, unknown> | null): boolean {
+  if (
+    /rate_limit_event|"error"\s*:\s*"rate_limit"|hit your limit|you['']ve hit your limit/i.test(stdout)
+  ) {
+    return true;
+  }
+  if (!resultJson) return false;
+  if (asString(resultJson.error, "") === "rate_limit") return true;
+  if (!asBoolean(resultJson.is_error, false)) return false;
+  const resultText = asString(resultJson.result, "").trim();
+  return /limit|quota|rate/i.test(resultText);
 }

--- a/packages/adapters/claude-local/src/server/process-defaults.ts
+++ b/packages/adapters/claude-local/src/server/process-defaults.ts
@@ -1,0 +1,66 @@
+import { asBoolean } from "@paperclipai/adapter-utils/server-utils";
+
+export function isPaperclipRunningAsRoot(): boolean {
+  return typeof process.getuid === "function" && process.getuid() === 0;
+}
+
+/**
+ * Claude CLI rejects --dangerously-skip-permissions when the process runs as root.
+ * On uid 0 this is always false, even when adapterConfig or the UI default sets it to true.
+ */
+export function resolveDangerouslySkipPermissions(configValue: unknown): boolean {
+  if (isPaperclipRunningAsRoot()) return false;
+  return asBoolean(configValue, true);
+}
+
+/**
+ * Without --dangerously-skip-permissions, Claude requires per-tool approval; in --print mode there is no user to approve.
+ * Passing an explicit allowlist pre-approves these tools (verified for root + Bash/curl to Paperclip API).
+ * Extend via adapter `extraArgs` with your own `--allowed-tools` (then this default is not injected).
+ * MCP tool names vary by server; add them in extraArgs if needed (e.g. `mcp__openclaw__messages_send`).
+ */
+export const CLAUDE_ROOT_HEADLESS_ALLOWED_TOOLS =
+  [
+    "Bash(*)",
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "Skill",
+    "Task",
+    "TaskOutput",
+    "TaskStop",
+    "ToolSearch",
+    "TodoWrite",
+    "NotebookEdit",
+    "AskUserQuestion",
+    "CronCreate",
+    "CronDelete",
+    "CronList",
+    "RemoteTrigger",
+    "EnterPlanMode",
+    "ExitPlanMode",
+    "EnterWorktree",
+    "ExitWorktree",
+  ].join(",");
+
+export function argvIncludesAllowedToolsFlag(argv: readonly string[]): boolean {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i] ?? "";
+    if (a === "--allowed-tools" || a === "--allowedTools") return true;
+    if (a.startsWith("--allowed-tools=") || a.startsWith("--allowedTools=")) return true;
+  }
+  return false;
+}
+
+/** When root cannot use --dangerously-skip-permissions, inject --allowed-tools unless the operator set it in extraArgs. */
+export function shouldInjectRootHeadlessAllowedTools(
+  dangerouslySkipPermissions: boolean,
+  extraArgs: readonly string[],
+): boolean {
+  if (!isPaperclipRunningAsRoot() || dangerouslySkipPermissions) return false;
+  return !argvIncludesAllowedToolsFlag(extraArgs);
+}

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -15,8 +15,13 @@ import {
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
 import path from "node:path";
-import { detectClaudeLoginRequired, parseClaudeStreamJson } from "./parse.js";
+import { detectClaudeLoginRequired, isClaudeRateLimitedOutput, parseClaudeStreamJson } from "./parse.js";
 import { isBedrockModelId } from "./models.js";
+import {
+  CLAUDE_ROOT_HEADLESS_ALLOWED_TOOLS,
+  resolveDangerouslySkipPermissions,
+  shouldInjectRootHeadlessAllowedTools,
+} from "./process-defaults.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -154,7 +159,7 @@ export async function testEnvironment(
       const effort = asString(config.effort, "").trim();
       const chrome = asBoolean(config.chrome, false);
       const maxTurns = asNumber(config.maxTurnsPerRun, 0);
-      const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+      const dangerouslySkipPermissions = resolveDangerouslySkipPermissions(config.dangerouslySkipPermissions);
       const extraArgs = (() => {
         const fromExtraArgs = asStringArray(config.extraArgs);
         if (fromExtraArgs.length > 0) return fromExtraArgs;
@@ -162,6 +167,9 @@ export async function testEnvironment(
       })();
 
       const args = ["--print", "-", "--output-format", "stream-json", "--verbose"];
+      if (shouldInjectRootHeadlessAllowedTools(dangerouslySkipPermissions, extraArgs)) {
+        args.push("--allowed-tools", CLAUDE_ROOT_HEADLESS_ALLOWED_TOOLS);
+      }
       if (dangerouslySkipPermissions) args.push("--dangerously-skip-permissions");
       if (chrome) args.push("--chrome");
       // For Bedrock: only pass --model when the ID is a Bedrock-native identifier.
@@ -212,22 +220,36 @@ export async function testEnvironment(
             ? `Run \`claude login\` and complete sign-in at ${loginMeta.loginUrl}, then retry.`
             : "Run `claude login` in this environment, then retry the probe.",
         });
-      } else if ((probe.exitCode ?? 1) === 0) {
-        const summary = parsedStream.summary.trim();
-        const hasHello = /\bhello\b/i.test(summary);
-        checks.push({
-          code: hasHello ? "claude_hello_probe_passed" : "claude_hello_probe_unexpected_output",
-          level: hasHello ? "info" : "warn",
-          message: hasHello
-            ? "Claude hello probe succeeded."
-            : "Claude probe ran but did not return `hello` as expected.",
-          ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
-          ...(hasHello
-            ? {}
-            : {
-                hint: "Try the probe manually (`claude --print - --output-format stream-json --verbose`) and prompt `Respond with hello`.",
-              }),
-        });
+      } else if (parsedStream.resultJson != null || probe.exitCode === 0) {
+        // Claude exits 1 when the final stream `result` has is_error (e.g. subscription rate limits) even though JSON is valid.
+        if (isClaudeRateLimitedOutput(probe.stdout, parsedStream.resultJson)) {
+          const summary = parsedStream.summary.trim();
+          checks.push({
+            code: "claude_hello_probe_rate_limited",
+            level: "warn",
+            message:
+              "Claude CLI ran but reported a usage limit, so the hello probe could not get a normal model reply.",
+            ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+            ...(detail && !summary ? { detail } : {}),
+            hint: "Wait for the limit to reset, set ANTHROPIC_API_KEY if you use API billing, or try again later. Installation and auth are fine.",
+          });
+        } else {
+          const summary = parsedStream.summary.trim();
+          const hasHello = /\bhello\b/i.test(summary);
+          checks.push({
+            code: hasHello ? "claude_hello_probe_passed" : "claude_hello_probe_unexpected_output",
+            level: hasHello ? "info" : "warn",
+            message: hasHello
+              ? "Claude hello probe succeeded."
+              : "Claude probe ran but did not return `hello` as expected.",
+            ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+            ...(hasHello
+              ? {}
+              : {
+                  hint: "Try the probe manually (`claude --print - --output-format stream-json --verbose`) and prompt `Respond with hello`.",
+                }),
+          });
+        }
       } else {
         checks.push({
           code: "claude_hello_probe_failed",

--- a/packages/adapters/openclaw-gateway/src/defaults.ts
+++ b/packages/adapters/openclaw-gateway/src/defaults.ts
@@ -1,0 +1,2 @@
+/** When adapterConfig.url is empty: same-host OpenClaw gateway default. */
+export const DEFAULT_OPENCLAW_GATEWAY_WS_URL = "ws://127.0.0.1:18789";

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -16,9 +16,10 @@ Don't use when:
 - Your deployment does not permit outbound WebSocket access from the Paperclip server.
 
 Core fields:
-- url (string, required): OpenClaw gateway WebSocket URL (ws:// or wss://)
+- url (string, optional): OpenClaw gateway WebSocket URL (ws:// or wss://); if omitted, defaults to ws://127.0.0.1:18789 (same host)
 - headers (object, optional): handshake headers; supports x-openclaw-token / x-openclaw-auth
 - authToken (string, optional): shared gateway token override
+- Server fallback (no token in config): env \`PAPERCLIP_OPENCLAW_GATEWAY_TOKEN\` or \`PAPERCLIP_OPENCLAW_GATEWAY_TOKEN_FILE\` (path to \`gateway.token\`) is read by the adapter when the agent config has no credentials.
 - password (string, optional): gateway shared password, if configured
 
 Gateway connect identity fields:
@@ -42,11 +43,9 @@ Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run
 - sessionKey (string, optional): fixed session key when strategy=fixed (default paperclip)
 
-Standard outbound payload additions:
-- paperclip (object): standardized Paperclip context added to every gateway agent request
-- paperclip.workspace (object, optional): resolved execution workspace for this run
-- paperclip.workspaces (array, optional): additional workspace hints Paperclip exposed to the run
-- paperclip.workspaceRuntime (object, optional): reserved workspace runtime metadata when explicitly supplied outside normal heartbeat execution
+Standard outbound context (OpenClaw agent params forbid extra root keys):
+- The same structured Paperclip context is appended to the gateway field "extraSystemPrompt" as a "## Paperclip context" JSON block (a root "paperclip" property is rejected).
+- Includes workspace, workspaces, workspaceRuntime, wake metadata, and env-derived fields as built by the adapter.
 
 Standard result metadata supported:
 - meta.runtimeServices (array, optional): normalized adapter-managed runtime service reports

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -11,8 +11,10 @@ import {
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
 } from "@paperclipai/adapter-utils/server-utils";
+import { readFileSync } from "node:fs";
 import crypto, { randomUUID } from "node:crypto";
 import { WebSocket } from "ws";
+import { DEFAULT_OPENCLAW_GATEWAY_WS_URL } from "../defaults.js";
 
 type SessionKeyStrategy = "fixed" | "issue" | "run";
 
@@ -1042,16 +1044,7 @@ function extractResultText(value: unknown): string | null {
 }
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const urlValue = asString(ctx.config.url, "").trim();
-  if (!urlValue) {
-    return {
-      exitCode: 1,
-      signal: null,
-      timedOut: false,
-      errorMessage: "OpenClaw gateway adapter missing url",
-      errorCode: "openclaw_gateway_url_missing",
-    };
-  }
+  const urlValue = asString(ctx.config.url, "").trim() || DEFAULT_OPENCLAW_GATEWAY_WS_URL;
 
   const parsedUrl = normalizeUrl(urlValue);
   if (!parsedUrl) {
@@ -1083,7 +1076,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const transportHint = nonEmpty(ctx.config.streamTransport) ?? nonEmpty(ctx.config.transport);
 
   const headers = toStringRecord(ctx.config.headers);
-  const authToken = resolveAuthToken(parseObject(ctx.config), headers);
+  let authToken = resolveAuthToken(parseObject(ctx.config), headers);
+  if (!authToken) {
+    authToken =
+      nonEmpty(process.env.PAPERCLIP_OPENCLAW_GATEWAY_TOKEN) ??
+      nonEmpty(process.env.OPENCLAW_GATEWAY_TOKEN);
+  }
+  if (!authToken) {
+    const tokenFile = process.env.PAPERCLIP_OPENCLAW_GATEWAY_TOKEN_FILE?.trim();
+    if (tokenFile) {
+      try {
+        authToken = nonEmpty(readFileSync(tokenFile, "utf8"));
+      } catch {
+        // ignore missing/unreadable file
+      }
+    }
+  }
   const password = nonEmpty(ctx.config.password);
   const deviceToken = nonEmpty(ctx.config.deviceToken);
 
@@ -1132,7 +1140,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  // OpenClaw gateway agent params schema uses additionalProperties: false — no root `paperclip`.
+  delete agentParams.paperclip;
+  const paperclipContextBlock = [
+    "## Paperclip context",
+    "",
+    "```json",
+    JSON.stringify(paperclipPayload, null, 2),
+    "```",
+  ].join("\n");
+  const existingExtra = nonEmpty(agentParams.extraSystemPrompt);
+  agentParams.extraSystemPrompt = existingExtra
+    ? `${existingExtra}\n\n${paperclipContextBlock}`
+    : paperclipContextBlock;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/packages/adapters/openclaw-gateway/src/server/test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/test.ts
@@ -4,8 +4,10 @@ import type {
   AdapterEnvironmentTestResult,
 } from "@paperclipai/adapter-utils";
 import { asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import { readFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { WebSocket } from "ws";
+import { DEFAULT_OPENCLAW_GATEWAY_WS_URL } from "../defaults.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -192,21 +194,15 @@ export async function testEnvironment(
 ): Promise<AdapterEnvironmentTestResult> {
   const checks: AdapterEnvironmentCheck[] = [];
   const config = parseObject(ctx.config);
-  const urlValue = asString(config.url, "").trim();
+  const urlValue = asString(config.url, "").trim() || DEFAULT_OPENCLAW_GATEWAY_WS_URL;
 
-  if (!urlValue) {
+  if (!asString(config.url, "").trim()) {
     checks.push({
-      code: "openclaw_gateway_url_missing",
-      level: "error",
-      message: "OpenClaw gateway adapter requires a WebSocket URL.",
-      hint: "Set adapterConfig.url to ws://host:port (or wss://).",
+      code: "openclaw_gateway_url_defaulted",
+      level: "info",
+      message: `No adapterConfig.url set; using default ${DEFAULT_OPENCLAW_GATEWAY_WS_URL}.`,
+      hint: "Set adapterConfig.url explicitly if your gateway is not on the same host.",
     });
-    return {
-      adapterType: ctx.adapterType,
-      status: summarizeStatus(checks),
-      checks,
-      testedAt: new Date().toISOString(),
-    };
   }
 
   let url: URL | null = null;
@@ -247,7 +243,22 @@ export async function testEnvironment(
   }
 
   const headers = toStringRecord(config.headers);
-  const authToken = resolveAuthToken(config, headers);
+  let authToken = resolveAuthToken(config, headers);
+  if (!authToken) {
+    authToken =
+      nonEmpty(process.env.PAPERCLIP_OPENCLAW_GATEWAY_TOKEN) ??
+      nonEmpty(process.env.OPENCLAW_GATEWAY_TOKEN);
+  }
+  if (!authToken) {
+    const tokenFile = process.env.PAPERCLIP_OPENCLAW_GATEWAY_TOKEN_FILE?.trim();
+    if (tokenFile) {
+      try {
+        authToken = nonEmpty(readFileSync(tokenFile, "utf8"));
+      } catch {
+        // ignore
+      }
+    }
+  }
   const password = nonEmpty(config.password);
   const role = nonEmpty(config.role) ?? "operator";
   const scopes = toStringArray(config.scopes);

--- a/packages/adapters/openclaw-gateway/src/ui/build-config.ts
+++ b/packages/adapters/openclaw-gateway/src/ui/build-config.ts
@@ -1,4 +1,5 @@
 import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_OPENCLAW_GATEWAY_WS_URL } from "../defaults.js";
 
 function parseJsonObject(text: string): Record<string, unknown> | null {
   const trimmed = text.trim();
@@ -14,7 +15,13 @@ function parseJsonObject(text: string): Record<string, unknown> | null {
 
 export function buildOpenClawGatewayConfig(v: CreateConfigValues): Record<string, unknown> {
   const ac: Record<string, unknown> = {};
-  if (v.url) ac.url = v.url;
+  const trimmedUrl = typeof v.url === "string" ? v.url.trim() : "";
+  ac.url = trimmedUrl || DEFAULT_OPENCLAW_GATEWAY_WS_URL;
+  const gatewayTok =
+    typeof v.openclawGatewayToken === "string" ? v.openclawGatewayToken.trim() : "";
+  if (gatewayTok) {
+    ac.headers = { "x-openclaw-token": gatewayTok };
+  }
   ac.timeoutSec = 120;
   ac.waitTimeoutMs = 120000;
   ac.sessionKeyStrategy = "issue";

--- a/server/src/__tests__/claude-local-adapter-environment.test.ts
+++ b/server/src/__tests__/claude-local-adapter-environment.test.ts
@@ -4,6 +4,32 @@ import os from "node:os";
 import path from "node:path";
 import { testEnvironment } from "@paperclipai/adapter-claude-local/server";
 
+/** Fake Claude CLI: valid stream-json but exit 1 (matches subscription / org rate limits). */
+async function writeRateLimitedFakeClaude(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.readFileSync(0, "utf8");
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "s-rate", model: "claude-sonnet" }));
+console.log(JSON.stringify({ type: "rate_limit_event", rate_limit_info: { status: "rejected" } }));
+console.log(JSON.stringify({
+  type: "assistant",
+  session_id: "s-rate",
+  error: "rate_limit",
+  message: { content: [{ type: "text", text: "You've hit your limit" }] },
+}));
+console.log(JSON.stringify({
+  type: "result",
+  subtype: "success",
+  is_error: true,
+  session_id: "s-rate",
+  result: "You've hit your limit · resets soon",
+}));
+process.exit(1);
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 const ORIGINAL_ANTHROPIC = process.env.ANTHROPIC_API_KEY;
 const ORIGINAL_BEDROCK = process.env.CLAUDE_CODE_USE_BEDROCK;
 const ORIGINAL_BEDROCK_URL = process.env.ANTHROPIC_BEDROCK_BASE_URL;
@@ -179,5 +205,45 @@ describe("claude_local environment diagnostics", () => {
     const stats = await fs.stat(cwd);
     expect(stats.isDirectory()).toBe(true);
     await fs.rm(path.dirname(cwd), { recursive: true, force: true });
+  });
+
+  /**
+   * Regression: real `claude` exits 1 with valid stream-json when the final `result` has is_error (e.g. rate limits).
+   * The probe must not treat that as claude_hello_probe_failed solely from exit code.
+   *
+   * Related upstream discussion: https://github.com/paperclipai/paperclip/pull/3162 (exit 0 + is_error path).
+   */
+  it("classifies exit 1 + rate_limit stream-json as rate-limited warn, not probe error", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+    delete process.env.ANTHROPIC_BEDROCK_BASE_URL;
+
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-probe-ratelimit-"));
+    const binDir = path.join(root, "bin");
+    const workspace = path.join(root, "workspace");
+    const claudePath = path.join(binDir, "claude");
+    await fs.mkdir(binDir, { recursive: true });
+    await fs.mkdir(workspace, { recursive: true });
+    await writeRateLimitedFakeClaude(claudePath);
+
+    try {
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "claude_local",
+        config: {
+          command: claudePath,
+          cwd: workspace,
+        },
+      });
+
+      expect(result.checks.some((c) => c.code === "claude_hello_probe_failed")).toBe(false);
+      expect(
+        result.checks.some((c) => c.code === "claude_hello_probe_rate_limited" && c.level === "warn"),
+      ).toBe(true);
+      expect(result.checks.some((c) => c.level === "error")).toBe(false);
+      expect(result.status).toBe("warn");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/server/src/__tests__/claude-local-parse-rate-limit.test.ts
+++ b/server/src/__tests__/claude-local-parse-rate-limit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isClaudeRateLimitedOutput } from "@paperclipai/adapter-claude-local/server";
+
+describe("isClaudeRateLimitedOutput", () => {
+  it("detects rate_limit_event in stdout", () => {
+    const stdout = '{"type":"rate_limit_event","rate_limit_info":{}}\n';
+    expect(isClaudeRateLimitedOutput(stdout, null)).toBe(true);
+  });
+
+  it("detects result JSON with is_error and limit wording", () => {
+    const resultJson = {
+      type: "result",
+      is_error: true,
+      result: "You've hit your limit · resets 12pm (UTC)",
+    };
+    expect(isClaudeRateLimitedOutput("", resultJson)).toBe(true);
+  });
+
+  it("returns false for normal success result", () => {
+    const resultJson = {
+      type: "result",
+      is_error: false,
+      result: "hello",
+    };
+    expect(isClaudeRateLimitedOutput("", resultJson)).toBe(false);
+  });
+});

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -409,12 +409,11 @@ describe("heartbeat comment wake batching", () => {
       }, 90_000);
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          commentIds: [comment2.id, comment3.id],
-          latestCommentId: comment3.id,
-        },
-      });
+      expect(secondPayload.paperclip).toBeUndefined();
+      const secondExtra = String(secondPayload.extraSystemPrompt ?? "");
+      expect(secondExtra).toContain("## Paperclip context");
+      expect(secondExtra).toContain(comment2.id);
+      expect(secondExtra).toContain(comment3.id);
       expect(String(secondPayload.message ?? "")).toContain("Second comment");
       expect(String(secondPayload.message ?? "")).toContain("Third comment");
       expect(String(secondPayload.message ?? "")).not.toContain("First comment");
@@ -489,19 +488,13 @@ describe("heartbeat comment wake batching", () => {
       expect(firstRun).not.toBeNull();
       await waitFor(() => gateway.getAgentPayloads().length === 1);
       const firstPayload = gateway.getAgentPayloads()[0] ?? {};
-      expect(firstPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_assigned",
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Require a comment",
-            status: "todo",
-            priority: "medium",
-          },
-          commentIds: [],
-        },
-      });
+      expect(firstPayload.paperclip).toBeUndefined();
+      const firstExtra = String(firstPayload.extraSystemPrompt ?? "");
+      expect(firstExtra).toContain("## Paperclip context");
+      expect(firstExtra).toContain("issue_assigned");
+      expect(firstExtra).toContain(issueId);
+      expect(firstExtra).toContain("Require a comment");
+      expect(firstExtra).toContain(`${issuePrefix}-1`);
       expect(String(firstPayload.message ?? "")).toContain("## Paperclip Wake Payload");
       expect(String(firstPayload.message ?? "")).toContain("Do not switch to another issue until you have handled this wake.");
       expect(String(firstPayload.message ?? "")).toContain(`${issuePrefix}-1 Require a comment`);

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -502,12 +502,13 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
-      expect(payload?.paperclip).toMatchObject({
-        wake: {
-          latestCommentId: "comment-2",
-          commentIds: ["comment-1", "comment-2"],
-        },
-      });
+      // OpenClaw agent params schema forbids a root `paperclip` key; context is merged into extraSystemPrompt.
+      expect(payload?.paperclip).toBeUndefined();
+      const extra = String(payload?.extraSystemPrompt ?? "");
+      expect(extra).toContain("## Paperclip context");
+      expect(extra).toContain("\"wake\"");
+      expect(extra).toContain("comment-2");
+      expect(extra).toContain("pap-123-test");
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
     } finally {
@@ -515,10 +516,11 @@ describe("openclaw gateway adapter execute", () => {
     }
   });
 
-  it("fails fast when url is missing", async () => {
+  it("uses default loopback gateway URL when url is omitted (no url_missing error)", async () => {
     const result = await execute(buildContext({}));
+    expect(result.errorCode).not.toBe("openclaw_gateway_url_missing");
+    // Default ws://127.0.0.1:18789 — without a listening gateway, expect a connection-style failure.
     expect(result.exitCode).toBe(1);
-    expect(result.errorCode).toBe("openclaw_gateway_url_missing");
   });
 
   it("returns adapter-managed runtime services from gateway result meta", async () => {
@@ -664,14 +666,17 @@ describe("openclaw gateway ui build config", () => {
 });
 
 describe("openclaw gateway testEnvironment", () => {
-  it("reports missing url as failure", async () => {
+  it("defaults empty url to loopback and records openclaw_gateway_url_defaulted", async () => {
     const result = await testEnvironment({
       companyId: "company-123",
       adapterType: "openclaw_gateway",
       config: {},
     });
 
-    expect(result.status).toBe("fail");
-    expect(result.checks.some((check) => check.code === "openclaw_gateway_url_missing")).toBe(true);
+    expect(result.checks.some((check) => check.code === "openclaw_gateway_url_defaulted")).toBe(true);
+    expect(result.checks.some((check) => check.code === "openclaw_gateway_url_missing")).toBe(false);
+    expect(result.checks.some((check) => check.code === "openclaw_gateway_url_valid")).toBe(true);
+    // Probe outcome depends on whether a gateway listens on 127.0.0.1:18789.
+    expect(["pass", "warn", "fail"]).toContain(result.status);
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -367,6 +367,7 @@ export async function startServer(): Promise<StartedServer> {
         }
         port = detectedPort;
         logger.info(`Using embedded PostgreSQL because no DATABASE_URL set (dataDir=${dataDir}, port=${port})`);
+        const runningAsRoot = typeof process.getuid === "function" && process.getuid() === 0;
         embeddedPostgres = new EmbeddedPostgres({
           databaseDir: dataDir,
           user: "paperclip",
@@ -376,6 +377,7 @@ export async function startServer(): Promise<StartedServer> {
           initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
           onLog: appendEmbeddedPostgresLog,
           onError: appendEmbeddedPostgresLog,
+          ...(runningAsRoot ? { createPostgresUser: true as const } : {}),
         });
 
         if (!clusterAlreadyInitialized) {

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -93,8 +93,6 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     label: "OpenClaw Gateway",
     description: "Invoke OpenClaw via gateway protocol",
     icon: Bot,
-    comingSoon: true,
-    disabledLabel: "Configure OpenClaw within the App",
   },
   process: {
     label: "Process",

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -132,6 +132,15 @@ export function OpenClawGatewayConfigFields({
         mark={mark}
       />
 
+      {isCreate && set && (
+        <SecretField
+          label="Gateway auth token (x-openclaw-token)"
+          value={values!.openclawGatewayToken ?? ""}
+          onCommit={(v) => set({ openclawGatewayToken: v.trim() })}
+          placeholder="From gateway.token or openclaw.json → gateway.auth.token"
+        />
+      )}
+
       {!isCreate && (
         <>
           <Field label="Paperclip API URL override">

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -17,6 +17,7 @@ export const defaultCreateValues: CreateConfigValues = {
   envVars: "",
   envBindings: {},
   url: "",
+  openclawGatewayToken: "",
   bootstrapPrompt: "",
   payloadTemplateJson: "",
   workspaceStrategyType: "project_primary",


### PR DESCRIPTION
## Summary
Three focused commits (see history):

1. **openclaw-gateway** — Send Paperclip context in `extraSystemPrompt` (OpenClaw rejects root `paperclip`). Default `ws://127.0.0.1:18789`; token from `PAPERCLIP_OPENCLAW_GATEWAY_TOKEN` / `_FILE`.
2. **claude-local** — Hello probe: CLI may exit 1 with valid stream-json on rate limits; classify as warn, not hard failure. Tests with fake `claude` binary + parse unit tests.
3. **UI + server** — Gateway token field on agent create, enable OpenClaw in adapter picker; optional `CreateConfigValues.openclawGatewayToken`; embedded Postgres `createPostgresUser` when uid=0.

## Traceability
- Refs https://github.com/paperclipai/paperclip/issues/617 — Related https://github.com/paperclipai/paperclip/pull/2935
- Related https://github.com/paperclipai/paperclip/pull/3162 (Claude probe / `is_error` discussion)
- Refs https://github.com/paperclipai/paperclip/issues/744 — Related https://github.com/paperclipai/paperclip/issues/930

## Verification
```bash
pnpm exec vitest run server/src/__tests__/openclaw-gateway-adapter.test.ts \
  server/src/__tests__/claude-local-adapter-environment.test.ts \
  server/src/__tests__/claude-local-parse-rate-limit.test.ts
pnpm exec tsc --noEmit -p server && pnpm exec tsc --noEmit -p ui
```


Made with [Cursor](https://cursor.com)