### PR TITLE
[codex] Clarify Claude instruction sibling file base path

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -387,7 +387,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     preparedInstructionsFile = true;
     try {
       const instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
-      const pathDirective = `\nThe above agent instructions were loaded from ${instructionsFilePath}. Resolve any relative file references from ${instructionsFileDir}.`;
+      const pathDirective =
+        `\nThe above agent instructions were loaded from ${instructionsFilePath}. ` +
+        `Resolve any relative file references from ${instructionsFileDir}. ` +
+        `This base directory is authoritative for sibling instruction files such as ` +
+        `./HEARTBEAT.md, ./SOUL.md, and ./TOOLS.md; do not resolve those from the parent agent directory.`;
       const combinedPath = path.join(skillsDir, "agent-instructions.md");
       await fs.writeFile(combinedPath, instructionsContent + pathDirective, "utf-8");
       effectiveInstructionsFilePath = combinedPath;

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -320,7 +320,10 @@ describe("claude execute", () => {
       expect(captured[1]?.appendedSystemPromptFilePath).not.toBe(instructionsFile);
       expect(captured[1]?.appendedSystemPromptFileContents).toContain("# Agent instructions");
       expect(captured[1]?.appendedSystemPromptFileContents).toContain(
-        `The above agent instructions were loaded from ${instructionsFile}. Resolve any relative file references from ${path.dirname(instructionsFile)}/.`,
+        `The above agent instructions were loaded from ${instructionsFile}. ` +
+        `Resolve any relative file references from ${path.dirname(instructionsFile)}/. ` +
+        `This base directory is authoritative for sibling instruction files such as ` +
+        `./HEARTBEAT.md, ./SOUL.md, and ./TOOLS.md; do not resolve those from the parent agent directory.`,
       );
       expect(metaEvents).toHaveLength(2);
       expect(metaEvents[0]?.commandNotes).toHaveLength(0);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Local adapters like Claude Code load agent instruction bundles and let agents read sibling files such as HEARTBEAT.md during execution
> - New CEO agents receive a managed instructions bundle, and those files are persisted under the managed bundle directory
> - A desktop onboarding failure showed the agent trying to resolve sibling instruction files from the parent agent directory instead of the managed bundle directory
> - That ambiguity can cause fresh onboarded CEOs to fail immediately when they try to read HEARTBEAT.md, SOUL.md, or TOOLS.md
> - This pull request makes the Claude adapter path directive explicit that sibling instruction files must resolve from the managed instructions directory, not the parent agent directory
> - The benefit is a smaller, targeted fix for onboarding-time agent failures without changing bundle storage or broader adapter behavior

## What Changed

- Clarified the Claude adapter instruction wrapper so it explicitly treats the instructions file directory as the authoritative base for sibling files like `./HEARTBEAT.md`, `./SOUL.md`, and `./TOOLS.md`.
- Updated the Claude execute regression test to assert the stronger path directive during the resume-to-fresh fallback path.

## Verification

- Ran `pnpm vitest server/src/__tests__/claude-local-execute.test.ts`
- Confirmed the targeted Claude execute suite passes locally (7/7 tests).

## Risks

- Low risk. This only changes the supplemental path guidance appended to Claude-managed instructions and updates the matching regression test. It does not change bundle persistence, runtime state, or non-Claude adapters.

## Model Used

- OpenAI GPT-5 via Codex, tool-using coding agent in Codex CLI environment, reasoning-heavy interactive code editing workflow.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
