### PR TITLE
fix(server): re-read index.html per request to fix black page on direct URL navigation

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -258,9 +258,11 @@ export async function createApp(
     ];
     const uiDist = candidates.find((p) => fs.existsSync(path.join(p, "index.html")));
     if (uiDist) {
-      const indexHtml = applyUiBranding(fs.readFileSync(path.join(uiDist, "index.html"), "utf-8"));
+      const indexHtmlPath = path.join(uiDist, "index.html");
       app.use(express.static(uiDist));
       app.get(/.*/, (_req, res) => {
+        // Re-read index.html on each request so UI rebuilds are picked up without a server restart
+        const indexHtml = applyUiBranding(fs.readFileSync(indexHtmlPath, "utf-8"));
         res.status(200).set("Content-Type", "text/html").end(indexHtml);
       });
     } else {


### PR DESCRIPTION
Direct URL navigation caused a black page because index.html was cached at server startup with an old asset hash. After a UI rebuild, the old hash file no longer existed, so express.static fell through to the catch-all which served HTML for a .js request. Fix: re-read index.html on each request (matches vite-dev behavior). Closes ANGA-766.