### PR TITLE
Fix plugin page routes doubling company prefix on company switch

### DIFF
--- a/ui/src/lib/company-routes.test.ts
+++ b/ui/src/lib/company-routes.test.ts
@@ -20,4 +20,28 @@ describe("company routes", () => {
       "/execution-workspaces/workspace-123",
     );
   });
+
+  /**
+   * Regression test for https://github.com/paperclipai/paperclip/issues/3264
+   *
+   * Plugin page routes (e.g. youtube-trends) are not in BOARD_ROUTE_ROOTS.
+   * toCompanyRelativePath must still strip the company prefix from these
+   * paths so that company-switch navigation does not double the prefix.
+   */
+  it("strips company prefix from plugin page routes", () => {
+    expect(toCompanyRelativePath("/ACM/youtube-trends")).toBe("/youtube-trends");
+    expect(toCompanyRelativePath("/HAR/youtube-insights")).toBe("/youtube-insights");
+    expect(toCompanyRelativePath("/PAP/my-custom-plugin-page")).toBe("/my-custom-plugin-page");
+  });
+
+  it("still strips company prefix from board routes", () => {
+    expect(toCompanyRelativePath("/PAP/dashboard")).toBe("/dashboard");
+    expect(toCompanyRelativePath("/PAP/issues")).toBe("/issues");
+    expect(toCompanyRelativePath("/PAP/routines")).toBe("/routines");
+  });
+
+  it("does not strip global route roots", () => {
+    expect(toCompanyRelativePath("/auth/login")).toBe("/auth/login");
+    expect(toCompanyRelativePath("/docs/guide")).toBe("/docs/guide");
+  });
 });

--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -81,8 +81,8 @@ export function toCompanyRelativePath(path: string): string {
   const segments = pathname.split("/").filter(Boolean);
 
   if (segments.length >= 2) {
-    const second = segments[1]!.toLowerCase();
-    if (!GLOBAL_ROUTE_ROOTS.has(segments[0]!.toLowerCase()) && BOARD_ROUTE_ROOTS.has(second)) {
+    const first = segments[0]!.toLowerCase();
+    if (!GLOBAL_ROUTE_ROOTS.has(first) && !BOARD_ROUTE_ROOTS.has(first)) {
       return `/${segments.slice(1).join("/")}${search}${hash}`;
     }
   }


### PR DESCRIPTION
## Summary

- Fix `toCompanyRelativePath()` to strip company prefix from plugin page routes, not just board routes
- Add regression tests for plugin page routes, board routes, and global routes

Fixes #3264

## Root Cause

`toCompanyRelativePath()` only stripped the company prefix when the second path segment was in `BOARD_ROUTE_ROOTS`. Plugin page routes (e.g. `youtube-trends`) are not in that set, so the prefix was preserved in localStorage. On company switch, `useCompanyPageMemory` prepended the new prefix to the un-stripped path, doubling it.

## Test plan

- [x] Existing tests pass
- [x] New regression tests for plugin page routes pass
- [ ] Manual: install a plugin with page routes on two companies, switch between them while on a plugin page — URL should not double the prefix