### PR TITLE
[codex] add codex local login flow

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -21,7 +21,7 @@ import {
   joinPromptSections,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
-import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
+import { detectCodexLoginRequired, parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 
@@ -210,6 +210,114 @@ export async function ensureCodexSkillsInjected(
     skillsEntries.map((entry) => entry.runtimeName),
     onLog,
   );
+}
+
+interface CodexExecutionInput {
+  runId: string;
+  agent: AdapterExecutionContext["agent"];
+  config: Record<string, unknown>;
+  context: Record<string, unknown>;
+  authToken?: string;
+  onLog: AdapterExecutionContext["onLog"];
+}
+
+interface CodexRuntimeConfig {
+  command: string;
+  cwd: string;
+  env: Record<string, string>;
+  timeoutSec: number;
+  graceSec: number;
+}
+
+async function buildCodexRuntimeConfig(input: CodexExecutionInput): Promise<CodexRuntimeConfig> {
+  const { runId, agent, config, context, authToken, onLog } = input;
+  const command = asString(config.command, "codex");
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const envConfig = parseObject(config.env);
+  const configuredCodexHome =
+    typeof envConfig.CODEX_HOME === "string" && envConfig.CODEX_HOME.trim().length > 0
+      ? path.resolve(envConfig.CODEX_HOME.trim())
+      : null;
+
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  const preparedManagedCodexHome =
+    configuredCodexHome ? null : await prepareManagedCodexHome(process.env, onLog, agent.companyId);
+  const defaultCodexHome = resolveManagedCodexHomeDir(process.env, agent.companyId);
+  const effectiveCodexHome = configuredCodexHome ?? preparedManagedCodexHome ?? defaultCodexHome;
+  await fs.mkdir(effectiveCodexHome, { recursive: true });
+
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.CODEX_HOME = effectiveCodexHome;
+  env.PAPERCLIP_RUN_ID = runId;
+
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  await ensureCommandResolvable(command, cwd, runtimeEnv);
+
+  return {
+    command,
+    cwd,
+    env,
+    timeoutSec: asNumber(config.timeoutSec, 0),
+    graceSec: asNumber(config.graceSec, 20),
+  };
+}
+
+export async function runCodexLogin(input: {
+  runId: string;
+  agent: AdapterExecutionContext["agent"];
+  config: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  authToken?: string;
+  onLog?: AdapterExecutionContext["onLog"];
+}) {
+  const onLog = input.onLog ?? (async () => {});
+  const runtime = await buildCodexRuntimeConfig({
+    runId: input.runId,
+    agent: input.agent,
+    config: input.config,
+    context: input.context ?? {},
+    authToken: input.authToken,
+    onLog,
+  });
+
+  const proc = await runChildProcess(input.runId, runtime.command, ["login"], {
+    cwd: runtime.cwd,
+    env: runtime.env,
+    timeoutSec: runtime.timeoutSec,
+    graceSec: runtime.graceSec,
+    onLog,
+  });
+
+  const loginMeta = detectCodexLoginRequired({
+    stdout: proc.stdout,
+    stderr: proc.stderr,
+  });
+
+  return {
+    exitCode: proc.exitCode,
+    signal: proc.signal,
+    timedOut: proc.timedOut,
+    stdout: proc.stdout,
+    stderr: proc.stderr,
+    loginUrl: loginMeta.loginUrl,
+  };
 }
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
@@ -543,6 +651,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     attempt: { proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string }; rawStderr: string; parsed: ReturnType<typeof parseCodexJsonl> },
     clearSessionOnMissingSession = false,
   ): AdapterExecutionResult => {
+    const loginMeta = detectCodexLoginRequired({
+      stdout: attempt.proc.stdout,
+      stderr: attempt.rawStderr,
+      errorMessage: attempt.parsed.errorMessage,
+    });
+
     if (attempt.proc.timedOut) {
       return {
         exitCode: attempt.proc.exitCode,
@@ -578,6 +692,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         (attempt.proc.exitCode ?? 0) === 0
           ? null
           : fallbackErrorMessage,
+      errorCode:
+        (attempt.proc.exitCode ?? 0) !== 0 && loginMeta.requiresLogin ? "codex_auth_required" : null,
+      errorMeta: loginMeta.loginUrl != null ? { loginUrl: loginMeta.loginUrl } : undefined,
       usage: attempt.parsed.usage,
       sessionId: resolvedSessionId,
       sessionParams: resolvedSessionParams,

--- a/packages/adapters/codex-local/src/server/index.ts
+++ b/packages/adapters/codex-local/src/server/index.ts
@@ -1,7 +1,7 @@
-export { execute, ensureCodexSkillsInjected } from "./execute.js";
+export { execute, ensureCodexSkillsInjected, runCodexLogin } from "./execute.js";
 export { listCodexSkills, syncCodexSkills } from "./skills.js";
 export { testEnvironment } from "./test.js";
-export { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
+export { detectCodexLoginRequired, parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 export {
   getQuotaWindows,
   readCodexAuthInfo,

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -1,5 +1,9 @@
 import { asString, asNumber, parseObject, parseJson } from "@paperclipai/adapter-utils/server-utils";
 
+const CODEX_AUTH_REQUIRED_RE =
+  /(?:not\s+logged\s+in|login\s+required|authentication\s+required|unauthorized|invalid(?:\s+or\s+missing)?\s+api(?:[_\s-]?key)?|openai[_\s-]?api[_\s-]?key|api[_\s-]?key.*required|please\s+run\s+`?codex\s+login`?)/i;
+const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
+
 export function parseCodexJsonl(stdout: string) {
   let sessionId: string | null = null;
   const messages: string[] = [];
@@ -58,6 +62,40 @@ export function parseCodexJsonl(stdout: string) {
     summary: messages.join("\n\n").trim(),
     usage,
     errorMessage,
+  };
+}
+
+export function extractCodexLoginUrl(text: string): string | null {
+  const match = text.match(URL_RE);
+  if (!match || match.length === 0) return null;
+  for (const rawUrl of match) {
+    const cleaned = rawUrl.replace(/[\])}.!,?;:'\"]+$/g, "");
+    if (
+      cleaned.includes("openai") ||
+      cleaned.includes("chatgpt") ||
+      cleaned.includes("codex") ||
+      cleaned.includes("auth")
+    ) {
+      return cleaned;
+    }
+  }
+  return match[0]?.replace(/[\])}.!,?;:'\"]+$/g, "") ?? null;
+}
+
+export function detectCodexLoginRequired(input: {
+  stdout: string;
+  stderr: string;
+  errorMessage?: string | null;
+}): { requiresLogin: boolean; loginUrl: string | null } {
+  const messages = [input.errorMessage ?? "", input.stdout, input.stderr]
+    .join("\n")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return {
+    requiresLogin: messages.some((line) => CODEX_AUTH_REQUIRED_RE.test(line)),
+    loginUrl: extractCodexLoginUrl([input.stdout, input.stderr].join("\n")),
   };
 }
 

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -14,7 +14,7 @@ import {
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
 import path from "node:path";
-import { parseCodexJsonl } from "./parse.js";
+import { detectCodexLoginRequired, parseCodexJsonl } from "./parse.js";
 import { codexHomeDir, readCodexAuthInfo } from "./quota.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
@@ -48,9 +48,6 @@ function summarizeProbeDetail(stdout: string, stderr: string, parsedError: strin
   const max = 240;
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
 }
-
-const CODEX_AUTH_REQUIRED_RE =
-  /(?:not\s+logged\s+in|login\s+required|authentication\s+required|unauthorized|invalid(?:\s+or\s+missing)?\s+api(?:[_\s-]?key)?|openai[_\s-]?api[_\s-]?key|api[_\s-]?key.*required|please\s+run\s+`?codex\s+login`?)/i;
 
 export async function testEnvironment(
   ctx: AdapterEnvironmentTestContext,
@@ -122,8 +119,8 @@ export async function testEnvironment(
       checks.push({
         code: "codex_openai_api_key_missing",
         level: "warn",
-        message: "OPENAI_API_KEY is not set. Codex runs may fail until authentication is configured.",
-        hint: "Set OPENAI_API_KEY in adapter env, shell environment, or run `codex auth` to log in.",
+        message: "OPENAI_API_KEY is not set. Codex will rely on local CLI authentication.",
+        hint: "Run `codex login` to authenticate locally if this agent is not already signed in.",
       });
     }
   }
@@ -181,7 +178,11 @@ export async function testEnvironment(
       );
       const parsed = parseCodexJsonl(probe.stdout);
       const detail = summarizeProbeDetail(probe.stdout, probe.stderr, parsed.errorMessage);
-      const authEvidence = `${parsed.errorMessage ?? ""}\n${probe.stdout}\n${probe.stderr}`.trim();
+      const loginMeta = detectCodexLoginRequired({
+        stdout: probe.stdout,
+        stderr: probe.stderr,
+        errorMessage: parsed.errorMessage,
+      });
 
       if (probe.timedOut) {
         checks.push({
@@ -206,13 +207,15 @@ export async function testEnvironment(
                 hint: "Try the probe manually (`codex exec --json -` then prompt: Respond with hello) to inspect full output.",
               }),
         });
-      } else if (CODEX_AUTH_REQUIRED_RE.test(authEvidence)) {
+      } else if (loginMeta.requiresLogin) {
         checks.push({
           code: "codex_hello_probe_auth_required",
           level: "warn",
           message: "Codex CLI is installed, but authentication is not ready.",
           ...(detail ? { detail } : {}),
-          hint: "Configure OPENAI_API_KEY in adapter env/shell or run `codex login`, then retry the probe.",
+          hint: loginMeta.loginUrl
+            ? `Run \`codex login\` and complete sign-in at ${loginMeta.loginUrl}, then retry the probe.`
+            : "Run `codex login`, then retry the probe.",
         });
       } else {
         checks.push({

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -52,6 +52,7 @@ import { redactCurrentUserValue } from "../log-redaction.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { runClaudeLogin } from "@paperclipai/adapter-claude-local/server";
+import { runCodexLogin } from "@paperclipai/adapter-codex-local/server";
 import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
   DEFAULT_CODEX_LOCAL_MODEL,
@@ -2165,6 +2166,37 @@ export function agentRoutes(db: Db) {
     const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(agent.companyId, config);
     const result = await runClaudeLogin({
       runId: `claude-login-${randomUUID()}`,
+      agent: {
+        id: agent.id,
+        companyId: agent.companyId,
+        name: agent.name,
+        adapterType: agent.adapterType,
+        adapterConfig: agent.adapterConfig,
+      },
+      config: runtimeConfig,
+    });
+
+    res.json(result);
+  });
+
+  router.post("/agents/:id/codex-login", async (req, res) => {
+    assertBoard(req);
+    const id = req.params.id as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
+    if (agent.adapterType !== "codex_local") {
+      res.status(400).json({ error: "Login is only supported for codex_local agents" });
+      return;
+    }
+
+    const config = asRecord(agent.adapterConfig) ?? {};
+    const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(agent.companyId, config);
+    const result = await runCodexLogin({
+      runId: `codex-login-${randomUUID()}`,
       agent: {
         id: agent.id,
         companyId: agent.companyId,

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -34,7 +34,7 @@ export interface DetectedAdapterModel {
   source: string;
 }
 
-export interface ClaudeLoginResult {
+export interface AdapterCliLoginResult {
   exitCode: number | null;
   signal: string | null;
   timedOut: boolean;
@@ -192,7 +192,9 @@ export const agentsApi = {
     companyId?: string,
   ) => api.post<AgentWakeupResponse>(agentPath(id, companyId, "/wakeup"), data),
   loginWithClaude: (id: string, companyId?: string) =>
-    api.post<ClaudeLoginResult>(agentPath(id, companyId, "/claude-login"), {}),
+    api.post<AdapterCliLoginResult>(agentPath(id, companyId, "/claude-login"), {}),
+  loginWithCodex: (id: string, companyId?: string) =>
+    api.post<AdapterCliLoginResult>(agentPath(id, companyId, "/codex-login"), {}),
   availableSkills: () =>
     api.get<{ skills: AvailableSkill[] }>("/skills/available"),
 };

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   agentsApi,
   type AgentKey,
-  type ClaudeLoginResult,
+  type AdapterCliLoginResult,
   type AgentPermissionUpdate,
 } from "../api/agents";
 import { companySkillsApi } from "../api/companySkills";
@@ -2899,10 +2899,10 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
   const run = hydratedRun ?? initialRun;
   const metrics = runMetrics(run);
   const [sessionOpen, setSessionOpen] = useState(false);
-  const [claudeLoginResult, setClaudeLoginResult] = useState<ClaudeLoginResult | null>(null);
+  const [cliLoginResult, setCliLoginResult] = useState<AdapterCliLoginResult | null>(null);
 
   useEffect(() => {
-    setClaudeLoginResult(null);
+    setCliLoginResult(null);
   }, [run.id]);
 
   const cancelRun = useMutation({
@@ -3003,8 +3003,21 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
 
   const runClaudeLogin = useMutation({
     mutationFn: () => agentsApi.loginWithClaude(run.agentId, run.companyId),
+    onMutate: () => {
+      setCliLoginResult(null);
+    },
     onSuccess: (data) => {
-      setClaudeLoginResult(data);
+      setCliLoginResult(data);
+    },
+  });
+
+  const runCodexLogin = useMutation({
+    mutationFn: () => agentsApi.loginWithCodex(run.agentId, run.companyId),
+    onMutate: () => {
+      setCliLoginResult(null);
+    },
+    onSuccess: (data) => {
+      setCliLoginResult(data);
     },
   });
 
@@ -3134,29 +3147,76 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
                       : "Failed to run Claude login"}
                   </p>
                 )}
-                {claudeLoginResult?.loginUrl && (
+                {cliLoginResult?.loginUrl && (
                   <p className="text-xs">
                     Login URL:
                     <a
-                      href={claudeLoginResult.loginUrl}
+                      href={cliLoginResult.loginUrl}
                       className="text-blue-600 underline underline-offset-2 ml-1 break-all dark:text-blue-400"
                       target="_blank"
                       rel="noreferrer"
                     >
-                      {claudeLoginResult.loginUrl}
+                      {cliLoginResult.loginUrl}
                     </a>
                   </p>
                 )}
-                {claudeLoginResult && (
+                {cliLoginResult && (
                   <>
-                    {!!claudeLoginResult.stdout && (
+                    {!!cliLoginResult.stdout && (
                       <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-3 text-xs font-mono text-foreground overflow-x-auto whitespace-pre-wrap">
-                        {claudeLoginResult.stdout}
+                        {cliLoginResult.stdout}
                       </pre>
                     )}
-                    {!!claudeLoginResult.stderr && (
+                    {!!cliLoginResult.stderr && (
                       <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-3 text-xs font-mono text-red-700 dark:text-red-300 overflow-x-auto whitespace-pre-wrap">
-                        {claudeLoginResult.stderr}
+                        {cliLoginResult.stderr}
+                      </pre>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+            {run.errorCode === "codex_auth_required" && adapterType === "codex_local" && (
+              <div className="space-y-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => runCodexLogin.mutate()}
+                  disabled={runCodexLogin.isPending}
+                >
+                  {runCodexLogin.isPending ? "Running codex login..." : "Login to Codex"}
+                </Button>
+                {runCodexLogin.isError && (
+                  <p className="text-xs text-destructive">
+                    {runCodexLogin.error instanceof Error
+                      ? runCodexLogin.error.message
+                      : "Failed to run Codex login"}
+                  </p>
+                )}
+                {cliLoginResult?.loginUrl && (
+                  <p className="text-xs">
+                    Login URL:
+                    <a
+                      href={cliLoginResult.loginUrl}
+                      className="text-blue-600 underline underline-offset-2 ml-1 break-all dark:text-blue-400"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {cliLoginResult.loginUrl}
+                    </a>
+                  </p>
+                )}
+                {cliLoginResult && (
+                  <>
+                    {!!cliLoginResult.stdout && (
+                      <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-3 text-xs font-mono text-foreground overflow-x-auto whitespace-pre-wrap">
+                        {cliLoginResult.stdout}
+                      </pre>
+                    )}
+                    {!!cliLoginResult.stderr && (
+                      <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-3 text-xs font-mono text-red-700 dark:text-red-300 overflow-x-auto whitespace-pre-wrap">
+                        {cliLoginResult.stderr}
                       </pre>
                     )}
                   </>


### PR DESCRIPTION
## What changed
- added a local Codex login flow in the codex-local adapter using the same managed `CODEX_HOME` strategy Paperclip already uses at runtime
- surfaced `codex_auth_required` from Codex runs so the UI can react when local auth is missing
- added a backend agent route and UI action to run `codex login` from the agent detail screen, mirroring the existing Claude login flow
- updated Codex environment-test messaging to prefer local CLI auth instead of steering users toward API-key setup first

## Why
Codex was already available as a local adapter, but Paperclip only exposed an interactive login recovery path for Claude. When Codex lacked local auth, runs failed without a dedicated error code or UI action to recover in place.

## Impact
- Codex local agents can now be authenticated from inside Paperclip without configuring `OPENAI_API_KEY`
- Paperclip keeps using the managed/shared Codex home setup already present in the adapter
- existing API-key support remains untouched

## Validation
- `pnpm typecheck`
- `pnpm --filter @paperclipai/adapter-codex-local build`
- `pnpm --filter @paperclipai/ui build`
- `pnpm build` still fails on Windows in `packages/db` because the repo build script calls `cp -r`, which is unrelated to this change
