### PR TITLE
feat(ui): localize board UI to zh-CN

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -48,8 +48,10 @@ import { NotFoundPage } from "./pages/NotFound";
 import { queryKeys } from "./lib/queryKeys";
 import { useCompany } from "./context/CompanyContext";
 import { useDialog } from "./context/DialogContext";
+import { useGeneralSettings } from "./context/GeneralSettingsContext";
 import { loadLastInboxTab } from "./lib/inbox";
 import { shouldRedirectCompanylessRouteToOnboarding } from "./lib/onboarding-route";
+import { textFor } from "./lib/ui-language";
 
 function BootstrapPendingPage({ hasActiveInvite = false }: { hasActiveInvite?: boolean }) {
   return (
@@ -199,21 +201,34 @@ function LegacySettingsRedirect() {
 function OnboardingRoutePage() {
   const { companies } = useCompany();
   const { openOnboarding } = useDialog();
+  const { uiLanguage } = useGeneralSettings();
   const { companyPrefix } = useParams<{ companyPrefix?: string }>();
   const matchedCompany = companyPrefix
     ? companies.find((company) => company.issuePrefix.toUpperCase() === companyPrefix.toUpperCase()) ?? null
     : null;
 
   const title = matchedCompany
-    ? `Add another agent to ${matchedCompany.name}`
+    ? textFor(uiLanguage, {
+        en: `Add another agent to ${matchedCompany.name}`,
+        "zh-CN": `为 ${matchedCompany.name} 再添加一个智能体`,
+      })
     : companies.length > 0
-      ? "Create another company"
-      : "Create your first company";
+      ? textFor(uiLanguage, { en: "Create another company", "zh-CN": "创建另一家公司" })
+      : textFor(uiLanguage, { en: "Create your first company", "zh-CN": "创建第一家公司" });
   const description = matchedCompany
-    ? "Run onboarding again to add an agent and a starter task for this company."
+    ? textFor(uiLanguage, {
+        en: "Run onboarding again to add an agent and a starter task for this company.",
+        "zh-CN": "重新运行 onboarding，为这家公司添加一个智能体和一个起始任务。",
+      })
     : companies.length > 0
-      ? "Run onboarding again to create another company and seed its first agent."
-      : "Get started by creating a company and your first agent.";
+      ? textFor(uiLanguage, {
+          en: "Run onboarding again to create another company and seed its first agent.",
+          "zh-CN": "重新运行 onboarding，创建另一家公司并初始化它的第一个智能体。",
+        })
+      : textFor(uiLanguage, {
+          en: "Get started by creating a company and your first agent.",
+          "zh-CN": "从创建一家公司和你的第一个智能体开始。",
+        });
 
   return (
     <div className="mx-auto max-w-xl py-10">
@@ -228,7 +243,9 @@ function OnboardingRoutePage() {
                 : openOnboarding()
             }
           >
-            {matchedCompany ? "Add Agent" : "Start Onboarding"}
+            {matchedCompany
+              ? textFor(uiLanguage, { en: "Add Agent", "zh-CN": "添加智能体" })
+              : textFor(uiLanguage, { en: "Start Onboarding", "zh-CN": "开始引导" })}
           </Button>
         </div>
       </div>
@@ -291,16 +308,21 @@ function UnprefixedBoardRedirect() {
 
 function NoCompaniesStartPage() {
   const { openOnboarding } = useDialog();
+  const { uiLanguage } = useGeneralSettings();
 
   return (
     <div className="mx-auto max-w-xl py-10">
       <div className="rounded-lg border border-border bg-card p-6">
-        <h1 className="text-xl font-semibold">Create your first company</h1>
+        <h1 className="text-xl font-semibold">
+          {textFor(uiLanguage, { en: "Create your first company", "zh-CN": "创建第一家公司" })}
+        </h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Get started by creating a company.
+          {textFor(uiLanguage, { en: "Get started by creating a company.", "zh-CN": "从创建一家公司开始。" })}
         </p>
         <div className="mt-4">
-          <Button onClick={() => openOnboarding()}>New Company</Button>
+          <Button onClick={() => openOnboarding()}>
+            {textFor(uiLanguage, { en: "New Company", "zh-CN": "新建公司" })}
+          </Button>
         </div>
       </div>
     </div>

--- a/ui/src/adapters/codex-local/config-fields.tsx
+++ b/ui/src/adapters/codex-local/config-fields.tsx
@@ -7,6 +7,8 @@ import {
 } from "../../components/agent-config-primitives";
 import { ChoosePathButton } from "../../components/PathInstructionsModal";
 import { LocalWorkspaceRuntimeFields } from "../local-workspace-runtime-fields";
+import { useGeneralSettings } from "../../context/GeneralSettingsContext";
+import { textFor } from "../../lib/ui-language";
 
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
@@ -25,13 +27,19 @@ export function CodexLocalConfigFields({
   models,
   hideInstructionsFile,
 }: AdapterConfigFieldsProps) {
+  const { uiLanguage } = useGeneralSettings();
   const bypassEnabled =
     config.dangerouslyBypassApprovalsAndSandbox === true || config.dangerouslyBypassSandbox === true;
+  const copy = {
+    instructionsFile: textFor(uiLanguage, { en: "Agent instructions file", "zh-CN": "智能体说明文件" }),
+    bypassSandbox: textFor(uiLanguage, { en: "Bypass sandbox", "zh-CN": "绕过沙箱" }),
+    enableSearch: textFor(uiLanguage, { en: "Enable search", "zh-CN": "启用搜索" }),
+  };
 
   return (
     <>
       {!hideInstructionsFile && (
-        <Field label="Agent instructions file" hint={instructionsFileHint}>
+        <Field label={copy.instructionsFile} hint={instructionsFileHint}>
           <div className="flex items-center gap-2">
             <DraftInput
               value={
@@ -57,7 +65,7 @@ export function CodexLocalConfigFields({
         </Field>
       )}
       <ToggleField
-        label="Bypass sandbox"
+        label={copy.bypassSandbox}
         hint={help.dangerouslyBypassSandbox}
         checked={
           isCreate
@@ -75,7 +83,7 @@ export function CodexLocalConfigFields({
         }
       />
       <ToggleField
-        label="Enable search"
+        label={copy.enableSearch}
         hint={help.search}
         checked={
           isCreate

--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -11,6 +11,8 @@ import { ExternalLink } from "lucide-react";
 import { Identity } from "./Identity";
 import { RunChatSurface } from "./RunChatSurface";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 const MIN_DASHBOARD_RUNS = 4;
 
@@ -23,6 +25,7 @@ interface ActiveAgentsPanelProps {
 }
 
 export function ActiveAgentsPanel({ companyId }: ActiveAgentsPanelProps) {
+  const { uiLanguage } = useGeneralSettings();
   const { data: liveRuns } = useQuery({
     queryKey: [...queryKeys.liveRuns(companyId), "dashboard"],
     queryFn: () => heartbeatsApi.liveRunsForCompany(companyId, MIN_DASHBOARD_RUNS),
@@ -48,15 +51,25 @@ export function ActiveAgentsPanel({ companyId }: ActiveAgentsPanelProps) {
     companyId,
     maxChunksPerRun: 120,
   });
+  const copy = {
+    agents: textFor(uiLanguage, {
+      en: "Agents",
+      "zh-CN": "智能体",
+    }),
+    noRecentRuns: textFor(uiLanguage, {
+      en: "No recent agent runs.",
+      "zh-CN": "最近没有智能体运行记录。",
+    }),
+  };
 
   return (
     <div>
       <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-        Agents
+        {copy.agents}
       </h3>
       {runs.length === 0 ? (
         <div className="rounded-xl border border-border p-4">
-          <p className="text-sm text-muted-foreground">No recent agent runs.</p>
+          <p className="text-sm text-muted-foreground">{copy.noRecentRuns}</p>
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-4 xl:grid-cols-4">
@@ -92,6 +105,21 @@ function AgentRunCard({
   hasOutput: boolean;
   isActive: boolean;
 }) {
+  const { uiLanguage } = useGeneralSettings();
+  const copy = {
+    liveNow: textFor(uiLanguage, {
+      en: "Live now",
+      "zh-CN": "正在运行",
+    }),
+    finished: textFor(uiLanguage, {
+      en: "Finished",
+      "zh-CN": "已完成",
+    }),
+    started: textFor(uiLanguage, {
+      en: "Started",
+      "zh-CN": "开始于",
+    }),
+  };
   return (
     <div className={cn(
       "flex h-[320px] flex-col overflow-hidden rounded-xl border shadow-sm",
@@ -114,7 +142,13 @@ function AgentRunCard({
               <Identity name={run.agentName} size="sm" className="[&>span:last-child]:!text-[11px]" />
             </div>
             <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
-              <span>{isActive ? "Live now" : run.finishedAt ? `Finished ${relativeTime(run.finishedAt)}` : `Started ${relativeTime(run.createdAt)}`}</span>
+              <span>
+                {isActive
+                  ? copy.liveNow
+                  : run.finishedAt
+                    ? `${copy.finished} ${relativeTime(run.finishedAt)}`
+                    : `${copy.started} ${relativeTime(run.createdAt)}`}
+              </span>
             </div>
           </div>
 

--- a/ui/src/components/ActivityCharts.tsx
+++ b/ui/src/components/ActivityCharts.tsx
@@ -1,4 +1,5 @@
 import type { HeartbeatRun } from "@paperclipai/shared";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 
 /* ---- Utilities ---- */
 
@@ -59,6 +60,7 @@ export function ChartCard({ title, subtitle, children }: { title: string; subtit
 /* ---- Chart Components ---- */
 
 export function RunActivityChart({ runs }: { runs: HeartbeatRun[] }) {
+  const { uiLanguage } = useGeneralSettings();
   const days = getLast14Days();
 
   const grouped = new Map<string, { succeeded: number; failed: number; other: number }>();
@@ -75,7 +77,7 @@ export function RunActivityChart({ runs }: { runs: HeartbeatRun[] }) {
   const maxValue = Math.max(...Array.from(grouped.values()).map(v => v.succeeded + v.failed + v.other), 1);
   const hasData = Array.from(grouped.values()).some(v => v.succeeded + v.failed + v.other > 0);
 
-  if (!hasData) return <p className="text-xs text-muted-foreground">No runs yet</p>;
+  if (!hasData) return <p className="text-xs text-muted-foreground">{uiLanguage === "zh-CN" ? "还没有运行记录" : "No runs yet"}</p>;
 
   return (
     <div>
@@ -114,6 +116,7 @@ const priorityColors: Record<string, string> = {
 const priorityOrder = ["critical", "high", "medium", "low"] as const;
 
 export function PriorityChart({ issues }: { issues: { priority: string; createdAt: Date }[] }) {
+  const { uiLanguage } = useGeneralSettings();
   const days = getLast14Days();
   const grouped = new Map<string, Record<string, number>>();
   for (const day of days) grouped.set(day, { critical: 0, high: 0, medium: 0, low: 0 });
@@ -127,7 +130,7 @@ export function PriorityChart({ issues }: { issues: { priority: string; createdA
   const maxValue = Math.max(...Array.from(grouped.values()).map(v => Object.values(v).reduce((a, b) => a + b, 0)), 1);
   const hasData = Array.from(grouped.values()).some(v => Object.values(v).reduce((a, b) => a + b, 0) > 0);
 
-  if (!hasData) return <p className="text-xs text-muted-foreground">No issues</p>;
+  if (!hasData) return <p className="text-xs text-muted-foreground">{uiLanguage === "zh-CN" ? "暂无任务" : "No issues"}</p>;
 
   return (
     <div>
@@ -152,7 +155,12 @@ export function PriorityChart({ issues }: { issues: { priority: string; createdA
         })}
       </div>
       <DateLabels days={days} />
-      <ChartLegend items={priorityOrder.map(p => ({ color: priorityColors[p], label: p.charAt(0).toUpperCase() + p.slice(1) }))} />
+      <ChartLegend items={priorityOrder.map((p) => ({
+        color: priorityColors[p],
+        label: uiLanguage === "zh-CN"
+          ? ({ critical: "紧急", high: "高", medium: "中", low: "低" }[p])
+          : p.charAt(0).toUpperCase() + p.slice(1),
+      }))} />
     </div>
   );
 }
@@ -178,6 +186,7 @@ const statusLabels: Record<string, string> = {
 };
 
 export function IssueStatusChart({ issues }: { issues: { status: string; createdAt: Date }[] }) {
+  const { uiLanguage } = useGeneralSettings();
   const days = getLast14Days();
   const allStatuses = new Set<string>();
   const grouped = new Map<string, Record<string, number>>();
@@ -194,7 +203,7 @@ export function IssueStatusChart({ issues }: { issues: { status: string; created
   const maxValue = Math.max(...Array.from(grouped.values()).map(v => Object.values(v).reduce((a, b) => a + b, 0)), 1);
   const hasData = allStatuses.size > 0;
 
-  if (!hasData) return <p className="text-xs text-muted-foreground">No issues</p>;
+  if (!hasData) return <p className="text-xs text-muted-foreground">{uiLanguage === "zh-CN" ? "暂无任务" : "No issues"}</p>;
 
   return (
     <div>
@@ -219,12 +228,26 @@ export function IssueStatusChart({ issues }: { issues: { status: string; created
         })}
       </div>
       <DateLabels days={days} />
-      <ChartLegend items={statusOrder.map(s => ({ color: statusColors[s] ?? "#6b7280", label: statusLabels[s] ?? s }))} />
+      <ChartLegend items={statusOrder.map((s) => ({
+        color: statusColors[s] ?? "#6b7280",
+        label: uiLanguage === "zh-CN"
+          ? ({
+            todo: "待处理",
+            in_progress: "进行中",
+            in_review: "审核中",
+            done: "已完成",
+            blocked: "阻塞",
+            cancelled: "已取消",
+            backlog: "待规划",
+          }[s] ?? s)
+          : (statusLabels[s] ?? s),
+      }))} />
     </div>
   );
 }
 
 export function SuccessRateChart({ runs }: { runs: HeartbeatRun[] }) {
+  const { uiLanguage } = useGeneralSettings();
   const days = getLast14Days();
   const grouped = new Map<string, { succeeded: number; total: number }>();
   for (const day of days) grouped.set(day, { succeeded: 0, total: 0 });
@@ -237,7 +260,7 @@ export function SuccessRateChart({ runs }: { runs: HeartbeatRun[] }) {
   }
 
   const hasData = Array.from(grouped.values()).some(v => v.total > 0);
-  if (!hasData) return <p className="text-xs text-muted-foreground">No runs yet</p>;
+  if (!hasData) return <p className="text-xs text-muted-foreground">{uiLanguage === "zh-CN" ? "还没有运行记录" : "No runs yet"}</p>;
 
   return (
     <div>

--- a/ui/src/components/ActivityRow.tsx
+++ b/ui/src/components/ActivityRow.tsx
@@ -4,6 +4,8 @@ import { timeAgo } from "../lib/timeAgo";
 import { cn } from "../lib/utils";
 import { formatActivityVerb } from "../lib/activity-format";
 import { deriveProjectUrlKey, type ActivityEvent, type Agent } from "@paperclipai/shared";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 function entityLink(entityType: string, entityId: string, name?: string | null): string | null {
   switch (entityType) {
@@ -25,7 +27,8 @@ interface ActivityRowProps {
 }
 
 export function ActivityRow({ event, agentMap, entityNameMap, entityTitleMap, className }: ActivityRowProps) {
-  const verb = formatActivityVerb(event.action, event.details, { agentMap });
+  const { uiLanguage } = useGeneralSettings();
+  const verb = formatActivityVerb(event.action, event.details, { agentMap, uiLanguage });
 
   const isHeartbeatEvent = event.entityType === "heartbeat_run";
   const heartbeatAgentId = isHeartbeatEvent
@@ -43,7 +46,13 @@ export function ActivityRow({ event, agentMap, entityNameMap, entityTitleMap, cl
     : entityLink(event.entityType, event.entityId, name);
 
   const actor = event.actorType === "agent" ? agentMap.get(event.actorId) : null;
-  const actorName = actor?.name ?? (event.actorType === "system" ? "System" : event.actorType === "user" ? "Board" : event.actorId || "Unknown");
+  const actorName = actor?.name ?? (
+    event.actorType === "system"
+      ? textFor(uiLanguage, { en: "System", "zh-CN": "系统" })
+      : event.actorType === "user"
+        ? textFor(uiLanguage, { en: "Board", "zh-CN": "董事会" })
+        : event.actorId || textFor(uiLanguage, { en: "Unknown", "zh-CN": "未知" })
+  );
 
   const inner = (
     <div className="flex gap-3">

--- a/ui/src/components/AgentActionButtons.tsx
+++ b/ui/src/components/AgentActionButtons.tsx
@@ -1,5 +1,7 @@
 import { Pause, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 export function RunButton({
   onClick,
@@ -12,10 +14,14 @@ export function RunButton({
   label?: string;
   size?: "sm" | "default";
 }) {
+  const { uiLanguage } = useGeneralSettings();
+  const resolvedLabel = label === "Run now"
+    ? textFor(uiLanguage, { en: "Run now", "zh-CN": "立即运行" })
+    : label;
   return (
     <Button variant="outline" size={size} onClick={onClick} disabled={disabled}>
       <Play className="h-3.5 w-3.5 sm:mr-1" />
-      <span className="hidden sm:inline">{label}</span>
+      <span className="hidden sm:inline">{resolvedLabel}</span>
     </Button>
   );
 }
@@ -33,11 +39,12 @@ export function PauseResumeButton({
   disabled?: boolean;
   size?: "sm" | "default";
 }) {
+  const { uiLanguage } = useGeneralSettings();
   if (isPaused) {
     return (
       <Button variant="outline" size={size} onClick={onResume} disabled={disabled}>
         <Play className="h-3.5 w-3.5 sm:mr-1" />
-        <span className="hidden sm:inline">Resume</span>
+        <span className="hidden sm:inline">{textFor(uiLanguage, { en: "Resume", "zh-CN": "恢复" })}</span>
       </Button>
     );
   }
@@ -45,7 +52,7 @@ export function PauseResumeButton({
   return (
     <Button variant="outline" size={size} onClick={onPause} disabled={disabled}>
       <Pause className="h-3.5 w-3.5 sm:mr-1" />
-      <span className="hidden sm:inline">Pause</span>
+      <span className="hidden sm:inline">{textFor(uiLanguage, { en: "Pause", "zh-CN": "暂停" })}</span>
     </Button>
   );
 }

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -27,6 +27,8 @@ import { cn } from "../lib/utils";
 import { extractModelName, extractProviderId } from "../lib/model-utils";
 import { queryKeys } from "../lib/queryKeys";
 import { useCompany } from "../context/CompanyContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 import {
   Field,
   ToggleField,
@@ -169,12 +171,29 @@ const claudeThinkingEffortOptions = [
   { id: "high", label: "High" },
 ] as const;
 
+function translatedOptionLabel(label: string, uiLanguage: "en" | "zh-CN") {
+  if (uiLanguage !== "zh-CN") return label;
+  const labels: Record<string, string> = {
+    Auto: "自动",
+    Minimal: "极低",
+    Low: "低",
+    Medium: "中",
+    High: "高",
+    "X-High": "超高",
+    Max: "最大",
+    Plan: "规划",
+    Ask: "询问",
+  };
+  return labels[label] ?? label;
+}
+
 
 /* ---- Form ---- */
 
 export function AgentConfigForm(props: AgentConfigFormProps) {
   const { mode, adapterModels: externalModels } = props;
   const isCreate = mode === "create";
+  const { uiLanguage } = useGeneralSettings();
   const cards = props.sectionLayout === "cards";
   const showAdapterTypeField = props.showAdapterTypeField ?? true;
   const showAdapterTestEnvironmentButton = props.showAdapterTestEnvironmentButton ?? true;
@@ -379,6 +398,44 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   // Popover states
   const [modelOpen, setModelOpen] = useState(false);
   const [thinkingEffortOpen, setThinkingEffortOpen] = useState(false);
+  const copy = {
+    unsavedChanges: textFor(uiLanguage, { en: "Unsaved changes", "zh-CN": "有未保存更改" }),
+    saving: textFor(uiLanguage, { en: "Saving...", "zh-CN": "保存中..." }),
+    save: textFor(uiLanguage, { en: "Save", "zh-CN": "保存" }),
+    identity: textFor(uiLanguage, { en: "Identity", "zh-CN": "身份信息" }),
+    name: textFor(uiLanguage, { en: "Name", "zh-CN": "名称" }),
+    agentName: textFor(uiLanguage, { en: "Agent name", "zh-CN": "智能体名称" }),
+    title: textFor(uiLanguage, { en: "Title", "zh-CN": "职位" }),
+    titlePlaceholder: textFor(uiLanguage, { en: "e.g. VP of Engineering", "zh-CN": "例如：工程副总裁" }),
+    reportsTo: textFor(uiLanguage, { en: "Reports to", "zh-CN": "汇报对象" }),
+    chooseManager: textFor(uiLanguage, { en: "Choose manager…", "zh-CN": "选择上级…" }),
+    capabilities: textFor(uiLanguage, { en: "Capabilities", "zh-CN": "能力描述" }),
+    capabilitiesPlaceholder: textFor(uiLanguage, { en: "Describe what this agent can do...", "zh-CN": "描述这个智能体能做什么..." }),
+    adapter: textFor(uiLanguage, { en: "Adapter", "zh-CN": "适配器" }),
+    testing: textFor(uiLanguage, { en: "Testing...", "zh-CN": "检测中..." }),
+    testEnvironment: textFor(uiLanguage, { en: "Test environment", "zh-CN": "测试环境" }),
+    adapterType: textFor(uiLanguage, { en: "Adapter type", "zh-CN": "适配器类型" }),
+    environmentTestFailed: textFor(uiLanguage, { en: "Environment test failed", "zh-CN": "环境检测失败" }),
+    permissionsConfig: textFor(uiLanguage, { en: "Permissions & Configuration", "zh-CN": "权限与配置" }),
+    command: textFor(uiLanguage, { en: "Command", "zh-CN": "命令" }),
+    detectModel: textFor(uiLanguage, { en: "Detect model", "zh-CN": "检测模型" }),
+    noModelDetected: textFor(uiLanguage, { en: "No model detected. Select or enter one manually.", "zh-CN": "未检测到模型，请手动选择或输入。" }),
+    adapterModelsFailed: textFor(uiLanguage, { en: "Failed to load adapter models.", "zh-CN": "加载适配器模型失败。" }),
+    codexMinimalWarning: textFor(uiLanguage, { en: "Codex may reject `minimal` thinking when search is enabled.", "zh-CN": "启用搜索时，Codex 可能会拒绝 `minimal` 思考强度。" }),
+    extraArgs: textFor(uiLanguage, { en: "Extra args (comma-separated)", "zh-CN": "附加参数（逗号分隔）" }),
+    extraArgsPlaceholder: textFor(uiLanguage, { en: "e.g. --verbose, --foo=bar", "zh-CN": "例如：--verbose, --foo=bar" }),
+    envVars: textFor(uiLanguage, { en: "Environment variables", "zh-CN": "环境变量" }),
+    timeoutSec: textFor(uiLanguage, { en: "Timeout (sec)", "zh-CN": "超时（秒）" }),
+    graceSec: textFor(uiLanguage, { en: "Interrupt grace period (sec)", "zh-CN": "中断宽限期（秒）" }),
+    runPolicy: textFor(uiLanguage, { en: "Run Policy", "zh-CN": "运行策略" }),
+    heartbeatOnInterval: textFor(uiLanguage, { en: "Heartbeat on interval", "zh-CN": "按间隔运行心跳" }),
+    sec: textFor(uiLanguage, { en: "sec", "zh-CN": "秒" }),
+    runHeartbeatEvery: textFor(uiLanguage, { en: "Run heartbeat every", "zh-CN": "每隔多久运行一次心跳" }),
+    advancedRunPolicy: textFor(uiLanguage, { en: "Advanced Run Policy", "zh-CN": "高级运行策略" }),
+    wakeOnDemand: textFor(uiLanguage, { en: "Wake on demand", "zh-CN": "按需唤醒" }),
+    cooldownSec: textFor(uiLanguage, { en: "Cooldown (sec)", "zh-CN": "冷却时间（秒）" }),
+    maxConcurrentRuns: textFor(uiLanguage, { en: "Max concurrent runs", "zh-CN": "最大并发运行数" }),
+  };
 
   // Create mode helpers
   const val = isCreate ? props.values : null;
@@ -469,13 +526,13 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       {isDirty && !props.hideInlineSave && (
         <div className="sticky top-0 z-10 flex items-center justify-end px-4 py-2 bg-background/90 backdrop-blur-sm border-b border-primary/20">
           <div className="flex items-center gap-3">
-            <span className="text-xs text-muted-foreground">Unsaved changes</span>
+            <span className="text-xs text-muted-foreground">{copy.unsavedChanges}</span>
             <Button
               size="sm"
               onClick={handleSave}
               disabled={!isCreate && props.isSaving}
             >
-              {!isCreate && props.isSaving ? "Saving..." : "Save"}
+              {!isCreate && props.isSaving ? copy.saving : copy.save}
             </Button>
           </div>
         </div>
@@ -485,42 +542,42 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       {!isCreate && (
         <div className={cn(!cards && "border-b border-border")}>
           {cards
-            ? <h3 className="text-sm font-medium mb-3">Identity</h3>
-            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">Identity</div>
+            ? <h3 className="text-sm font-medium mb-3">{copy.identity}</h3>
+            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">{copy.identity}</div>
           }
           <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
-            <Field label="Name" hint={help.name}>
+            <Field label={copy.name} hint={help.name}>
               <DraftInput
                 value={eff("identity", "name", props.agent.name)}
                 onCommit={(v) => mark("identity", "name", v)}
                 immediate
                 className={inputClass}
-                placeholder="Agent name"
+                placeholder={copy.agentName}
               />
             </Field>
-            <Field label="Title" hint={help.title}>
+            <Field label={copy.title} hint={help.title}>
               <DraftInput
                 value={eff("identity", "title", props.agent.title ?? "")}
                 onCommit={(v) => mark("identity", "title", v || null)}
                 immediate
                 className={inputClass}
-                placeholder="e.g. VP of Engineering"
+                placeholder={copy.titlePlaceholder}
               />
             </Field>
-            <Field label="Reports to" hint={help.reportsTo}>
+            <Field label={copy.reportsTo} hint={help.reportsTo}>
               <ReportsToPicker
                 agents={companyAgents}
                 value={eff("identity", "reportsTo", props.agent.reportsTo ?? null)}
                 onChange={(id) => mark("identity", "reportsTo", id)}
                 excludeAgentIds={[props.agent.id]}
-                chooseLabel="Choose manager…"
+                chooseLabel={copy.chooseManager}
               />
             </Field>
-            <Field label="Capabilities" hint={help.capabilities}>
+            <Field label={copy.capabilities} hint={help.capabilities}>
               <MarkdownEditor
                 value={eff("identity", "capabilities", props.agent.capabilities ?? "") ?? ""}
                 onChange={(v) => mark("identity", "capabilities", v || null)}
-                placeholder="Describe what this agent can do..."
+                placeholder={copy.capabilitiesPlaceholder}
                 contentClassName="min-h-[44px] text-sm font-mono"
                 imageUploadHandler={async (file) => {
                   const asset = await uploadMarkdownImage.mutateAsync({
@@ -563,8 +620,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       <div className={cn(!cards && (isCreate ? "border-t border-border" : "border-b border-border"))}>
         <div className={cn(cards ? "flex items-center justify-between mb-3" : "px-4 py-2 flex items-center justify-between gap-2")}>
           {cards
-            ? <h3 className="text-sm font-medium">Adapter</h3>
-            : <span className="text-xs font-medium text-muted-foreground">Adapter</span>
+            ? <h3 className="text-sm font-medium">{copy.adapter}</h3>
+            : <span className="text-xs font-medium text-muted-foreground">{copy.adapter}</span>
           }
           {showAdapterTestEnvironmentButton && (
             <Button
@@ -575,13 +632,13 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               onClick={() => testEnvironment.mutate()}
               disabled={testEnvironment.isPending || !selectedCompanyId}
             >
-              {testEnvironment.isPending ? "Testing..." : "Test environment"}
+              {testEnvironment.isPending ? copy.testing : copy.testEnvironment}
             </Button>
           )}
         </div>
         <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
           {showAdapterTypeField && (
-            <Field label="Adapter type" hint={help.adapterType}>
+            <Field label={copy.adapterType} hint={help.adapterType}>
               <AdapterTypeDropdown
                 value={adapterType}
                 disabledTypes={disabledTypes}
@@ -639,7 +696,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
               {testEnvironment.error instanceof Error
                 ? testEnvironment.error.message
-                : "Environment test failed"}
+                : copy.environmentTestFailed}
             </div>
           )}
 
@@ -703,11 +760,11 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       {isLocal && (
         <div className={cn(!cards && "border-b border-border")}>
           {cards
-            ? <h3 className="text-sm font-medium mb-3">Permissions &amp; Configuration</h3>
-            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">Permissions &amp; Configuration</div>
+            ? <h3 className="text-sm font-medium mb-3">{copy.permissionsConfig}</h3>
+            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">{copy.permissionsConfig}</div>
           }
           <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
-              <Field label="Command" hint={help.localCommand}>
+              <Field label={copy.command} hint={help.localCommand}>
                 <DraftInput
                   value={
                     isCreate
@@ -754,14 +811,14 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   const result = await refetchDetectedModel();
                   return result.data?.model ?? null;
                 }}
-                detectModelLabel="Detect model"
-                emptyDetectHint="No model detected. Select or enter one manually."
+                detectModelLabel={copy.detectModel}
+                emptyDetectHint={copy.noModelDetected}
               />
               {fetchedModelsError && (
                 <p className="text-xs text-destructive">
                   {fetchedModelsError instanceof Error
                     ? fetchedModelsError.message
-                    : "Failed to load adapter models."}
+                    : copy.adapterModelsFailed}
                 </p>
               )}
 
@@ -782,7 +839,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     codexSearchEnabled &&
                     currentThinkingEffort === "minimal" && (
                       <p className="text-xs text-amber-400">
-                        Codex may reject `minimal` thinking when search is enabled.
+                        {copy.codexMinimalWarning}
                       </p>
                     )}
                 </>
@@ -818,7 +875,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               )}
               <uiAdapter.ConfigFields {...adapterFieldProps} />
 
-              <Field label="Extra args (comma-separated)" hint={help.extraArgs}>
+              <Field label={copy.extraArgs} hint={help.extraArgs}>
                 <DraftInput
                   value={
                     isCreate
@@ -832,11 +889,11 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   }
                   immediate
                   className={inputClass}
-                  placeholder="e.g. --verbose, --foo=bar"
+                  placeholder={copy.extraArgsPlaceholder}
                 />
               </Field>
 
-              <Field label="Environment variables" hint={help.envVars}>
+              <Field label={copy.envVars} hint={help.envVars}>
                 <EnvVarEditor
                   value={
                     isCreate
@@ -860,7 +917,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               {/* Edit-only: timeout + grace period */}
               {!isCreate && (
                 <>
-                  <Field label="Timeout (sec)" hint={help.timeoutSec}>
+                  <Field label={copy.timeoutSec} hint={help.timeoutSec}>
                     <DraftNumberInput
                       value={eff(
                         "adapterConfig",
@@ -872,7 +929,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       className={inputClass}
                     />
                   </Field>
-                  <Field label="Interrupt grace period (sec)" hint={help.graceSec}>
+                  <Field label={copy.graceSec} hint={help.graceSec}>
                     <DraftNumberInput
                       value={eff(
                         "adapterConfig",
@@ -894,19 +951,19 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       {isCreate && showCreateRunPolicySection ? (
         <div className={cn(!cards && "border-b border-border")}>
           {cards
-            ? <h3 className="text-sm font-medium flex items-center gap-2 mb-3"><Heart className="h-3 w-3" /> Run Policy</h3>
-            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground flex items-center gap-2"><Heart className="h-3 w-3" /> Run Policy</div>
+            ? <h3 className="text-sm font-medium flex items-center gap-2 mb-3"><Heart className="h-3 w-3" /> {copy.runPolicy}</h3>
+            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground flex items-center gap-2"><Heart className="h-3 w-3" /> {copy.runPolicy}</div>
           }
           <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
             <ToggleWithNumber
-              label="Heartbeat on interval"
+              label={copy.heartbeatOnInterval}
               hint={help.heartbeatInterval}
               checked={val!.heartbeatEnabled}
               onCheckedChange={(v) => set!({ heartbeatEnabled: v })}
               number={val!.intervalSec}
               onNumberChange={(v) => set!({ intervalSec: v })}
-              numberLabel="sec"
-              numberPrefix="Run heartbeat every"
+              numberLabel={copy.sec}
+              numberPrefix={copy.runHeartbeatEvery}
               numberHint={help.intervalSec}
               showNumber={val!.heartbeatEnabled}
             />
@@ -915,33 +972,33 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       ) : !isCreate ? (
         <div className={cn(!cards && "border-b border-border")}>
           {cards
-            ? <h3 className="text-sm font-medium flex items-center gap-2 mb-3"><Heart className="h-3 w-3" /> Run Policy</h3>
-            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground flex items-center gap-2"><Heart className="h-3 w-3" /> Run Policy</div>
+            ? <h3 className="text-sm font-medium flex items-center gap-2 mb-3"><Heart className="h-3 w-3" /> {copy.runPolicy}</h3>
+            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground flex items-center gap-2"><Heart className="h-3 w-3" /> {copy.runPolicy}</div>
           }
           <div className={cn(cards ? "border border-border rounded-lg overflow-hidden" : "")}>
             <div className={cn(cards ? "p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
               <ToggleWithNumber
-                label="Heartbeat on interval"
+                label={copy.heartbeatOnInterval}
                 hint={help.heartbeatInterval}
                 checked={eff("heartbeat", "enabled", heartbeat.enabled === true)}
                 onCheckedChange={(v) => mark("heartbeat", "enabled", v)}
                 number={eff("heartbeat", "intervalSec", Number(heartbeat.intervalSec ?? 300))}
                 onNumberChange={(v) => mark("heartbeat", "intervalSec", v)}
-                numberLabel="sec"
-                numberPrefix="Run heartbeat every"
+                numberLabel={copy.sec}
+                numberPrefix={copy.runHeartbeatEvery}
                 numberHint={help.intervalSec}
                 showNumber={eff("heartbeat", "enabled", heartbeat.enabled === true)}
               />
             </div>
             <CollapsibleSection
-              title="Advanced Run Policy"
+              title={copy.advancedRunPolicy}
               bordered={cards}
               open={runPolicyAdvancedOpen}
               onToggle={() => setRunPolicyAdvancedOpen(!runPolicyAdvancedOpen)}
             >
             <div className="space-y-3">
               <ToggleField
-                label="Wake on demand"
+                label={copy.wakeOnDemand}
                 hint={help.wakeOnDemand}
                 checked={eff(
                   "heartbeat",
@@ -950,7 +1007,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 )}
                 onChange={(v) => mark("heartbeat", "wakeOnDemand", v)}
               />
-              <Field label="Cooldown (sec)" hint={help.cooldownSec}>
+              <Field label={copy.cooldownSec} hint={help.cooldownSec}>
                 <DraftNumberInput
                   value={eff(
                     "heartbeat",
@@ -962,7 +1019,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   className={inputClass}
                 />
               </Field>
-              <Field label="Max concurrent runs" hint={help.maxConcurrentRuns}>
+              <Field label={copy.maxConcurrentRuns} hint={help.maxConcurrentRuns}>
                 <DraftNumberInput
                   value={eff(
                     "heartbeat",
@@ -985,8 +1042,13 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
 }
 
 function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestResult }) {
+  const { uiLanguage } = useGeneralSettings();
   const statusLabel =
-    result.status === "pass" ? "Passed" : result.status === "warn" ? "Warnings" : "Failed";
+    result.status === "pass"
+      ? textFor(uiLanguage, { en: "Passed", "zh-CN": "通过" })
+      : result.status === "warn"
+        ? textFor(uiLanguage, { en: "Warnings", "zh-CN": "警告" })
+        : textFor(uiLanguage, { en: "Failed", "zh-CN": "失败" });
   const statusClass =
     result.status === "pass"
       ? "text-green-700 dark:text-green-300 border-green-300 dark:border-green-500/40 bg-green-50 dark:bg-green-500/10"
@@ -1011,7 +1073,7 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
             <span className="mx-1 opacity-60">·</span>
             <span>{check.message}</span>
             {check.detail && <span className="block opacity-75 break-all">({check.detail})</span>}
-            {check.hint && <span className="block opacity-90 break-words">Hint: {check.hint}</span>}
+            {check.hint && <span className="block opacity-90 break-words">{textFor(uiLanguage, { en: "Hint", "zh-CN": "提示" })}: {check.hint}</span>}
           </div>
         ))}
       </div>
@@ -1030,6 +1092,7 @@ function AdapterTypeDropdown({
   onChange: (type: string) => void;
   disabledTypes: Set<string>;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const [open, setOpen] = useState(false);
   const adapterList = useMemo(
     () =>
@@ -1074,7 +1137,7 @@ function AdapterTypeDropdown({
               <span>{item.label}</span>
             </span>
             {item.comingSoon && (
-              <span className="text-[10px] text-muted-foreground">Coming soon</span>
+              <span className="text-[10px] text-muted-foreground">{textFor(uiLanguage, { en: "Coming soon", "zh-CN": "即将推出" })}</span>
             )}
           </button>
         ))}
@@ -1114,6 +1177,7 @@ function ModelDropdown({
   detectModelLabel?: string;
   emptyDetectHint?: string;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const [modelSearch, setModelSearch] = useState("");
   const [detectingModel, setDetectingModel] = useState(false);
   const selected = models.find((m) => m.id === value);
@@ -1186,7 +1250,7 @@ function ModelDropdown({
   }
 
   return (
-    <Field label="Model" hint={help.model}>
+    <Field label={textFor(uiLanguage, { en: "Model", "zh-CN": "模型" })} hint={help.model}>
       <Popover
         open={open}
         onOpenChange={(nextOpen) => {
@@ -1199,7 +1263,11 @@ function ModelDropdown({
             <span className={cn(!value && "text-muted-foreground")}>
               {selected
                 ? selected.label
-                : value || (allowDefault ? "Default" : required ? "Select model (required)" : "Select model")}
+                : value || (allowDefault
+                  ? textFor(uiLanguage, { en: "Default", "zh-CN": "默认" })
+                  : required
+                    ? textFor(uiLanguage, { en: "Select model (required)", "zh-CN": "选择模型（必填）" })
+                    : textFor(uiLanguage, { en: "Select model", "zh-CN": "选择模型" }))}
             </span>
             <ChevronDown className="h-3 w-3 text-muted-foreground" />
           </button>
@@ -1208,7 +1276,9 @@ function ModelDropdown({
           <div className="relative mb-1">
             <input
               className="w-full px-2 py-1.5 pr-6 text-xs bg-transparent outline-none border-b border-border placeholder:text-muted-foreground/50"
-              placeholder={creatable ? "Search models... (type to create)" : "Search models..."}
+              placeholder={creatable
+                ? textFor(uiLanguage, { en: "Search models... (type to create)", "zh-CN": "搜索模型...（输入以创建）" })
+                : textFor(uiLanguage, { en: "Search models...", "zh-CN": "搜索模型..." })}
               value={modelSearch}
               onChange={(e) => setModelSearch(e.target.value)}
               autoFocus
@@ -1239,7 +1309,13 @@ function ModelDropdown({
                 <path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
                 <path d="M3 3v5h5" />
               </svg>
-              {detectingModel ? "Detecting..." : detectedModel ? (detectModelLabel?.replace(/^Detect\b/, "Re-detect") ?? "Re-detect from config") : (detectModelLabel ?? "Detect from config")}
+              {detectingModel
+                ? textFor(uiLanguage, { en: "Detecting...", "zh-CN": "检测中..." })
+                : detectedModel
+                  ? (uiLanguage === "zh-CN"
+                    ? "重新检测模型"
+                    : (detectModelLabel?.replace(/^Detect\b/, "Re-detect") ?? "Re-detect from config"))
+                  : (detectModelLabel ?? textFor(uiLanguage, { en: "Detect from config", "zh-CN": "从配置检测" }))}
             </button>
           )}
           {value && (!models.some((m) => m.id === value) || promotedModelIds.has(value)) && (
@@ -1256,7 +1332,7 @@ function ModelDropdown({
                 {models.find((m) => m.id === value)?.label ?? value}
               </span>
               <span className="shrink-0 ml-auto text-[9px] font-medium px-1.5 py-0.5 rounded-full bg-green-500/15 text-green-400 border border-green-500/20">
-                current
+                {textFor(uiLanguage, { en: "current", "zh-CN": "当前" })}
               </span>
             </button>
           )}
@@ -1275,7 +1351,7 @@ function ModelDropdown({
                 {models.find((m) => m.id === detectedModel)?.label ?? detectedModel}
               </span>
               <span className="shrink-0 ml-auto text-[9px] font-medium px-1.5 py-0.5 rounded-full bg-blue-500/15 text-blue-400 border border-blue-500/20">
-                detected
+                {textFor(uiLanguage, { en: "detected", "zh-CN": "已检测" })}
               </span>
             </button>
           )}
@@ -1299,7 +1375,7 @@ function ModelDropdown({
                     {entry?.label ?? candidate}
                   </span>
                   <span className="shrink-0 ml-auto text-[9px] font-medium px-1.5 py-0.5 rounded-full bg-sky-500/15 text-sky-400 border border-sky-500/20">
-                    config
+                    {textFor(uiLanguage, { en: "config", "zh-CN": "配置" })}
                   </span>
                 </button>
               );
@@ -1317,7 +1393,7 @@ function ModelDropdown({
                   onOpenChange(false);
                 }}
               >
-                Default
+                {textFor(uiLanguage, { en: "Default", "zh-CN": "默认" })}
               </button>
             )}
             {canCreateManualModel && (
@@ -1330,7 +1406,7 @@ function ModelDropdown({
                   setModelSearch("");
                 }}
               >
-                <span>Use manual model</span>
+                <span>{textFor(uiLanguage, { en: "Use manual model", "zh-CN": "使用手动输入的模型" })}</span>
                 <span className="text-xs font-mono text-muted-foreground">{manualModel}</span>
               </button>
             )}
@@ -1365,8 +1441,8 @@ function ModelDropdown({
               <div className="px-2 py-2 space-y-2">
                 <p className="text-xs text-muted-foreground">
                   {onDetectModel
-                    ? (emptyDetectHint ?? "No model detected yet. Enter a provider/model manually.")
-                    : "No models found."}
+                    ? (emptyDetectHint ?? textFor(uiLanguage, { en: "No model detected yet. Enter a provider/model manually.", "zh-CN": "尚未检测到模型，请手动输入 provider/model。" }))
+                    : textFor(uiLanguage, { en: "No models found.", "zh-CN": "未找到模型。" })}
                 </p>
               </div>
             )}
@@ -1390,14 +1466,15 @@ function ThinkingEffortDropdown({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const selected = options.find((option) => option.id === value) ?? options[0];
 
   return (
-    <Field label="Thinking effort" hint={help.thinkingEffort}>
+    <Field label={textFor(uiLanguage, { en: "Thinking effort", "zh-CN": "思考强度" })} hint={help.thinkingEffort}>
       <Popover open={open} onOpenChange={onOpenChange}>
         <PopoverTrigger asChild>
           <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm hover:bg-accent/50 transition-colors w-full justify-between">
-            <span className={cn(!value && "text-muted-foreground")}>{selected?.label ?? "Auto"}</span>
+            <span className={cn(!value && "text-muted-foreground")}>{translatedOptionLabel(selected?.label ?? "Auto", uiLanguage)}</span>
             <ChevronDown className="h-3 w-3 text-muted-foreground" />
           </button>
         </PopoverTrigger>
@@ -1414,7 +1491,7 @@ function ThinkingEffortDropdown({
                 onOpenChange(false);
               }}
             >
-              <span>{option.label}</span>
+              <span>{translatedOptionLabel(option.label, uiLanguage)}</span>
               {option.id ? <span className="text-xs text-muted-foreground font-mono">{option.id}</span> : null}
             </button>
           ))}

--- a/ui/src/components/ApprovalPayload.tsx
+++ b/ui/src/components/ApprovalPayload.tsx
@@ -1,5 +1,6 @@
 import { UserPlus, Lightbulb, ShieldAlert, ShieldCheck } from "lucide-react";
 import { formatCents } from "../lib/utils";
+import { readStoredUiLanguage, textFor } from "../lib/ui-language";
 
 export const typeLabel: Record<string, string> = {
   hire_agent: "Hire Agent",
@@ -7,6 +8,22 @@ export const typeLabel: Record<string, string> = {
   budget_override_required: "Budget Override",
   request_board_approval: "Board Approval",
 };
+
+function localizedApprovalTypeLabel(type: string): string {
+  const uiLanguage = readStoredUiLanguage();
+  switch (type) {
+    case "hire_agent":
+      return textFor(uiLanguage, { en: "Hire Agent", "zh-CN": "招聘智能体" });
+    case "approve_ceo_strategy":
+      return textFor(uiLanguage, { en: "CEO Strategy", "zh-CN": "CEO 战略" });
+    case "budget_override_required":
+      return textFor(uiLanguage, { en: "Budget Override", "zh-CN": "预算超限" });
+    case "request_board_approval":
+      return textFor(uiLanguage, { en: "Board Approval", "zh-CN": "董事会审批" });
+    default:
+      return typeLabel[type] ?? type;
+  }
+}
 
 function firstNonEmptyString(...values: unknown[]): string | null {
   for (const value of values) {
@@ -28,7 +45,7 @@ export function approvalSubject(payload?: Record<string, unknown> | null): strin
 
 /** Build a contextual label for an approval, e.g. "Hire Agent: Designer" */
 export function approvalLabel(type: string, payload?: Record<string, unknown> | null): string {
-  const base = typeLabel[type] ?? type;
+  const base = localizedApprovalTypeLabel(type);
   const subject = approvalSubject(payload);
   if (subject) {
     return `${base}: ${subject}`;

--- a/ui/src/components/BillerSpendCard.tsx
+++ b/ui/src/components/BillerSpendCard.tsx
@@ -3,6 +3,8 @@ import type { CostByBiller, CostByProviderModel } from "@paperclipai/shared";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { QuotaBar } from "./QuotaBar";
 import { billingTypeDisplayName, formatCents, formatTokens, providerDisplayName } from "@/lib/utils";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 interface BillerSpendCardProps {
   row: CostByBiller;
@@ -19,6 +21,7 @@ export function BillerSpendCard({
   totalCompanySpendCents,
   providerRows,
 }: BillerSpendCardProps) {
+  const { uiLanguage } = useGeneralSettings();
   const providerBreakdown = useMemo(() => {
     const map = new Map<string, { provider: string; costCents: number; inputTokens: number; outputTokens: number }>();
     for (const entry of providerRows) {
@@ -62,13 +65,19 @@ export function BillerSpendCard({
               {providerDisplayName(row.biller)}
             </CardTitle>
             <CardDescription className="text-xs mt-0.5">
-              <span className="font-mono">{formatTokens(row.inputTokens + row.cachedInputTokens)}</span> in
+              <span className="font-mono">{formatTokens(row.inputTokens + row.cachedInputTokens)}</span> {textFor(uiLanguage, { en: "in", "zh-CN": "输入" })}
               {" · "}
-              <span className="font-mono">{formatTokens(row.outputTokens)}</span> out
+              <span className="font-mono">{formatTokens(row.outputTokens)}</span> {textFor(uiLanguage, { en: "out", "zh-CN": "输出" })}
               {" · "}
-              {row.providerCount} provider{row.providerCount === 1 ? "" : "s"}
+              {textFor(uiLanguage, {
+                en: `${row.providerCount} provider${row.providerCount === 1 ? "" : "s"}`,
+                "zh-CN": `${row.providerCount} 个 provider`,
+              })}
               {" · "}
-              {row.modelCount} model{row.modelCount === 1 ? "" : "s"}
+              {textFor(uiLanguage, {
+                en: `${row.modelCount} model${row.modelCount === 1 ? "" : "s"}`,
+                "zh-CN": `${row.modelCount} 个模型`,
+              })}
             </CardDescription>
           </div>
           <span className="text-xl font-bold tabular-nums shrink-0">
@@ -80,21 +89,35 @@ export function BillerSpendCard({
       <CardContent className="px-4 pb-4 pt-3 space-y-4">
         {budgetMonthlyCents > 0 && (
           <QuotaBar
-            label="Period spend"
+            label={textFor(uiLanguage, { en: "Period spend", "zh-CN": "周期支出" })}
             percentUsed={budgetPct}
             leftLabel={formatCents(row.costCents)}
-            rightLabel={`${Math.round(budgetPct)}% of allocation`}
+            rightLabel={textFor(uiLanguage, {
+              en: `${Math.round(budgetPct)}% of allocation`,
+              "zh-CN": `占分配额度的 ${Math.round(budgetPct)}%`,
+            })}
           />
         )}
 
         <div className="text-xs text-muted-foreground">
-          {row.apiRunCount > 0 ? `${row.apiRunCount} metered run${row.apiRunCount === 1 ? "" : "s"}` : "0 metered runs"}
+          {row.apiRunCount > 0
+            ? textFor(uiLanguage, {
+                en: `${row.apiRunCount} metered run${row.apiRunCount === 1 ? "" : "s"}`,
+                "zh-CN": `${row.apiRunCount} 次按量运行`,
+              })
+            : textFor(uiLanguage, { en: "0 metered runs", "zh-CN": "0 次按量运行" })}
           {" · "}
           {row.subscriptionRunCount > 0
-            ? `${row.subscriptionRunCount} subscription run${row.subscriptionRunCount === 1 ? "" : "s"}`
-            : "0 subscription runs"}
+            ? textFor(uiLanguage, {
+                en: `${row.subscriptionRunCount} subscription run${row.subscriptionRunCount === 1 ? "" : "s"}`,
+                "zh-CN": `${row.subscriptionRunCount} 次订阅运行`,
+              })
+            : textFor(uiLanguage, { en: "0 subscription runs", "zh-CN": "0 次订阅运行" })}
           {" · "}
-          {formatCents(weekSpendCents)} this week
+          {textFor(uiLanguage, {
+            en: `${formatCents(weekSpendCents)} this week`,
+            "zh-CN": `本周 ${formatCents(weekSpendCents)}`,
+          })}
         </div>
 
         {billingTypeBreakdown.length > 0 && (
@@ -102,7 +125,7 @@ export function BillerSpendCard({
             <div className="border-t border-border" />
             <div className="space-y-2">
               <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                Billing types
+                {textFor(uiLanguage, { en: "Billing types", "zh-CN": "计费类型" })}
               </p>
               <div className="space-y-1.5">
                 {billingTypeBreakdown.map(([billingType, costCents]) => (
@@ -121,7 +144,7 @@ export function BillerSpendCard({
             <div className="border-t border-border" />
             <div className="space-y-2">
               <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                Upstream providers
+                {textFor(uiLanguage, { en: "Upstream providers", "zh-CN": "上游 provider" })}
               </p>
               <div className="space-y-1.5">
                 {providerBreakdown.map((entry) => (

--- a/ui/src/components/BudgetIncidentCard.tsx
+++ b/ui/src/components/BudgetIncidentCard.tsx
@@ -5,6 +5,8 @@ import { formatCents } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 function centsInputValue(value: number) {
   return (value / 100).toFixed(2);
@@ -27,6 +29,7 @@ export function BudgetIncidentCard({
   onKeepPaused: () => void;
   isMutating?: boolean;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const [draftAmount, setDraftAmount] = useState(
     centsInputValue(Math.max(incident.amountObserved + 1000, incident.amountLimit)),
   );
@@ -38,11 +41,18 @@ export function BudgetIncidentCard({
         <div className="flex items-start justify-between gap-3">
           <div>
             <div className="text-[11px] uppercase tracking-[0.22em] text-red-200/80">
-              {incident.scopeType} hard stop
+              {incident.scopeType === "project"
+                ? textFor(uiLanguage, { en: "project hard stop", "zh-CN": "项目硬停止" })
+                : incident.scopeType === "agent"
+                  ? textFor(uiLanguage, { en: "agent hard stop", "zh-CN": "智能体硬停止" })
+                  : textFor(uiLanguage, { en: "company hard stop", "zh-CN": "公司硬停止" })}
             </div>
             <CardTitle className="mt-1 text-base text-red-50">{incident.scopeName}</CardTitle>
             <CardDescription className="mt-1 text-red-100/70">
-              Spending reached {formatCents(incident.amountObserved)} against a limit of {formatCents(incident.amountLimit)}.
+              {textFor(uiLanguage, {
+                en: `Spending reached ${formatCents(incident.amountObserved)} against a limit of ${formatCents(incident.amountLimit)}.`,
+                "zh-CN": `已花费 ${formatCents(incident.amountObserved)}，超过限制 ${formatCents(incident.amountLimit)}。`,
+              })}
             </CardDescription>
           </div>
           <div className="rounded-full border border-red-400/30 bg-red-500/10 p-2 text-red-200">
@@ -55,14 +65,20 @@ export function BudgetIncidentCard({
           <PauseCircle className="mt-0.5 h-4 w-4 shrink-0" />
           <div>
             {incident.scopeType === "project"
-              ? "Project execution is paused. New work in this project will not start until you resolve the budget incident."
-              : "This scope is paused. New heartbeats will not start until you resolve the budget incident."}
+              ? textFor(uiLanguage, {
+                  en: "Project execution is paused. New work in this project will not start until you resolve the budget incident.",
+                  "zh-CN": "项目执行已暂停。在你处理完预算事件之前，此项目中的新工作不会启动。",
+                })
+              : textFor(uiLanguage, {
+                  en: "This scope is paused. New heartbeats will not start until you resolve the budget incident.",
+                  "zh-CN": "该范围已暂停。在你处理完预算事件之前，新的心跳不会启动。",
+                })}
           </div>
         </div>
 
         <div className="rounded-xl border border-border/60 bg-background/60 p-3">
           <label className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-            New budget (USD)
+            {textFor(uiLanguage, { en: "New budget (USD)", "zh-CN": "新预算（USD）" })}
           </label>
           <div className="mt-2 flex flex-col gap-3 sm:flex-row">
             <Input
@@ -79,19 +95,21 @@ export function BudgetIncidentCard({
               }}
             >
               <ArrowUpRight className="h-4 w-4" />
-              {isMutating ? "Applying..." : "Raise budget & resume"}
+              {isMutating
+                ? textFor(uiLanguage, { en: "Applying...", "zh-CN": "应用中..." })
+                : textFor(uiLanguage, { en: "Raise budget & resume", "zh-CN": "提高预算并恢复" })}
             </Button>
           </div>
           {parsed !== null && parsed <= incident.amountObserved ? (
             <p className="mt-2 text-xs text-red-200/80">
-              The new budget must exceed current observed spend.
+              {textFor(uiLanguage, { en: "The new budget must exceed current observed spend.", "zh-CN": "新预算必须高于当前已观测支出。" })}
             </p>
           ) : null}
         </div>
 
         <div className="flex justify-end">
           <Button variant="ghost" className="text-muted-foreground" disabled={isMutating} onClick={onKeepPaused}>
-            Keep paused
+            {textFor(uiLanguage, { en: "Keep paused", "zh-CN": "保持暂停" })}
           </Button>
         </div>
       </CardContent>

--- a/ui/src/components/BudgetPolicyCard.tsx
+++ b/ui/src/components/BudgetPolicyCard.tsx
@@ -5,6 +5,8 @@ import { cn, formatCents } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 function centsInputValue(value: number) {
   return (value / 100).toFixed(2);
@@ -18,8 +20,10 @@ function parseDollarInput(value: string) {
   return Math.round(parsed * 100);
 }
 
-function windowLabel(windowKind: BudgetPolicySummary["windowKind"]) {
-  return windowKind === "lifetime" ? "Lifetime budget" : "Monthly UTC budget";
+function windowLabel(windowKind: BudgetPolicySummary["windowKind"], uiLanguage: "en" | "zh-CN") {
+  return windowKind === "lifetime"
+    ? textFor(uiLanguage, { en: "Lifetime budget", "zh-CN": "生命周期预算" })
+    : textFor(uiLanguage, { en: "Monthly UTC budget", "zh-CN": "按 UTC 月度预算" });
 }
 
 function statusTone(status: BudgetPolicySummary["status"]) {
@@ -41,6 +45,7 @@ export function BudgetPolicyCard({
   compact?: boolean;
   variant?: "card" | "plain";
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const [draftBudget, setDraftBudget] = useState(centsInputValue(summary.amount));
 
   useEffect(() => {
@@ -52,42 +57,90 @@ export function BudgetPolicyCard({
   const progress = summary.amount > 0 ? Math.min(100, summary.utilizationPercent) : 0;
   const StatusIcon = summary.status === "hard_stop" ? ShieldAlert : summary.status === "warning" ? AlertTriangle : Wallet;
   const isPlain = variant === "plain";
+  const scopeTypeLabel = summary.scopeType === "company"
+    ? textFor(uiLanguage, { en: "company", "zh-CN": "公司" })
+    : summary.scopeType === "agent"
+      ? textFor(uiLanguage, { en: "agent", "zh-CN": "智能体" })
+      : textFor(uiLanguage, { en: "project", "zh-CN": "项目" });
+  const statusLabel = summary.paused
+    ? textFor(uiLanguage, { en: "Paused", "zh-CN": "已暂停" })
+    : summary.status === "warning"
+      ? textFor(uiLanguage, { en: "Warning", "zh-CN": "警告" })
+      : summary.status === "hard_stop"
+        ? textFor(uiLanguage, { en: "Hard stop", "zh-CN": "硬停止" })
+        : textFor(uiLanguage, { en: "Healthy", "zh-CN": "正常" });
 
   const observedBudgetGrid = isPlain ? (
     <div className="grid gap-6 sm:grid-cols-2">
       <div>
-        <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Observed</div>
+        <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+          {textFor(uiLanguage, { en: "Observed", "zh-CN": "已观测" })}
+        </div>
         <div className="mt-2 text-xl font-semibold tabular-nums">{formatCents(summary.observedAmount)}</div>
         <div className="mt-1 text-xs text-muted-foreground">
-          {summary.amount > 0 ? `${summary.utilizationPercent}% of limit` : "No cap configured"}
+          {summary.amount > 0
+            ? textFor(uiLanguage, {
+                en: `${summary.utilizationPercent}% of limit`,
+                "zh-CN": `已达上限的 ${summary.utilizationPercent}%`,
+              })
+            : textFor(uiLanguage, { en: "No cap configured", "zh-CN": "未配置上限" })}
         </div>
       </div>
       <div>
-        <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Budget</div>
+        <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+          {textFor(uiLanguage, { en: "Budget", "zh-CN": "预算" })}
+        </div>
         <div className="mt-2 text-xl font-semibold tabular-nums">
-          {summary.amount > 0 ? formatCents(summary.amount) : "Disabled"}
+          {summary.amount > 0 ? formatCents(summary.amount) : textFor(uiLanguage, { en: "Disabled", "zh-CN": "已禁用" })}
         </div>
         <div className="mt-1 text-xs text-muted-foreground">
-          Soft alert at {summary.warnPercent}%{summary.paused && summary.pauseReason ? ` · ${summary.pauseReason} pause` : ""}
+          {textFor(uiLanguage, {
+            en: `Soft alert at ${summary.warnPercent}%`,
+            "zh-CN": `${summary.warnPercent}% 时触发软告警`,
+          })}
+          {summary.paused && summary.pauseReason
+            ? textFor(uiLanguage, {
+                en: ` · ${summary.pauseReason} pause`,
+                "zh-CN": ` · ${summary.pauseReason} 暂停`,
+              })
+            : ""}
         </div>
       </div>
     </div>
   ) : (
     <div className="grid gap-3 sm:grid-cols-2">
       <div className="rounded-xl border border-border/70 bg-black/[0.18] px-4 py-3">
-        <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Observed</div>
+        <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+          {textFor(uiLanguage, { en: "Observed", "zh-CN": "已观测" })}
+        </div>
         <div className="mt-2 text-xl font-semibold tabular-nums">{formatCents(summary.observedAmount)}</div>
         <div className="mt-1 text-xs text-muted-foreground">
-          {summary.amount > 0 ? `${summary.utilizationPercent}% of limit` : "No cap configured"}
+          {summary.amount > 0
+            ? textFor(uiLanguage, {
+                en: `${summary.utilizationPercent}% of limit`,
+                "zh-CN": `已达上限的 ${summary.utilizationPercent}%`,
+              })
+            : textFor(uiLanguage, { en: "No cap configured", "zh-CN": "未配置上限" })}
         </div>
       </div>
       <div className="rounded-xl border border-border/70 bg-black/[0.18] px-4 py-3">
-        <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Budget</div>
+        <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+          {textFor(uiLanguage, { en: "Budget", "zh-CN": "预算" })}
+        </div>
         <div className="mt-2 text-xl font-semibold tabular-nums">
-          {summary.amount > 0 ? formatCents(summary.amount) : "Disabled"}
+          {summary.amount > 0 ? formatCents(summary.amount) : textFor(uiLanguage, { en: "Disabled", "zh-CN": "已禁用" })}
         </div>
         <div className="mt-1 text-xs text-muted-foreground">
-          Soft alert at {summary.warnPercent}%{summary.paused && summary.pauseReason ? ` · ${summary.pauseReason} pause` : ""}
+          {textFor(uiLanguage, {
+            en: `Soft alert at ${summary.warnPercent}%`,
+            "zh-CN": `${summary.warnPercent}% 时触发软告警`,
+          })}
+          {summary.paused && summary.pauseReason
+            ? textFor(uiLanguage, {
+                en: ` · ${summary.pauseReason} pause`,
+                "zh-CN": ` · ${summary.pauseReason} 暂停`,
+              })
+            : ""}
         </div>
       </div>
     </div>
@@ -96,8 +149,8 @@ export function BudgetPolicyCard({
   const progressSection = (
     <div className="space-y-2">
       <div className="flex items-center justify-between text-xs text-muted-foreground">
-        <span>Remaining</span>
-        <span>{summary.amount > 0 ? formatCents(summary.remainingAmount) : "Unlimited"}</span>
+        <span>{textFor(uiLanguage, { en: "Remaining", "zh-CN": "剩余" })}</span>
+        <span>{summary.amount > 0 ? formatCents(summary.remainingAmount) : textFor(uiLanguage, { en: "Unlimited", "zh-CN": "不限额" })}</span>
       </div>
       <div className={cn("h-2 overflow-hidden rounded-full", isPlain ? "bg-border/70" : "bg-muted/70")}>
         <div
@@ -120,8 +173,14 @@ export function BudgetPolicyCard({
       <PauseCircle className="mt-0.5 h-4 w-4 shrink-0" />
       <div>
         {summary.scopeType === "project"
-          ? "Execution is paused for this project until the budget is raised or the incident is dismissed."
-          : "Heartbeats are paused for this scope until the budget is raised or the incident is dismissed."}
+          ? textFor(uiLanguage, {
+              en: "Execution is paused for this project until the budget is raised or the incident is dismissed.",
+              "zh-CN": "该项目的执行已暂停，直到提高预算或解除该事件。",
+            })
+          : textFor(uiLanguage, {
+              en: "Heartbeats are paused for this scope until the budget is raised or the incident is dismissed.",
+              "zh-CN": "该范围的心跳已暂停，直到提高预算或解除该事件。",
+            })}
       </div>
     </div>
   ) : null;
@@ -130,7 +189,7 @@ export function BudgetPolicyCard({
     <div className={cn("flex flex-col gap-3 sm:flex-row sm:items-end", isPlain ? "" : "rounded-xl border border-border/70 bg-background/50 p-3")}>
       <div className="min-w-0 flex-1">
         <label className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-          Budget (USD)
+          {textFor(uiLanguage, { en: "Budget (USD)", "zh-CN": "预算（USD）" })}
         </label>
         <Input
           value={draftBudget}
@@ -146,7 +205,11 @@ export function BudgetPolicyCard({
         }}
         disabled={!canSave || isSaving || parsedDraft === null}
       >
-        {isSaving ? "Saving..." : summary.amount > 0 ? "Update budget" : "Set budget"}
+        {isSaving
+          ? textFor(uiLanguage, { en: "Saving...", "zh-CN": "保存中..." })
+          : summary.amount > 0
+            ? textFor(uiLanguage, { en: "Update budget", "zh-CN": "更新预算" })
+            : textFor(uiLanguage, { en: "Set budget", "zh-CN": "设置预算" })}
       </Button>
     </div>
   ) : null;
@@ -157,10 +220,10 @@ export function BudgetPolicyCard({
         <div className="flex items-start justify-between gap-6">
           <div>
             <div className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
-              {summary.scopeType}
+              {scopeTypeLabel}
             </div>
             <div className="mt-2 text-xl font-semibold">{summary.scopeName}</div>
-            <div className="mt-2 text-sm text-muted-foreground">{windowLabel(summary.windowKind)}</div>
+            <div className="mt-2 text-sm text-muted-foreground">{windowLabel(summary.windowKind, uiLanguage)}</div>
           </div>
           <div
             className={cn(
@@ -173,7 +236,7 @@ export function BudgetPolicyCard({
             )}
           >
             <StatusIcon className="h-3.5 w-3.5" />
-            {summary.paused ? "Paused" : summary.status === "warning" ? "Warning" : summary.status === "hard_stop" ? "Hard stop" : "Healthy"}
+            {statusLabel}
           </div>
         </div>
 
@@ -182,7 +245,9 @@ export function BudgetPolicyCard({
         {pausedPane}
         {saveSection}
         {parsedDraft === null ? (
-          <p className="text-xs text-destructive">Enter a valid non-negative dollar amount.</p>
+          <p className="text-xs text-destructive">
+            {textFor(uiLanguage, { en: "Enter a valid non-negative dollar amount.", "zh-CN": "请输入有效的非负美元金额。" })}
+          </p>
         ) : null}
       </div>
     );
@@ -194,14 +259,14 @@ export function BudgetPolicyCard({
         <div className="flex items-start justify-between gap-3">
           <div>
             <div className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
-              {summary.scopeType}
+              {scopeTypeLabel}
             </div>
             <CardTitle className="mt-1 text-base">{summary.scopeName}</CardTitle>
-            <CardDescription className="mt-1">{windowLabel(summary.windowKind)}</CardDescription>
+            <CardDescription className="mt-1">{windowLabel(summary.windowKind, uiLanguage)}</CardDescription>
           </div>
           <div className={cn("inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] uppercase tracking-[0.18em]", statusTone(summary.status))}>
             <StatusIcon className="h-3.5 w-3.5" />
-            {summary.paused ? "Paused" : summary.status === "warning" ? "Warning" : summary.status === "hard_stop" ? "Hard stop" : "Healthy"}
+            {statusLabel}
           </div>
         </div>
       </CardHeader>
@@ -211,7 +276,9 @@ export function BudgetPolicyCard({
         {pausedPane}
         {saveSection}
         {parsedDraft === null ? (
-          <p className="text-xs text-destructive">Enter a valid non-negative dollar amount.</p>
+          <p className="text-xs text-destructive">
+            {textFor(uiLanguage, { en: "Enter a valid non-negative dollar amount.", "zh-CN": "请输入有效的非负美元金额。" })}
+          </p>
         ) : null}
       </CardContent>
     </Card>

--- a/ui/src/components/CompanySwitcher.tsx
+++ b/ui/src/components/CompanySwitcher.tsx
@@ -1,6 +1,7 @@
 import { ChevronsUpDown, Plus, Settings } from "lucide-react";
 import { Link } from "@/lib/router";
 import { useCompany } from "../context/CompanyContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -10,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { textFor } from "../lib/ui-language";
 
 function statusDotColor(status?: string): string {
   switch (status) {
@@ -26,7 +28,31 @@ function statusDotColor(status?: string): string {
 
 export function CompanySwitcher() {
   const { companies, selectedCompany, setSelectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const sidebarCompanies = companies.filter((company) => company.status !== "archived");
+
+  const copy = {
+    selectCompany: textFor(uiLanguage, {
+      en: "Select company",
+      "zh-CN": "选择公司",
+    }),
+    companies: textFor(uiLanguage, {
+      en: "Companies",
+      "zh-CN": "公司",
+    }),
+    noCompanies: textFor(uiLanguage, {
+      en: "No companies",
+      "zh-CN": "暂无公司",
+    }),
+    companySettings: textFor(uiLanguage, {
+      en: "Company Settings",
+      "zh-CN": "公司设置",
+    }),
+    manageCompanies: textFor(uiLanguage, {
+      en: "Manage Companies",
+      "zh-CN": "管理公司",
+    }),
+  };
 
   return (
     <DropdownMenu>
@@ -40,14 +66,14 @@ export function CompanySwitcher() {
               <span className={`h-2 w-2 rounded-full shrink-0 ${statusDotColor(selectedCompany.status)}`} />
             )}
             <span className="text-sm font-medium truncate">
-              {selectedCompany?.name ?? "Select company"}
+              {selectedCompany?.name ?? copy.selectCompany}
             </span>
           </div>
           <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-[220px]">
-        <DropdownMenuLabel>Companies</DropdownMenuLabel>
+        <DropdownMenuLabel>{copy.companies}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {sidebarCompanies.map((company) => (
           <DropdownMenuItem
@@ -60,19 +86,19 @@ export function CompanySwitcher() {
           </DropdownMenuItem>
         ))}
         {sidebarCompanies.length === 0 && (
-          <DropdownMenuItem disabled>No companies</DropdownMenuItem>
+          <DropdownMenuItem disabled>{copy.noCompanies}</DropdownMenuItem>
         )}
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <Link to="/company/settings" className="no-underline text-inherit">
             <Settings className="h-4 w-4 mr-2" />
-            Company Settings
+            {copy.companySettings}
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
           <Link to="/companies" className="no-underline text-inherit">
             <Plus className="h-4 w-4 mr-2" />
-            Manage Companies
+            {copy.manageCompanies}
           </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/ui/src/components/EnvVarEditor.tsx
+++ b/ui/src/components/EnvVarEditor.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import type { CompanySecret, EnvBinding } from "@paperclipai/shared";
 import { X } from "lucide-react";
 import { cn } from "../lib/utils";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
@@ -65,6 +67,7 @@ export function EnvVarEditor({
   onCreateSecret: (name: string, value: string) => Promise<CompanySecret>;
   onChange: (env: Record<string, EnvBinding> | undefined) => void;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const [rows, setRows] = useState<Row[]>(() => toRows(value));
   const [sealError, setSealError] = useState<string | null>(null);
   const valueRef = useRef(value);
@@ -144,8 +147,8 @@ export function EnvVarEditor({
     const plain = row.plainValue;
     if (!key || plain.length === 0) return;
 
-    const suggested = defaultSecretName(key) || "secret";
-    const name = window.prompt("Secret name", suggested)?.trim();
+    const suggested = defaultSecretName(key) || textFor(uiLanguage, { en: "secret", "zh-CN": "secret" });
+    const name = window.prompt(textFor(uiLanguage, { en: "Secret name", "zh-CN": "密钥名称" }), suggested)?.trim();
     if (!name) return;
 
     try {
@@ -153,9 +156,20 @@ export function EnvVarEditor({
       const created = await onCreateSecret(name, plain);
       updateRow(index, { source: "secret", secretId: created.id });
     } catch (error) {
-      setSealError(error instanceof Error ? error.message : "Failed to create secret");
+      setSealError(error instanceof Error ? error.message : textFor(uiLanguage, { en: "Failed to create secret", "zh-CN": "创建密钥失败" }));
     }
   }
+  const copy = {
+    plain: textFor(uiLanguage, { en: "Plain", "zh-CN": "明文" }),
+    secret: textFor(uiLanguage, { en: "Secret", "zh-CN": "密钥" }),
+    selectSecret: textFor(uiLanguage, { en: "Select secret...", "zh-CN": "选择密钥..." }),
+    new: textFor(uiLanguage, { en: "New", "zh-CN": "新建" }),
+    createFromCurrent: textFor(uiLanguage, { en: "Create secret from current plain value", "zh-CN": "根据当前明文值创建密钥" }),
+    value: textFor(uiLanguage, { en: "value", "zh-CN": "值" }),
+    seal: textFor(uiLanguage, { en: "Seal", "zh-CN": "加密保存" }),
+    sealTitle: textFor(uiLanguage, { en: "Store value as secret and replace with reference", "zh-CN": "将该值保存为密钥并替换为引用" }),
+    runtimeNote: textFor(uiLanguage, { en: "PAPERCLIP_* variables are injected automatically at runtime.", "zh-CN": "PAPERCLIP_* 变量会在运行时自动注入。" }),
+  };
 
   return (
     <div className="space-y-1.5">
@@ -183,8 +197,8 @@ export function EnvVarEditor({
                 })
               }
             >
-              <option value="plain">Plain</option>
-              <option value="secret">Secret</option>
+              <option value="plain">{copy.plain}</option>
+              <option value="secret">{copy.secret}</option>
             </select>
             {row.source === "secret" ? (
               <>
@@ -193,7 +207,7 @@ export function EnvVarEditor({
                   value={row.secretId}
                   onChange={(event) => updateRow(index, { secretId: event.target.value })}
                 >
-                  <option value="">Select secret...</option>
+                  <option value="">{copy.selectSecret}</option>
                   {secrets.map((secret) => (
                     <option key={secret.id} value={secret.id}>
                       {secret.name}
@@ -205,16 +219,16 @@ export function EnvVarEditor({
                   className="inline-flex items-center rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/50 transition-colors shrink-0"
                   onClick={() => sealRow(index)}
                   disabled={!row.key.trim() || !row.plainValue}
-                  title="Create secret from current plain value"
+                  title={copy.createFromCurrent}
                 >
-                  New
+                  {copy.new}
                 </button>
               </>
             ) : (
               <>
                 <input
                   className={cn(inputClass, "flex-[3]")}
-                  placeholder="value"
+                  placeholder={copy.value}
                   value={row.plainValue}
                   onChange={(event) => updateRow(index, { plainValue: event.target.value })}
                 />
@@ -223,9 +237,9 @@ export function EnvVarEditor({
                   className="inline-flex items-center rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/50 transition-colors shrink-0"
                   onClick={() => sealRow(index)}
                   disabled={!row.key.trim() || !row.plainValue}
-                  title="Store value as secret and replace with reference"
+                  title={copy.sealTitle}
                 >
-                  Seal
+                  {copy.seal}
                 </button>
               </>
             )}
@@ -245,7 +259,7 @@ export function EnvVarEditor({
       })}
       {sealError && <p className="text-[11px] text-destructive">{sealError}</p>}
       <p className="text-[11px] text-muted-foreground/60">
-        PAPERCLIP_* variables are injected automatically at runtime.
+        {copy.runtimeNote}
       </p>
     </div>
   );

--- a/ui/src/components/FinanceBillerCard.tsx
+++ b/ui/src/components/FinanceBillerCard.tsx
@@ -1,12 +1,15 @@
 import type { FinanceByBiller } from "@paperclipai/shared";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCents, providerDisplayName } from "@/lib/utils";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 interface FinanceBillerCardProps {
   row: FinanceByBiller;
 }
 
 export function FinanceBillerCard({ row }: FinanceBillerCardProps) {
+  const { uiLanguage } = useGeneralSettings();
   return (
     <Card>
       <CardHeader className="px-4 pt-4 pb-1">
@@ -14,27 +17,38 @@ export function FinanceBillerCard({ row }: FinanceBillerCardProps) {
           <div>
             <CardTitle className="text-base">{providerDisplayName(row.biller)}</CardTitle>
             <CardDescription className="mt-1 text-xs">
-              {row.eventCount} event{row.eventCount === 1 ? "" : "s"} across {row.kindCount} kind{row.kindCount === 1 ? "" : "s"}
+              {textFor(uiLanguage, {
+                en: `${row.eventCount} event${row.eventCount === 1 ? "" : "s"} across ${row.kindCount} kind${row.kindCount === 1 ? "" : "s"}`,
+                "zh-CN": `${row.eventCount} 条事件，覆盖 ${row.kindCount} 种类型`,
+              })}
             </CardDescription>
           </div>
           <div className="text-right">
             <div className="text-lg font-semibold tabular-nums">{formatCents(row.netCents)}</div>
-            <div className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">net</div>
+            <div className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+              {textFor(uiLanguage, { en: "net", "zh-CN": "净额" })}
+            </div>
           </div>
         </div>
       </CardHeader>
       <CardContent className="space-y-3 px-4 pb-4 pt-3">
         <div className="grid gap-2 text-sm sm:grid-cols-3">
           <div className="border border-border p-3">
-            <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">debits</div>
+            <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+              {textFor(uiLanguage, { en: "debits", "zh-CN": "支出" })}
+            </div>
             <div className="mt-1 font-medium tabular-nums">{formatCents(row.debitCents)}</div>
           </div>
           <div className="border border-border p-3">
-            <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">credits</div>
+            <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+              {textFor(uiLanguage, { en: "credits", "zh-CN": "入账" })}
+            </div>
             <div className="mt-1 font-medium tabular-nums">{formatCents(row.creditCents)}</div>
           </div>
           <div className="border border-border p-3">
-            <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">estimated</div>
+            <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+              {textFor(uiLanguage, { en: "estimated", "zh-CN": "估算" })}
+            </div>
             <div className="mt-1 font-medium tabular-nums">{formatCents(row.estimatedDebitCents)}</div>
           </div>
         </div>

--- a/ui/src/components/FinanceKindCard.tsx
+++ b/ui/src/components/FinanceKindCard.tsx
@@ -1,21 +1,26 @@
 import type { FinanceByKind } from "@paperclipai/shared";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { financeEventKindDisplayName, formatCents } from "@/lib/utils";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 interface FinanceKindCardProps {
   rows: FinanceByKind[];
 }
 
 export function FinanceKindCard({ rows }: FinanceKindCardProps) {
+  const { uiLanguage } = useGeneralSettings();
   return (
     <Card>
       <CardHeader className="px-4 pt-4 pb-1">
-        <CardTitle className="text-base">Financial event mix</CardTitle>
-        <CardDescription>Account-level charges grouped by event kind.</CardDescription>
+        <CardTitle className="text-base">{textFor(uiLanguage, { en: "Financial event mix", "zh-CN": "财务事件构成" })}</CardTitle>
+        <CardDescription>
+          {textFor(uiLanguage, { en: "Account-level charges grouped by event kind.", "zh-CN": "按事件类型聚合的账户级费用。" })}
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-2 px-4 pb-4 pt-3">
         {rows.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No finance events in this period.</p>
+          <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "No finance events in this period.", "zh-CN": "当前时间范围内没有财务事件。" })}</p>
         ) : (
           rows.map((row) => (
             <div
@@ -25,13 +30,19 @@ export function FinanceKindCard({ rows }: FinanceKindCardProps) {
               <div className="min-w-0">
                 <div className="truncate text-sm font-medium">{financeEventKindDisplayName(row.eventKind)}</div>
                 <div className="text-xs text-muted-foreground">
-                  {row.eventCount} event{row.eventCount === 1 ? "" : "s"} · {row.billerCount} biller{row.billerCount === 1 ? "" : "s"}
+                  {textFor(uiLanguage, {
+                    en: `${row.eventCount} event${row.eventCount === 1 ? "" : "s"} · ${row.billerCount} biller${row.billerCount === 1 ? "" : "s"}`,
+                    "zh-CN": `${row.eventCount} 条事件 · ${row.billerCount} 个 biller`,
+                  })}
                 </div>
               </div>
               <div className="text-right tabular-nums">
                 <div className="text-sm font-medium">{formatCents(row.netCents)}</div>
                 <div className="text-xs text-muted-foreground">
-                  {formatCents(row.debitCents)} debits
+                  {textFor(uiLanguage, {
+                    en: `${formatCents(row.debitCents)} debits`,
+                    "zh-CN": `${formatCents(row.debitCents)} 支出`,
+                  })}
                 </div>
               </div>
             </div>

--- a/ui/src/components/FinanceTimelineCard.tsx
+++ b/ui/src/components/FinanceTimelineCard.tsx
@@ -8,6 +8,8 @@ import {
   formatDateTime,
   providerDisplayName,
 } from "@/lib/utils";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 interface FinanceTimelineCardProps {
   rows: FinanceEvent[];
@@ -18,15 +20,22 @@ export function FinanceTimelineCard({
   rows,
   emptyMessage = "No financial events in this period.",
 }: FinanceTimelineCardProps) {
+  const { uiLanguage } = useGeneralSettings();
   return (
     <Card>
       <CardHeader className="px-4 pt-4 pb-1">
-        <CardTitle className="text-base">Recent financial events</CardTitle>
-        <CardDescription>Top-ups, fees, credits, commitments, and other non-request charges.</CardDescription>
+        <CardTitle className="text-base">{textFor(uiLanguage, { en: "Recent financial events", "zh-CN": "最近财务事件" })}</CardTitle>
+        <CardDescription>
+          {textFor(uiLanguage, { en: "Top-ups, fees, credits, commitments, and other non-request charges.", "zh-CN": "充值、费用、积分、承诺金及其他非请求级收费。" })}
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3 px-4 pb-4 pt-3">
         {rows.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+          <p className="text-sm text-muted-foreground">
+            {emptyMessage === "No financial events in this period."
+              ? textFor(uiLanguage, { en: emptyMessage, "zh-CN": "当前时间范围内没有财务事件。" })
+              : emptyMessage}
+          </p>
         ) : (
           rows.map((row) => (
             <div
@@ -50,16 +59,20 @@ export function FinanceTimelineCard({
                   {(row.description || row.externalInvoiceId || row.region || row.pricingTier) && (
                     <div className="space-y-1 text-xs text-muted-foreground">
                       {row.description ? <div>{row.description}</div> : null}
-                      {row.externalInvoiceId ? <div>invoice {row.externalInvoiceId}</div> : null}
-                      {row.region ? <div>region {row.region}</div> : null}
-                      {row.pricingTier ? <div>tier {row.pricingTier}</div> : null}
+                      {row.externalInvoiceId ? <div>{textFor(uiLanguage, { en: `invoice ${row.externalInvoiceId}`, "zh-CN": `发票 ${row.externalInvoiceId}` })}</div> : null}
+                      {row.region ? <div>{textFor(uiLanguage, { en: `region ${row.region}`, "zh-CN": `区域 ${row.region}` })}</div> : null}
+                      {row.pricingTier ? <div>{textFor(uiLanguage, { en: `tier ${row.pricingTier}`, "zh-CN": `层级 ${row.pricingTier}` })}</div> : null}
                     </div>
                   )}
                 </div>
                 <div className="text-right tabular-nums">
                   <div className="text-sm font-semibold">{formatCents(row.amountCents)}</div>
                   <div className="text-xs text-muted-foreground">{row.currency}</div>
-                  {row.estimated ? <div className="text-[11px] uppercase tracking-[0.12em] text-amber-600">estimated</div> : null}
+                  {row.estimated ? (
+                    <div className="text-[11px] uppercase tracking-[0.12em] text-amber-600">
+                      {textFor(uiLanguage, { en: "estimated", "zh-CN": "估算" })}
+                    </div>
+                  ) : null}
                 </div>
               </div>
             </div>

--- a/ui/src/components/InlineEditor.tsx
+++ b/ui/src/components/InlineEditor.tsx
@@ -2,6 +2,8 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { cn } from "../lib/utils";
 import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "./MarkdownEditor";
 import { useAutosaveIndicator } from "../hooks/useAutosaveIndicator";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 interface InlineEditorProps {
   value: string;
@@ -51,6 +53,7 @@ export function InlineEditor({
   onDropFile,
   mentions,
 }: InlineEditorProps) {
+  const { uiLanguage } = useGeneralSettings();
   const [editing, setEditing] = useState(false);
   const [multilineFocused, setMultilineFocused] = useState(false);
   const [draft, setDraft] = useState(value);
@@ -246,12 +249,12 @@ export function InlineEditor({
             )}
           >
             {autosaveState === "saving"
-              ? "Autosaving..."
+              ? textFor(uiLanguage, { en: "Autosaving...", "zh-CN": "自动保存中..." })
               : autosaveState === "saved"
-                ? "Saved"
+                ? textFor(uiLanguage, { en: "Saved", "zh-CN": "已保存" })
                 : autosaveState === "error"
-                  ? "Could not save"
-                  : "Idle"}
+                  ? textFor(uiLanguage, { en: "Could not save", "zh-CN": "无法保存" })
+                  : textFor(uiLanguage, { en: "Idle", "zh-CN": "空闲" })}
           </span>
         </div>
       </div>

--- a/ui/src/components/InstanceSidebar.tsx
+++ b/ui/src/components/InstanceSidebar.tsx
@@ -3,30 +3,60 @@ import { Clock3, Cpu, FlaskConical, Puzzle, Settings, SlidersHorizontal } from "
 import { NavLink } from "@/lib/router";
 import { pluginsApi } from "@/api/plugins";
 import { queryKeys } from "@/lib/queryKeys";
+import { useGeneralSettings } from "@/context/GeneralSettingsContext";
 import { SidebarNavItem } from "./SidebarNavItem";
+import { textFor } from "@/lib/ui-language";
 
 export function InstanceSidebar() {
+  const { uiLanguage } = useGeneralSettings();
   const { data: plugins } = useQuery({
     queryKey: queryKeys.plugins.all,
     queryFn: () => pluginsApi.list(),
   });
+
+  const copy = {
+    title: textFor(uiLanguage, {
+      en: "Instance Settings",
+      "zh-CN": "实例设置",
+    }),
+    general: textFor(uiLanguage, {
+      en: "General",
+      "zh-CN": "通用",
+    }),
+    heartbeats: textFor(uiLanguage, {
+      en: "Heartbeats",
+      "zh-CN": "心跳",
+    }),
+    experimental: textFor(uiLanguage, {
+      en: "Experimental",
+      "zh-CN": "实验功能",
+    }),
+    plugins: textFor(uiLanguage, {
+      en: "Plugins",
+      "zh-CN": "插件",
+    }),
+    adapters: textFor(uiLanguage, {
+      en: "Adapters",
+      "zh-CN": "适配器",
+    }),
+  };
 
   return (
     <aside className="w-60 h-full min-h-0 border-r border-border bg-background flex flex-col">
       <div className="flex items-center gap-2 px-3 h-12 shrink-0">
         <Settings className="h-4 w-4 text-muted-foreground shrink-0 ml-1" />
         <span className="flex-1 text-sm font-bold text-foreground truncate">
-          Instance Settings
+          {copy.title}
         </span>
       </div>
 
       <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide flex flex-col gap-4 px-3 py-2">
         <div className="flex flex-col gap-0.5">
-          <SidebarNavItem to="/instance/settings/general" label="General" icon={SlidersHorizontal} end />
-          <SidebarNavItem to="/instance/settings/heartbeats" label="Heartbeats" icon={Clock3} end />
-          <SidebarNavItem to="/instance/settings/experimental" label="Experimental" icon={FlaskConical} />
-          <SidebarNavItem to="/instance/settings/plugins" label="Plugins" icon={Puzzle} />
-          <SidebarNavItem to="/instance/settings/adapters" label="Adapters" icon={Cpu} />
+          <SidebarNavItem to="/instance/settings/general" label={copy.general} icon={SlidersHorizontal} end />
+          <SidebarNavItem to="/instance/settings/heartbeats" label={copy.heartbeats} icon={Clock3} end />
+          <SidebarNavItem to="/instance/settings/experimental" label={copy.experimental} icon={FlaskConical} />
+          <SidebarNavItem to="/instance/settings/plugins" label={copy.plugins} icon={Puzzle} />
+          <SidebarNavItem to="/instance/settings/adapters" label={copy.adapters} icon={Cpu} />
           {(plugins ?? []).length > 0 ? (
             <div className="ml-4 mt-1 flex flex-col gap-0.5 border-l border-border/70 pl-3">
               {(plugins ?? []).map((plugin) => (

--- a/ui/src/components/IssueColumns.tsx
+++ b/ui/src/components/IssueColumns.tsx
@@ -16,35 +16,18 @@ import { formatAssigneeUserLabel } from "../lib/assignees";
 import type { InboxIssueColumn } from "../lib/inbox";
 import { cn } from "../lib/utils";
 import { timeAgo } from "../lib/timeAgo";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { readStoredUiLanguage, textFor } from "../lib/ui-language";
 import { Identity } from "./Identity";
 import { StatusIcon } from "./StatusIcon";
 
 export const issueTrailingColumns: InboxIssueColumn[] = ["assignee", "project", "workspace", "parent", "labels", "updated"];
 
-const issueColumnLabels: Record<InboxIssueColumn, string> = {
-  status: "Status",
-  id: "ID",
-  assignee: "Assignee",
-  project: "Project",
-  workspace: "Workspace",
-  parent: "Parent issue",
-  labels: "Tags",
-  updated: "Last updated",
-};
-
-const issueColumnDescriptions: Record<InboxIssueColumn, string> = {
-  status: "Issue state chip on the left edge.",
-  id: "Ticket identifier like PAP-1009.",
-  assignee: "Assigned agent or board user.",
-  project: "Linked project pill with its color.",
-  workspace: "Execution or project workspace used for the issue.",
-  parent: "Parent issue identifier and title.",
-  labels: "Issue labels and tags.",
-  updated: "Latest visible activity time.",
-};
-
 export function issueActivityText(issue: Issue): string {
-  return `Updated ${timeAgo(issue.lastActivityAt ?? issue.lastExternalCommentAt ?? issue.updatedAt)}`;
+  const uiLanguage = readStoredUiLanguage();
+  return uiLanguage === "zh-CN"
+    ? `更新于 ${timeAgo(issue.lastActivityAt ?? issue.lastExternalCommentAt ?? issue.updatedAt)}`
+    : `Updated ${timeAgo(issue.lastActivityAt ?? issue.lastExternalCommentAt ?? issue.updatedAt)}`;
 }
 
 function issueTrailingGridTemplate(columns: InboxIssueColumn[]): string {
@@ -73,6 +56,33 @@ export function IssueColumnPicker({
   onResetColumns: () => void;
   title: string;
 }) {
+  const { uiLanguage } = useGeneralSettings();
+  const issueColumnLabels: Record<InboxIssueColumn, string> = {
+    status: textFor(uiLanguage, { en: "Status", "zh-CN": "状态" }),
+    id: "ID",
+    assignee: textFor(uiLanguage, { en: "Assignee", "zh-CN": "负责人" }),
+    project: textFor(uiLanguage, { en: "Project", "zh-CN": "项目" }),
+    workspace: textFor(uiLanguage, { en: "Workspace", "zh-CN": "工作区" }),
+    parent: textFor(uiLanguage, { en: "Parent issue", "zh-CN": "父任务" }),
+    labels: textFor(uiLanguage, { en: "Tags", "zh-CN": "标签" }),
+    updated: textFor(uiLanguage, { en: "Last updated", "zh-CN": "最近更新" }),
+  };
+  const issueColumnDescriptions: Record<InboxIssueColumn, string> = {
+    status: textFor(uiLanguage, { en: "Issue state chip on the left edge.", "zh-CN": "左侧显示的任务状态标签。" }),
+    id: textFor(uiLanguage, { en: "Ticket identifier like PAP-1009.", "zh-CN": "类似 PAP-1009 的任务编号。" }),
+    assignee: textFor(uiLanguage, { en: "Assigned agent or board user.", "zh-CN": "已分配的智能体或看板用户。" }),
+    project: textFor(uiLanguage, { en: "Linked project pill with its color.", "zh-CN": "带颜色的关联项目标签。" }),
+    workspace: textFor(uiLanguage, { en: "Execution or project workspace used for the issue.", "zh-CN": "任务使用的执行工作区或项目工作区。" }),
+    parent: textFor(uiLanguage, { en: "Parent issue identifier and title.", "zh-CN": "父任务编号和标题。" }),
+    labels: textFor(uiLanguage, { en: "Issue labels and tags.", "zh-CN": "任务标签。" }),
+    updated: textFor(uiLanguage, { en: "Latest visible activity time.", "zh-CN": "最近可见活动时间。" }),
+  };
+  const copy = {
+    columns: textFor(uiLanguage, { en: "Columns", "zh-CN": "列" }),
+    desktopRows: textFor(uiLanguage, { en: "Desktop issue rows", "zh-CN": "桌面端任务行" }),
+    resetDefaults: textFor(uiLanguage, { en: "Reset defaults", "zh-CN": "恢复默认" }),
+    resetSummary: textFor(uiLanguage, { en: "status, id, updated", "zh-CN": "状态、编号、更新时间" }),
+  };
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -83,14 +93,14 @@ export function IssueColumnPicker({
           className="hidden h-8 shrink-0 px-2 text-xs sm:inline-flex"
         >
           <Columns3 className="mr-1 h-3.5 w-3.5" />
-          Columns
+          {copy.columns}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-[300px] rounded-xl border-border/70 p-1.5 shadow-xl shadow-black/10">
         <DropdownMenuLabel className="px-2 pb-1 pt-1.5">
           <div className="space-y-1">
             <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-              Desktop issue rows
+              {copy.desktopRows}
             </div>
             <div className="text-sm font-medium text-foreground">
               {title}
@@ -121,8 +131,8 @@ export function IssueColumnPicker({
           onSelect={onResetColumns}
           className="rounded-lg px-3 py-2 text-sm"
         >
-          Reset defaults
-          <span className="ml-auto text-xs text-muted-foreground">status, id, updated</span>
+          {copy.resetDefaults}
+          <span className="ml-auto text-xs text-muted-foreground">{copy.resetSummary}</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
@@ -142,6 +152,7 @@ export function InboxIssueMetaLeading({
   showIdentifier?: boolean;
   statusSlot?: ReactNode;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   return (
     <>
       {showStatus ? (
@@ -176,7 +187,7 @@ export function InboxIssueMetaLeading({
               "text-blue-600 dark:text-blue-400",
             )}
           >
-            Live
+            {textFor(uiLanguage, { en: "Live", "zh-CN": "在线" })}
           </span>
         </span>
       )}
@@ -207,8 +218,9 @@ export function InboxIssueTrailingColumns({
   parentTitle: string | null;
   assigneeContent?: ReactNode;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const activityText = timeAgo(issue.lastActivityAt ?? issue.lastExternalCommentAt ?? issue.updatedAt);
-  const userLabel = formatAssigneeUserLabel(issue.assigneeUserId, currentUserId) ?? "User";
+  const userLabel = formatAssigneeUserLabel(issue.assigneeUserId, currentUserId) ?? textFor(uiLanguage, { en: "User", "zh-CN": "用户" });
 
   return (
     <span
@@ -243,7 +255,7 @@ export function InboxIssueTrailingColumns({
 
           return (
             <span key={column} className="min-w-0 truncate text-xs text-muted-foreground">
-              Unassigned
+              {textFor(uiLanguage, { en: "Unassigned", "zh-CN": "未分配" })}
             </span>
           );
         }

--- a/ui/src/components/IssueRow.tsx
+++ b/ui/src/components/IssueRow.tsx
@@ -2,8 +2,10 @@ import type { ReactNode } from "react";
 import type { Issue } from "@paperclipai/shared";
 import { Link } from "@/lib/router";
 import { X } from "lucide-react";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { createIssueDetailPath, rememberIssueDetailLocationState } from "../lib/issueDetailBreadcrumb";
 import { cn } from "../lib/utils";
+import { textFor } from "../lib/ui-language";
 import { StatusIcon } from "./StatusIcon";
 
 type UnreadState = "hidden" | "visible" | "fading";
@@ -43,11 +45,16 @@ export function IssueRow({
   archiveDisabled,
   className,
 }: IssueRowProps) {
+  const { uiLanguage } = useGeneralSettings();
   const issuePathId = issue.identifier ?? issue.id;
   const identifier = issue.identifier ?? issue.id.slice(0, 8);
   const showUnreadSlot = unreadState !== null;
   const showUnreadDot = unreadState === "visible" || unreadState === "fading";
   const selectedStatusClass = selected ? "!text-muted-foreground !border-muted-foreground" : undefined;
+  const copy = {
+    markAsRead: textFor(uiLanguage, { en: "Mark as read", "zh-CN": "标记为已读" }),
+    dismissFromInbox: textFor(uiLanguage, { en: "Dismiss from inbox", "zh-CN": "从收件箱移除" }),
+  };
 
   return (
     <Link
@@ -121,7 +128,7 @@ export function IssueRow({
                 "inline-flex h-4 w-4 items-center justify-center rounded-full transition-colors",
                 selected ? "hover:bg-muted/80" : "hover:bg-blue-500/20",
               )}
-              aria-label="Mark as read"
+              aria-label={copy.markAsRead}
             >
               <span
                 className={cn(
@@ -147,7 +154,7 @@ export function IssueRow({
               }}
               disabled={archiveDisabled}
               className="inline-flex h-4 w-4 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-30"
-              aria-label="Dismiss from inbox"
+              aria-label={copy.dismissFromInbox}
             >
               <X className="h-3.5 w-3.5" />
             </button>

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -2,6 +2,7 @@ import { startTransition, useDeferredValue, useEffect, useMemo, useState, useCal
 import { useQuery } from "@tanstack/react-query";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { executionWorkspacesApi } from "../api/execution-workspaces";
 import { issuesApi } from "../api/issues";
 import { authApi } from "../api/auth";
@@ -41,6 +42,8 @@ import { CircleDot, Plus, Filter, ArrowUpDown, Layers, Check, X, ChevronRight, L
 import { KanbanBoard } from "./KanbanBoard";
 import { buildIssueTree, countDescendants } from "../lib/issue-tree";
 import type { Issue, Project } from "@paperclipai/shared";
+import type { UiLanguage } from "../lib/ui-language";
+import { textFor } from "../lib/ui-language";
 
 /* ── Helpers ── */
 
@@ -48,7 +51,23 @@ const statusOrder = ["in_progress", "todo", "backlog", "in_review", "blocked", "
 const priorityOrder = ["critical", "high", "medium", "low"];
 const ISSUE_SEARCH_DEBOUNCE_MS = 150;
 
-function statusLabel(status: string): string {
+function statusLabel(status: string, uiLanguage: UiLanguage): string {
+  if (uiLanguage === "zh-CN") {
+    const labels: Record<string, string> = {
+      backlog: "待规划",
+      todo: "待处理",
+      in_progress: "进行中",
+      in_review: "审核中",
+      blocked: "阻塞",
+      done: "已完成",
+      cancelled: "已取消",
+      critical: "紧急",
+      high: "高",
+      medium: "中",
+      low: "低",
+    };
+    return labels[status] ?? status.replace(/_/g, " ");
+  }
   return status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
@@ -82,12 +101,6 @@ const defaultViewState: IssueViewState = {
   collapsedParents: [],
 };
 
-const quickFilterPresets = [
-  { label: "All", statuses: [] as string[] },
-  { label: "Active", statuses: ["todo", "in_progress", "in_review", "blocked"] },
-  { label: "Backlog", statuses: ["backlog"] },
-  { label: "Done", statuses: ["done", "cancelled"] },
-];
 function getViewState(key: string): IssueViewState {
   try {
     const raw = localStorage.getItem(key);
@@ -193,9 +206,13 @@ interface IssuesListProps {
 function IssueSearchInput({
   value,
   onDebouncedChange,
+  placeholder,
+  ariaLabel,
 }: {
   value: string;
   onDebouncedChange?: (search: string) => void;
+  placeholder: string;
+  ariaLabel: string;
 }) {
   const [draftValue, setDraftValue] = useState(value);
   const lastCommittedValueRef = useRef(value);
@@ -226,9 +243,9 @@ function IssueSearchInput({
         onChange={(e) => {
           setDraftValue(e.target.value);
         }}
-        placeholder="Search issues..."
+        placeholder={placeholder}
         className="pl-7 text-xs sm:text-sm"
-        aria-label="Search issues"
+        aria-label={ariaLabel}
       />
     </div>
   );
@@ -252,6 +269,7 @@ export function IssuesList({
 }: IssuesListProps) {
   const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialog();
+  const { uiLanguage } = useGeneralSettings();
   const { data: session } = useQuery({
     queryKey: queryKeys.auth.session,
     queryFn: () => authApi.getSession(),
@@ -263,6 +281,47 @@ export function IssuesList({
   });
   const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
   const isolatedWorkspacesEnabled = experimentalSettings?.enableIsolatedWorkspaces === true;
+  const copy = {
+    searchIssues: textFor(uiLanguage, { en: "Search issues...", "zh-CN": "搜索任务..." }),
+    searchIssuesAria: textFor(uiLanguage, { en: "Search issues", "zh-CN": "搜索任务" }),
+    newIssue: textFor(uiLanguage, { en: "New Issue", "zh-CN": "新建任务" }),
+    listView: textFor(uiLanguage, { en: "List view", "zh-CN": "列表视图" }),
+    boardView: textFor(uiLanguage, { en: "Board view", "zh-CN": "看板视图" }),
+    chooseColumns: textFor(uiLanguage, { en: "Choose which issue columns stay visible", "zh-CN": "选择要显示的任务列" }),
+    filter: textFor(uiLanguage, { en: "Filter", "zh-CN": "筛选" }),
+    filters: textFor(uiLanguage, { en: "Filters", "zh-CN": "筛选" }),
+    clear: textFor(uiLanguage, { en: "Clear", "zh-CN": "清除" }),
+    quickFilters: textFor(uiLanguage, { en: "Quick filters", "zh-CN": "快捷筛选" }),
+    status: textFor(uiLanguage, { en: "Status", "zh-CN": "状态" }),
+    priority: textFor(uiLanguage, { en: "Priority", "zh-CN": "优先级" }),
+    assignee: textFor(uiLanguage, { en: "Assignee", "zh-CN": "负责人" }),
+    noAssignee: textFor(uiLanguage, { en: "No assignee", "zh-CN": "未分配" }),
+    me: textFor(uiLanguage, { en: "Me", "zh-CN": "我" }),
+    labels: textFor(uiLanguage, { en: "Labels", "zh-CN": "标签" }),
+    project: textFor(uiLanguage, { en: "Project", "zh-CN": "项目" }),
+    sort: textFor(uiLanguage, { en: "Sort", "zh-CN": "排序" }),
+    group: textFor(uiLanguage, { en: "Group", "zh-CN": "分组" }),
+    title: textFor(uiLanguage, { en: "Title", "zh-CN": "标题" }),
+    created: textFor(uiLanguage, { en: "Created", "zh-CN": "创建时间" }),
+    updated: textFor(uiLanguage, { en: "Updated", "zh-CN": "更新时间" }),
+    workspace: textFor(uiLanguage, { en: "Workspace", "zh-CN": "工作区" }),
+    parentIssue: textFor(uiLanguage, { en: "Parent Issue", "zh-CN": "父任务" }),
+    none: textFor(uiLanguage, { en: "None", "zh-CN": "无" }),
+    noIssuesMatch: textFor(uiLanguage, { en: "No issues match the current filters or search.", "zh-CN": "没有任务符合当前筛选或搜索条件。" }),
+    createIssue: textFor(uiLanguage, { en: "Create Issue", "zh-CN": "创建任务" }),
+    noWorkspace: textFor(uiLanguage, { en: "No Workspace", "zh-CN": "无工作区" }),
+    noParent: textFor(uiLanguage, { en: "No Parent", "zh-CN": "无父任务" }),
+    unassigned: textFor(uiLanguage, { en: "Unassigned", "zh-CN": "未分配" }),
+    user: textFor(uiLanguage, { en: "User", "zh-CN": "用户" }),
+    searchAssignees: textFor(uiLanguage, { en: "Search assignees...", "zh-CN": "搜索负责人..." }),
+    noAssigneesFound: textFor(uiLanguage, { en: "No assignees found.", "zh-CN": "未找到负责人。" }),
+  };
+  const quickFilterPresets = [
+    { label: textFor(uiLanguage, { en: "All", "zh-CN": "全部" }), statuses: [] as string[] },
+    { label: textFor(uiLanguage, { en: "Active", "zh-CN": "进行中" }), statuses: ["todo", "in_progress", "in_review", "blocked"] },
+    { label: textFor(uiLanguage, { en: "Backlog", "zh-CN": "待规划" }), statuses: ["backlog"] },
+    { label: textFor(uiLanguage, { en: "Done", "zh-CN": "已完成" }), statuses: ["done", "cancelled"] },
+  ];
 
   // Scope the storage key per company so folding/view state is independent across companies.
   const scopedKey = selectedCompanyId ? `${viewStateKey}:${selectedCompanyId}` : viewStateKey;
@@ -443,13 +502,13 @@ export function IssuesList({
       const groups = groupBy(filtered, (i) => i.status);
       return statusOrder
         .filter((s) => groups[s]?.length)
-        .map((s) => ({ key: s, label: statusLabel(s), items: groups[s]! }));
+        .map((s) => ({ key: s, label: statusLabel(s, uiLanguage), items: groups[s]! }));
     }
     if (viewState.groupBy === "priority") {
       const groups = groupBy(filtered, (i) => i.priority);
       return priorityOrder
         .filter((p) => groups[p]?.length)
-        .map((p) => ({ key: p, label: statusLabel(p), items: groups[p]! }));
+        .map((p) => ({ key: p, label: statusLabel(p, uiLanguage), items: groups[p]! }));
     }
     if (viewState.groupBy === "workspace") {
       const groups = groupBy(filtered, (i) => i.projectWorkspaceId ?? "__no_workspace");
@@ -462,7 +521,7 @@ export function IssuesList({
         })
         .map((key) => ({
           key,
-          label: key === "__no_workspace" ? "No Workspace" : (workspaceNameMap.get(key) ?? key.slice(0, 8)),
+          label: key === "__no_workspace" ? copy.noWorkspace : (workspaceNameMap.get(key) ?? key.slice(0, 8)),
           items: groups[key]!,
         }));
     }
@@ -477,7 +536,7 @@ export function IssuesList({
         })
         .map((key) => ({
           key,
-          label: key === "__no_parent" ? "No Parent" : (issueTitleMap.get(key) ?? key.slice(0, 8)),
+          label: key === "__no_parent" ? copy.noParent : (issueTitleMap.get(key) ?? key.slice(0, 8)),
           items: groups[key]!,
         }));
     }
@@ -490,13 +549,13 @@ export function IssuesList({
       key,
       label:
         key === "__unassigned"
-          ? "Unassigned"
+          ? copy.unassigned
           : key.startsWith("__user:")
-            ? (formatAssigneeUserLabel(key.slice("__user:".length), currentUserId) ?? "User")
+            ? (formatAssigneeUserLabel(key.slice("__user:".length), currentUserId) ?? copy.user)
             : (agentName(key) ?? key.slice(0, 8)),
       items: groups[key]!,
     }));
-  }, [filtered, viewState.groupBy, agents, agentName, currentUserId, workspaceNameMap, issueTitleMap]);
+  }, [agentName, copy.noParent, copy.noWorkspace, copy.unassigned, copy.user, currentUserId, filtered, issueTitleMap, uiLanguage, viewState.groupBy, workspaceNameMap]);
 
   const newIssueDefaults = useCallback((groupKey?: string) => {
     const defaults: Record<string, string> = {};
@@ -543,7 +602,7 @@ export function IssuesList({
         <div className="flex min-w-0 items-center gap-2 sm:gap-3">
           <Button size="sm" variant="outline" onClick={() => openNewIssue(newIssueDefaults())}>
             <Plus className="h-4 w-4 sm:mr-1" />
-            <span className="hidden sm:inline">New Issue</span>
+            <span className="hidden sm:inline">{copy.newIssue}</span>
           </Button>
           <IssueSearchInput
             value={issueSearch}
@@ -551,6 +610,8 @@ export function IssuesList({
               setIssueSearch(nextSearch);
               onSearchChange?.(nextSearch);
             }}
+            placeholder={copy.searchIssues}
+            ariaLabel={copy.searchIssuesAria}
           />
         </div>
 
@@ -560,14 +621,14 @@ export function IssuesList({
             <button
               className={`p-1.5 transition-colors ${viewState.viewMode === "list" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground"}`}
               onClick={() => updateView({ viewMode: "list" })}
-              title="List view"
+              title={copy.listView}
             >
               <List className="h-3.5 w-3.5" />
             </button>
             <button
               className={`p-1.5 transition-colors ${viewState.viewMode === "board" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground"}`}
               onClick={() => updateView({ viewMode: "board" })}
-              title="Board view"
+              title={copy.boardView}
             >
               <Columns3 className="h-3.5 w-3.5" />
             </button>
@@ -578,7 +639,7 @@ export function IssuesList({
             visibleColumnSet={visibleIssueColumnSet}
             onToggleColumn={toggleIssueColumn}
             onResetColumns={() => setIssueColumns(DEFAULT_INBOX_ISSUE_COLUMNS)}
-            title="Choose which issue columns stay visible"
+            title={copy.chooseColumns}
           />
 
           {/* Filter */}
@@ -586,7 +647,7 @@ export function IssuesList({
             <PopoverTrigger asChild>
               <Button variant="ghost" size="sm" className={`text-xs ${activeFilterCount > 0 ? "text-blue-600 dark:text-blue-400" : ""}`}>
                 <Filter className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
-                <span className="hidden sm:inline">{activeFilterCount > 0 ? `Filters: ${activeFilterCount}` : "Filter"}</span>
+                <span className="hidden sm:inline">{activeFilterCount > 0 ? `${copy.filters}: ${activeFilterCount}` : copy.filter}</span>
                 {activeFilterCount > 0 && (
                   <span className="sm:hidden text-[10px] font-medium ml-0.5">{activeFilterCount}</span>
                 )}
@@ -604,20 +665,20 @@ export function IssuesList({
             <PopoverContent align="end" className="w-[min(480px,calc(100vw-2rem))] p-0">
               <div className="p-3 space-y-3">
                 <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium">Filters</span>
+                  <span className="text-sm font-medium">{copy.filters}</span>
                   {activeFilterCount > 0 && (
                     <button
                       className="text-xs text-muted-foreground hover:text-foreground"
-                      onClick={() => updateView({ statuses: [], priorities: [], assignees: [], labels: [] })}
+                      onClick={() => updateView({ statuses: [], priorities: [], assignees: [], labels: [], projects: [] })}
                     >
-                      Clear
+                      {copy.clear}
                     </button>
                   )}
                 </div>
 
                 {/* Quick filters */}
                 <div className="space-y-1.5">
-                  <span className="text-xs text-muted-foreground">Quick filters</span>
+                  <span className="text-xs text-muted-foreground">{copy.quickFilters}</span>
                   <div className="flex flex-wrap gap-1.5">
                     {quickFilterPresets.map((preset) => {
                       const isActive = arraysEqual(viewState.statuses, preset.statuses);
@@ -644,7 +705,7 @@ export function IssuesList({
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3">
                   {/* Status */}
                   <div className="space-y-1">
-                    <span className="text-xs text-muted-foreground">Status</span>
+                    <span className="text-xs text-muted-foreground">{copy.status}</span>
                     <div className="space-y-0.5">
                       {statusOrder.map((s) => (
                         <label key={s} className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
@@ -653,7 +714,7 @@ export function IssuesList({
                             onCheckedChange={() => updateView({ statuses: toggleInArray(viewState.statuses, s) })}
                           />
                           <StatusIcon status={s} />
-                          <span className="text-sm">{statusLabel(s)}</span>
+                          <span className="text-sm">{statusLabel(s, uiLanguage)}</span>
                         </label>
                       ))}
                     </div>
@@ -663,31 +724,31 @@ export function IssuesList({
                   <div className="space-y-3">
                     {/* Priority */}
                     <div className="space-y-1">
-                      <span className="text-xs text-muted-foreground">Priority</span>
+                      <span className="text-xs text-muted-foreground">{copy.priority}</span>
                       <div className="space-y-0.5">
                         {priorityOrder.map((p) => (
                           <label key={p} className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
                             <Checkbox
                               checked={viewState.priorities.includes(p)}
                               onCheckedChange={() => updateView({ priorities: toggleInArray(viewState.priorities, p) })}
-                            />
-                            <PriorityIcon priority={p} />
-                            <span className="text-sm">{statusLabel(p)}</span>
-                          </label>
-                        ))}
-                      </div>
+                          />
+                          <PriorityIcon priority={p} />
+                          <span className="text-sm">{statusLabel(p, uiLanguage)}</span>
+                        </label>
+                      ))}
+                    </div>
                     </div>
 
                     {/* Assignee */}
                     <div className="space-y-1">
-                      <span className="text-xs text-muted-foreground">Assignee</span>
+                      <span className="text-xs text-muted-foreground">{copy.assignee}</span>
                       <div className="space-y-0.5 max-h-32 overflow-y-auto">
                         <label className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
                           <Checkbox
                             checked={viewState.assignees.includes("__unassigned")}
                             onCheckedChange={() => updateView({ assignees: toggleInArray(viewState.assignees, "__unassigned") })}
                           />
-                          <span className="text-sm">No assignee</span>
+                          <span className="text-sm">{copy.noAssignee}</span>
                         </label>
                         {currentUserId && (
                           <label className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
@@ -696,7 +757,7 @@ export function IssuesList({
                               onCheckedChange={() => updateView({ assignees: toggleInArray(viewState.assignees, "__me") })}
                             />
                             <User className="h-3.5 w-3.5 text-muted-foreground" />
-                            <span className="text-sm">Me</span>
+                            <span className="text-sm">{copy.me}</span>
                           </label>
                         )}
                         {(agents ?? []).map((agent) => (
@@ -713,7 +774,7 @@ export function IssuesList({
 
                     {labels && labels.length > 0 && (
                       <div className="space-y-1">
-                        <span className="text-xs text-muted-foreground">Labels</span>
+                        <span className="text-xs text-muted-foreground">{copy.labels}</span>
                         <div className="space-y-0.5 max-h-32 overflow-y-auto">
                           {labels.map((label) => (
                             <label key={label.id} className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
@@ -731,7 +792,7 @@ export function IssuesList({
 
                     {projects && projects.length > 0 && (
                       <div className="space-y-1">
-                        <span className="text-xs text-muted-foreground">Project</span>
+                        <span className="text-xs text-muted-foreground">{copy.project}</span>
                         <div className="space-y-0.5 max-h-32 overflow-y-auto">
                           {projects.map((project) => (
                             <label key={project.id} className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
@@ -757,17 +818,17 @@ export function IssuesList({
               <PopoverTrigger asChild>
                 <Button variant="ghost" size="sm" className="text-xs">
                   <ArrowUpDown className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
-                  <span className="hidden sm:inline">Sort</span>
+                  <span className="hidden sm:inline">{copy.sort}</span>
                 </Button>
               </PopoverTrigger>
               <PopoverContent align="end" className="w-48 p-0">
                 <div className="p-2 space-y-0.5">
                   {([
-                    ["status", "Status"],
-                    ["priority", "Priority"],
-                    ["title", "Title"],
-                    ["created", "Created"],
-                    ["updated", "Updated"],
+                    ["status", copy.status],
+                    ["priority", copy.priority],
+                    ["title", copy.title],
+                    ["created", copy.created],
+                    ["updated", copy.updated],
                   ] as const).map(([field, label]) => (
                     <button
                       key={field}
@@ -801,18 +862,18 @@ export function IssuesList({
               <PopoverTrigger asChild>
                 <Button variant="ghost" size="sm" className="text-xs">
                   <Layers className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
-                  <span className="hidden sm:inline">Group</span>
+                  <span className="hidden sm:inline">{copy.group}</span>
                 </Button>
               </PopoverTrigger>
               <PopoverContent align="end" className="w-44 p-0">
                 <div className="p-2 space-y-0.5">
                   {([
-                    ["status", "Status"],
-                    ["priority", "Priority"],
-                    ["assignee", "Assignee"],
-                    ["workspace", "Workspace"],
-                    ["parent", "Parent Issue"],
-                    ["none", "None"],
+                    ["status", copy.status],
+                    ["priority", copy.priority],
+                    ["assignee", copy.assignee],
+                    ["workspace", copy.workspace],
+                    ["parent", copy.parentIssue],
+                    ["none", copy.none],
                   ] as const).map(([value, label]) => (
                     <button
                       key={value}
@@ -838,8 +899,8 @@ export function IssuesList({
       {!isLoading && filtered.length === 0 && viewState.viewMode === "list" && (
         <EmptyState
           icon={CircleDot}
-          message="No issues match the current filters or search."
-          action="Create Issue"
+          message={copy.noIssuesMatch}
+          action={copy.createIssue}
           onAction={() => openNewIssue(newIssueDefaults())}
         />
       )}
@@ -868,9 +929,9 @@ export function IssuesList({
               <div className="flex items-center py-1.5 pl-1 pr-3">
                 <CollapsibleTrigger className="flex items-center gap-1.5">
                   <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform [[data-state=open]>&]:rotate-90" />
-                  <span className="text-sm font-semibold uppercase tracking-wide">
-                    {group.label}
-                  </span>
+                    <span className="text-sm font-semibold uppercase tracking-wide">
+                      {group.label}
+                    </span>
                 </CollapsibleTrigger>
                 <Button
                   variant="ghost"
@@ -910,7 +971,9 @@ export function IssuesList({
                         issueLinkState={issueLinkState}
                         titleSuffix={hasChildren && !isExpanded ? (
                           <span className="ml-1.5 text-xs text-muted-foreground">
-                            ({totalDescendants} sub-task{totalDescendants !== 1 ? "s" : ""})
+                            {uiLanguage === "zh-CN"
+                              ? `(${totalDescendants} 个子任务)`
+                              : `(${totalDescendants} sub-task${totalDescendants !== 1 ? "s" : ""})`}
                           </span>
                         ) : undefined}
                         mobileLeading={
@@ -987,14 +1050,14 @@ export function IssuesList({
                                           <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-dashed border-muted-foreground/35 bg-muted/30">
                                             <User className="h-3 w-3" />
                                           </span>
-                                          {formatAssigneeUserLabel(issue.assigneeUserId, currentUserId) ?? "User"}
+                                          {formatAssigneeUserLabel(issue.assigneeUserId, currentUserId) ?? copy.user}
                                         </span>
                                       ) : (
                                         <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
                                           <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-dashed border-muted-foreground/35 bg-muted/30">
                                             <User className="h-3 w-3" />
                                           </span>
-                                          Assignee
+                                          {copy.assignee}
                                         </span>
                                       )}
                                     </button>
@@ -1007,7 +1070,7 @@ export function IssuesList({
                                   >
                                     <input
                                       className="mb-1 w-full border-b border-border bg-transparent px-2 py-1.5 text-xs outline-none placeholder:text-muted-foreground/50"
-                                      placeholder="Search assignees..."
+                                      placeholder={copy.searchAssignees}
                                       value={assigneeSearch}
                                       onChange={(e) => setAssigneeSearch(e.target.value)}
                                       autoFocus
@@ -1024,7 +1087,7 @@ export function IssuesList({
                                           assignIssue(issue.id, null, null);
                                         }}
                                       >
-                                        No assignee
+                                        {copy.noAssignee}
                                       </button>
                                       {currentUserId && (
                                         <button
@@ -1039,15 +1102,22 @@ export function IssuesList({
                                           }}
                                         >
                                           <User className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                                          <span>Me</span>
+                                          <span>{copy.me}</span>
                                         </button>
                                       )}
-                                      {(agents ?? [])
-                                        .filter((agent) => {
+                                      {(() => {
+                                        const filteredAgents = (agents ?? []).filter((agent) => {
                                           if (!assigneeSearch.trim()) return true;
                                           return agent.name.toLowerCase().includes(assigneeSearch.toLowerCase());
-                                        })
-                                        .map((agent) => (
+                                        });
+                                        if (filteredAgents.length === 0) {
+                                          return (
+                                            <div className="px-2 py-2 text-xs text-muted-foreground">
+                                              {copy.noAssigneesFound}
+                                            </div>
+                                          );
+                                        }
+                                        return filteredAgents.map((agent) => (
                                           <button
                                             key={agent.id}
                                             className={cn(
@@ -1062,7 +1132,8 @@ export function IssuesList({
                                           >
                                             <Identity name={agent.name} size="sm" className="min-w-0" />
                                           </button>
-                                        ))}
+                                        ));
+                                      })()}
                                     </div>
                                   </PopoverContent>
                                 </Popover>

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -20,6 +20,8 @@ import {
 import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 import type { Issue } from "@paperclipai/shared";
 
 const boardStatuses = [
@@ -32,7 +34,19 @@ const boardStatuses = [
   "cancelled",
 ];
 
-function statusLabel(status: string): string {
+function statusLabel(status: string, uiLanguage: "en" | "zh-CN"): string {
+  if (uiLanguage === "zh-CN") {
+    const labels: Record<string, string> = {
+      backlog: "待规划",
+      todo: "待处理",
+      in_progress: "进行中",
+      in_review: "审核中",
+      blocked: "阻塞",
+      done: "已完成",
+      cancelled: "已取消",
+    };
+    return labels[status] ?? status.replace(/_/g, " ");
+  }
   return status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
@@ -61,6 +75,7 @@ function KanbanColumn({
   agents?: Agent[];
   liveIssueIds?: Set<string>;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const { setNodeRef, isOver } = useDroppable({ id: status });
 
   const isEmpty = issues.length === 0;
@@ -72,7 +87,7 @@ function KanbanColumn({
         {(!isEmpty || isOver) && (
           <>
             <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              {statusLabel(status)}
+              {statusLabel(status, uiLanguage)}
             </span>
             <span className="text-xs text-muted-foreground/60 ml-auto tabular-nums">
               {issues.length}

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -35,6 +35,11 @@ import {
 import { queryKeys } from "../lib/queryKeys";
 import { scheduleMainContentFocus } from "../lib/main-content-focus";
 import { cn } from "../lib/utils";
+import {
+  readStoredUiLanguage,
+  textFor,
+  writeStoredUiLanguage,
+} from "../lib/ui-language";
 import { NotFoundPage } from "../pages/NotFound";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -72,6 +77,7 @@ export function Layout() {
   const [mobileNavVisible, setMobileNavVisible] = useState(true);
   const [instanceSettingsTarget, setInstanceSettingsTarget] = useState<string>(() => readRememberedInstanceSettingsPath());
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [uiLanguage, setUiLanguage] = useState(() => readStoredUiLanguage());
   const nextTheme = theme === "dark" ? "light" : "dark";
   const matchedCompany = useMemo(() => {
     if (!companyPrefix) return null;
@@ -90,10 +96,34 @@ export function Layout() {
     },
     refetchIntervalInBackground: true,
   });
-  const keyboardShortcutsEnabled = useQuery({
+  const generalSettings = useQuery({
     queryKey: queryKeys.instance.generalSettings,
     queryFn: () => instanceSettingsApi.getGeneral(),
-  }).data?.keyboardShortcuts === true;
+  }).data;
+  const keyboardShortcutsEnabled = generalSettings?.keyboardShortcuts === true;
+
+  const layoutText = useMemo(() => ({
+    skipToMain: textFor(uiLanguage, {
+      en: "Skip to Main Content",
+      "zh-CN": "跳到主要内容",
+    }),
+    documentation: textFor(uiLanguage, {
+      en: "Documentation",
+      "zh-CN": "文档",
+    }),
+    instanceSettings: textFor(uiLanguage, {
+      en: "Instance settings",
+      "zh-CN": "实例设置",
+    }),
+    closeSidebar: textFor(uiLanguage, {
+      en: "Close sidebar",
+      "zh-CN": "关闭侧边栏",
+    }),
+    switchTheme: textFor(uiLanguage, {
+      en: `Switch to ${nextTheme} mode`,
+      "zh-CN": `切换到${nextTheme === "dark" ? "深色" : "浅色"}模式`,
+    }),
+  }), [nextTheme, uiLanguage]);
 
   useEffect(() => {
     if (companiesLoading || onboardingTriggered.current) return;
@@ -275,8 +305,15 @@ export function Layout() {
     return scheduleMainContentFocus(mainContent);
   }, [location.pathname]);
 
+  useEffect(() => {
+    writeStoredUiLanguage(uiLanguage);
+    if (typeof document !== "undefined") {
+      document.documentElement.lang = uiLanguage;
+    }
+  }, [uiLanguage]);
+
   return (
-    <GeneralSettingsProvider value={{ keyboardShortcutsEnabled }}>
+    <GeneralSettingsProvider value={{ keyboardShortcutsEnabled, uiLanguage, setUiLanguage }}>
       <div
       className={cn(
         "bg-background text-foreground pt-[env(safe-area-inset-top)]",
@@ -287,7 +324,7 @@ export function Layout() {
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-[200] focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        Skip to Main Content
+        {layoutText.skipToMain}
       </a>
       <WorktreeBanner />
       <DevRestartBanner devServer={health?.devServer} />
@@ -297,7 +334,7 @@ export function Layout() {
             type="button"
             className="fixed inset-0 z-40 bg-black/50"
             onClick={() => setSidebarOpen(false)}
-            aria-label="Close sidebar"
+            aria-label={layoutText.closeSidebar}
           />
         )}
 
@@ -321,7 +358,7 @@ export function Layout() {
                   className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors text-foreground/80 hover:bg-accent/50 hover:text-foreground flex-1 min-w-0"
                 >
                   <BookOpen className="h-4 w-4 shrink-0" />
-                  <span className="truncate">Documentation</span>
+                  <span className="truncate">{layoutText.documentation}</span>
                 </a>
                 {health?.version && (
                   <Tooltip>
@@ -334,8 +371,8 @@ export function Layout() {
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>
                   <Link
                     to={instanceSettingsTarget}
-                    aria-label="Instance settings"
-                    title="Instance settings"
+                    aria-label={layoutText.instanceSettings}
+                    title={layoutText.instanceSettings}
                     onClick={() => {
                       if (isMobile) setSidebarOpen(false);
                     }}
@@ -349,8 +386,8 @@ export function Layout() {
                   size="icon-sm"
                   className="text-muted-foreground shrink-0"
                   onClick={toggleTheme}
-                  aria-label={`Switch to ${nextTheme} mode`}
-                  title={`Switch to ${nextTheme} mode`}
+                  aria-label={layoutText.switchTheme}
+                  title={layoutText.switchTheme}
                 >
                   {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
                 </Button>
@@ -379,7 +416,7 @@ export function Layout() {
                   className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors text-foreground/80 hover:bg-accent/50 hover:text-foreground flex-1 min-w-0"
                 >
                   <BookOpen className="h-4 w-4 shrink-0" />
-                  <span className="truncate">Documentation</span>
+                  <span className="truncate">{layoutText.documentation}</span>
                 </a>
                 {health?.version && (
                   <Tooltip>
@@ -392,8 +429,8 @@ export function Layout() {
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>
                   <Link
                     to={instanceSettingsTarget}
-                    aria-label="Instance settings"
-                    title="Instance settings"
+                    aria-label={layoutText.instanceSettings}
+                    title={layoutText.instanceSettings}
                     onClick={() => {
                       if (isMobile) setSidebarOpen(false);
                     }}
@@ -407,8 +444,8 @@ export function Layout() {
                   size="icon-sm"
                   className="text-muted-foreground shrink-0"
                   onClick={toggleTheme}
-                  aria-label={`Switch to ${nextTheme} mode`}
-                  title={`Switch to ${nextTheme} mode`}
+                  aria-label={layoutText.switchTheme}
+                  title={layoutText.switchTheme}
                 >
                   {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
                 </Button>

--- a/ui/src/components/MobileBottomNav.tsx
+++ b/ui/src/components/MobileBottomNav.tsx
@@ -9,8 +9,10 @@ import {
 } from "lucide-react";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { cn } from "../lib/utils";
 import { useInboxBadge } from "../hooks/useInboxBadge";
+import { textFor } from "../lib/ui-language";
 
 interface MobileBottomNavProps {
   visible: boolean;
@@ -37,23 +39,32 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
   const location = useLocation();
   const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialog();
+  const { uiLanguage } = useGeneralSettings();
   const inboxBadge = useInboxBadge(selectedCompanyId);
+  const copy = {
+    home: textFor(uiLanguage, { en: "Home", "zh-CN": "首页" }),
+    issues: textFor(uiLanguage, { en: "Issues", "zh-CN": "任务" }),
+    create: textFor(uiLanguage, { en: "Create", "zh-CN": "新建" }),
+    agents: textFor(uiLanguage, { en: "Agents", "zh-CN": "智能体" }),
+    inbox: textFor(uiLanguage, { en: "Inbox", "zh-CN": "收件箱" }),
+    mobileNavigation: textFor(uiLanguage, { en: "Mobile navigation", "zh-CN": "移动端导航" }),
+  };
 
   const items = useMemo<MobileNavItem[]>(
     () => [
-      { type: "link", to: "/dashboard", label: "Home", icon: House },
-      { type: "link", to: "/issues", label: "Issues", icon: CircleDot },
-      { type: "action", label: "Create", icon: SquarePen, onClick: () => openNewIssue() },
-      { type: "link", to: "/agents/all", label: "Agents", icon: Users },
+      { type: "link", to: "/dashboard", label: copy.home, icon: House },
+      { type: "link", to: "/issues", label: copy.issues, icon: CircleDot },
+      { type: "action", label: copy.create, icon: SquarePen, onClick: () => openNewIssue() },
+      { type: "link", to: "/agents/all", label: copy.agents, icon: Users },
       {
         type: "link",
         to: "/inbox",
-        label: "Inbox",
+        label: copy.inbox,
         icon: Inbox,
         badge: inboxBadge.inbox,
       },
     ],
-    [openNewIssue, inboxBadge.inbox],
+    [copy.agents, copy.create, copy.home, copy.inbox, copy.issues, openNewIssue, inboxBadge.inbox],
   );
 
   return (
@@ -62,7 +73,7 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
         "fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85 transition-transform duration-200 ease-out md:hidden pb-[env(safe-area-inset-bottom)]",
         visible ? "translate-y-0" : "translate-y-full",
       )}
-      aria-label="Mobile navigation"
+      aria-label={copy.mobileNavigation}
     >
       <div className="grid h-16 grid-cols-5 px-1">
         {items.map((item) => {

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -15,6 +15,7 @@ import { useProjectOrder } from "../hooks/useProjectOrder";
 import { getRecentAssigneeIds, sortAgentsByRecency, trackRecentAssignee } from "../lib/recent-assignees";
 import { buildExecutionPolicy } from "../lib/issue-execution-policy";
 import { useToast } from "../context/ToastContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import {
   assigneeValueFromSelection,
   currentUserAssigneeOption,
@@ -58,6 +59,7 @@ import { issueStatusText, issueStatusTextDefault, priorityColor, priorityColorDe
 import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "./MarkdownEditor";
 import { AgentIcon } from "./AgentIconPicker";
 import { InlineEntitySelector, type InlineEntityOption } from "./InlineEntitySelector";
+import { textFor, type UiLanguage } from "../lib/ui-language";
 
 const DRAFT_KEY = "paperclip:issue-draft";
 const DEBOUNCE_MS = 800;
@@ -225,26 +227,45 @@ function formatFileSize(file: File) {
   return `${(file.size / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-const statuses = [
-  { value: "backlog", label: "Backlog", color: issueStatusText.backlog ?? issueStatusTextDefault },
-  { value: "todo", label: "Todo", color: issueStatusText.todo ?? issueStatusTextDefault },
-  { value: "in_progress", label: "In Progress", color: issueStatusText.in_progress ?? issueStatusTextDefault },
-  { value: "in_review", label: "In Review", color: issueStatusText.in_review ?? issueStatusTextDefault },
-  { value: "done", label: "Done", color: issueStatusText.done ?? issueStatusTextDefault },
-];
+function buildStatusOptions(uiLanguage: UiLanguage) {
+  return [
+    { value: "backlog", label: textFor(uiLanguage, { en: "Backlog", "zh-CN": "待规划" }), color: issueStatusText.backlog ?? issueStatusTextDefault },
+    { value: "todo", label: textFor(uiLanguage, { en: "Todo", "zh-CN": "待办" }), color: issueStatusText.todo ?? issueStatusTextDefault },
+    { value: "in_progress", label: textFor(uiLanguage, { en: "In Progress", "zh-CN": "进行中" }), color: issueStatusText.in_progress ?? issueStatusTextDefault },
+    { value: "in_review", label: textFor(uiLanguage, { en: "In Review", "zh-CN": "评审中" }), color: issueStatusText.in_review ?? issueStatusTextDefault },
+    { value: "done", label: textFor(uiLanguage, { en: "Done", "zh-CN": "已完成" }), color: issueStatusText.done ?? issueStatusTextDefault },
+  ];
+}
 
-const priorities = [
-  { value: "critical", label: "Critical", icon: AlertTriangle, color: priorityColor.critical ?? priorityColorDefault },
-  { value: "high", label: "High", icon: ArrowUp, color: priorityColor.high ?? priorityColorDefault },
-  { value: "medium", label: "Medium", icon: Minus, color: priorityColor.medium ?? priorityColorDefault },
-  { value: "low", label: "Low", icon: ArrowDown, color: priorityColor.low ?? priorityColorDefault },
-];
+function buildPriorityOptions(uiLanguage: UiLanguage) {
+  return [
+    { value: "critical", label: textFor(uiLanguage, { en: "Critical", "zh-CN": "紧急" }), icon: AlertTriangle, color: priorityColor.critical ?? priorityColorDefault },
+    { value: "high", label: textFor(uiLanguage, { en: "High", "zh-CN": "高" }), icon: ArrowUp, color: priorityColor.high ?? priorityColorDefault },
+    { value: "medium", label: textFor(uiLanguage, { en: "Medium", "zh-CN": "中" }), icon: Minus, color: priorityColor.medium ?? priorityColorDefault },
+    { value: "low", label: textFor(uiLanguage, { en: "Low", "zh-CN": "低" }), icon: ArrowDown, color: priorityColor.low ?? priorityColorDefault },
+  ];
+}
 
-const EXECUTION_WORKSPACE_MODES = [
-  { value: "shared_workspace", label: "Project default" },
-  { value: "isolated_workspace", label: "New isolated workspace" },
-  { value: "reuse_existing", label: "Reuse existing workspace" },
-] as const;
+function buildExecutionWorkspaceModeOptions(uiLanguage: UiLanguage) {
+  return [
+    { value: "shared_workspace", label: textFor(uiLanguage, { en: "Project default", "zh-CN": "项目默认" }) },
+    { value: "isolated_workspace", label: textFor(uiLanguage, { en: "New isolated workspace", "zh-CN": "新的隔离工作区" }) },
+    { value: "reuse_existing", label: textFor(uiLanguage, { en: "Reuse existing workspace", "zh-CN": "复用现有工作区" }) },
+  ] as const;
+}
+
+function localizeThinkingEffortLabel(label: string, uiLanguage: UiLanguage) {
+  const labels: Record<string, { en: string; "zh-CN": string }> = {
+    Default: { en: "Default", "zh-CN": "默认" },
+    Minimal: { en: "Minimal", "zh-CN": "最小" },
+    Low: { en: "Low", "zh-CN": "低" },
+    Medium: { en: "Medium", "zh-CN": "中" },
+    High: { en: "High", "zh-CN": "高" },
+    "X-High": { en: "X-High", "zh-CN": "超高" },
+    Max: { en: "Max", "zh-CN": "最大" },
+  };
+  return textFor(uiLanguage, labels[label] ?? { en: label, "zh-CN": label });
+}
 
 function defaultProjectWorkspaceIdForProject(project: { workspaces?: Array<{ id: string; isPrimary: boolean }>; executionWorkspacePolicy?: { defaultProjectWorkspaceId?: string | null } | null } | null | undefined) {
   if (!project) return "";
@@ -281,6 +302,7 @@ export function NewIssueDialog() {
   const { companies, selectedCompanyId, selectedCompany } = useCompany();
   const queryClient = useQueryClient();
   const { pushToast } = useToast();
+  const { uiLanguage } = useGeneralSettings();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [status, setStatus] = useState("todo");
@@ -313,6 +335,10 @@ export function NewIssueDialog() {
     ?? (newIssueDefaults.parentId ? newIssueDefaults.parentId.slice(0, 8) : "");
   const parentExecutionWorkspaceId = newIssueDefaults.executionWorkspaceId ?? "";
   const parentExecutionWorkspaceLabel = newIssueDefaults.parentExecutionWorkspaceLabel ?? parentExecutionWorkspaceId;
+  const t = useCallback((en: string, zh: string) => textFor(uiLanguage, { en, "zh-CN": zh }), [uiLanguage]);
+  const statuses = useMemo(() => buildStatusOptions(uiLanguage), [uiLanguage]);
+  const priorities = useMemo(() => buildPriorityOptions(uiLanguage), [uiLanguage]);
+  const executionWorkspaceModes = useMemo(() => buildExecutionWorkspaceModeOptions(uiLanguage), [uiLanguage]);
 
   // Popover states
   const [statusOpen, setStatusOpen] = useState(false);
@@ -453,11 +479,14 @@ export function NewIssueDialog() {
         const prefix = (companies.find((company) => company.id === companyId)?.issuePrefix ?? "").trim();
         const issueRef = issue.identifier ?? issue.id;
         pushToast({
-          title: `Created ${issueRef} with upload warnings`,
-          body: `${failures.length} staged ${failures.length === 1 ? "file" : "files"} could not be added.`,
+          title: t(`Created ${issueRef} with upload warnings`, `已创建 ${issueRef}，但上传有警告`),
+          body: t(
+            `${failures.length} staged ${failures.length === 1 ? "file" : "files"} could not be added.`,
+            `${failures.length} 个暂存文件未能添加。`,
+          ),
           tone: "warn",
           action: prefix
-            ? { label: `Open ${issueRef}`, href: `/${prefix}/issues/${issueRef}` }
+            ? { label: t(`Open ${issueRef}`, `打开 ${issueRef}`), href: `/${prefix}/issues/${issueRef}` }
             : undefined,
         });
       }
@@ -469,7 +498,7 @@ export function NewIssueDialog() {
 
   const uploadDescriptionImage = useMutation({
     mutationFn: async (file: File) => {
-      if (!effectiveCompanyId) throw new Error("No company selected");
+      if (!effectiveCompanyId) throw new Error(t("No company selected", "未选择公司"));
       return assetsApi.uploadImage(effectiveCompanyId, file, "issues/drafts");
     },
   });
@@ -852,12 +881,12 @@ export function NewIssueDialog() {
     && !isUsingParentExecutionWorkspace;
   const assigneeOptionsTitle =
     assigneeAdapterType === "claude_local"
-      ? "Claude options"
+      ? t("Claude options", "Claude 选项")
       : assigneeAdapterType === "codex_local"
-        ? "Codex options"
+        ? t("Codex options", "Codex 选项")
         : assigneeAdapterType === "opencode_local"
-          ? "OpenCode options"
-        : "Agent options";
+          ? t("OpenCode options", "OpenCode 选项")
+        : t("Agent options", "智能体选项");
   const thinkingEffortOptions =
     assigneeAdapterType === "codex_local"
       ? ISSUE_THINKING_EFFORT_OPTIONS.codex_local
@@ -892,7 +921,7 @@ export function NewIssueDialog() {
   const hasSavedDraft = Boolean(savedDraft?.title.trim() || savedDraft?.description.trim());
   const canDiscardDraft = hasDraft || hasSavedDraft;
   const createIssueErrorMessage =
-    createIssue.error instanceof Error ? createIssue.error.message : "Failed to create issue. Try again.";
+    createIssue.error instanceof Error ? createIssue.error.message : t("Failed to create issue. Try again.", "创建任务失败，请重试。");
   const stagedDocuments = stagedFiles.filter((file) => file.kind === "document");
   const stagedAttachments = stagedFiles.filter((file) => file.kind === "attachment");
 
@@ -1032,7 +1061,7 @@ export function NewIssueDialog() {
               </PopoverContent>
             </Popover>
             <span className="text-muted-foreground/60">&rsaquo;</span>
-            <span>{isSubIssueMode ? "New sub-issue" : "New issue"}</span>
+            <span>{isSubIssueMode ? t("New sub-issue", "新建子任务") : t("New issue", "新建任务")}</span>
           </div>
           <div className="flex items-center gap-1">
             <Button
@@ -1060,7 +1089,7 @@ export function NewIssueDialog() {
         <div className="px-4 pt-4 pb-2 shrink-0">
           <textarea
             className="w-full text-lg font-semibold bg-transparent outline-none resize-none overflow-hidden placeholder:text-muted-foreground/50"
-            placeholder="Issue title"
+            placeholder={t("Issue title", "任务标题")}
             rows={1}
             value={title}
             onChange={(e) => {
@@ -1100,16 +1129,16 @@ export function NewIssueDialog() {
         <div className="px-4 pb-2 shrink-0">
           <div className="overflow-x-auto overscroll-x-contain">
             <div className="inline-flex items-center gap-2 text-sm text-muted-foreground flex-wrap sm:flex-nowrap sm:min-w-max">
-              <span className="w-6 shrink-0 text-center">For</span>
+              <span className="w-6 shrink-0 text-center">{t("For", "分配")}</span>
               <InlineEntitySelector
                 ref={assigneeSelectorRef}
                 value={assigneeValue}
                 options={assigneeOptions}
-                placeholder="Assignee"
+                placeholder={t("Assignee", "负责人")}
                 disablePortal
-                noneLabel="No assignee"
-                searchPlaceholder="Search assignees..."
-                emptyMessage="No assignees found."
+                noneLabel={t("No assignee", "未分配负责人")}
+                searchPlaceholder={t("Search assignees...", "搜索负责人...")}
+                emptyMessage={t("No assignees found.", "未找到负责人。")}
                 onChange={(value) => {
                   const nextAssignee = parseAssigneeValue(value);
                   if (nextAssignee.assigneeAgentId) {
@@ -1135,7 +1164,7 @@ export function NewIssueDialog() {
                       <span className="truncate">{option.label}</span>
                     )
                   ) : (
-                    <span className="text-muted-foreground">Assignee</span>
+                    <span className="text-muted-foreground">{t("Assignee", "负责人")}</span>
                   )
                 }
                 renderOption={(option) => {
@@ -1151,16 +1180,16 @@ export function NewIssueDialog() {
                   );
                 }}
               />
-              <span>in</span>
+              <span>{t("in", "归属")}</span>
               <InlineEntitySelector
                 ref={projectSelectorRef}
                 value={projectId}
                 options={projectOptions}
-                placeholder="Project"
+                placeholder={t("Project", "项目")}
                 disablePortal
-                noneLabel="No project"
-                searchPlaceholder="Search projects..."
-                emptyMessage="No projects found."
+                noneLabel={t("No project", "无项目")}
+                searchPlaceholder={t("Search projects...", "搜索项目...")}
+                emptyMessage={t("No projects found.", "未找到项目。")}
                 onChange={handleProjectChange}
                 onConfirm={() => {
                   descriptionEditorRef.current?.focus();
@@ -1175,7 +1204,7 @@ export function NewIssueDialog() {
                       <span className="truncate">{option.label}</span>
                     </>
                   ) : (
-                    <span className="text-muted-foreground">Project</span>
+                    <span className="text-muted-foreground">{t("Project", "项目")}</span>
                   )
                 }
                 renderOption={(option) => {
@@ -1199,7 +1228,7 @@ export function NewIssueDialog() {
                   <button
                     type="button"
                     className="inline-flex items-center justify-center rounded-md p-1 text-muted-foreground hover:bg-accent/50 transition-colors"
-                    title="Add reviewer or approver"
+                    title={t("Add reviewer or approver", "添加评审人或审批人")}
                   >
                     <MoreHorizontal className="h-4 w-4" />
                   </button>
@@ -1217,7 +1246,7 @@ export function NewIssueDialog() {
                     }}
                   >
                     <Eye className="h-3 w-3" />
-                    Reviewer
+                    {t("Reviewer", "评审人")}
                   </button>
                   <button
                     className={cn(
@@ -1231,7 +1260,7 @@ export function NewIssueDialog() {
                     }}
                   >
                     <ShieldCheck className="h-3 w-3" />
-                    Approver
+                    {t("Approver", "审批人")}
                   </button>
                 </PopoverContent>
               </Popover>
@@ -1245,11 +1274,11 @@ export function NewIssueDialog() {
               <InlineEntitySelector
                 value={reviewerValue}
                 options={assigneeOptions}
-                placeholder="Reviewer"
+                placeholder={t("Reviewer", "评审人")}
                 disablePortal
-                noneLabel="No reviewer"
-                searchPlaceholder="Search reviewers..."
-                emptyMessage="No reviewers found."
+                noneLabel={t("No reviewer", "无评审人")}
+                searchPlaceholder={t("Search reviewers...", "搜索评审人...")}
+                emptyMessage={t("No reviewers found.", "未找到评审人。")}
                 onChange={setReviewerValue}
                 renderTriggerValue={(option) =>
                   option ? (
@@ -1263,7 +1292,7 @@ export function NewIssueDialog() {
                       <span className="truncate">{option.label}</span>
                     </>
                   ) : (
-                    <span className="text-muted-foreground">Reviewer</span>
+                    <span className="text-muted-foreground">{t("Reviewer", "评审人")}</span>
                   )
                 }
                 renderOption={(option) => {
@@ -1289,11 +1318,11 @@ export function NewIssueDialog() {
               <InlineEntitySelector
                 value={approverValue}
                 options={assigneeOptions}
-                placeholder="Approver"
+                placeholder={t("Approver", "审批人")}
                 disablePortal
-                noneLabel="No approver"
-                searchPlaceholder="Search approvers..."
-                emptyMessage="No approvers found."
+                noneLabel={t("No approver", "无审批人")}
+                searchPlaceholder={t("Search approvers...", "搜索审批人...")}
+                emptyMessage={t("No approvers found.", "未找到审批人。")}
                 onChange={setApproverValue}
                 renderTriggerValue={(option) =>
                   option ? (
@@ -1307,7 +1336,7 @@ export function NewIssueDialog() {
                       <span className="truncate">{option.label}</span>
                     </>
                   ) : (
-                    <span className="text-muted-foreground">Approver</span>
+                    <span className="text-muted-foreground">{t("Approver", "审批人")}</span>
                   )
                 }
                 renderOption={(option) => {
@@ -1332,7 +1361,7 @@ export function NewIssueDialog() {
             <div className="max-w-full rounded-md border border-border bg-muted/30 px-2.5 py-1.5 text-xs text-muted-foreground">
               <div className="flex items-center gap-1.5">
                 <ListTree className="h-3.5 w-3.5 shrink-0" />
-                <span className="shrink-0">Sub-issue of</span>
+                <span className="shrink-0">{t("Sub-issue of", "子任务属于")}</span>
                 <span className="font-medium text-foreground">{parentIssueLabel}</span>
               </div>
               {newIssueDefaults.parentTitle ? (
@@ -1347,9 +1376,12 @@ export function NewIssueDialog() {
         {currentProject && currentProjectSupportsExecutionWorkspace && (
           <div className="px-4 py-3 shrink-0 space-y-2">
             <div className="space-y-1.5">
-              <div className="text-xs font-medium">Execution workspace</div>
+              <div className="text-xs font-medium">{t("Execution workspace", "执行工作区")}</div>
               <div className="text-[11px] text-muted-foreground">
-                Control whether this issue runs in the shared workspace, a new isolated workspace, or an existing one.
+                {t(
+                  "Control whether this issue runs in the shared workspace, a new isolated workspace, or an existing one.",
+                  "控制此任务是在共享工作区、新的隔离工作区，还是现有工作区中运行。",
+                )}
               </div>
               <select
                 className="w-full rounded border border-border bg-transparent px-2 py-1.5 text-xs outline-none"
@@ -1361,7 +1393,7 @@ export function NewIssueDialog() {
                   }
                 }}
               >
-                {EXECUTION_WORKSPACE_MODES.map((option) => (
+                {executionWorkspaceModes.map((option) => (
                   <option key={option.value} value={option.value}>
                     {option.label}
                   </option>
@@ -1373,7 +1405,7 @@ export function NewIssueDialog() {
                   value={selectedExecutionWorkspaceId}
                   onChange={(e) => setSelectedExecutionWorkspaceId(e.target.value)}
                 >
-                  <option value="">Choose an existing workspace</option>
+                  <option value="">{t("Choose an existing workspace", "选择现有工作区")}</option>
                   {deduplicatedReusableWorkspaces.map((workspace) => (
                     <option key={workspace.id} value={workspace.id}>
                       {workspace.name} · {workspace.status} · {workspace.branchName ?? workspace.cwd ?? workspace.id.slice(0, 8)}
@@ -1383,12 +1415,13 @@ export function NewIssueDialog() {
               )}
               {executionWorkspaceMode === "reuse_existing" && selectedReusableExecutionWorkspace && (
                 <div className="text-[11px] text-muted-foreground">
-                  Reusing {selectedReusableExecutionWorkspace.name} from {selectedReusableExecutionWorkspace.branchName ?? selectedReusableExecutionWorkspace.cwd ?? "existing execution workspace"}.
+                  {t("Reusing", "复用")} {selectedReusableExecutionWorkspace.name} {t("from", "来自")} {selectedReusableExecutionWorkspace.branchName ?? selectedReusableExecutionWorkspace.cwd ?? t("existing execution workspace", "现有执行工作区")}。
                 </div>
               )}
               {showParentWorkspaceWarning ? (
                 <div className="rounded-md border border-amber-300/60 bg-amber-50 px-2 py-1.5 text-[11px] text-amber-900 dark:border-amber-800/70 dark:bg-amber-950/30 dark:text-amber-100">
-                  Warning: this sub-issue will no longer use the parent issue workspace{parentExecutionWorkspaceLabel ? ` (${parentExecutionWorkspaceLabel})` : ""}.
+                  {t("Warning: this sub-issue will no longer use the parent issue workspace", "警告：此子任务将不再使用父任务工作区")}
+                  {parentExecutionWorkspaceLabel ? ` (${parentExecutionWorkspaceLabel})` : ""}。
                 </div>
               ) : null}
             </div>
@@ -1407,20 +1440,20 @@ export function NewIssueDialog() {
             {assigneeOptionsOpen && (
               <div className="mt-2 rounded-md border border-border p-3 bg-muted/20 space-y-3">
                 <div className="space-y-1.5">
-                  <div className="text-xs text-muted-foreground">Model</div>
+                  <div className="text-xs text-muted-foreground">{t("Model", "模型")}</div>
                   <InlineEntitySelector
                     value={assigneeModelOverride}
                     options={modelOverrideOptions}
-                    placeholder="Default model"
+                    placeholder={t("Default model", "默认模型")}
                     disablePortal
-                    noneLabel="Default model"
-                    searchPlaceholder="Search models..."
-                    emptyMessage="No models found."
+                    noneLabel={t("Default model", "默认模型")}
+                    searchPlaceholder={t("Search models...", "搜索模型...")}
+                    emptyMessage={t("No models found.", "未找到模型。")}
                     onChange={setAssigneeModelOverride}
                   />
                 </div>
                 <div className="space-y-1.5">
-                  <div className="text-xs text-muted-foreground">Thinking effort</div>
+                  <div className="text-xs text-muted-foreground">{t("Thinking effort", "思考强度")}</div>
                   <div className="flex items-center gap-1.5 flex-wrap">
                     {thinkingEffortOptions.map((option) => (
                       <button
@@ -1431,14 +1464,14 @@ export function NewIssueDialog() {
                         )}
                         onClick={() => setAssigneeThinkingEffort(option.value)}
                       >
-                        {option.label}
+                        {localizeThinkingEffortLabel(option.label, uiLanguage)}
                       </button>
                     ))}
                   </div>
                 </div>
                 {assigneeAdapterType === "claude_local" && (
                   <div className="flex items-center justify-between rounded-md border border-border px-2 py-1.5">
-                    <div className="text-xs text-muted-foreground">Enable Chrome (--chrome)</div>
+                    <div className="text-xs text-muted-foreground">{t("Enable Chrome (--chrome)", "启用 Chrome（--chrome）")}</div>
                     <ToggleSwitch
                       checked={assigneeChrome}
                       onCheckedChange={() => setAssigneeChrome((value) => !value)}
@@ -1468,7 +1501,7 @@ export function NewIssueDialog() {
               ref={descriptionEditorRef}
               value={description}
               onChange={setDescription}
-              placeholder="Add description..."
+              placeholder={t("Add description...", "添加描述...")}
               bordered={false}
               mentions={mentionOptions}
               contentClassName={cn("text-sm text-muted-foreground pb-12", expanded ? "min-h-[220px]" : "min-h-[120px]")}
@@ -1482,7 +1515,7 @@ export function NewIssueDialog() {
             <div className="mt-4 space-y-3 rounded-lg border border-border/70 p-3">
               {stagedDocuments.length > 0 ? (
                 <div className="space-y-2">
-                  <div className="text-xs font-medium text-muted-foreground">Documents</div>
+                  <div className="text-xs font-medium text-muted-foreground">{t("Documents", "文档")}</div>
                   <div className="space-y-2">
                     {stagedDocuments.map((file) => (
                       <div key={file.id} className="flex items-start justify-between gap-3 rounded-md border border-border/70 px-3 py-2">
@@ -1506,7 +1539,7 @@ export function NewIssueDialog() {
                           className="shrink-0 text-muted-foreground"
                           onClick={() => removeStagedFile(file.id)}
                           disabled={createIssue.isPending}
-                          title="Remove document"
+                          title={t("Remove document", "移除文档")}
                         >
                           <X className="h-3.5 w-3.5" />
                         </Button>
@@ -1518,7 +1551,7 @@ export function NewIssueDialog() {
 
               {stagedAttachments.length > 0 ? (
                 <div className="space-y-2">
-                  <div className="text-xs font-medium text-muted-foreground">Attachments</div>
+                  <div className="text-xs font-medium text-muted-foreground">{t("Attachments", "附件")}</div>
                   <div className="space-y-2">
                     {stagedAttachments.map((file) => (
                       <div key={file.id} className="flex items-start justify-between gap-3 rounded-md border border-border/70 px-3 py-2">
@@ -1537,7 +1570,7 @@ export function NewIssueDialog() {
                           className="shrink-0 text-muted-foreground"
                           onClick={() => removeStagedFile(file.id)}
                           disabled={createIssue.isPending}
-                          title="Remove attachment"
+                          title={t("Remove attachment", "移除附件")}
                         >
                           <X className="h-3.5 w-3.5" />
                         </Button>
@@ -1589,7 +1622,7 @@ export function NewIssueDialog() {
                 ) : (
                   <>
                     <Minus className="h-3 w-3 text-muted-foreground" />
-                    Priority
+                    {t("Priority", "优先级")}
                   </>
                 )}
               </button>
@@ -1631,7 +1664,7 @@ export function NewIssueDialog() {
             disabled={createIssue.isPending}
           >
             <Paperclip className="h-3 w-3" />
-            Upload
+            {t("Upload", "上传")}
           </button>
 
           {/* More (dates) */}
@@ -1644,11 +1677,11 @@ export function NewIssueDialog() {
             <PopoverContent className="w-44 p-1" align="start">
               <button className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-muted-foreground">
                 <Calendar className="h-3 w-3" />
-                Start date
+                {t("Start date", "开始日期")}
               </button>
               <button className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-muted-foreground">
                 <Calendar className="h-3 w-3" />
-                Due date
+                {t("Due date", "截止日期")}
               </button>
             </PopoverContent>
           </Popover>
@@ -1663,14 +1696,14 @@ export function NewIssueDialog() {
             onClick={discardDraft}
             disabled={createIssue.isPending || !canDiscardDraft}
           >
-            Discard Draft
+            {t("Discard Draft", "丢弃草稿")}
           </Button>
           <div className="flex items-center gap-3">
             <div className="min-h-5 text-right">
               {createIssue.isPending ? (
                 <span className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
                   <Loader2 className="h-3 w-3 animate-spin" />
-                  Creating issue...
+                  {t("Creating issue...", "正在创建任务...")}
                 </span>
               ) : createIssue.isError ? (
                 <span className="text-xs text-destructive">{createIssueErrorMessage}</span>
@@ -1685,7 +1718,13 @@ export function NewIssueDialog() {
             >
               <span className="inline-flex items-center justify-center gap-1.5">
                 {createIssue.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
-                <span>{createIssue.isPending ? "Creating..." : isSubIssueMode ? "Create Sub-Issue" : "Create Issue"}</span>
+                <span>
+                  {createIssue.isPending
+                    ? t("Creating...", "创建中...")
+                    : isSubIssueMode
+                      ? t("Create Sub-Issue", "创建子任务")
+                      : t("Create Issue", "创建任务")}
+                </span>
               </span>
             </Button>
           </div>

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -4,6 +4,7 @@ import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
 import { useLocation, useNavigate, useParams } from "@/lib/router";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { companiesApi } from "../api/companies";
 import { goalsApi } from "../api/goals";
 import { agentsApi } from "../api/agents";
@@ -42,6 +43,7 @@ import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
+import { textFor, type UiLanguage } from "../lib/ui-language";
 import {
   Building2,
   Bot,
@@ -59,20 +61,64 @@ import {
 type Step = 1 | 2 | 3 | 4;
 type AdapterType = string;
 
-const DEFAULT_TASK_DESCRIPTION = `You are the CEO. You set the direction for the company.
+function defaultTaskTitle(uiLanguage: UiLanguage) {
+  return textFor(uiLanguage, {
+    en: "Hire your first engineer and create a hiring plan",
+    "zh-CN": "招聘第一位工程师并制定招聘计划",
+  });
+}
+
+function defaultTaskDescription(uiLanguage: UiLanguage) {
+  return textFor(uiLanguage, {
+    en: `You are the CEO. You set the direction for the company.
 
 - hire a founding engineer
 - write a hiring plan
-- break the roadmap into concrete tasks and start delegating work`;
+- break the roadmap into concrete tasks and start delegating work`,
+    "zh-CN": `你是 CEO。你来为公司设定方向。
+
+- 招聘第一位创始工程师
+- 制定招聘计划
+- 把路线图拆成具体任务并开始分派`,
+  });
+}
+
+function adapterDescription(type: string, fallback: string, uiLanguage: UiLanguage) {
+  const descriptions: Record<string, { en: string; "zh-CN": string }> = {
+    claude_local: { en: "Local Claude agent", "zh-CN": "本地 Claude 智能体" },
+    codex_local: { en: "Local Codex agent", "zh-CN": "本地 Codex 智能体" },
+    gemini_local: { en: "Local Gemini agent", "zh-CN": "本地 Gemini 智能体" },
+    opencode_local: { en: "Local multi-provider agent", "zh-CN": "本地多 Provider 智能体" },
+    hermes_local: { en: "Local Hermes CLI agent", "zh-CN": "本地 Hermes CLI 智能体" },
+    pi_local: { en: "Local Pi agent", "zh-CN": "本地 Pi 智能体" },
+    cursor: { en: "Local Cursor agent", "zh-CN": "本地 Cursor 智能体" },
+    openclaw_gateway: { en: "Invoke OpenClaw via gateway protocol", "zh-CN": "通过 gateway 协议调用 OpenClaw" },
+  };
+  return textFor(uiLanguage, descriptions[type] ?? { en: fallback, "zh-CN": fallback });
+}
+
+function adapterDisabledLabel(type: string, fallback: string | undefined, uiLanguage: UiLanguage) {
+  if (type === "openclaw_gateway") {
+    return textFor(uiLanguage, {
+      en: fallback ?? "Configure OpenClaw within the App",
+      "zh-CN": "请在应用内配置 OpenClaw",
+    });
+  }
+  return fallback ?? textFor(uiLanguage, { en: "Coming soon", "zh-CN": "即将推出" });
+}
 
 export function OnboardingWizard() {
   const { onboardingOpen, onboardingOptions, closeOnboarding } = useDialog();
   const { companies, setSelectedCompanyId, loading: companiesLoading } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
   const { companyPrefix } = useParams<{ companyPrefix?: string }>();
   const [routeDismissed, setRouteDismissed] = useState(false);
+  const t = useCallback((en: string, zh: string) => textFor(uiLanguage, { en, "zh-CN": zh }), [uiLanguage]);
+  const taskTitleDefault = useMemo(() => defaultTaskTitle(uiLanguage), [uiLanguage]);
+  const taskDescriptionDefault = useMemo(() => defaultTaskDescription(uiLanguage), [uiLanguage]);
 
   // Sync disabled adapter types from server so adapter grid filters them out
   const disabledTypes = useDisabledAdaptersSync();
@@ -121,12 +167,8 @@ export function OnboardingWizard() {
   const [showMoreAdapters, setShowMoreAdapters] = useState(false);
 
   // Step 3
-  const [taskTitle, setTaskTitle] = useState(
-    "Hire your first engineer and create a hiring plan"
-  );
-  const [taskDescription, setTaskDescription] = useState(
-    DEFAULT_TASK_DESCRIPTION
-  );
+  const [taskTitle, setTaskTitle] = useState(taskTitleDefault);
+  const [taskDescription, setTaskDescription] = useState(taskDescriptionDefault);
 
   // Auto-grow textarea for task description
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -295,8 +337,8 @@ export function OnboardingWizard() {
     setAdapterEnvLoading(false);
     setForceUnsetAnthropicApiKey(false);
     setUnsetAnthropicLoading(false);
-    setTaskTitle("Hire your first engineer and create a hiring plan");
-    setTaskDescription(DEFAULT_TASK_DESCRIPTION);
+    setTaskTitle(taskTitleDefault);
+    setTaskDescription(taskDescriptionDefault);
     setCreatedCompanyId(null);
     setCreatedCompanyPrefix(null);
     setCreatedCompanyGoalId(null);
@@ -351,7 +393,7 @@ export function OnboardingWizard() {
   ): Promise<AdapterEnvironmentTestResult | null> {
     if (!createdCompanyId) {
       setAdapterEnvError(
-        "Create or select a company before testing adapter environment."
+        t("Create or select a company before testing adapter environment.", "请先创建或选择公司，再测试适配器环境。")
       );
       return null;
     }
@@ -369,7 +411,7 @@ export function OnboardingWizard() {
       return result;
     } catch (err) {
       setAdapterEnvError(
-        err instanceof Error ? err.message : "Adapter environment test failed"
+        err instanceof Error ? err.message : t("Adapter environment test failed", "适配器环境测试失败")
       );
       return null;
     } finally {
@@ -407,7 +449,7 @@ export function OnboardingWizard() {
 
       setStep(2);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create company");
+      setError(err instanceof Error ? err.message : t("Failed to create company", "创建公司失败"));
     } finally {
       setLoading(false);
     }
@@ -422,7 +464,7 @@ export function OnboardingWizard() {
         const selectedModelId = model.trim();
         if (!selectedModelId) {
           setError(
-            "OpenCode requires an explicit model in provider/model format."
+            t("OpenCode requires an explicit model in provider/model format.", "OpenCode 需要显式指定 provider/model 格式的模型。")
           );
           return;
         }
@@ -430,13 +472,13 @@ export function OnboardingWizard() {
           setError(
             adapterModelsError instanceof Error
               ? adapterModelsError.message
-              : "Failed to load OpenCode models."
+              : t("Failed to load OpenCode models.", "加载 OpenCode 模型失败。")
           );
           return;
         }
         if (adapterModelsLoading || adapterModelsFetching) {
           setError(
-            "OpenCode models are still loading. Please wait and try again."
+            t("OpenCode models are still loading. Please wait and try again.", "OpenCode 模型仍在加载，请稍后重试。")
           );
           return;
         }
@@ -444,8 +486,8 @@ export function OnboardingWizard() {
         if (!discoveredModels.some((entry) => entry.id === selectedModelId)) {
           setError(
             discoveredModels.length === 0
-              ? "No OpenCode models discovered. Run `opencode models` and authenticate providers."
-              : `Configured OpenCode model is unavailable: ${selectedModelId}`
+              ? t("No OpenCode models discovered. Run `opencode models` and authenticate providers.", "未发现 OpenCode 模型。请运行 `opencode models` 并完成 provider 认证。")
+              : t(`Configured OpenCode model is unavailable: ${selectedModelId}`, `当前配置的 OpenCode 模型不可用：${selectedModelId}`)
           );
           return;
         }
@@ -469,7 +511,7 @@ export function OnboardingWizard() {
       });
       setStep(3);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create agent");
+      setError(err instanceof Error ? err.message : t("Failed to create agent", "创建智能体失败"));
     } finally {
       setLoading(false);
     }
@@ -510,14 +552,14 @@ export function OnboardingWizard() {
       const result = await runAdapterEnvironmentTest(configWithUnset);
       if (result?.status === "fail") {
         setError(
-          "Retried with ANTHROPIC_API_KEY unset in adapter config, but the environment test is still failing."
+          t("Retried with ANTHROPIC_API_KEY unset in adapter config, but the environment test is still failing.", "已在适配器配置中清空 ANTHROPIC_API_KEY 并重试，但环境测试仍然失败。")
         );
       }
     } catch (err) {
       setError(
         err instanceof Error
           ? err.message
-          : "Failed to unset ANTHROPIC_API_KEY and retry."
+          : t("Failed to unset ANTHROPIC_API_KEY and retry.", "清空 ANTHROPIC_API_KEY 并重试失败。")
       );
     } finally {
       setUnsetAnthropicLoading(false);
@@ -583,7 +625,7 @@ export function OnboardingWizard() {
           : `/issues/${issueRef}`
       );
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create task");
+      setError(err instanceof Error ? err.message : t("Failed to create task", "创建任务失败"));
     } finally {
       setLoading(false);
     }
@@ -623,7 +665,7 @@ export function OnboardingWizard() {
             className="absolute top-4 left-4 z-10 rounded-sm p-1.5 text-muted-foreground/60 hover:text-foreground transition-colors"
           >
             <X className="h-5 w-5" />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{t("Close", "关闭")}</span>
           </button>
 
           {/* Left half — form */}
@@ -638,10 +680,10 @@ export function OnboardingWizard() {
               <div className="flex items-center gap-0 mb-8 border-b border-border">
                 {(
                   [
-                    { step: 1 as Step, label: "Company", icon: Building2 },
-                    { step: 2 as Step, label: "Agent", icon: Bot },
-                    { step: 3 as Step, label: "Task", icon: ListTodo },
-                    { step: 4 as Step, label: "Launch", icon: Rocket }
+                    { step: 1 as Step, label: t("Company", "公司"), icon: Building2 },
+                    { step: 2 as Step, label: t("Agent", "智能体"), icon: Bot },
+                    { step: 3 as Step, label: t("Task", "任务"), icon: ListTodo },
+                    { step: 4 as Step, label: t("Launch", "启动"), icon: Rocket }
                   ] as const
                 ).map(({ step: s, label, icon: Icon }) => (
                   <button
@@ -669,9 +711,9 @@ export function OnboardingWizard() {
                       <Building2 className="h-5 w-5 text-muted-foreground" />
                     </div>
                     <div>
-                      <h3 className="font-medium">Name your company</h3>
+                      <h3 className="font-medium">{t("Name your company", "为公司命名")}</h3>
                       <p className="text-xs text-muted-foreground">
-                        This is the organization your agents will work for.
+                        {t("This is the organization your agents will work for.", "这是你的智能体将要服务的组织。")}
                       </p>
                     </div>
                   </div>
@@ -684,11 +726,11 @@ export function OnboardingWizard() {
                           : "text-muted-foreground group-focus-within:text-foreground"
                       )}
                     >
-                      Company name
+                      {t("Company name", "公司名称")}
                     </label>
                     <input
                       className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
-                      placeholder="Acme Corp"
+                      placeholder={t("Acme Corp", "例如：未来科技")}
                       value={companyName}
                       onChange={(e) => setCompanyName(e.target.value)}
                       autoFocus
@@ -703,11 +745,11 @@ export function OnboardingWizard() {
                           : "text-muted-foreground group-focus-within:text-foreground"
                       )}
                     >
-                      Mission / goal (optional)
+                      {t("Mission / goal (optional)", "使命 / 目标（可选）")}
                     </label>
                     <textarea
                       className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50 resize-none min-h-[60px]"
-                      placeholder="What is this company trying to achieve?"
+                      placeholder={t("What is this company trying to achieve?", "这家公司想实现什么？")}
                       value={companyGoal}
                       onChange={(e) => setCompanyGoal(e.target.value)}
                     />
@@ -722,15 +764,15 @@ export function OnboardingWizard() {
                       <Bot className="h-5 w-5 text-muted-foreground" />
                     </div>
                     <div>
-                      <h3 className="font-medium">Create your first agent</h3>
+                      <h3 className="font-medium">{t("Create your first agent", "创建第一个智能体")}</h3>
                       <p className="text-xs text-muted-foreground">
-                        Choose how this agent will run tasks.
+                        {t("Choose how this agent will run tasks.", "选择这个智能体如何运行任务。")}
                       </p>
                     </div>
                   </div>
                   <div>
                     <label className="text-xs text-muted-foreground mb-1 block">
-                      Agent name
+                      {t("Agent name", "智能体名称")}
                     </label>
                     <input
                       className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
@@ -744,7 +786,7 @@ export function OnboardingWizard() {
                   {/* Adapter type radio cards */}
                   <div>
                     <label className="text-xs text-muted-foreground mb-2 block">
-                      Adapter type
+                      {t("Adapter type", "适配器类型")}
                     </label>
                     <div className="grid grid-cols-2 gap-2">
                       {recommendedAdapters.map((opt) => (
@@ -769,13 +811,13 @@ export function OnboardingWizard() {
                         >
                           {opt.recommended && (
                             <span className="absolute -top-1.5 right-1.5 bg-green-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full leading-none">
-                              Recommended
+                              {t("Recommended", "推荐")}
                             </span>
                           )}
                           <opt.icon className="h-4 w-4" />
                           <span className="font-medium">{opt.label}</span>
                           <span className="text-muted-foreground text-[10px]">
-                            {opt.description}
+                            {adapterDescription(opt.type, opt.description, uiLanguage)}
                           </span>
                         </button>
                       ))}
@@ -791,7 +833,7 @@ export function OnboardingWizard() {
                           showMoreAdapters ? "rotate-0" : "-rotate-90"
                         )}
                       />
-                      More Agent Adapter Types
+                      {t("More Agent Adapter Types", "更多智能体适配器类型")}
                     </button>
 
                     {showMoreAdapters && (
@@ -833,8 +875,8 @@ export function OnboardingWizard() {
                             <span className="font-medium">{opt.label}</span>
                             <span className="text-muted-foreground text-[10px]">
                               {opt.comingSoon
-                                ? opt.disabledLabel ?? "Coming soon"
-                                : opt.description}
+                                ? adapterDisabledLabel(opt.type, opt.disabledLabel, uiLanguage)
+                                : adapterDescription(opt.type, opt.description, uiLanguage)}
                             </span>
                           </button>
                         ))}
@@ -847,7 +889,7 @@ export function OnboardingWizard() {
                     <div className="space-y-3">
                       <div>
                         <label className="text-xs text-muted-foreground mb-1 block">
-                          Model
+                          {t("Model", "模型")}
                         </label>
                         <Popover
                           open={modelOpen}
@@ -867,8 +909,8 @@ export function OnboardingWizard() {
                                   ? selectedModel.label
                                   : model ||
                                     (adapterType === "opencode_local"
-                                      ? "Select model (required)"
-                                      : "Default")}
+                                      ? t("Select model (required)", "选择模型（必填）")
+                                      : t("Default", "默认"))}
                               </span>
                               <ChevronDown className="h-3 w-3 text-muted-foreground" />
                             </button>
@@ -879,7 +921,7 @@ export function OnboardingWizard() {
                           >
                             <input
                               className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
-                              placeholder="Search models..."
+                              placeholder={t("Search models...", "搜索模型...")}
                               value={modelSearch}
                               onChange={(e) => setModelSearch(e.target.value)}
                               autoFocus
@@ -895,7 +937,7 @@ export function OnboardingWizard() {
                                   setModelOpen(false);
                                 }}
                               >
-                                Default
+                                {t("Default", "默认")}
                               </button>
                             )}
                             <div className="max-h-[240px] overflow-y-auto">
@@ -936,7 +978,7 @@ export function OnboardingWizard() {
                             </div>
                             {filteredModels.length === 0 && (
                               <p className="px-2 py-1.5 text-xs text-muted-foreground">
-                                No models discovered.
+                                {t("No models discovered.", "未发现模型。")}
                               </p>
                             )}
                           </PopoverContent>
@@ -950,11 +992,10 @@ export function OnboardingWizard() {
                       <div className="flex items-center justify-between gap-2">
                         <div>
                           <p className="text-xs font-medium">
-                            Adapter environment check
+                            {t("Adapter environment check", "适配器环境检查")}
                           </p>
                           <p className="text-[11px] text-muted-foreground">
-                            Runs a live probe that asks the adapter CLI to
-                            respond with hello.
+                            {t("Runs a live probe that asks the adapter CLI to respond with hello.", "执行一次实时探测，要求适配器 CLI 回复 hello。")}
                           </p>
                         </div>
                         <Button
@@ -964,7 +1005,7 @@ export function OnboardingWizard() {
                           disabled={adapterEnvLoading}
                           onClick={() => void runAdapterEnvironmentTest()}
                         >
-                          {adapterEnvLoading ? "Testing..." : "Test now"}
+                          {adapterEnvLoading ? t("Testing...", "测试中...") : t("Test now", "立即测试")}
                         </Button>
                       </div>
 
@@ -978,19 +1019,18 @@ export function OnboardingWizard() {
                       adapterEnvResult.status === "pass" ? (
                         <div className="flex items-center gap-2 rounded-md border border-green-300 dark:border-green-500/40 bg-green-50 dark:bg-green-500/10 px-3 py-2 text-xs text-green-700 dark:text-green-300 animate-in fade-in slide-in-from-bottom-1 duration-300">
                           <Check className="h-3.5 w-3.5 shrink-0" />
-                          <span className="font-medium">Passed</span>
+                          <span className="font-medium">{t("Passed", "通过")}</span>
                         </div>
                       ) : adapterEnvResult ? (
-                        <AdapterEnvironmentResult result={adapterEnvResult} />
+                        <AdapterEnvironmentResult result={adapterEnvResult} uiLanguage={uiLanguage} />
                       ) : null}
 
                       {shouldSuggestUnsetAnthropicApiKey && (
                         <div className="rounded-md border border-amber-300/60 bg-amber-50/40 px-2.5 py-2 space-y-2">
                           <p className="text-[11px] text-amber-900/90 leading-relaxed">
-                            Claude failed while{" "}
+                            {t("Claude failed while", "Claude 在")}
                             <span className="font-mono">ANTHROPIC_API_KEY</span>{" "}
-                            is set. You can clear it in this CEO adapter config
-                            and retry the probe.
+                            {t("is set. You can clear it in this CEO adapter config and retry the probe.", "已设置时失败。你可以在这个 CEO 适配器配置中清空它，然后重试探测。")}
                           </p>
                           <Button
                             size="sm"
@@ -1002,15 +1042,15 @@ export function OnboardingWizard() {
                             onClick={() => void handleUnsetAnthropicApiKey()}
                           >
                             {unsetAnthropicLoading
-                              ? "Retrying..."
-                              : "Unset ANTHROPIC_API_KEY"}
+                              ? t("Retrying...", "重试中...")
+                              : t("Unset ANTHROPIC_API_KEY", "清空 ANTHROPIC_API_KEY")}
                           </Button>
                         </div>
                       )}
 
                       {adapterEnvResult && adapterEnvResult.status === "fail" && (
                         <div className="rounded-md border border-border/70 bg-muted/20 px-2.5 py-2 text-[11px] space-y-1.5">
-                          <p className="font-medium">Manual debug</p>
+                          <p className="font-medium">{t("Manual debug", "手动调试")}</p>
                           <p className="text-muted-foreground font-mono break-all">
                             {adapterType === "cursor"
                               ? `${effectiveAdapterCommand} -p --mode ask --output-format json \"Respond with hello.\"`
@@ -1023,7 +1063,7 @@ export function OnboardingWizard() {
                               : `${effectiveAdapterCommand} --print - --output-format stream-json --verbose`}
                           </p>
                           <p className="text-muted-foreground">
-                            Prompt:{" "}
+                            {t("Prompt:", "提示词：")}{" "}
                             <span className="font-mono">Respond with hello.</span>
                           </p>
                           {adapterType === "cursor" ||
@@ -1031,7 +1071,7 @@ export function OnboardingWizard() {
                           adapterType === "gemini_local" ||
                           adapterType === "opencode_local" ? (
                             <p className="text-muted-foreground">
-                              If auth fails, set{" "}
+                              {t("If auth fails, set", "如果认证失败，请设置")}{" "}
                               <span className="font-mono">
                                 {adapterType === "cursor"
                                   ? "CURSOR_API_KEY"
@@ -1039,7 +1079,7 @@ export function OnboardingWizard() {
                                     ? "GEMINI_API_KEY"
                                     : "OPENAI_API_KEY"}
                               </span>{" "}
-                              in env or run{" "}
+                              {t("in env or run", "到环境变量中，或运行")}{" "}
                               <span className="font-mono">
                                 {adapterType === "cursor"
                                   ? "agent login"
@@ -1049,13 +1089,13 @@ export function OnboardingWizard() {
                                       ? "gemini auth"
                                       : "opencode auth login"}
                               </span>
-                              .
+                              {t(".", "。")}
                             </p>
                           ) : (
                             <p className="text-muted-foreground">
-                              If login is required, run{" "}
+                              {t("If login is required, run", "如果需要登录，请运行")}{" "}
                               <span className="font-mono">claude login</span>{" "}
-                              and retry.
+                              {t("and retry.", "后重试。")}
                             </p>
                           )}
                         </div>
@@ -1068,8 +1108,8 @@ export function OnboardingWizard() {
                     <div>
                       <label className="text-xs text-muted-foreground mb-1 block">
                         {adapterType === "openclaw_gateway"
-                          ? "Gateway URL"
-                          : "Webhook URL"}
+                          ? t("Gateway URL", "网关地址")
+                          : t("Webhook URL", "Webhook 地址")}
                       </label>
                       <input
                         className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
@@ -1093,20 +1133,19 @@ export function OnboardingWizard() {
                       <ListTodo className="h-5 w-5 text-muted-foreground" />
                     </div>
                     <div>
-                      <h3 className="font-medium">Give it something to do</h3>
+                      <h3 className="font-medium">{t("Give it something to do", "给它一个任务")}</h3>
                       <p className="text-xs text-muted-foreground">
-                        Give your agent a small task to start with — a bug fix,
-                        a research question, writing a script.
+                        {t("Give your agent a small task to start with — a bug fix, a research question, writing a script.", "先给你的智能体一个小任务开始，比如修 bug、做研究、写脚本。")}
                       </p>
                     </div>
                   </div>
                   <div>
                     <label className="text-xs text-muted-foreground mb-1 block">
-                      Task title
+                      {t("Task title", "任务标题")}
                     </label>
                     <input
                       className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
-                      placeholder="e.g. Research competitor pricing"
+                      placeholder={t("e.g. Research competitor pricing", "例如：研究竞品定价")}
                       value={taskTitle}
                       onChange={(e) => setTaskTitle(e.target.value)}
                       autoFocus
@@ -1114,12 +1153,12 @@ export function OnboardingWizard() {
                   </div>
                   <div>
                     <label className="text-xs text-muted-foreground mb-1 block">
-                      Description (optional)
+                      {t("Description (optional)", "描述（可选）")}
                     </label>
                     <textarea
                       ref={textareaRef}
                       className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50 resize-none min-h-[120px] max-h-[300px] overflow-y-auto"
-                      placeholder="Add more detail about what the agent should do..."
+                      placeholder={t("Add more detail about what the agent should do...", "补充更多任务细节...")}
                       value={taskDescription}
                       onChange={(e) => setTaskDescription(e.target.value)}
                     />
@@ -1134,10 +1173,9 @@ export function OnboardingWizard() {
                       <Rocket className="h-5 w-5 text-muted-foreground" />
                     </div>
                     <div>
-                      <h3 className="font-medium">Ready to launch</h3>
+                      <h3 className="font-medium">{t("Ready to launch", "准备启动")}</h3>
                       <p className="text-xs text-muted-foreground">
-                        Everything is set up. Launching now will create the
-                        starter task, wake the agent, and open the issue.
+                        {t("Everything is set up. Launching now will create the starter task, wake the agent, and open the issue.", "一切都已设置完成。现在启动会创建起始任务、唤醒智能体，并打开该任务。")}
                       </p>
                     </div>
                   </div>
@@ -1148,7 +1186,7 @@ export function OnboardingWizard() {
                         <p className="text-sm font-medium truncate">
                           {companyName}
                         </p>
-                        <p className="text-xs text-muted-foreground">Company</p>
+                        <p className="text-xs text-muted-foreground">{t("Company", "公司")}</p>
                       </div>
                       <Check className="h-4 w-4 text-green-500 shrink-0" />
                     </div>
@@ -1170,7 +1208,7 @@ export function OnboardingWizard() {
                         <p className="text-sm font-medium truncate">
                           {taskTitle}
                         </p>
-                        <p className="text-xs text-muted-foreground">Task</p>
+                        <p className="text-xs text-muted-foreground">{t("Task", "任务")}</p>
                       </div>
                       <Check className="h-4 w-4 text-green-500 shrink-0" />
                     </div>
@@ -1196,7 +1234,7 @@ export function OnboardingWizard() {
                       disabled={loading}
                     >
                       <ArrowLeft className="h-3.5 w-3.5 mr-1" />
-                      Back
+                      {t("Back", "返回")}
                     </Button>
                   )}
                 </div>
@@ -1212,7 +1250,7 @@ export function OnboardingWizard() {
                       ) : (
                         <ArrowRight className="h-3.5 w-3.5 mr-1" />
                       )}
-                      {loading ? "Creating..." : "Next"}
+                      {loading ? t("Creating...", "创建中...") : t("Next", "下一步")}
                     </Button>
                   )}
                   {step === 2 && (
@@ -1228,7 +1266,7 @@ export function OnboardingWizard() {
                       ) : (
                         <ArrowRight className="h-3.5 w-3.5 mr-1" />
                       )}
-                      {loading ? "Creating..." : "Next"}
+                      {loading ? t("Creating...", "创建中...") : t("Next", "下一步")}
                     </Button>
                   )}
                   {step === 3 && (
@@ -1242,7 +1280,7 @@ export function OnboardingWizard() {
                       ) : (
                         <ArrowRight className="h-3.5 w-3.5 mr-1" />
                       )}
-                      {loading ? "Creating..." : "Next"}
+                      {loading ? t("Creating...", "创建中...") : t("Next", "下一步")}
                     </Button>
                   )}
                   {step === 4 && (
@@ -1252,7 +1290,7 @@ export function OnboardingWizard() {
                       ) : (
                         <ArrowRight className="h-3.5 w-3.5 mr-1" />
                       )}
-                      {loading ? "Creating..." : "Create & Open Issue"}
+                      {loading ? t("Creating...", "创建中...") : t("Create & Open Issue", "创建并打开任务")}
                     </Button>
                   )}
                 </div>
@@ -1276,16 +1314,18 @@ export function OnboardingWizard() {
 }
 
 function AdapterEnvironmentResult({
-  result
+  result,
+  uiLanguage,
 }: {
   result: AdapterEnvironmentTestResult;
+  uiLanguage: UiLanguage;
 }) {
   const statusLabel =
     result.status === "pass"
-      ? "Passed"
+      ? textFor(uiLanguage, { en: "Passed", "zh-CN": "通过" })
       : result.status === "warn"
-      ? "Warnings"
-      : "Failed";
+      ? textFor(uiLanguage, { en: "Warnings", "zh-CN": "警告" })
+      : textFor(uiLanguage, { en: "Failed", "zh-CN": "失败" });
   const statusClass =
     result.status === "pass"
       ? "text-green-700 dark:text-green-300 border-green-300 dark:border-green-500/40 bg-green-50 dark:bg-green-500/10"
@@ -1319,7 +1359,7 @@ function AdapterEnvironmentResult({
             )}
             {check.hint && (
               <span className="block opacity-90 break-words">
-                Hint: {check.hint}
+                {textFor(uiLanguage, { en: "Hint:", "zh-CN": "提示：" })} {check.hint}
               </span>
             )}
           </div>

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -9,8 +9,10 @@ import { instanceSettingsApi } from "../api/instanceSettings";
 import { projectsApi } from "../api/projects";
 import { secretsApi } from "../api/secrets";
 import { useCompany } from "../context/CompanyContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { queryKeys } from "../lib/queryKeys";
 import { statusBadge, statusBadgeDefault } from "../lib/status-colors";
+import { textFor, type UiLanguage } from "../lib/ui-language";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -22,13 +24,37 @@ import { DraftInput } from "./agent-config-primitives";
 import { InlineEditor } from "./InlineEditor";
 import { EnvVarEditor } from "./EnvVarEditor";
 
-const PROJECT_STATUSES = [
-  { value: "backlog", label: "Backlog" },
-  { value: "planned", label: "Planned" },
-  { value: "in_progress", label: "In Progress" },
-  { value: "completed", label: "Completed" },
-  { value: "cancelled", label: "Cancelled" },
-];
+function buildProjectStatuses(uiLanguage: UiLanguage) {
+  return [
+    { value: "backlog", label: textFor(uiLanguage, { en: "Backlog", "zh-CN": "待规划" }) },
+    { value: "planned", label: textFor(uiLanguage, { en: "Planned", "zh-CN": "已计划" }) },
+    { value: "in_progress", label: textFor(uiLanguage, { en: "In Progress", "zh-CN": "进行中" }) },
+    { value: "completed", label: textFor(uiLanguage, { en: "Completed", "zh-CN": "已完成" }) },
+    { value: "cancelled", label: textFor(uiLanguage, { en: "Cancelled", "zh-CN": "已取消" }) },
+  ];
+}
+
+function projectStatusLabel(status: string, uiLanguage: UiLanguage) {
+  return buildProjectStatuses(uiLanguage).find((entry) => entry.value === status)?.label ?? status.replaceAll("_", " ");
+}
+
+function runtimeServiceStatusLabel(status: string, uiLanguage: UiLanguage) {
+  const labels: Record<string, { en: string; "zh-CN": string }> = {
+    starting: { en: "Starting", "zh-CN": "启动中" },
+    running: { en: "Running", "zh-CN": "运行中" },
+    stopped: { en: "Stopped", "zh-CN": "已停止" },
+    failed: { en: "Failed", "zh-CN": "失败" },
+  };
+  return textFor(uiLanguage, labels[status] ?? { en: status, "zh-CN": status });
+}
+
+function runtimeServiceLifecycleLabel(lifecycle: string, uiLanguage: UiLanguage) {
+  const labels: Record<string, { en: string; "zh-CN": string }> = {
+    shared: { en: "Shared", "zh-CN": "共享" },
+    ephemeral: { en: "Ephemeral", "zh-CN": "临时" },
+  };
+  return textFor(uiLanguage, labels[lifecycle] ?? { en: lifecycle, "zh-CN": lifecycle });
+}
 
 interface ProjectPropertiesProps {
   project: Project;
@@ -54,12 +80,12 @@ export type ProjectConfigFieldKey =
   | "execution_workspace_provision_command"
   | "execution_workspace_teardown_command";
 
-function SaveIndicator({ state }: { state: ProjectFieldSaveState }) {
+function SaveIndicator({ state, uiLanguage }: { state: ProjectFieldSaveState; uiLanguage: UiLanguage }) {
   if (state === "saving") {
     return (
       <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
         <Loader2 className="h-3 w-3 animate-spin" />
-        Saving
+        {textFor(uiLanguage, { en: "Saving", "zh-CN": "保存中" })}
       </span>
     );
   }
@@ -67,7 +93,7 @@ function SaveIndicator({ state }: { state: ProjectFieldSaveState }) {
     return (
       <span className="inline-flex items-center gap-1 text-[11px] text-green-600 dark:text-green-400">
         <Check className="h-3 w-3" />
-        Saved
+        {textFor(uiLanguage, { en: "Saved", "zh-CN": "已保存" })}
       </span>
     );
   }
@@ -75,7 +101,7 @@ function SaveIndicator({ state }: { state: ProjectFieldSaveState }) {
     return (
       <span className="inline-flex items-center gap-1 text-[11px] text-destructive">
         <AlertCircle className="h-3 w-3" />
-        Failed
+        {textFor(uiLanguage, { en: "Failed", "zh-CN": "失败" })}
       </span>
     );
   }
@@ -85,14 +111,16 @@ function SaveIndicator({ state }: { state: ProjectFieldSaveState }) {
 function FieldLabel({
   label,
   state,
+  uiLanguage,
 }: {
   label: string;
   state: ProjectFieldSaveState;
+  uiLanguage: UiLanguage;
 }) {
   return (
     <div className="flex items-center gap-1.5">
       <span className="text-xs text-muted-foreground">{label}</span>
-      <SaveIndicator state={state} />
+      <SaveIndicator state={state} uiLanguage={uiLanguage} />
     </div>
   );
 }
@@ -118,9 +146,18 @@ function PropertyRow({
   );
 }
 
-function ProjectStatusPicker({ status, onChange }: { status: string; onChange: (status: string) => void }) {
+function ProjectStatusPicker({
+  status,
+  onChange,
+  uiLanguage,
+}: {
+  status: string;
+  onChange: (status: string) => void;
+  uiLanguage: UiLanguage;
+}) {
   const [open, setOpen] = useState(false);
   const colorClass = statusBadge[status] ?? statusBadgeDefault;
+  const statuses = buildProjectStatuses(uiLanguage);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -131,11 +168,11 @@ function ProjectStatusPicker({ status, onChange }: { status: string; onChange: (
             colorClass,
           )}
         >
-          {status.replace("_", " ")}
+          {projectStatusLabel(status, uiLanguage)}
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-40 p-1" align="start">
-        {PROJECT_STATUSES.map((s) => (
+        {statuses.map((s) => (
           <Button
             key={s.value}
             variant="ghost"
@@ -158,26 +195,44 @@ function ArchiveDangerZone({
   project,
   onArchive,
   archivePending,
+  uiLanguage,
 }: {
   project: Project;
   onArchive: (archived: boolean) => void;
   archivePending?: boolean;
+  uiLanguage: UiLanguage;
 }) {
   const [confirming, setConfirming] = useState(false);
   const isArchive = !project.archivedAt;
-  const action = isArchive ? "Archive" : "Unarchive";
+  const action = isArchive
+    ? textFor(uiLanguage, { en: "Archive", "zh-CN": "归档" })
+    : textFor(uiLanguage, { en: "Unarchive", "zh-CN": "取消归档" });
 
   return (
     <div className="space-y-3 rounded-md border border-destructive/40 bg-destructive/5 px-4 py-4">
       <p className="text-sm text-muted-foreground">
         {isArchive
-          ? "Archive this project to hide it from the sidebar and project selectors."
-          : "Unarchive this project to restore it in the sidebar and project selectors."}
+          ? textFor(
+              uiLanguage,
+              {
+                en: "Archive this project to hide it from the sidebar and project selectors.",
+                "zh-CN": "归档后，此项目会从侧边栏和项目选择器中隐藏。",
+              },
+            )
+          : textFor(
+              uiLanguage,
+              {
+                en: "Unarchive this project to restore it in the sidebar and project selectors.",
+                "zh-CN": "取消归档后，此项目会重新出现在侧边栏和项目选择器中。",
+              },
+            )}
       </p>
       {archivePending ? (
         <Button size="sm" variant="destructive" disabled>
           <Loader2 className="h-3 w-3 animate-spin mr-1" />
-          {isArchive ? "Archiving..." : "Unarchiving..."}
+          {isArchive
+            ? textFor(uiLanguage, { en: "Archiving...", "zh-CN": "归档中..." })
+            : textFor(uiLanguage, { en: "Unarchiving...", "zh-CN": "取消归档中..." })}
         </Button>
       ) : confirming ? (
         <div className="flex items-center gap-2">
@@ -192,14 +247,14 @@ function ArchiveDangerZone({
               onArchive(isArchive);
             }}
           >
-            Confirm
+            {textFor(uiLanguage, { en: "Confirm", "zh-CN": "确认" })}
           </Button>
           <Button
             size="sm"
             variant="outline"
             onClick={() => setConfirming(false)}
           >
-            Cancel
+            {textFor(uiLanguage, { en: "Cancel", "zh-CN": "取消" })}
           </Button>
         </div>
       ) : (
@@ -209,9 +264,9 @@ function ArchiveDangerZone({
           onClick={() => setConfirming(true)}
         >
           {isArchive ? (
-            <><Archive className="h-3 w-3 mr-1" />{action} project</>
+            <><Archive className="h-3 w-3 mr-1" />{textFor(uiLanguage, { en: "Archive project", "zh-CN": "归档项目" })}</>
           ) : (
-            <><ArchiveRestore className="h-3 w-3 mr-1" />{action} project</>
+            <><ArchiveRestore className="h-3 w-3 mr-1" />{textFor(uiLanguage, { en: "Unarchive project", "zh-CN": "取消归档项目" })}</>
           )}
         </Button>
       )}
@@ -221,6 +276,7 @@ function ArchiveDangerZone({
 
 export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSaveState, onArchive, archivePending }: ProjectPropertiesProps) {
   const { selectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const queryClient = useQueryClient();
   const [goalOpen, setGoalOpen] = useState(false);
   const [executionWorkspaceAdvancedOpen, setExecutionWorkspaceAdvancedOpen] = useState(false);
@@ -228,6 +284,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
   const [workspaceCwd, setWorkspaceCwd] = useState("");
   const [workspaceRepoUrl, setWorkspaceRepoUrl] = useState("");
   const [workspaceError, setWorkspaceError] = useState<string | null>(null);
+  const t = (en: string, zh: string) => textFor(uiLanguage, { en, "zh-CN": zh });
 
   const commitField = (field: ProjectConfigFieldKey, data: Record<string, unknown>) => {
     if (onFieldUpdate) {
@@ -255,7 +312,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
   });
   const createSecret = useMutation({
     mutationFn: (input: { name: string; value: string }) => {
-      if (!selectedCompanyId) throw new Error("Select a company to create secrets");
+      if (!selectedCompanyId) throw new Error(t("Select a company to create secrets", "请选择公司以创建密钥"));
       return secretsApi.create(selectedCompanyId, input);
     },
     onSuccess: () => {
@@ -437,7 +494,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
       return;
     }
     if (!isAbsolutePath(cwd)) {
-      setWorkspaceError("Local folder must be a full absolute path.");
+      setWorkspaceError(t("Local folder must be a full absolute path.", "本地文件夹必须是完整的绝对路径。"));
       return;
     }
     setWorkspaceError(null);
@@ -452,7 +509,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
       return;
     }
     if (!looksLikeRepoUrl(repoUrl)) {
-      setWorkspaceError("Repo must use a valid GitHub or GitHub Enterprise repo URL.");
+      setWorkspaceError(t("Repo must use a valid GitHub or GitHub Enterprise repo URL.", "仓库必须使用有效的 GitHub 或 GitHub Enterprise 仓库 URL。"));
       return;
     }
     setWorkspaceError(null);
@@ -462,8 +519,8 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
   const clearLocalWorkspace = () => {
     const confirmed = window.confirm(
       codebase.repoUrl
-        ? "Clear local folder from this workspace?"
-        : "Delete this workspace local folder?",
+        ? t("Clear local folder from this workspace?", "要从此工作区中清除本地文件夹吗？")
+        : t("Delete this workspace local folder?", "要删除此工作区的本地文件夹吗？"),
     );
     if (!confirmed) return;
     persistCodebase({ cwd: null });
@@ -473,8 +530,8 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
     const hasLocalFolder = Boolean(codebase.localFolder);
     const confirmed = window.confirm(
       hasLocalFolder
-        ? "Clear repo from this workspace?"
-        : "Delete this workspace repo?",
+        ? t("Clear repo from this workspace?", "要从此工作区中清除仓库吗？")
+        : t("Delete this workspace repo?", "要删除此工作区的仓库吗？"),
     );
     if (!confirmed) return;
     if (primaryCodebaseWorkspace && hasLocalFolder) {
@@ -490,21 +547,21 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
   return (
     <div>
       <div className="space-y-1 pb-4">
-        <PropertyRow label={<FieldLabel label="Name" state={fieldState("name")} />}>
+        <PropertyRow label={<FieldLabel label={t("Name", "名称")} state={fieldState("name")} uiLanguage={uiLanguage} />}>
           {onUpdate || onFieldUpdate ? (
             <DraftInput
               value={project.name}
               onCommit={(name) => commitField("name", { name })}
               immediate
               className="w-full rounded border border-border bg-transparent px-2 py-1 text-sm outline-none"
-              placeholder="Project name"
+              placeholder={t("Project name", "项目名称")}
             />
           ) : (
             <span className="text-sm">{project.name}</span>
           )}
         </PropertyRow>
         <PropertyRow
-          label={<FieldLabel label="Description" state={fieldState("description")} />}
+          label={<FieldLabel label={t("Description", "描述")} state={fieldState("description")} uiLanguage={uiLanguage} />}
           alignStart
           valueClassName="space-y-0.5"
         >
@@ -515,32 +572,33 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
               nullable
               as="p"
               className="text-sm text-muted-foreground"
-              placeholder="Add a description..."
+              placeholder={t("Add a description...", "添加描述...")}
               multiline
             />
           ) : (
             <p className="text-sm text-muted-foreground">
-              {project.description?.trim() || "No description"}
+              {project.description?.trim() || t("No description", "暂无描述")}
             </p>
           )}
         </PropertyRow>
-        <PropertyRow label={<FieldLabel label="Status" state={fieldState("status")} />}>
+        <PropertyRow label={<FieldLabel label={t("Status", "状态")} state={fieldState("status")} uiLanguage={uiLanguage} />}>
           {onUpdate || onFieldUpdate ? (
             <ProjectStatusPicker
               status={project.status}
               onChange={(status) => commitField("status", { status })}
+              uiLanguage={uiLanguage}
             />
           ) : (
             <StatusBadge status={project.status} />
           )}
         </PropertyRow>
         {project.leadAgentId && (
-          <PropertyRow label="Lead">
+          <PropertyRow label={t("Lead", "负责人")}>
             <span className="text-sm font-mono">{project.leadAgentId.slice(0, 8)}</span>
           </PropertyRow>
         )}
         <PropertyRow
-          label={<FieldLabel label="Goals" state={fieldState("goals")} />}
+          label={<FieldLabel label={t("Goals", "目标")} state={fieldState("goals")} uiLanguage={uiLanguage} />}
           alignStart
           valueClassName="space-y-2"
         >
@@ -559,7 +617,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                       className="text-muted-foreground hover:text-foreground"
                       type="button"
                       onClick={() => removeGoal(goal.id)}
-                      aria-label={`Remove goal ${goal.title}`}
+                      aria-label={t(`Remove goal ${goal.title}`, `移除目标 ${goal.title}`)}
                     >
                       <X className="h-3 w-3" />
                     </button>
@@ -578,13 +636,13 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                   disabled={availableGoals.length === 0}
                 >
                   <Plus className="h-3 w-3 mr-1" />
-                  Goal
+                  {t("Goal", "目标")}
                 </Button>
               </PopoverTrigger>
               <PopoverContent className="w-56 p-1" align="start">
                 {availableGoals.length === 0 ? (
                   <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                    All goals linked.
+                    {t("All goals linked.", "所有目标均已关联。")}
                   </div>
                 ) : (
                   availableGoals.map((goal) => (
@@ -602,7 +660,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
           )}
         </PropertyRow>
         <PropertyRow
-          label={<FieldLabel label="Env" state={fieldState("env")} />}
+          label={<FieldLabel label={t("Env", "环境变量")} state={fieldState("env")} uiLanguage={uiLanguage} />}
           alignStart
           valueClassName="space-y-2"
         >
@@ -617,18 +675,21 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
               onChange={(env) => commitField("env", { env: env ?? null })}
             />
             <p className="text-[11px] text-muted-foreground">
-              Applied to all runs for issues in this project. Project values override agent env on key conflicts.
+              {t(
+                "Applied to all runs for issues in this project. Project values override agent env on key conflicts.",
+                "应用于此项目下所有任务的运行。若键冲突，项目级值会覆盖智能体环境变量。",
+              )}
             </p>
           </div>
         </PropertyRow>
-        <PropertyRow label={<FieldLabel label="Created" state="idle" />}>
+        <PropertyRow label={<FieldLabel label={t("Created", "创建时间")} state="idle" uiLanguage={uiLanguage} />}>
           <span className="text-sm">{formatDate(project.createdAt)}</span>
         </PropertyRow>
-        <PropertyRow label={<FieldLabel label="Updated" state="idle" />}>
+        <PropertyRow label={<FieldLabel label={t("Updated", "更新时间")} state="idle" uiLanguage={uiLanguage} />}>
           <span className="text-sm">{formatDate(project.updatedAt)}</span>
         </PropertyRow>
         {project.targetDate && (
-          <PropertyRow label={<FieldLabel label="Target Date" state="idle" />}>
+          <PropertyRow label={<FieldLabel label={t("Target Date", "目标日期")} state="idle" uiLanguage={uiLanguage} />}>
             <span className="text-sm">{formatDate(project.targetDate)}</span>
           </PropertyRow>
         )}
@@ -639,25 +700,28 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
       <div className="space-y-1 py-4">
         <div className="space-y-2">
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <span>Codebase</span>
+            <span>{t("Codebase", "代码库")}</span>
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
                   type="button"
                   className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-border text-[10px] text-muted-foreground hover:text-foreground"
-                  aria-label="Codebase help"
+                  aria-label={t("Codebase help", "代码库帮助")}
                 >
                   ?
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top">
-                Repo identifies the source of truth. Local folder is the default place agents write code.
+                {t(
+                  "Repo identifies the source of truth. Local folder is the default place agents write code.",
+                  "仓库用于标识代码的事实来源，本地文件夹则是智能体默认写入代码的位置。",
+                )}
               </TooltipContent>
             </Tooltip>
           </div>
           <div className="space-y-2 rounded-md border border-border/70 p-3">
             <div className="space-y-1">
-              <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Repo</div>
+              <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{t("Repo", "仓库")}</div>
               {codebase.repoUrl ? (
                 <div className="flex items-center justify-between gap-2">
                   {isSafeExternalUrl(codebase.repoUrl) ? (
@@ -688,13 +752,13 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                         setWorkspaceError(null);
                       }}
                     >
-                      Change repo
+                      {t("Change repo", "更改仓库")}
                     </Button>
                     <Button
                       variant="ghost"
                       size="icon-xs"
                       onClick={clearRepoWorkspace}
-                      aria-label="Clear repo"
+                      aria-label={t("Clear repo", "清除仓库")}
                     >
                       <Trash2 className="h-3 w-3" />
                     </Button>
@@ -702,7 +766,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                 </div>
               ) : (
                 <div className="flex items-center justify-between gap-2">
-                  <div className="text-xs text-muted-foreground">Not set.</div>
+                  <div className="text-xs text-muted-foreground">{t("Not set.", "未设置。")}</div>
                   <Button
                     variant="outline"
                     size="xs"
@@ -713,21 +777,21 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                       setWorkspaceError(null);
                     }}
                   >
-                    Set repo
+                    {t("Set repo", "设置仓库")}
                   </Button>
                 </div>
               )}
             </div>
 
             <div className="space-y-1">
-              <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Local folder</div>
+              <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{t("Local folder", "本地文件夹")}</div>
               <div className="flex items-center justify-between gap-2">
                 <div className="min-w-0 space-y-1">
                   <div className="min-w-0 truncate font-mono text-xs text-muted-foreground">
                     {codebase.effectiveLocalFolder}
                   </div>
                   {codebase.origin === "managed_checkout" && (
-                    <div className="text-[11px] text-muted-foreground">Paperclip-managed folder.</div>
+                    <div className="text-[11px] text-muted-foreground">{t("Paperclip-managed folder.", "由 Paperclip 管理的文件夹。")}</div>
                   )}
                 </div>
                 <div className="flex items-center gap-1">
@@ -741,14 +805,16 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                       setWorkspaceError(null);
                     }}
                   >
-                    {codebase.localFolder ? "Change local folder" : "Set local folder"}
+                    {codebase.localFolder
+                      ? t("Change local folder", "更改本地文件夹")
+                      : t("Set local folder", "设置本地文件夹")}
                   </Button>
                   {codebase.localFolder ? (
                     <Button
                       variant="ghost"
                       size="icon-xs"
                       onClick={clearLocalWorkspace}
-                      aria-label="Clear local folder"
+                      aria-label={t("Clear local folder", "清除本地文件夹")}
                     >
                       <Trash2 className="h-3 w-3" />
                     </Button>
@@ -759,7 +825,10 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
 
             {hasAdditionalLegacyWorkspaces && (
               <div className="text-[11px] text-muted-foreground">
-                Additional legacy workspace records exist on this project. Paperclip is using the primary workspace as the codebase view.
+                {t(
+                  "Additional legacy workspace records exist on this project. Paperclip is using the primary workspace as the codebase view.",
+                  "此项目中还存在额外的旧版工作区记录。Paperclip 当前使用主工作区作为代码库视图。",
+                )}
               </div>
             )}
 
@@ -783,7 +852,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                                 : "bg-muted text-muted-foreground",
                           )}
                         >
-                          {service.status}
+                          {runtimeServiceStatusLabel(service.status, uiLanguage)}
                         </span>
                       </div>
                       <div className="text-[11px] text-muted-foreground">
@@ -797,12 +866,12 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                             {service.url}
                           </a>
                         ) : (
-                          service.command ?? "No URL"
+                          service.command ?? t("No URL", "无 URL")
                         )}
                       </div>
                     </div>
                     <div className="text-[10px] text-muted-foreground whitespace-nowrap">
-                      {service.lifecycle}
+                      {runtimeServiceLifecycleLabel(service.lifecycle, uiLanguage)}
                     </div>
                   </div>
                 ))}
@@ -828,7 +897,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                   disabled={(!workspaceCwd.trim() && !primaryCodebaseWorkspace) || createWorkspace.isPending || updateWorkspace.isPending}
                   onClick={submitLocalWorkspace}
                 >
-                  Save
+                  {t("Save", "保存")}
                 </Button>
                 <Button
                   variant="ghost"
@@ -840,7 +909,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                     setWorkspaceError(null);
                   }}
                 >
-                  Cancel
+                  {t("Cancel", "取消")}
                 </Button>
               </div>
             </div>
@@ -861,7 +930,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                   disabled={(!workspaceRepoUrl.trim() && !primaryCodebaseWorkspace) || createWorkspace.isPending || updateWorkspace.isPending}
                   onClick={submitRepoWorkspace}
                 >
-                  Save
+                  {t("Save", "保存")}
                 </Button>
                 <Button
                   variant="ghost"
@@ -873,7 +942,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                     setWorkspaceError(null);
                   }}
                 >
-                  Cancel
+                  {t("Cancel", "取消")}
                 </Button>
               </div>
             </div>
@@ -882,13 +951,13 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
             <p className="text-xs text-destructive">{workspaceError}</p>
           )}
           {createWorkspace.isError && (
-            <p className="text-xs text-destructive">Failed to save workspace.</p>
+            <p className="text-xs text-destructive">{t("Failed to save workspace.", "保存工作区失败。")}</p>
           )}
           {removeWorkspace.isError && (
-            <p className="text-xs text-destructive">Failed to delete workspace.</p>
+            <p className="text-xs text-destructive">{t("Failed to delete workspace.", "删除工作区失败。")}</p>
           )}
           {updateWorkspace.isError && (
-            <p className="text-xs text-destructive">Failed to update workspace.</p>
+            <p className="text-xs text-destructive">{t("Failed to update workspace.", "更新工作区失败。")}</p>
           )}
         </div>
 
@@ -898,19 +967,22 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
 
             <div className="py-1.5 space-y-2">
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <span>Execution Workspaces</span>
+                <span>{t("Execution Workspaces", "执行工作区")}</span>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button
                       type="button"
                       className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-border text-[10px] text-muted-foreground hover:text-foreground"
-                      aria-label="Execution workspaces help"
+                      aria-label={t("Execution workspaces help", "执行工作区帮助")}
                     >
                       ?
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="top">
-                    Project-owned defaults for isolated issue checkouts and execution workspace behavior.
+                    {t(
+                      "Project-owned defaults for isolated issue checkouts and execution workspace behavior.",
+                      "项目级默认设置，用于控制隔离任务检出和执行工作区行为。",
+                    )}
                   </TooltipContent>
                 </Tooltip>
               </div>
@@ -918,11 +990,14 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                 <div className="flex items-center justify-between gap-3">
                   <div className="space-y-0.5">
                     <div className="flex items-center gap-2 text-sm font-medium">
-                      <span>Enable isolated issue checkouts</span>
-                      <SaveIndicator state={fieldState("execution_workspace_enabled")} />
+                      <span>{t("Enable isolated issue checkouts", "启用隔离任务检出")}</span>
+                      <SaveIndicator state={fieldState("execution_workspace_enabled")} uiLanguage={uiLanguage} />
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      Let issues choose between the project's primary checkout and an isolated execution workspace.
+                      {t(
+                        "Let issues choose between the project's primary checkout and an isolated execution workspace.",
+                        "允许任务在项目主检出和隔离执行工作区之间选择。",
+                      )}
                     </div>
                   </div>
                   {onUpdate || onFieldUpdate ? (
@@ -936,7 +1011,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                     />
                   ) : (
                     <span className="text-xs text-muted-foreground">
-                      {executionWorkspacesEnabled ? "Enabled" : "Disabled"}
+                      {executionWorkspacesEnabled ? t("Enabled", "已启用") : t("Disabled", "已禁用")}
                     </span>
                   )}
                 </div>
@@ -946,11 +1021,14 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                     <div className="flex items-center justify-between gap-3">
                       <div className="space-y-0.5">
                         <div className="flex items-center gap-2 text-sm">
-                          <span>New issues default to isolated checkout</span>
-                          <SaveIndicator state={fieldState("execution_workspace_default_mode")} />
+                          <span>{t("New issues default to isolated checkout", "新任务默认使用隔离检出")}</span>
+                          <SaveIndicator state={fieldState("execution_workspace_default_mode")} uiLanguage={uiLanguage} />
                         </div>
                         <div className="text-[11px] text-muted-foreground">
-                          If disabled, new issues stay on the project's primary checkout unless someone opts in.
+                          {t(
+                            "If disabled, new issues stay on the project's primary checkout unless someone opts in.",
+                            "关闭后，新任务将默认停留在项目主检出中，除非有人手动开启隔离工作区。",
+                          )}
                         </div>
                       </div>
                       <ToggleSwitch
@@ -975,21 +1053,21 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                         onClick={() => setExecutionWorkspaceAdvancedOpen((open) => !open)}
                       >
                         {executionWorkspaceAdvancedOpen
-                          ? "Hide advanced checkout settings"
-                          : "Show advanced checkout settings"}
+                          ? t("Hide advanced checkout settings", "隐藏高级检出设置")
+                          : t("Show advanced checkout settings", "显示高级检出设置")}
                       </button>
                     </div>
 
                     {executionWorkspaceAdvancedOpen ? (
                       <div className="space-y-3">
                         <div className="text-xs text-muted-foreground">
-                          Host-managed implementation: <span className="text-foreground">Git worktree</span>
+                          {t("Host-managed implementation:", "宿主管理实现：")} <span className="text-foreground">Git worktree</span>
                         </div>
                         <div>
                           <div className="mb-1 flex items-center gap-1.5">
                             <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                              <span>Base ref</span>
-                              <SaveIndicator state={fieldState("execution_workspace_base_ref")} />
+                              <span>{t("Base ref", "基础引用")}</span>
+                              <SaveIndicator state={fieldState("execution_workspace_base_ref")} uiLanguage={uiLanguage} />
                             </label>
                           </div>
                           <DraftInput
@@ -1012,8 +1090,8 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                         <div>
                           <div className="mb-1 flex items-center gap-1.5">
                             <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                              <span>Branch template</span>
-                              <SaveIndicator state={fieldState("execution_workspace_branch_template")} />
+                              <span>{t("Branch template", "分支模板")}</span>
+                              <SaveIndicator state={fieldState("execution_workspace_branch_template")} uiLanguage={uiLanguage} />
                             </label>
                           </div>
                           <DraftInput
@@ -1036,8 +1114,8 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                         <div>
                           <div className="mb-1 flex items-center gap-1.5">
                             <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                              <span>Worktree parent dir</span>
-                              <SaveIndicator state={fieldState("execution_workspace_worktree_parent_dir")} />
+                              <span>{t("Worktree parent dir", "工作树父目录")}</span>
+                              <SaveIndicator state={fieldState("execution_workspace_worktree_parent_dir")} uiLanguage={uiLanguage} />
                             </label>
                           </div>
                           <DraftInput
@@ -1060,8 +1138,8 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                         <div>
                           <div className="mb-1 flex items-center gap-1.5">
                             <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                              <span>Provision command</span>
-                              <SaveIndicator state={fieldState("execution_workspace_provision_command")} />
+                              <span>{t("Provision command", "准备命令")}</span>
+                              <SaveIndicator state={fieldState("execution_workspace_provision_command")} uiLanguage={uiLanguage} />
                             </label>
                           </div>
                           <DraftInput
@@ -1084,8 +1162,8 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                         <div>
                           <div className="mb-1 flex items-center gap-1.5">
                             <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                              <span>Teardown command</span>
-                              <SaveIndicator state={fieldState("execution_workspace_teardown_command")} />
+                              <span>{t("Teardown command", "清理命令")}</span>
+                              <SaveIndicator state={fieldState("execution_workspace_teardown_command")} uiLanguage={uiLanguage} />
                             </label>
                           </div>
                           <DraftInput
@@ -1106,8 +1184,10 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                           />
                         </div>
                         <p className="text-[11px] text-muted-foreground">
-                          Provision runs inside the derived worktree before agent execution. Teardown is stored here for
-                          future cleanup flows.
+                          {t(
+                            "Provision runs inside the derived worktree before agent execution. Teardown is stored here for future cleanup flows.",
+                            "准备命令会在派生出的 worktree 中、智能体执行前运行。清理命令会保存在这里，供后续清理流程使用。",
+                          )}
                         </p>
                       </div>
                     ) : null}
@@ -1125,12 +1205,13 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
           <Separator className="my-4" />
           <div className="space-y-4 py-4">
             <div className="text-xs font-medium text-destructive uppercase tracking-wide">
-              Danger Zone
+              {t("Danger Zone", "危险操作区")}
             </div>
             <ArchiveDangerZone
               project={project}
               onArchive={onArchive}
               archivePending={archivePending}
+              uiLanguage={uiLanguage}
             />
           </div>
         </>

--- a/ui/src/components/ProviderQuotaCard.tsx
+++ b/ui/src/components/ProviderQuotaCard.tsx
@@ -12,6 +12,8 @@ import {
   providerDisplayName,
   quotaSourceDisplayName,
 } from "@/lib/utils";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 // ordered display labels for rolling-window rows
 const ROLLING_WINDOWS = ["5h", "24h", "7d"] as const;
@@ -48,6 +50,7 @@ export function ProviderQuotaCard({
   quotaSource = null,
   quotaLoading = false,
 }: ProviderQuotaCardProps) {
+  const { uiLanguage } = useGeneralSettings();
   // single-pass aggregation over rows — memoized so the 8 derived values are not
   // recomputed on every parent render tick (providers tab polls every 30s, and each
   // card is mounted twice: once in the "all" tab grid and once in its per-provider tab).
@@ -138,16 +141,17 @@ export function ProviderQuotaCard({
               {providerDisplayName(provider)}
             </CardTitle>
             <CardDescription className="text-xs mt-0.5">
-              <span className="font-mono">{formatTokens(totalInputTokens)}</span> in
+              <span className="font-mono">{formatTokens(totalInputTokens)}</span> {textFor(uiLanguage, { en: "in", "zh-CN": "输入" })}
               {" · "}
-              <span className="font-mono">{formatTokens(totalOutputTokens)}</span> out
+              <span className="font-mono">{formatTokens(totalOutputTokens)}</span> {textFor(uiLanguage, { en: "out", "zh-CN": "输出" })}
               {(totalApiRuns > 0 || totalSubRuns > 0) && (
                 <span className="ml-1.5">
                   ·{" "}
-                  {totalApiRuns > 0 && `~${totalApiRuns} api`}
+                  {totalApiRuns > 0 && textFor(uiLanguage, { en: `~${totalApiRuns} api`, "zh-CN": `~${totalApiRuns} 次 API` })}
                   {totalApiRuns > 0 && totalSubRuns > 0 && " / "}
-                  {totalSubRuns > 0 && `~${totalSubRuns} sub`}
-                  {" runs"}
+                  {totalSubRuns > 0 && textFor(uiLanguage, { en: `~${totalSubRuns} sub`, "zh-CN": `~${totalSubRuns} 次订阅` })}
+                  {" "}
+                  {textFor(uiLanguage, { en: "runs", "zh-CN": "运行" })}
                 </span>
               )}
             </CardDescription>
@@ -162,17 +166,23 @@ export function ProviderQuotaCard({
         {hasBudget && (
           <div className="space-y-3">
             <QuotaBar
-              label="Period spend"
+              label={textFor(uiLanguage, { en: "Period spend", "zh-CN": "周期支出" })}
               percentUsed={budgetPct}
               leftLabel={formatCents(totalCostCents)}
-              rightLabel={`${Math.round(budgetPct)}% of allocation`}
+              rightLabel={textFor(uiLanguage, {
+                en: `${Math.round(budgetPct)}% of allocation`,
+                "zh-CN": `占分配额度的 ${Math.round(budgetPct)}%`,
+              })}
               showDeficitNotch={showDeficitNotch}
             />
             <QuotaBar
-              label="This week"
+              label={textFor(uiLanguage, { en: "This week", "zh-CN": "本周" })}
               percentUsed={weekPct}
               leftLabel={formatCents(weekSpendCents)}
-              rightLabel={`~${formatCents(Math.round(weeklyBudgetShare))} / wk`}
+              rightLabel={textFor(uiLanguage, {
+                en: `~${formatCents(Math.round(weeklyBudgetShare))} / wk`,
+                "zh-CN": `~${formatCents(Math.round(weeklyBudgetShare))} / 周`,
+              })}
               showDeficitNotch={weekPct >= 100}
             />
           </div>
@@ -184,7 +194,7 @@ export function ProviderQuotaCard({
             <div className="border-t border-border" />
             <div className="space-y-2">
               <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                Rolling windows
+                {textFor(uiLanguage, { en: "Rolling windows", "zh-CN": "滚动窗口" })}
               </p>
               <div className="space-y-2.5">
                 {ROLLING_WINDOWS.map((w) => {
@@ -223,20 +233,20 @@ export function ProviderQuotaCard({
             <div className="border-t border-border" />
             <div className="space-y-2">
               <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                Subscription
+                {textFor(uiLanguage, { en: "Subscription", "zh-CN": "订阅" })}
               </p>
               <p className="text-xs text-muted-foreground">
-                <span className="font-mono text-foreground">{totalSubRuns}</span> runs
+                <span className="font-mono text-foreground">{totalSubRuns}</span> {textFor(uiLanguage, { en: "runs", "zh-CN": "次运行" })}
                 {" · "}
                 {totalSubTokens > 0 && (
                   <>
-                    <span className="font-mono text-foreground">{formatTokens(totalSubTokens)}</span> total
+                    <span className="font-mono text-foreground">{formatTokens(totalSubTokens)}</span> {textFor(uiLanguage, { en: "total", "zh-CN": "总计" })}
                     {" · "}
                   </>
                 )}
-                <span className="font-mono text-foreground">{formatTokens(totalSubInputTokens)}</span> in
+                <span className="font-mono text-foreground">{formatTokens(totalSubInputTokens)}</span> {textFor(uiLanguage, { en: "in", "zh-CN": "输入" })}
                 {" · "}
-                <span className="font-mono text-foreground">{formatTokens(totalSubOutputTokens)}</span> out
+                <span className="font-mono text-foreground">{formatTokens(totalSubOutputTokens)}</span> {textFor(uiLanguage, { en: "out", "zh-CN": "输出" })}
               </p>
               {subSharePct > 0 && (
                 <>
@@ -247,7 +257,10 @@ export function ProviderQuotaCard({
                     />
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    {Math.round(subSharePct)}% of token usage via subscription
+                    {textFor(uiLanguage, {
+                      en: `${Math.round(subSharePct)}% of token usage via subscription`,
+                      "zh-CN": `通过订阅产生了 ${Math.round(subSharePct)}% 的 token 用量`,
+                    })}
                   </p>
                 </>
               )}
@@ -278,7 +291,7 @@ export function ProviderQuotaCard({
                       </div>
                       <div className="flex items-center gap-3 shrink-0 tabular-nums text-xs">
                         <span className="text-muted-foreground">
-                          {formatTokens(rowTokens)} tok
+                          {formatTokens(rowTokens)} {textFor(uiLanguage, { en: "tok", "zh-CN": "tok" })}
                         </span>
                         <span className="font-medium">{formatCents(row.costCents)}</span>
                       </div>
@@ -288,13 +301,19 @@ export function ProviderQuotaCard({
                       <div
                         className="absolute inset-y-0 left-0 bg-primary/60 transition-[width] duration-150"
                         style={{ width: `${tokenPct}%` }}
-                        title={`${Math.round(tokenPct)}% of provider tokens`}
+                        title={textFor(uiLanguage, {
+                          en: `${Math.round(tokenPct)}% of provider tokens`,
+                          "zh-CN": `占 provider token 的 ${Math.round(tokenPct)}%`,
+                        })}
                       />
                       {/* cost share overlay — narrower, opaque, shows relative cost weight */}
                       <div
                         className="absolute inset-y-0 left-0 bg-primary/85 transition-[width] duration-150"
                         style={{ width: `${costPct}%` }}
-                        title={`${Math.round(costPct)}% of provider cost`}
+                        title={textFor(uiLanguage, {
+                          en: `${Math.round(costPct)}% of provider cost`,
+                          "zh-CN": `占 provider 成本的 ${Math.round(costPct)}%`,
+                        })}
                       />
                     </div>
                   </div>
@@ -311,7 +330,7 @@ export function ProviderQuotaCard({
             <div className="space-y-2">
               <div className="flex items-center justify-between gap-3">
                 <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                  Subscription quota
+                  {textFor(uiLanguage, { en: "Subscription quota", "zh-CN": "订阅配额" })}
                 </p>
                 {quotaSource && !isClaudeQuotaPanel && !isCodexQuotaPanel ? (
                   <span className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
@@ -350,7 +369,12 @@ export function ProviderQuotaCard({
                             {qw.valueLabel != null ? (
                               <span className="font-medium tabular-nums">{qw.valueLabel}</span>
                             ) : qw.usedPercent != null ? (
-                              <span className="font-medium tabular-nums">{qw.usedPercent}% used</span>
+                              <span className="font-medium tabular-nums">
+                                {textFor(uiLanguage, {
+                                  en: `${qw.usedPercent}% used`,
+                                  "zh-CN": `已用 ${qw.usedPercent}%`,
+                                })}
+                              </span>
                             ) : null}
                           </div>
                           {qw.usedPercent != null && fillColor != null && (
@@ -367,7 +391,10 @@ export function ProviderQuotaCard({
                             </p>
                           ) : qw.resetsAt ? (
                             <p className="text-xs text-muted-foreground">
-                              resets {new Date(qw.resetsAt).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+                              {textFor(uiLanguage, {
+                                en: `resets ${new Date(qw.resetsAt).toLocaleDateString(undefined, { month: "short", day: "numeric" })}`,
+                                "zh-CN": `重置时间 ${new Date(qw.resetsAt).toLocaleDateString(undefined, { month: "short", day: "numeric" })}`,
+                              })}
                             </p>
                           ) : null}
                         </div>

--- a/ui/src/components/RoutineRunVariablesDialog.tsx
+++ b/ui/src/components/RoutineRunVariablesDialog.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { IssueExecutionWorkspaceSettings, Project, RoutineVariable } from "@paperclipai/shared";
 import { useQuery } from "@tanstack/react-query";
 import { instanceSettingsApi } from "../api/instanceSettings";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { queryKeys } from "../lib/queryKeys";
+import { textFor } from "../lib/ui-language";
 import { IssueWorkspaceCard } from "./IssueWorkspaceCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -129,6 +131,7 @@ export function RoutineRunVariablesDialog({
   isPending: boolean;
   onSubmit: (data: RoutineRunDialogSubmitData) => void;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [workspaceConfig, setWorkspaceConfig] = useState(() => buildInitialWorkspaceConfig(project));
   const [workspaceConfigValid, setWorkspaceConfigValid] = useState(true);
@@ -195,9 +198,9 @@ export function RoutineRunVariablesDialog({
     <Dialog open={open} onOpenChange={(next) => !isPending && onOpenChange(next)}>
       <DialogContent className="max-w-xl">
         <DialogHeader>
-          <DialogTitle>Run routine</DialogTitle>
+          <DialogTitle>{textFor(uiLanguage, { en: "Run routine", "zh-CN": "运行例行任务" })}</DialogTitle>
           <DialogDescription>
-            Fill in the routine variables before starting the execution issue.
+            {textFor(uiLanguage, { en: "Fill in the routine variables before starting the execution issue.", "zh-CN": "在启动执行任务前，先填写例行任务变量。" })}
           </DialogDescription>
         </DialogHeader>
 
@@ -226,9 +229,9 @@ export function RoutineRunVariablesDialog({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="__unset__">No value</SelectItem>
-                    <SelectItem value="true">True</SelectItem>
-                    <SelectItem value="false">False</SelectItem>
+                    <SelectItem value="__unset__">{textFor(uiLanguage, { en: "No value", "zh-CN": "无值" })}</SelectItem>
+                    <SelectItem value="true">{textFor(uiLanguage, { en: "True", "zh-CN": "是" })}</SelectItem>
+                    <SelectItem value="false">{textFor(uiLanguage, { en: "False", "zh-CN": "否" })}</SelectItem>
                   </SelectContent>
                 </Select>
               ) : variable.type === "select" ? (
@@ -240,10 +243,10 @@ export function RoutineRunVariablesDialog({
                   }))}
                 >
                   <SelectTrigger>
-                    <SelectValue placeholder="Choose a value" />
+                    <SelectValue placeholder={textFor(uiLanguage, { en: "Choose a value", "zh-CN": "请选择一个值" })} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="__unset__">No value</SelectItem>
+                    <SelectItem value="__unset__">{textFor(uiLanguage, { en: "No value", "zh-CN": "无值" })}</SelectItem>
                     {variable.options.map((option) => (
                       <SelectItem key={option} value={option}>{option}</SelectItem>
                     ))}
@@ -275,17 +278,17 @@ export function RoutineRunVariablesDialog({
         <DialogFooter showCloseButton={false}>
           {missingRequired.length > 0 ? (
             <p className="mr-auto text-xs text-amber-600">
-              Missing: {missingRequired.join(", ")}
+              {uiLanguage === "zh-CN" ? `缺少：${missingRequired.join("、")}` : `Missing: ${missingRequired.join(", ")}`}
             </p>
           ) : workspaceSelectionEnabled && !workspaceConfigValid ? (
             <p className="mr-auto text-xs text-amber-600">
-              Choose an existing workspace before running.
+              {textFor(uiLanguage, { en: "Choose an existing workspace before running.", "zh-CN": "运行前请先选择一个已有工作区。" })}
             </p>
           ) : (
             <span className="mr-auto" />
           )}
           <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={isPending}>
-            Cancel
+            {textFor(uiLanguage, { en: "Cancel", "zh-CN": "取消" })}
           </Button>
           <Button
             onClick={() => {
@@ -314,7 +317,9 @@ export function RoutineRunVariablesDialog({
             }}
             disabled={isPending || !canSubmit}
           >
-            {isPending ? "Running..." : "Run routine"}
+            {isPending
+              ? textFor(uiLanguage, { en: "Running...", "zh-CN": "运行中..." })
+              : textFor(uiLanguage, { en: "Run routine", "zh-CN": "运行例行任务" })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/ui/src/components/RoutineVariablesEditor.tsx
+++ b/ui/src/components/RoutineVariablesEditor.tsx
@@ -3,6 +3,8 @@ import { ChevronDown, ChevronRight } from "lucide-react";
 import { syncRoutineVariablesWithTemplate, type RoutineVariable } from "@paperclipai/shared";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -46,6 +48,7 @@ export function RoutineVariablesEditor({
   value: RoutineVariable[];
   onChange: (value: RoutineVariable[]) => void;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const [open, setOpen] = useState(true);
   const syncedVariables = useMemo(
     () => syncRoutineVariablesWithTemplate([title, description], value),
@@ -68,9 +71,12 @@ export function RoutineVariablesEditor({
     <Collapsible open={open} onOpenChange={setOpen}>
       <CollapsibleTrigger className="flex w-full items-center justify-between rounded-lg border border-border/70 px-3 py-2 text-left">
         <div>
-          <p className="text-sm font-medium">Variables</p>
+          <p className="text-sm font-medium">{textFor(uiLanguage, { en: "Variables", "zh-CN": "变量" })}</p>
           <p className="text-xs text-muted-foreground">
-            Detected from `{"{{name}}"}` placeholders in the routine title and instructions.
+            {textFor(uiLanguage, {
+              en: `Detected from ${"{{name}}"} placeholders in the routine title and instructions.`,
+              "zh-CN": `根据例行任务标题和说明中的 ${"{{name}}"} 占位符自动识别。`,
+            })}
           </p>
         </div>
         {open ? <ChevronDown className="h-4 w-4 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 text-muted-foreground" />}
@@ -83,13 +89,13 @@ export function RoutineVariablesEditor({
                 {`{{${variable.name}}}`}
               </Badge>
               <span className="text-xs text-muted-foreground">
-                Prompt the user for this value before each manual run.
+                {textFor(uiLanguage, { en: "Prompt the user for this value before each manual run.", "zh-CN": "每次手动运行前都向用户询问这个值。" })}
               </span>
             </div>
 
             <div className="grid gap-3 md:grid-cols-2">
               <div className="space-y-1.5">
-                <Label className="text-xs">Label</Label>
+                <Label className="text-xs">{textFor(uiLanguage, { en: "Label", "zh-CN": "标签" })}</Label>
                 <Input
                   value={variable.label ?? ""}
                   onChange={(event) => onChange(updateVariableList(syncedVariables, variable.name, (current) => ({
@@ -101,7 +107,7 @@ export function RoutineVariablesEditor({
               </div>
 
               <div className="space-y-1.5">
-                <Label className="text-xs">Type</Label>
+                <Label className="text-xs">{textFor(uiLanguage, { en: "Type", "zh-CN": "类型" })}</Label>
                 <Select
                   value={variable.type}
                   onValueChange={(type) => onChange(updateVariableList(syncedVariables, variable.name, (current) => ({
@@ -124,7 +130,7 @@ export function RoutineVariablesEditor({
 
               <div className="space-y-1.5 md:col-span-2">
                 <div className="flex items-center justify-between gap-3">
-                  <Label className="text-xs">Default value</Label>
+                  <Label className="text-xs">{textFor(uiLanguage, { en: "Default value", "zh-CN": "默认值" })}</Label>
                   <label className="flex items-center gap-2 text-xs text-muted-foreground">
                     <input
                       type="checkbox"
@@ -134,7 +140,7 @@ export function RoutineVariablesEditor({
                         required: event.target.checked,
                       })))}
                     />
-                    Required
+                    {textFor(uiLanguage, { en: "Required", "zh-CN": "必填" })}
                   </label>
                 </div>
 
@@ -159,15 +165,15 @@ export function RoutineVariablesEditor({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="__unset__">No default</SelectItem>
-                      <SelectItem value="true">True</SelectItem>
-                      <SelectItem value="false">False</SelectItem>
+                      <SelectItem value="__unset__">{textFor(uiLanguage, { en: "No default", "zh-CN": "无默认值" })}</SelectItem>
+                      <SelectItem value="true">{textFor(uiLanguage, { en: "True", "zh-CN": "是" })}</SelectItem>
+                      <SelectItem value="false">{textFor(uiLanguage, { en: "False", "zh-CN": "否" })}</SelectItem>
                     </SelectContent>
                   </Select>
                 ) : variable.type === "select" ? (
                   <div className="grid gap-3 md:grid-cols-2">
                     <div className="space-y-1.5">
-                      <Label className="text-xs">Options</Label>
+                      <Label className="text-xs">{textFor(uiLanguage, { en: "Options", "zh-CN": "选项" })}</Label>
                       <Input
                         value={variable.options.join(", ")}
                         onChange={(event) => {
@@ -185,7 +191,7 @@ export function RoutineVariablesEditor({
                       />
                     </div>
                     <div className="space-y-1.5">
-                      <Label className="text-xs">Default option</Label>
+                      <Label className="text-xs">{textFor(uiLanguage, { en: "Default option", "zh-CN": "默认选项" })}</Label>
                       <Select
                         value={typeof variable.defaultValue === "string" ? variable.defaultValue : "__unset__"}
                         onValueChange={(next) => onChange(updateVariableList(syncedVariables, variable.name, (current) => ({
@@ -194,10 +200,10 @@ export function RoutineVariablesEditor({
                         })))}
                       >
                         <SelectTrigger>
-                          <SelectValue placeholder="No default" />
+                          <SelectValue placeholder={textFor(uiLanguage, { en: "No default", "zh-CN": "无默认值" })} />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="__unset__">No default</SelectItem>
+                          <SelectItem value="__unset__">{textFor(uiLanguage, { en: "No default", "zh-CN": "无默认值" })}</SelectItem>
                           {variable.options.map((option) => (
                             <SelectItem key={option} value={option}>{option}</SelectItem>
                           ))}
@@ -213,7 +219,7 @@ export function RoutineVariablesEditor({
                       ...current,
                       defaultValue: event.target.value || null,
                     })))}
-                    placeholder={variable.type === "number" ? "42" : "Default value"}
+                    placeholder={variable.type === "number" ? "42" : textFor(uiLanguage, { en: "Default value", "zh-CN": "默认值" })}
                   />
                 )}
               </div>
@@ -226,9 +232,13 @@ export function RoutineVariablesEditor({
 }
 
 export function RoutineVariablesHint() {
+  const { uiLanguage } = useGeneralSettings();
   return (
     <div className="rounded-lg border border-dashed border-border/70 px-3 py-2 text-xs text-muted-foreground">
-      Use `{"{{variable_name}}"}` placeholders in the instructions to prompt for inputs when the routine runs.
+      {textFor(uiLanguage, {
+        en: `Use ${"{{variable_name}}"} placeholders in the instructions to prompt for inputs when the routine runs.`,
+        "zh-CN": `在说明中使用 ${"{{variable_name}}"} 占位符，例行任务运行时就会提示输入这些值。`,
+      })}
     </div>
   );
 }

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -19,15 +19,18 @@ import { SidebarProjects } from "./SidebarProjects";
 import { SidebarAgents } from "./SidebarAgents";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { heartbeatsApi } from "../api/heartbeats";
 import { queryKeys } from "../lib/queryKeys";
 import { useInboxBadge } from "../hooks/useInboxBadge";
 import { Button } from "@/components/ui/button";
 import { PluginSlotOutlet } from "@/plugins/slots";
+import { textFor } from "../lib/ui-language";
 
 export function Sidebar() {
   const { openNewIssue } = useDialog();
   const { selectedCompanyId, selectedCompany } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const inboxBadge = useInboxBadge(selectedCompanyId);
   const { data: liveRuns } = useQuery({
     queryKey: queryKeys.liveRuns(selectedCompanyId!),
@@ -46,6 +49,65 @@ export function Sidebar() {
     companyPrefix: selectedCompany?.issuePrefix ?? null,
   };
 
+  const copy = {
+    selectCompany: textFor(uiLanguage, {
+      en: "Select company",
+      "zh-CN": "选择公司",
+    }),
+    newIssue: textFor(uiLanguage, {
+      en: "New Issue",
+      "zh-CN": "新建任务",
+    }),
+    dashboard: textFor(uiLanguage, {
+      en: "Dashboard",
+      "zh-CN": "仪表盘",
+    }),
+    inbox: textFor(uiLanguage, {
+      en: "Inbox",
+      "zh-CN": "收件箱",
+    }),
+    work: textFor(uiLanguage, {
+      en: "Work",
+      "zh-CN": "工作",
+    }),
+    issues: textFor(uiLanguage, {
+      en: "Issues",
+      "zh-CN": "任务",
+    }),
+    routines: textFor(uiLanguage, {
+      en: "Routines",
+      "zh-CN": "例行任务",
+    }),
+    goals: textFor(uiLanguage, {
+      en: "Goals",
+      "zh-CN": "目标",
+    }),
+    company: textFor(uiLanguage, {
+      en: "Company",
+      "zh-CN": "公司",
+    }),
+    org: textFor(uiLanguage, {
+      en: "Org",
+      "zh-CN": "组织架构",
+    }),
+    skills: textFor(uiLanguage, {
+      en: "Skills",
+      "zh-CN": "技能",
+    }),
+    costs: textFor(uiLanguage, {
+      en: "Costs",
+      "zh-CN": "成本",
+    }),
+    activity: textFor(uiLanguage, {
+      en: "Activity",
+      "zh-CN": "活动",
+    }),
+    settings: textFor(uiLanguage, {
+      en: "Settings",
+      "zh-CN": "设置",
+    }),
+  };
+
   return (
     <aside className="w-60 h-full min-h-0 border-r border-border bg-background flex flex-col">
       {/* Top bar: Company name (bold) + Search — aligned with top sections (no visible border) */}
@@ -57,7 +119,7 @@ export function Sidebar() {
           />
         )}
         <span className="flex-1 text-sm font-bold text-foreground truncate pl-1">
-          {selectedCompany?.name ?? "Select company"}
+          {selectedCompany?.name ?? copy.selectCompany}
         </span>
         <Button
           variant="ghost"
@@ -77,12 +139,12 @@ export function Sidebar() {
             className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
           >
             <SquarePen className="h-4 w-4 shrink-0" />
-            <span className="truncate">New Issue</span>
+            <span className="truncate">{copy.newIssue}</span>
           </button>
-          <SidebarNavItem to="/dashboard" label="Dashboard" icon={LayoutDashboard} liveCount={liveRunCount} />
+          <SidebarNavItem to="/dashboard" label={copy.dashboard} icon={LayoutDashboard} liveCount={liveRunCount} />
           <SidebarNavItem
             to="/inbox"
-            label="Inbox"
+            label={copy.inbox}
             icon={Inbox}
             badge={inboxBadge.inbox}
             badgeTone={inboxBadge.failedRuns > 0 ? "danger" : "default"}
@@ -97,22 +159,22 @@ export function Sidebar() {
           />
         </div>
 
-        <SidebarSection label="Work">
-          <SidebarNavItem to="/issues" label="Issues" icon={CircleDot} />
-          <SidebarNavItem to="/routines" label="Routines" icon={Repeat} textBadge="Beta" textBadgeTone="amber" />
-          <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+        <SidebarSection label={copy.work}>
+          <SidebarNavItem to="/issues" label={copy.issues} icon={CircleDot} />
+          <SidebarNavItem to="/routines" label={copy.routines} icon={Repeat} textBadge={uiLanguage === "zh-CN" ? "测试版" : "Beta"} textBadgeTone="amber" />
+          <SidebarNavItem to="/goals" label={copy.goals} icon={Target} />
         </SidebarSection>
 
         <SidebarProjects />
 
         <SidebarAgents />
 
-        <SidebarSection label="Company">
-          <SidebarNavItem to="/org" label="Org" icon={Network} />
-          <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
-          <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
-          <SidebarNavItem to="/activity" label="Activity" icon={History} />
-          <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
+        <SidebarSection label={copy.company}>
+          <SidebarNavItem to="/org" label={copy.org} icon={Network} />
+          <SidebarNavItem to="/skills" label={copy.skills} icon={Boxes} />
+          <SidebarNavItem to="/costs" label={copy.costs} icon={DollarSign} />
+          <SidebarNavItem to="/activity" label={copy.activity} icon={History} />
+          <SidebarNavItem to="/company/settings" label={copy.settings} icon={Settings} />
         </SidebarSection>
 
         <PluginSlotOutlet

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -5,6 +5,7 @@ import { ChevronRight, Plus } from "lucide-react";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useSidebar } from "../context/SidebarContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { agentsApi } from "../api/agents";
 import { authApi } from "../api/auth";
 import { heartbeatsApi } from "../api/heartbeats";
@@ -19,12 +20,32 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import type { Agent } from "@paperclipai/shared";
+import { textFor } from "../lib/ui-language";
 export function SidebarAgents() {
   const [open, setOpen] = useState(true);
   const { selectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { openNewAgent } = useDialog();
   const { isMobile, setSidebarOpen } = useSidebar();
   const location = useLocation();
+  const copy = {
+    agents: textFor(uiLanguage, {
+      en: "Agents",
+      "zh-CN": "智能体",
+    }),
+    newAgent: textFor(uiLanguage, {
+      en: "New agent",
+      "zh-CN": "新建智能体",
+    }),
+    budgetPaused: textFor(uiLanguage, {
+      en: "Agent paused by budget",
+      "zh-CN": "智能体因预算被暂停",
+    }),
+    live: textFor(uiLanguage, {
+      en: "live",
+      "zh-CN": "在线",
+    }),
+  };
 
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
@@ -81,7 +102,7 @@ export function SidebarAgents() {
               )}
             />
             <span className="text-[10px] font-medium uppercase tracking-widest font-mono text-muted-foreground/60">
-              Agents
+              {copy.agents}
             </span>
           </CollapsibleTrigger>
           <button
@@ -90,7 +111,7 @@ export function SidebarAgents() {
               openNewAgent();
             }}
             className="flex items-center justify-center h-4 w-4 rounded text-muted-foreground/60 hover:text-foreground hover:bg-accent/50 transition-colors"
-            aria-label="New agent"
+            aria-label={copy.newAgent}
           >
             <Plus className="h-3 w-3" />
           </button>
@@ -120,7 +141,7 @@ export function SidebarAgents() {
                 {(agent.pauseReason === "budget" || runCount > 0) && (
                   <span className="ml-auto flex items-center gap-1.5 shrink-0">
                     {agent.pauseReason === "budget" ? (
-                      <BudgetSidebarMarker title="Agent paused by budget" />
+                      <BudgetSidebarMarker title={copy.budgetPaused} />
                     ) : null}
                     {runCount > 0 ? (
                       <span className="relative flex h-2 w-2">
@@ -130,7 +151,7 @@ export function SidebarAgents() {
                     ) : null}
                     {runCount > 0 ? (
                       <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">
-                        {runCount} live
+                        {runCount} {copy.live}
                       </span>
                     ) : null}
                   </span>

--- a/ui/src/components/SidebarProjects.tsx
+++ b/ui/src/components/SidebarProjects.tsx
@@ -20,6 +20,7 @@ import { projectsApi } from "../api/projects";
 import { queryKeys } from "../lib/queryKeys";
 import { cn, projectRouteRef } from "../lib/utils";
 import { useProjectOrder } from "../hooks/useProjectOrder";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { BudgetSidebarMarker } from "./BudgetSidebarMarker";
 import {
   Collapsible,
@@ -28,6 +29,7 @@ import {
 } from "@/components/ui/collapsible";
 import { PluginSlotMount, usePluginSlots } from "@/plugins/slots";
 import type { Project } from "@paperclipai/shared";
+import { textFor } from "../lib/ui-language";
 
 type ProjectSidebarSlot = ReturnType<typeof usePluginSlots>["slots"][number];
 
@@ -56,6 +58,11 @@ function SortableProjectItem({
     transition,
     isDragging,
   } = useSortable({ id: project.id });
+  const { uiLanguage } = useGeneralSettings();
+  const budgetPausedTitle = textFor(uiLanguage, {
+    en: "Project paused by budget",
+    "zh-CN": "项目因预算被暂停",
+  });
 
   const routeRef = projectRouteRef(project);
 
@@ -89,7 +96,7 @@ function SortableProjectItem({
             style={{ backgroundColor: project.color ?? "#6366f1" }}
           />
           <span className="flex-1 truncate">{project.name}</span>
-          {project.pauseReason === "budget" ? <BudgetSidebarMarker title="Project paused by budget" /> : null}
+          {project.pauseReason === "budget" ? <BudgetSidebarMarker title={budgetPausedTitle} /> : null}
         </NavLink>
         {projectSidebarSlots.length > 0 && (
           <div className="ml-5 flex flex-col gap-0.5">
@@ -118,9 +125,24 @@ function SortableProjectItem({
 export function SidebarProjects() {
   const [open, setOpen] = useState(true);
   const { selectedCompany, selectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { openNewProject } = useDialog();
   const { isMobile, setSidebarOpen } = useSidebar();
   const location = useLocation();
+  const copy = {
+    projects: textFor(uiLanguage, {
+      en: "Projects",
+      "zh-CN": "项目",
+    }),
+    newProject: textFor(uiLanguage, {
+      en: "New project",
+      "zh-CN": "新建项目",
+    }),
+    budgetPaused: textFor(uiLanguage, {
+      en: "Project paused by budget",
+      "zh-CN": "项目因预算被暂停",
+    }),
+  };
 
   const { data: projects } = useQuery({
     queryKey: queryKeys.projects.list(selectedCompanyId!),
@@ -186,7 +208,7 @@ export function SidebarProjects() {
               )}
             />
             <span className="text-[10px] font-medium uppercase tracking-widest font-mono text-muted-foreground/60">
-              Projects
+              {copy.projects}
             </span>
           </CollapsibleTrigger>
           <button
@@ -195,7 +217,7 @@ export function SidebarProjects() {
               openNewProject();
             }}
             className="flex items-center justify-center h-4 w-4 rounded text-muted-foreground/60 hover:text-foreground hover:bg-accent/50 transition-colors"
-            aria-label="New project"
+            aria-label={copy.newProject}
           >
             <Plus className="h-3 w-3" />
           </button>

--- a/ui/src/components/StatusBadge.tsx
+++ b/ui/src/components/StatusBadge.tsx
@@ -1,7 +1,28 @@
 import { cn } from "../lib/utils";
 import { statusBadge, statusBadgeDefault } from "../lib/status-colors";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 export function StatusBadge({ status }: { status: string }) {
+  const { uiLanguage } = useGeneralSettings();
+  const labelMap: Record<string, string> = {
+    idle: textFor(uiLanguage, { en: "idle", "zh-CN": "空闲" }),
+    active: textFor(uiLanguage, { en: "active", "zh-CN": "活跃" }),
+    running: textFor(uiLanguage, { en: "running", "zh-CN": "运行中" }),
+    paused: textFor(uiLanguage, { en: "paused", "zh-CN": "已暂停" }),
+    error: textFor(uiLanguage, { en: "error", "zh-CN": "异常" }),
+    queued: textFor(uiLanguage, { en: "queued", "zh-CN": "排队中" }),
+    blocked: textFor(uiLanguage, { en: "blocked", "zh-CN": "阻塞" }),
+    open: textFor(uiLanguage, { en: "open", "zh-CN": "打开" }),
+    done: textFor(uiLanguage, { en: "done", "zh-CN": "完成" }),
+    closed: textFor(uiLanguage, { en: "closed", "zh-CN": "已关闭" }),
+    approved: textFor(uiLanguage, { en: "approved", "zh-CN": "已批准" }),
+    rejected: textFor(uiLanguage, { en: "rejected", "zh-CN": "已拒绝" }),
+    terminated: textFor(uiLanguage, { en: "terminated", "zh-CN": "已终止" }),
+    pending_approval: textFor(uiLanguage, { en: "pending approval", "zh-CN": "待审批" }),
+    in_progress: textFor(uiLanguage, { en: "in progress", "zh-CN": "进行中" }),
+  };
+  const label = labelMap[status] ?? status.replace(/_/g, " ");
   return (
     <span
       className={cn(
@@ -9,7 +30,7 @@ export function StatusBadge({ status }: { status: string }) {
         statusBadge[status] ?? statusBadgeDefault
       )}
     >
-      {status.replace("_", " ")}
+      {label}
     </span>
   );
 }

--- a/ui/src/components/SwipeToArchive.tsx
+++ b/ui/src/components/SwipeToArchive.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Archive } from "lucide-react";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { cn } from "../lib/utils";
+import { textFor } from "../lib/ui-language";
 
 interface SwipeToArchiveProps {
   children: ReactNode;
@@ -21,6 +23,7 @@ export function SwipeToArchive({
   selected = false,
   className,
 }: SwipeToArchiveProps) {
+  const { uiLanguage } = useGeneralSettings();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const startPointRef = useRef<{ x: number; y: number } | null>(null);
   const widthRef = useRef(0);
@@ -146,7 +149,7 @@ export function SwipeToArchive({
       >
         <span className="inline-flex items-center gap-2 text-sm font-medium">
           <Archive className="h-4 w-4" />
-          Archive
+          {textFor(uiLanguage, { en: "Archive", "zh-CN": "归档" })}
         </span>
       </div>
       <div

--- a/ui/src/components/ui/command.tsx
+++ b/ui/src/components/ui/command.tsx
@@ -6,6 +6,8 @@ import { SearchIcon, XIcon } from "lucide-react"
 import { Dialog as DialogPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
+import { useGeneralSettings } from "@/context/GeneralSettingsContext"
+import { textFor } from "@/lib/ui-language"
 import {
   Dialog,
   DialogContent,
@@ -31,8 +33,8 @@ function Command({
 }
 
 function CommandDialog({
-  title = "Command Palette",
-  description = "Search for a command to run...",
+  title,
+  description,
   children,
   className,
   showCloseButton = true,
@@ -43,11 +45,24 @@ function CommandDialog({
   className?: string
   showCloseButton?: boolean
 }) {
+  const { uiLanguage } = useGeneralSettings()
+  const defaultTitle = textFor(uiLanguage, {
+    en: "Command Palette",
+    "zh-CN": "命令面板",
+  })
+  const defaultDescription = textFor(uiLanguage, {
+    en: "Search for a command to run...",
+    "zh-CN": "搜索要执行的命令...",
+  })
+  const closeLabel = textFor(uiLanguage, {
+    en: "Close",
+    "zh-CN": "关闭",
+  })
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
+        <DialogTitle>{title ?? defaultTitle}</DialogTitle>
+        <DialogDescription>{description ?? defaultDescription}</DialogDescription>
       </DialogHeader>
       <DialogContent
         className={cn("overflow-hidden p-0", className)}
@@ -62,7 +77,7 @@ function CommandDialog({
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-0 right-2 flex h-12 items-center rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{closeLabel}</span>
           </DialogPrimitive.Close>
         )}
       </DialogContent>

--- a/ui/src/context/GeneralSettingsContext.tsx
+++ b/ui/src/context/GeneralSettingsContext.tsx
@@ -1,12 +1,17 @@
 import type { ReactNode } from "react";
 import { createContext, useContext } from "react";
+import { readStoredUiLanguage, type UiLanguage } from "@/lib/ui-language";
 
 export interface GeneralSettingsContextValue {
   keyboardShortcutsEnabled: boolean;
+  uiLanguage: UiLanguage;
+  setUiLanguage: (language: UiLanguage) => void;
 }
 
 const GeneralSettingsContext = createContext<GeneralSettingsContextValue>({
   keyboardShortcutsEnabled: false,
+  uiLanguage: readStoredUiLanguage(),
+  setUiLanguage: () => {},
 });
 
 export function GeneralSettingsProvider({

--- a/ui/src/lib/activity-format.ts
+++ b/ui/src/lib/activity-format.ts
@@ -1,4 +1,5 @@
 import type { Agent } from "@paperclipai/shared";
+import { textFor, type UiLanguage } from "./ui-language";
 
 type ActivityDetails = Record<string, unknown> | null | undefined;
 
@@ -17,72 +18,84 @@ type ActivityIssueReference = {
 interface ActivityFormatOptions {
   agentMap?: Map<string, Agent>;
   currentUserId?: string | null;
+  uiLanguage?: UiLanguage;
 }
 
-const ACTIVITY_ROW_VERBS: Record<string, string> = {
-  "issue.created": "created",
-  "issue.updated": "updated",
-  "issue.checked_out": "checked out",
-  "issue.released": "released",
-  "issue.comment_added": "commented on",
-  "issue.attachment_added": "attached file to",
-  "issue.attachment_removed": "removed attachment from",
-  "issue.document_created": "created document for",
-  "issue.document_updated": "updated document on",
-  "issue.document_deleted": "deleted document from",
-  "issue.commented": "commented on",
-  "issue.deleted": "deleted",
-  "agent.created": "created",
-  "agent.updated": "updated",
-  "agent.paused": "paused",
-  "agent.resumed": "resumed",
-  "agent.terminated": "terminated",
-  "agent.key_created": "created API key for",
-  "agent.budget_updated": "updated budget for",
-  "agent.runtime_session_reset": "reset session for",
-  "heartbeat.invoked": "invoked heartbeat for",
-  "heartbeat.cancelled": "cancelled heartbeat for",
-  "approval.created": "requested approval",
-  "approval.approved": "approved",
-  "approval.rejected": "rejected",
-  "project.created": "created",
-  "project.updated": "updated",
-  "project.deleted": "deleted",
-  "goal.created": "created",
-  "goal.updated": "updated",
-  "goal.deleted": "deleted",
-  "cost.reported": "reported cost for",
-  "cost.recorded": "recorded cost for",
-  "company.created": "created company",
-  "company.updated": "updated company",
-  "company.archived": "archived",
-  "company.budget_updated": "updated budget for",
+const ACTIVITY_ROW_VERBS: Record<string, { en: string; "zh-CN": string }> = {
+  "issue.created": { en: "created", "zh-CN": "创建了" },
+  "issue.updated": { en: "updated", "zh-CN": "更新了" },
+  "issue.checked_out": { en: "checked out", "zh-CN": "检出了" },
+  "issue.released": { en: "released", "zh-CN": "发布了" },
+  "issue.comment_added": { en: "commented on", "zh-CN": "评论了" },
+  "issue.attachment_added": { en: "attached file to", "zh-CN": "添加了附件到" },
+  "issue.attachment_removed": { en: "removed attachment from", "zh-CN": "移除了附件自" },
+  "issue.document_created": { en: "created document for", "zh-CN": "创建了文档给" },
+  "issue.document_updated": { en: "updated document on", "zh-CN": "更新了文档于" },
+  "issue.document_deleted": { en: "deleted document from", "zh-CN": "删除了文档自" },
+  "issue.commented": { en: "commented on", "zh-CN": "评论了" },
+  "issue.deleted": { en: "deleted", "zh-CN": "删除了" },
+  "agent.created": { en: "created", "zh-CN": "创建了" },
+  "agent.updated": { en: "updated", "zh-CN": "更新了" },
+  "agent.paused": { en: "paused", "zh-CN": "暂停了" },
+  "agent.resumed": { en: "resumed", "zh-CN": "恢复了" },
+  "agent.terminated": { en: "terminated", "zh-CN": "终止了" },
+  "agent.key_created": { en: "created API key for", "zh-CN": "为其创建了 API 密钥" },
+  "agent.budget_updated": { en: "updated budget for", "zh-CN": "更新了预算给" },
+  "agent.runtime_session_reset": { en: "reset session for", "zh-CN": "重置了会话给" },
+  "heartbeat.invoked": { en: "invoked heartbeat for", "zh-CN": "触发了心跳给" },
+  "heartbeat.cancelled": { en: "cancelled heartbeat for", "zh-CN": "取消了心跳给" },
+  "approval.created": { en: "requested approval", "zh-CN": "发起了审批" },
+  "approval.approved": { en: "approved", "zh-CN": "批准了" },
+  "approval.rejected": { en: "rejected", "zh-CN": "拒绝了" },
+  "project.created": { en: "created", "zh-CN": "创建了" },
+  "project.updated": { en: "updated", "zh-CN": "更新了" },
+  "project.deleted": { en: "deleted", "zh-CN": "删除了" },
+  "goal.created": { en: "created", "zh-CN": "创建了" },
+  "goal.updated": { en: "updated", "zh-CN": "更新了" },
+  "goal.deleted": { en: "deleted", "zh-CN": "删除了" },
+  "cost.reported": { en: "reported cost for", "zh-CN": "上报了成本给" },
+  "cost.recorded": { en: "recorded cost for", "zh-CN": "记录了成本给" },
+  "company.created": { en: "created company", "zh-CN": "创建了公司" },
+  "company.updated": { en: "updated company", "zh-CN": "更新了公司" },
+  "company.archived": { en: "archived", "zh-CN": "归档了" },
+  "company.budget_updated": { en: "updated budget for", "zh-CN": "更新了预算给" },
 };
 
-const ISSUE_ACTIVITY_LABELS: Record<string, string> = {
-  "issue.created": "created the issue",
-  "issue.updated": "updated the issue",
-  "issue.checked_out": "checked out the issue",
-  "issue.released": "released the issue",
-  "issue.comment_added": "added a comment",
-  "issue.feedback_vote_saved": "saved feedback on an AI output",
-  "issue.attachment_added": "added an attachment",
-  "issue.attachment_removed": "removed an attachment",
-  "issue.document_created": "created a document",
-  "issue.document_updated": "updated a document",
-  "issue.document_deleted": "deleted a document",
-  "issue.deleted": "deleted the issue",
-  "agent.created": "created an agent",
-  "agent.updated": "updated the agent",
-  "agent.paused": "paused the agent",
-  "agent.resumed": "resumed the agent",
-  "agent.terminated": "terminated the agent",
-  "heartbeat.invoked": "invoked a heartbeat",
-  "heartbeat.cancelled": "cancelled a heartbeat",
-  "approval.created": "requested approval",
-  "approval.approved": "approved",
-  "approval.rejected": "rejected",
+const ISSUE_ACTIVITY_LABELS: Record<string, { en: string; "zh-CN": string }> = {
+  "issue.created": { en: "created the issue", "zh-CN": "创建了任务" },
+  "issue.updated": { en: "updated the issue", "zh-CN": "更新了任务" },
+  "issue.checked_out": { en: "checked out the issue", "zh-CN": "检出了任务" },
+  "issue.released": { en: "released the issue", "zh-CN": "发布了任务" },
+  "issue.comment_added": { en: "added a comment", "zh-CN": "添加了评论" },
+  "issue.feedback_vote_saved": { en: "saved feedback on an AI output", "zh-CN": "保存了对 AI 输出的反馈" },
+  "issue.attachment_added": { en: "added an attachment", "zh-CN": "添加了附件" },
+  "issue.attachment_removed": { en: "removed an attachment", "zh-CN": "移除了附件" },
+  "issue.document_created": { en: "created a document", "zh-CN": "创建了文档" },
+  "issue.document_updated": { en: "updated a document", "zh-CN": "更新了文档" },
+  "issue.document_deleted": { en: "deleted a document", "zh-CN": "删除了文档" },
+  "issue.deleted": { en: "deleted the issue", "zh-CN": "删除了任务" },
+  "agent.created": { en: "created an agent", "zh-CN": "创建了智能体" },
+  "agent.updated": { en: "updated the agent", "zh-CN": "更新了智能体" },
+  "agent.paused": { en: "paused the agent", "zh-CN": "暂停了智能体" },
+  "agent.resumed": { en: "resumed the agent", "zh-CN": "恢复了智能体" },
+  "agent.terminated": { en: "terminated the agent", "zh-CN": "终止了智能体" },
+  "heartbeat.invoked": { en: "invoked a heartbeat", "zh-CN": "触发了心跳" },
+  "heartbeat.cancelled": { en: "cancelled a heartbeat", "zh-CN": "取消了心跳" },
+  "approval.created": { en: "requested approval", "zh-CN": "发起了审批" },
+  "approval.approved": { en: "approved", "zh-CN": "批准了" },
+  "approval.rejected": { en: "rejected", "zh-CN": "拒绝了" },
 };
+
+function resolveUiLanguage(options: ActivityFormatOptions): UiLanguage {
+  return options.uiLanguage ?? "en";
+}
+
+function localizedText(
+  copy: { en: string; "zh-CN": string },
+  uiLanguage: UiLanguage,
+): string {
+  return textFor(uiLanguage, copy);
+}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
@@ -116,48 +129,74 @@ function readIssueReferences(details: ActivityDetails, key: string): ActivityIss
   return value.filter(isActivityIssueReference);
 }
 
-function formatUserLabel(userId: string | null | undefined, currentUserId?: string | null): string {
-  if (!userId || userId === "local-board") return "Board";
-  if (currentUserId && userId === currentUserId) return "You";
-  return `user ${userId.slice(0, 5)}`;
+function formatUserLabel(
+  userId: string | null | undefined,
+  currentUserId?: string | null,
+  uiLanguage: UiLanguage = "en",
+): string {
+  if (!userId || userId === "local-board") {
+    return localizedText({ en: "Board", "zh-CN": "董事会" }, uiLanguage);
+  }
+  if (currentUserId && userId === currentUserId) {
+    return localizedText({ en: "You", "zh-CN": "你" }, uiLanguage);
+  }
+  return uiLanguage === "zh-CN" ? `用户 ${userId.slice(0, 5)}` : `user ${userId.slice(0, 5)}`;
 }
 
 function formatParticipantLabel(participant: ActivityParticipant, options: ActivityFormatOptions): string {
+  const uiLanguage = resolveUiLanguage(options);
   if (participant.type === "agent") {
     const agentId = participant.agentId ?? "";
-    return options.agentMap?.get(agentId)?.name ?? "agent";
+    return options.agentMap?.get(agentId)?.name ?? localizedText({ en: "agent", "zh-CN": "智能体" }, uiLanguage);
   }
-  return formatUserLabel(participant.userId, options.currentUserId);
+  return formatUserLabel(participant.userId, options.currentUserId, uiLanguage);
 }
 
-function formatIssueReferenceLabel(reference: ActivityIssueReference): string {
+function formatIssueReferenceLabel(reference: ActivityIssueReference, uiLanguage: UiLanguage = "en"): string {
   if (reference.identifier) return reference.identifier;
   if (reference.title) return reference.title;
   if (reference.id) return reference.id.slice(0, 8);
-  return "issue";
+  return localizedText({ en: "issue", "zh-CN": "任务" }, uiLanguage);
 }
 
 function formatChangedEntityLabel(
   singular: string,
   plural: string,
+  singularZh: string,
+  pluralZh: string,
   labels: string[],
+  uiLanguage: UiLanguage,
 ): string {
+  if (uiLanguage === "zh-CN") {
+    if (labels.length <= 0) return pluralZh;
+    return `${labels.length === 1 ? singularZh : pluralZh} ${labels.join("、")}`;
+  }
   if (labels.length <= 0) return plural;
   if (labels.length === 1) return `${singular} ${labels[0]}`;
   return `${labels.length} ${plural}`;
 }
 
-function formatIssueUpdatedVerb(details: ActivityDetails): string | null {
+function formatIssueUpdatedVerb(details: ActivityDetails, uiLanguage: UiLanguage): string | null {
   if (!details) return null;
   const previous = asRecord(details._previous) ?? {};
   if (details.status !== undefined) {
     const from = previous.status;
+    if (uiLanguage === "zh-CN") {
+      return from
+        ? `将状态从 ${humanizeValue(from)} 改为 ${humanizeValue(details.status)}`
+        : `将状态改为 ${humanizeValue(details.status)}`;
+    }
     return from
       ? `changed status from ${humanizeValue(from)} to ${humanizeValue(details.status)} on`
       : `changed status to ${humanizeValue(details.status)} on`;
   }
   if (details.priority !== undefined) {
     const from = previous.priority;
+    if (uiLanguage === "zh-CN") {
+      return from
+        ? `将优先级从 ${humanizeValue(from)} 改为 ${humanizeValue(details.priority)}`
+        : `将优先级改为 ${humanizeValue(details.priority)}`;
+    }
     return from
       ? `changed priority from ${humanizeValue(from)} to ${humanizeValue(details.priority)} on`
       : `changed priority to ${humanizeValue(details.priority)} on`;
@@ -165,7 +204,7 @@ function formatIssueUpdatedVerb(details: ActivityDetails): string | null {
   return null;
 }
 
-function formatIssueUpdatedAction(details: ActivityDetails): string | null {
+function formatIssueUpdatedAction(details: ActivityDetails, uiLanguage: UiLanguage): string | null {
   if (!details) return null;
   const previous = asRecord(details._previous) ?? {};
   const parts: string[] = [];
@@ -173,26 +212,42 @@ function formatIssueUpdatedAction(details: ActivityDetails): string | null {
   if (details.status !== undefined) {
     const from = previous.status;
     parts.push(
-      from
-        ? `changed the status from ${humanizeValue(from)} to ${humanizeValue(details.status)}`
-        : `changed the status to ${humanizeValue(details.status)}`,
+      uiLanguage === "zh-CN"
+        ? from
+          ? `将状态从 ${humanizeValue(from)} 改为 ${humanizeValue(details.status)}`
+          : `将状态改为 ${humanizeValue(details.status)}`
+        : from
+          ? `changed the status from ${humanizeValue(from)} to ${humanizeValue(details.status)}`
+          : `changed the status to ${humanizeValue(details.status)}`,
     );
   }
   if (details.priority !== undefined) {
     const from = previous.priority;
     parts.push(
-      from
-        ? `changed the priority from ${humanizeValue(from)} to ${humanizeValue(details.priority)}`
-        : `changed the priority to ${humanizeValue(details.priority)}`,
+      uiLanguage === "zh-CN"
+        ? from
+          ? `将优先级从 ${humanizeValue(from)} 改为 ${humanizeValue(details.priority)}`
+          : `将优先级改为 ${humanizeValue(details.priority)}`
+        : from
+          ? `changed the priority from ${humanizeValue(from)} to ${humanizeValue(details.priority)}`
+          : `changed the priority to ${humanizeValue(details.priority)}`,
     );
   }
   if (details.assigneeAgentId !== undefined || details.assigneeUserId !== undefined) {
-    parts.push(details.assigneeAgentId || details.assigneeUserId ? "assigned the issue" : "unassigned the issue");
+    parts.push(
+      details.assigneeAgentId || details.assigneeUserId
+        ? localizedText({ en: "assigned the issue", "zh-CN": "分配了任务" }, uiLanguage)
+        : localizedText({ en: "unassigned the issue", "zh-CN": "取消了任务分配" }, uiLanguage),
+    );
   }
-  if (details.title !== undefined) parts.push("updated the title");
-  if (details.description !== undefined) parts.push("updated the description");
+  if (details.title !== undefined) {
+    parts.push(localizedText({ en: "updated the title", "zh-CN": "更新了标题" }, uiLanguage));
+  }
+  if (details.description !== undefined) {
+    parts.push(localizedText({ en: "updated the description", "zh-CN": "更新了描述" }, uiLanguage));
+  }
 
-  return parts.length > 0 ? parts.join(", ") : null;
+  return parts.length > 0 ? parts.join(uiLanguage === "zh-CN" ? "，" : ", ") : null;
 }
 
 function formatStructuredIssueChange(input: {
@@ -203,19 +258,24 @@ function formatStructuredIssueChange(input: {
 }): string | null {
   const details = input.details;
   if (!details) return null;
+  const uiLanguage = resolveUiLanguage(input.options);
 
   if (input.action === "issue.blockers_updated") {
-    const added = readIssueReferences(details, "addedBlockedByIssues").map(formatIssueReferenceLabel);
-    const removed = readIssueReferences(details, "removedBlockedByIssues").map(formatIssueReferenceLabel);
+    const added = readIssueReferences(details, "addedBlockedByIssues").map((reference) => formatIssueReferenceLabel(reference, uiLanguage));
+    const removed = readIssueReferences(details, "removedBlockedByIssues").map((reference) => formatIssueReferenceLabel(reference, uiLanguage));
     if (added.length > 0 && removed.length === 0) {
-      const changed = formatChangedEntityLabel("blocker", "blockers", added);
+      const changed = formatChangedEntityLabel("blocker", "blockers", "阻塞任务", "阻塞任务", added, uiLanguage);
+      if (uiLanguage === "zh-CN") return input.forIssueDetail ? `添加了${changed}` : `添加了${changed}`;
       return input.forIssueDetail ? `added ${changed}` : `added ${changed} to`;
     }
     if (removed.length > 0 && added.length === 0) {
-      const changed = formatChangedEntityLabel("blocker", "blockers", removed);
+      const changed = formatChangedEntityLabel("blocker", "blockers", "阻塞任务", "阻塞任务", removed, uiLanguage);
+      if (uiLanguage === "zh-CN") return input.forIssueDetail ? `移除了${changed}` : `移除了${changed}`;
       return input.forIssueDetail ? `removed ${changed}` : `removed ${changed} from`;
     }
-    return input.forIssueDetail ? "updated blockers" : "updated blockers on";
+    return uiLanguage === "zh-CN"
+      ? "更新了阻塞项"
+      : (input.forIssueDetail ? "updated blockers" : "updated blockers on");
   }
 
   if (input.action === "issue.reviewers_updated" || input.action === "issue.approvers_updated") {
@@ -223,15 +283,21 @@ function formatStructuredIssueChange(input: {
     const removed = readParticipants(details, "removedParticipants").map((participant) => formatParticipantLabel(participant, input.options));
     const singular = input.action === "issue.reviewers_updated" ? "reviewer" : "approver";
     const plural = input.action === "issue.reviewers_updated" ? "reviewers" : "approvers";
+    const singularZh = input.action === "issue.reviewers_updated" ? "评审人" : "审批人";
+    const pluralZh = singularZh;
     if (added.length > 0 && removed.length === 0) {
-      const changed = formatChangedEntityLabel(singular, plural, added);
+      const changed = formatChangedEntityLabel(singular, plural, singularZh, pluralZh, added, uiLanguage);
+      if (uiLanguage === "zh-CN") return input.forIssueDetail ? `添加了${changed}` : `添加了${changed}`;
       return input.forIssueDetail ? `added ${changed}` : `added ${changed} to`;
     }
     if (removed.length > 0 && added.length === 0) {
-      const changed = formatChangedEntityLabel(singular, plural, removed);
+      const changed = formatChangedEntityLabel(singular, plural, singularZh, pluralZh, removed, uiLanguage);
+      if (uiLanguage === "zh-CN") return input.forIssueDetail ? `移除了${changed}` : `移除了${changed}`;
       return input.forIssueDetail ? `removed ${changed}` : `removed ${changed} from`;
     }
-    return input.forIssueDetail ? `updated ${plural}` : `updated ${plural} on`;
+    return uiLanguage === "zh-CN"
+      ? `更新了${pluralZh}`
+      : (input.forIssueDetail ? `updated ${plural}` : `updated ${plural} on`);
   }
 
   return null;
@@ -242,8 +308,9 @@ export function formatActivityVerb(
   details?: Record<string, unknown> | null,
   options: ActivityFormatOptions = {},
 ): string {
+  const uiLanguage = resolveUiLanguage(options);
   if (action === "issue.updated") {
-    const issueUpdatedVerb = formatIssueUpdatedVerb(details);
+    const issueUpdatedVerb = formatIssueUpdatedVerb(details, uiLanguage);
     if (issueUpdatedVerb) return issueUpdatedVerb;
   }
 
@@ -255,7 +322,8 @@ export function formatActivityVerb(
   });
   if (structuredChange) return structuredChange;
 
-  return ACTIVITY_ROW_VERBS[action] ?? action.replace(/[._]/g, " ");
+  const copy = ACTIVITY_ROW_VERBS[action];
+  return copy ? localizedText(copy, uiLanguage) : action.replace(/[._]/g, " ");
 }
 
 export function formatIssueActivityAction(
@@ -263,8 +331,9 @@ export function formatIssueActivityAction(
   details?: Record<string, unknown> | null,
   options: ActivityFormatOptions = {},
 ): string {
+  const uiLanguage = resolveUiLanguage(options);
   if (action === "issue.updated") {
-    const issueUpdatedAction = formatIssueUpdatedAction(details);
+    const issueUpdatedAction = formatIssueUpdatedAction(details, uiLanguage);
     if (issueUpdatedAction) return issueUpdatedAction;
   }
 
@@ -280,10 +349,12 @@ export function formatIssueActivityAction(
     (action === "issue.document_created" || action === "issue.document_updated" || action === "issue.document_deleted") &&
     details
   ) {
-    const key = typeof details.key === "string" ? details.key : "document";
+    const key = typeof details.key === "string"
+      ? details.key
+      : localizedText({ en: "document", "zh-CN": "文档" }, uiLanguage);
     const title = typeof details.title === "string" && details.title ? ` (${details.title})` : "";
-    return `${ISSUE_ACTIVITY_LABELS[action] ?? action} ${key}${title}`;
+    return `${localizedText(ISSUE_ACTIVITY_LABELS[action] ?? { en: action, "zh-CN": action }, uiLanguage)} ${key}${title}`;
   }
 
-  return ISSUE_ACTIVITY_LABELS[action] ?? action.replace(/[._]/g, " ");
+  return localizedText(ISSUE_ACTIVITY_LABELS[action] ?? { en: action.replace(/[._]/g, " "), "zh-CN": action.replace(/[._]/g, " ") }, uiLanguage);
 }

--- a/ui/src/lib/assignees.ts
+++ b/ui/src/lib/assignees.ts
@@ -64,9 +64,10 @@ export function parseAssigneeValue(value: string): AssigneeSelection {
 
 export function currentUserAssigneeOption(currentUserId: string | null | undefined): AssigneeOption[] {
   if (!currentUserId) return [];
+  const uiLanguage = readStoredUiLanguage();
   return [{
     id: assigneeValueFromSelection({ assigneeUserId: currentUserId }),
-    label: "Me",
+    label: uiLanguage === "zh-CN" ? "我" : "Me",
     searchText: currentUserId === "local-board" ? "me board human local-board" : `me human ${currentUserId}`,
   }];
 }
@@ -76,7 +77,9 @@ export function formatAssigneeUserLabel(
   currentUserId: string | null | undefined,
 ): string | null {
   if (!userId) return null;
-  if (currentUserId && userId === currentUserId) return "You";
-  if (userId === "local-board") return "Board";
+  const uiLanguage = readStoredUiLanguage();
+  if (currentUserId && userId === currentUserId) return uiLanguage === "zh-CN" ? "你" : "You";
+  if (userId === "local-board") return uiLanguage === "zh-CN" ? "董事会" : "Board";
   return userId.slice(0, 5);
 }
+import { readStoredUiLanguage } from "./ui-language";

--- a/ui/src/lib/timeAgo.ts
+++ b/ui/src/lib/timeAgo.ts
@@ -1,3 +1,5 @@
+import { readStoredUiLanguage } from "./ui-language";
+
 const MINUTE = 60;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
@@ -8,24 +10,26 @@ export function timeAgo(date: Date | string): string {
   const now = Date.now();
   const then = new Date(date).getTime();
   const seconds = Math.round((now - then) / 1000);
+  const locale = readStoredUiLanguage() === "zh-CN" ? "zh-CN" : "en-US";
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
 
-  if (seconds < MINUTE) return "just now";
+  if (seconds < MINUTE) return locale === "zh-CN" ? "刚刚" : "just now";
   if (seconds < HOUR) {
     const m = Math.floor(seconds / MINUTE);
-    return `${m}m ago`;
+    return rtf.format(-m, "minute");
   }
   if (seconds < DAY) {
     const h = Math.floor(seconds / HOUR);
-    return `${h}h ago`;
+    return rtf.format(-h, "hour");
   }
   if (seconds < WEEK) {
     const d = Math.floor(seconds / DAY);
-    return `${d}d ago`;
+    return rtf.format(-d, "day");
   }
   if (seconds < MONTH) {
     const w = Math.floor(seconds / WEEK);
-    return `${w}w ago`;
+    return rtf.format(-w, "week");
   }
   const mo = Math.floor(seconds / MONTH);
-  return `${mo}mo ago`;
+  return rtf.format(-mo, "month");
 }

--- a/ui/src/lib/ui-language.ts
+++ b/ui/src/lib/ui-language.ts
@@ -1,0 +1,45 @@
+export const UI_LANGUAGES = ["en", "zh-CN"] as const;
+
+export type UiLanguage = (typeof UI_LANGUAGES)[number];
+
+export const UI_LANGUAGE_STORAGE_KEY = "paperclip.uiLanguage";
+
+export function isUiLanguage(value: unknown): value is UiLanguage {
+  return typeof value === "string" && UI_LANGUAGES.includes(value as UiLanguage);
+}
+
+export function getDefaultUiLanguage(): UiLanguage {
+  if (typeof navigator !== "undefined" && navigator.language.toLowerCase().startsWith("zh")) {
+    return "zh-CN";
+  }
+  return "en";
+}
+
+export function resolveUiLanguage(value: unknown): UiLanguage {
+  return isUiLanguage(value) ? value : getDefaultUiLanguage();
+}
+
+export function readStoredUiLanguage(): UiLanguage {
+  if (typeof window === "undefined") return getDefaultUiLanguage();
+  try {
+    return resolveUiLanguage(window.localStorage.getItem(UI_LANGUAGE_STORAGE_KEY));
+  } catch {
+    return getDefaultUiLanguage();
+  }
+}
+
+export function writeStoredUiLanguage(language: UiLanguage) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(UI_LANGUAGE_STORAGE_KEY, language);
+  } catch {
+    // Ignore storage failures in restricted environments.
+  }
+}
+
+export function textFor(
+  language: UiLanguage,
+  copy: Record<UiLanguage, string>,
+): string {
+  return copy[language];
+}

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -2,9 +2,14 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { deriveAgentUrlKey, deriveProjectUrlKey, normalizeProjectUrlKey, hasNonAsciiContent } from "@paperclipai/shared";
 import type { BillingType, FinanceDirection, FinanceEventKind } from "@paperclipai/shared";
+import { readStoredUiLanguage } from "./ui-language";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+function getUiLocale(): string {
+  return readStoredUiLanguage() === "zh-CN" ? "zh-CN" : "en-US";
 }
 
 export function formatCents(cents: number): string {
@@ -12,7 +17,7 @@ export function formatCents(cents: number): string {
 }
 
 export function formatDate(date: Date | string): string {
-  return new Date(date).toLocaleDateString("en-US", {
+  return new Date(date).toLocaleDateString(getUiLocale(), {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -20,7 +25,7 @@ export function formatDate(date: Date | string): string {
 }
 
 export function formatDateTime(date: Date | string): string {
-  return new Date(date).toLocaleString("en-US", {
+  return new Date(date).toLocaleString(getUiLocale(), {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -30,7 +35,7 @@ export function formatDateTime(date: Date | string): string {
 }
 
 export function formatShortDate(date: Date | string): string {
-  return new Date(date).toLocaleString("en-US", {
+  return new Date(date).toLocaleString(getUiLocale(), {
     month: "short",
     day: "numeric",
   });
@@ -40,13 +45,15 @@ export function relativeTime(date: Date | string): string {
   const now = Date.now();
   const then = new Date(date).getTime();
   const diffSec = Math.round((now - then) / 1000);
-  if (diffSec < 60) return "just now";
+  const locale = getUiLocale();
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+  if (diffSec < 60) return locale === "zh-CN" ? "刚刚" : "just now";
   const diffMin = Math.round(diffSec / 60);
-  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffMin < 60) return rtf.format(-diffMin, "minute");
   const diffHr = Math.round(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffHr < 24) return rtf.format(-diffHr, "hour");
   const diffDay = Math.round(diffHr / 24);
-  if (diffDay < 30) return `${diffDay}d ago`;
+  if (diffDay < 30) return rtf.format(-diffDay, "day");
   return formatDate(date);
 }
 
@@ -72,25 +79,44 @@ export function providerDisplayName(provider: string): string {
 }
 
 export function billingTypeDisplayName(billingType: BillingType): string {
-  const map: Record<BillingType, string> = {
-    metered_api: "Metered API",
-    subscription_included: "Subscription",
-    subscription_overage: "Subscription overage",
-    credits: "Credits",
-    fixed: "Fixed",
-    unknown: "Unknown",
-  };
+  const zh = readStoredUiLanguage() === "zh-CN";
+  const map: Record<BillingType, string> = zh
+    ? {
+        metered_api: "按量 API",
+        subscription_included: "订阅额度",
+        subscription_overage: "订阅超额",
+        credits: "积分",
+        fixed: "固定费用",
+        unknown: "未知",
+      }
+    : {
+        metered_api: "Metered API",
+        subscription_included: "Subscription",
+        subscription_overage: "Subscription overage",
+        credits: "Credits",
+        fixed: "Fixed",
+        unknown: "Unknown",
+      };
   return map[billingType];
 }
 
 export function quotaSourceDisplayName(source: string): string {
-  const map: Record<string, string> = {
-    "anthropic-oauth": "Anthropic OAuth",
-    "claude-cli": "Claude CLI",
-    "bedrock": "AWS Bedrock",
-    "codex-rpc": "Codex app server",
-    "codex-wham": "ChatGPT WHAM",
-  };
+  const zh = readStoredUiLanguage() === "zh-CN";
+  const map: Record<string, string> = zh
+    ? {
+        "anthropic-oauth": "Anthropic OAuth",
+        "claude-cli": "Claude CLI",
+        "bedrock": "AWS Bedrock",
+        "codex-rpc": "Codex 应用服务",
+        "codex-wham": "ChatGPT WHAM",
+      }
+    : {
+        "anthropic-oauth": "Anthropic OAuth",
+        "claude-cli": "Claude CLI",
+        "bedrock": "AWS Bedrock",
+        "codex-rpc": "Codex app server",
+        "codex-wham": "ChatGPT WHAM",
+      };
   return map[source] ?? source;
 }
 
@@ -127,27 +153,47 @@ export function visibleRunCostUsd(
 }
 
 export function financeEventKindDisplayName(eventKind: FinanceEventKind): string {
-  const map: Record<FinanceEventKind, string> = {
-    inference_charge: "Inference charge",
-    platform_fee: "Platform fee",
-    credit_purchase: "Credit purchase",
-    credit_refund: "Credit refund",
-    credit_expiry: "Credit expiry",
-    byok_fee: "BYOK fee",
-    gateway_overhead: "Gateway overhead",
-    log_storage_charge: "Log storage",
-    logpush_charge: "Logpush",
-    provisioned_capacity_charge: "Provisioned capacity",
-    training_charge: "Training",
-    custom_model_import_charge: "Custom model import",
-    custom_model_storage_charge: "Custom model storage",
-    manual_adjustment: "Manual adjustment",
-  };
+  const zh = readStoredUiLanguage() === "zh-CN";
+  const map: Record<FinanceEventKind, string> = zh
+    ? {
+        inference_charge: "推理费用",
+        platform_fee: "平台费用",
+        credit_purchase: "积分购买",
+        credit_refund: "积分退款",
+        credit_expiry: "积分过期",
+        byok_fee: "BYOK 费用",
+        gateway_overhead: "网关附加费用",
+        log_storage_charge: "日志存储",
+        logpush_charge: "日志推送",
+        provisioned_capacity_charge: "预置容量",
+        training_charge: "训练费用",
+        custom_model_import_charge: "自定义模型导入",
+        custom_model_storage_charge: "自定义模型存储",
+        manual_adjustment: "手动调整",
+      }
+    : {
+        inference_charge: "Inference charge",
+        platform_fee: "Platform fee",
+        credit_purchase: "Credit purchase",
+        credit_refund: "Credit refund",
+        credit_expiry: "Credit expiry",
+        byok_fee: "BYOK fee",
+        gateway_overhead: "Gateway overhead",
+        log_storage_charge: "Log storage",
+        logpush_charge: "Logpush",
+        provisioned_capacity_charge: "Provisioned capacity",
+        training_charge: "Training",
+        custom_model_import_charge: "Custom model import",
+        custom_model_storage_charge: "Custom model storage",
+        manual_adjustment: "Manual adjustment",
+      };
   return map[eventKind];
 }
 
 export function financeDirectionDisplayName(direction: FinanceDirection): string {
-  return direction === "credit" ? "Credit" : "Debit";
+  return readStoredUiLanguage() === "zh-CN"
+    ? (direction === "credit" ? "入账" : "支出")
+    : (direction === "credit" ? "Credit" : "Debit");
 }
 
 /** Build an issue URL using the human-readable identifier when available. */

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -7,6 +7,7 @@ import { projectsApi } from "../api/projects";
 import { goalsApi } from "../api/goals";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { queryKeys } from "../lib/queryKeys";
 import { EmptyState } from "../components/EmptyState";
 import { ActivityRow } from "../components/ActivityRow";
@@ -20,15 +21,31 @@ import {
 } from "@/components/ui/select";
 import { History } from "lucide-react";
 import type { Agent } from "@paperclipai/shared";
+import { textFor } from "../lib/ui-language";
+
+function activityEntityTypeLabel(type: string, uiLanguage: "en" | "zh-CN") {
+  const labels: Record<string, { en: string; "zh-CN": string }> = {
+    all: { en: "All types", "zh-CN": "全部类型" },
+    issue: { en: "Issue", "zh-CN": "任务" },
+    agent: { en: "Agent", "zh-CN": "智能体" },
+    project: { en: "Project", "zh-CN": "项目" },
+    goal: { en: "Goal", "zh-CN": "目标" },
+    approval: { en: "Approval", "zh-CN": "审批" },
+    heartbeat_run: { en: "Heartbeat run", "zh-CN": "心跳运行" },
+    company: { en: "Company", "zh-CN": "公司" },
+  };
+  return textFor(uiLanguage, labels[type] ?? { en: type.charAt(0).toUpperCase() + type.slice(1), "zh-CN": type });
+}
 
 export function Activity() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const { uiLanguage } = useGeneralSettings();
   const [filter, setFilter] = useState("all");
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Activity" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: textFor(uiLanguage, { en: "Activity", "zh-CN": "活动" }) }]);
+  }, [setBreadcrumbs, uiLanguage]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.activity(selectedCompanyId!),
@@ -82,7 +99,7 @@ export function Activity() {
   }, [issues]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={History} message="Select a company to view activity." />;
+    return <EmptyState icon={History} message={textFor(uiLanguage, { en: "Select a company to view activity.", "zh-CN": "请选择一个公司以查看活动。" })} />;
   }
 
   if (isLoading) {
@@ -103,13 +120,13 @@ export function Activity() {
       <div className="flex items-center justify-end">
         <Select value={filter} onValueChange={setFilter}>
           <SelectTrigger className="w-[140px] h-8 text-xs">
-            <SelectValue placeholder="Filter by type" />
+            <SelectValue placeholder={textFor(uiLanguage, { en: "Filter by type", "zh-CN": "按类型筛选" })} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">All types</SelectItem>
+            <SelectItem value="all">{activityEntityTypeLabel("all", uiLanguage)}</SelectItem>
             {entityTypes.map((type) => (
               <SelectItem key={type} value={type}>
-                {type.charAt(0).toUpperCase() + type.slice(1)}
+                {activityEntityTypeLabel(type, uiLanguage)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -119,7 +136,7 @@ export function Activity() {
       {error && <p className="text-sm text-destructive">{error.message}</p>}
 
       {filtered && filtered.length === 0 && (
-        <EmptyState icon={History} message="No activity yet." />
+        <EmptyState icon={History} message={textFor(uiLanguage, { en: "No activity yet.", "zh-CN": "还没有活动记录。" })} />
       )}
 
       {filtered && filtered.length > 0 && (

--- a/ui/src/pages/AdapterManager.tsx
+++ b/ui/src/pages/AdapterManager.tsx
@@ -9,6 +9,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Cpu, Plus, Power, Trash2, FolderOpen, Package, RefreshCw, Download } from "lucide-react";
 import { useCompany } from "@/context/CompanyContext";
 import { useBreadcrumbs } from "@/context/BreadcrumbContext";
+import { useGeneralSettings } from "@/context/GeneralSettingsContext";
 import { adaptersApi } from "@/api/adapters";
 import type { AdapterInfo } from "@/api/adapters";
 import { getAdapterLabel } from "@/adapters/adapter-display-registry";
@@ -32,6 +33,11 @@ import { cn } from "@/lib/utils";
 import { ChoosePathButton } from "@/components/PathInstructionsModal";
 import { invalidateDynamicParser } from "@/adapters/dynamic-loader";
 import { invalidateConfigSchemaCache } from "@/adapters/schema-config-fields";
+import { textFor, type UiLanguage } from "@/lib/ui-language";
+
+function formatModelsCount(language: UiLanguage, count: number): string {
+  return language === "zh-CN" ? `${count} 个模型` : `${count} models`;
+}
 
 function AdapterRow({
   adapter,
@@ -66,6 +72,58 @@ function AdapterRow({
   toggleTitleDisabled?: string;
   disabledBadgeLabel?: string;
 }) {
+  const { uiLanguage } = useGeneralSettings();
+  const copy = {
+    external: textFor(uiLanguage, {
+      en: "External",
+      "zh-CN": "外部",
+    }),
+    builtIn: textFor(uiLanguage, {
+      en: "Built-in",
+      "zh-CN": "内置",
+    }),
+    installedFromLocalPath: textFor(uiLanguage, {
+      en: "Installed from local path",
+      "zh-CN": "从本地路径安装",
+    }),
+    installedFromNpm: textFor(uiLanguage, {
+      en: "Installed from npm",
+      "zh-CN": "从 npm 安装",
+    }),
+    overridesBuiltIn: textFor(uiLanguage, {
+      en: "Overrides built-in",
+      "zh-CN": "覆盖内置适配器",
+    }),
+    overriddenBy: textFor(uiLanguage, {
+      en: "Overridden by",
+      "zh-CN": "已被覆盖：",
+    }),
+    hiddenFromMenus: textFor(uiLanguage, {
+      en: "Hidden from menus",
+      "zh-CN": "已从菜单中隐藏",
+    }),
+    reinstallAdapter: textFor(uiLanguage, {
+      en: "Reinstall adapter (pull latest from npm)",
+      "zh-CN": "重装适配器（从 npm 拉取最新版本）",
+    }),
+    reloadAdapter: textFor(uiLanguage, {
+      en: "Reload adapter (hot-swap)",
+      "zh-CN": "重新加载适配器（热替换）",
+    }),
+    showInMenus: textFor(uiLanguage, {
+      en: "Show in agent menus",
+      "zh-CN": "在 agent 菜单中显示",
+    }),
+    hideFromMenus: textFor(uiLanguage, {
+      en: "Hide from agent menus",
+      "zh-CN": "从 agent 菜单中隐藏",
+    }),
+    removeAdapter: textFor(uiLanguage, {
+      en: "Remove adapter",
+      "zh-CN": "移除适配器",
+    }),
+  };
+
   return (
     <li>
       <div className="flex items-center gap-4 px-4 py-3">
@@ -74,11 +132,11 @@ function AdapterRow({
             <span className={cn("font-medium", adapter.disabled && "text-muted-foreground line-through")}>
               {adapter.label || getAdapterLabel(adapter.type)}
             </span>
-            <Badge variant="outline">{adapter.source === "external" ? "External" : "Built-in"}</Badge>
+            <Badge variant="outline">{adapter.source === "external" ? copy.external : copy.builtIn}</Badge>
             {adapter.source === "external" && (
               adapter.isLocalPath
-                ? <span title="Installed from local path"><FolderOpen className="h-4 w-4 text-amber-500" /></span>
-                : <span title="Installed from npm"><Package className="h-4 w-4 text-red-500" /></span>
+                ? <span title={copy.installedFromLocalPath}><FolderOpen className="h-4 w-4 text-amber-500" /></span>
+                : <span title={copy.installedFromNpm}><Package className="h-4 w-4 text-red-500" /></span>
             )}
             {adapter.version && (
               <Badge variant="secondary" className="font-mono text-[10px]">
@@ -87,17 +145,17 @@ function AdapterRow({
             )}
             {adapter.overriddenBuiltin && (
               <Badge variant="secondary" className="text-blue-600 border-blue-400">
-                Overrides built-in
+                {copy.overridesBuiltIn}
               </Badge>
             )}
             {overriddenBy && (
               <Badge variant="secondary" className="text-blue-600 border-blue-400">
-                Overridden by {overriddenBy}
+                {copy.overriddenBy} {overriddenBy}
               </Badge>
             )}
             {adapter.disabled && (
               <Badge variant="secondary" className="text-amber-600 border-amber-400">
-                {disabledBadgeLabel ?? "Hidden from menus"}
+                {disabledBadgeLabel ?? copy.hiddenFromMenus}
               </Badge>
             )}
           </div>
@@ -106,7 +164,7 @@ function AdapterRow({
             {adapter.packageName && adapter.packageName !== adapter.type && (
               <> · {adapter.packageName}</>
             )}
-            {" · "}{adapter.modelsCount} models
+            {" · "}{formatModelsCount(uiLanguage, adapter.modelsCount)}
           </p>
         </div>
         <div className="flex items-center gap-2 shrink-0">
@@ -115,7 +173,7 @@ function AdapterRow({
               variant="outline"
               size="icon-sm"
               className="h-8 w-8"
-              title="Reinstall adapter (pull latest from npm)"
+              title={copy.reinstallAdapter}
               disabled={isReinstalling}
               onClick={() => onReinstall(adapter.type)}
             >
@@ -127,7 +185,7 @@ function AdapterRow({
               variant="outline"
               size="icon-sm"
               className="h-8 w-8"
-              title="Reload adapter (hot-swap)"
+              title={copy.reloadAdapter}
               disabled={isReloading}
               onClick={() => onReload(adapter.type)}
             >
@@ -139,8 +197,8 @@ function AdapterRow({
             size="icon-sm"
             className="h-8 w-8"
             title={adapter.disabled
-              ? (toggleTitleEnabled ?? "Show in agent menus")
-              : (toggleTitleDisabled ?? "Hide from agent menus")}
+              ? (toggleTitleEnabled ?? copy.showInMenus)
+              : (toggleTitleDisabled ?? copy.hideFromMenus)}
             disabled={isToggling}
             onClick={() => onToggle(adapter.type, !adapter.disabled)}
           >
@@ -148,13 +206,13 @@ function AdapterRow({
           </Button>
           {canRemove && (
             <Button
-              variant="outline"
-              size="icon-sm"
-              className="h-8 w-8 text-destructive hover:text-destructive"
-              title="Remove adapter"
-              onClick={() => onRemove(adapter.type)}
-            >
-              <Trash2 className="h-4 w-4" />
+            variant="outline"
+            size="icon-sm"
+            className="h-8 w-8 text-destructive hover:text-destructive"
+            title={copy.removeAdapter}
+            onClick={() => onRemove(adapter.type)}
+          >
+            <Trash2 className="h-4 w-4" />
             </Button>
           )}
         </div>
@@ -185,6 +243,54 @@ function ReinstallDialog({
   onConfirm: () => void;
   onCancel: () => void;
 }) {
+  const { uiLanguage } = useGeneralSettings();
+  const copy = {
+    title: textFor(uiLanguage, {
+      en: "Reinstall Adapter",
+      "zh-CN": "重装适配器",
+    }),
+    package: textFor(uiLanguage, {
+      en: "Package",
+      "zh-CN": "包名",
+    }),
+    current: textFor(uiLanguage, {
+      en: "Current",
+      "zh-CN": "当前版本",
+    }),
+    latestOnNpm: textFor(uiLanguage, {
+      en: "Latest on npm",
+      "zh-CN": "npm 最新版本",
+    }),
+    unknown: textFor(uiLanguage, {
+      en: "unknown",
+      "zh-CN": "未知",
+    }),
+    checking: textFor(uiLanguage, {
+      en: "checking...",
+      "zh-CN": "检查中...",
+    }),
+    unavailable: textFor(uiLanguage, {
+      en: "unavailable",
+      "zh-CN": "不可用",
+    }),
+    alreadyLatest: textFor(uiLanguage, {
+      en: "Already on the latest version.",
+      "zh-CN": "已经是最新版本。",
+    }),
+    cancel: textFor(uiLanguage, {
+      en: "Cancel",
+      "zh-CN": "取消",
+    }),
+    reinstall: textFor(uiLanguage, {
+      en: "Reinstall",
+      "zh-CN": "重装",
+    }),
+    reinstalling: textFor(uiLanguage, {
+      en: "Reinstalling...",
+      "zh-CN": "重装中...",
+    }),
+  };
+
   const { data: latestVersion, isLoading: isFetchingVersion } = useQuery({
     queryKey: ["npm-latest-version", adapter?.packageName],
     queryFn: () => {
@@ -201,49 +307,58 @@ function ReinstallDialog({
     <Dialog open={open} onOpenChange={(o) => { if (!o) onCancel(); }}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Reinstall Adapter</DialogTitle>
+          <DialogTitle>{copy.title}</DialogTitle>
           <DialogDescription>
-            This will pull the latest version of{" "}
-            <strong>{adapter?.packageName}</strong> from npm and hot-swap
-            the running adapter module. Existing agents will use the new
-            version on their next run.
+            {uiLanguage === "zh-CN" ? (
+              <>
+                这会从 npm 拉取 <strong>{adapter?.packageName}</strong> 的最新版本，并热替换当前运行的适配器模块。现有
+                agents 会在下次运行时使用新版本。
+              </>
+            ) : (
+              <>
+                This will pull the latest version of{" "}
+                <strong>{adapter?.packageName}</strong> from npm and hot-swap
+                the running adapter module. Existing agents will use the new
+                version on their next run.
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
 
         <div className="rounded-md border bg-muted/50 px-4 py-3 text-sm space-y-1">
           <div className="flex items-center justify-between">
-            <span className="text-muted-foreground">Package</span>
+            <span className="text-muted-foreground">{copy.package}</span>
             <span className="font-mono">{adapter?.packageName}</span>
           </div>
           <div className="flex items-center justify-between">
-            <span className="text-muted-foreground">Current</span>
+            <span className="text-muted-foreground">{copy.current}</span>
             <span className="font-mono">
-              {adapter?.version ? `v${adapter.version}` : "unknown"}
+              {adapter?.version ? `v${adapter.version}` : copy.unknown}
             </span>
           </div>
           <div className="flex items-center justify-between">
-            <span className="text-muted-foreground">Latest on npm</span>
+            <span className="text-muted-foreground">{copy.latestOnNpm}</span>
             <span className="font-mono">
               {isFetchingVersion
-                ? "checking..."
+                ? copy.checking
                 : latestVersion
                   ? `v${latestVersion}`
-                  : "unavailable"}
+                  : copy.unavailable}
             </span>
           </div>
           {isUpToDate && (
             <p className="text-xs text-muted-foreground pt-1">
-              Already on the latest version.
+              {copy.alreadyLatest}
             </p>
           )}
         </div>
 
         <DialogFooter>
           <Button variant="outline" onClick={onCancel} disabled={isReinstalling}>
-            Cancel
+            {copy.cancel}
           </Button>
           <Button disabled={isReinstalling} onClick={onConfirm}>
-            {isReinstalling ? "Reinstalling..." : "Reinstall"}
+            {isReinstalling ? copy.reinstalling : copy.reinstall}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -253,6 +368,7 @@ function ReinstallDialog({
 
 export function AdapterManager() {
   const { selectedCompany } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const { pushToast } = useToast();
@@ -263,14 +379,194 @@ export function AdapterManager() {
   const [installDialogOpen, setInstallDialogOpen] = useState(false);
   const [removeType, setRemoveType] = useState<string | null>(null);
   const [reinstallTarget, setReinstallTarget] = useState<AdapterInfo | null>(null);
+  const copy = {
+    company: textFor(uiLanguage, {
+      en: "Company",
+      "zh-CN": "公司",
+    }),
+    settings: textFor(uiLanguage, {
+      en: "Settings",
+      "zh-CN": "设置",
+    }),
+    adapters: textFor(uiLanguage, {
+      en: "Adapters",
+      "zh-CN": "适配器",
+    }),
+    loadingAdapters: textFor(uiLanguage, {
+      en: "Loading adapters...",
+      "zh-CN": "正在加载适配器...",
+    }),
+    alpha: textFor(uiLanguage, {
+      en: "Alpha",
+      "zh-CN": "Alpha",
+    }),
+    installAdapter: textFor(uiLanguage, {
+      en: "Install Adapter",
+      "zh-CN": "安装适配器",
+    }),
+    installExternalAdapter: textFor(uiLanguage, {
+      en: "Install External Adapter",
+      "zh-CN": "安装外部适配器",
+    }),
+    installExternalAdapterDescription: textFor(uiLanguage, {
+      en: "Add an adapter from npm or a local path. The adapter package must export createServerAdapter().",
+      "zh-CN": "从 npm 或本地路径添加适配器。适配器包必须导出 createServerAdapter()。",
+    }),
+    npmPackage: textFor(uiLanguage, {
+      en: "npm package",
+      "zh-CN": "npm 包",
+    }),
+    localPath: textFor(uiLanguage, {
+      en: "Local path",
+      "zh-CN": "本地路径",
+    }),
+    pathToPackage: textFor(uiLanguage, {
+      en: "Path to adapter package",
+      "zh-CN": "适配器包路径",
+    }),
+    acceptsPaths: textFor(uiLanguage, {
+      en: "Accepts Linux, WSL, and Windows paths. Windows paths are auto-converted.",
+      "zh-CN": "支持 Linux、WSL 和 Windows 路径。Windows 路径会自动转换。",
+    }),
+    packageName: textFor(uiLanguage, {
+      en: "Package Name",
+      "zh-CN": "包名",
+    }),
+    versionOptional: textFor(uiLanguage, {
+      en: "Version (optional)",
+      "zh-CN": "版本（可选）",
+    }),
+    cancel: textFor(uiLanguage, {
+      en: "Cancel",
+      "zh-CN": "取消",
+    }),
+    install: textFor(uiLanguage, {
+      en: "Install",
+      "zh-CN": "安装",
+    }),
+    installing: textFor(uiLanguage, {
+      en: "Installing...",
+      "zh-CN": "安装中...",
+    }),
+    externalAdaptersAlpha: textFor(uiLanguage, {
+      en: "External adapters are alpha.",
+      "zh-CN": "外部适配器仍处于 Alpha 阶段。",
+    }),
+    externalAdaptersAlphaDescription: textFor(uiLanguage, {
+      en: "The adapter plugin system is under active development. APIs and storage format may change. Use the power icon to hide adapters from agent menus without removing them.",
+      "zh-CN": "适配器插件系统仍在积极开发中，API 和存储格式都可能变化。可以使用电源图标把适配器从 agent 菜单中隐藏，而不必直接移除。",
+    }),
+    externalAdapters: textFor(uiLanguage, {
+      en: "External Adapters",
+      "zh-CN": "外部适配器",
+    }),
+    noExternalAdapters: textFor(uiLanguage, {
+      en: "No external adapters installed",
+      "zh-CN": "尚未安装外部适配器",
+    }),
+    noExternalAdaptersDescription: textFor(uiLanguage, {
+      en: "Install an adapter package to extend model support.",
+      "zh-CN": "安装适配器包以扩展模型支持。",
+    }),
+    pauseExternalOverride: textFor(uiLanguage, {
+      en: "Pause external override",
+      "zh-CN": "暂停外部覆盖",
+    }),
+    resumeExternalOverride: textFor(uiLanguage, {
+      en: "Resume external override",
+      "zh-CN": "恢复外部覆盖",
+    }),
+    overridePaused: textFor(uiLanguage, {
+      en: "Override paused",
+      "zh-CN": "覆盖已暂停",
+    }),
+    builtInAdapters: textFor(uiLanguage, {
+      en: "Built-in Adapters",
+      "zh-CN": "内置适配器",
+    }),
+    noBuiltInAdapters: textFor(uiLanguage, {
+      en: "No built-in adapters found.",
+      "zh-CN": "未找到内置适配器。",
+    }),
+    removeAdapter: textFor(uiLanguage, {
+      en: "Remove Adapter",
+      "zh-CN": "移除适配器",
+    }),
+    remove: textFor(uiLanguage, {
+      en: "Remove",
+      "zh-CN": "移除",
+    }),
+    removing: textFor(uiLanguage, {
+      en: "Removing...",
+      "zh-CN": "移除中...",
+    }),
+    adapterInstalled: textFor(uiLanguage, {
+      en: "Adapter installed",
+      "zh-CN": "适配器安装成功",
+    }),
+    installFailed: textFor(uiLanguage, {
+      en: "Install failed",
+      "zh-CN": "安装失败",
+    }),
+    adapterRemoved: textFor(uiLanguage, {
+      en: "Adapter removed",
+      "zh-CN": "适配器已移除",
+    }),
+    removalFailed: textFor(uiLanguage, {
+      en: "Removal failed",
+      "zh-CN": "移除失败",
+    }),
+    toggleFailed: textFor(uiLanguage, {
+      en: "Toggle failed",
+      "zh-CN": "切换失败",
+    }),
+    overrideToggleFailed: textFor(uiLanguage, {
+      en: "Override toggle failed",
+      "zh-CN": "覆盖切换失败",
+    }),
+    adapterReloaded: textFor(uiLanguage, {
+      en: "Adapter reloaded",
+      "zh-CN": "适配器已重新加载",
+    }),
+    reloadFailed: textFor(uiLanguage, {
+      en: "Reload failed",
+      "zh-CN": "重新加载失败",
+    }),
+    adapterReinstalled: textFor(uiLanguage, {
+      en: "Adapter reinstalled",
+      "zh-CN": "适配器已重装",
+    }),
+    reinstallFailed: textFor(uiLanguage, {
+      en: "Reinstall failed",
+      "zh-CN": "重装失败",
+    }),
+  };
+  const formatVersionSuffix = (version?: string | null) =>
+    version
+      ? uiLanguage === "zh-CN"
+        ? `（v${version}）`
+        : ` (v${version})`
+      : "";
+  const registeredBody = (type: string, version?: string | null) =>
+    uiLanguage === "zh-CN"
+      ? `类型“${type}”已成功注册。${formatVersionSuffix(version)}`
+      : `Type "${type}" registered successfully.${formatVersionSuffix(version)}`;
+  const reloadedBody = (type: string, version?: string | null) =>
+    uiLanguage === "zh-CN"
+      ? `类型“${type}”已重新加载。${formatVersionSuffix(version)}`
+      : `Type "${type}" reloaded.${formatVersionSuffix(version)}`;
+  const updatedFromNpmBody = (type: string, version?: string | null) =>
+    uiLanguage === "zh-CN"
+      ? `类型“${type}”已从 npm 更新。${formatVersionSuffix(version)}`
+      : `Type "${type}" updated from npm.${formatVersionSuffix(version)}`;
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: selectedCompany?.name ?? "Company", href: "/dashboard" },
-      { label: "Settings", href: "/instance/settings/general" },
-      { label: "Adapters" },
+      { label: selectedCompany?.name ?? copy.company, href: "/dashboard" },
+      { label: copy.settings, href: "/instance/settings/general" },
+      { label: copy.adapters },
     ]);
-  }, [selectedCompany?.name, setBreadcrumbs]);
+  }, [copy.adapters, copy.company, copy.settings, selectedCompany?.name, setBreadcrumbs]);
 
   const { data: adapters, isLoading } = useQuery({
     queryKey: queryKeys.adapters.all,
@@ -291,13 +587,13 @@ export function AdapterManager() {
       setInstallVersion("");
       setIsLocalPath(false);
       pushToast({
-        title: "Adapter installed",
-        body: `Type "${result.type}" registered successfully.${result.version ? ` (v${result.version})` : ""}`,
+        title: copy.adapterInstalled,
+        body: registeredBody(result.type, result.version),
         tone: "success",
       });
     },
     onError: (err: Error) => {
-      pushToast({ title: "Install failed", body: err.message, tone: "error" });
+      pushToast({ title: copy.installFailed, body: err.message, tone: "error" });
     },
   });
 
@@ -305,10 +601,10 @@ export function AdapterManager() {
     mutationFn: (type: string) => adaptersApi.remove(type),
     onSuccess: () => {
       invalidate();
-      pushToast({ title: "Adapter removed", tone: "success" });
+      pushToast({ title: copy.adapterRemoved, tone: "success" });
     },
     onError: (err: Error) => {
-      pushToast({ title: "Removal failed", body: err.message, tone: "error" });
+      pushToast({ title: copy.removalFailed, body: err.message, tone: "error" });
     },
   });
 
@@ -319,7 +615,7 @@ export function AdapterManager() {
       invalidate();
     },
     onError: (err: Error) => {
-      pushToast({ title: "Toggle failed", body: err.message, tone: "error" });
+      pushToast({ title: copy.toggleFailed, body: err.message, tone: "error" });
     },
   });
 
@@ -330,7 +626,7 @@ export function AdapterManager() {
       invalidate();
     },
     onError: (err: Error) => {
-      pushToast({ title: "Override toggle failed", body: err.message, tone: "error" });
+      pushToast({ title: copy.overrideToggleFailed, body: err.message, tone: "error" });
     },
   });
 
@@ -341,13 +637,13 @@ export function AdapterManager() {
       invalidateDynamicParser(result.type);
       invalidateConfigSchemaCache(result.type);
       pushToast({
-        title: "Adapter reloaded",
-        body: `Type "${result.type}" reloaded.${result.version ? ` (v${result.version})` : ""}`,
+        title: copy.adapterReloaded,
+        body: reloadedBody(result.type, result.version),
         tone: "success",
       });
     },
     onError: (err: Error) => {
-      pushToast({ title: "Reload failed", body: err.message, tone: "error" });
+      pushToast({ title: copy.reloadFailed, body: err.message, tone: "error" });
     },
   });
 
@@ -358,13 +654,13 @@ export function AdapterManager() {
       invalidateDynamicParser(result.type);
       invalidateConfigSchemaCache(result.type);
       pushToast({
-        title: "Adapter reinstalled",
-        body: `Type "${result.type}" updated from npm.${result.version ? ` (v${result.version})` : ""}`,
+        title: copy.adapterReinstalled,
+        body: updatedFromNpmBody(result.type, result.version),
         tone: "success",
       });
     },
     onError: (err: Error) => {
-      pushToast({ title: "Reinstall failed", body: err.message, tone: "error" });
+      pushToast({ title: copy.reinstallFailed, body: err.message, tone: "error" });
     },
   });
 
@@ -388,7 +684,7 @@ export function AdapterManager() {
       menuDisabled: !!a.disabled,
     }));
 
-  if (isLoading) return <div className="p-4 text-sm text-muted-foreground">Loading adapters...</div>;
+  if (isLoading) return <div className="p-4 text-sm text-muted-foreground">{copy.loadingAdapters}</div>;
 
   const isMutating = installMutation.isPending || removeMutation.isPending || toggleMutation.isPending || overrideMutation.isPending || reloadMutation.isPending || reinstallMutation.isPending;
 
@@ -398,9 +694,9 @@ export function AdapterManager() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Cpu className="h-6 w-6 text-muted-foreground" />
-          <h1 className="text-xl font-semibold">Adapters</h1>
+          <h1 className="text-xl font-semibold">{copy.adapters}</h1>
           <Badge variant="outline" className="text-amber-600 border-amber-400">
-            Alpha
+            {copy.alpha}
           </Badge>
         </div>
 
@@ -408,14 +704,16 @@ export function AdapterManager() {
           <DialogTrigger asChild>
             <Button size="sm" className="gap-2">
               <Plus className="h-4 w-4" />
-              Install Adapter
+              {copy.installAdapter}
             </Button>
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Install External Adapter</DialogTitle>
+              <DialogTitle>{copy.installExternalAdapter}</DialogTitle>
               <DialogDescription>
-                Add an adapter from npm or a local path. The adapter package must export <code className="text-xs bg-muted px-1 py-0.5 rounded">createServerAdapter()</code>.
+                {copy.installExternalAdapterDescription}
+                {" "}
+                <code className="text-xs bg-muted px-1 py-0.5 rounded">createServerAdapter()</code>.
               </DialogDescription>
             </DialogHeader>
             <div className="grid gap-4 py-4">
@@ -432,7 +730,7 @@ export function AdapterManager() {
                   onClick={() => setIsLocalPath(false)}
                 >
                   <Package className="h-3.5 w-3.5" />
-                  npm package
+                  {copy.npmPackage}
                 </button>
                 <button
                   type="button"
@@ -445,14 +743,14 @@ export function AdapterManager() {
                   onClick={() => setIsLocalPath(true)}
                 >
                   <FolderOpen className="h-3.5 w-3.5" />
-                  Local path
+                  {copy.localPath}
                 </button>
               </div>
 
               {isLocalPath ? (
                 /* Local path input */
                 <div className="grid gap-2">
-                  <Label htmlFor="adapterLocalPath">Path to adapter package</Label>
+                  <Label htmlFor="adapterLocalPath">{copy.pathToPackage}</Label>
                   <div className="flex gap-2">
                     <Input
                       id="adapterLocalPath"
@@ -464,14 +762,14 @@ export function AdapterManager() {
                     <ChoosePathButton />
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Accepts Linux, WSL, and Windows paths. Windows paths are auto-converted.
+                    {copy.acceptsPaths}
                   </p>
                 </div>
               ) : (
                 /* npm package input */
                 <>
                   <div className="grid gap-2">
-                    <Label htmlFor="adapterPackageName">Package Name</Label>
+                    <Label htmlFor="adapterPackageName">{copy.packageName}</Label>
                     <Input
                       id="adapterPackageName"
                       placeholder="my-paperclip-adapter"
@@ -480,7 +778,7 @@ export function AdapterManager() {
                     />
                   </div>
                   <div className="grid gap-2">
-                    <Label htmlFor="adapterVersion">Version (optional)</Label>
+                    <Label htmlFor="adapterVersion">{copy.versionOptional}</Label>
                     <Input
                       id="adapterVersion"
                       placeholder="latest"
@@ -492,7 +790,7 @@ export function AdapterManager() {
               )}
             </div>
             <DialogFooter>
-              <Button variant="outline" onClick={() => setInstallDialogOpen(false)}>Cancel</Button>
+              <Button variant="outline" onClick={() => setInstallDialogOpen(false)}>{copy.cancel}</Button>
               <Button
                 onClick={() =>
                   installMutation.mutate({
@@ -503,7 +801,7 @@ export function AdapterManager() {
                 }
                 disabled={!installPackage || installMutation.isPending}
               >
-                {installMutation.isPending ? "Installing..." : "Install"}
+                {installMutation.isPending ? copy.installing : copy.install}
               </Button>
             </DialogFooter>
           </DialogContent>
@@ -515,10 +813,9 @@ export function AdapterManager() {
         <div className="flex items-start gap-3">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" />
           <div className="space-y-1 text-sm">
-            <p className="font-medium text-foreground">External adapters are alpha.</p>
+            <p className="font-medium text-foreground">{copy.externalAdaptersAlpha}</p>
             <p className="text-muted-foreground">
-              The adapter plugin system is under active development. APIs and storage format may change.
-              Use the power icon to hide adapters from agent menus without removing them.
+              {copy.externalAdaptersAlphaDescription}
             </p>
           </div>
         </div>
@@ -528,16 +825,16 @@ export function AdapterManager() {
       <section className="space-y-3">
         <div className="flex items-center gap-2">
           <Cpu className="h-5 w-5 text-muted-foreground" />
-          <h2 className="text-base font-semibold">External Adapters</h2>
+          <h2 className="text-base font-semibold">{copy.externalAdapters}</h2>
         </div>
 
         {externalAdapters.length === 0 ? (
           <Card className="bg-muted/30">
             <CardContent className="flex flex-col items-center justify-center py-10">
               <Cpu className="h-10 w-10 text-muted-foreground mb-4" />
-              <p className="text-sm font-medium">No external adapters installed</p>
+              <p className="text-sm font-medium">{copy.noExternalAdapters}</p>
               <p className="text-xs text-muted-foreground mt-1">
-                Install an adapter package to extend model support.
+                {copy.noExternalAdaptersDescription}
               </p>
             </CardContent>
           </Card>
@@ -569,9 +866,9 @@ export function AdapterManager() {
                   isToggling={isBuiltinOverride ? overrideMutation.isPending : toggleMutation.isPending}
                   isReloading={reloadMutation.isPending}
                   isReinstalling={reinstallMutation.isPending}
-                  toggleTitleDisabled={isBuiltinOverride ? "Pause external override" : undefined}
-                  toggleTitleEnabled={isBuiltinOverride ? "Resume external override" : undefined}
-                  disabledBadgeLabel={isBuiltinOverride ? "Override paused" : undefined}
+                  toggleTitleDisabled={isBuiltinOverride ? copy.pauseExternalOverride : undefined}
+                  toggleTitleEnabled={isBuiltinOverride ? copy.resumeExternalOverride : undefined}
+                  disabledBadgeLabel={isBuiltinOverride ? copy.overridePaused : undefined}
                 />
               );
             })}
@@ -583,11 +880,11 @@ export function AdapterManager() {
       <section className="space-y-3">
         <div className="flex items-center gap-2">
           <Cpu className="h-5 w-5 text-muted-foreground" />
-          <h2 className="text-base font-semibold">Built-in Adapters</h2>
+          <h2 className="text-base font-semibold">{copy.builtInAdapters}</h2>
         </div>
 
         {builtinAdapters.length === 0 && overriddenBuiltins.length === 0 ? (
-          <div className="text-sm text-muted-foreground">No built-in adapters found.</div>
+          <div className="text-sm text-muted-foreground">{copy.noBuiltInAdapters}</div>
         ) : (
           <ul className="divide-y rounded-md border bg-card">
             {builtinAdapters.map((adapter) => (
@@ -629,18 +926,30 @@ export function AdapterManager() {
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Remove Adapter</DialogTitle>
+            <DialogTitle>{copy.removeAdapter}</DialogTitle>
             <DialogDescription>
-              Are you sure you want to remove the <strong>{removeType}</strong> adapter?
-              It will be unregistered and removed from the adapter store.
-              {removeType && adapters?.find((a) => a.type === removeType)?.packageName && (
-                <> npm packages will be cleaned up from disk.</>
+              {uiLanguage === "zh-CN" ? (
+                <>
+                  确认要移除 <strong>{removeType}</strong> 适配器吗？它会从适配器存储中注销并删除。
+                  {removeType && adapters?.find((a) => a.type === removeType)?.packageName && (
+                    <> 对应的 npm 包也会从磁盘中清理。</>
+                  )}
+                  {" "}此操作无法撤销。
+                </>
+              ) : (
+                <>
+                  Are you sure you want to remove the <strong>{removeType}</strong> adapter?
+                  It will be unregistered and removed from the adapter store.
+                  {removeType && adapters?.find((a) => a.type === removeType)?.packageName && (
+                    <> npm packages will be cleaned up from disk.</>
+                  )}
+                  {" "}This action cannot be undone.
+                </>
               )}
-              {" "}This action cannot be undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setRemoveType(null)}>Cancel</Button>
+            <Button variant="outline" onClick={() => setRemoveType(null)}>{copy.cancel}</Button>
             <Button
               variant="destructive"
               disabled={removeMutation.isPending}
@@ -652,7 +961,7 @@ export function AdapterManager() {
                 }
               }}
             >
-              {removeMutation.isPending ? "Removing..." : "Remove"}
+              {removeMutation.isPending ? copy.removing : copy.remove}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -18,6 +18,7 @@ import { issuesApi } from "../api/issues";
 import { usePanel } from "../context/PanelContext";
 import { useSidebar } from "../context/SidebarContext";
 import { useCompany } from "../context/CompanyContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { useToast } from "../context/ToastContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
@@ -97,6 +98,7 @@ import {
   arraysEqual,
   isReadOnlyUnmanagedSkillEntry,
 } from "../lib/agent-skills-state";
+import { textFor, type UiLanguage } from "../lib/ui-language";
 
 const runStatusIcons: Record<string, { icon: typeof CheckCircle2; color: string }> = {
   succeeded: { icon: CheckCircle2, color: "text-green-600 dark:text-green-400" },
@@ -162,12 +164,50 @@ function formatEnvForDisplay(envValue: unknown, censorUsernameInLogs: boolean): 
     .join("\n");
 }
 
-const sourceLabels: Record<string, string> = {
-  timer: "Timer",
-  assignment: "Assignment",
-  on_demand: "On-demand",
-  automation: "Automation",
-};
+function sourceLabel(source: string, uiLanguage: UiLanguage): string {
+  const labels: Record<string, { en: string; zh: string }> = {
+    timer: { en: "Timer", zh: "定时器" },
+    assignment: { en: "Assignment", zh: "任务分配" },
+    on_demand: { en: "On-demand", zh: "按需触发" },
+    automation: { en: "Automation", zh: "自动化" },
+  };
+  const label = labels[source];
+  return label ? (uiLanguage === "zh-CN" ? label.zh : label.en) : source;
+}
+
+function agentDetailViewLabel(view: AgentDetailView, uiLanguage: UiLanguage): string {
+  const labels: Record<AgentDetailView, { en: string; zh: string }> = {
+    dashboard: { en: "Dashboard", zh: "仪表盘" },
+    instructions: { en: "Instructions", zh: "说明" },
+    configuration: { en: "Configuration", zh: "配置" },
+    skills: { en: "Skills", zh: "技能" },
+    runs: { en: "Runs", zh: "运行记录" },
+    budget: { en: "Budget", zh: "预算" },
+  };
+  return uiLanguage === "zh-CN" ? labels[view].zh : labels[view].en;
+}
+
+function workspaceOperationPhaseLabel(phase: WorkspaceOperation["phase"], uiLanguage: UiLanguage) {
+  const labels: Record<string, { en: string; zh: string }> = {
+    worktree_prepare: { en: "Worktree setup", zh: "工作树准备" },
+    workspace_provision: { en: "Provision", zh: "工作区创建" },
+    workspace_teardown: { en: "Teardown", zh: "工作区回收" },
+    worktree_cleanup: { en: "Worktree cleanup", zh: "工作树清理" },
+  };
+  const label = labels[phase];
+  return label ? (uiLanguage === "zh-CN" ? label.zh : label.en) : phase;
+}
+
+function workspaceOperationStatusLabel(status: WorkspaceOperation["status"], uiLanguage: UiLanguage) {
+  const labels: Record<string, { en: string; zh: string }> = {
+    succeeded: { en: "Succeeded", zh: "成功" },
+    failed: { en: "Failed", zh: "失败" },
+    running: { en: "Running", zh: "运行中" },
+    skipped: { en: "Skipped", zh: "已跳过" },
+  };
+  const label = labels[status];
+  return label ? (uiLanguage === "zh-CN" ? label.zh : label.en) : status.replace("_", " ");
+}
 
 const LIVE_SCROLL_BOTTOM_TOLERANCE_PX = 32;
 type ScrollContainer = Window | HTMLElement;
@@ -297,6 +337,7 @@ export function RunInvocationCard({
   payload: Record<string, unknown>;
   censorUsernameInLogs: boolean;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const commandLine = [
     typeof payload.command === "string" ? payload.command : null,
     ...(Array.isArray(payload.commandArgs)
@@ -312,32 +353,43 @@ export function RunInvocationCard({
     || payload.prompt !== undefined
     || payload.context !== undefined
     || payload.env !== undefined;
+  const copy = {
+    invocation: textFor(uiLanguage, { en: "Invocation", "zh-CN": "调用信息" }),
+    adapter: textFor(uiLanguage, { en: "Adapter", "zh-CN": "适配器" }),
+    workingDir: textFor(uiLanguage, { en: "Working dir", "zh-CN": "工作目录" }),
+    details: textFor(uiLanguage, { en: "Details", "zh-CN": "详情" }),
+    command: textFor(uiLanguage, { en: "Command", "zh-CN": "命令" }),
+    commandNotes: textFor(uiLanguage, { en: "Command notes", "zh-CN": "命令说明" }),
+    prompt: textFor(uiLanguage, { en: "Prompt", "zh-CN": "提示词" }),
+    context: textFor(uiLanguage, { en: "Context", "zh-CN": "上下文" }),
+    environment: textFor(uiLanguage, { en: "Environment", "zh-CN": "环境变量" }),
+  };
 
   return (
     <div className="rounded-lg border border-border bg-background/60 p-3 space-y-2">
-      <div className="text-xs font-medium text-muted-foreground">Invocation</div>
+      <div className="text-xs font-medium text-muted-foreground">{copy.invocation}</div>
       {typeof payload.adapterType === "string" && (
-        <div className="text-xs"><span className="text-muted-foreground">Adapter: </span>{payload.adapterType}</div>
+        <div className="text-xs"><span className="text-muted-foreground">{copy.adapter}: </span>{payload.adapterType}</div>
       )}
       {typeof payload.cwd === "string" && (
-        <div className="text-xs break-all"><span className="text-muted-foreground">Working dir: </span><span className="font-mono">{payload.cwd}</span></div>
+        <div className="text-xs break-all"><span className="text-muted-foreground">{copy.workingDir}: </span><span className="font-mono">{payload.cwd}</span></div>
       )}
       {hasAdvancedDetails && (
         <Collapsible>
           <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors group">
             <ChevronRight className="h-3 w-3 transition-transform group-data-[state=open]:rotate-90" />
-            Details
+            {copy.details}
           </CollapsibleTrigger>
           <CollapsibleContent className="pt-2 space-y-2">
             {commandLine && (
               <div className="text-xs break-all">
-                <span className="text-muted-foreground">Command: </span>
+                <span className="text-muted-foreground">{copy.command}: </span>
                 <span className="font-mono">{commandLine}</span>
               </div>
             )}
             {Array.isArray(payload.commandNotes) && payload.commandNotes.length > 0 && (
               <div>
-                <div className="text-xs text-muted-foreground mb-1">Command notes</div>
+                <div className="text-xs text-muted-foreground mb-1">{copy.commandNotes}</div>
                 <ul className="list-disc pl-5 space-y-1">
                   {payload.commandNotes
                     .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
@@ -351,7 +403,7 @@ export function RunInvocationCard({
             )}
             {payload.prompt !== undefined && (
               <div>
-                <div className="text-xs text-muted-foreground mb-1">Prompt</div>
+                <div className="text-xs text-muted-foreground mb-1">{copy.prompt}</div>
                 <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap">
                   {typeof payload.prompt === "string"
                     ? redactPathText(payload.prompt, censorUsernameInLogs)
@@ -361,7 +413,7 @@ export function RunInvocationCard({
             )}
             {payload.context !== undefined && (
               <div>
-                <div className="text-xs text-muted-foreground mb-1">Context</div>
+                <div className="text-xs text-muted-foreground mb-1">{copy.context}</div>
                 <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap">
                   {JSON.stringify(redactPathValue(payload.context, censorUsernameInLogs), null, 2)}
                 </pre>
@@ -369,7 +421,7 @@ export function RunInvocationCard({
             )}
             {payload.env !== undefined && (
               <div>
-                <div className="text-xs text-muted-foreground mb-1">Environment</div>
+                <div className="text-xs text-muted-foreground mb-1">{copy.environment}</div>
                 <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap font-mono">
                   {formatEnvForDisplay(payload.env, censorUsernameInLogs)}
                 </pre>
@@ -402,21 +454,6 @@ function parseStoredLogContent(content: string): RunLogChunk[] {
   return parsed;
 }
 
-function workspaceOperationPhaseLabel(phase: WorkspaceOperation["phase"]) {
-  switch (phase) {
-    case "worktree_prepare":
-      return "Worktree setup";
-    case "workspace_provision":
-      return "Provision";
-    case "workspace_teardown":
-      return "Teardown";
-    case "worktree_cleanup":
-      return "Worktree cleanup";
-    default:
-      return phase;
-  }
-}
-
 function workspaceOperationStatusTone(status: WorkspaceOperation["status"]) {
   switch (status) {
     case "succeeded":
@@ -433,6 +470,7 @@ function workspaceOperationStatusTone(status: WorkspaceOperation["status"]) {
 }
 
 function WorkspaceOperationStatusBadge({ status }: { status: WorkspaceOperation["status"] }) {
+  const { uiLanguage } = useGeneralSettings();
   return (
     <span
       className={cn(
@@ -440,7 +478,7 @@ function WorkspaceOperationStatusBadge({ status }: { status: WorkspaceOperation[
         workspaceOperationStatusTone(status),
       )}
     >
-      {status.replace("_", " ")}
+      {workspaceOperationStatusLabel(status, uiLanguage)}
     </span>
   );
 }
@@ -452,6 +490,7 @@ function WorkspaceOperationLogViewer({
   operation: WorkspaceOperation;
   censorUsernameInLogs: boolean;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const [open, setOpen] = useState(false);
   const { data: logData, isLoading, error } = useQuery({
     queryKey: ["workspace-operation-log", operation.id],
@@ -464,6 +503,13 @@ function WorkspaceOperationLogViewer({
     () => (logData?.content ? parseStoredLogContent(logData.content) : []),
     [logData?.content],
   );
+  const copy = {
+    hideLog: textFor(uiLanguage, { en: "Hide full log", "zh-CN": "隐藏完整日志" }),
+    showLog: textFor(uiLanguage, { en: "Show full log", "zh-CN": "显示完整日志" }),
+    loading: textFor(uiLanguage, { en: "Loading log...", "zh-CN": "正在加载日志..." }),
+    failed: textFor(uiLanguage, { en: "Failed to load workspace operation log", "zh-CN": "加载工作区操作日志失败" }),
+    empty: textFor(uiLanguage, { en: "No persisted log lines.", "zh-CN": "没有已持久化的日志行。" }),
+  };
 
   return (
     <div className="space-y-2">
@@ -472,25 +518,25 @@ function WorkspaceOperationLogViewer({
         className="text-[11px] text-muted-foreground underline underline-offset-2 hover:text-foreground"
         onClick={() => setOpen((value) => !value)}
       >
-        {open ? "Hide full log" : "Show full log"}
+        {open ? copy.hideLog : copy.showLog}
       </button>
       {open && (
         <div className="rounded-md border border-border bg-background/70 p-2">
-          {isLoading && <div className="text-xs text-muted-foreground">Loading log...</div>}
+          {isLoading && <div className="text-xs text-muted-foreground">{copy.loading}</div>}
           {error && (
             <div className="text-xs text-destructive">
-              {error instanceof Error ? error.message : "Failed to load workspace operation log"}
+              {error instanceof Error ? error.message : copy.failed}
             </div>
           )}
           {!isLoading && !error && chunks.length === 0 && (
-            <div className="text-xs text-muted-foreground">No persisted log lines.</div>
+            <div className="text-xs text-muted-foreground">{copy.empty}</div>
           )}
           {chunks.length > 0 && (
             <div className="max-h-64 overflow-y-auto rounded bg-neutral-100 p-2 font-mono text-xs dark:bg-neutral-950">
               {chunks.map((chunk, index) => (
                 <div key={`${chunk.ts}-${index}`} className="flex gap-2">
                   <span className="shrink-0 text-neutral-500">
-                    {new Date(chunk.ts).toLocaleTimeString("en-US", { hour12: false })}
+                    {new Date(chunk.ts).toLocaleTimeString(uiLanguage === "zh-CN" ? "zh-CN" : "en-US", { hour12: false })}
                   </span>
                   <span
                     className={cn(
@@ -522,12 +568,28 @@ function WorkspaceOperationsSection({
   operations: WorkspaceOperation[];
   censorUsernameInLogs: boolean;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   if (operations.length === 0) return null;
+  const copy = {
+    workspace: textFor(uiLanguage, { en: "Workspace", "zh-CN": "工作区" }),
+    to: textFor(uiLanguage, { en: "to", "zh-CN": "到" }),
+    command: textFor(uiLanguage, { en: "Command", "zh-CN": "命令" }),
+    workingDir: textFor(uiLanguage, { en: "Working dir", "zh-CN": "工作目录" }),
+    branch: textFor(uiLanguage, { en: "Branch", "zh-CN": "分支" }),
+    baseRef: textFor(uiLanguage, { en: "Base ref", "zh-CN": "基准引用" }),
+    worktree: textFor(uiLanguage, { en: "Worktree", "zh-CN": "工作树" }),
+    repoRoot: textFor(uiLanguage, { en: "Repo root", "zh-CN": "仓库根目录" }),
+    cleanup: textFor(uiLanguage, { en: "Cleanup", "zh-CN": "清理方式" }),
+    createdByRun: textFor(uiLanguage, { en: "Created by this run", "zh-CN": "由本次运行创建" }),
+    reusedWorkspace: textFor(uiLanguage, { en: "Reused existing workspace", "zh-CN": "复用了现有工作区" }),
+    stderrExcerpt: textFor(uiLanguage, { en: "stderr excerpt", "zh-CN": "stderr 摘录" }),
+    stdoutExcerpt: textFor(uiLanguage, { en: "stdout excerpt", "zh-CN": "stdout 摘录" }),
+  };
 
   return (
     <div className="rounded-lg border border-border bg-background/60 p-3 space-y-3">
       <div className="text-xs font-medium text-muted-foreground">
-        Workspace ({operations.length})
+        {copy.workspace} ({operations.length})
       </div>
       <div className="space-y-3">
         {operations.map((operation) => {
@@ -535,22 +597,22 @@ function WorkspaceOperationsSection({
           return (
             <div key={operation.id} className="rounded-md border border-border/70 bg-background/70 p-3 space-y-2">
               <div className="flex flex-wrap items-center gap-2">
-                <div className="text-sm font-medium">{workspaceOperationPhaseLabel(operation.phase)}</div>
+                <div className="text-sm font-medium">{workspaceOperationPhaseLabel(operation.phase, uiLanguage)}</div>
                 <WorkspaceOperationStatusBadge status={operation.status} />
                 <div className="text-[11px] text-muted-foreground">
                   {relativeTime(operation.startedAt)}
-                  {operation.finishedAt && ` to ${relativeTime(operation.finishedAt)}`}
+                  {operation.finishedAt && ` ${copy.to} ${relativeTime(operation.finishedAt)}`}
                 </div>
               </div>
               {operation.command && (
                 <div className="text-xs break-all">
-                  <span className="text-muted-foreground">Command: </span>
+                  <span className="text-muted-foreground">{copy.command}: </span>
                   <span className="font-mono">{operation.command}</span>
                 </div>
               )}
               {operation.cwd && (
                 <div className="text-xs break-all">
-                  <span className="text-muted-foreground">Working dir: </span>
+                  <span className="text-muted-foreground">{copy.workingDir}: </span>
                   <span className="font-mono">{operation.cwd}</span>
                 </div>
               )}
@@ -561,30 +623,30 @@ function WorkspaceOperationsSection({
                 || asNonEmptyString(metadata?.cleanupAction)) && (
                 <div className="grid gap-1 text-xs sm:grid-cols-2">
                   {asNonEmptyString(metadata?.branchName) && (
-                    <div><span className="text-muted-foreground">Branch: </span><span className="font-mono">{metadata?.branchName as string}</span></div>
+                    <div><span className="text-muted-foreground">{copy.branch}: </span><span className="font-mono">{metadata?.branchName as string}</span></div>
                   )}
                   {asNonEmptyString(metadata?.baseRef) && (
-                    <div><span className="text-muted-foreground">Base ref: </span><span className="font-mono">{metadata?.baseRef as string}</span></div>
+                    <div><span className="text-muted-foreground">{copy.baseRef}: </span><span className="font-mono">{metadata?.baseRef as string}</span></div>
                   )}
                   {asNonEmptyString(metadata?.worktreePath) && (
-                    <div className="break-all"><span className="text-muted-foreground">Worktree: </span><span className="font-mono">{metadata?.worktreePath as string}</span></div>
+                    <div className="break-all"><span className="text-muted-foreground">{copy.worktree}: </span><span className="font-mono">{metadata?.worktreePath as string}</span></div>
                   )}
                   {asNonEmptyString(metadata?.repoRoot) && (
-                    <div className="break-all"><span className="text-muted-foreground">Repo root: </span><span className="font-mono">{metadata?.repoRoot as string}</span></div>
+                    <div className="break-all"><span className="text-muted-foreground">{copy.repoRoot}: </span><span className="font-mono">{metadata?.repoRoot as string}</span></div>
                   )}
                   {asNonEmptyString(metadata?.cleanupAction) && (
-                    <div><span className="text-muted-foreground">Cleanup: </span><span className="font-mono">{metadata?.cleanupAction as string}</span></div>
+                    <div><span className="text-muted-foreground">{copy.cleanup}: </span><span className="font-mono">{metadata?.cleanupAction as string}</span></div>
                   )}
                 </div>
               )}
               {typeof metadata?.created === "boolean" && (
                 <div className="text-xs text-muted-foreground">
-                  {metadata.created ? "Created by this run" : "Reused existing workspace"}
+                  {metadata.created ? copy.createdByRun : copy.reusedWorkspace}
                 </div>
               )}
               {operation.stderrExcerpt && operation.stderrExcerpt.trim() && (
                 <div>
-                  <div className="mb-1 text-xs text-red-700 dark:text-red-300">stderr excerpt</div>
+                  <div className="mb-1 text-xs text-red-700 dark:text-red-300">{copy.stderrExcerpt}</div>
                   <pre className="rounded-md bg-red-50 p-2 text-xs whitespace-pre-wrap break-all text-red-800 dark:bg-neutral-950 dark:text-red-100">
                     {redactPathText(operation.stderrExcerpt, censorUsernameInLogs)}
                   </pre>
@@ -592,7 +654,7 @@ function WorkspaceOperationsSection({
               )}
               {operation.stdoutExcerpt && operation.stdoutExcerpt.trim() && (
                 <div>
-                  <div className="mb-1 text-xs text-muted-foreground">stdout excerpt</div>
+                  <div className="mb-1 text-xs text-muted-foreground">{copy.stdoutExcerpt}</div>
                   <pre className="rounded-md bg-neutral-100 p-2 text-xs whitespace-pre-wrap break-all dark:bg-neutral-950">
                     {redactPathText(operation.stdoutExcerpt, censorUsernameInLogs)}
                   </pre>
@@ -620,6 +682,7 @@ export function AgentDetail() {
     runId?: string;
   }>();
   const { companies, selectedCompanyId, setSelectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { closePanel } = usePanel();
   const { openNewIssue } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
@@ -728,6 +791,23 @@ export function AgentDetail() {
     () => (heartbeats ?? []).find((r) => r.status === "running" || r.status === "queued") ?? null,
     [heartbeats],
   );
+  const copy = {
+    agents: textFor(uiLanguage, { en: "Agents", "zh-CN": "智能体" }),
+    agentFallback: textFor(uiLanguage, { en: "Agent", "zh-CN": "智能体" }),
+    assignTask: textFor(uiLanguage, { en: "Assign Task", "zh-CN": "分配任务" }),
+    runHeartbeat: textFor(uiLanguage, { en: "Run Heartbeat", "zh-CN": "运行心跳" }),
+    live: textFor(uiLanguage, { en: "Live", "zh-CN": "实时" }),
+    copyAgentId: textFor(uiLanguage, { en: "Copy Agent ID", "zh-CN": "复制智能体 ID" }),
+    resetSessions: textFor(uiLanguage, { en: "Reset Sessions", "zh-CN": "重置会话" }),
+    terminate: textFor(uiLanguage, { en: "Terminate", "zh-CN": "终止" }),
+    pendingApproval: textFor(uiLanguage, {
+      en: "This agent is pending board approval and cannot be invoked yet.",
+      "zh-CN": "该智能体仍在等待审批，暂时无法调用。",
+    }),
+    cancel: textFor(uiLanguage, { en: "Cancel", "zh-CN": "取消" }),
+    saving: textFor(uiLanguage, { en: "Saving…", "zh-CN": "保存中…" }),
+    save: textFor(uiLanguage, { en: "Save", "zh-CN": "保存" }),
+  };
 
   useEffect(() => {
     if (!agent) return;
@@ -851,32 +931,32 @@ export function AgentDetail() {
 
   useEffect(() => {
     const crumbs: { label: string; href?: string }[] = [
-      { label: "Agents", href: "/agents" },
+      { label: copy.agents, href: "/agents" },
     ];
-    const agentName = agent?.name ?? routeAgentRef ?? "Agent";
+    const agentName = agent?.name ?? routeAgentRef ?? copy.agentFallback;
     if (activeView === "dashboard" && !urlRunId) {
       crumbs.push({ label: agentName });
     } else {
       crumbs.push({ label: agentName, href: `/agents/${canonicalAgentRef}/dashboard` });
       if (urlRunId) {
-        crumbs.push({ label: "Runs", href: `/agents/${canonicalAgentRef}/runs` });
-        crumbs.push({ label: `Run ${urlRunId.slice(0, 8)}` });
+        crumbs.push({ label: agentDetailViewLabel("runs", uiLanguage), href: `/agents/${canonicalAgentRef}/runs` });
+        crumbs.push({ label: `${textFor(uiLanguage, { en: "Run", "zh-CN": "运行" })} ${urlRunId.slice(0, 8)}` });
       } else if (activeView === "instructions") {
-        crumbs.push({ label: "Instructions" });
+        crumbs.push({ label: agentDetailViewLabel("instructions", uiLanguage) });
       } else if (activeView === "configuration") {
-        crumbs.push({ label: "Configuration" });
+        crumbs.push({ label: agentDetailViewLabel("configuration", uiLanguage) });
       // } else if (activeView === "skills") { // TODO: bring back later
       //   crumbs.push({ label: "Skills" });
       } else if (activeView === "runs") {
-        crumbs.push({ label: "Runs" });
+        crumbs.push({ label: agentDetailViewLabel("runs", uiLanguage) });
       } else if (activeView === "budget") {
-        crumbs.push({ label: "Budget" });
+        crumbs.push({ label: agentDetailViewLabel("budget", uiLanguage) });
       } else {
-        crumbs.push({ label: "Dashboard" });
+        crumbs.push({ label: agentDetailViewLabel("dashboard", uiLanguage) });
       }
     }
     setBreadcrumbs(crumbs);
-  }, [setBreadcrumbs, agent, routeAgentRef, canonicalAgentRef, activeView, urlRunId]);
+  }, [setBreadcrumbs, agent, routeAgentRef, canonicalAgentRef, activeView, urlRunId, copy.agents, copy.agentFallback, uiLanguage]);
 
   useEffect(() => {
     closePanel();
@@ -928,12 +1008,12 @@ export function AgentDetail() {
             onClick={() => openNewIssue({ assigneeAgentId: agent.id })}
           >
             <Plus className="h-3.5 w-3.5 sm:mr-1" />
-            <span className="hidden sm:inline">Assign Task</span>
+            <span className="hidden sm:inline">{copy.assignTask}</span>
           </Button>
           <RunButton
             onClick={() => agentAction.mutate("invoke")}
             disabled={agentAction.isPending || isPendingApproval}
-            label="Run Heartbeat"
+            label={copy.runHeartbeat}
           />
           <PauseResumeButton
             isPaused={agent.status === "paused"}
@@ -951,7 +1031,7 @@ export function AgentDetail() {
                 <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
                 <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
               </span>
-              <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">Live</span>
+              <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">{copy.live}</span>
             </Link>
           )}
 
@@ -971,7 +1051,7 @@ export function AgentDetail() {
                 }}
               >
                 <Copy className="h-3 w-3" />
-                Copy Agent ID
+                {copy.copyAgentId}
               </button>
               <button
                 className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
@@ -981,7 +1061,7 @@ export function AgentDetail() {
                 }}
               >
                 <RotateCcw className="h-3 w-3" />
-                Reset Sessions
+                {copy.resetSessions}
               </button>
               <button
                 className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-destructive"
@@ -991,7 +1071,7 @@ export function AgentDetail() {
                 }}
               >
                 <Trash2 className="h-3 w-3" />
-                Terminate
+                {copy.terminate}
               </button>
             </PopoverContent>
           </Popover>
@@ -1005,12 +1085,12 @@ export function AgentDetail() {
         >
           <PageTabBar
             items={[
-              { value: "dashboard", label: "Dashboard" },
-              { value: "instructions", label: "Instructions" },
-              { value: "skills", label: "Skills" },
-              { value: "configuration", label: "Configuration" },
-              { value: "runs", label: "Runs" },
-              { value: "budget", label: "Budget" },
+              { value: "dashboard", label: agentDetailViewLabel("dashboard", uiLanguage) },
+              { value: "instructions", label: agentDetailViewLabel("instructions", uiLanguage) },
+              { value: "skills", label: agentDetailViewLabel("skills", uiLanguage) },
+              { value: "configuration", label: agentDetailViewLabel("configuration", uiLanguage) },
+              { value: "runs", label: agentDetailViewLabel("runs", uiLanguage) },
+              { value: "budget", label: agentDetailViewLabel("budget", uiLanguage) },
             ]}
             value={activeView}
             onValueChange={(value) => navigate(`/agents/${canonicalAgentRef}/${value}`)}
@@ -1021,7 +1101,7 @@ export function AgentDetail() {
       {actionError && <p className="text-sm text-destructive">{actionError}</p>}
       {isPendingApproval && (
         <p className="text-sm text-amber-500">
-          This agent is pending board approval and cannot be invoked yet.
+          {copy.pendingApproval}
         </p>
       )}
 
@@ -1042,14 +1122,14 @@ export function AgentDetail() {
               onClick={() => cancelConfigActionRef.current?.()}
               disabled={configSaving}
             >
-              Cancel
+              {copy.cancel}
             </Button>
             <Button
               size="sm"
               onClick={() => saveConfigActionRef.current?.()}
               disabled={configSaving}
             >
-              {configSaving ? "Saving…" : "Save"}
+              {configSaving ? copy.saving : copy.save}
             </Button>
           </div>
         </div>
@@ -1068,14 +1148,14 @@ export function AgentDetail() {
               onClick={() => cancelConfigActionRef.current?.()}
               disabled={configSaving}
             >
-              Cancel
+              {copy.cancel}
             </Button>
             <Button
               size="sm"
               onClick={() => saveConfigActionRef.current?.()}
               disabled={configSaving}
             >
-              {configSaving ? "Saving…" : "Save"}
+              {configSaving ? copy.saving : copy.save}
             </Button>
           </div>
         </div>
@@ -1162,6 +1242,7 @@ function SummaryRow({ label, children }: { label: string; children: React.ReactN
 }
 
 function LatestRunCard({ runs, agentId }: { runs: HeartbeatRun[]; agentId: string }) {
+  const { uiLanguage } = useGeneralSettings();
   if (runs.length === 0) return null;
 
   const sorted = [...runs].sort(
@@ -1194,6 +1275,11 @@ function LatestRunCard({ runs, agentId }: { runs: HeartbeatRun[]; agentId: strin
     }
     return excerpt.join(" ");
   }, [summaryRaw]);
+  const copy = {
+    liveRun: textFor(uiLanguage, { en: "Live Run", "zh-CN": "实时运行" }),
+    latestRun: textFor(uiLanguage, { en: "Latest Run", "zh-CN": "最近运行" }),
+    viewDetails: textFor(uiLanguage, { en: "View details", "zh-CN": "查看详情" }),
+  };
 
   return (
     <div className="space-y-3">
@@ -1205,13 +1291,13 @@ function LatestRunCard({ runs, agentId }: { runs: HeartbeatRun[]; agentId: strin
               <span className="relative inline-flex rounded-full h-2 w-2 bg-cyan-400" />
             </span>
           )}
-          {isLive ? "Live Run" : "Latest Run"}
+          {isLive ? copy.liveRun : copy.latestRun}
         </h3>
         <Link
           to={`/agents/${agentId}/runs/${run.id}`}
           className="shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors no-underline"
         >
-          View details &rarr;
+          {copy.viewDetails} &rarr;
         </Link>
       </div>
 
@@ -1233,7 +1319,7 @@ function LatestRunCard({ runs, agentId }: { runs: HeartbeatRun[]; agentId: strin
               : run.invocationSource === "on_demand" ? "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300"
               : "bg-muted text-muted-foreground"
           )}>
-            {sourceLabels[run.invocationSource] ?? run.invocationSource}
+            {sourceLabel(run.invocationSource, uiLanguage)}
           </span>
           <span className="ml-auto text-xs text-muted-foreground">{relativeTime(run.createdAt)}</span>
         </div>
@@ -1265,6 +1351,18 @@ function AgentOverview({
   agentId: string;
   agentRouteId: string;
 }) {
+  const { uiLanguage } = useGeneralSettings();
+  const copy = {
+    runActivity: textFor(uiLanguage, { en: "Run Activity", "zh-CN": "运行活跃度" }),
+    issuesByPriority: textFor(uiLanguage, { en: "Issues by Priority", "zh-CN": "按优先级统计任务" }),
+    issuesByStatus: textFor(uiLanguage, { en: "Issues by Status", "zh-CN": "按状态统计任务" }),
+    successRate: textFor(uiLanguage, { en: "Success Rate", "zh-CN": "成功率" }),
+    last14Days: textFor(uiLanguage, { en: "Last 14 days", "zh-CN": "最近 14 天" }),
+    recentIssues: textFor(uiLanguage, { en: "Recent Issues", "zh-CN": "最近任务" }),
+    seeAll: textFor(uiLanguage, { en: "See All", "zh-CN": "查看全部" }),
+    noRecentIssues: textFor(uiLanguage, { en: "No recent issues.", "zh-CN": "最近没有任务。" }),
+    costs: textFor(uiLanguage, { en: "Costs", "zh-CN": "成本" }),
+  };
   return (
     <div className="space-y-8">
       {/* Latest Run */}
@@ -1272,16 +1370,16 @@ function AgentOverview({
 
       {/* Charts */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <ChartCard title="Run Activity" subtitle="Last 14 days">
+        <ChartCard title={copy.runActivity} subtitle={copy.last14Days}>
           <RunActivityChart runs={runs} />
         </ChartCard>
-        <ChartCard title="Issues by Priority" subtitle="Last 14 days">
+        <ChartCard title={copy.issuesByPriority} subtitle={copy.last14Days}>
           <PriorityChart issues={assignedIssues} />
         </ChartCard>
-        <ChartCard title="Issues by Status" subtitle="Last 14 days">
+        <ChartCard title={copy.issuesByStatus} subtitle={copy.last14Days}>
           <IssueStatusChart issues={assignedIssues} />
         </ChartCard>
-        <ChartCard title="Success Rate" subtitle="Last 14 days">
+        <ChartCard title={copy.successRate} subtitle={copy.last14Days}>
           <SuccessRateChart runs={runs} />
         </ChartCard>
       </div>
@@ -1289,16 +1387,16 @@ function AgentOverview({
       {/* Recent Issues */}
       <div className="space-y-3">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium">Recent Issues</h3>
+          <h3 className="text-sm font-medium">{copy.recentIssues}</h3>
           <Link
             to={`/issues?participantAgentId=${agentId}`}
             className="text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
-            See All &rarr;
+            {copy.seeAll} &rarr;
           </Link>
         </div>
         {assignedIssues.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No recent issues.</p>
+          <p className="text-sm text-muted-foreground">{copy.noRecentIssues}</p>
         ) : (
           <div className="border border-border rounded-lg">
             {assignedIssues.slice(0, 10).map((issue) => (
@@ -1312,7 +1410,9 @@ function AgentOverview({
             ))}
             {assignedIssues.length > 10 && (
               <div className="px-3 py-2 text-xs text-muted-foreground text-center border-t border-border">
-                +{assignedIssues.length - 10} more issues
+                {uiLanguage === "zh-CN"
+                  ? `另外还有 ${assignedIssues.length - 10} 个任务`
+                  : `+${assignedIssues.length - 10} more issues`}
               </div>
             )}
           </div>
@@ -1321,7 +1421,7 @@ function AgentOverview({
 
       {/* Costs */}
       <div className="space-y-3">
-        <h3 className="text-sm font-medium">Costs</h3>
+        <h3 className="text-sm font-medium">{copy.costs}</h3>
         <CostsSection runtimeState={runtimeState} runs={runs} />
       </div>
     </div>
@@ -1337,12 +1437,24 @@ function CostsSection({
   runtimeState?: AgentRuntimeState;
   runs: HeartbeatRun[];
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const runsWithCost = runs
     .filter((r) => {
       const metrics = runMetrics(r);
       return metrics.cost > 0 || metrics.input > 0 || metrics.output > 0 || metrics.cached > 0;
     })
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  const copy = {
+    inputTokens: textFor(uiLanguage, { en: "Input tokens", "zh-CN": "输入令牌" }),
+    outputTokens: textFor(uiLanguage, { en: "Output tokens", "zh-CN": "输出令牌" }),
+    cachedTokens: textFor(uiLanguage, { en: "Cached tokens", "zh-CN": "缓存令牌" }),
+    totalCost: textFor(uiLanguage, { en: "Total cost", "zh-CN": "总成本" }),
+    date: textFor(uiLanguage, { en: "Date", "zh-CN": "日期" }),
+    run: textFor(uiLanguage, { en: "Run", "zh-CN": "运行" }),
+    input: textFor(uiLanguage, { en: "Input", "zh-CN": "输入" }),
+    output: textFor(uiLanguage, { en: "Output", "zh-CN": "输出" }),
+    cost: textFor(uiLanguage, { en: "Cost", "zh-CN": "成本" }),
+  };
 
   return (
     <div className="space-y-4">
@@ -1350,19 +1462,19 @@ function CostsSection({
         <div className="border border-border rounded-lg p-4">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 tabular-nums">
             <div>
-              <span className="text-xs text-muted-foreground block">Input tokens</span>
+              <span className="text-xs text-muted-foreground block">{copy.inputTokens}</span>
               <span className="text-lg font-semibold">{formatTokens(runtimeState.totalInputTokens)}</span>
             </div>
             <div>
-              <span className="text-xs text-muted-foreground block">Output tokens</span>
+              <span className="text-xs text-muted-foreground block">{copy.outputTokens}</span>
               <span className="text-lg font-semibold">{formatTokens(runtimeState.totalOutputTokens)}</span>
             </div>
             <div>
-              <span className="text-xs text-muted-foreground block">Cached tokens</span>
+              <span className="text-xs text-muted-foreground block">{copy.cachedTokens}</span>
               <span className="text-lg font-semibold">{formatTokens(runtimeState.totalCachedInputTokens)}</span>
             </div>
             <div>
-              <span className="text-xs text-muted-foreground block">Total cost</span>
+              <span className="text-xs text-muted-foreground block">{copy.totalCost}</span>
               <span className="text-lg font-semibold">{formatCents(runtimeState.totalCostCents)}</span>
             </div>
           </div>
@@ -1373,11 +1485,11 @@ function CostsSection({
           <table className="w-full text-xs">
             <thead>
               <tr className="border-b border-border bg-accent/20">
-                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Date</th>
-                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Run</th>
-                <th className="text-right px-3 py-2 font-medium text-muted-foreground">Input</th>
-                <th className="text-right px-3 py-2 font-medium text-muted-foreground">Output</th>
-                <th className="text-right px-3 py-2 font-medium text-muted-foreground">Cost</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">{copy.date}</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">{copy.run}</th>
+                <th className="text-right px-3 py-2 font-medium text-muted-foreground">{copy.input}</th>
+                <th className="text-right px-3 py-2 font-medium text-muted-foreground">{copy.output}</th>
+                <th className="text-right px-3 py-2 font-medium text-muted-foreground">{copy.cost}</th>
               </tr>
             </thead>
             <tbody>
@@ -1427,6 +1539,7 @@ function AgentConfigurePage({
   onSavingChange: (saving: boolean) => void;
   updatePermissions: { mutate: (permissions: AgentPermissionUpdate) => void; isPending: boolean };
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const queryClient = useQueryClient();
   const [revisionsOpen, setRevisionsOpen] = useState(false);
 
@@ -1443,6 +1556,14 @@ function AgentConfigurePage({
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.configRevisions(agent.id) });
     },
   });
+  const copy = {
+    apiKeys: textFor(uiLanguage, { en: "API Keys", "zh-CN": "API 密钥" }),
+    configurationRevisions: textFor(uiLanguage, { en: "Configuration Revisions", "zh-CN": "配置修订记录" }),
+    noConfigurationRevisions: textFor(uiLanguage, { en: "No configuration revisions yet.", "zh-CN": "还没有配置修订记录。" }),
+    restore: textFor(uiLanguage, { en: "Restore", "zh-CN": "恢复" }),
+    changed: textFor(uiLanguage, { en: "Changed", "zh-CN": "变更字段" }),
+    noTrackedChanges: textFor(uiLanguage, { en: "no tracked changes", "zh-CN": "无可追踪变更" }),
+  };
 
   return (
     <div className="max-w-3xl space-y-6">
@@ -1458,7 +1579,7 @@ function AgentConfigurePage({
         hideInstructionsFile
       />
       <div>
-        <h3 className="text-sm font-medium mb-3">API Keys</h3>
+        <h3 className="text-sm font-medium mb-3">{copy.apiKeys}</h3>
         <KeysTab agentId={agentId} companyId={companyId} />
       </div>
 
@@ -1472,13 +1593,13 @@ function AgentConfigurePage({
             ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
             : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
           }
-          Configuration Revisions
+          {copy.configurationRevisions}
           <span className="text-xs font-normal text-muted-foreground">{configRevisions?.length ?? 0}</span>
         </button>
         {revisionsOpen && (
           <div className="mt-3">
             {(configRevisions ?? []).length === 0 ? (
-              <p className="text-sm text-muted-foreground">No configuration revisions yet.</p>
+              <p className="text-sm text-muted-foreground">{copy.noConfigurationRevisions}</p>
             ) : (
               <div className="space-y-2">
                 {(configRevisions ?? []).slice(0, 10).map((revision) => (
@@ -1498,12 +1619,12 @@ function AgentConfigurePage({
                         onClick={() => rollbackConfig.mutate(revision.id)}
                         disabled={rollbackConfig.isPending}
                       >
-                        Restore
+                        {copy.restore}
                       </Button>
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      Changed:{" "}
-                      {revision.changedKeys.length > 0 ? revision.changedKeys.join(", ") : "no tracked changes"}
+                      {copy.changed}:{" "}
+                      {revision.changedKeys.length > 0 ? revision.changedKeys.join(", ") : copy.noTrackedChanges}
                     </p>
                   </div>
                 ))}
@@ -1540,6 +1661,7 @@ function ConfigurationTab({
   hideInstructionsFile?: boolean;
 }) {
   const queryClient = useQueryClient();
+  const { uiLanguage } = useGeneralSettings();
   const { pushToast } = useToast();
   const [awaitingRefreshAfterSave, setAwaitingRefreshAfterSave] = useState(false);
   const lastAgentRef = useRef(agent);
@@ -1571,8 +1693,12 @@ function ConfigurationTab({
           ? err.message
           : err instanceof Error
             ? err.message
-            : "Could not save agent";
-      pushToast({ title: "Save failed", body: message, tone: "error" });
+            : textFor(uiLanguage, { en: "Could not save agent", "zh-CN": "无法保存智能体" });
+      pushToast({
+        title: textFor(uiLanguage, { en: "Save failed", "zh-CN": "保存失败" }),
+        body: message,
+        tone: "error",
+      });
     },
   });
 
@@ -1594,12 +1720,21 @@ function ConfigurationTab({
   const taskAssignLocked = agent.role === "ceo" || canCreateAgents;
   const taskAssignHint =
     taskAssignSource === "ceo_role"
-      ? "Enabled automatically for CEO agents."
+      ? textFor(uiLanguage, { en: "Enabled automatically for CEO agents.", "zh-CN": "CEO 智能体会自动启用此权限。" })
       : taskAssignSource === "agent_creator"
-        ? "Enabled automatically while this agent can create new agents."
+        ? textFor(uiLanguage, { en: "Enabled automatically while this agent can create new agents.", "zh-CN": "当该智能体可以创建新智能体时，会自动启用此权限。" })
         : taskAssignSource === "explicit_grant"
-          ? "Enabled via explicit company permission grant."
-          : "Disabled unless explicitly granted.";
+          ? textFor(uiLanguage, { en: "Enabled via explicit company permission grant.", "zh-CN": "通过公司的显式权限授予启用。" })
+          : textFor(uiLanguage, { en: "Disabled unless explicitly granted.", "zh-CN": "除非显式授权，否则保持禁用。" });
+  const copy = {
+    permissions: textFor(uiLanguage, { en: "Permissions", "zh-CN": "权限" }),
+    canCreateAgents: textFor(uiLanguage, { en: "Can create new agents", "zh-CN": "可创建新智能体" }),
+    canCreateAgentsHint: textFor(uiLanguage, {
+      en: "Lets this agent create or hire agents and implicitly assign tasks.",
+      "zh-CN": "允许该智能体创建或招募智能体，并隐式获得任务分配能力。",
+    }),
+    canAssignTasks: textFor(uiLanguage, { en: "Can assign tasks", "zh-CN": "可分配任务" }),
+  };
 
   return (
     <div className="space-y-6">
@@ -1619,13 +1754,13 @@ function ConfigurationTab({
       />
 
       <div>
-        <h3 className="text-sm font-medium mb-3">Permissions</h3>
+        <h3 className="text-sm font-medium mb-3">{copy.permissions}</h3>
         <div className="border border-border rounded-lg p-4 space-y-4">
           <div className="flex items-center justify-between gap-4 text-sm">
             <div className="space-y-1">
-              <div>Can create new agents</div>
+              <div>{copy.canCreateAgents}</div>
               <p className="text-xs text-muted-foreground">
-                Lets this agent create or hire agents and implicitly assign tasks.
+                {copy.canCreateAgentsHint}
               </p>
             </div>
             <ToggleSwitch
@@ -1641,7 +1776,7 @@ function ConfigurationTab({
           </div>
           <div className="flex items-center justify-between gap-4 text-sm">
             <div className="space-y-1">
-              <div>Can assign tasks</div>
+              <div>{copy.canAssignTasks}</div>
               <p className="text-xs text-muted-foreground">
                 {taskAssignHint}
               </p>
@@ -1682,6 +1817,7 @@ function PromptsTab({
 }) {
   const queryClient = useQueryClient();
   const { selectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { isMobile } = useSidebar();
   const [selectedFile, setSelectedFile] = useState<string>("AGENTS.md");
   const [showFilePanel, setShowFilePanel] = useState(false);
@@ -1971,12 +2107,33 @@ function PromptsTab({
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
   }, [filePanelWidth]);
+  const copy = {
+    localOnly: textFor(uiLanguage, { en: "Instructions bundles are only available for local adapters.", "zh-CN": "说明文件包仅适用于本地适配器。" }),
+    advanced: textFor(uiLanguage, { en: "Advanced", "zh-CN": "高级" }),
+    mode: textFor(uiLanguage, { en: "Mode", "zh-CN": "模式" }),
+    managed: textFor(uiLanguage, { en: "Managed", "zh-CN": "托管" }),
+    external: textFor(uiLanguage, { en: "External", "zh-CN": "外部" }),
+    rootPath: textFor(uiLanguage, { en: "Root path", "zh-CN": "根路径" }),
+    managedShort: textFor(uiLanguage, { en: "(managed)", "zh-CN": "（托管）" }),
+    entryFile: textFor(uiLanguage, { en: "Entry file", "zh-CN": "入口文件" }),
+    files: textFor(uiLanguage, { en: "Files", "zh-CN": "文件" }),
+    create: textFor(uiLanguage, { en: "Create", "zh-CN": "创建" }),
+    cancel: textFor(uiLanguage, { en: "Cancel", "zh-CN": "取消" }),
+    virtualFile: textFor(uiLanguage, { en: "virtual file", "zh-CN": "虚拟文件" }),
+    entry: textFor(uiLanguage, { en: "entry", "zh-CN": "入口" }),
+    deprecatedVirtualFile: textFor(uiLanguage, { en: "Deprecated virtual file", "zh-CN": "已弃用的虚拟文件" }),
+    newBundleFile: textFor(uiLanguage, { en: "New file in this bundle", "zh-CN": "该文件包中的新文件" }),
+    delete: textFor(uiLanguage, { en: "Delete", "zh-CN": "删除" }),
+    deleteConfirm: textFor(uiLanguage, { en: "Delete", "zh-CN": "删除" }),
+    agentInstructions: textFor(uiLanguage, { en: "Agent instructions", "zh-CN": "智能体说明" }),
+    fileContents: textFor(uiLanguage, { en: "File contents", "zh-CN": "文件内容" }),
+  };
 
   if (!isLocal) {
     return (
       <div className="max-w-3xl">
         <p className="text-sm text-muted-foreground">
-          Instructions bundles are only available for local adapters.
+          {copy.localOnly}
         </p>
       </div>
     );
@@ -2001,14 +2158,14 @@ function PromptsTab({
       <Collapsible defaultOpen={currentMode === "external"}>
         <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors group">
           <ChevronRight className="h-3 w-3 transition-transform group-data-[state=open]:rotate-90" />
-          Advanced
+          {copy.advanced}
         </CollapsibleTrigger>
         <CollapsibleContent className="pt-4 pb-6">
           <TooltipProvider>
             <div className="grid gap-x-6 gap-y-4 sm:grid-cols-[auto_1fr_1fr]">
               <label className="space-y-1.5">
                 <span className="text-xs font-medium text-muted-foreground flex items-center gap-1">
-                  Mode
+                  {copy.mode}
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <HelpCircle className="h-3 w-3 text-muted-foreground cursor-help" />
@@ -2040,7 +2197,7 @@ function PromptsTab({
                       setSelectedFile(nextEntryFile);
                     }}
                   >
-                    Managed
+                    {copy.managed}
                   </Button>
                   <Button
                     type="button"
@@ -2057,13 +2214,13 @@ function PromptsTab({
                       setSelectedFile(externalBundle?.selectedFile ?? nextEntryFile);
                     }}
                   >
-                    External
+                    {copy.external}
                   </Button>
                 </div>
               </label>
               <label className="space-y-1.5 min-w-0">
                 <span className="text-xs font-medium text-muted-foreground flex items-center gap-1">
-                  Root path
+                  {copy.rootPath}
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <HelpCircle className="h-3 w-3 text-muted-foreground cursor-help" />
@@ -2075,7 +2232,7 @@ function PromptsTab({
                 </span>
                 {currentMode === "managed" ? (
                   <div className="flex items-center gap-1.5 font-mono text-xs text-muted-foreground pt-1.5">
-                    <span className="min-w-0 truncate" title={currentRootPath || undefined}>{currentRootPath || "(managed)"}</span>
+                    <span className="min-w-0 truncate" title={currentRootPath || undefined}>{currentRootPath || copy.managedShort}</span>
                     {currentRootPath && (
                       <CopyText text={currentRootPath} className="shrink-0">
                         <Copy className="h-3.5 w-3.5" />
@@ -2112,7 +2269,7 @@ function PromptsTab({
               </label>
               <label className="space-y-1.5">
                 <span className="text-xs font-medium text-muted-foreground flex items-center gap-1">
-                  Entry file
+                  {copy.entryFile}
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <HelpCircle className="h-3 w-3 text-muted-foreground cursor-help" />
@@ -2152,13 +2309,13 @@ function PromptsTab({
       </Collapsible>
 
       <div ref={containerRef} className={cn("flex gap-0", isMobile && "flex-col gap-3")}>
-        <div className={cn(
-          "border border-border rounded-lg p-3 space-y-3 shrink-0",
+          <div className={cn(
+            "border border-border rounded-lg p-3 space-y-3 shrink-0",
           isMobile && showFilePanel && "block",
           isMobile && !showFilePanel && "hidden",
         )} style={isMobile ? undefined : { width: filePanelWidth }}>
           <div className="flex items-center justify-between">
-            <h4 className="text-sm font-medium">Files</h4>
+            <h4 className="text-sm font-medium">{copy.files}</h4>
             <div className="flex items-center gap-1">
               {!showNewFileInput && (
                 <Button
@@ -2216,7 +2373,7 @@ function PromptsTab({
                     setShowNewFileInput(false);
                   }}
                 >
-                  Create
+                  {copy.create}
                 </Button>
                 <Button
                   type="button"
@@ -2228,7 +2385,7 @@ function PromptsTab({
                     setNewFilePath("");
                   }}
                 >
-                  Cancel
+                  {copy.cancel}
                 </Button>
               </div>
             </div>
@@ -2259,7 +2416,7 @@ function PromptsTab({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span className="ml-3 shrink-0 rounded border border-amber-500/40 bg-amber-500/10 text-amber-200 px-1.5 py-0.5 text-[10px] uppercase tracking-wide cursor-help">
-                        virtual file
+                        {copy.virtualFile}
                       </span>
                     </TooltipTrigger>
                     <TooltipContent side="right" sideOffset={4}>
@@ -2270,7 +2427,7 @@ function PromptsTab({
               }
               return (
                 <span className="ml-3 shrink-0 rounded border border-border text-muted-foreground px-1.5 py-0.5 text-[10px] uppercase tracking-wide">
-                  {file.isEntryFile ? "entry" : `${file.size}b`}
+                  {file.isEntryFile ? copy.entry : `${file.size}b`}
                 </span>
               );
             }}
@@ -2304,9 +2461,9 @@ function PromptsTab({
                 <p className="text-xs text-muted-foreground">
                   {selectedFileExists
                     ? selectedFileSummary?.deprecated
-                      ? "Deprecated virtual file"
-                      : `${selectedFileDetail?.language ?? "text"} file`
-                    : "New file in this bundle"}
+                      ? copy.deprecatedVirtualFile
+                      : `${selectedFileDetail?.language ?? "text"} ${textFor(uiLanguage, { en: "file", "zh-CN": "文件" })}`
+                    : copy.newBundleFile}
                 </p>
               </div>
             </div>
@@ -2316,7 +2473,7 @@ function PromptsTab({
                 size="sm"
                 variant="outline"
                 onClick={() => {
-                  if (confirm(`Delete ${selectedOrEntryFile}?`)) {
+                  if (confirm(uiLanguage === "zh-CN" ? `删除 ${selectedOrEntryFile}？` : `Delete ${selectedOrEntryFile}?`)) {
                     deleteFile.mutate(selectedOrEntryFile, {
                       onSuccess: () => {
                         setSelectedFile(currentEntryFile);
@@ -2327,7 +2484,7 @@ function PromptsTab({
                 }}
                 disabled={deleteFile.isPending}
               >
-                Delete
+                {copy.delete}
               </Button>
             )}
           </div>
@@ -2339,7 +2496,7 @@ function PromptsTab({
               key={selectedOrEntryFile}
               value={displayValue}
               onChange={(value) => setDraft(value ?? "")}
-              placeholder="# Agent instructions"
+              placeholder={`# ${copy.agentInstructions}`}
               contentClassName="min-h-[420px] text-sm font-mono"
               imageUploadHandler={async (file) => {
                 const namespace = `agents/${agent.id}/instructions/${selectedOrEntryFile.replaceAll("/", "-")}`;
@@ -2352,7 +2509,7 @@ function PromptsTab({
               value={displayValue}
               onChange={(event) => setDraft(event.target.value)}
               className="min-h-[420px] w-full rounded-md border border-border bg-transparent px-3 py-2 font-mono text-sm outline-none"
-              placeholder="File contents"
+              placeholder={copy.fileContents}
             />
           )}
         </div>
@@ -2436,6 +2593,7 @@ function AgentSkillsTab({
     adapterEntry: AgentSkillEntry | null;
   };
 
+  const { uiLanguage } = useGeneralSettings();
   const queryClient = useQueryClient();
   const [skillDraft, setSkillDraft] = useState<string[]>([]);
   const [lastSavedSkills, setLastSavedSkills] = useState<string[]>([]);
@@ -2588,28 +2746,48 @@ function AgentSkillsTab({
   const skillApplicationLabel = useMemo(() => {
     switch (skillSnapshot?.mode) {
       case "persistent":
-        return "Kept in the workspace";
+        return textFor(uiLanguage, { en: "Kept in the workspace", "zh-CN": "保留在工作区中" });
       case "ephemeral":
-        return "Applied when the agent runs";
+        return textFor(uiLanguage, { en: "Applied when the agent runs", "zh-CN": "在智能体运行时应用" });
       case "unsupported":
-        return "Tracked only";
+        return textFor(uiLanguage, { en: "Tracked only", "zh-CN": "仅跟踪，不管理" });
       default:
-        return "Unknown";
+        return textFor(uiLanguage, { en: "Unknown", "zh-CN": "未知" });
     }
-  }, [skillSnapshot?.mode]);
+  }, [skillSnapshot?.mode, uiLanguage]);
   const unsupportedSkillMessage = useMemo(() => {
     if (skillSnapshot?.mode !== "unsupported") return null;
     if (agent.adapterType === "openclaw_gateway") {
-      return "Paperclip cannot manage OpenClaw skills here. Visit your OpenClaw instance to manage this agent's skills.";
+      return textFor(uiLanguage, {
+        en: "Paperclip cannot manage OpenClaw skills here. Visit your OpenClaw instance to manage this agent's skills.",
+        "zh-CN": "Paperclip 无法在这里管理 OpenClaw 技能。请前往你的 OpenClaw 实例管理该智能体的技能。",
+      });
     }
-    return "Paperclip cannot manage skills for this adapter yet. Manage them in the adapter directly.";
-  }, [agent.adapterType, skillSnapshot?.mode]);
+    return textFor(uiLanguage, {
+      en: "Paperclip cannot manage skills for this adapter yet. Manage them in the adapter directly.",
+      "zh-CN": "Paperclip 目前还不能管理这个适配器的技能，请直接在适配器中管理。",
+    });
+  }, [agent.adapterType, skillSnapshot?.mode, uiLanguage]);
   const hasUnsavedChanges = !arraysEqual(skillDraft, lastSavedSkills);
   const saveStatusLabel = syncSkills.isPending
-    ? "Saving changes..."
+    ? textFor(uiLanguage, { en: "Saving changes...", "zh-CN": "正在保存更改..." })
     : hasUnsavedChanges
-      ? "Saving soon..."
+      ? textFor(uiLanguage, { en: "Saving soon...", "zh-CN": "即将保存..." })
       : null;
+  const copy = {
+    viewCompanySkills: textFor(uiLanguage, { en: "View company skills library", "zh-CN": "查看公司技能库" }),
+    view: textFor(uiLanguage, { en: "View", "zh-CN": "查看" }),
+    location: textFor(uiLanguage, { en: "Location", "zh-CN": "位置" }),
+    manageInAdapter: textFor(uiLanguage, { en: "Manage skills in the adapter directly.", "zh-CN": "请直接在适配器中管理技能。" }),
+    importFirst: textFor(uiLanguage, { en: "Import skills into the company library first, then attach them here.", "zh-CN": "请先将技能导入公司技能库，然后再在这里附加。" }),
+    requiredByPaperclip: textFor(uiLanguage, { en: "Required by Paperclip", "zh-CN": "由 Paperclip 强制要求" }),
+    userInstalledSkills: textFor(uiLanguage, { en: "User-installed skills, not managed by Paperclip", "zh-CN": "用户安装的技能，不由 Paperclip 管理" }),
+    missingRequestedSkills: textFor(uiLanguage, { en: "Requested skills missing from the company library", "zh-CN": "请求的技能未出现在公司技能库中" }),
+    adapter: textFor(uiLanguage, { en: "Adapter", "zh-CN": "适配器" }),
+    skillsApplied: textFor(uiLanguage, { en: "Skills applied", "zh-CN": "技能应用方式" }),
+    selectedSkills: textFor(uiLanguage, { en: "Selected skills", "zh-CN": "已选技能" }),
+    updateFailed: textFor(uiLanguage, { en: "Failed to update skills", "zh-CN": "更新技能失败" }),
+  };
 
   return (
     <div className="max-w-4xl space-y-5">
@@ -2618,7 +2796,7 @@ function AgentSkillsTab({
           to="/skills"
           className="text-sm font-medium text-foreground underline-offset-4 no-underline transition-colors hover:text-foreground/70 hover:underline"
         >
-          View company skills library
+          {copy.viewCompanySkills}
         </Link>
         {saveStatusLabel ? (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -2665,7 +2843,7 @@ function AgentSkillsTab({
                         to={skill.linkTo}
                         className="shrink-0 text-xs text-muted-foreground no-underline hover:text-foreground"
                       >
-                        View
+                        {copy.view}
                       </Link>
                     ) : null}
                   </div>
@@ -2678,7 +2856,7 @@ function AgentSkillsTab({
                     <p className="mt-1 text-xs text-muted-foreground">{skill.originLabel}</p>
                   )}
                   {skill.readOnly && skill.locationLabel && (
-                    <p className="mt-1 text-xs text-muted-foreground">Location: {skill.locationLabel}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{copy.location}: {skill.locationLabel}</p>
                   )}
                   {skill.detail && (
                     <p className="mt-1 text-xs text-muted-foreground">{skill.detail}</p>
@@ -2727,7 +2905,7 @@ function AgentSkillsTab({
                         <span>{checkbox}</span>
                       </TooltipTrigger>
                       <TooltipContent side="top">
-                        {unsupportedSkillMessage ?? "Manage skills in the adapter directly."}
+                        {unsupportedSkillMessage ?? copy.manageInAdapter}
                       </TooltipContent>
                     </Tooltip>
                   ) : (
@@ -2742,7 +2920,7 @@ function AgentSkillsTab({
               return (
                 <section className="border-y border-border">
                   <div className="px-3 py-6 text-sm text-muted-foreground">
-                    Import skills into the company library first, then attach them here.
+                    {copy.importFirst}
                   </div>
                 </section>
               );
@@ -2760,7 +2938,7 @@ function AgentSkillsTab({
                   <section className="border-y border-border">
                     <div className="border-b border-border bg-muted/40 px-3 py-2">
                       <span className="text-xs font-medium text-muted-foreground">
-                        Required by Paperclip
+                        {copy.requiredByPaperclip}
                       </span>
                     </div>
                     {requiredSkillRows.map(renderSkillRow)}
@@ -2777,7 +2955,7 @@ function AgentSkillsTab({
                       onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setUnmanagedOpen((v) => !v); } }}
                     >
                       <span className="text-xs font-medium text-muted-foreground">
-                        ({unmanagedSkillRows.length}) User-installed skills, not managed by Paperclip
+                        ({unmanagedSkillRows.length}) {copy.userInstalledSkills}
                       </span>
                       {unmanagedOpen ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
                     </div>
@@ -2790,7 +2968,7 @@ function AgentSkillsTab({
 
           {desiredOnlyMissingSkills.length > 0 && (
             <div className="rounded-xl border border-amber-300/60 bg-amber-50/60 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-950/20 dark:text-amber-200">
-              <div className="font-medium">Requested skills missing from the company library</div>
+              <div className="font-medium">{copy.missingRequestedSkills}</div>
               <div className="mt-1 text-xs">
                 {desiredOnlyMissingSkills.join(", ")}
               </div>
@@ -2800,22 +2978,22 @@ function AgentSkillsTab({
           <section className="border-t border-border pt-4">
             <div className="grid gap-2 text-sm sm:grid-cols-2">
               <div className="flex items-center justify-between gap-3 border-b border-border/60 py-2">
-                <span className="text-muted-foreground">Adapter</span>
+                <span className="text-muted-foreground">{copy.adapter}</span>
                 <span className="font-medium">{adapterLabels[agent.adapterType] ?? agent.adapterType}</span>
               </div>
               <div className="flex items-center justify-between gap-3 border-b border-border/60 py-2">
-                <span className="text-muted-foreground">Skills applied</span>
+                <span className="text-muted-foreground">{copy.skillsApplied}</span>
                 <span>{skillApplicationLabel}</span>
               </div>
               <div className="flex items-center justify-between gap-3 border-b border-border/60 py-2">
-                <span className="text-muted-foreground">Selected skills</span>
+                <span className="text-muted-foreground">{copy.selectedSkills}</span>
                 <span>{skillDraft.length}</span>
               </div>
             </div>
 
             {syncSkills.isError && (
               <p className="mt-3 text-xs text-destructive">
-                {syncSkills.error instanceof Error ? syncSkills.error.message : "Failed to update skills"}
+                {syncSkills.error instanceof Error ? syncSkills.error.message : copy.updateFailed}
               </p>
             )}
           </section>
@@ -2828,6 +3006,7 @@ function AgentSkillsTab({
 /* ---- Runs Tab ---- */
 
 function RunListItem({ run, isSelected, agentId }: { run: HeartbeatRun; isSelected: boolean; agentId: string }) {
+  const { uiLanguage } = useGeneralSettings();
   const statusInfo = runStatusIcons[run.status] ?? { icon: Clock, color: "text-neutral-400" };
   const StatusIcon = statusInfo.icon;
   const metrics = runMetrics(run);
@@ -2855,7 +3034,7 @@ function RunListItem({ run, isSelected, agentId }: { run: HeartbeatRun; isSelect
             : run.invocationSource === "on_demand" ? "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300"
             : "bg-muted text-muted-foreground"
         )}>
-          {sourceLabels[run.invocationSource] ?? run.invocationSource}
+          {sourceLabel(run.invocationSource, uiLanguage)}
         </span>
         <span className="ml-auto text-[11px] text-muted-foreground shrink-0">
           {relativeTime(run.createdAt)}
@@ -2868,7 +3047,7 @@ function RunListItem({ run, isSelected, agentId }: { run: HeartbeatRun; isSelect
       )}
       {(metrics.totalTokens > 0 || metrics.cost > 0) && (
         <div className="flex items-center gap-2 pl-5.5 text-[11px] text-muted-foreground tabular-nums">
-          {metrics.totalTokens > 0 && <span>{formatTokens(metrics.totalTokens)} tok</span>}
+          {metrics.totalTokens > 0 && <span>{formatTokens(metrics.totalTokens)} {textFor(uiLanguage, { en: "tok", "zh-CN": "令牌" })}</span>}
           {metrics.cost > 0 && <span>${metrics.cost.toFixed(3)}</span>}
         </div>
       )}
@@ -2893,10 +3072,11 @@ function RunsTab({
   adapterType: string;
   adapterConfig: Record<string, unknown>;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const { isMobile } = useSidebar();
 
   if (runs.length === 0) {
-    return <p className="text-sm text-muted-foreground">No runs yet.</p>;
+    return <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "No runs yet.", "zh-CN": "还没有运行记录。" })}</p>;
   }
 
   // Sort by created descending
@@ -2918,7 +3098,7 @@ function RunsTab({
             className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
           >
             <ArrowLeft className="h-3.5 w-3.5" />
-            Back to runs
+            {textFor(uiLanguage, { en: "Back to runs", "zh-CN": "返回运行记录" })}
           </Link>
           <RunDetail key={selectedRun.id} run={selectedRun} agentRouteId={agentRouteId} adapterType={adapterType} adapterConfig={adapterConfig} />
         </div>
@@ -2961,6 +3141,7 @@ function RunsTab({
 /* ---- Run Detail (expanded) ---- */
 
 function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }: { run: HeartbeatRun; agentRouteId: string; adapterType: string; adapterConfig: Record<string, unknown> }) {
+  const { uiLanguage } = useGeneralSettings();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { data: hydratedRun } = useQuery({
@@ -3009,7 +3190,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
         payload: resumePayload,
       }, run.companyId);
       if (!("id" in result)) {
-        throw new Error(result.message ?? "Resume request was skipped.");
+        throw new Error(result.message ?? textFor(uiLanguage, { en: "Resume request was skipped.", "zh-CN": "恢复请求被跳过。" }));
       }
       return result;
     },
@@ -3041,7 +3222,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
         payload: retryPayload,
       }, run.companyId);
       if (!("id" in result)) {
-        throw new Error(result.message ?? "Retry was skipped.");
+        throw new Error(result.message ?? textFor(uiLanguage, { en: "Retry was skipped.", "zh-CN": "重试被跳过。" }));
       }
       return result;
     },
@@ -3097,8 +3278,8 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
   }, [isRunning, run.startedAt]);
 
   const timeFormat: Intl.DateTimeFormatOptions = { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false };
-  const startTime = run.startedAt ? new Date(run.startedAt).toLocaleTimeString("en-US", timeFormat) : null;
-  const endTime = run.finishedAt ? new Date(run.finishedAt).toLocaleTimeString("en-US", timeFormat) : null;
+  const startTime = run.startedAt ? new Date(run.startedAt).toLocaleTimeString(uiLanguage === "zh-CN" ? "zh-CN" : "en-US", timeFormat) : null;
+  const endTime = run.finishedAt ? new Date(run.finishedAt).toLocaleTimeString(uiLanguage === "zh-CN" ? "zh-CN" : "en-US", timeFormat) : null;
   const durationSec = run.startedAt && run.finishedAt
     ? Math.round((new Date(run.finishedAt).getTime() - new Date(run.startedAt).getTime()) / 1000)
     : null;
@@ -3108,6 +3289,51 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
   const sessionChanged = run.sessionIdBefore && run.sessionIdAfter && run.sessionIdBefore !== run.sessionIdAfter;
   const sessionId = run.sessionIdAfter || run.sessionIdBefore;
   const hasNonZeroExit = run.exitCode !== null && run.exitCode !== 0;
+  const copy = {
+    cancelling: textFor(uiLanguage, { en: "Cancelling…", "zh-CN": "取消中…" }),
+    cancel: textFor(uiLanguage, { en: "Cancel", "zh-CN": "取消" }),
+    resuming: textFor(uiLanguage, { en: "Resuming…", "zh-CN": "恢复中…" }),
+    resume: textFor(uiLanguage, { en: "Resume", "zh-CN": "恢复" }),
+    retrying: textFor(uiLanguage, { en: "Retrying…", "zh-CN": "重试中…" }),
+    retry: textFor(uiLanguage, { en: "Retry", "zh-CN": "重试" }),
+    resumeFailed: textFor(uiLanguage, { en: "Failed to resume run", "zh-CN": "恢复运行失败" }),
+    retryFailed: textFor(uiLanguage, { en: "Failed to retry run", "zh-CN": "重试运行失败" }),
+    duration: textFor(uiLanguage, { en: "Duration", "zh-CN": "耗时" }),
+    runningClaudeLogin: textFor(uiLanguage, { en: "Running claude login...", "zh-CN": "正在执行 Claude 登录..." }),
+    loginToClaude: textFor(uiLanguage, { en: "Login to Claude Code", "zh-CN": "登录 Claude Code" }),
+    claudeLoginFailed: textFor(uiLanguage, { en: "Failed to run Claude login", "zh-CN": "执行 Claude 登录失败" }),
+    loginUrl: textFor(uiLanguage, { en: "Login URL", "zh-CN": "登录链接" }),
+    signal: textFor(uiLanguage, { en: "signal", "zh-CN": "信号" }),
+    input: textFor(uiLanguage, { en: "Input", "zh-CN": "输入" }),
+    output: textFor(uiLanguage, { en: "Output", "zh-CN": "输出" }),
+    cached: textFor(uiLanguage, { en: "Cached", "zh-CN": "缓存" }),
+    cost: textFor(uiLanguage, { en: "Cost", "zh-CN": "成本" }),
+    session: textFor(uiLanguage, { en: "Session", "zh-CN": "会话" }),
+    changed: textFor(uiLanguage, { en: "changed", "zh-CN": "已变化" }),
+    before: textFor(uiLanguage, { en: "Before", "zh-CN": "之前" }),
+    id: "ID",
+    after: textFor(uiLanguage, { en: "After", "zh-CN": "之后" }),
+    clearSessionConfirm: textFor(uiLanguage, {
+      en: "Clear session for these issues touched by this run?",
+      "zh-CN": "要清除此运行触及的这些任务的会话吗？",
+    }),
+    clearSessionSingle: textFor(uiLanguage, {
+      en: "Clear session for 1 issue touched by this run?",
+      "zh-CN": "要清除此运行触及的 1 个任务的会话吗？",
+    }),
+    clearSessionPluralPrefix: textFor(uiLanguage, {
+      en: "Clear session for",
+      "zh-CN": "要清除此运行触及的",
+    }),
+    clearSessionPluralSuffix: textFor(uiLanguage, {
+      en: "issues touched by this run?",
+      "zh-CN": "个任务的会话吗？",
+    }),
+    clearingSession: textFor(uiLanguage, { en: "clearing session...", "zh-CN": "正在清除会话..." }),
+    clearSessionForIssues: textFor(uiLanguage, { en: "clear session for these issues", "zh-CN": "清除这些任务的会话" }),
+    clearSessionsFailed: textFor(uiLanguage, { en: "Failed to clear sessions", "zh-CN": "清除会话失败" }),
+    issuesTouched: textFor(uiLanguage, { en: "Issues Touched", "zh-CN": "触及的任务" }),
+  };
 
   return (
     <div className="space-y-4 min-w-0">
@@ -3126,7 +3352,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                   onClick={() => cancelRun.mutate()}
                   disabled={cancelRun.isPending}
                 >
-                  {cancelRun.isPending ? "Cancelling…" : "Cancel"}
+                  {cancelRun.isPending ? copy.cancelling : copy.cancel}
                 </Button>
               )}
               {canResumeLostRun && (
@@ -3138,7 +3364,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                   disabled={resumeRun.isPending}
                 >
                   <RotateCcw className="h-3.5 w-3.5 mr-1" />
-                  {resumeRun.isPending ? "Resuming…" : "Resume"}
+                  {resumeRun.isPending ? copy.resuming : copy.resume}
                 </Button>
               )}
               {canRetryRun && !canResumeLostRun && (
@@ -3150,7 +3376,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                   disabled={retryRun.isPending}
                 >
                   <RotateCcw className="h-3.5 w-3.5 mr-1" />
-                  {retryRun.isPending ? "Retrying…" : "Retry"}
+                  {retryRun.isPending ? copy.retrying : copy.retry}
                 </Button>
               )}
             </div>
@@ -3177,12 +3403,12 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
             })()}
             {resumeRun.isError && (
               <div className="text-xs text-destructive">
-                {resumeRun.error instanceof Error ? resumeRun.error.message : "Failed to resume run"}
+                {resumeRun.error instanceof Error ? resumeRun.error.message : copy.resumeFailed}
               </div>
             )}
             {retryRun.isError && (
               <div className="text-xs text-destructive">
-                {retryRun.error instanceof Error ? retryRun.error.message : "Failed to retry run"}
+                {retryRun.error instanceof Error ? retryRun.error.message : copy.retryFailed}
               </div>
             )}
             {startTime && (
@@ -3198,7 +3424,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                 </div>
                 {displayDurationSec !== null && (
                   <div className="text-xs text-muted-foreground">
-                    Duration: {displayDurationSec >= 60 ? `${Math.floor(displayDurationSec / 60)}m ${displayDurationSec % 60}s` : `${displayDurationSec}s`}
+                    {copy.duration}: {displayDurationSec >= 60 ? `${Math.floor(displayDurationSec / 60)}m ${displayDurationSec % 60}s` : `${displayDurationSec}s`}
                   </div>
                 )}
               </div>
@@ -3218,18 +3444,18 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                   onClick={() => runClaudeLogin.mutate()}
                   disabled={runClaudeLogin.isPending}
                 >
-                  {runClaudeLogin.isPending ? "Running claude login..." : "Login to Claude Code"}
+                  {runClaudeLogin.isPending ? copy.runningClaudeLogin : copy.loginToClaude}
                 </Button>
                 {runClaudeLogin.isError && (
                   <p className="text-xs text-destructive">
                     {runClaudeLogin.error instanceof Error
                       ? runClaudeLogin.error.message
-                      : "Failed to run Claude login"}
+                      : copy.claudeLoginFailed}
                   </p>
                 )}
                 {claudeLoginResult?.loginUrl && (
                   <p className="text-xs">
-                    Login URL:
+                    {copy.loginUrl}:
                     <a
                       href={claudeLoginResult.loginUrl}
                       className="text-blue-600 underline underline-offset-2 ml-1 break-all dark:text-blue-400"
@@ -3259,7 +3485,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
             {hasNonZeroExit && (
               <div className="text-xs text-red-600 dark:text-red-400">
                 Exit code {run.exitCode}
-                {run.signal && <span className="text-muted-foreground ml-1">(signal: {run.signal})</span>}
+                {run.signal && <span className="text-muted-foreground ml-1">({copy.signal}: {run.signal})</span>}
               </div>
             )}
           </div>
@@ -3268,19 +3494,19 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
           {hasMetrics && (
             <div className="border-t sm:border-t-0 sm:border-l border-border p-4 grid grid-cols-2 gap-x-4 sm:gap-x-8 gap-y-3 content-center tabular-nums">
               <div>
-                <div className="text-xs text-muted-foreground">Input</div>
+                <div className="text-xs text-muted-foreground">{copy.input}</div>
                 <div className="text-sm font-medium font-mono">{formatTokens(metrics.input)}</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground">Output</div>
+                <div className="text-xs text-muted-foreground">{copy.output}</div>
                 <div className="text-sm font-medium font-mono">{formatTokens(metrics.output)}</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground">Cached</div>
+                <div className="text-xs text-muted-foreground">{copy.cached}</div>
                 <div className="text-sm font-medium font-mono">{formatTokens(metrics.cached)}</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground">Cost</div>
+                <div className="text-xs text-muted-foreground">{copy.cost}</div>
                 <div className="text-sm font-medium font-mono">{metrics.cost > 0 ? `$${metrics.cost.toFixed(4)}` : "-"}</div>
               </div>
             </div>
@@ -3295,20 +3521,20 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
               onClick={() => setSessionOpen((v) => !v)}
             >
               <ChevronRight className={cn("h-3 w-3 transition-transform", sessionOpen && "rotate-90")} />
-              Session
-              {sessionChanged && <span className="text-yellow-400 ml-1">(changed)</span>}
+              {copy.session}
+              {sessionChanged && <span className="text-yellow-400 ml-1">({copy.changed})</span>}
             </button>
             {sessionOpen && (
               <div className="px-4 pb-3 space-y-1 text-xs">
                 {run.sessionIdBefore && (
                   <div className="flex items-center gap-2">
-                    <span className="text-muted-foreground w-12">{sessionChanged ? "Before" : "ID"}</span>
+                    <span className="text-muted-foreground w-12">{sessionChanged ? copy.before : copy.id}</span>
                     <CopyText text={run.sessionIdBefore} className="font-mono" />
                   </div>
                 )}
                 {sessionChanged && run.sessionIdAfter && (
                   <div className="flex items-center gap-2">
-                    <span className="text-muted-foreground w-12">After</span>
+                    <span className="text-muted-foreground w-12">{copy.after}</span>
                     <CopyText text={run.sessionIdAfter} className="font-mono" />
                   </div>
                 )}
@@ -3320,22 +3546,24 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                       disabled={clearSessionsForTouchedIssues.isPending}
                       onClick={() => {
                         const issueCount = touchedIssueIds.length;
-                        const confirmed = window.confirm(
-                          `Clear session for ${issueCount} issue${issueCount === 1 ? "" : "s"} touched by this run?`,
-                        );
+                        const confirmed = window.confirm(issueCount === 1
+                          ? copy.clearSessionSingle
+                          : uiLanguage === "zh-CN"
+                            ? `${copy.clearSessionPluralPrefix}${issueCount}${copy.clearSessionPluralSuffix}`
+                            : `${copy.clearSessionPluralPrefix} ${issueCount} issues touched by this run?`);
                         if (!confirmed) return;
                         clearSessionsForTouchedIssues.mutate();
                       }}
                     >
                       {clearSessionsForTouchedIssues.isPending
-                        ? "clearing session..."
-                        : "clear session for these issues"}
+                        ? copy.clearingSession
+                        : copy.clearSessionForIssues}
                     </button>
                     {clearSessionsForTouchedIssues.isError && (
                       <p className="text-[11px] text-destructive mt-1">
                         {clearSessionsForTouchedIssues.error instanceof Error
                           ? clearSessionsForTouchedIssues.error.message
-                          : "Failed to clear sessions"}
+                          : copy.clearSessionsFailed}
                       </p>
                     )}
                   </div>
@@ -3349,7 +3577,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
       {/* Issues touched by this run */}
       {touchedIssues && touchedIssues.length > 0 && (
         <div className="space-y-2">
-          <span className="text-xs font-medium text-muted-foreground">Issues Touched ({touchedIssues.length})</span>
+          <span className="text-xs font-medium text-muted-foreground">{copy.issuesTouched} ({touchedIssues.length})</span>
           <div className="border border-border rounded-lg divide-y divide-border">
             {touchedIssues.map((issue) => (
               <Link
@@ -3394,6 +3622,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
 /* ---- Log Viewer ---- */
 
 function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: string }) {
+  const { uiLanguage } = useGeneralSettings();
   const [events, setEvents] = useState<HeartbeatRunEvent[]>([]);
   const [logLines, setLogLines] = useState<Array<{ ts: string; stream: "stdout" | "stderr" | "system"; chunk: string }>>([]);
   const [loading, setLoading] = useState(true);
@@ -3782,13 +4011,28 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
   useEffect(() => {
     setTranscriptMode("nice");
   }, [run.id]);
+  const copy = {
+    loadingRunLogs: textFor(uiLanguage, { en: "Loading run logs...", "zh-CN": "正在加载运行日志..." }),
+    noLogEvents: textFor(uiLanguage, { en: "No log events.", "zh-CN": "没有日志事件。" }),
+    transcript: textFor(uiLanguage, { en: "Transcript", "zh-CN": "转录" }),
+    jumpToLive: textFor(uiLanguage, { en: "Jump to live", "zh-CN": "跳到最新" }),
+    live: textFor(uiLanguage, { en: "Live", "zh-CN": "实时" }),
+    waitingForTranscript: textFor(uiLanguage, { en: "Waiting for transcript...", "zh-CN": "等待转录内容..." }),
+    noPersistedTranscript: textFor(uiLanguage, { en: "No persisted transcript for this run.", "zh-CN": "该运行没有已持久化的转录内容。" }),
+    failureDetails: textFor(uiLanguage, { en: "Failure details", "zh-CN": "失败详情" }),
+    error: textFor(uiLanguage, { en: "Error", "zh-CN": "错误" }),
+    stderrExcerpt: textFor(uiLanguage, { en: "stderr excerpt", "zh-CN": "stderr 摘录" }),
+    adapterResultJson: textFor(uiLanguage, { en: "adapter result JSON", "zh-CN": "适配器结果 JSON" }),
+    stdoutExcerpt: textFor(uiLanguage, { en: "stdout excerpt", "zh-CN": "stdout 摘录" }),
+    events: textFor(uiLanguage, { en: "Events", "zh-CN": "事件" }),
+  };
 
   if (loading && logLoading) {
-    return <p className="text-xs text-muted-foreground">Loading run logs...</p>;
+    return <p className="text-xs text-muted-foreground">{copy.loadingRunLogs}</p>;
   }
 
   if (events.length === 0 && logLines.length === 0 && !logError) {
-    return <p className="text-xs text-muted-foreground">No log events.</p>;
+    return <p className="text-xs text-muted-foreground">{copy.noLogEvents}</p>;
   }
 
   const levelColors: Record<string, string> = {
@@ -3815,7 +4059,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
 
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-muted-foreground">
-          Transcript ({transcript.length})
+          {copy.transcript} ({transcript.length})
         </span>
         <div className="flex items-center gap-2">
           <div className="inline-flex rounded-lg border border-border/70 bg-background/70 p-0.5">
@@ -3847,7 +4091,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
                 lastMetricsRef.current = readScrollMetrics(container);
               }}
             >
-              Jump to live
+              {copy.jumpToLive}
             </Button>
           )}
           {isLive && (
@@ -3856,7 +4100,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
                 <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-cyan-400 opacity-75" />
                 <span className="relative inline-flex rounded-full h-2 w-2 bg-cyan-400" />
               </span>
-              Live
+              {copy.live}
             </span>
           )}
         </div>
@@ -3866,7 +4110,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           entries={transcript}
           mode={transcriptMode}
           streaming={isLive}
-          emptyMessage={run.logRef ? "Waiting for transcript..." : "No persisted transcript for this run."}
+          emptyMessage={run.logRef ? copy.waitingForTranscript : copy.noPersistedTranscript}
         />
         {logError && (
           <div className="mt-3 rounded-xl border border-red-500/20 bg-red-500/[0.06] px-3 py-2 text-xs text-red-700 dark:text-red-300">
@@ -3878,16 +4122,16 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
 
       {(run.status === "failed" || run.status === "timed_out") && (
         <div className="rounded-lg border border-red-300 dark:border-red-500/30 bg-red-50 dark:bg-red-950/20 p-3 space-y-2">
-          <div className="text-xs font-medium text-red-700 dark:text-red-300">Failure details</div>
+          <div className="text-xs font-medium text-red-700 dark:text-red-300">{copy.failureDetails}</div>
           {run.error && (
             <div className="text-xs text-red-600 dark:text-red-200">
-              <span className="text-red-700 dark:text-red-300">Error: </span>
+              <span className="text-red-700 dark:text-red-300">{copy.error}: </span>
               {redactPathText(run.error, censorUsernameInLogs)}
             </div>
           )}
           {run.stderrExcerpt && run.stderrExcerpt.trim() && (
             <div>
-              <div className="text-xs text-red-700 dark:text-red-300 mb-1">stderr excerpt</div>
+              <div className="text-xs text-red-700 dark:text-red-300 mb-1">{copy.stderrExcerpt}</div>
               <pre className="bg-red-50 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap text-red-800 dark:text-red-100">
                 {redactPathText(run.stderrExcerpt, censorUsernameInLogs)}
               </pre>
@@ -3895,7 +4139,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           )}
           {run.resultJson && (
             <div>
-              <div className="text-xs text-red-700 dark:text-red-300 mb-1">adapter result JSON</div>
+              <div className="text-xs text-red-700 dark:text-red-300 mb-1">{copy.adapterResultJson}</div>
               <pre className="bg-red-50 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap text-red-800 dark:text-red-100">
                 {JSON.stringify(redactPathValue(run.resultJson, censorUsernameInLogs), null, 2)}
               </pre>
@@ -3903,7 +4147,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           )}
           {run.stdoutExcerpt && run.stdoutExcerpt.trim() && !run.resultJson && (
             <div>
-              <div className="text-xs text-red-700 dark:text-red-300 mb-1">stdout excerpt</div>
+              <div className="text-xs text-red-700 dark:text-red-300 mb-1">{copy.stdoutExcerpt}</div>
               <pre className="bg-red-50 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap text-red-800 dark:text-red-100">
                 {redactPathText(run.stdoutExcerpt, censorUsernameInLogs)}
               </pre>
@@ -3914,7 +4158,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
 
       {events.length > 0 && (
         <div>
-          <div className="mb-2 text-xs font-medium text-muted-foreground">Events ({events.length})</div>
+          <div className="mb-2 text-xs font-medium text-muted-foreground">{copy.events} ({events.length})</div>
           <div className="bg-neutral-100 dark:bg-neutral-950 rounded-lg p-3 font-mono text-xs space-y-0.5">
             {events.map((evt) => {
               const color = evt.color
@@ -3925,7 +4169,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
               return (
                 <div key={evt.id} className="flex gap-2">
                   <span className="text-neutral-400 dark:text-neutral-600 shrink-0 select-none w-16">
-                    {new Date(evt.createdAt).toLocaleTimeString("en-US", { hour12: false })}
+                    {new Date(evt.createdAt).toLocaleTimeString(uiLanguage === "zh-CN" ? "zh-CN" : "en-US", { hour12: false })}
                   </span>
                   <span className={cn("shrink-0 w-14", evt.stream ? (streamColors[evt.stream] ?? "text-neutral-500") : "text-neutral-500")}>
                     {evt.stream ? `[${evt.stream}]` : ""}
@@ -3950,6 +4194,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
 /* ---- Keys Tab ---- */
 
 function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }) {
+  const { uiLanguage } = useGeneralSettings();
   const queryClient = useQueryClient();
   const [newKeyName, setNewKeyName] = useState("");
   const [newToken, setNewToken] = useState<string | null>(null);
@@ -3962,7 +4207,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
   });
 
   const createKey = useMutation({
-    mutationFn: () => agentsApi.createKey(agentId, newKeyName.trim() || "Default", companyId),
+    mutationFn: () => agentsApi.createKey(agentId, newKeyName.trim() || copy.defaultKeyName, companyId),
     onSuccess: (data) => {
       setNewToken(data.token);
       setTokenVisible(true);
@@ -3987,6 +4232,29 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
 
   const activeKeys = (keys ?? []).filter((k: AgentKey) => !k.revokedAt);
   const revokedKeys = (keys ?? []).filter((k: AgentKey) => k.revokedAt);
+  const copy = {
+    defaultKeyName: textFor(uiLanguage, { en: "Default", "zh-CN": "默认" }),
+    keyCreated: textFor(uiLanguage, { en: "API key created — copy it now, it will not be shown again.", "zh-CN": "API 密钥已创建，请立即复制，之后将不再显示。" }),
+    hide: textFor(uiLanguage, { en: "Hide", "zh-CN": "隐藏" }),
+    show: textFor(uiLanguage, { en: "Show", "zh-CN": "显示" }),
+    copy: textFor(uiLanguage, { en: "Copy", "zh-CN": "复制" }),
+    copied: textFor(uiLanguage, { en: "Copied!", "zh-CN": "已复制！" }),
+    dismiss: textFor(uiLanguage, { en: "Dismiss", "zh-CN": "关闭" }),
+    createApiKey: textFor(uiLanguage, { en: "Create API Key", "zh-CN": "创建 API 密钥" }),
+    apiKeyHint: textFor(uiLanguage, {
+      en: "API keys allow this agent to authenticate calls to the Paperclip server.",
+      "zh-CN": "API 密钥允许该智能体对 Paperclip 服务端进行鉴权调用。",
+    }),
+    keyNamePlaceholder: textFor(uiLanguage, { en: "Key name (e.g. production)", "zh-CN": "密钥名称（例如 production）" }),
+    create: textFor(uiLanguage, { en: "Create", "zh-CN": "创建" }),
+    loadingKeys: textFor(uiLanguage, { en: "Loading keys...", "zh-CN": "正在加载密钥..." }),
+    noActiveKeys: textFor(uiLanguage, { en: "No active API keys.", "zh-CN": "没有可用的 API 密钥。" }),
+    activeKeys: textFor(uiLanguage, { en: "Active Keys", "zh-CN": "有效密钥" }),
+    created: textFor(uiLanguage, { en: "Created", "zh-CN": "创建于" }),
+    revoke: textFor(uiLanguage, { en: "Revoke", "zh-CN": "吊销" }),
+    revokedKeys: textFor(uiLanguage, { en: "Revoked Keys", "zh-CN": "已吊销密钥" }),
+    revoked: textFor(uiLanguage, { en: "Revoked", "zh-CN": "吊销于" }),
+  };
 
   return (
     <div className="space-y-6">
@@ -3994,7 +4262,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
       {newToken && (
         <div className="border border-yellow-300 dark:border-yellow-600/40 bg-yellow-50 dark:bg-yellow-500/5 rounded-lg p-4 space-y-2">
           <p className="text-sm font-medium text-yellow-700 dark:text-yellow-400">
-            API key created — copy it now, it will not be shown again.
+            {copy.keyCreated}
           </p>
           <div className="flex items-center gap-2">
             <code className="flex-1 bg-neutral-100 dark:bg-neutral-950 rounded px-3 py-1.5 text-xs font-mono text-green-700 dark:text-green-300 truncate">
@@ -4004,7 +4272,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
               variant="ghost"
               size="icon-sm"
               onClick={() => setTokenVisible((v) => !v)}
-              title={tokenVisible ? "Hide" : "Show"}
+              title={tokenVisible ? copy.hide : copy.show}
             >
               {tokenVisible ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
             </Button>
@@ -4012,11 +4280,11 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
               variant="ghost"
               size="icon-sm"
               onClick={copyToken}
-              title="Copy"
+              title={copy.copy}
             >
               <Copy className="h-3.5 w-3.5" />
             </Button>
-            {copied && <span className="text-xs text-green-400">Copied!</span>}
+            {copied && <span className="text-xs text-green-400">{copy.copied}</span>}
           </div>
           <Button
             variant="ghost"
@@ -4024,7 +4292,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
             className="text-muted-foreground text-xs"
             onClick={() => setNewToken(null)}
           >
-            Dismiss
+            {copy.dismiss}
           </Button>
         </div>
       )}
@@ -4033,14 +4301,14 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
       <div className="border border-border rounded-lg p-4 space-y-3">
         <h3 className="text-xs font-medium text-muted-foreground flex items-center gap-2">
           <Key className="h-3.5 w-3.5" />
-          Create API Key
+          {copy.createApiKey}
         </h3>
         <p className="text-xs text-muted-foreground">
-          API keys allow this agent to authenticate calls to the Paperclip server.
+          {copy.apiKeyHint}
         </p>
         <div className="flex items-center gap-2">
           <Input
-            placeholder="Key name (e.g. production)"
+            placeholder={copy.keyNamePlaceholder}
             value={newKeyName}
             onChange={(e) => setNewKeyName(e.target.value)}
             className="h-8 text-sm"
@@ -4054,22 +4322,22 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
             disabled={createKey.isPending}
           >
             <Plus className="h-3.5 w-3.5 mr-1" />
-            Create
+            {copy.create}
           </Button>
         </div>
       </div>
 
       {/* Active keys */}
-      {isLoading && <p className="text-sm text-muted-foreground">Loading keys...</p>}
+      {isLoading && <p className="text-sm text-muted-foreground">{copy.loadingKeys}</p>}
 
       {!isLoading && activeKeys.length === 0 && !newToken && (
-        <p className="text-sm text-muted-foreground">No active API keys.</p>
+        <p className="text-sm text-muted-foreground">{copy.noActiveKeys}</p>
       )}
 
       {activeKeys.length > 0 && (
         <div>
           <h3 className="text-xs font-medium text-muted-foreground mb-2">
-            Active Keys
+            {copy.activeKeys}
           </h3>
           <div className="border border-border rounded-lg divide-y divide-border">
             {activeKeys.map((key: AgentKey) => (
@@ -4077,7 +4345,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
                 <div>
                   <span className="text-sm font-medium">{key.name}</span>
                   <span className="text-xs text-muted-foreground ml-3">
-                    Created {formatDate(key.createdAt)}
+                    {copy.created} {formatDate(key.createdAt)}
                   </span>
                 </div>
                 <Button
@@ -4087,7 +4355,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
                   onClick={() => revokeKey.mutate(key.id)}
                   disabled={revokeKey.isPending}
                 >
-                  Revoke
+                  {copy.revoke}
                 </Button>
               </div>
             ))}
@@ -4099,7 +4367,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
       {revokedKeys.length > 0 && (
         <div>
           <h3 className="text-xs font-medium text-muted-foreground mb-2">
-            Revoked Keys
+            {copy.revokedKeys}
           </h3>
           <div className="border border-border rounded-lg divide-y divide-border opacity-50">
             {revokedKeys.map((key: AgentKey) => (
@@ -4107,7 +4375,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
                 <div>
                   <span className="text-sm line-through">{key.name}</span>
                   <span className="text-xs text-muted-foreground ml-3">
-                    Revoked {key.revokedAt ? formatDate(key.revokedAt) : ""}
+                    {copy.revoked} {key.revokedAt ? formatDate(key.revokedAt) : ""}
                   </span>
                 </div>
               </div>

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -7,6 +7,7 @@ import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useSidebar } from "../context/SidebarContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { queryKeys } from "../lib/queryKeys";
 import { StatusBadge } from "../components/StatusBadge";
 import { agentStatusDot, agentStatusDotDefault } from "../lib/status-colors";
@@ -21,6 +22,7 @@ import { Bot, Plus, List, GitBranch, SlidersHorizontal } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
 
 import { getAdapterLabel } from "../adapters/adapter-display-registry";
+import { textFor } from "../lib/ui-language";
 
 const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;
 
@@ -55,6 +57,7 @@ function filterOrgTree(nodes: OrgNode[], tab: FilterTab, showTerminated: boolean
 
 export function Agents() {
   const { selectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { openNewAgent } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
   const navigate = useNavigate();
@@ -67,6 +70,58 @@ export function Agents() {
   const effectiveView: "list" | "org" = forceListView ? "list" : view;
   const [showTerminated, setShowTerminated] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const copy = {
+    agents: textFor(uiLanguage, {
+      en: "Agents",
+      "zh-CN": "智能体",
+    }),
+    selectCompany: textFor(uiLanguage, {
+      en: "Select a company to view agents.",
+      "zh-CN": "请先选择公司以查看智能体。",
+    }),
+    all: textFor(uiLanguage, {
+      en: "All",
+      "zh-CN": "全部",
+    }),
+    active: textFor(uiLanguage, {
+      en: "Active",
+      "zh-CN": "活跃",
+    }),
+    paused: textFor(uiLanguage, {
+      en: "Paused",
+      "zh-CN": "暂停",
+    }),
+    error: textFor(uiLanguage, {
+      en: "Error",
+      "zh-CN": "异常",
+    }),
+    filters: textFor(uiLanguage, {
+      en: "Filters",
+      "zh-CN": "筛选",
+    }),
+    showTerminated: textFor(uiLanguage, {
+      en: "Show terminated",
+      "zh-CN": "显示已终止",
+    }),
+    newAgent: textFor(uiLanguage, {
+      en: "New Agent",
+      "zh-CN": "新建智能体",
+    }),
+    agentCount: (count: number) =>
+      uiLanguage === "zh-CN" ? `${count} 个智能体` : `${count} agent${count !== 1 ? "s" : ""}`,
+    noAgents: textFor(uiLanguage, {
+      en: "Create your first agent to get started.",
+      "zh-CN": "创建你的第一个智能体开始使用。",
+    }),
+    noAgentsMatchFilter: textFor(uiLanguage, {
+      en: "No agents match the selected filter.",
+      "zh-CN": "没有智能体匹配当前筛选条件。",
+    }),
+    noOrgHierarchy: textFor(uiLanguage, {
+      en: "No organizational hierarchy defined.",
+      "zh-CN": "尚未定义组织层级结构。",
+    }),
+  };
 
   const { data: agents, isLoading, error } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
@@ -109,11 +164,11 @@ export function Agents() {
   }, [agents]);
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Agents" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy.agents }]);
+  }, [copy.agents, setBreadcrumbs]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Bot} message="Select a company to view agents." />;
+    return <EmptyState icon={Bot} message={copy.selectCompany} />;
   }
 
   if (isLoading) {
@@ -129,10 +184,10 @@ export function Agents() {
         <Tabs value={tab} onValueChange={(v) => navigate(`/agents/${v}`)}>
           <PageTabBar
             items={[
-              { value: "all", label: "All" },
-              { value: "active", label: "Active" },
-              { value: "paused", label: "Paused" },
-              { value: "error", label: "Error" },
+              { value: "all", label: copy.all },
+              { value: "active", label: copy.active },
+              { value: "paused", label: copy.paused },
+              { value: "error", label: copy.error },
             ]}
             value={tab}
             onValueChange={(v) => navigate(`/agents/${v}`)}
@@ -149,7 +204,7 @@ export function Agents() {
               onClick={() => setFiltersOpen(!filtersOpen)}
             >
               <SlidersHorizontal className="h-3 w-3" />
-              Filters
+              {copy.filters}
               {showTerminated && <span className="ml-0.5 px-1 bg-foreground/10 rounded text-[10px]">1</span>}
             </button>
             {filtersOpen && (
@@ -164,7 +219,7 @@ export function Agents() {
                   )}>
                     {showTerminated && <span className="text-background text-[10px] leading-none">&#10003;</span>}
                   </span>
-                  Show terminated
+                  {copy.showTerminated}
                 </button>
               </div>
             )}
@@ -194,13 +249,13 @@ export function Agents() {
           )}
           <Button size="sm" variant="outline" onClick={openNewAgent}>
             <Plus className="h-3.5 w-3.5 mr-1.5" />
-            New Agent
+            {copy.newAgent}
           </Button>
         </div>
       </div>
 
       {filtered.length > 0 && (
-        <p className="text-xs text-muted-foreground">{filtered.length} agent{filtered.length !== 1 ? "s" : ""}</p>
+        <p className="text-xs text-muted-foreground">{copy.agentCount(filtered.length)}</p>
       )}
 
       {error && <p className="text-sm text-destructive">{error.message}</p>}
@@ -208,8 +263,8 @@ export function Agents() {
       {agents && agents.length === 0 && (
         <EmptyState
           icon={Bot}
-          message="Create your first agent to get started."
-          action="New Agent"
+          message={copy.noAgents}
+          action={copy.newAgent}
           onAction={openNewAgent}
         />
       )}
@@ -273,7 +328,7 @@ export function Agents() {
 
       {effectiveView === "list" && agents && agents.length > 0 && filtered.length === 0 && (
         <p className="text-sm text-muted-foreground text-center py-8">
-          No agents match the selected filter.
+          {copy.noAgentsMatchFilter}
         </p>
       )}
 
@@ -288,13 +343,13 @@ export function Agents() {
 
       {effectiveView === "org" && orgTree && orgTree.length > 0 && filteredOrg.length === 0 && (
         <p className="text-sm text-muted-foreground text-center py-8">
-          No agents match the selected filter.
+          {copy.noAgentsMatchFilter}
         </p>
       )}
 
       {effectiveView === "org" && orgTree && orgTree.length === 0 && (
         <p className="text-sm text-muted-foreground text-center py-8">
-          No organizational hierarchy defined.
+          {copy.noOrgHierarchy}
         </p>
       )}
     </div>
@@ -390,6 +445,11 @@ function LiveRunIndicator({
   runId: string;
   liveCount: number;
 }) {
+  const { uiLanguage } = useGeneralSettings();
+  const liveLabel = textFor(uiLanguage, {
+    en: "Live",
+    "zh-CN": "在线",
+  });
   return (
     <Link
       to={`/agents/${agentRef}/runs/${runId}`}
@@ -401,7 +461,7 @@ function LiveRunIndicator({
         <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
       </span>
       <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">
-        Live{liveCount > 1 ? ` (${liveCount})` : ""}
+        {liveLabel}{liveCount > 1 ? ` (${liveCount})` : ""}
       </span>
     </Link>
   );

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { DEFAULT_FEEDBACK_DATA_SHARING_TERMS_VERSION } from "@paperclipai/shared";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { useToast } from "../context/ToastContext";
 import { companiesApi } from "../api/companies";
 import { accessApi } from "../api/access";
@@ -17,6 +18,7 @@ import {
   ToggleField,
   HintIcon
 } from "../components/agent-config-primitives";
+import { textFor } from "../lib/ui-language";
 
 type AgentSnippetInput = {
   onboardingTextUrl: string;
@@ -33,9 +35,265 @@ export function CompanySettings() {
     selectedCompanyId,
     setSelectedCompanyId
   } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { setBreadcrumbs } = useBreadcrumbs();
   const { pushToast } = useToast();
   const queryClient = useQueryClient();
+  const copy = {
+    company: textFor(uiLanguage, {
+      en: "Company",
+      "zh-CN": "公司",
+    }),
+    settings: textFor(uiLanguage, {
+      en: "Settings",
+      "zh-CN": "设置",
+    }),
+    noCompanySelected: textFor(uiLanguage, {
+      en: "No company selected. Select a company from the switcher above.",
+      "zh-CN": "当前没有选中公司。请先从上方切换器选择一个公司。",
+    }),
+    title: textFor(uiLanguage, {
+      en: "Company Settings",
+      "zh-CN": "公司设置",
+    }),
+    general: textFor(uiLanguage, {
+      en: "General",
+      "zh-CN": "通用",
+    }),
+    companyName: textFor(uiLanguage, {
+      en: "Company name",
+      "zh-CN": "公司名称",
+    }),
+    companyNameHint: textFor(uiLanguage, {
+      en: "The display name for your company.",
+      "zh-CN": "公司对外显示的名称。",
+    }),
+    description: textFor(uiLanguage, {
+      en: "Description",
+      "zh-CN": "描述",
+    }),
+    descriptionHint: textFor(uiLanguage, {
+      en: "Optional description shown in the company profile.",
+      "zh-CN": "显示在公司资料中的可选描述。",
+    }),
+    descriptionPlaceholder: textFor(uiLanguage, {
+      en: "Optional company description",
+      "zh-CN": "可选的公司描述",
+    }),
+    appearance: textFor(uiLanguage, {
+      en: "Appearance",
+      "zh-CN": "外观",
+    }),
+    logo: textFor(uiLanguage, {
+      en: "Logo",
+      "zh-CN": "Logo",
+    }),
+    logoHint: textFor(uiLanguage, {
+      en: "Upload a PNG, JPEG, WEBP, GIF, or SVG logo image.",
+      "zh-CN": "上传 PNG、JPEG、WEBP、GIF 或 SVG 格式的 logo 图片。",
+    }),
+    removing: textFor(uiLanguage, {
+      en: "Removing...",
+      "zh-CN": "移除中...",
+    }),
+    removeLogo: textFor(uiLanguage, {
+      en: "Remove logo",
+      "zh-CN": "移除 Logo",
+    }),
+    logoUploadFailed: textFor(uiLanguage, {
+      en: "Logo upload failed",
+      "zh-CN": "Logo 上传失败",
+    }),
+    uploadingLogo: textFor(uiLanguage, {
+      en: "Uploading logo...",
+      "zh-CN": "正在上传 Logo...",
+    }),
+    brandColor: textFor(uiLanguage, {
+      en: "Brand color",
+      "zh-CN": "品牌颜色",
+    }),
+    brandColorHint: textFor(uiLanguage, {
+      en: "Sets the hue for the company icon. Leave empty for auto-generated color.",
+      "zh-CN": "设置公司图标的主色调。留空则自动生成颜色。",
+    }),
+    auto: textFor(uiLanguage, {
+      en: "Auto",
+      "zh-CN": "自动",
+    }),
+    clear: textFor(uiLanguage, {
+      en: "Clear",
+      "zh-CN": "清空",
+    }),
+    saving: textFor(uiLanguage, {
+      en: "Saving...",
+      "zh-CN": "保存中...",
+    }),
+    saveChanges: textFor(uiLanguage, {
+      en: "Save changes",
+      "zh-CN": "保存更改",
+    }),
+    saved: textFor(uiLanguage, {
+      en: "Saved",
+      "zh-CN": "已保存",
+    }),
+    saveFailed: textFor(uiLanguage, {
+      en: "Failed to save",
+      "zh-CN": "保存失败",
+    }),
+    hiring: textFor(uiLanguage, {
+      en: "Hiring",
+      "zh-CN": "招聘",
+    }),
+    requireBoardApproval: textFor(uiLanguage, {
+      en: "Require board approval for new hires",
+      "zh-CN": "新招聘需要董事会审批",
+    }),
+    requireBoardApprovalHint: textFor(uiLanguage, {
+      en: "New agent hires stay pending until approved by board.",
+      "zh-CN": "新 agent 的招聘在董事会批准前会保持待处理状态。",
+    }),
+    feedbackSharing: textFor(uiLanguage, {
+      en: "Feedback Sharing",
+      "zh-CN": "反馈共享",
+    }),
+    allowFeedbackSharing: textFor(uiLanguage, {
+      en: "Allow sharing voted AI outputs with Paperclip Labs",
+      "zh-CN": "允许把已投票的 AI 输出共享给 Paperclip Labs",
+    }),
+    allowFeedbackSharingHint: textFor(uiLanguage, {
+      en: "Only AI-generated outputs you explicitly vote on are eligible for feedback sharing.",
+      "zh-CN": "只有你明确投票过的 AI 输出才有资格被共享。",
+    }),
+    feedbackSharingDescription: textFor(uiLanguage, {
+      en: "Votes are always saved locally. This setting controls whether voted AI outputs may also be marked for sharing with Paperclip Labs.",
+      "zh-CN": "投票记录始终会保存在本地。这个设置决定已投票的 AI 输出是否也可以被标记为共享给 Paperclip Labs。",
+    }),
+    termsVersion: textFor(uiLanguage, {
+      en: "Terms version",
+      "zh-CN": "条款版本",
+    }),
+    enabledAt: textFor(uiLanguage, {
+      en: "Enabled",
+      "zh-CN": "已启用",
+    }),
+    byUser: textFor(uiLanguage, {
+      en: "by",
+      "zh-CN": "由",
+    }),
+    sharingDisabled: textFor(uiLanguage, {
+      en: "Sharing is currently disabled.",
+      "zh-CN": "当前共享处于关闭状态。",
+    }),
+    readTerms: textFor(uiLanguage, {
+      en: "Read our terms of service",
+      "zh-CN": "查看服务条款",
+    }),
+    invites: textFor(uiLanguage, {
+      en: "Invites",
+      "zh-CN": "邀请",
+    }),
+    invitesDescription: textFor(uiLanguage, {
+      en: "Generate an OpenClaw agent invite snippet.",
+      "zh-CN": "生成 OpenClaw agent 的邀请片段。",
+    }),
+    invitesHint: textFor(uiLanguage, {
+      en: "Creates a short-lived OpenClaw agent invite and renders a copy-ready prompt.",
+      "zh-CN": "创建一个短时有效的 OpenClaw agent 邀请，并生成可直接复制的提示词。",
+    }),
+    generating: textFor(uiLanguage, {
+      en: "Generating...",
+      "zh-CN": "生成中...",
+    }),
+    generateInvite: textFor(uiLanguage, {
+      en: "Generate OpenClaw Invite Prompt",
+      "zh-CN": "生成 OpenClaw 邀请提示词",
+    }),
+    createInviteFailed: textFor(uiLanguage, {
+      en: "Failed to create invite",
+      "zh-CN": "创建邀请失败",
+    }),
+    invitePrompt: textFor(uiLanguage, {
+      en: "OpenClaw Invite Prompt",
+      "zh-CN": "OpenClaw 邀请提示词",
+    }),
+    copied: textFor(uiLanguage, {
+      en: "Copied",
+      "zh-CN": "已复制",
+    }),
+    copiedSnippet: textFor(uiLanguage, {
+      en: "Copied snippet",
+      "zh-CN": "已复制片段",
+    }),
+    copySnippet: textFor(uiLanguage, {
+      en: "Copy snippet",
+      "zh-CN": "复制片段",
+    }),
+    companyPackages: textFor(uiLanguage, {
+      en: "Company Packages",
+      "zh-CN": "公司包",
+    }),
+    companyPackagesDescription: textFor(uiLanguage, {
+      en: "Import and export have moved to dedicated pages accessible from the Org Chart header.",
+      "zh-CN": "导入和导出已经移动到独立页面，可以从组织架构页头部进入。",
+    }),
+    export: textFor(uiLanguage, {
+      en: "Export",
+      "zh-CN": "导出",
+    }),
+    import: textFor(uiLanguage, {
+      en: "Import",
+      "zh-CN": "导入",
+    }),
+    dangerZone: textFor(uiLanguage, {
+      en: "Danger Zone",
+      "zh-CN": "危险区域",
+    }),
+    archiveDescription: textFor(uiLanguage, {
+      en: "Archive this company to hide it from the sidebar. This persists in the database.",
+      "zh-CN": "归档这个公司后，它会从侧边栏中隐藏，并且这个状态会持久化到数据库。",
+    }),
+    archiving: textFor(uiLanguage, {
+      en: "Archiving...",
+      "zh-CN": "归档中...",
+    }),
+    alreadyArchived: textFor(uiLanguage, {
+      en: "Already archived",
+      "zh-CN": "已归档",
+    }),
+    archiveCompany: textFor(uiLanguage, {
+      en: "Archive company",
+      "zh-CN": "归档公司",
+    }),
+    archiveFailed: textFor(uiLanguage, {
+      en: "Failed to archive company",
+      "zh-CN": "归档公司失败",
+    }),
+    archiveConfirm: (name: string) =>
+      textFor(uiLanguage, {
+        en: `Archive company "${name}"? It will be hidden from the sidebar.`,
+        "zh-CN": `确认归档公司“${name}”吗？归档后它会从侧边栏中隐藏。`,
+      }),
+    feedbackSharingEnabledToast: textFor(uiLanguage, {
+      en: "Feedback sharing enabled",
+      "zh-CN": "反馈共享已启用",
+    }),
+    feedbackSharingDisabledToast: textFor(uiLanguage, {
+      en: "Feedback sharing disabled",
+      "zh-CN": "反馈共享已关闭",
+    }),
+    feedbackSharingUpdateFailedToast: textFor(uiLanguage, {
+      en: "Failed to update feedback sharing",
+      "zh-CN": "更新反馈共享失败",
+    }),
+    unknownError: textFor(uiLanguage, {
+      en: "Unknown error",
+      "zh-CN": "未知错误",
+    }),
+    orgChart: textFor(uiLanguage, {
+      en: "Org Chart",
+      "zh-CN": "组织架构",
+    }),
+  };
   // General settings local state
   const [companyName, setCompanyName] = useState("");
   const [description, setDescription] = useState("");
@@ -92,14 +350,14 @@ export function CompanySettings() {
     onSuccess: (_company, enabled) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
       pushToast({
-        title: enabled ? "Feedback sharing enabled" : "Feedback sharing disabled",
+        title: enabled ? copy.feedbackSharingEnabledToast : copy.feedbackSharingDisabledToast,
         tone: "success",
       });
     },
     onError: (err) => {
       pushToast({
-        title: "Failed to update feedback sharing",
-        body: err instanceof Error ? err.message : "Unknown error",
+        title: copy.feedbackSharingUpdateFailedToast,
+        body: err instanceof Error ? err.message : copy.unknownError,
         tone: "error",
       });
     },
@@ -153,7 +411,7 @@ export function CompanySettings() {
     },
     onError: (err) => {
       setInviteError(
-        err instanceof Error ? err.message : "Failed to create invite"
+        err instanceof Error ? err.message : copy.createInviteFailed
       );
     }
   });
@@ -224,15 +482,15 @@ export function CompanySettings() {
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: selectedCompany?.name ?? "Company", href: "/dashboard" },
-      { label: "Settings" }
+      { label: selectedCompany?.name ?? copy.company, href: "/dashboard" },
+      { label: copy.settings }
     ]);
-  }, [setBreadcrumbs, selectedCompany?.name]);
+  }, [copy.company, copy.settings, setBreadcrumbs, selectedCompany?.name]);
 
   if (!selectedCompany) {
     return (
       <div className="text-sm text-muted-foreground">
-        No company selected. Select a company from the switcher above.
+        {copy.noCompanySelected}
       </div>
     );
   }
@@ -249,16 +507,16 @@ export function CompanySettings() {
     <div className="max-w-2xl space-y-6">
       <div className="flex items-center gap-2">
         <Settings className="h-5 w-5 text-muted-foreground" />
-        <h1 className="text-lg font-semibold">Company Settings</h1>
+        <h1 className="text-lg font-semibold">{copy.title}</h1>
       </div>
 
       {/* General */}
       <div className="space-y-4">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          General
+          {copy.general}
         </div>
         <div className="space-y-3 rounded-md border border-border px-4 py-4">
-          <Field label="Company name" hint="The display name for your company.">
+          <Field label={copy.companyName} hint={copy.companyNameHint}>
             <input
               className="w-full rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none"
               type="text"
@@ -267,14 +525,14 @@ export function CompanySettings() {
             />
           </Field>
           <Field
-            label="Description"
-            hint="Optional description shown in the company profile."
+            label={copy.description}
+            hint={copy.descriptionHint}
           >
             <input
               className="w-full rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none"
               type="text"
               value={description}
-              placeholder="Optional company description"
+              placeholder={copy.descriptionPlaceholder}
               onChange={(e) => setDescription(e.target.value)}
             />
           </Field>
@@ -284,7 +542,7 @@ export function CompanySettings() {
       {/* Appearance */}
       <div className="space-y-4">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          Appearance
+          {copy.appearance}
         </div>
         <div className="space-y-3 rounded-md border border-border px-4 py-4">
           <div className="flex items-start gap-4">
@@ -298,8 +556,8 @@ export function CompanySettings() {
             </div>
             <div className="flex-1 space-y-3">
               <Field
-                label="Logo"
-                hint="Upload a PNG, JPEG, WEBP, GIF, or SVG logo image."
+                label={copy.logo}
+                hint={copy.logoHint}
               >
                 <div className="space-y-2">
                   <input
@@ -316,7 +574,7 @@ export function CompanySettings() {
                         onClick={handleClearLogo}
                         disabled={clearLogoMutation.isPending}
                       >
-                        {clearLogoMutation.isPending ? "Removing..." : "Remove logo"}
+                        {clearLogoMutation.isPending ? copy.removing : copy.removeLogo}
                       </Button>
                     </div>
                   )}
@@ -325,7 +583,7 @@ export function CompanySettings() {
                       {logoUploadError ??
                         (logoUploadMutation.error instanceof Error
                           ? logoUploadMutation.error.message
-                          : "Logo upload failed")}
+                          : copy.logoUploadFailed)}
                     </span>
                   )}
                   {clearLogoMutation.isError && (
@@ -334,13 +592,13 @@ export function CompanySettings() {
                     </span>
                   )}
                   {logoUploadMutation.isPending && (
-                    <span className="text-xs text-muted-foreground">Uploading logo...</span>
+                    <span className="text-xs text-muted-foreground">{copy.uploadingLogo}</span>
                   )}
                 </div>
               </Field>
               <Field
-                label="Brand color"
-                hint="Sets the hue for the company icon. Leave empty for auto-generated color."
+                label={copy.brandColor}
+                hint={copy.brandColorHint}
               >
                 <div className="flex items-center gap-2">
                   <input
@@ -358,7 +616,7 @@ export function CompanySettings() {
                         setBrandColor(v);
                       }
                     }}
-                    placeholder="Auto"
+                    placeholder={copy.auto}
                     className="w-28 rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm font-mono outline-none"
                   />
                   {brandColor && (
@@ -368,7 +626,7 @@ export function CompanySettings() {
                       onClick={() => setBrandColor("")}
                       className="text-xs text-muted-foreground"
                     >
-                      Clear
+                      {copy.clear}
                     </Button>
                   )}
                 </div>
@@ -386,16 +644,16 @@ export function CompanySettings() {
             onClick={handleSaveGeneral}
             disabled={generalMutation.isPending || !companyName.trim()}
           >
-            {generalMutation.isPending ? "Saving..." : "Save changes"}
+            {generalMutation.isPending ? copy.saving : copy.saveChanges}
           </Button>
           {generalMutation.isSuccess && (
-            <span className="text-xs text-muted-foreground">Saved</span>
+            <span className="text-xs text-muted-foreground">{copy.saved}</span>
           )}
           {generalMutation.isError && (
             <span className="text-xs text-destructive">
               {generalMutation.error instanceof Error
                   ? generalMutation.error.message
-                  : "Failed to save"}
+                  : copy.saveFailed}
             </span>
           )}
         </div>
@@ -404,12 +662,12 @@ export function CompanySettings() {
       {/* Hiring */}
       <div className="space-y-4" data-testid="company-settings-team-section">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          Hiring
+          {copy.hiring}
         </div>
         <div className="rounded-md border border-border px-4 py-3">
           <ToggleField
-            label="Require board approval for new hires"
-            hint="New agent hires stay pending until approved by board."
+            label={copy.requireBoardApproval}
+            hint={copy.requireBoardApprovalHint}
             checked={!!selectedCompany.requireBoardApprovalForNewAgents}
             onChange={(v) => settingsMutation.mutate(v)}
             toggleTestId="company-settings-team-approval-toggle"
@@ -419,31 +677,31 @@ export function CompanySettings() {
 
       <div className="space-y-4">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          Feedback Sharing
+          {copy.feedbackSharing}
         </div>
         <div className="space-y-3 rounded-md border border-border px-4 py-4">
           <ToggleField
-            label="Allow sharing voted AI outputs with Paperclip Labs"
-            hint="Only AI-generated outputs you explicitly vote on are eligible for feedback sharing."
+            label={copy.allowFeedbackSharing}
+            hint={copy.allowFeedbackSharingHint}
             checked={!!selectedCompany.feedbackDataSharingEnabled}
             onChange={(enabled) => feedbackSharingMutation.mutate(enabled)}
           />
           <p className="text-sm text-muted-foreground">
-            Votes are always saved locally. This setting controls whether voted AI outputs may also be marked for sharing with Paperclip Labs.
+            {copy.feedbackSharingDescription}
           </p>
           <div className="space-y-1 text-xs text-muted-foreground">
             <div>
-              Terms version: {selectedCompany.feedbackDataSharingTermsVersion ?? DEFAULT_FEEDBACK_DATA_SHARING_TERMS_VERSION}
+              {copy.termsVersion}: {selectedCompany.feedbackDataSharingTermsVersion ?? DEFAULT_FEEDBACK_DATA_SHARING_TERMS_VERSION}
             </div>
             {selectedCompany.feedbackDataSharingConsentAt ? (
               <div>
-                Enabled {new Date(selectedCompany.feedbackDataSharingConsentAt).toLocaleString()}
+                {copy.enabledAt} {new Date(selectedCompany.feedbackDataSharingConsentAt).toLocaleString()}
                 {selectedCompany.feedbackDataSharingConsentByUserId
-                  ? ` by ${selectedCompany.feedbackDataSharingConsentByUserId}`
+                  ? ` ${copy.byUser} ${selectedCompany.feedbackDataSharingConsentByUserId}`
                   : ""}
               </div>
             ) : (
-              <div>Sharing is currently disabled.</div>
+              <div>{copy.sharingDisabled}</div>
             )}
             {FEEDBACK_TERMS_URL ? (
               <a
@@ -452,7 +710,7 @@ export function CompanySettings() {
                 rel="noreferrer"
                 className="inline-flex text-foreground underline underline-offset-4"
               >
-                Read our terms of service
+                {copy.readTerms}
               </a>
             ) : null}
           </div>
@@ -462,14 +720,14 @@ export function CompanySettings() {
       {/* Invites */}
       <div className="space-y-4" data-testid="company-settings-invites-section">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          Invites
+          {copy.invites}
         </div>
         <div className="space-y-3 rounded-md border border-border px-4 py-4">
           <div className="flex items-center gap-1.5">
             <span className="text-xs text-muted-foreground">
-              Generate an OpenClaw agent invite snippet.
+              {copy.invitesDescription}
             </span>
-            <HintIcon text="Creates a short-lived OpenClaw agent invite and renders a copy-ready prompt." />
+            <HintIcon text={copy.invitesHint} />
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <Button
@@ -479,8 +737,8 @@ export function CompanySettings() {
               disabled={inviteMutation.isPending}
             >
               {inviteMutation.isPending
-                ? "Generating..."
-                : "Generate OpenClaw Invite Prompt"}
+                ? copy.generating
+                : copy.generateInvite}
             </Button>
           </div>
           {inviteError && (
@@ -493,7 +751,7 @@ export function CompanySettings() {
             >
               <div className="flex items-center justify-between gap-2">
                 <div className="text-xs text-muted-foreground">
-                  OpenClaw Invite Prompt
+                  {copy.invitePrompt}
                 </div>
                 {snippetCopied && (
                   <span
@@ -501,7 +759,7 @@ export function CompanySettings() {
                     className="flex items-center gap-1 text-xs text-green-600 animate-pulse"
                   >
                     <Check className="h-3 w-3" />
-                    Copied
+                    {copy.copied}
                   </span>
                 )}
               </div>
@@ -528,7 +786,7 @@ export function CompanySettings() {
                       }
                     }}
                   >
-                    {snippetCopied ? "Copied snippet" : "Copy snippet"}
+                    {snippetCopied ? copy.copiedSnippet : copy.copySnippet}
                   </Button>
                 </div>
               </div>
@@ -540,24 +798,24 @@ export function CompanySettings() {
       {/* Import / Export */}
       <div className="space-y-4">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          Company Packages
+          {copy.companyPackages}
         </div>
         <div className="rounded-md border border-border px-4 py-4">
           <p className="text-sm text-muted-foreground">
-            Import and export have moved to dedicated pages accessible from the{" "}
-            <a href="/org" className="underline hover:text-foreground">Org Chart</a> header.
+            {copy.companyPackagesDescription}{" "}
+            <a href="/org" className="underline hover:text-foreground">{copy.orgChart}</a>.
           </p>
           <div className="mt-3 flex items-center gap-2">
             <Button size="sm" variant="outline" asChild>
               <Link to="/company/export">
                 <Download className="mr-1.5 h-3.5 w-3.5" />
-                Export
+                {copy.export}
               </Link>
             </Button>
             <Button size="sm" variant="outline" asChild>
               <Link to="/company/import">
                 <Upload className="mr-1.5 h-3.5 w-3.5" />
-                Import
+                {copy.import}
               </Link>
             </Button>
           </div>
@@ -567,12 +825,11 @@ export function CompanySettings() {
       {/* Danger Zone */}
       <div className="space-y-4">
         <div className="text-xs font-medium text-destructive uppercase tracking-wide">
-          Danger Zone
+          {copy.dangerZone}
         </div>
         <div className="space-y-3 rounded-md border border-destructive/40 bg-destructive/5 px-4 py-4">
           <p className="text-sm text-muted-foreground">
-            Archive this company to hide it from the sidebar. This persists in
-            the database.
+            {copy.archiveDescription}
           </p>
           <div className="flex items-center gap-2">
             <Button
@@ -584,9 +841,7 @@ export function CompanySettings() {
               }
               onClick={() => {
                 if (!selectedCompanyId) return;
-                const confirmed = window.confirm(
-                  `Archive company "${selectedCompany.name}"? It will be hidden from the sidebar.`
-                );
+                const confirmed = window.confirm(copy.archiveConfirm(selectedCompany.name));
                 if (!confirmed) return;
                 const nextCompanyId =
                   companies.find(
@@ -601,16 +856,16 @@ export function CompanySettings() {
               }}
             >
               {archiveMutation.isPending
-                ? "Archiving..."
+                ? copy.archiving
                 : selectedCompany.status === "archived"
-                ? "Already archived"
-                : "Archive company"}
+                ? copy.alreadyArchived
+                : copy.archiveCompany}
             </Button>
             {archiveMutation.isError && (
               <span className="text-xs text-destructive">
                 {archiveMutation.error instanceof Error
                   ? archiveMutation.error.message
-                  : "Failed to archive company"}
+                  : copy.archiveFailed}
               </span>
             )}
           </div>

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -26,12 +26,14 @@ import { ProviderQuotaCard } from "../components/ProviderQuotaCard";
 import { StatusBadge } from "../components/StatusBadge";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useCompany } from "../context/CompanyContext";
-import { useDateRange, PRESET_KEYS, PRESET_LABELS } from "../hooks/useDateRange";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { useDateRange, PRESET_KEYS } from "../hooks/useDateRange";
 import { queryKeys } from "../lib/queryKeys";
 import { billingTypeDisplayName, cn, formatCents, formatTokens, providerDisplayName } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { textFor } from "../lib/ui-language";
 
 const NO_COMPANY = "__none__";
 
@@ -108,37 +110,53 @@ function FinanceSummaryCard({
   estimatedDebitCents: number;
   eventCount: number;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   return (
     <Card>
       <CardHeader className="px-5 pt-5 pb-2">
-        <CardTitle className="text-base">Finance ledger</CardTitle>
+        <CardTitle className="text-base">{textFor(uiLanguage, { en: "Finance ledger", "zh-CN": "财务台账" })}</CardTitle>
         <CardDescription>
-          Account-level charges that do not map to a single inference request.
+          {textFor(uiLanguage, {
+            en: "Account-level charges that do not map to a single inference request.",
+            "zh-CN": "不映射到单次推理请求的账户级收费。",
+          })}
         </CardDescription>
       </CardHeader>
       <CardContent className="grid gap-3 px-5 pb-5 pt-2 sm:grid-cols-2 xl:grid-cols-4">
         <MetricTile
-          label="Debits"
+          label={textFor(uiLanguage, { en: "Debits", "zh-CN": "支出" })}
           value={formatCents(debitCents)}
-          subtitle={`${eventCount} total event${eventCount === 1 ? "" : "s"} in range`}
+          subtitle={textFor(uiLanguage, {
+            en: `${eventCount} total event${eventCount === 1 ? "" : "s"} in range`,
+            "zh-CN": `当前范围内共 ${eventCount} 条事件`,
+          })}
           icon={ArrowUpRight}
         />
         <MetricTile
-          label="Credits"
+          label={textFor(uiLanguage, { en: "Credits", "zh-CN": "入账" })}
           value={formatCents(creditCents)}
-          subtitle="Refunds, offsets, and credit returns"
+          subtitle={textFor(uiLanguage, {
+            en: "Refunds, offsets, and credit returns",
+            "zh-CN": "退款、冲抵与积分返还",
+          })}
           icon={ArrowDownLeft}
         />
         <MetricTile
-          label="Net"
+          label={textFor(uiLanguage, { en: "Net", "zh-CN": "净额" })}
           value={formatCents(netCents)}
-          subtitle="Debit minus credit for the selected period"
+          subtitle={textFor(uiLanguage, {
+            en: "Debit minus credit for the selected period",
+            "zh-CN": "所选时间范围内的支出减入账",
+          })}
           icon={ReceiptText}
         />
         <MetricTile
-          label="Estimated"
+          label={textFor(uiLanguage, { en: "Estimated", "zh-CN": "估算" })}
           value={formatCents(estimatedDebitCents)}
-          subtitle="Estimated debits that are not yet invoice-authoritative"
+          subtitle={textFor(uiLanguage, {
+            en: "Estimated debits that are not yet invoice-authoritative",
+            "zh-CN": "尚未以发票为准的预估支出",
+          })}
           icon={Coins}
         />
       </CardContent>
@@ -149,6 +167,7 @@ function FinanceSummaryCard({
 export function Costs() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const { uiLanguage } = useGeneralSettings();
   const queryClient = useQueryClient();
 
   const [mainTab, setMainTab] = useState<"overview" | "budgets" | "providers" | "billers" | "finance">("overview");
@@ -168,8 +187,8 @@ export function Costs() {
   } = useDateRange();
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Costs" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: textFor(uiLanguage, { en: "Costs", "zh-CN": "成本" }) }]);
+  }, [setBreadcrumbs, uiLanguage]);
 
   const [today, setToday] = useState(() => new Date().toDateString());
   const todayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -464,7 +483,7 @@ export function Costs() {
         value: "all",
         label: (
           <span className="flex items-center gap-1.5">
-            <span>All providers</span>
+            <span>{textFor(uiLanguage, { en: "All providers", "zh-CN": "全部提供方" })}</span>
             {providerKeys.length > 0 ? (
               <>
                 <span className="font-mono text-xs text-muted-foreground">{formatTokens(allTokens)}</span>
@@ -479,7 +498,7 @@ export function Costs() {
         label: <ProviderTabLabel provider={provider} rows={byProvider.get(provider) ?? []} />,
       })),
     ];
-  }, [byProvider]);
+  }, [byProvider, uiLanguage]);
 
   const billerTabItems = useMemo(() => {
     const billerKeys = Array.from(byBiller.keys());
@@ -496,7 +515,7 @@ export function Costs() {
         value: "all",
         label: (
           <span className="flex items-center gap-1.5">
-            <span>All billers</span>
+            <span>{textFor(uiLanguage, { en: "All billers", "zh-CN": "全部计费方" })}</span>
             {billerKeys.length > 0 ? (
               <>
                 <span className="font-mono text-xs text-muted-foreground">{formatTokens(allTokens)}</span>
@@ -511,7 +530,7 @@ export function Costs() {
         label: <BillerTabLabel biller={biller} rows={byBiller.get(biller) ?? []} />,
       })),
     ];
-  }, [byBiller]);
+  }, [byBiller, uiLanguage]);
 
   const inferenceTokenTotal =
     (spendData?.byAgent ?? []).reduce(
@@ -527,9 +546,17 @@ export function Costs() {
     agent: budgetPolicies.filter((policy) => policy.scopeType === "agent"),
     project: budgetPolicies.filter((policy) => policy.scopeType === "project"),
   }), [budgetPolicies]);
+  const presetLabels = useMemo(() => ({
+    mtd: textFor(uiLanguage, { en: "Month to Date", "zh-CN": "本月至今" }),
+    "7d": textFor(uiLanguage, { en: "Last 7 Days", "zh-CN": "最近 7 天" }),
+    "30d": textFor(uiLanguage, { en: "Last 30 Days", "zh-CN": "最近 30 天" }),
+    ytd: textFor(uiLanguage, { en: "Year to Date", "zh-CN": "今年至今" }),
+    all: textFor(uiLanguage, { en: "All Time", "zh-CN": "全部时间" }),
+    custom: textFor(uiLanguage, { en: "Custom", "zh-CN": "自定义" }),
+  }), [uiLanguage]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={DollarSign} message="Select a company to view costs." />;
+    return <EmptyState icon={DollarSign} message={textFor(uiLanguage, { en: "Select a company to view costs.", "zh-CN": "请选择一个公司以查看成本。" })} />;
   }
 
   const showCustomPrompt = preset === "custom" && !customReady;
@@ -541,9 +568,12 @@ export function Costs() {
       <div className="space-y-5">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div>
-                <h1 className="text-3xl font-semibold tracking-tight">Costs</h1>
+                <h1 className="text-3xl font-semibold tracking-tight">{textFor(uiLanguage, { en: "Costs", "zh-CN": "成本" })}</h1>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                  Inference spend, platform fees, credits, and live quota windows.
+                  {textFor(uiLanguage, {
+                    en: "Inference spend, platform fees, credits, and live quota windows.",
+                    "zh-CN": "推理支出、平台费用、积分，以及实时配额窗口。",
+                  })}
                 </p>
             </div>
 
@@ -555,7 +585,7 @@ export function Costs() {
                   size="sm"
                   onClick={() => setPreset(key)}
                 >
-                  {PRESET_LABELS[key]}
+                  {presetLabels[key]}
                 </Button>
               ))}
             </div>
@@ -569,7 +599,7 @@ export function Costs() {
                 onChange={(event) => setCustomFrom(event.target.value)}
                 className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
               />
-              <span className="text-sm text-muted-foreground">to</span>
+              <span className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "to", "zh-CN": "至" })}</span>
               <input
                 type="date"
                 value={customTo}
@@ -581,37 +611,52 @@ export function Costs() {
 
           <div className="grid gap-3 lg:grid-cols-4">
             <MetricTile
-              label="Inference spend"
+              label={textFor(uiLanguage, { en: "Inference spend", "zh-CN": "推理支出" })}
               value={formatCents(spendData?.summary.spendCents ?? 0)}
-              subtitle={`${formatTokens(inferenceTokenTotal)} tokens across request-scoped events`}
+              subtitle={textFor(uiLanguage, {
+                en: `${formatTokens(inferenceTokenTotal)} tokens across request-scoped events`,
+                "zh-CN": `请求级事件共 ${formatTokens(inferenceTokenTotal)} tokens`,
+              })}
               icon={DollarSign}
             />
             <MetricTile
-              label="Budget"
+              label={textFor(uiLanguage, { en: "Budget", "zh-CN": "预算" })}
               value={activeBudgetIncidents.length > 0 ? String(activeBudgetIncidents.length) : (
                 spendData?.summary.budgetCents && spendData.summary.budgetCents > 0
                   ? `${spendData.summary.utilizationPercent}%`
-                  : "Open"
+                  : textFor(uiLanguage, { en: "Open", "zh-CN": "开放" })
               )}
               subtitle={
                 activeBudgetIncidents.length > 0
-                  ? `${budgetData?.pausedAgentCount ?? 0} agents paused · ${budgetData?.pausedProjectCount ?? 0} projects paused`
+                  ? textFor(uiLanguage, {
+                      en: `${budgetData?.pausedAgentCount ?? 0} agents paused · ${budgetData?.pausedProjectCount ?? 0} projects paused`,
+                      "zh-CN": `${budgetData?.pausedAgentCount ?? 0} 个智能体已暂停 · ${budgetData?.pausedProjectCount ?? 0} 个项目已暂停`,
+                    })
                   : spendData?.summary.budgetCents && spendData.summary.budgetCents > 0
-                    ? `${formatCents(spendData.summary.spendCents)} of ${formatCents(spendData.summary.budgetCents)}`
-                    : "No monthly cap configured"
+                    ? textFor(uiLanguage, {
+                        en: `${formatCents(spendData.summary.spendCents)} of ${formatCents(spendData.summary.budgetCents)}`,
+                        "zh-CN": `${formatCents(spendData.summary.spendCents)} / ${formatCents(spendData.summary.budgetCents)}`,
+                      })
+                    : textFor(uiLanguage, { en: "No monthly cap configured", "zh-CN": "未配置月度上限" })
               }
               icon={Coins}
             />
             <MetricTile
-              label="Finance net"
+              label={textFor(uiLanguage, { en: "Finance net", "zh-CN": "财务净额" })}
               value={formatCents(financeData?.summary.netCents ?? 0)}
-              subtitle={`${formatCents(financeData?.summary.debitCents ?? 0)} debits · ${formatCents(financeData?.summary.creditCents ?? 0)} credits`}
+              subtitle={textFor(uiLanguage, {
+                en: `${formatCents(financeData?.summary.debitCents ?? 0)} debits · ${formatCents(financeData?.summary.creditCents ?? 0)} credits`,
+                "zh-CN": `${formatCents(financeData?.summary.debitCents ?? 0)} 支出 · ${formatCents(financeData?.summary.creditCents ?? 0)} 入账`,
+              })}
               icon={ReceiptText}
             />
             <MetricTile
-              label="Finance events"
+              label={textFor(uiLanguage, { en: "Finance events", "zh-CN": "财务事件" })}
               value={String(financeData?.summary.eventCount ?? 0)}
-              subtitle={`${formatCents(financeData?.summary.estimatedDebitCents ?? 0)} estimated in range`}
+              subtitle={textFor(uiLanguage, {
+                en: `${formatCents(financeData?.summary.estimatedDebitCents ?? 0)} estimated in range`,
+                "zh-CN": `当前范围内预估 ${formatCents(financeData?.summary.estimatedDebitCents ?? 0)}`,
+              })}
               icon={ArrowUpRight}
             />
           </div>
@@ -619,16 +664,16 @@ export function Costs() {
 
       <Tabs value={mainTab} onValueChange={(value) => setMainTab(value as typeof mainTab)}>
         <TabsList variant="line" className="justify-start">
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="budgets">Budgets</TabsTrigger>
-          <TabsTrigger value="providers">Providers</TabsTrigger>
-          <TabsTrigger value="billers">Billers</TabsTrigger>
-          <TabsTrigger value="finance">Finance</TabsTrigger>
+          <TabsTrigger value="overview">{textFor(uiLanguage, { en: "Overview", "zh-CN": "总览" })}</TabsTrigger>
+          <TabsTrigger value="budgets">{textFor(uiLanguage, { en: "Budgets", "zh-CN": "预算" })}</TabsTrigger>
+          <TabsTrigger value="providers">{textFor(uiLanguage, { en: "Providers", "zh-CN": "提供方" })}</TabsTrigger>
+          <TabsTrigger value="billers">{textFor(uiLanguage, { en: "Billers", "zh-CN": "计费方" })}</TabsTrigger>
+          <TabsTrigger value="finance">{textFor(uiLanguage, { en: "Finance", "zh-CN": "财务" })}</TabsTrigger>
         </TabsList>
 
         <TabsContent value="overview" className="mt-4 space-y-4">
           {showCustomPrompt ? (
-            <p className="text-sm text-muted-foreground">Select a start and end date to load data.</p>
+            <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "Select a start and end date to load data.", "zh-CN": "请选择开始和结束日期以加载数据。" })}</p>
           ) : showOverviewLoading ? (
             <PageSkeleton variant="costs" />
           ) : overviewError ? (
@@ -657,9 +702,12 @@ export function Costs() {
               <div className="grid gap-4 xl:grid-cols-[1.3fr,1fr]">
                 <Card>
                   <CardHeader className="px-5 pt-5 pb-2">
-                    <CardTitle className="text-base">Inference ledger</CardTitle>
+                    <CardTitle className="text-base">{textFor(uiLanguage, { en: "Inference ledger", "zh-CN": "推理台账" })}</CardTitle>
                     <CardDescription>
-                      Request-scoped inference spend for the selected period.
+                      {textFor(uiLanguage, {
+                        en: "Request-scoped inference spend for the selected period.",
+                        "zh-CN": "所选时间范围内按请求归因的推理支出。",
+                      })}
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4 px-5 pb-5 pt-2">
@@ -670,12 +718,17 @@ export function Costs() {
                         </div>
                         <div className="mt-1 text-sm text-muted-foreground">
                           {spendData?.summary.budgetCents && spendData.summary.budgetCents > 0
-                            ? `Budget ${formatCents(spendData.summary.budgetCents)}`
-                            : "Unlimited budget"}
+                            ? textFor(uiLanguage, {
+                                en: `Budget ${formatCents(spendData.summary.budgetCents)}`,
+                                "zh-CN": `预算 ${formatCents(spendData.summary.budgetCents)}`,
+                              })
+                            : textFor(uiLanguage, { en: "Unlimited budget", "zh-CN": "不限额预算" })}
                         </div>
                       </div>
                       <div className="border border-border px-4 py-3 text-right">
-                        <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">usage</div>
+                        <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+                          {textFor(uiLanguage, { en: "usage", "zh-CN": "用量" })}
+                        </div>
                         <div className="mt-1 text-lg font-medium tabular-nums">
                           {formatTokens(inferenceTokenTotal)}
                         </div>
@@ -697,7 +750,10 @@ export function Costs() {
                           />
                         </div>
                         <div className="text-xs text-muted-foreground">
-                          {spendData.summary.utilizationPercent}% of monthly budget consumed in this range.
+                          {textFor(uiLanguage, {
+                            en: `${spendData.summary.utilizationPercent}% of monthly budget consumed in this range.`,
+                            "zh-CN": `当前范围内已消耗月度预算的 ${spendData.summary.utilizationPercent}%。`,
+                          })}
                         </div>
                       </div>
                     ) : null}
@@ -716,12 +772,12 @@ export function Costs() {
               <div className="grid gap-4 xl:grid-cols-[1.25fr,0.95fr]">
                 <Card>
                   <CardHeader className="px-5 pt-5 pb-2">
-                    <CardTitle className="text-base">By agent</CardTitle>
-                    <CardDescription>What each agent consumed in the selected period.</CardDescription>
+                    <CardTitle className="text-base">{textFor(uiLanguage, { en: "By agent", "zh-CN": "按智能体" })}</CardTitle>
+                    <CardDescription>{textFor(uiLanguage, { en: "What each agent consumed in the selected period.", "zh-CN": "所选时间范围内各智能体的消耗。" })}</CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-2 px-5 pb-5 pt-2">
                     {(spendData?.byAgent.length ?? 0) === 0 ? (
-                      <p className="text-sm text-muted-foreground">No cost events yet.</p>
+                      <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "No cost events yet.", "zh-CN": "还没有成本事件。" })}</p>
                     ) : (
                       spendData?.byAgent.map((row) => {
                         const modelRows = agentModelRows.get(row.agentId) ?? [];
@@ -747,15 +803,20 @@ export function Costs() {
                               <div className="text-right text-sm tabular-nums">
                                 <div className="font-medium">{formatCents(row.costCents)}</div>
                                 <div className="text-xs text-muted-foreground">
-                                  in {formatTokens(row.inputTokens + row.cachedInputTokens)} · out {formatTokens(row.outputTokens)}
+                                  {textFor(uiLanguage, {
+                                    en: `in ${formatTokens(row.inputTokens + row.cachedInputTokens)} · out ${formatTokens(row.outputTokens)}`,
+                                    "zh-CN": `输入 ${formatTokens(row.inputTokens + row.cachedInputTokens)} · 输出 ${formatTokens(row.outputTokens)}`,
+                                  })}
                                 </div>
                                 {(row.apiRunCount > 0 || row.subscriptionRunCount > 0) ? (
                                   <div className="text-xs text-muted-foreground">
-                                    {row.apiRunCount > 0 ? `${row.apiRunCount} api` : "0 api"}
+                                    {row.apiRunCount > 0
+                                      ? textFor(uiLanguage, { en: `${row.apiRunCount} api`, "zh-CN": `${row.apiRunCount} 次 API` })
+                                      : textFor(uiLanguage, { en: "0 api", "zh-CN": "0 次 API" })}
                                     {" · "}
                                     {row.subscriptionRunCount > 0
-                                      ? `${row.subscriptionRunCount} subscription`
-                                      : "0 subscription"}
+                                      ? textFor(uiLanguage, { en: `${row.subscriptionRunCount} subscription`, "zh-CN": `${row.subscriptionRunCount} 次订阅` })
+                                      : textFor(uiLanguage, { en: "0 subscription", "zh-CN": "0 次订阅" })}
                                   </div>
                                 ) : null}
                               </div>
@@ -786,7 +847,7 @@ export function Costs() {
                                           <span className="ml-1 font-normal text-muted-foreground">({sharePct}%)</span>
                                         </div>
                                         <div className="text-muted-foreground">
-                                          {formatTokens(modelRow.inputTokens + modelRow.cachedInputTokens + modelRow.outputTokens)} tok
+                                          {formatTokens(modelRow.inputTokens + modelRow.cachedInputTokens + modelRow.outputTokens)} {textFor(uiLanguage, { en: "tok", "zh-CN": "tok" })}
                                         </div>
                                       </div>
                                     </div>
@@ -804,19 +865,19 @@ export function Costs() {
                 <div className="space-y-4">
                   <Card>
                     <CardHeader className="px-5 pt-5 pb-2">
-                      <CardTitle className="text-base">By project</CardTitle>
-                      <CardDescription>Run costs attributed through project-linked issues.</CardDescription>
+                      <CardTitle className="text-base">{textFor(uiLanguage, { en: "By project", "zh-CN": "按项目" })}</CardTitle>
+                      <CardDescription>{textFor(uiLanguage, { en: "Run costs attributed through project-linked issues.", "zh-CN": "通过项目关联任务归因的运行成本。" })}</CardDescription>
                     </CardHeader>
                     <CardContent className="space-y-2 px-5 pb-5 pt-2">
                       {(spendData?.byProject.length ?? 0) === 0 ? (
-                        <p className="text-sm text-muted-foreground">No project-attributed run costs yet.</p>
+                        <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "No project-attributed run costs yet.", "zh-CN": "还没有归因到项目的运行成本。" })}</p>
                       ) : (
                         spendData?.byProject.map((row, index) => (
                           <div
                             key={row.projectId ?? `unattributed-${index}`}
                             className="flex items-center justify-between gap-3 border border-border px-3 py-2 text-sm"
                           >
-                            <span className="truncate">{row.projectName ?? row.projectId ?? "Unattributed"}</span>
+                            <span className="truncate">{row.projectName ?? row.projectId ?? textFor(uiLanguage, { en: "Unattributed", "zh-CN": "未归因" })}</span>
                             <span className="font-medium tabular-nums">{formatCents(row.costCents)}</span>
                           </div>
                         ))
@@ -824,7 +885,13 @@ export function Costs() {
                     </CardContent>
                   </Card>
 
-                  <FinanceTimelineCard rows={topFinanceEvents.slice(0, 6)} emptyMessage="No finance events yet. Add account-level charges once biller invoices or credits land." />
+                  <FinanceTimelineCard
+                    rows={topFinanceEvents.slice(0, 6)}
+                    emptyMessage={textFor(uiLanguage, {
+                      en: "No finance events yet. Add account-level charges once biller invoices or credits land.",
+                      "zh-CN": "还没有财务事件。等 biller 发票或积分到账后，可在此添加账户级费用。",
+                    })}
+                  />
                 </div>
               </div>
             </>
@@ -840,34 +907,37 @@ export function Costs() {
             <>
               <Card className="border-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))]">
                 <CardHeader className="px-5 pt-5 pb-3">
-                  <CardTitle className="text-base">Budget control plane</CardTitle>
+                  <CardTitle className="text-base">{textFor(uiLanguage, { en: "Budget control plane", "zh-CN": "预算控制台" })}</CardTitle>
                   <CardDescription>
-                    Hard-stop spend limits for agents and projects. Provider subscription quota stays separate and appears under Providers.
+                    {textFor(uiLanguage, {
+                      en: "Hard-stop spend limits for agents and projects. Provider subscription quota stays separate and appears under Providers.",
+                      "zh-CN": "智能体和项目的硬停止支出限制。Provider 订阅配额独立显示在 Providers 下。",
+                    })}
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="grid gap-3 px-5 pb-5 pt-0 md:grid-cols-4">
                   <MetricTile
-                    label="Active incidents"
+                    label={textFor(uiLanguage, { en: "Active incidents", "zh-CN": "活动事件" })}
                     value={String(activeBudgetIncidents.length)}
-                    subtitle="Open soft or hard threshold crossings"
+                    subtitle={textFor(uiLanguage, { en: "Open soft or hard threshold crossings", "zh-CN": "未处理的软阈值或硬阈值越线" })}
                     icon={ReceiptText}
                   />
                   <MetricTile
-                    label="Pending approvals"
+                    label={textFor(uiLanguage, { en: "Pending approvals", "zh-CN": "待审批" })}
                     value={String(budgetData?.pendingApprovalCount ?? 0)}
-                    subtitle="Budget override approvals awaiting board action"
+                    subtitle={textFor(uiLanguage, { en: "Budget override approvals awaiting board action", "zh-CN": "等待董事会处理的预算覆盖审批" })}
                     icon={ArrowUpRight}
                   />
                   <MetricTile
-                    label="Paused agents"
+                    label={textFor(uiLanguage, { en: "Paused agents", "zh-CN": "已暂停智能体" })}
                     value={String(budgetData?.pausedAgentCount ?? 0)}
-                    subtitle="Agent heartbeats blocked by budget"
+                    subtitle={textFor(uiLanguage, { en: "Agent heartbeats blocked by budget", "zh-CN": "被预算阻塞的智能体心跳" })}
                     icon={Coins}
                   />
                   <MetricTile
-                    label="Paused projects"
+                    label={textFor(uiLanguage, { en: "Paused projects", "zh-CN": "已暂停项目" })}
                     value={String(budgetData?.pausedProjectCount ?? 0)}
-                    subtitle="Project execution blocked by budget"
+                    subtitle={textFor(uiLanguage, { en: "Project execution blocked by budget", "zh-CN": "被预算阻塞的项目执行" })}
                     icon={DollarSign}
                   />
                 </CardContent>
@@ -876,9 +946,12 @@ export function Costs() {
               {activeBudgetIncidents.length > 0 ? (
                 <div className="space-y-3">
                   <div>
-                    <h2 className="text-lg font-semibold">Active incidents</h2>
+                    <h2 className="text-lg font-semibold">{textFor(uiLanguage, { en: "Active incidents", "zh-CN": "活动事件" })}</h2>
                     <p className="text-sm text-muted-foreground">
-                      Resolve hard stops here by raising the budget or explicitly keeping the scope paused.
+                      {textFor(uiLanguage, {
+                        en: "Resolve hard stops here by raising the budget or explicitly keeping the scope paused.",
+                        "zh-CN": "你可以在这里通过提高预算或显式保持暂停来处理硬停止事件。",
+                      })}
                     </p>
                   </div>
                   <div className="grid gap-4 xl:grid-cols-2">
@@ -907,13 +980,19 @@ export function Costs() {
                   return (
                     <section key={scopeType} className="space-y-3">
                       <div>
-                        <h2 className="text-lg font-semibold capitalize">{scopeType} budgets</h2>
+                        <h2 className="text-lg font-semibold capitalize">
+                          {scopeType === "company"
+                            ? textFor(uiLanguage, { en: "Company budgets", "zh-CN": "公司预算" })
+                            : scopeType === "agent"
+                              ? textFor(uiLanguage, { en: "Agent budgets", "zh-CN": "智能体预算" })
+                              : textFor(uiLanguage, { en: "Project budgets", "zh-CN": "项目预算" })}
+                        </h2>
                         <p className="text-sm text-muted-foreground">
                           {scopeType === "company"
-                            ? "Company-wide monthly policy."
+                            ? textFor(uiLanguage, { en: "Company-wide monthly policy.", "zh-CN": "公司级月度策略。" })
                             : scopeType === "agent"
-                              ? "Recurring monthly spend policies for individual agents."
-                              : "Lifetime spend policies for execution-bound projects."}
+                              ? textFor(uiLanguage, { en: "Recurring monthly spend policies for individual agents.", "zh-CN": "单个智能体的循环月度支出策略。" })
+                              : textFor(uiLanguage, { en: "Lifetime spend policies for execution-bound projects.", "zh-CN": "执行型项目的生命周期支出策略。" })}
                         </p>
                       </div>
                       <div className="grid gap-4 xl:grid-cols-2">
@@ -939,7 +1018,10 @@ export function Costs() {
                 {budgetPolicies.length === 0 ? (
                   <Card>
                     <CardContent className="px-5 py-8 text-sm text-muted-foreground">
-                      No budget policies yet. Set agent and project budgets from their detail pages, or use the existing company monthly budget control.
+                      {textFor(uiLanguage, {
+                        en: "No budget policies yet. Set agent and project budgets from their detail pages, or use the existing company monthly budget control.",
+                        "zh-CN": "还没有预算策略。你可以在智能体和项目详情页设置预算，或使用现有的公司月度预算控制。",
+                      })}
                     </CardContent>
                   </Card>
                 ) : null}
@@ -950,7 +1032,7 @@ export function Costs() {
 
         <TabsContent value="providers" className="mt-4 space-y-4">
           {showCustomPrompt ? (
-            <p className="text-sm text-muted-foreground">Select a start and end date to load data.</p>
+            <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "Select a start and end date to load data.", "zh-CN": "请选择开始和结束日期以加载数据。" })}</p>
           ) : (
             <>
               <Tabs value={effectiveProvider} onValueChange={setActiveProvider}>
@@ -958,7 +1040,7 @@ export function Costs() {
 
                 <TabsContent value="all" className="mt-4">
                   {providers.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">No cost events in this period.</p>
+                    <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "No cost events in this period.", "zh-CN": "当前时间范围内没有成本事件。" })}</p>
                   ) : (
                     <div className="grid gap-4 md:grid-cols-2">
                       {providers.map((provider) => (
@@ -1005,7 +1087,7 @@ export function Costs() {
 
         <TabsContent value="billers" className="mt-4 space-y-4">
           {showCustomPrompt ? (
-            <p className="text-sm text-muted-foreground">Select a start and end date to load data.</p>
+            <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "Select a start and end date to load data.", "zh-CN": "请选择开始和结束日期以加载数据。" })}</p>
           ) : (
             <>
               <Tabs value={effectiveBiller} onValueChange={setActiveBiller}>
@@ -1013,7 +1095,7 @@ export function Costs() {
 
                 <TabsContent value="all" className="mt-4">
                   {billers.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">No billable events in this period.</p>
+                    <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "No billable events in this period.", "zh-CN": "当前时间范围内没有可计费事件。" })}</p>
                   ) : (
                     <div className="grid gap-4 md:grid-cols-2">
                       {billers.map((biller) => {
@@ -1058,7 +1140,7 @@ export function Costs() {
 
         <TabsContent value="finance" className="mt-4 space-y-4">
           {showCustomPrompt ? (
-            <p className="text-sm text-muted-foreground">Select a start and end date to load data.</p>
+            <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "Select a start and end date to load data.", "zh-CN": "请选择开始和结束日期以加载数据。" })}</p>
           ) : financeLoading ? (
             <PageSkeleton variant="costs" />
           ) : financeError ? (
@@ -1077,12 +1159,12 @@ export function Costs() {
                 <div className="space-y-4">
                   <Card>
                     <CardHeader className="px-5 pt-5 pb-2">
-                      <CardTitle className="text-base">By biller</CardTitle>
-                      <CardDescription>Account-level financial events grouped by who charged or credited them.</CardDescription>
+                      <CardTitle className="text-base">{textFor(uiLanguage, { en: "By biller", "zh-CN": "按 biller" })}</CardTitle>
+                      <CardDescription>{textFor(uiLanguage, { en: "Account-level financial events grouped by who charged or credited them.", "zh-CN": "按收费或入账方聚合的账户级财务事件。" })}</CardDescription>
                     </CardHeader>
                     <CardContent className="grid gap-4 px-5 pb-5 pt-2 md:grid-cols-2">
                       {(financeData?.byBiller.length ?? 0) === 0 ? (
-                        <p className="text-sm text-muted-foreground">No finance events yet.</p>
+                        <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "No finance events yet.", "zh-CN": "还没有财务事件。" })}</p>
                       ) : (
                         financeData?.byBiller.map((row) => <FinanceBillerCard key={row.biller} row={row} />)
                       )}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -10,6 +10,7 @@ import { heartbeatsApi } from "../api/heartbeats";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { queryKeys } from "../lib/queryKeys";
 import { MetricCard } from "../components/MetricCard";
 import { EmptyState } from "../components/EmptyState";
@@ -25,6 +26,7 @@ import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRa
 import { PageSkeleton } from "../components/PageSkeleton";
 import type { Agent, Issue } from "@paperclipai/shared";
 import { PluginSlotOutlet } from "@/plugins/slots";
+import { textFor } from "../lib/ui-language";
 
 function getRecentIssues(issues: Issue[]): Issue[] {
   return [...issues]
@@ -33,12 +35,99 @@ function getRecentIssues(issues: Issue[]): Issue[] {
 
 export function Dashboard() {
   const { selectedCompanyId, companies } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { openOnboarding } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
   const [animatedActivityIds, setAnimatedActivityIds] = useState<Set<string>>(new Set());
   const seenActivityIdsRef = useRef<Set<string>>(new Set());
   const hydratedActivityRef = useRef(false);
   const activityAnimationTimersRef = useRef<number[]>([]);
+  const copy = {
+    dashboard: textFor(uiLanguage, {
+      en: "Dashboard",
+      "zh-CN": "仪表盘",
+    }),
+    welcome: textFor(uiLanguage, {
+      en: "Welcome to Paperclip. Set up your first company and agent to get started.",
+      "zh-CN": "欢迎使用 Paperclip。先创建第一个公司和智能体开始使用。",
+    }),
+    getStarted: textFor(uiLanguage, {
+      en: "Get Started",
+      "zh-CN": "开始使用",
+    }),
+    createOrSelectCompany: textFor(uiLanguage, {
+      en: "Create or select a company to view the dashboard.",
+      "zh-CN": "创建或选择一个公司以查看仪表盘。",
+    }),
+    noAgents: textFor(uiLanguage, {
+      en: "You have no agents.",
+      "zh-CN": "你还没有智能体。",
+    }),
+    createOneHere: textFor(uiLanguage, {
+      en: "Create one here",
+      "zh-CN": "点这里创建",
+    }),
+    openBudgets: textFor(uiLanguage, {
+      en: "Open budgets",
+      "zh-CN": "打开预算",
+    }),
+    agentsEnabled: textFor(uiLanguage, {
+      en: "Agents Enabled",
+      "zh-CN": "已启用智能体",
+    }),
+    tasksInProgress: textFor(uiLanguage, {
+      en: "Tasks In Progress",
+      "zh-CN": "进行中的任务",
+    }),
+    monthSpend: textFor(uiLanguage, {
+      en: "Month Spend",
+      "zh-CN": "本月花费",
+    }),
+    pendingApprovals: textFor(uiLanguage, {
+      en: "Pending Approvals",
+      "zh-CN": "待审批",
+    }),
+    unlimitedBudget: textFor(uiLanguage, {
+      en: "Unlimited budget",
+      "zh-CN": "预算不限",
+    }),
+    awaitingBoardReview: textFor(uiLanguage, {
+      en: "Awaiting board review",
+      "zh-CN": "等待董事会审核",
+    }),
+    runActivity: textFor(uiLanguage, {
+      en: "Run Activity",
+      "zh-CN": "运行活动",
+    }),
+    issuesByPriority: textFor(uiLanguage, {
+      en: "Issues by Priority",
+      "zh-CN": "按优先级统计任务",
+    }),
+    issuesByStatus: textFor(uiLanguage, {
+      en: "Issues by Status",
+      "zh-CN": "按状态统计任务",
+    }),
+    successRate: textFor(uiLanguage, {
+      en: "Success Rate",
+      "zh-CN": "成功率",
+    }),
+    last14Days: textFor(uiLanguage, {
+      en: "Last 14 days",
+      "zh-CN": "最近 14 天",
+    }),
+    recentActivity: textFor(uiLanguage, {
+      en: "Recent Activity",
+      "zh-CN": "最近活动",
+    }),
+    recentTasks: textFor(uiLanguage, {
+      en: "Recent Tasks",
+      "zh-CN": "最近任务",
+    }),
+    noTasks: textFor(uiLanguage, {
+      en: "No tasks yet.",
+      "zh-CN": "还没有任务。",
+    }),
+  };
 
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
@@ -47,8 +136,8 @@ export function Dashboard() {
   });
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Dashboard" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy.dashboard }]);
+  }, [copy.dashboard, setBreadcrumbs]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.dashboard(selectedCompanyId!),
@@ -168,14 +257,14 @@ export function Dashboard() {
       return (
         <EmptyState
           icon={LayoutDashboard}
-          message="Welcome to Paperclip. Set up your first company and agent to get started."
-          action="Get Started"
+          message={copy.welcome}
+          action={copy.getStarted}
           onAction={openOnboarding}
         />
       );
     }
     return (
-      <EmptyState icon={LayoutDashboard} message="Create or select a company to view the dashboard." />
+      <EmptyState icon={LayoutDashboard} message={copy.createOrSelectCompany} />
     );
   }
 
@@ -194,14 +283,14 @@ export function Dashboard() {
           <div className="flex items-center gap-2.5">
             <Bot className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
             <p className="text-sm text-amber-900 dark:text-amber-100">
-              You have no agents.
+              {copy.noAgents}
             </p>
           </div>
           <button
             onClick={() => openOnboarding({ initialStep: 2, companyId: selectedCompanyId! })}
             className="text-sm font-medium text-amber-700 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100 underline underline-offset-2 shrink-0"
           >
-            Create one here
+            {copy.createOneHere}
           </button>
         </div>
       )}
@@ -216,15 +305,19 @@ export function Dashboard() {
                 <PauseCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-300" />
                 <div>
                   <p className="text-sm font-medium text-red-50">
-                    {data.budgets.activeIncidents} active budget incident{data.budgets.activeIncidents === 1 ? "" : "s"}
+                    {uiLanguage === "zh-CN"
+                      ? `${data.budgets.activeIncidents} 个活跃预算事件`
+                      : `${data.budgets.activeIncidents} active budget incident${data.budgets.activeIncidents === 1 ? "" : "s"}`}
                   </p>
                   <p className="text-xs text-red-100/70">
-                    {data.budgets.pausedAgents} agents paused · {data.budgets.pausedProjects} projects paused · {data.budgets.pendingApprovals} pending budget approvals
+                    {uiLanguage === "zh-CN"
+                      ? `${data.budgets.pausedAgents} 个智能体已暂停 · ${data.budgets.pausedProjects} 个项目已暂停 · ${data.budgets.pendingApprovals} 个预算审批待处理`
+                      : `${data.budgets.pausedAgents} agents paused · ${data.budgets.pausedProjects} projects paused · ${data.budgets.pendingApprovals} pending budget approvals`}
                   </p>
                 </div>
               </div>
               <Link to="/costs" className="text-sm underline underline-offset-2 text-red-100">
-                Open budgets
+                {copy.openBudgets}
               </Link>
             </div>
           ) : null}
@@ -233,67 +326,72 @@ export function Dashboard() {
             <MetricCard
               icon={Bot}
               value={data.agents.active + data.agents.running + data.agents.paused + data.agents.error}
-              label="Agents Enabled"
+              label={copy.agentsEnabled}
               to="/agents"
               description={
                 <span>
-                  {data.agents.running} running{", "}
-                  {data.agents.paused} paused{", "}
-                  {data.agents.error} errors
+                  {uiLanguage === "zh-CN"
+                    ? `${data.agents.running} 运行中，${data.agents.paused} 已暂停，${data.agents.error} 异常`
+                    : `${data.agents.running} running, ${data.agents.paused} paused, ${data.agents.error} errors`}
                 </span>
               }
             />
             <MetricCard
               icon={CircleDot}
               value={data.tasks.inProgress}
-              label="Tasks In Progress"
+              label={copy.tasksInProgress}
               to="/issues"
               description={
                 <span>
-                  {data.tasks.open} open{", "}
-                  {data.tasks.blocked} blocked
+                  {uiLanguage === "zh-CN"
+                    ? `${data.tasks.open} 打开，${data.tasks.blocked} 阻塞`
+                    : `${data.tasks.open} open, ${data.tasks.blocked} blocked`}
                 </span>
               }
             />
             <MetricCard
               icon={DollarSign}
               value={formatCents(data.costs.monthSpendCents)}
-              label="Month Spend"
+              label={copy.monthSpend}
               to="/costs"
               description={
                 <span>
                   {data.costs.monthBudgetCents > 0
-                    ? `${data.costs.monthUtilizationPercent}% of ${formatCents(data.costs.monthBudgetCents)} budget`
-                    : "Unlimited budget"}
+                    ? uiLanguage === "zh-CN"
+                      ? `已使用预算 ${data.costs.monthUtilizationPercent}% / ${formatCents(data.costs.monthBudgetCents)}`
+                      : `${data.costs.monthUtilizationPercent}% of ${formatCents(data.costs.monthBudgetCents)} budget`
+                    : copy.unlimitedBudget}
                 </span>
               }
             />
             <MetricCard
               icon={ShieldCheck}
               value={data.pendingApprovals + data.budgets.pendingApprovals}
-              label="Pending Approvals"
+              label={copy.pendingApprovals}
               to="/approvals"
               description={
                 <span>
                   {data.budgets.pendingApprovals > 0
-                    ? `${data.budgets.pendingApprovals} budget overrides awaiting board review`
-                    : "Awaiting board review"}
+                    ? uiLanguage === "zh-CN"
+                      ? `${data.budgets.pendingApprovals} 个预算覆盖等待董事会审核`
+                      : `${data.budgets.pendingApprovals} budget overrides awaiting board review`
+                    : copy.awaitingBoardReview}
                 </span>
               }
             />
           </div>
 
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-            <ChartCard title="Run Activity" subtitle="Last 14 days">
+            <ChartCard title={copy.runActivity} subtitle={copy.last14Days}>
               <RunActivityChart runs={runs ?? []} />
             </ChartCard>
-            <ChartCard title="Issues by Priority" subtitle="Last 14 days">
+            <ChartCard title={copy.issuesByPriority} subtitle={copy.last14Days}>
               <PriorityChart issues={issues ?? []} />
             </ChartCard>
-            <ChartCard title="Issues by Status" subtitle="Last 14 days">
+            <ChartCard title={copy.issuesByStatus} subtitle={copy.last14Days}>
               <IssueStatusChart issues={issues ?? []} />
             </ChartCard>
-            <ChartCard title="Success Rate" subtitle="Last 14 days">
+            <ChartCard title={copy.successRate} subtitle={copy.last14Days}>
               <SuccessRateChart runs={runs ?? []} />
             </ChartCard>
           </div>
@@ -310,7 +408,7 @@ export function Dashboard() {
             {recentActivity.length > 0 && (
               <div className="min-w-0">
                 <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-                  Recent Activity
+                  {copy.recentActivity}
                 </h3>
                 <div className="border border-border divide-y divide-border overflow-hidden">
                   {recentActivity.map((event) => (
@@ -330,11 +428,11 @@ export function Dashboard() {
             {/* Recent Tasks */}
             <div className="min-w-0">
               <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-                Recent Tasks
+                {copy.recentTasks}
               </h3>
               {recentIssues.length === 0 ? (
                 <div className="border border-border p-4">
-                  <p className="text-sm text-muted-foreground">No tasks yet.</p>
+                  <p className="text-sm text-muted-foreground">{copy.noTasks}</p>
                 </div>
               ) : (
                 <div className="border border-border divide-y divide-border overflow-hidden">

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -102,6 +102,7 @@ import {
   type InboxWorkItem,
 } from "../lib/inbox";
 import { useDismissedInboxAlerts, useInboxDismissals, useReadInboxItems } from "../hooks/useInboxBadge";
+import { readStoredUiLanguage, textFor } from "../lib/ui-language";
 
 export { InboxIssueMetaLeading, InboxIssueTrailingColumns } from "../components/IssueColumns";
 
@@ -128,10 +129,27 @@ function firstNonEmptyLine(value: string | null | undefined): string | null {
 }
 
 function runFailureMessage(run: HeartbeatRun): string {
-  return firstNonEmptyLine(run.error) ?? firstNonEmptyLine(run.stderrExcerpt) ?? "Run exited with an error.";
+  const uiLanguage = readStoredUiLanguage();
+  return firstNonEmptyLine(run.error)
+    ?? firstNonEmptyLine(run.stderrExcerpt)
+    ?? textFor(uiLanguage, {
+      en: "Run exited with an error.",
+      "zh-CN": "运行因错误而退出。",
+    });
 }
 
 function approvalStatusLabel(status: Approval["status"]): string {
+  const uiLanguage = readStoredUiLanguage();
+  if (uiLanguage === "zh-CN") {
+    const labels: Partial<Record<Approval["status"], string>> = {
+      pending: "待审批",
+      approved: "已批准",
+      revision_requested: "请求修改",
+      rejected: "已拒绝",
+      cancelled: "已取消",
+    };
+    return labels[status] ?? status.replaceAll("_", " ");
+  }
   return status.replaceAll("_", " ");
 }
 
@@ -180,11 +198,20 @@ export function FailedRunInboxRow({
   selected?: boolean;
   className?: string;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const issueId = readIssueIdFromRun(run);
   const issue = issueId ? issueById.get(issueId) ?? null : null;
   const displayError = runFailureMessage(run);
   const showUnreadSlot = unreadState !== null;
   const showUnreadDot = unreadState === "visible" || unreadState === "fading";
+  const copy = {
+    markAsRead: textFor(uiLanguage, { en: "Mark as read", "zh-CN": "标记为已读" }),
+    dismissFromInbox: textFor(uiLanguage, { en: "Dismiss from inbox", "zh-CN": "从收件箱移除" }),
+    failedRun: textFor(uiLanguage, { en: "Failed run", "zh-CN": "失败运行" }),
+    retry: textFor(uiLanguage, { en: "Retry", "zh-CN": "重试" }),
+    retrying: textFor(uiLanguage, { en: "Retrying…", "zh-CN": "重试中…" }),
+    dismiss: textFor(uiLanguage, { en: "Dismiss", "zh-CN": "移除" }),
+  };
 
   return (
     <div className={cn(
@@ -202,7 +229,7 @@ export function FailedRunInboxRow({
                   "inline-flex h-4 w-4 items-center justify-center rounded-full transition-colors",
                   "hover:bg-blue-500/20",
                 )}
-                aria-label="Mark as read"
+                aria-label={copy.markAsRead}
               >
                 <span className={cn(
                   "block h-2 w-2 rounded-full transition-opacity duration-300",
@@ -216,7 +243,7 @@ export function FailedRunInboxRow({
                 onClick={onArchive}
                 disabled={archiveDisabled}
                 className="inline-flex h-4 w-4 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-30"
-                aria-label="Dismiss from inbox"
+                aria-label={copy.dismissFromInbox}
               >
                 <X className="h-3.5 w-3.5" />
               </button>
@@ -247,7 +274,7 @@ export function FailedRunInboxRow({
                   {issue.title}
                 </>
               ) : (
-                <>Failed run{linkedAgentName ? ` — ${linkedAgentName}` : ""}</>
+                <>{copy.failedRun}{linkedAgentName ? ` — ${linkedAgentName}` : ""}</>
               )}
             </span>
             <span className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
@@ -268,14 +295,14 @@ export function FailedRunInboxRow({
             disabled={isRetrying}
           >
             <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
-            {isRetrying ? "Retrying…" : "Retry"}
+            {isRetrying ? copy.retrying : copy.retry}
           </Button>
           {!showUnreadSlot && (
             <button
               type="button"
               onClick={onDismiss}
               className="rounded-md p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100"
-              aria-label="Dismiss"
+              aria-label={copy.dismiss}
             >
               <X className="h-4 w-4" />
             </button>
@@ -292,14 +319,14 @@ export function FailedRunInboxRow({
           disabled={isRetrying}
         >
           <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
-          {isRetrying ? "Retrying…" : "Retry"}
+          {isRetrying ? copy.retrying : copy.retry}
         </Button>
         {!showUnreadSlot && (
           <button
             type="button"
             onClick={onDismiss}
             className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-            aria-label="Dismiss"
+            aria-label={copy.dismiss}
           >
             <X className="h-4 w-4" />
           </button>
@@ -334,6 +361,7 @@ function ApprovalInboxRow({
   selected?: boolean;
   className?: string;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const Icon = typeIcon[approval.type] ?? defaultTypeIcon;
   const label = approvalLabel(approval.type, approval.payload as Record<string, unknown> | null);
   const showResolutionButtons =
@@ -341,6 +369,14 @@ function ApprovalInboxRow({
     ACTIONABLE_APPROVAL_STATUSES.has(approval.status);
   const showUnreadSlot = unreadState !== null;
   const showUnreadDot = unreadState === "visible" || unreadState === "fading";
+  const copy = {
+    markAsRead: textFor(uiLanguage, { en: "Mark as read", "zh-CN": "标记为已读" }),
+    dismissFromInbox: textFor(uiLanguage, { en: "Dismiss from inbox", "zh-CN": "从收件箱移除" }),
+    requestedBy: textFor(uiLanguage, { en: "requested by", "zh-CN": "申请人" }),
+    updated: textFor(uiLanguage, { en: "updated", "zh-CN": "更新于" }),
+    approve: textFor(uiLanguage, { en: "Approve", "zh-CN": "批准" }),
+    reject: textFor(uiLanguage, { en: "Reject", "zh-CN": "拒绝" }),
+  };
 
   return (
     <div className={cn(
@@ -358,7 +394,7 @@ function ApprovalInboxRow({
                   "inline-flex h-4 w-4 items-center justify-center rounded-full transition-colors",
                   "hover:bg-blue-500/20",
                 )}
-                aria-label="Mark as read"
+                aria-label={copy.markAsRead}
               >
                 <span className={cn(
                   "block h-2 w-2 rounded-full transition-opacity duration-300",
@@ -372,7 +408,7 @@ function ApprovalInboxRow({
                 onClick={onArchive}
                 disabled={archiveDisabled}
                 className="inline-flex h-4 w-4 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-30"
-                aria-label="Dismiss from inbox"
+                aria-label={copy.dismissFromInbox}
               >
                 <X className="h-3.5 w-3.5" />
               </button>
@@ -399,8 +435,8 @@ function ApprovalInboxRow({
             </span>
             <span className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
               <span className="capitalize">{approvalStatusLabel(approval.status)}</span>
-              {requesterName ? <span>requested by {requesterName}</span> : null}
-              <span>updated {timeAgo(approval.updatedAt)}</span>
+              {requesterName ? <span>{copy.requestedBy} {requesterName}</span> : null}
+              <span>{copy.updated} {timeAgo(approval.updatedAt)}</span>
             </span>
           </span>
         </Link>
@@ -412,7 +448,7 @@ function ApprovalInboxRow({
               onClick={onApprove}
               disabled={isPending}
             >
-              Approve
+              {copy.approve}
             </Button>
             <Button
               variant="destructive"
@@ -421,7 +457,7 @@ function ApprovalInboxRow({
               onClick={onReject}
               disabled={isPending}
             >
-              Reject
+              {copy.reject}
             </Button>
           </div>
         ) : null}
@@ -434,7 +470,7 @@ function ApprovalInboxRow({
             onClick={onApprove}
             disabled={isPending}
           >
-            Approve
+            {copy.approve}
           </Button>
           <Button
             variant="destructive"
@@ -443,7 +479,7 @@ function ApprovalInboxRow({
             onClick={onReject}
             disabled={isPending}
           >
-            Reject
+            {copy.reject}
           </Button>
         </div>
       ) : null}
@@ -474,12 +510,25 @@ function JoinRequestInboxRow({
   selected?: boolean;
   className?: string;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const label =
     joinRequest.requestType === "human"
-      ? "Human join request"
-      : `Agent join request${joinRequest.agentName ? `: ${joinRequest.agentName}` : ""}`;
+      ? textFor(uiLanguage, { en: "Human join request", "zh-CN": "人工加入申请" })
+      : textFor(uiLanguage, {
+        en: `Agent join request${joinRequest.agentName ? `: ${joinRequest.agentName}` : ""}`,
+        "zh-CN": `智能体加入申请${joinRequest.agentName ? `：${joinRequest.agentName}` : ""}`,
+      });
   const showUnreadSlot = unreadState !== null;
   const showUnreadDot = unreadState === "visible" || unreadState === "fading";
+  const copy = {
+    markAsRead: textFor(uiLanguage, { en: "Mark as read", "zh-CN": "标记为已读" }),
+    dismissFromInbox: textFor(uiLanguage, { en: "Dismiss from inbox", "zh-CN": "从收件箱移除" }),
+    requested: textFor(uiLanguage, { en: "requested", "zh-CN": "申请于" }),
+    fromIp: textFor(uiLanguage, { en: "from IP", "zh-CN": "来源 IP" }),
+    adapter: textFor(uiLanguage, { en: "adapter", "zh-CN": "适配器" }),
+    approve: textFor(uiLanguage, { en: "Approve", "zh-CN": "批准" }),
+    reject: textFor(uiLanguage, { en: "Reject", "zh-CN": "拒绝" }),
+  };
 
   return (
     <div className={cn(
@@ -497,7 +546,7 @@ function JoinRequestInboxRow({
                   "inline-flex h-4 w-4 items-center justify-center rounded-full transition-colors",
                   "hover:bg-blue-500/20",
                 )}
-                aria-label="Mark as read"
+                aria-label={copy.markAsRead}
               >
                 <span className={cn(
                   "block h-2 w-2 rounded-full transition-opacity duration-300",
@@ -511,7 +560,7 @@ function JoinRequestInboxRow({
                 onClick={onArchive}
                 disabled={archiveDisabled}
                 className="inline-flex h-4 w-4 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-30"
-                aria-label="Dismiss from inbox"
+                aria-label={copy.dismissFromInbox}
               >
                 <X className="h-3.5 w-3.5" />
               </button>
@@ -531,8 +580,8 @@ function JoinRequestInboxRow({
               {label}
             </span>
             <span className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-              <span>requested {timeAgo(joinRequest.createdAt)} from IP {joinRequest.requestIp}</span>
-              {joinRequest.adapterType && <span>adapter: {joinRequest.adapterType}</span>}
+              <span>{copy.requested} {timeAgo(joinRequest.createdAt)} {copy.fromIp} {joinRequest.requestIp}</span>
+              {joinRequest.adapterType && <span>{copy.adapter}: {joinRequest.adapterType}</span>}
             </span>
           </span>
         </div>
@@ -543,7 +592,7 @@ function JoinRequestInboxRow({
             onClick={onApprove}
             disabled={isPending}
           >
-            Approve
+            {copy.approve}
           </Button>
           <Button
             variant="destructive"
@@ -552,7 +601,7 @@ function JoinRequestInboxRow({
             onClick={onReject}
             disabled={isPending}
           >
-            Reject
+            {copy.reject}
           </Button>
         </div>
       </div>
@@ -563,7 +612,7 @@ function JoinRequestInboxRow({
           onClick={onApprove}
           disabled={isPending}
         >
-          Approve
+          {copy.approve}
         </Button>
         <Button
           variant="destructive"
@@ -572,7 +621,7 @@ function JoinRequestInboxRow({
           onClick={onReject}
           disabled={isPending}
         >
-          Reject
+          {copy.reject}
         </Button>
       </div>
     </div>
@@ -587,7 +636,45 @@ export function Inbox() {
   const location = useLocation();
   const queryClient = useQueryClient();
   const [actionError, setActionError] = useState<string | null>(null);
-  const { keyboardShortcutsEnabled } = useGeneralSettings();
+  const { keyboardShortcutsEnabled, uiLanguage } = useGeneralSettings();
+  const copy = {
+    inbox: textFor(uiLanguage, { en: "Inbox", "zh-CN": "收件箱" }),
+    selectCompany: textFor(uiLanguage, { en: "Select a company to view inbox.", "zh-CN": "请先选择公司以查看收件箱。" }),
+    searchInbox: textFor(uiLanguage, { en: "Search inbox…", "zh-CN": "搜索收件箱..." }),
+    mine: textFor(uiLanguage, { en: "Mine", "zh-CN": "我的" }),
+    recent: textFor(uiLanguage, { en: "Recent", "zh-CN": "最近" }),
+    unread: textFor(uiLanguage, { en: "Unread", "zh-CN": "未读" }),
+    all: textFor(uiLanguage, { en: "All", "zh-CN": "全部" }),
+    enableNesting: textFor(uiLanguage, { en: "Enable parent-child nesting", "zh-CN": "启用父子任务分组" }),
+    disableNesting: textFor(uiLanguage, { en: "Disable parent-child nesting", "zh-CN": "关闭父子任务分组" }),
+    chooseInboxColumns: textFor(uiLanguage, { en: "Choose which inbox columns stay visible", "zh-CN": "选择要显示的收件箱列" }),
+    markAllAsRead: textFor(uiLanguage, { en: "Mark all as read", "zh-CN": "全部标为已读" }),
+    marking: textFor(uiLanguage, { en: "Marking…", "zh-CN": "标记中…" }),
+    markAllAsReadTitle: textFor(uiLanguage, { en: "Mark all as read?", "zh-CN": "要全部标记为已读吗？" }),
+    cancel: textFor(uiLanguage, { en: "Cancel", "zh-CN": "取消" }),
+    category: textFor(uiLanguage, { en: "Category", "zh-CN": "分类" }),
+    allCategories: textFor(uiLanguage, { en: "All categories", "zh-CN": "全部分类" }),
+    myRecentIssues: textFor(uiLanguage, { en: "My recent issues", "zh-CN": "我最近处理的任务" }),
+    joinRequests: textFor(uiLanguage, { en: "Join requests", "zh-CN": "加入申请" }),
+    approvals: textFor(uiLanguage, { en: "Approvals", "zh-CN": "审批" }),
+    failedRuns: textFor(uiLanguage, { en: "Failed runs", "zh-CN": "失败运行" }),
+    alerts: textFor(uiLanguage, { en: "Alerts", "zh-CN": "提醒" }),
+    approvalStatus: textFor(uiLanguage, { en: "Approval status", "zh-CN": "审批状态" }),
+    allApprovalStatuses: textFor(uiLanguage, { en: "All approval statuses", "zh-CN": "全部审批状态" }),
+    needsAction: textFor(uiLanguage, { en: "Needs action", "zh-CN": "待处理" }),
+    resolved: textFor(uiLanguage, { en: "Resolved", "zh-CN": "已处理" }),
+    noInboxMatchSearch: textFor(uiLanguage, { en: "No inbox items match your search.", "zh-CN": "没有符合搜索条件的收件箱项目。" }),
+    inboxZero: textFor(uiLanguage, { en: "Inbox zero.", "zh-CN": "收件箱清空了。" }),
+    noNewInboxItems: textFor(uiLanguage, { en: "No new inbox items.", "zh-CN": "没有新的收件箱项目。" }),
+    noRecentInboxItems: textFor(uiLanguage, { en: "No recent inbox items.", "zh-CN": "没有最近的收件箱项目。" }),
+    noInboxItemsMatchFilters: textFor(uiLanguage, { en: "No inbox items match these filters.", "zh-CN": "没有符合这些筛选条件的收件箱项目。" }),
+    earlier: textFor(uiLanguage, { en: "Earlier", "zh-CN": "更早" }),
+    dismiss: textFor(uiLanguage, { en: "Dismiss", "zh-CN": "移除" }),
+    agentHasErrors: textFor(uiLanguage, { en: "agent has errors", "zh-CN": "个智能体出现错误" }),
+    agentsHaveErrors: textFor(uiLanguage, { en: "agents have errors", "zh-CN": "个智能体出现错误" }),
+    budgetAt: textFor(uiLanguage, { en: "Budget at", "zh-CN": "本月预算已使用" }),
+    utilizationThisMonth: textFor(uiLanguage, { en: "utilization this month", "zh-CN": "" }),
+  };
   const { data: experimentalSettings } = useQuery({
     queryKey: queryKeys.instance.experimentalSettings,
     queryFn: () => instanceSettingsApi.getExperimental(),
@@ -610,11 +697,11 @@ export function Inbox() {
   const issueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(
-        "Inbox",
+        copy.inbox,
         `${location.pathname}${location.search}${location.hash}`,
         "inbox",
       ),
-    [location.pathname, location.search, location.hash],
+    [copy.inbox, location.pathname, location.search, location.hash],
   );
 
   const { data: session } = useQuery({
@@ -643,8 +730,8 @@ export function Inbox() {
   });
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Inbox" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy.inbox }]);
+  }, [copy.inbox, setBreadcrumbs]);
 
   useEffect(() => {
     saveLastInboxTab(tab);
@@ -994,7 +1081,7 @@ export function Inbox() {
       navigate(`/approvals/${id}?resolved=approved`);
     },
     onError: (err) => {
-      setActionError(err instanceof Error ? err.message : "Failed to approve");
+      setActionError(err instanceof Error ? err.message : textFor(uiLanguage, { en: "Failed to approve", "zh-CN": "批准失败" }));
     },
   });
 
@@ -1005,7 +1092,7 @@ export function Inbox() {
       queryClient.invalidateQueries({ queryKey: queryKeys.approvals.list(selectedCompanyId!) });
     },
     onError: (err) => {
-      setActionError(err instanceof Error ? err.message : "Failed to reject");
+      setActionError(err instanceof Error ? err.message : textFor(uiLanguage, { en: "Failed to reject", "zh-CN": "拒绝失败" }));
     },
   });
 
@@ -1020,7 +1107,7 @@ export function Inbox() {
       queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
     },
     onError: (err) => {
-      setActionError(err instanceof Error ? err.message : "Failed to approve join request");
+      setActionError(err instanceof Error ? err.message : textFor(uiLanguage, { en: "Failed to approve join request", "zh-CN": "批准加入申请失败" }));
     },
   });
 
@@ -1033,7 +1120,7 @@ export function Inbox() {
       queryClient.invalidateQueries({ queryKey: queryKeys.sidebarBadges(selectedCompanyId!) });
     },
     onError: (err) => {
-      setActionError(err instanceof Error ? err.message : "Failed to reject join request");
+      setActionError(err instanceof Error ? err.message : textFor(uiLanguage, { en: "Failed to reject join request", "zh-CN": "拒绝加入申请失败" }));
     },
   });
 
@@ -1055,7 +1142,7 @@ export function Inbox() {
         payload,
       });
       if (!("id" in result)) {
-        throw new Error(result.message ?? "Retry was skipped.");
+        throw new Error(result.message ?? textFor(uiLanguage, { en: "Retry was skipped.", "zh-CN": "已跳过重试。" }));
       }
       return { newRun: result, originalRun: run };
     },
@@ -1121,7 +1208,7 @@ export function Inbox() {
       return { previousData };
     },
     onError: (err, id, context) => {
-      setActionError(err instanceof Error ? err.message : "Failed to archive issue");
+      setActionError(err instanceof Error ? err.message : textFor(uiLanguage, { en: "Failed to archive issue", "zh-CN": "归档任务失败" }));
       setArchivingIssueIds((prev) => {
         const next = new Set(prev);
         next.delete(id);
@@ -1420,7 +1507,7 @@ export function Inbox() {
   }, [selectedIndex]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={InboxIcon} message="Select a company to view inbox." />;
+    return <EmptyState icon={InboxIcon} message={copy.selectCompany} />;
   }
 
   const hasRunFailures = failedRuns.length > 0;
@@ -1471,12 +1558,12 @@ export function Inbox() {
         {/* Search — full-width row on mobile, inline on desktop */}
         <div className="relative sm:hidden">
           <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="search"
-            placeholder="Search inbox…"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="h-8 w-full pl-8 text-xs"
+            <Input
+              type="search"
+              placeholder={copy.searchInbox}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-8 w-full pl-8 text-xs"
           />
         </div>
         <div className="flex items-center justify-between gap-2">
@@ -1485,14 +1572,14 @@ export function Inbox() {
             items={[
               {
                 value: "mine",
-                label: "Mine",
+                label: copy.mine,
               },
               {
                 value: "recent",
-                label: "Recent",
+                label: copy.recent,
               },
-              { value: "unread", label: "Unread" },
-              { value: "all", label: "All" },
+              { value: "unread", label: copy.unread },
+              { value: "all", label: copy.all },
             ]}
           />
         </Tabs>
@@ -1502,7 +1589,7 @@ export function Inbox() {
             <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input
               type="search"
-              placeholder="Search inbox…"
+              placeholder={copy.searchInbox}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="h-8 w-[220px] pl-8 text-xs"
@@ -1514,7 +1601,7 @@ export function Inbox() {
             size="icon"
             className={cn("hidden h-8 w-8 shrink-0 sm:inline-flex", nestingEnabled && "bg-accent")}
             onClick={toggleNesting}
-            title={nestingEnabled ? "Disable parent-child nesting" : "Enable parent-child nesting"}
+            title={nestingEnabled ? copy.disableNesting : copy.enableNesting}
           >
             <ListTree className="h-3.5 w-3.5" />
           </Button>
@@ -1523,7 +1610,7 @@ export function Inbox() {
             visibleColumnSet={visibleIssueColumnSet}
             onToggleColumn={toggleIssueColumn}
             onResetColumns={() => setIssueColumns(DEFAULT_INBOX_ISSUE_COLUMNS)}
-            title="Choose which inbox columns stay visible"
+            title={copy.chooseInboxColumns}
           />
           {canMarkAllRead && (
             <>
@@ -1535,19 +1622,21 @@ export function Inbox() {
                 onClick={() => setShowMarkAllReadConfirm(true)}
                 disabled={markAllReadMutation.isPending}
               >
-                {markAllReadMutation.isPending ? "Marking…" : "Mark all as read"}
+                {markAllReadMutation.isPending ? copy.marking : copy.markAllAsRead}
               </Button>
               <Dialog open={showMarkAllReadConfirm} onOpenChange={setShowMarkAllReadConfirm}>
                 <DialogContent className="sm:max-w-md">
                   <DialogHeader>
-                    <DialogTitle>Mark all as read?</DialogTitle>
+                    <DialogTitle>{copy.markAllAsReadTitle}</DialogTitle>
                     <DialogDescription>
-                      This will mark {unreadIssueIds.length} unread {unreadIssueIds.length === 1 ? "item" : "items"} as read.
+                      {uiLanguage === "zh-CN"
+                        ? `这会将 ${unreadIssueIds.length} 个未读项目标记为已读。`
+                        : `This will mark ${unreadIssueIds.length} unread ${unreadIssueIds.length === 1 ? "item" : "items"} as read.`}
                     </DialogDescription>
                   </DialogHeader>
                   <DialogFooter>
                     <Button variant="outline" onClick={() => setShowMarkAllReadConfirm(false)}>
-                      Cancel
+                      {copy.cancel}
                     </Button>
                     <Button
                       onClick={() => {
@@ -1555,7 +1644,7 @@ export function Inbox() {
                         markAllReadMutation.mutate(unreadIssueIds);
                       }}
                     >
-                      Mark all as read
+                      {copy.markAllAsRead}
                     </Button>
                   </DialogFooter>
                 </DialogContent>
@@ -1573,15 +1662,15 @@ export function Inbox() {
             onValueChange={(value) => setAllCategoryFilter(value as InboxCategoryFilter)}
           >
             <SelectTrigger className="h-8 w-[170px] text-xs">
-              <SelectValue placeholder="Category" />
+              <SelectValue placeholder={copy.category} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="everything">All categories</SelectItem>
-              <SelectItem value="issues_i_touched">My recent issues</SelectItem>
-              <SelectItem value="join_requests">Join requests</SelectItem>
-              <SelectItem value="approvals">Approvals</SelectItem>
-              <SelectItem value="failed_runs">Failed runs</SelectItem>
-              <SelectItem value="alerts">Alerts</SelectItem>
+              <SelectItem value="everything">{copy.allCategories}</SelectItem>
+              <SelectItem value="issues_i_touched">{copy.myRecentIssues}</SelectItem>
+              <SelectItem value="join_requests">{copy.joinRequests}</SelectItem>
+              <SelectItem value="approvals">{copy.approvals}</SelectItem>
+              <SelectItem value="failed_runs">{copy.failedRuns}</SelectItem>
+              <SelectItem value="alerts">{copy.alerts}</SelectItem>
             </SelectContent>
           </Select>
 
@@ -1591,12 +1680,12 @@ export function Inbox() {
               onValueChange={(value) => setAllApprovalFilter(value as InboxApprovalFilter)}
             >
               <SelectTrigger className="h-8 w-[170px] text-xs">
-                <SelectValue placeholder="Approval status" />
+                <SelectValue placeholder={copy.approvalStatus} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All approval statuses</SelectItem>
-                <SelectItem value="actionable">Needs action</SelectItem>
-                <SelectItem value="resolved">Resolved</SelectItem>
+                <SelectItem value="all">{copy.allApprovalStatuses}</SelectItem>
+                <SelectItem value="actionable">{copy.needsAction}</SelectItem>
+                <SelectItem value="resolved">{copy.resolved}</SelectItem>
               </SelectContent>
             </Select>
           )}
@@ -1615,14 +1704,14 @@ export function Inbox() {
           icon={searchQuery.trim() ? Search : InboxIcon}
           message={
             searchQuery.trim()
-              ? "No inbox items match your search."
+              ? copy.noInboxMatchSearch
               : tab === "mine"
-              ? "Inbox zero."
+              ? copy.inboxZero
               : tab === "unread"
-              ? "No new inbox items."
+              ? copy.noNewInboxItems
               : tab === "recent"
-                ? "No recent inbox items."
-                : "No inbox items match these filters."
+                ? copy.noRecentInboxItems
+                : copy.noInboxItemsMatchFilters
           }
         />
       )}
@@ -1676,7 +1765,7 @@ export function Inbox() {
                     <div key="today-divider" className="flex items-center gap-3 px-4 my-2">
                       <div className="flex-1 border-t border-zinc-600" />
                       <span className="shrink-0 text-[11px] font-medium uppercase tracking-wider text-zinc-500">
-                        Earlier
+                        {copy.earlier}
                       </span>
                     </div>,
                   );
@@ -1845,7 +1934,9 @@ export function Inbox() {
                       }
                       titleSuffix={hasChildren && !isExpanded && depth === 0 ? (
                         <span className="ml-1.5 text-xs text-muted-foreground">
-                          ({childIssues.length} sub-task{childIssues.length !== 1 ? "s" : ""})
+                          {uiLanguage === "zh-CN"
+                            ? `(${childIssues.length} 个子任务)`
+                            : `(${childIssues.length} sub-task${childIssues.length !== 1 ? "s" : ""})`}
                         </span>
                       ) : undefined}
                       mobileMeta={issueActivityText(iss).toLowerCase()}
@@ -1947,7 +2038,7 @@ export function Inbox() {
           {showSeparatorBefore("alerts") && <Separator />}
           <div>
             <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-              Alerts
+              {copy.alerts}
             </h3>
             <div className="divide-y divide-border border border-border">
               {showAggregateAgentError && (
@@ -1959,14 +2050,16 @@ export function Inbox() {
                     <AlertTriangle className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
                     <span className="text-sm">
                       <span className="font-medium">{dashboard!.agents.error}</span>{" "}
-                      {dashboard!.agents.error === 1 ? "agent has" : "agents have"} errors
+                      {uiLanguage === "zh-CN"
+                        ? copy.agentHasErrors
+                        : `${dashboard!.agents.error === 1 ? "agent has" : "agents have"} errors`}
                     </span>
                   </Link>
                   <button
                     type="button"
                     onClick={() => dismissAlert("alert:agent-errors")}
                     className="rounded-md p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover/alert:opacity-100"
-                    aria-label="Dismiss"
+                    aria-label={copy.dismiss}
                   >
                     <X className="h-3.5 w-3.5" />
                   </button>
@@ -1980,16 +2073,25 @@ export function Inbox() {
                   >
                     <AlertTriangle className="h-4 w-4 shrink-0 text-yellow-400" />
                     <span className="text-sm">
-                      Budget at{" "}
-                      <span className="font-medium">{dashboard!.costs.monthUtilizationPercent}%</span>{" "}
-                      utilization this month
+                      {uiLanguage === "zh-CN" ? (
+                        <>
+                          本月预算已使用{" "}
+                          <span className="font-medium">{dashboard!.costs.monthUtilizationPercent}%</span>
+                        </>
+                      ) : (
+                        <>
+                          {copy.budgetAt}{" "}
+                          <span className="font-medium">{dashboard!.costs.monthUtilizationPercent}%</span>{" "}
+                          {copy.utilizationThisMonth}
+                        </>
+                      )}
                     </span>
                   </Link>
                   <button
                     type="button"
                     onClick={() => dismissAlert("alert:budget")}
                     className="rounded-md p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover/alert:opacity-100"
-                    aria-label="Dismiss"
+                    aria-label={copy.dismiss}
                   >
                     <X className="h-3.5 w-3.5" />
                   </button>

--- a/ui/src/pages/InstanceExperimentalSettings.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.tsx
@@ -2,21 +2,75 @@ import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FlaskConical } from "lucide-react";
 import { instanceSettingsApi } from "@/api/instanceSettings";
+import { useGeneralSettings } from "@/context/GeneralSettingsContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
+import { textFor } from "@/lib/ui-language";
 
 export function InstanceExperimentalSettings() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const [actionError, setActionError] = useState<string | null>(null);
+  const { uiLanguage } = useGeneralSettings();
+
+  const copy = {
+    instanceSettings: textFor(uiLanguage, {
+      en: "Instance Settings",
+      "zh-CN": "实例设置",
+    }),
+    experimental: textFor(uiLanguage, {
+      en: "Experimental",
+      "zh-CN": "实验功能",
+    }),
+    loading: textFor(uiLanguage, {
+      en: "Loading experimental settings...",
+      "zh-CN": "正在加载实验设置...",
+    }),
+    loadError: textFor(uiLanguage, {
+      en: "Failed to load experimental settings.",
+      "zh-CN": "加载实验设置失败。",
+    }),
+    updateError: textFor(uiLanguage, {
+      en: "Failed to update experimental settings.",
+      "zh-CN": "更新实验设置失败。",
+    }),
+    headerDescription: textFor(uiLanguage, {
+      en: "Opt into features that are still being evaluated before they become default behavior.",
+      "zh-CN": "启用仍在评估中的功能，这些功能未来可能会成为默认行为。",
+    }),
+    isolatedTitle: textFor(uiLanguage, {
+      en: "Enable Isolated Workspaces",
+      "zh-CN": "启用隔离工作区",
+    }),
+    isolatedDescription: textFor(uiLanguage, {
+      en: "Show execution workspace controls in project configuration and allow isolated workspace behavior for new and existing issue runs.",
+      "zh-CN": "在项目配置中显示执行工作区控制项，并为新的和已有的 issue 运行启用隔离工作区行为。",
+    }),
+    isolatedAria: textFor(uiLanguage, {
+      en: "Toggle isolated workspaces experimental setting",
+      "zh-CN": "切换隔离工作区实验设置",
+    }),
+    restartTitle: textFor(uiLanguage, {
+      en: "Auto-Restart Dev Server When Idle",
+      "zh-CN": "空闲时自动重启开发服务器",
+    }),
+    restartDescription: textFor(uiLanguage, {
+      en: "In `pnpm dev:once`, wait for all queued and running local agent runs to finish, then restart the server automatically when backend changes or migrations make the current boot stale.",
+      "zh-CN": "在 `pnpm dev:once` 下，等待所有排队中和运行中的本地 agent 任务结束后，当后端变更或迁移让当前启动状态过期时自动重启服务。",
+    }),
+    restartAria: textFor(uiLanguage, {
+      en: "Toggle guarded dev-server auto-restart",
+      "zh-CN": "切换开发服务器自动重启",
+    }),
+  };
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: "Instance Settings" },
-      { label: "Experimental" },
+      { label: copy.instanceSettings },
+      { label: copy.experimental },
     ]);
-  }, [setBreadcrumbs]);
+  }, [copy.experimental, copy.instanceSettings, setBreadcrumbs]);
 
   const experimentalQuery = useQuery({
     queryKey: queryKeys.instance.experimentalSettings,
@@ -34,12 +88,12 @@ export function InstanceExperimentalSettings() {
       ]);
     },
     onError: (error) => {
-      setActionError(error instanceof Error ? error.message : "Failed to update experimental settings.");
+      setActionError(error instanceof Error ? error.message : copy.updateError);
     },
   });
 
   if (experimentalQuery.isLoading) {
-    return <div className="text-sm text-muted-foreground">Loading experimental settings...</div>;
+    return <div className="text-sm text-muted-foreground">{copy.loading}</div>;
   }
 
   if (experimentalQuery.error) {
@@ -47,7 +101,7 @@ export function InstanceExperimentalSettings() {
       <div className="text-sm text-destructive">
         {experimentalQuery.error instanceof Error
           ? experimentalQuery.error.message
-          : "Failed to load experimental settings."}
+          : copy.loadError}
       </div>
     );
   }
@@ -60,10 +114,10 @@ export function InstanceExperimentalSettings() {
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <FlaskConical className="h-5 w-5 text-muted-foreground" />
-          <h1 className="text-lg font-semibold">Experimental</h1>
+          <h1 className="text-lg font-semibold">{copy.experimental}</h1>
         </div>
         <p className="text-sm text-muted-foreground">
-          Opt into features that are still being evaluated before they become default behavior.
+          {copy.headerDescription}
         </p>
       </div>
 
@@ -76,17 +130,16 @@ export function InstanceExperimentalSettings() {
       <section className="rounded-xl border border-border bg-card p-5">
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Enable Isolated Workspaces</h2>
+            <h2 className="text-sm font-semibold">{copy.isolatedTitle}</h2>
             <p className="max-w-2xl text-sm text-muted-foreground">
-              Show execution workspace controls in project configuration and allow isolated workspace behavior for new
-              and existing issue runs.
+              {copy.isolatedDescription}
             </p>
           </div>
           <ToggleSwitch
             checked={enableIsolatedWorkspaces}
             onCheckedChange={() => toggleMutation.mutate({ enableIsolatedWorkspaces: !enableIsolatedWorkspaces })}
             disabled={toggleMutation.isPending}
-            aria-label="Toggle isolated workspaces experimental setting"
+            aria-label={copy.isolatedAria}
           />
         </div>
       </section>
@@ -94,17 +147,16 @@ export function InstanceExperimentalSettings() {
       <section className="rounded-xl border border-border bg-card p-5">
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Auto-Restart Dev Server When Idle</h2>
+            <h2 className="text-sm font-semibold">{copy.restartTitle}</h2>
             <p className="max-w-2xl text-sm text-muted-foreground">
-              In `pnpm dev:once`, wait for all queued and running local agent runs to finish, then restart the server
-              automatically when backend changes or migrations make the current boot stale.
+              {copy.restartDescription}
             </p>
           </div>
           <ToggleSwitch
             checked={autoRestartDevServerWhenIdle}
             onCheckedChange={() => toggleMutation.mutate({ autoRestartDevServerWhenIdle: !autoRestartDevServerWhenIdle })}
             disabled={toggleMutation.isPending}
-            aria-label="Toggle guarded dev-server auto-restart"
+            aria-label={copy.restartAria}
           />
         </div>
       </section>

--- a/ui/src/pages/InstanceGeneralSettings.tsx
+++ b/ui/src/pages/InstanceGeneralSettings.tsx
@@ -4,11 +4,13 @@ import type { PatchInstanceGeneralSettings } from "@paperclipai/shared";
 import { LogOut, SlidersHorizontal } from "lucide-react";
 import { authApi } from "@/api/auth";
 import { instanceSettingsApi } from "@/api/instanceSettings";
+import { useGeneralSettings } from "@/context/GeneralSettingsContext";
 import { Button } from "../components/ui/button";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { cn } from "../lib/utils";
+import { textFor } from "@/lib/ui-language";
 
 const FEEDBACK_TERMS_URL = import.meta.env.VITE_FEEDBACK_TERMS_URL?.trim() || "https://paperclip.ing/tos";
 
@@ -16,6 +18,138 @@ export function InstanceGeneralSettings() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const [actionError, setActionError] = useState<string | null>(null);
+  const { uiLanguage, setUiLanguage } = useGeneralSettings();
+
+  const copy = {
+    instanceSettings: textFor(uiLanguage, {
+      en: "Instance Settings",
+      "zh-CN": "实例设置",
+    }),
+    general: textFor(uiLanguage, {
+      en: "General",
+      "zh-CN": "通用",
+    }),
+    loading: textFor(uiLanguage, {
+      en: "Loading general settings...",
+      "zh-CN": "正在加载通用设置...",
+    }),
+    loadError: textFor(uiLanguage, {
+      en: "Failed to load general settings.",
+      "zh-CN": "加载通用设置失败。",
+    }),
+    updateError: textFor(uiLanguage, {
+      en: "Failed to update general settings.",
+      "zh-CN": "更新通用设置失败。",
+    }),
+    headerDescription: textFor(uiLanguage, {
+      en: "Configure instance-wide defaults that affect how operator-visible logs are displayed.",
+      "zh-CN": "配置实例级默认项，控制操作员可见日志和设置界面的显示方式。",
+    }),
+    displayLanguage: textFor(uiLanguage, {
+      en: "Display language",
+      "zh-CN": "显示语言",
+    }),
+    displayLanguageDescription: textFor(uiLanguage, {
+      en: "Switch the settings area and shared navigation chrome between English and Simplified Chinese. This preference is saved in this browser.",
+      "zh-CN": "在英文和简体中文之间切换设置页及共享导航文案。这个偏好会保存在当前浏览器中。",
+    }),
+    english: textFor(uiLanguage, {
+      en: "English",
+      "zh-CN": "English",
+    }),
+    englishDescription: textFor(uiLanguage, {
+      en: "Show settings in English.",
+      "zh-CN": "以英文显示设置界面。",
+    }),
+    chinese: textFor(uiLanguage, {
+      en: "Simplified Chinese",
+      "zh-CN": "简体中文",
+    }),
+    chineseDescription: textFor(uiLanguage, {
+      en: "Show settings in Chinese.",
+      "zh-CN": "以中文显示设置界面。",
+    }),
+    censorUsernameTitle: textFor(uiLanguage, {
+      en: "Censor username in logs",
+      "zh-CN": "隐藏日志中的用户名",
+    }),
+    censorUsernameDescription: textFor(uiLanguage, {
+      en: "Hide the username segment in home-directory paths and similar operator-visible log output. Standalone username mentions outside of paths are not yet masked in the live transcript view. This is off by default.",
+      "zh-CN": "在家目录路径和类似的操作员可见日志输出中隐藏用户名片段。路径之外单独出现的用户名目前还不会在实时转录视图中被遮罩。默认关闭。",
+    }),
+    censorUsernameAria: textFor(uiLanguage, {
+      en: "Toggle username log censoring",
+      "zh-CN": "切换日志用户名隐藏",
+    }),
+    keyboardShortcutsTitle: textFor(uiLanguage, {
+      en: "Keyboard shortcuts",
+      "zh-CN": "键盘快捷键",
+    }),
+    keyboardShortcutsDescription: textFor(uiLanguage, {
+      en: "Enable app keyboard shortcuts, including inbox navigation and global shortcuts like creating issues or toggling panels. This is off by default.",
+      "zh-CN": "启用应用快捷键，包括收件箱导航，以及创建 issue、切换面板等全局快捷键。默认关闭。",
+    }),
+    keyboardShortcutsAria: textFor(uiLanguage, {
+      en: "Toggle keyboard shortcuts",
+      "zh-CN": "切换键盘快捷键",
+    }),
+    feedbackTitle: textFor(uiLanguage, {
+      en: "AI feedback sharing",
+      "zh-CN": "AI 反馈共享",
+    }),
+    feedbackDescription: textFor(uiLanguage, {
+      en: "Control whether thumbs up and thumbs down votes can send the voted AI output to Paperclip Labs. Votes are always saved locally.",
+      "zh-CN": "控制点赞和点踩是否可以把被投票的 AI 输出发送给 Paperclip Labs。投票记录始终会保存在本地。",
+    }),
+    feedbackTerms: textFor(uiLanguage, {
+      en: "Read our terms of service",
+      "zh-CN": "查看服务条款",
+    }),
+    feedbackPrompt: textFor(uiLanguage, {
+      en: "No default is saved yet. The next thumbs up or thumbs down choice will ask once and then save the answer here.",
+      "zh-CN": "当前还没有保存默认值。下次点赞或点踩时会询问一次，并把结果保存在这里。",
+    }),
+    feedbackAllow: textFor(uiLanguage, {
+      en: "Always allow",
+      "zh-CN": "始终允许",
+    }),
+    feedbackAllowDescription: textFor(uiLanguage, {
+      en: "Share voted AI outputs automatically.",
+      "zh-CN": "自动共享被投票的 AI 输出。",
+    }),
+    feedbackDeny: textFor(uiLanguage, {
+      en: "Don't allow",
+      "zh-CN": "不允许",
+    }),
+    feedbackDenyDescription: textFor(uiLanguage, {
+      en: "Keep voted AI outputs local only.",
+      "zh-CN": "仅在本地保留被投票的 AI 输出。",
+    }),
+    feedbackDevNote: textFor(uiLanguage, {
+      en: "To retest the first-use prompt in local dev, remove the feedbackDataSharingPreference key from the instance_settings.general JSON row for this instance, or set it back to \"prompt\". Unset and \"prompt\" both mean no default has been chosen yet.",
+      "zh-CN": "如果要在本地开发里重新测试首次提示，可以从当前实例的 instance_settings.general JSON 行里删除 feedbackDataSharingPreference，或者把它改回 \"prompt\"。未设置和 \"prompt\" 都表示还没有选择默认值。",
+    }),
+    signOutTitle: textFor(uiLanguage, {
+      en: "Sign out",
+      "zh-CN": "退出登录",
+    }),
+    signOutDescription: textFor(uiLanguage, {
+      en: "Sign out of this Paperclip instance. You will be redirected to the login page.",
+      "zh-CN": "退出当前 Paperclip 实例登录。之后你会被重定向到登录页。",
+    }),
+    signOutPending: textFor(uiLanguage, {
+      en: "Signing out...",
+      "zh-CN": "正在退出...",
+    }),
+    signOutCta: textFor(uiLanguage, {
+      en: "Sign out",
+      "zh-CN": "退出登录",
+    }),
+    signOutError: textFor(uiLanguage, {
+      en: "Failed to sign out.",
+      "zh-CN": "退出登录失败。",
+    }),
+  };
 
   const signOutMutation = useMutation({
     mutationFn: () => authApi.signOut(),
@@ -23,16 +157,16 @@ export function InstanceGeneralSettings() {
       queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
     },
     onError: (error) => {
-      setActionError(error instanceof Error ? error.message : "Failed to sign out.");
+      setActionError(error instanceof Error ? error.message : copy.signOutError);
     },
   });
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: "Instance Settings" },
-      { label: "General" },
+      { label: copy.instanceSettings },
+      { label: copy.general },
     ]);
-  }, [setBreadcrumbs]);
+  }, [copy.general, copy.instanceSettings, setBreadcrumbs]);
 
   const generalQuery = useQuery({
     queryKey: queryKeys.instance.generalSettings,
@@ -46,12 +180,12 @@ export function InstanceGeneralSettings() {
       await queryClient.invalidateQueries({ queryKey: queryKeys.instance.generalSettings });
     },
     onError: (error) => {
-      setActionError(error instanceof Error ? error.message : "Failed to update general settings.");
+      setActionError(error instanceof Error ? error.message : copy.updateError);
     },
   });
 
   if (generalQuery.isLoading) {
-    return <div className="text-sm text-muted-foreground">Loading general settings...</div>;
+    return <div className="text-sm text-muted-foreground">{copy.loading}</div>;
   }
 
   if (generalQuery.error) {
@@ -59,7 +193,7 @@ export function InstanceGeneralSettings() {
       <div className="text-sm text-destructive">
         {generalQuery.error instanceof Error
           ? generalQuery.error.message
-          : "Failed to load general settings."}
+          : copy.loadError}
       </div>
     );
   }
@@ -73,10 +207,10 @@ export function InstanceGeneralSettings() {
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <SlidersHorizontal className="h-5 w-5 text-muted-foreground" />
-          <h1 className="text-lg font-semibold">General</h1>
+          <h1 className="text-lg font-semibold">{copy.general}</h1>
         </div>
         <p className="text-sm text-muted-foreground">
-          Configure instance-wide defaults that affect how operator-visible logs are displayed.
+          {copy.headerDescription}
         </p>
       </div>
 
@@ -87,20 +221,63 @@ export function InstanceGeneralSettings() {
       )}
 
       <section className="rounded-xl border border-border bg-card p-5">
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <h2 className="text-sm font-semibold">{copy.displayLanguage}</h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              {copy.displayLanguageDescription}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {[
+              {
+                value: "en" as const,
+                label: copy.english,
+                description: copy.englishDescription,
+              },
+              {
+                value: "zh-CN" as const,
+                label: copy.chinese,
+                description: copy.chineseDescription,
+              },
+            ].map((option) => {
+              const active = uiLanguage === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={cn(
+                    "rounded-lg border px-3 py-2 text-left transition-colors",
+                    active
+                      ? "border-foreground bg-accent text-foreground"
+                      : "border-border bg-background hover:bg-accent/50",
+                  )}
+                  onClick={() => setUiLanguage(option.value)}
+                >
+                  <div className="text-sm font-medium">{option.label}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {option.description}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-border bg-card p-5">
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Censor username in logs</h2>
+            <h2 className="text-sm font-semibold">{copy.censorUsernameTitle}</h2>
             <p className="max-w-2xl text-sm text-muted-foreground">
-              Hide the username segment in home-directory paths and similar operator-visible log output. Standalone
-              username mentions outside of paths are not yet masked in the live transcript view. This is off by
-              default.
+              {copy.censorUsernameDescription}
             </p>
           </div>
           <ToggleSwitch
             checked={censorUsernameInLogs}
             onCheckedChange={() => updateGeneralMutation.mutate({ censorUsernameInLogs: !censorUsernameInLogs })}
             disabled={updateGeneralMutation.isPending}
-            aria-label="Toggle username log censoring"
+            aria-label={copy.censorUsernameAria}
           />
         </div>
       </section>
@@ -108,17 +285,16 @@ export function InstanceGeneralSettings() {
       <section className="rounded-xl border border-border bg-card p-5">
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Keyboard shortcuts</h2>
+            <h2 className="text-sm font-semibold">{copy.keyboardShortcutsTitle}</h2>
             <p className="max-w-2xl text-sm text-muted-foreground">
-              Enable app keyboard shortcuts, including inbox navigation and global shortcuts like creating issues or
-              toggling panels. This is off by default.
+              {copy.keyboardShortcutsDescription}
             </p>
           </div>
           <ToggleSwitch
             checked={keyboardShortcuts}
             onCheckedChange={() => updateGeneralMutation.mutate({ keyboardShortcuts: !keyboardShortcuts })}
             disabled={updateGeneralMutation.isPending}
-            aria-label="Toggle keyboard shortcuts"
+            aria-label={copy.keyboardShortcutsAria}
           />
         </div>
       </section>
@@ -126,10 +302,9 @@ export function InstanceGeneralSettings() {
       <section className="rounded-xl border border-border bg-card p-5">
         <div className="space-y-4">
           <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">AI feedback sharing</h2>
+            <h2 className="text-sm font-semibold">{copy.feedbackTitle}</h2>
             <p className="max-w-2xl text-sm text-muted-foreground">
-              Control whether thumbs up and thumbs down votes can send the voted AI output to
-              Paperclip Labs. Votes are always saved locally.
+              {copy.feedbackDescription}
             </p>
             {FEEDBACK_TERMS_URL ? (
               <a
@@ -138,27 +313,26 @@ export function InstanceGeneralSettings() {
                 rel="noreferrer"
                 className="inline-flex text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
               >
-                Read our terms of service
+                {copy.feedbackTerms}
               </a>
             ) : null}
           </div>
           {feedbackDataSharingPreference === "prompt" ? (
             <div className="rounded-lg border border-border/70 bg-accent/20 px-3 py-2 text-sm text-muted-foreground">
-              No default is saved yet. The next thumbs up or thumbs down choice will ask once and
-              then save the answer here.
+              {copy.feedbackPrompt}
             </div>
           ) : null}
           <div className="flex flex-wrap gap-2">
             {[
               {
                 value: "allowed",
-                label: "Always allow",
-                description: "Share voted AI outputs automatically.",
+                label: copy.feedbackAllow,
+                description: copy.feedbackAllowDescription,
               },
               {
                 value: "not_allowed",
-                label: "Don't allow",
-                description: "Keep voted AI outputs local only.",
+                label: copy.feedbackDeny,
+                description: copy.feedbackDenyDescription,
               },
             ].map((option) => {
               const active = feedbackDataSharingPreference === option.value;
@@ -190,11 +364,7 @@ export function InstanceGeneralSettings() {
             })}
           </div>
           <p className="text-xs text-muted-foreground">
-            To retest the first-use prompt in local dev, remove the{" "}
-            <code>feedbackDataSharingPreference</code> key from the{" "}
-            <code>instance_settings.general</code> JSON row for this instance, or set it back to{" "}
-            <code>"prompt"</code>. Unset and <code>"prompt"</code> both mean no default has been
-            chosen yet.
+            {copy.feedbackDevNote}
           </p>
         </div>
       </section>
@@ -202,9 +372,9 @@ export function InstanceGeneralSettings() {
       <section className="rounded-xl border border-border bg-card p-5">
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Sign out</h2>
+            <h2 className="text-sm font-semibold">{copy.signOutTitle}</h2>
             <p className="max-w-2xl text-sm text-muted-foreground">
-              Sign out of this Paperclip instance. You will be redirected to the login page.
+              {copy.signOutDescription}
             </p>
           </div>
           <Button
@@ -214,7 +384,7 @@ export function InstanceGeneralSettings() {
             onClick={() => signOutMutation.mutate()}
           >
             <LogOut className="size-4" />
-            {signOutMutation.isPending ? "Signing out..." : "Sign out"}
+            {signOutMutation.isPending ? copy.signOutPending : copy.signOutCta}
           </Button>
         </div>
       </section>

--- a/ui/src/pages/InstanceSettings.tsx
+++ b/ui/src/pages/InstanceSettings.tsx
@@ -6,12 +6,14 @@ import { Link } from "@/lib/router";
 import { heartbeatsApi } from "../api/heartbeats";
 import { agentsApi } from "../api/agents";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { EmptyState } from "../components/EmptyState";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { queryKeys } from "../lib/queryKeys";
 import { formatDateTime, relativeTime } from "../lib/utils";
+import { textFor } from "../lib/ui-language";
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
@@ -30,13 +32,106 @@ export function InstanceSettings() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const [actionError, setActionError] = useState<string | null>(null);
+  const { uiLanguage } = useGeneralSettings();
+
+  const copy = {
+    instanceSettings: textFor(uiLanguage, {
+      en: "Instance Settings",
+      "zh-CN": "实例设置",
+    }),
+    heartbeats: textFor(uiLanguage, {
+      en: "Heartbeats",
+      "zh-CN": "心跳",
+    }),
+    title: textFor(uiLanguage, {
+      en: "Scheduler Heartbeats",
+      "zh-CN": "调度器心跳",
+    }),
+    description: textFor(uiLanguage, {
+      en: "Agents with a timer heartbeat enabled across all of your companies.",
+      "zh-CN": "展示你所有公司中启用了定时心跳的 agent。",
+    }),
+    loading: textFor(uiLanguage, {
+      en: "Loading scheduler heartbeats...",
+      "zh-CN": "正在加载调度器心跳...",
+    }),
+    loadError: textFor(uiLanguage, {
+      en: "Failed to load scheduler heartbeats.",
+      "zh-CN": "加载调度器心跳失败。",
+    }),
+    updateError: textFor(uiLanguage, {
+      en: "Failed to update heartbeat.",
+      "zh-CN": "更新心跳失败。",
+    }),
+    disableAllError: textFor(uiLanguage, {
+      en: "Failed to disable all heartbeats.",
+      "zh-CN": "批量关闭心跳失败。",
+    }),
+    active: textFor(uiLanguage, {
+      en: "active",
+      "zh-CN": "活跃",
+    }),
+    disabled: textFor(uiLanguage, {
+      en: "disabled",
+      "zh-CN": "已关闭",
+    }),
+    company: textFor(uiLanguage, {
+      en: "company",
+      "zh-CN": "个公司",
+    }),
+    companies: textFor(uiLanguage, {
+      en: "companies",
+      "zh-CN": "个公司",
+    }),
+    disableAll: textFor(uiLanguage, {
+      en: "Disable All",
+      "zh-CN": "全部关闭",
+    }),
+    disabling: textFor(uiLanguage, {
+      en: "Disabling...",
+      "zh-CN": "关闭中...",
+    }),
+    disableConfirm: (count: number, noun: string) =>
+      textFor(uiLanguage, {
+        en: `Disable timer heartbeats for all ${count} enabled ${noun}?`,
+        "zh-CN": `确认关闭全部 ${count} 个已启用${noun === "agent" ? " agent" : "个 agent"}的定时心跳吗？`,
+      }),
+    noHeartbeats: textFor(uiLanguage, {
+      en: "No scheduler heartbeats match the current criteria.",
+      "zh-CN": "当前条件下没有匹配的调度器心跳。",
+    }),
+    statusOn: textFor(uiLanguage, {
+      en: "On",
+      "zh-CN": "开",
+    }),
+    statusOff: textFor(uiLanguage, {
+      en: "Off",
+      "zh-CN": "关",
+    }),
+    never: textFor(uiLanguage, {
+      en: "never",
+      "zh-CN": "从未",
+    }),
+    fullConfig: textFor(uiLanguage, {
+      en: "Full agent config",
+      "zh-CN": "完整 agent 配置",
+    }),
+    disableTimerHeartbeat: textFor(uiLanguage, {
+      en: "Disable Timer Heartbeat",
+      "zh-CN": "关闭定时心跳",
+    }),
+    enableTimerHeartbeat: textFor(uiLanguage, {
+      en: "Enable Timer Heartbeat",
+      "zh-CN": "开启定时心跳",
+    }),
+  };
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: "Instance Settings" },
-      { label: "Heartbeats" },
+      { label: copy.instanceSettings },
+      { label: copy.heartbeats },
     ]);
-  }, [setBreadcrumbs]);
+  }, [copy.heartbeats, copy.instanceSettings, setBreadcrumbs]);
 
   const heartbeatsQuery = useQuery({
     queryKey: queryKeys.instance.schedulerHeartbeats,
@@ -73,7 +168,7 @@ export function InstanceSettings() {
       ]);
     },
     onError: (error) => {
-      setActionError(error instanceof Error ? error.message : "Failed to update heartbeat.");
+      setActionError(error instanceof Error ? error.message : copy.updateError);
     },
   });
 
@@ -126,7 +221,7 @@ export function InstanceSettings() {
       ]);
     },
     onError: (error) => {
-      setActionError(error instanceof Error ? error.message : "Failed to disable all heartbeats.");
+      setActionError(error instanceof Error ? error.message : copy.disableAllError);
     },
   });
 
@@ -150,7 +245,7 @@ export function InstanceSettings() {
   }, [agents]);
 
   if (heartbeatsQuery.isLoading) {
-    return <div className="text-sm text-muted-foreground">Loading scheduler heartbeats...</div>;
+    return <div className="text-sm text-muted-foreground">{copy.loading}</div>;
   }
 
   if (heartbeatsQuery.error) {
@@ -158,7 +253,7 @@ export function InstanceSettings() {
       <div className="text-sm text-destructive">
         {heartbeatsQuery.error instanceof Error
           ? heartbeatsQuery.error.message
-          : "Failed to load scheduler heartbeats."}
+          : copy.loadError}
       </div>
     );
   }
@@ -168,17 +263,17 @@ export function InstanceSettings() {
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <Settings className="h-5 w-5 text-muted-foreground" />
-          <h1 className="text-lg font-semibold">Scheduler Heartbeats</h1>
+          <h1 className="text-lg font-semibold">{copy.title}</h1>
         </div>
         <p className="text-sm text-muted-foreground">
-          Agents with a timer heartbeat enabled across all of your companies.
+          {copy.description}
         </p>
       </div>
 
       <div className="flex items-center gap-4 text-sm text-muted-foreground">
-        <span><span className="font-semibold text-foreground">{activeCount}</span> active</span>
-        <span><span className="font-semibold text-foreground">{disabledCount}</span> disabled</span>
-        <span><span className="font-semibold text-foreground">{grouped.length}</span> {grouped.length === 1 ? "company" : "companies"}</span>
+        <span><span className="font-semibold text-foreground">{activeCount}</span> {copy.active}</span>
+        <span><span className="font-semibold text-foreground">{disabledCount}</span> {copy.disabled}</span>
+        <span><span className="font-semibold text-foreground">{grouped.length}</span> {grouped.length === 1 ? copy.company : copy.companies}</span>
         {anyEnabled && (
           <Button
             variant="destructive"
@@ -187,13 +282,13 @@ export function InstanceSettings() {
             disabled={disableAllMutation.isPending}
             onClick={() => {
               const noun = enabledCount === 1 ? "agent" : "agents";
-              if (!window.confirm(`Disable timer heartbeats for all ${enabledCount} enabled ${noun}?`)) {
+              if (!window.confirm(copy.disableConfirm(enabledCount, noun))) {
                 return;
               }
               disableAllMutation.mutate(agents);
             }}
           >
-            {disableAllMutation.isPending ? "Disabling..." : "Disable All"}
+            {disableAllMutation.isPending ? copy.disabling : copy.disableAll}
           </Button>
         )}
       </div>
@@ -207,7 +302,7 @@ export function InstanceSettings() {
       {agents.length === 0 ? (
         <EmptyState
           icon={Clock3}
-          message="No scheduler heartbeats match the current criteria."
+          message={copy.noHeartbeats}
         />
       ) : (
         <div className="space-y-4">
@@ -229,7 +324,7 @@ export function InstanceSettings() {
                           variant={agent.schedulerActive ? "default" : "outline"}
                           className="shrink-0 text-[10px] px-1.5 py-0"
                         >
-                          {agent.schedulerActive ? "On" : "Off"}
+                          {agent.schedulerActive ? copy.statusOn : copy.statusOff}
                         </Badge>
                         <Link
                           to={buildAgentHref(agent)}
@@ -249,13 +344,13 @@ export function InstanceSettings() {
                         >
                           {agent.lastHeartbeatAt
                             ? relativeTime(agent.lastHeartbeatAt)
-                            : "never"}
+                            : copy.never}
                         </span>
                         <span className="ml-auto flex items-center gap-1.5 shrink-0">
                           <Link
                             to={buildAgentHref(agent)}
                             className="text-muted-foreground hover:text-foreground"
-                            title="Full agent config"
+                            title={copy.fullConfig}
                           >
                             <ExternalLink className="h-3.5 w-3.5" />
                           </Link>
@@ -266,7 +361,7 @@ export function InstanceSettings() {
                             disabled={saving}
                             onClick={() => toggleMutation.mutate(agent)}
                           >
-                            {saving ? "..." : agent.heartbeatEnabled ? "Disable Timer Heartbeat" : "Enable Timer Heartbeat"}
+                            {saving ? "..." : agent.heartbeatEnabled ? copy.disableTimerHeartbeat : copy.enableTimerHeartbeat}
                           </Button>
                         </span>
                       </div>

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -7,18 +7,31 @@ import { projectsApi } from "../api/projects";
 import { heartbeatsApi } from "../api/heartbeats";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { queryKeys } from "../lib/queryKeys";
 import { createIssueDetailLocationState } from "../lib/issueDetailBreadcrumb";
 import { EmptyState } from "../components/EmptyState";
 import { IssuesList } from "../components/IssuesList";
 import { CircleDot } from "lucide-react";
+import { textFor } from "../lib/ui-language";
 
 export function Issues() {
   const { selectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { setBreadcrumbs } = useBreadcrumbs();
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
+  const copy = {
+    issues: textFor(uiLanguage, {
+      en: "Issues",
+      "zh-CN": "任务",
+    }),
+    selectCompany: textFor(uiLanguage, {
+      en: "Select a company to view issues.",
+      "zh-CN": "请先选择公司以查看任务。",
+    }),
+  };
 
   const initialSearch = searchParams.get("q") ?? "";
   const participantAgentId = searchParams.get("participantAgentId") ?? undefined;
@@ -68,16 +81,16 @@ export function Issues() {
   const issueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(
-        "Issues",
+        copy.issues,
         `${location.pathname}${location.search}${location.hash}`,
         "issues",
       ),
-    [location.pathname, location.search, location.hash],
+    [copy.issues, location.pathname, location.search, location.hash],
   );
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Issues" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy.issues }]);
+  }, [copy.issues, setBreadcrumbs]);
 
   const { data: issues, isLoading, error } = useQuery({
     queryKey: [...queryKeys.issues.list(selectedCompanyId!), "participant-agent", participantAgentId ?? "__all__"],
@@ -94,7 +107,7 @@ export function Issues() {
   });
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={CircleDot} message="Select a company to view issues." />;
+    return <EmptyState icon={CircleDot} message={copy.selectCompany} />;
   }
 
   return (

--- a/ui/src/pages/NotFound.tsx
+++ b/ui/src/pages/NotFound.tsx
@@ -4,6 +4,8 @@ import { AlertTriangle, Compass } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useCompany } from "../context/CompanyContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+import { textFor } from "../lib/ui-language";
 
 type NotFoundScope = "board" | "invalid_company_prefix" | "global";
 
@@ -16,21 +18,58 @@ export function NotFoundPage({ scope = "global", requestedPrefix }: NotFoundPage
   const location = useLocation();
   const { setBreadcrumbs } = useBreadcrumbs();
   const { companies, selectedCompany } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
+  const copy = {
+    notFound: textFor(uiLanguage, {
+      en: "Not Found",
+      "zh-CN": "未找到",
+    }),
+    companyNotFound: textFor(uiLanguage, {
+      en: "Company not found",
+      "zh-CN": "未找到公司",
+    }),
+    pageNotFound: textFor(uiLanguage, {
+      en: "Page not found",
+      "zh-CN": "页面不存在",
+    }),
+    unknown: textFor(uiLanguage, {
+      en: "unknown",
+      "zh-CN": "未知",
+    }),
+    routeDoesNotExist: textFor(uiLanguage, {
+      en: "This route does not exist.",
+      "zh-CN": "这个路由不存在。",
+    }),
+    requestedPath: textFor(uiLanguage, {
+      en: "Requested path:",
+      "zh-CN": "请求路径：",
+    }),
+    openDashboard: textFor(uiLanguage, {
+      en: "Open dashboard",
+      "zh-CN": "打开仪表盘",
+    }),
+    goHome: textFor(uiLanguage, {
+      en: "Go home",
+      "zh-CN": "回到首页",
+    }),
+  };
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Not Found" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy.notFound }]);
+  }, [copy.notFound, setBreadcrumbs]);
 
   const fallbackCompany = selectedCompany ?? companies[0] ?? null;
   const dashboardHref = fallbackCompany ? `/${fallbackCompany.issuePrefix}/dashboard` : "/";
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
   const normalizedPrefix = requestedPrefix?.toUpperCase();
 
-  const title = scope === "invalid_company_prefix" ? "Company not found" : "Page not found";
+  const title = scope === "invalid_company_prefix" ? copy.companyNotFound : copy.pageNotFound;
   const description =
     scope === "invalid_company_prefix"
-      ? `No company matches prefix "${normalizedPrefix ?? "unknown"}".`
-      : "This route does not exist.";
+      ? uiLanguage === "zh-CN"
+        ? `没有公司匹配前缀“${normalizedPrefix ?? copy.unknown}”。`
+        : `No company matches prefix "${normalizedPrefix ?? copy.unknown}".`
+      : copy.routeDoesNotExist;
 
   return (
     <div className="mx-auto max-w-2xl py-10">
@@ -46,18 +85,18 @@ export function NotFoundPage({ scope = "global", requestedPrefix }: NotFoundPage
         </div>
 
         <div className="mt-4 rounded-md border border-border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
-          Requested path: <code className="font-mono">{currentPath}</code>
+          {copy.requestedPath} <code className="font-mono">{currentPath}</code>
         </div>
 
         <div className="mt-5 flex flex-wrap gap-2">
           <Button asChild>
             <Link to={dashboardHref}>
               <Compass className="mr-1.5 h-4 w-4" />
-              Open dashboard
+              {copy.openDashboard}
             </Link>
           </Button>
           <Button variant="outline" asChild>
-            <Link to="/">Go home</Link>
+            <Link to="/">{copy.goHome}</Link>
           </Button>
         </div>
       </div>

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { agentsApi, type OrgNode } from "../api/agents";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { queryKeys } from "../lib/queryKeys";
 import { agentUrl } from "../lib/utils";
 import { Button } from "@/components/ui/button";
@@ -12,6 +13,7 @@ import { PageSkeleton } from "../components/PageSkeleton";
 import { AgentIcon } from "../components/AgentIconPicker";
 import { Download, Network, Upload } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
+import { textFor } from "../lib/ui-language";
 
 // Layout constants
 const CARD_W = 200;
@@ -132,8 +134,47 @@ const defaultDotColor = "#a3a3a3";
 
 export function OrgChart() {
   const { selectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { setBreadcrumbs } = useBreadcrumbs();
   const navigate = useNavigate();
+  const copy = {
+    orgChart: textFor(uiLanguage, {
+      en: "Org Chart",
+      "zh-CN": "组织架构",
+    }),
+    selectCompany: textFor(uiLanguage, {
+      en: "Select a company to view the org chart.",
+      "zh-CN": "请先选择公司以查看组织架构。",
+    }),
+    noHierarchy: textFor(uiLanguage, {
+      en: "No organizational hierarchy defined.",
+      "zh-CN": "尚未定义组织层级结构。",
+    }),
+    importCompany: textFor(uiLanguage, {
+      en: "Import company",
+      "zh-CN": "导入公司",
+    }),
+    exportCompany: textFor(uiLanguage, {
+      en: "Export company",
+      "zh-CN": "导出公司",
+    }),
+    zoomIn: textFor(uiLanguage, {
+      en: "Zoom in",
+      "zh-CN": "放大",
+    }),
+    zoomOut: textFor(uiLanguage, {
+      en: "Zoom out",
+      "zh-CN": "缩小",
+    }),
+    fitToScreen: textFor(uiLanguage, {
+      en: "Fit to screen",
+      "zh-CN": "适应屏幕",
+    }),
+    fit: textFor(uiLanguage, {
+      en: "Fit",
+      "zh-CN": "适配",
+    }),
+  };
 
   const { data: orgTree, isLoading } = useQuery({
     queryKey: queryKeys.org(selectedCompanyId!),
@@ -154,8 +195,8 @@ export function OrgChart() {
   }, [agents]);
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Org Chart" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy.orgChart }]);
+  }, [copy.orgChart, setBreadcrumbs]);
 
   // Layout computation
   const layout = useMemo(() => layoutForest(orgTree ?? []), [orgTree]);
@@ -247,7 +288,7 @@ export function OrgChart() {
   }, [zoom, pan]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Network} message="Select a company to view the org chart." />;
+    return <EmptyState icon={Network} message={copy.selectCompany} />;
   }
 
   if (isLoading) {
@@ -255,7 +296,7 @@ export function OrgChart() {
   }
 
   if (orgTree && orgTree.length === 0) {
-    return <EmptyState icon={Network} message="No organizational hierarchy defined." />;
+    return <EmptyState icon={Network} message={copy.noHierarchy} />;
   }
 
   return (
@@ -264,13 +305,13 @@ export function OrgChart() {
       <Link to="/company/import">
         <Button variant="outline" size="sm">
           <Upload className="mr-1.5 h-3.5 w-3.5" />
-          Import company
+          {copy.importCompany}
         </Button>
       </Link>
       <Link to="/company/export">
         <Button variant="outline" size="sm">
           <Download className="mr-1.5 h-3.5 w-3.5" />
-          Export company
+          {copy.exportCompany}
         </Button>
       </Link>
     </div>
@@ -299,7 +340,7 @@ export function OrgChart() {
             }
             setZoom(newZoom);
           }}
-          aria-label="Zoom in"
+          aria-label={copy.zoomIn}
         >
           +
         </button>
@@ -316,7 +357,7 @@ export function OrgChart() {
             }
             setZoom(newZoom);
           }}
-          aria-label="Zoom out"
+          aria-label={copy.zoomOut}
         >
           &minus;
         </button>
@@ -334,10 +375,10 @@ export function OrgChart() {
             setZoom(fitZoom);
             setPan({ x: (cW - chartW) / 2, y: (cH - chartH) / 2 });
           }}
-          title="Fit to screen"
-          aria-label="Fit chart to screen"
+          title={copy.fitToScreen}
+          aria-label={copy.fitToScreen}
         >
-          Fit
+          {copy.fit}
         </button>
       </div>
 

--- a/ui/src/pages/PluginManager.tsx
+++ b/ui/src/pages/PluginManager.tsx
@@ -11,6 +11,7 @@ import { Link } from "@/lib/router";
 import { AlertTriangle, FlaskConical, Plus, Power, Puzzle, Settings, Trash } from "lucide-react";
 import { useCompany } from "@/context/CompanyContext";
 import { useBreadcrumbs } from "@/context/BreadcrumbContext";
+import { useGeneralSettings } from "@/context/GeneralSettingsContext";
 import { pluginsApi } from "@/api/plugins";
 import { queryKeys } from "@/lib/queryKeys";
 import { Button } from "@/components/ui/button";
@@ -29,6 +30,7 @@ import {
 } from "@/components/ui/dialog";
 import { useToast } from "@/context/ToastContext";
 import { cn } from "@/lib/utils";
+import { textFor, type UiLanguage } from "@/lib/ui-language";
 
 function firstNonEmptyLine(value: string | null | undefined): string | null {
   if (!value) return null;
@@ -39,8 +41,25 @@ function firstNonEmptyLine(value: string | null | undefined): string | null {
   return line ?? null;
 }
 
-function getPluginErrorSummary(plugin: PluginRecord): string {
-  return firstNonEmptyLine(plugin.lastError) ?? "Plugin entered an error state without a stored error message.";
+function getPluginErrorSummary(plugin: PluginRecord, fallback: string): string {
+  return firstNonEmptyLine(plugin.lastError) ?? fallback;
+}
+
+function getPluginStatusLabel(language: UiLanguage, status: string): string {
+  switch (status) {
+    case "ready":
+      return textFor(language, { en: "Ready", "zh-CN": "就绪" });
+    case "error":
+      return textFor(language, { en: "Error", "zh-CN": "错误" });
+    case "disabled":
+      return textFor(language, { en: "Disabled", "zh-CN": "已禁用" });
+    case "installing":
+      return textFor(language, { en: "Installing", "zh-CN": "安装中" });
+    case "uninstalling":
+      return textFor(language, { en: "Uninstalling", "zh-CN": "卸载中" });
+    default:
+      return status;
+  }
 }
 
 /**
@@ -62,6 +81,7 @@ function getPluginErrorSummary(plugin: PluginRecord): string {
  */
 export function PluginManager() {
   const { selectedCompany } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const { pushToast } = useToast();
@@ -71,14 +91,236 @@ export function PluginManager() {
   const [uninstallPluginId, setUninstallPluginId] = useState<string | null>(null);
   const [uninstallPluginName, setUninstallPluginName] = useState<string>("");
   const [errorDetailsPlugin, setErrorDetailsPlugin] = useState<PluginRecord | null>(null);
+  const copy = {
+    company: textFor(uiLanguage, {
+      en: "Company",
+      "zh-CN": "公司",
+    }),
+    settings: textFor(uiLanguage, {
+      en: "Settings",
+      "zh-CN": "设置",
+    }),
+    plugins: textFor(uiLanguage, {
+      en: "Plugins",
+      "zh-CN": "插件",
+    }),
+    loadingPlugins: textFor(uiLanguage, {
+      en: "Loading plugins...",
+      "zh-CN": "正在加载插件...",
+    }),
+    loadPluginsFailed: textFor(uiLanguage, {
+      en: "Failed to load plugins.",
+      "zh-CN": "加载插件失败。",
+    }),
+    title: textFor(uiLanguage, {
+      en: "Plugin Manager",
+      "zh-CN": "插件管理",
+    }),
+    installPlugin: textFor(uiLanguage, {
+      en: "Install Plugin",
+      "zh-CN": "安装插件",
+    }),
+    installPluginTitle: textFor(uiLanguage, {
+      en: "Install Plugin",
+      "zh-CN": "安装插件",
+    }),
+    installPluginDescription: textFor(uiLanguage, {
+      en: "Enter the npm package name of the plugin you wish to install.",
+      "zh-CN": "输入要安装的插件 npm 包名。",
+    }),
+    npmPackageName: textFor(uiLanguage, {
+      en: "npm Package Name",
+      "zh-CN": "npm 包名",
+    }),
+    cancel: textFor(uiLanguage, {
+      en: "Cancel",
+      "zh-CN": "取消",
+    }),
+    installing: textFor(uiLanguage, {
+      en: "Installing...",
+      "zh-CN": "安装中...",
+    }),
+    install: textFor(uiLanguage, {
+      en: "Install",
+      "zh-CN": "安装",
+    }),
+    pluginsAlpha: textFor(uiLanguage, {
+      en: "Plugins are alpha.",
+      "zh-CN": "插件功能仍处于 Alpha 阶段。",
+    }),
+    pluginsAlphaDescription: textFor(uiLanguage, {
+      en: "The plugin runtime and API surface are still changing. Expect breaking changes while this feature settles.",
+      "zh-CN": "插件运行时和 API 仍在持续调整中，这项功能稳定前可能会有不兼容变更。",
+    }),
+    availablePlugins: textFor(uiLanguage, {
+      en: "Available Plugins",
+      "zh-CN": "可用插件",
+    }),
+    examples: textFor(uiLanguage, {
+      en: "Examples",
+      "zh-CN": "示例",
+    }),
+    loadingExamples: textFor(uiLanguage, {
+      en: "Loading bundled examples...",
+      "zh-CN": "正在加载内置示例...",
+    }),
+    loadExamplesFailed: textFor(uiLanguage, {
+      en: "Failed to load bundled examples.",
+      "zh-CN": "加载内置示例失败。",
+    }),
+    noExamples: textFor(uiLanguage, {
+      en: "No bundled example plugins were found in this checkout.",
+      "zh-CN": "当前代码仓库中没有找到内置示例插件。",
+    }),
+    example: textFor(uiLanguage, {
+      en: "Example",
+      "zh-CN": "示例",
+    }),
+    notInstalled: textFor(uiLanguage, {
+      en: "Not installed",
+      "zh-CN": "未安装",
+    }),
+    enable: textFor(uiLanguage, {
+      en: "Enable",
+      "zh-CN": "启用",
+    }),
+    openSettings: textFor(uiLanguage, {
+      en: "Open Settings",
+      "zh-CN": "打开设置",
+    }),
+    review: textFor(uiLanguage, {
+      en: "Review",
+      "zh-CN": "查看",
+    }),
+    installExample: textFor(uiLanguage, {
+      en: "Install Example",
+      "zh-CN": "安装示例",
+    }),
+    installedPlugins: textFor(uiLanguage, {
+      en: "Installed Plugins",
+      "zh-CN": "已安装插件",
+    }),
+    noPluginsInstalled: textFor(uiLanguage, {
+      en: "No plugins installed",
+      "zh-CN": "尚未安装插件",
+    }),
+    noPluginsInstalledDescription: textFor(uiLanguage, {
+      en: "Install a plugin to extend functionality.",
+      "zh-CN": "安装插件以扩展功能。",
+    }),
+    noDescription: textFor(uiLanguage, {
+      en: "No description provided.",
+      "zh-CN": "未提供描述。",
+    }),
+    pluginError: textFor(uiLanguage, {
+      en: "Plugin error",
+      "zh-CN": "插件错误",
+    }),
+    viewFullError: textFor(uiLanguage, {
+      en: "View full error",
+      "zh-CN": "查看完整错误",
+    }),
+    disable: textFor(uiLanguage, {
+      en: "Disable",
+      "zh-CN": "停用",
+    }),
+    uninstall: textFor(uiLanguage, {
+      en: "Uninstall",
+      "zh-CN": "卸载",
+    }),
+    configure: textFor(uiLanguage, {
+      en: "Configure",
+      "zh-CN": "配置",
+    }),
+    uninstallPluginTitle: textFor(uiLanguage, {
+      en: "Uninstall Plugin",
+      "zh-CN": "卸载插件",
+    }),
+    uninstallPluginDescription: textFor(uiLanguage, {
+      en: "Are you sure you want to uninstall this plugin? This action cannot be undone.",
+      "zh-CN": "确认要卸载这个插件吗？此操作无法撤销。",
+    }),
+    uninstalling: textFor(uiLanguage, {
+      en: "Uninstalling...",
+      "zh-CN": "卸载中...",
+    }),
+    errorDetails: textFor(uiLanguage, {
+      en: "Error Details",
+      "zh-CN": "错误详情",
+    }),
+    pluginGeneric: textFor(uiLanguage, {
+      en: "Plugin",
+      "zh-CN": "插件",
+    }),
+    errorStateDescription: textFor(uiLanguage, {
+      en: "hit an error state.",
+      "zh-CN": "进入了错误状态。",
+    }),
+    whatErrored: textFor(uiLanguage, {
+      en: "What errored",
+      "zh-CN": "错误摘要",
+    }),
+    noErrorSummary: textFor(uiLanguage, {
+      en: "No error summary available.",
+      "zh-CN": "没有可用的错误摘要。",
+    }),
+    errorWithoutStoredMessage: textFor(uiLanguage, {
+      en: "Plugin entered an error state without a stored error message.",
+      "zh-CN": "插件进入了错误状态，但没有保存错误信息。",
+    }),
+    fullErrorOutput: textFor(uiLanguage, {
+      en: "Full error output",
+      "zh-CN": "完整错误输出",
+    }),
+    noStoredErrorMessage: textFor(uiLanguage, {
+      en: "No stored error message.",
+      "zh-CN": "没有保存的错误信息。",
+    }),
+    close: textFor(uiLanguage, {
+      en: "Close",
+      "zh-CN": "关闭",
+    }),
+    installSuccess: textFor(uiLanguage, {
+      en: "Plugin installed successfully",
+      "zh-CN": "插件安装成功",
+    }),
+    installFailed: textFor(uiLanguage, {
+      en: "Failed to install plugin",
+      "zh-CN": "插件安装失败",
+    }),
+    uninstallSuccess: textFor(uiLanguage, {
+      en: "Plugin uninstalled successfully",
+      "zh-CN": "插件卸载成功",
+    }),
+    uninstallFailed: textFor(uiLanguage, {
+      en: "Failed to uninstall plugin",
+      "zh-CN": "插件卸载失败",
+    }),
+    enableSuccess: textFor(uiLanguage, {
+      en: "Plugin enabled",
+      "zh-CN": "插件已启用",
+    }),
+    enableFailed: textFor(uiLanguage, {
+      en: "Failed to enable plugin",
+      "zh-CN": "启用插件失败",
+    }),
+    disableSuccess: textFor(uiLanguage, {
+      en: "Plugin disabled",
+      "zh-CN": "插件已停用",
+    }),
+    disableFailed: textFor(uiLanguage, {
+      en: "Failed to disable plugin",
+      "zh-CN": "停用插件失败",
+    }),
+  };
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: selectedCompany?.name ?? "Company", href: "/dashboard" },
-      { label: "Settings", href: "/instance/settings/heartbeats" },
-      { label: "Plugins" },
+      { label: selectedCompany?.name ?? copy.company, href: "/dashboard" },
+      { label: copy.settings, href: "/instance/settings/heartbeats" },
+      { label: copy.plugins },
     ]);
-  }, [selectedCompany?.name, setBreadcrumbs]);
+  }, [copy.company, copy.plugins, copy.settings, selectedCompany?.name, setBreadcrumbs]);
 
   const { data: plugins, isLoading, error } = useQuery({
     queryKey: queryKeys.plugins.all,
@@ -103,10 +345,10 @@ export function PluginManager() {
       invalidatePluginQueries();
       setInstallDialogOpen(false);
       setInstallPackage("");
-      pushToast({ title: "Plugin installed successfully", tone: "success" });
+      pushToast({ title: copy.installSuccess, tone: "success" });
     },
     onError: (err: Error) => {
-      pushToast({ title: "Failed to install plugin", body: err.message, tone: "error" });
+      pushToast({ title: copy.installFailed, body: err.message, tone: "error" });
     },
   });
 
@@ -114,10 +356,10 @@ export function PluginManager() {
     mutationFn: (pluginId: string) => pluginsApi.uninstall(pluginId),
     onSuccess: () => {
       invalidatePluginQueries();
-      pushToast({ title: "Plugin uninstalled successfully", tone: "success" });
+      pushToast({ title: copy.uninstallSuccess, tone: "success" });
     },
     onError: (err: Error) => {
-      pushToast({ title: "Failed to uninstall plugin", body: err.message, tone: "error" });
+      pushToast({ title: copy.uninstallFailed, body: err.message, tone: "error" });
     },
   });
 
@@ -125,10 +367,10 @@ export function PluginManager() {
     mutationFn: (pluginId: string) => pluginsApi.enable(pluginId),
     onSuccess: () => {
       invalidatePluginQueries();
-      pushToast({ title: "Plugin enabled", tone: "success" });
+      pushToast({ title: copy.enableSuccess, tone: "success" });
     },
     onError: (err: Error) => {
-      pushToast({ title: "Failed to enable plugin", body: err.message, tone: "error" });
+      pushToast({ title: copy.enableFailed, body: err.message, tone: "error" });
     },
   });
 
@@ -136,10 +378,10 @@ export function PluginManager() {
     mutationFn: (pluginId: string) => pluginsApi.disable(pluginId),
     onSuccess: () => {
       invalidatePluginQueries();
-      pushToast({ title: "Plugin disabled", tone: "info" });
+      pushToast({ title: copy.disableSuccess, tone: "info" });
     },
     onError: (err: Error) => {
-      pushToast({ title: "Failed to disable plugin", body: err.message, tone: "error" });
+      pushToast({ title: copy.disableFailed, body: err.message, tone: "error" });
     },
   });
 
@@ -150,39 +392,39 @@ export function PluginManager() {
   const errorSummaryByPluginId = useMemo(
     () =>
       new Map(
-        installedPlugins.map((plugin) => [plugin.id, getPluginErrorSummary(plugin)])
+        installedPlugins.map((plugin) => [plugin.id, getPluginErrorSummary(plugin, copy.errorWithoutStoredMessage)])
       ),
-    [installedPlugins]
+    [copy.errorWithoutStoredMessage, installedPlugins]
   );
 
-  if (isLoading) return <div className="p-4 text-sm text-muted-foreground">Loading plugins...</div>;
-  if (error) return <div className="p-4 text-sm text-destructive">Failed to load plugins.</div>;
+  if (isLoading) return <div className="p-4 text-sm text-muted-foreground">{copy.loadingPlugins}</div>;
+  if (error) return <div className="p-4 text-sm text-destructive">{copy.loadPluginsFailed}</div>;
 
   return (
     <div className="space-y-6 max-w-5xl">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Puzzle className="h-6 w-6 text-muted-foreground" />
-          <h1 className="text-xl font-semibold">Plugin Manager</h1>
+          <h1 className="text-xl font-semibold">{copy.title}</h1>
         </div>
         
         <Dialog open={installDialogOpen} onOpenChange={setInstallDialogOpen}>
           <DialogTrigger asChild>
             <Button size="sm" className="gap-2">
               <Plus className="h-4 w-4" />
-              Install Plugin
+              {copy.installPlugin}
             </Button>
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Install Plugin</DialogTitle>
+              <DialogTitle>{copy.installPluginTitle}</DialogTitle>
               <DialogDescription>
-                Enter the npm package name of the plugin you wish to install.
+                {copy.installPluginDescription}
               </DialogDescription>
             </DialogHeader>
             <div className="grid gap-4 py-4">
               <div className="grid gap-2">
-                <Label htmlFor="packageName">npm Package Name</Label>
+                <Label htmlFor="packageName">{copy.npmPackageName}</Label>
                 <Input
                   id="packageName"
                   placeholder="@paperclipai/plugin-example"
@@ -192,12 +434,12 @@ export function PluginManager() {
               </div>
             </div>
             <DialogFooter>
-              <Button variant="outline" onClick={() => setInstallDialogOpen(false)}>Cancel</Button>
+              <Button variant="outline" onClick={() => setInstallDialogOpen(false)}>{copy.cancel}</Button>
               <Button
                 onClick={() => installMutation.mutate({ packageName: installPackage })}
                 disabled={!installPackage || installMutation.isPending}
               >
-                {installMutation.isPending ? "Installing..." : "Install"}
+                {installMutation.isPending ? copy.installing : copy.install}
               </Button>
             </DialogFooter>
           </DialogContent>
@@ -208,9 +450,9 @@ export function PluginManager() {
         <div className="flex items-start gap-3">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" />
           <div className="space-y-1 text-sm">
-            <p className="font-medium text-foreground">Plugins are alpha.</p>
+            <p className="font-medium text-foreground">{copy.pluginsAlpha}</p>
             <p className="text-muted-foreground">
-              The plugin runtime and API surface are still changing. Expect breaking changes while this feature settles.
+              {copy.pluginsAlphaDescription}
             </p>
           </div>
         </div>
@@ -219,17 +461,17 @@ export function PluginManager() {
       <section className="space-y-3">
         <div className="flex items-center gap-2">
           <FlaskConical className="h-5 w-5 text-muted-foreground" />
-          <h2 className="text-base font-semibold">Available Plugins</h2>
-          <Badge variant="outline">Examples</Badge>
+          <h2 className="text-base font-semibold">{copy.availablePlugins}</h2>
+          <Badge variant="outline">{copy.examples}</Badge>
         </div>
 
         {examplesQuery.isLoading ? (
-          <div className="text-sm text-muted-foreground">Loading bundled examples...</div>
+          <div className="text-sm text-muted-foreground">{copy.loadingExamples}</div>
         ) : examplesQuery.error ? (
-          <div className="text-sm text-destructive">Failed to load bundled examples.</div>
+          <div className="text-sm text-destructive">{copy.loadExamplesFailed}</div>
         ) : examples.length === 0 ? (
           <div className="rounded-md border border-dashed px-4 py-3 text-sm text-muted-foreground">
-            No bundled example plugins were found in this checkout.
+            {copy.noExamples}
           </div>
         ) : (
           <ul className="divide-y rounded-md border bg-card">
@@ -246,16 +488,16 @@ export function PluginManager() {
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-2">
                         <span className="font-medium">{example.displayName}</span>
-                        <Badge variant="outline">Example</Badge>
+                        <Badge variant="outline">{copy.example}</Badge>
                         {installedPlugin ? (
                           <Badge
                             variant={installedPlugin.status === "ready" ? "default" : "secondary"}
                             className={installedPlugin.status === "ready" ? "bg-green-600 hover:bg-green-700" : ""}
                           >
-                            {installedPlugin.status}
+                            {getPluginStatusLabel(uiLanguage, installedPlugin.status)}
                           </Badge>
                         ) : (
-                          <Badge variant="secondary">Not installed</Badge>
+                          <Badge variant="secondary">{copy.notInstalled}</Badge>
                         )}
                       </div>
                       <p className="mt-1 text-sm text-muted-foreground">{example.description}</p>
@@ -271,12 +513,12 @@ export function PluginManager() {
                               disabled={enableMutation.isPending}
                               onClick={() => enableMutation.mutate(installedPlugin.id)}
                             >
-                              Enable
+                              {copy.enable}
                             </Button>
                           )}
                           <Button variant="outline" size="sm" asChild>
                             <Link to={`/instance/settings/plugins/${installedPlugin.id}`}>
-                              {installedPlugin.status === "ready" ? "Open Settings" : "Review"}
+                              {installedPlugin.status === "ready" ? copy.openSettings : copy.review}
                             </Link>
                           </Button>
                         </>
@@ -291,7 +533,7 @@ export function PluginManager() {
                             })
                           }
                         >
-                          {installPending ? "Installing..." : "Install Example"}
+                          {installPending ? copy.installing : copy.installExample}
                         </Button>
                       )}
                     </div>
@@ -306,16 +548,16 @@ export function PluginManager() {
       <section className="space-y-3">
         <div className="flex items-center gap-2">
           <Puzzle className="h-5 w-5 text-muted-foreground" />
-          <h2 className="text-base font-semibold">Installed Plugins</h2>
+          <h2 className="text-base font-semibold">{copy.installedPlugins}</h2>
         </div>
 
         {!installedPlugins.length ? (
           <Card className="bg-muted/30">
             <CardContent className="flex flex-col items-center justify-center py-10">
               <Puzzle className="h-10 w-10 text-muted-foreground mb-4" />
-              <p className="text-sm font-medium">No plugins installed</p>
+              <p className="text-sm font-medium">{copy.noPluginsInstalled}</p>
               <p className="text-xs text-muted-foreground mt-1">
-                Install a plugin to extend functionality.
+                {copy.noPluginsInstalledDescription}
               </p>
             </CardContent>
           </Card>
@@ -334,7 +576,7 @@ export function PluginManager() {
                         {plugin.manifestJson.displayName ?? plugin.packageName}
                       </Link>
                       {examplePackageNames.has(plugin.packageName) && (
-                        <Badge variant="outline">Example</Badge>
+                        <Badge variant="outline">{copy.example}</Badge>
                       )}
                     </div>
                     <div>
@@ -343,7 +585,7 @@ export function PluginManager() {
                       </p>
                     </div>
                     <p className="text-sm text-muted-foreground truncate mt-0.5" title={plugin.manifestJson.description}>
-                      {plugin.manifestJson.description || "No description provided."}
+                      {plugin.manifestJson.description || copy.noDescription}
                     </p>
                     {plugin.status === "error" && (
                       <div className="mt-3 rounded-md border border-red-500/25 bg-red-500/[0.06] px-3 py-2">
@@ -351,7 +593,7 @@ export function PluginManager() {
                           <div className="min-w-0 flex-1">
                             <div className="flex items-center gap-2 text-sm font-medium text-red-700 dark:text-red-300">
                               <AlertTriangle className="h-4 w-4 shrink-0" />
-                              <span>Plugin error</span>
+                              <span>{copy.pluginError}</span>
                             </div>
                             <p
                               className="mt-1 text-sm text-red-700/90 dark:text-red-200/90 break-words"
@@ -366,7 +608,7 @@ export function PluginManager() {
                             className="border-red-500/30 bg-background/60 text-red-700 hover:bg-red-500/10 hover:text-red-800 dark:text-red-200 dark:hover:text-red-100"
                             onClick={() => setErrorDetailsPlugin(plugin)}
                           >
-                            View full error
+                            {copy.viewFullError}
                           </Button>
                         </div>
                       </div>
@@ -388,13 +630,13 @@ export function PluginManager() {
                             plugin.status === "ready" ? "bg-green-600 hover:bg-green-700" : ""
                           )}
                         >
-                          {plugin.status}
+                          {getPluginStatusLabel(uiLanguage, plugin.status)}
                         </Badge>
                         <Button
                           variant="outline"
                           size="icon-sm"
                           className="h-8 w-8"
-                          title={plugin.status === "ready" ? "Disable" : "Enable"}
+                          title={plugin.status === "ready" ? copy.disable : copy.enable}
                           onClick={() => {
                             if (plugin.status === "ready") {
                               disableMutation.mutate(plugin.id);
@@ -410,7 +652,7 @@ export function PluginManager() {
                           variant="outline"
                           size="icon-sm"
                           className="h-8 w-8 text-destructive hover:text-destructive"
-                          title="Uninstall"
+                          title={copy.uninstall}
                           onClick={() => {
                             setUninstallPluginId(plugin.id);
                             setUninstallPluginName(plugin.manifestJson.displayName ?? plugin.packageName);
@@ -423,7 +665,7 @@ export function PluginManager() {
                       <Button variant="outline" size="sm" className="mt-2 h-8" asChild>
                         <Link to={`/instance/settings/plugins/${plugin.id}`}>
                           <Settings className="h-4 w-4" />
-                          Configure
+                          {copy.configure}
                         </Link>
                       </Button>
                     </div>
@@ -441,13 +683,15 @@ export function PluginManager() {
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Uninstall Plugin</DialogTitle>
+            <DialogTitle>{copy.uninstallPluginTitle}</DialogTitle>
             <DialogDescription>
-              Are you sure you want to uninstall <strong>{uninstallPluginName}</strong>? This action cannot be undone.
+              <strong>{uninstallPluginName}</strong>
+              {" "}
+              {copy.uninstallPluginDescription}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setUninstallPluginId(null)}>Cancel</Button>
+            <Button variant="outline" onClick={() => setUninstallPluginId(null)}>{copy.cancel}</Button>
             <Button
               variant="destructive"
               disabled={uninstallMutation.isPending}
@@ -459,7 +703,7 @@ export function PluginManager() {
                 }
               }}
             >
-              {uninstallMutation.isPending ? "Uninstalling..." : "Uninstall"}
+              {uninstallMutation.isPending ? copy.uninstalling : copy.uninstall}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -471,9 +715,11 @@ export function PluginManager() {
       >
         <DialogContent className="sm:max-w-2xl">
           <DialogHeader>
-            <DialogTitle>Error Details</DialogTitle>
+            <DialogTitle>{copy.errorDetails}</DialogTitle>
             <DialogDescription>
-              {errorDetailsPlugin?.manifestJson.displayName ?? errorDetailsPlugin?.packageName ?? "Plugin"} hit an error state.
+              {errorDetailsPlugin?.manifestJson.displayName ?? errorDetailsPlugin?.packageName ?? copy.pluginGeneric}
+              {" "}
+              {copy.errorStateDescription}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
@@ -482,24 +728,24 @@ export function PluginManager() {
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-700 dark:text-red-300" />
                 <div className="space-y-1 text-sm">
                   <p className="font-medium text-red-700 dark:text-red-300">
-                    What errored
+                    {copy.whatErrored}
                   </p>
                   <p className="text-red-700/90 dark:text-red-200/90 break-words">
-                    {errorDetailsPlugin ? getPluginErrorSummary(errorDetailsPlugin) : "No error summary available."}
+                    {errorDetailsPlugin ? getPluginErrorSummary(errorDetailsPlugin, copy.errorWithoutStoredMessage) : copy.noErrorSummary}
                   </p>
                 </div>
               </div>
             </div>
             <div className="space-y-2">
-              <p className="text-sm font-medium">Full error output</p>
+              <p className="text-sm font-medium">{copy.fullErrorOutput}</p>
               <pre className="max-h-[50vh] overflow-auto rounded-md border bg-muted/40 p-3 text-xs leading-5 whitespace-pre-wrap break-words">
-                {errorDetailsPlugin?.lastError ?? "No stored error message."}
+                {errorDetailsPlugin?.lastError ?? copy.noStoredErrorMessage}
               </pre>
             </div>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setErrorDetailsPlugin(null)}>
-              Close
+              {copy.close}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/ui/src/pages/PluginSettings.tsx
+++ b/ui/src/pages/PluginSettings.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Puzzle, ArrowLeft, ShieldAlert, ActivitySquare, CheckCircle, XCircle, Loader2, Clock, Cpu, Webhook, CalendarClock, AlertTriangle } from "lucide-react";
 import { useCompany } from "@/context/CompanyContext";
 import { useBreadcrumbs } from "@/context/BreadcrumbContext";
+import { useGeneralSettings } from "@/context/GeneralSettingsContext";
 import { Link, Navigate, useParams } from "@/lib/router";
 import { PluginSlotMount, usePluginSlots } from "@/plugins/slots";
 import { pluginsApi } from "@/api/plugins";
@@ -25,6 +26,53 @@ import {
   getDefaultValues,
   type JsonSchemaNode,
 } from "@/components/JsonSchemaForm";
+import { textFor, type UiLanguage } from "@/lib/ui-language";
+
+function getUiLocale(language: UiLanguage): string {
+  return language === "zh-CN" ? "zh-CN" : "en";
+}
+
+function getStatusLabel(language: UiLanguage, status: string): string {
+  switch (status) {
+    case "ready":
+      return textFor(language, { en: "Ready", "zh-CN": "就绪" });
+    case "error":
+      return textFor(language, { en: "Error", "zh-CN": "错误" });
+    case "running":
+      return textFor(language, { en: "Running", "zh-CN": "运行中" });
+    case "healthy":
+      return textFor(language, { en: "Healthy", "zh-CN": "健康" });
+    case "unhealthy":
+      return textFor(language, { en: "Unhealthy", "zh-CN": "异常" });
+    case "success":
+    case "succeeded":
+      return textFor(language, { en: "Success", "zh-CN": "成功" });
+    case "failed":
+      return textFor(language, { en: "Failed", "zh-CN": "失败" });
+    case "pending":
+      return textFor(language, { en: "Pending", "zh-CN": "等待中" });
+    case "queued":
+      return textFor(language, { en: "Queued", "zh-CN": "排队中" });
+    case "cancelled":
+      return textFor(language, { en: "Cancelled", "zh-CN": "已取消" });
+    case "processed":
+      return textFor(language, { en: "Processed", "zh-CN": "已处理" });
+    case "received":
+      return textFor(language, { en: "Received", "zh-CN": "已接收" });
+    case "warn":
+      return textFor(language, { en: "Warn", "zh-CN": "警告" });
+    case "debug":
+      return textFor(language, { en: "Debug", "zh-CN": "调试" });
+    case "info":
+      return textFor(language, { en: "Info", "zh-CN": "信息" });
+    case "manual":
+      return textFor(language, { en: "Manual", "zh-CN": "手动" });
+    case "schedule":
+      return textFor(language, { en: "Schedule", "zh-CN": "定时" });
+    default:
+      return status;
+  }
+}
 
 /**
  * PluginSettings page component.
@@ -59,9 +107,190 @@ import {
  */
 export function PluginSettings() {
   const { selectedCompany, selectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { setBreadcrumbs } = useBreadcrumbs();
   const { companyPrefix, pluginId } = useParams<{ companyPrefix?: string; pluginId: string }>();
   const [activeTab, setActiveTab] = useState<"configuration" | "status">("configuration");
+  const copy = {
+    company: textFor(uiLanguage, {
+      en: "Company",
+      "zh-CN": "公司",
+    }),
+    settings: textFor(uiLanguage, {
+      en: "Settings",
+      "zh-CN": "设置",
+    }),
+    plugins: textFor(uiLanguage, {
+      en: "Plugins",
+      "zh-CN": "插件",
+    }),
+    pluginDetails: textFor(uiLanguage, {
+      en: "Plugin Details",
+      "zh-CN": "插件详情",
+    }),
+    loadingPluginDetails: textFor(uiLanguage, {
+      en: "Loading plugin details...",
+      "zh-CN": "正在加载插件详情...",
+    }),
+    noDescription: textFor(uiLanguage, {
+      en: "No description provided.",
+      "zh-CN": "未提供描述。",
+    }),
+    configuration: textFor(uiLanguage, {
+      en: "Configuration",
+      "zh-CN": "配置",
+    }),
+    status: textFor(uiLanguage, {
+      en: "Status",
+      "zh-CN": "状态",
+    }),
+    about: textFor(uiLanguage, {
+      en: "About",
+      "zh-CN": "关于",
+    }),
+    description: textFor(uiLanguage, {
+      en: "Description",
+      "zh-CN": "描述",
+    }),
+    author: textFor(uiLanguage, {
+      en: "Author",
+      "zh-CN": "作者",
+    }),
+    categories: textFor(uiLanguage, {
+      en: "Categories",
+      "zh-CN": "分类",
+    }),
+    none: textFor(uiLanguage, {
+      en: "None",
+      "zh-CN": "无",
+    }),
+    pluginSettings: textFor(uiLanguage, {
+      en: "Settings",
+      "zh-CN": "设置",
+    }),
+    noSettingsRequired: textFor(uiLanguage, {
+      en: "This plugin does not require any settings.",
+      "zh-CN": "这个插件不需要额外设置。",
+    }),
+    runtimeDashboard: textFor(uiLanguage, {
+      en: "Runtime Dashboard",
+      "zh-CN": "运行时面板",
+    }),
+    runtimeDashboardDescription: textFor(uiLanguage, {
+      en: "Worker process, scheduled jobs, and webhook deliveries",
+      "zh-CN": "Worker 进程、计划任务和 Webhook 投递情况",
+    }),
+    workerProcess: textFor(uiLanguage, {
+      en: "Worker Process",
+      "zh-CN": "Worker 进程",
+    }),
+    pid: textFor(uiLanguage, {
+      en: "PID",
+      "zh-CN": "PID",
+    }),
+    uptime: textFor(uiLanguage, {
+      en: "Uptime",
+      "zh-CN": "运行时长",
+    }),
+    pendingRpcs: textFor(uiLanguage, {
+      en: "Pending RPCs",
+      "zh-CN": "待处理 RPC",
+    }),
+    crashes: textFor(uiLanguage, {
+      en: "Crashes",
+      "zh-CN": "崩溃次数",
+    }),
+    consecutiveAndTotalCrashes: (consecutive: number, total: number) =>
+      uiLanguage === "zh-CN"
+        ? `连续 ${consecutive} 次 / 总计 ${total} 次`
+        : `${consecutive} consecutive / ${total} total`,
+    lastCrash: textFor(uiLanguage, {
+      en: "Last Crash",
+      "zh-CN": "最近崩溃时间",
+    }),
+    noWorkerProcess: textFor(uiLanguage, {
+      en: "No worker process registered.",
+      "zh-CN": "没有已注册的 worker 进程。",
+    }),
+    recentJobRuns: textFor(uiLanguage, {
+      en: "Recent Job Runs",
+      "zh-CN": "最近任务运行",
+    }),
+    noJobRuns: textFor(uiLanguage, {
+      en: "No job runs recorded yet.",
+      "zh-CN": "还没有记录到任务运行。",
+    }),
+    recentWebhookDeliveries: textFor(uiLanguage, {
+      en: "Recent Webhook Deliveries",
+      "zh-CN": "最近 Webhook 投递",
+    }),
+    noWebhookDeliveries: textFor(uiLanguage, {
+      en: "No webhook deliveries recorded yet.",
+      "zh-CN": "还没有记录到 Webhook 投递。",
+    }),
+    lastChecked: textFor(uiLanguage, {
+      en: "Last checked:",
+      "zh-CN": "最近检查：",
+    }),
+    diagnosticsUnavailable: textFor(uiLanguage, {
+      en: "Runtime diagnostics are unavailable right now.",
+      "zh-CN": "当前无法获取运行时诊断信息。",
+    }),
+    recentLogs: textFor(uiLanguage, {
+      en: "Recent Logs",
+      "zh-CN": "最近日志",
+    }),
+    logEntries: (count: number) =>
+      uiLanguage === "zh-CN" ? `最近 ${count} 条日志` : `Last ${count} log entries`,
+    healthStatus: textFor(uiLanguage, {
+      en: "Health Status",
+      "zh-CN": "健康状态",
+    }),
+    checkingHealth: textFor(uiLanguage, {
+      en: "Checking health...",
+      "zh-CN": "正在检查健康状态...",
+    }),
+    overall: textFor(uiLanguage, {
+      en: "Overall",
+      "zh-CN": "总体",
+    }),
+    lifecycle: textFor(uiLanguage, {
+      en: "Lifecycle",
+      "zh-CN": "生命周期",
+    }),
+    healthChecksWhenReady: textFor(uiLanguage, {
+      en: "Health checks run once the plugin is ready.",
+      "zh-CN": "插件进入就绪状态后才会执行健康检查。",
+    }),
+    details: textFor(uiLanguage, {
+      en: "Details",
+      "zh-CN": "详情",
+    }),
+    pluginId: textFor(uiLanguage, {
+      en: "Plugin ID",
+      "zh-CN": "插件 ID",
+    }),
+    pluginKey: textFor(uiLanguage, {
+      en: "Plugin Key",
+      "zh-CN": "插件 Key",
+    }),
+    npmPackage: textFor(uiLanguage, {
+      en: "NPM Package",
+      "zh-CN": "NPM 包",
+    }),
+    version: textFor(uiLanguage, {
+      en: "Version",
+      "zh-CN": "版本",
+    }),
+    permissions: textFor(uiLanguage, {
+      en: "Permissions",
+      "zh-CN": "权限",
+    }),
+    noPermissionsRequested: textFor(uiLanguage, {
+      en: "No special permissions requested.",
+      "zh-CN": "未请求特殊权限。",
+    }),
+  };
 
   const { data: plugin, isLoading: pluginLoading } = useQuery({
     queryKey: queryKeys.plugins.detail(pluginId!),
@@ -114,19 +343,19 @@ export function PluginSettings() {
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: selectedCompany?.name ?? "Company", href: "/dashboard" },
-      { label: "Settings", href: "/instance/settings/heartbeats" },
-      { label: "Plugins", href: "/instance/settings/plugins" },
-      { label: plugin?.manifestJson?.displayName ?? plugin?.packageName ?? "Plugin Details" },
+      { label: selectedCompany?.name ?? copy.company, href: "/dashboard" },
+      { label: copy.settings, href: "/instance/settings/heartbeats" },
+      { label: copy.plugins, href: "/instance/settings/plugins" },
+      { label: plugin?.manifestJson?.displayName ?? plugin?.packageName ?? copy.pluginDetails },
     ]);
-  }, [selectedCompany?.name, setBreadcrumbs, companyPrefix, plugin]);
+  }, [companyPrefix, copy.company, copy.pluginDetails, copy.plugins, copy.settings, plugin, selectedCompany?.name, setBreadcrumbs]);
 
   useEffect(() => {
     setActiveTab("configuration");
   }, [pluginId]);
 
   if (pluginLoading) {
-    return <div className="p-4 text-sm text-muted-foreground">Loading plugin details...</div>;
+    return <div className="p-4 text-sm text-muted-foreground">{copy.loadingPluginDetails}</div>;
   }
 
   if (!plugin) {
@@ -140,7 +369,7 @@ export function PluginSettings() {
       : plugin.status === "error"
         ? "destructive"
         : "secondary";
-  const pluginDescription = plugin.manifestJson.description || "No description provided.";
+  const pluginDescription = plugin.manifestJson.description || copy.noDescription;
   const pluginCapabilities = plugin.manifestJson.capabilities ?? [];
 
   return (
@@ -155,7 +384,7 @@ export function PluginSettings() {
           <Puzzle className="h-6 w-6 text-muted-foreground" />
           <h1 className="text-xl font-semibold">{plugin.manifestJson.displayName ?? plugin.packageName}</h1>
           <Badge variant={statusVariant} className="ml-2">
-            {displayStatus}
+            {getStatusLabel(uiLanguage, displayStatus)}
           </Badge>
           <Badge variant="outline" className="ml-1">
             v{plugin.manifestJson.version ?? plugin.version}
@@ -167,8 +396,8 @@ export function PluginSettings() {
         <PageTabBar
           align="start"
           items={[
-            { value: "configuration", label: "Configuration" },
-            { value: "status", label: "Status" },
+            { value: "configuration", label: copy.configuration },
+            { value: "status", label: copy.status },
           ]}
           value={activeTab}
           onValueChange={(value) => setActiveTab(value as "configuration" | "status")}
@@ -177,19 +406,19 @@ export function PluginSettings() {
         <TabsContent value="configuration" className="space-y-6">
           <div className="space-y-8">
             <section className="space-y-5">
-              <h2 className="text-base font-semibold">About</h2>
+              <h2 className="text-base font-semibold">{copy.about}</h2>
               <div className="grid gap-8 lg:grid-cols-[minmax(0,1.4fr)_minmax(220px,0.8fr)]">
                 <div className="space-y-2">
-                  <h3 className="text-sm font-medium text-muted-foreground">Description</h3>
+                  <h3 className="text-sm font-medium text-muted-foreground">{copy.description}</h3>
                   <p className="text-sm leading-6 text-foreground/90">{pluginDescription}</p>
                 </div>
                 <div className="space-y-4 text-sm">
                   <div className="space-y-1.5">
-                    <h3 className="font-medium text-muted-foreground">Author</h3>
-                    <p className="text-foreground">{plugin.manifestJson.author}</p>
+                    <h3 className="font-medium text-muted-foreground">{copy.author}</h3>
+                    <p className="text-foreground">{plugin.manifestJson.author || copy.none}</p>
                   </div>
                   <div className="space-y-2">
-                    <h3 className="font-medium text-muted-foreground">Categories</h3>
+                    <h3 className="font-medium text-muted-foreground">{copy.categories}</h3>
                     <div className="flex flex-wrap gap-2">
                       {plugin.categories.length > 0 ? (
                         plugin.categories.map((category) => (
@@ -198,7 +427,7 @@ export function PluginSettings() {
                           </Badge>
                         ))
                       ) : (
-                        <span className="text-foreground">None</span>
+                        <span className="text-foreground">{copy.none}</span>
                       )}
                     </div>
                   </div>
@@ -210,7 +439,7 @@ export function PluginSettings() {
 
             <section className="space-y-4">
               <div className="space-y-1">
-                <h2 className="text-base font-semibold">Settings</h2>
+                <h2 className="text-base font-semibold">{copy.pluginSettings}</h2>
               </div>
               {hasCustomSettingsPage ? (
                 <div className="space-y-3">
@@ -237,7 +466,7 @@ export function PluginSettings() {
                 />
               ) : (
                 <p className="text-sm text-muted-foreground">
-                  This plugin does not require any settings.
+                  {copy.noSettingsRequired}
                 </p>
               )}
             </section>
@@ -251,10 +480,10 @@ export function PluginSettings() {
                 <CardHeader>
                   <CardTitle className="text-base flex items-center gap-1.5">
                     <Cpu className="h-4 w-4" />
-                    Runtime Dashboard
+                    {copy.runtimeDashboard}
                   </CardTitle>
                   <CardDescription>
-                    Worker process, scheduled jobs, and webhook deliveries
+                    {copy.runtimeDashboardDescription}
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-6">
@@ -263,26 +492,26 @@ export function PluginSettings() {
                       <div>
                         <h3 className="text-sm font-medium mb-3 flex items-center gap-1.5">
                           <Cpu className="h-3.5 w-3.5 text-muted-foreground" />
-                          Worker Process
+                          {copy.workerProcess}
                         </h3>
                         {dashboardData.worker ? (
                           <div className="grid grid-cols-2 gap-3 text-sm">
                             <div className="flex justify-between">
-                              <span className="text-muted-foreground">Status</span>
+                              <span className="text-muted-foreground">{copy.status}</span>
                               <Badge variant={dashboardData.worker.status === "running" ? "default" : "secondary"}>
-                                {dashboardData.worker.status}
+                                {getStatusLabel(uiLanguage, dashboardData.worker.status)}
                               </Badge>
                             </div>
                             <div className="flex justify-between">
-                              <span className="text-muted-foreground">PID</span>
+                              <span className="text-muted-foreground">{copy.pid}</span>
                               <span className="font-mono text-xs">{dashboardData.worker.pid ?? "—"}</span>
                             </div>
                             <div className="flex justify-between">
-                              <span className="text-muted-foreground">Uptime</span>
-                              <span className="text-xs">{formatUptime(dashboardData.worker.uptime)}</span>
+                              <span className="text-muted-foreground">{copy.uptime}</span>
+                              <span className="text-xs">{formatUptime(dashboardData.worker.uptime, uiLanguage)}</span>
                             </div>
                             <div className="flex justify-between">
-                              <span className="text-muted-foreground">Pending RPCs</span>
+                              <span className="text-muted-foreground">{copy.pendingRpcs}</span>
                               <span className="text-xs">{dashboardData.worker.pendingRequests}</span>
                             </div>
                             {dashboardData.worker.totalCrashes > 0 && (
@@ -290,23 +519,26 @@ export function PluginSettings() {
                                 <div className="flex justify-between col-span-2">
                                   <span className="text-muted-foreground flex items-center gap-1">
                                     <AlertTriangle className="h-3 w-3 text-amber-500" />
-                                    Crashes
+                                    {copy.crashes}
                                   </span>
                                   <span className="text-xs">
-                                    {dashboardData.worker.consecutiveCrashes} consecutive / {dashboardData.worker.totalCrashes} total
+                                    {copy.consecutiveAndTotalCrashes(
+                                      dashboardData.worker.consecutiveCrashes,
+                                      dashboardData.worker.totalCrashes,
+                                    )}
                                   </span>
                                 </div>
                                 {dashboardData.worker.lastCrashAt && (
                                   <div className="flex justify-between col-span-2">
-                                    <span className="text-muted-foreground">Last Crash</span>
-                                    <span className="text-xs">{formatTimestamp(dashboardData.worker.lastCrashAt)}</span>
+                                    <span className="text-muted-foreground">{copy.lastCrash}</span>
+                                    <span className="text-xs">{formatTimestamp(dashboardData.worker.lastCrashAt, uiLanguage)}</span>
                                   </div>
                                 )}
                               </>
                             )}
                           </div>
                         ) : (
-                          <p className="text-sm text-muted-foreground italic">No worker process registered.</p>
+                          <p className="text-sm text-muted-foreground italic">{copy.noWorkerProcess}</p>
                         )}
                       </div>
 
@@ -315,7 +547,7 @@ export function PluginSettings() {
                       <div>
                         <h3 className="text-sm font-medium mb-3 flex items-center gap-1.5">
                           <CalendarClock className="h-3.5 w-3.5 text-muted-foreground" />
-                          Recent Job Runs
+                          {copy.recentJobRuns}
                         </h3>
                         {dashboardData.recentJobRuns.length > 0 ? (
                           <div className="space-y-2">
@@ -330,18 +562,18 @@ export function PluginSettings() {
                                     {run.jobKey ?? run.jobId.slice(0, 8)}
                                   </span>
                                   <Badge variant="outline" className="px-1 py-0 text-[10px]">
-                                    {run.trigger}
+                                    {getStatusLabel(uiLanguage, run.trigger)}
                                   </Badge>
                                 </div>
                                 <div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
-                                  {run.durationMs != null ? <span>{formatDuration(run.durationMs)}</span> : null}
-                                  <span title={run.createdAt}>{formatRelativeTime(run.createdAt)}</span>
+                                  {run.durationMs != null ? <span>{formatDuration(run.durationMs, uiLanguage)}</span> : null}
+                                  <span title={run.createdAt}>{formatRelativeTime(run.createdAt, uiLanguage)}</span>
                                 </div>
                               </div>
                             ))}
                           </div>
                         ) : (
-                          <p className="text-sm text-muted-foreground italic">No job runs recorded yet.</p>
+                          <p className="text-sm text-muted-foreground italic">{copy.noJobRuns}</p>
                         )}
                       </div>
 
@@ -350,7 +582,7 @@ export function PluginSettings() {
                       <div>
                         <h3 className="text-sm font-medium mb-3 flex items-center gap-1.5">
                           <Webhook className="h-3.5 w-3.5 text-muted-foreground" />
-                          Recent Webhook Deliveries
+                          {copy.recentWebhookDeliveries}
                         </h3>
                         {dashboardData.recentWebhookDeliveries.length > 0 ? (
                           <div className="space-y-2">
@@ -366,25 +598,25 @@ export function PluginSettings() {
                                   </span>
                                 </div>
                                 <div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
-                                  {delivery.durationMs != null ? <span>{formatDuration(delivery.durationMs)}</span> : null}
-                                  <span title={delivery.createdAt}>{formatRelativeTime(delivery.createdAt)}</span>
+                                  {delivery.durationMs != null ? <span>{formatDuration(delivery.durationMs, uiLanguage)}</span> : null}
+                                  <span title={delivery.createdAt}>{formatRelativeTime(delivery.createdAt, uiLanguage)}</span>
                                 </div>
                               </div>
                             ))}
                           </div>
                         ) : (
-                          <p className="text-sm text-muted-foreground italic">No webhook deliveries recorded yet.</p>
+                          <p className="text-sm text-muted-foreground italic">{copy.noWebhookDeliveries}</p>
                         )}
                       </div>
 
                       <div className="flex items-center gap-1.5 border-t border-border/50 pt-2 text-xs text-muted-foreground">
                         <Clock className="h-3 w-3" />
-                        Last checked: {new Date(dashboardData.checkedAt).toLocaleTimeString()}
+                        {copy.lastChecked} {new Intl.DateTimeFormat(getUiLocale(uiLanguage), { timeStyle: "medium" }).format(new Date(dashboardData.checkedAt))}
                       </div>
                     </>
                   ) : (
                     <p className="text-sm text-muted-foreground">
-                      Runtime diagnostics are unavailable right now.
+                      {copy.diagnosticsUnavailable}
                     </p>
                   )}
                 </CardContent>
@@ -395,9 +627,9 @@ export function PluginSettings() {
                   <CardHeader>
                     <CardTitle className="text-base flex items-center gap-1.5">
                       <ActivitySquare className="h-4 w-4" />
-                      Recent Logs
+                      {copy.recentLogs}
                     </CardTitle>
-                    <CardDescription>Last {recentLogs.length} log entries</CardDescription>
+                    <CardDescription>{copy.logEntries(recentLogs.length)}</CardDescription>
                   </CardHeader>
                   <CardContent>
                     <div className="max-h-64 space-y-1 overflow-y-auto font-mono text-xs">
@@ -414,8 +646,10 @@ export function PluginSettings() {
                                   : "text-muted-foreground"
                           }`}
                         >
-                          <span className="shrink-0 text-muted-foreground/50">{new Date(entry.createdAt).toLocaleTimeString()}</span>
-                          <Badge variant="outline" className="h-4 shrink-0 px-1 text-[10px]">{entry.level}</Badge>
+                          <span className="shrink-0 text-muted-foreground/50">
+                            {new Intl.DateTimeFormat(getUiLocale(uiLanguage), { timeStyle: "medium" }).format(new Date(entry.createdAt))}
+                          </span>
+                          <Badge variant="outline" className="h-4 shrink-0 px-1 text-[10px]">{getStatusLabel(uiLanguage, entry.level)}</Badge>
                           <span className="truncate" title={entry.message}>{entry.message}</span>
                         </div>
                       ))}
@@ -430,18 +664,18 @@ export function PluginSettings() {
                 <CardHeader>
                   <CardTitle className="text-base flex items-center gap-1.5">
                     <ActivitySquare className="h-4 w-4" />
-                    Health Status
+                    {copy.healthStatus}
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
                   {healthLoading ? (
-                    <p className="text-sm text-muted-foreground">Checking health...</p>
+                    <p className="text-sm text-muted-foreground">{copy.checkingHealth}</p>
                   ) : healthData ? (
                     <div className="space-y-4 text-sm">
                       <div className="flex items-center justify-between">
-                        <span className="text-muted-foreground">Overall</span>
+                        <span className="text-muted-foreground">{copy.overall}</span>
                         <Badge variant={healthData.healthy ? "default" : "destructive"}>
-                          {healthData.status}
+                          {getStatusLabel(uiLanguage, healthData.status)}
                         </Badge>
                       </div>
 
@@ -469,12 +703,12 @@ export function PluginSettings() {
                       ) : null}
                     </div>
                   ) : (
-                    <div className="space-y-3 text-sm text-muted-foreground">
+                      <div className="space-y-3 text-sm text-muted-foreground">
                       <div className="flex items-center justify-between">
-                        <span>Lifecycle</span>
-                        <Badge variant={statusVariant}>{displayStatus}</Badge>
+                        <span>{copy.lifecycle}</span>
+                        <Badge variant={statusVariant}>{getStatusLabel(uiLanguage, displayStatus)}</Badge>
                       </div>
-                      <p>Health checks run once the plugin is ready.</p>
+                      <p>{copy.healthChecksWhenReady}</p>
                       {plugin.lastError ? (
                         <div className="break-words rounded border border-destructive/20 bg-destructive/10 p-2 text-xs text-destructive">
                           {plugin.lastError}
@@ -487,25 +721,25 @@ export function PluginSettings() {
 
               <Card>
                 <CardHeader>
-                  <CardTitle className="text-base">Details</CardTitle>
+                  <CardTitle className="text-base">{copy.details}</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-3 text-sm text-muted-foreground">
                   <div className="flex justify-between gap-3">
-                    <span>Plugin ID</span>
+                    <span>{copy.pluginId}</span>
                     <span className="font-mono text-xs text-right">{plugin.id}</span>
                   </div>
                   <div className="flex justify-between gap-3">
-                    <span>Plugin Key</span>
+                    <span>{copy.pluginKey}</span>
                     <span className="font-mono text-xs text-right">{plugin.pluginKey}</span>
                   </div>
                   <div className="flex justify-between gap-3">
-                    <span>NPM Package</span>
+                    <span>{copy.npmPackage}</span>
                     <span className="max-w-[170px] truncate text-right text-xs" title={plugin.packageName}>
                       {plugin.packageName}
                     </span>
                   </div>
                   <div className="flex justify-between gap-3">
-                    <span>Version</span>
+                    <span>{copy.version}</span>
                     <span className="text-right text-foreground">v{plugin.manifestJson.version ?? plugin.version}</span>
                   </div>
                 </CardContent>
@@ -515,7 +749,7 @@ export function PluginSettings() {
                 <CardHeader>
                   <CardTitle className="text-base flex items-center gap-1.5">
                     <ShieldAlert className="h-4 w-4" />
-                    Permissions
+                    {copy.permissions}
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
@@ -528,7 +762,7 @@ export function PluginSettings() {
                       ))}
                     </ul>
                   ) : (
-                    <p className="text-sm text-muted-foreground italic">No special permissions requested.</p>
+                    <p className="text-sm text-muted-foreground italic">{copy.noPermissionsRequested}</p>
                   )}
                 </CardContent>
               </Card>
@@ -563,7 +797,46 @@ interface PluginConfigFormProps {
  * re-renders on field changes, not the entire page.
  */
 function PluginConfigForm({ pluginId, schema, initialValues, isLoading, pluginStatus, supportsConfigTest }: PluginConfigFormProps) {
+  const { uiLanguage } = useGeneralSettings();
   const queryClient = useQueryClient();
+  const copy = {
+    configurationSaved: textFor(uiLanguage, {
+      en: "Configuration saved.",
+      "zh-CN": "配置已保存。",
+    }),
+    configurationSaveFailed: textFor(uiLanguage, {
+      en: "Failed to save configuration.",
+      "zh-CN": "保存配置失败。",
+    }),
+    configurationTestPassed: textFor(uiLanguage, {
+      en: "Configuration test passed.",
+      "zh-CN": "配置测试通过。",
+    }),
+    configurationTestFailed: textFor(uiLanguage, {
+      en: "Configuration test failed.",
+      "zh-CN": "配置测试失败。",
+    }),
+    loadingConfiguration: textFor(uiLanguage, {
+      en: "Loading configuration...",
+      "zh-CN": "正在加载配置...",
+    }),
+    saving: textFor(uiLanguage, {
+      en: "Saving...",
+      "zh-CN": "保存中...",
+    }),
+    saveConfiguration: textFor(uiLanguage, {
+      en: "Save Configuration",
+      "zh-CN": "保存配置",
+    }),
+    testing: textFor(uiLanguage, {
+      en: "Testing...",
+      "zh-CN": "测试中...",
+    }),
+    testConfiguration: textFor(uiLanguage, {
+      en: "Test Configuration",
+      "zh-CN": "测试配置",
+    }),
+  };
 
   // Form values: start with saved values, fall back to schema defaults
   const [values, setValues] = useState<Record<string, unknown>>(() => ({
@@ -600,14 +873,14 @@ function PluginConfigForm({ pluginId, schema, initialValues, isLoading, pluginSt
     mutationFn: (configJson: Record<string, unknown>) =>
       pluginsApi.saveConfig(pluginId, configJson),
     onSuccess: () => {
-      setSaveMessage({ type: "success", text: "Configuration saved." });
+      setSaveMessage({ type: "success", text: copy.configurationSaved });
       setTestResult(null);
       queryClient.invalidateQueries({ queryKey: queryKeys.plugins.config(pluginId) });
       // Clear success message after 3s
       setTimeout(() => setSaveMessage(null), 3000);
     },
     onError: (err: Error) => {
-      setSaveMessage({ type: "error", text: err.message || "Failed to save configuration." });
+      setSaveMessage({ type: "error", text: err.message || copy.configurationSaveFailed });
     },
   });
 
@@ -617,13 +890,13 @@ function PluginConfigForm({ pluginId, schema, initialValues, isLoading, pluginSt
       pluginsApi.testConfig(pluginId, configJson),
     onSuccess: (result) => {
       if (result.valid) {
-        setTestResult({ type: "success", text: "Configuration test passed." });
+        setTestResult({ type: "success", text: copy.configurationTestPassed });
       } else {
-        setTestResult({ type: "error", text: result.message || "Configuration test failed." });
+        setTestResult({ type: "error", text: result.message || copy.configurationTestFailed });
       }
     },
     onError: (err: Error) => {
-      setTestResult({ type: "error", text: err.message || "Configuration test failed." });
+      setTestResult({ type: "error", text: err.message || copy.configurationTestFailed });
     },
   });
 
@@ -661,7 +934,7 @@ function PluginConfigForm({ pluginId, schema, initialValues, isLoading, pluginSt
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
         <Loader2 className="h-4 w-4 animate-spin" />
-        Loading configuration...
+        {copy.loadingConfiguration}
       </div>
     );
   }
@@ -711,10 +984,10 @@ function PluginConfigForm({ pluginId, schema, initialValues, isLoading, pluginSt
           {saveMutation.isPending ? (
             <>
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Saving...
+              {copy.saving}
             </>
           ) : (
-            "Save Configuration"
+            copy.saveConfiguration
           )}
         </Button>
         {pluginStatus === "ready" && supportsConfigTest && (
@@ -727,10 +1000,10 @@ function PluginConfigForm({ pluginId, schema, initialValues, isLoading, pluginSt
             {testMutation.isPending ? (
               <>
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Testing...
+                {copy.testing}
               </>
             ) : (
-              "Test Configuration"
+              copy.testConfiguration
             )}
           </Button>
         )}
@@ -746,9 +1019,18 @@ function PluginConfigForm({ pluginId, schema, initialValues, isLoading, pluginSt
 /**
  * Format an uptime value (in milliseconds) to a human-readable string.
  */
-function formatUptime(uptimeMs: number | null): string {
+function formatUptime(uptimeMs: number | null, language: UiLanguage): string {
   if (uptimeMs == null) return "—";
   const totalSeconds = Math.floor(uptimeMs / 1000);
+  if (language === "zh-CN") {
+    if (totalSeconds < 60) return `${totalSeconds}秒`;
+    const minutes = Math.floor(totalSeconds / 60);
+    if (minutes < 60) return `${minutes}分 ${totalSeconds % 60}秒`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}小时 ${minutes % 60}分`;
+    const days = Math.floor(hours / 24);
+    return `${days}天 ${hours % 24}小时`;
+  }
   if (totalSeconds < 60) return `${totalSeconds}s`;
   const minutes = Math.floor(totalSeconds / 60);
   if (minutes < 60) return `${minutes}m ${totalSeconds % 60}s`;
@@ -761,7 +1043,12 @@ function formatUptime(uptimeMs: number | null): string {
 /**
  * Format a duration in milliseconds to a compact display string.
  */
-function formatDuration(ms: number): string {
+function formatDuration(ms: number, language: UiLanguage): string {
+  if (language === "zh-CN") {
+    if (ms < 1000) return `${ms}毫秒`;
+    if (ms < 60000) return `${(ms / 1000).toFixed(1)}秒`;
+    return `${(ms / 60000).toFixed(1)}分钟`;
+  }
   if (ms < 1000) return `${ms}ms`;
   if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
   return `${(ms / 60000).toFixed(1)}m`;
@@ -770,27 +1057,33 @@ function formatDuration(ms: number): string {
 /**
  * Format an ISO timestamp to a relative time string (e.g., "2m ago").
  */
-function formatRelativeTime(isoString: string): string {
+function formatRelativeTime(isoString: string, language: UiLanguage): string {
   const now = Date.now();
   const then = new Date(isoString).getTime();
   const diffMs = now - then;
+  const rtf = new Intl.RelativeTimeFormat(getUiLocale(language), { numeric: "auto" });
 
-  if (diffMs < 0) return "just now";
+  if (diffMs < 0) {
+    return language === "zh-CN" ? "刚刚" : "just now";
+  }
   const seconds = Math.floor(diffMs / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 60) return rtf.format(-seconds, "second");
   const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
+  if (minutes < 60) return rtf.format(-minutes, "minute");
   const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
+  if (hours < 24) return rtf.format(-hours, "hour");
   const days = Math.floor(hours / 24);
-  return `${days}d ago`;
+  return rtf.format(-days, "day");
 }
 
 /**
  * Format a unix timestamp (ms since epoch) to a locale string.
  */
-function formatTimestamp(epochMs: number): string {
-  return new Date(epochMs).toLocaleString();
+function formatTimestamp(epochMs: number, language: UiLanguage): string {
+  return new Intl.DateTimeFormat(getUiLocale(language), {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(epochMs));
 }
 
 /**

--- a/ui/src/pages/ProjectDetail.tsx
+++ b/ui/src/pages/ProjectDetail.tsx
@@ -12,6 +12,7 @@ import { heartbeatsApi } from "../api/heartbeats";
 import { assetsApi } from "../api/assets";
 import { usePanel } from "../context/PanelContext";
 import { useCompany } from "../context/CompanyContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { useToast } from "../context/ToastContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
@@ -33,12 +34,36 @@ import { PluginLauncherOutlet } from "@/plugins/launchers";
 import { PluginSlotMount, PluginSlotOutlet, usePluginSlots } from "@/plugins/slots";
 import { Copy, FolderOpen, GitBranch, Loader2, Play, Square } from "lucide-react";
 import { IssuesQuicklook } from "../components/IssuesQuicklook";
+import { textFor } from "../lib/ui-language";
 
 /* ── Top-level tab types ── */
 
 type ProjectBaseTab = "overview" | "list" | "workspaces" | "configuration" | "budget";
 type ProjectPluginTab = `plugin:${string}`;
 type ProjectTab = ProjectBaseTab | ProjectPluginTab;
+
+function executionWorkspaceStatusLabel(status: ExecutionWorkspace["status"], uiLanguage: "en" | "zh-CN") {
+  return textFor(uiLanguage, {
+    en:
+      status === "cleanup_failed"
+        ? "Cleanup failed"
+        : status === "in_review"
+          ? "In Review"
+          : status.charAt(0).toUpperCase() + status.slice(1).replaceAll("_", " "),
+    "zh-CN":
+      status === "active"
+        ? "活跃"
+        : status === "idle"
+          ? "空闲"
+          : status === "in_review"
+            ? "评审中"
+            : status === "archived"
+              ? "已归档"
+              : status === "cleanup_failed"
+                ? "清理失败"
+                : status,
+  });
+}
 
 function isProjectPluginTab(value: string | null): value is ProjectPluginTab {
   return typeof value === "string" && value.startsWith("plugin:");
@@ -68,6 +93,7 @@ function OverviewContent({
   onUpdate: (data: Record<string, unknown>) => void;
   imageUploadHandler?: (file: File) => Promise<string>;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   return (
     <div className="space-y-6">
       <InlineEditor
@@ -76,21 +102,21 @@ function OverviewContent({
         nullable
         as="p"
         className="text-sm text-muted-foreground"
-        placeholder="Add a description..."
+        placeholder={textFor(uiLanguage, { en: "Add a description...", "zh-CN": "添加描述..." })}
         multiline
         imageUploadHandler={imageUploadHandler}
       />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
         <div>
-          <span className="text-muted-foreground">Status</span>
+          <span className="text-muted-foreground">{textFor(uiLanguage, { en: "Status", "zh-CN": "状态" })}</span>
           <div className="mt-1">
             <StatusBadge status={project.status} />
           </div>
         </div>
         {project.targetDate && (
           <div>
-            <span className="text-muted-foreground">Target Date</span>
+            <span className="text-muted-foreground">{textFor(uiLanguage, { en: "Target Date", "zh-CN": "目标日期" })}</span>
             <p>{project.targetDate}</p>
           </div>
         )}
@@ -108,6 +134,7 @@ function ColorPicker({
   currentColor: string;
   onSelect: (color: string) => void;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -128,7 +155,7 @@ function ColorPicker({
         onClick={() => setOpen(!open)}
         className="shrink-0 h-5 w-5 rounded-md cursor-pointer hover:ring-2 hover:ring-foreground/20 transition-[box-shadow]"
         style={{ backgroundColor: currentColor }}
-        aria-label="Change project color"
+        aria-label={textFor(uiLanguage, { en: "Change project color", "zh-CN": "更改项目颜色" })}
       />
       {open && (
         <div className="absolute top-full left-0 mt-2 p-2 bg-popover border border-border rounded-lg shadow-lg z-50 w-max">
@@ -146,7 +173,7 @@ function ColorPicker({
                     : "hover:ring-2 hover:ring-foreground/30"
                 }`}
                 style={{ backgroundColor: color }}
-                aria-label={`Select color ${color}`}
+                aria-label={textFor(uiLanguage, { en: `Select color ${color}`, "zh-CN": `选择颜色 ${color}` })}
               />
             ))}
           </div>
@@ -228,6 +255,7 @@ function ProjectWorkspacesContent({
   projectRef: string;
   summaries: ReturnType<typeof buildProjectWorkspaceSummaries>;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const queryClient = useQueryClient();
   const [runtimeActionKey, setRuntimeActionKey] = useState<string | null>(null);
   const [closingWorkspace, setClosingWorkspace] = useState<{
@@ -257,7 +285,7 @@ function ProjectWorkspacesContent({
   });
 
   if (summaries.length === 0) {
-    return <p className="text-sm text-muted-foreground">No non-default workspace activity yet.</p>;
+    return <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "No non-default workspace activity yet.", "zh-CN": "还没有非默认工作区活动。" })}</p>;
   }
 
   const activeSummaries = summaries.filter((summary) => summary.executionWorkspaceStatus !== "cleanup_failed");
@@ -300,7 +328,9 @@ function ProjectWorkspacesContent({
               </span>
             ) : null}
             {summary.executionWorkspaceStatus && summary.executionWorkspaceStatus !== "active" ? (
-              <span className="text-[11px] text-muted-foreground">{summary.executionWorkspaceStatus}</span>
+              <span className="text-[11px] text-muted-foreground">
+                {executionWorkspaceStatusLabel(summary.executionWorkspaceStatus, uiLanguage)}
+              </span>
             ) : null}
           </div>
 
@@ -328,7 +358,7 @@ function ProjectWorkspacesContent({
                 ) : (
                   <Play className="h-3 w-3" />
                 )}
-                {hasRunningServices ? "Stop" : "Start"}
+                {hasRunningServices ? textFor(uiLanguage, { en: "Stop", "zh-CN": "停止" }) : textFor(uiLanguage, { en: "Start", "zh-CN": "启动" })}
               </Button>
             ) : null}
             {summary.kind === "execution_workspace" && summary.executionWorkspaceId && summary.executionWorkspaceStatus ? (
@@ -342,7 +372,9 @@ function ProjectWorkspacesContent({
                   status: summary.executionWorkspaceStatus!,
                 })}
               >
-                {summary.executionWorkspaceStatus === "cleanup_failed" ? "Retry close" : "Close"}
+                {summary.executionWorkspaceStatus === "cleanup_failed"
+                  ? textFor(uiLanguage, { en: "Retry close", "zh-CN": "重试关闭" })
+                  : textFor(uiLanguage, { en: "Close", "zh-CN": "关闭" })}
               </Button>
             ) : null}
           </div>
@@ -362,7 +394,7 @@ function ProjectWorkspacesContent({
               <span className="truncate font-mono" title={summary.cwd}>
                 {truncatePath(summary.cwd)}
               </span>
-              <CopyText text={summary.cwd} className="shrink-0" copiedLabel="Path copied">
+              <CopyText text={summary.cwd} className="shrink-0" copiedLabel={textFor(uiLanguage, { en: "Path copied", "zh-CN": "路径已复制" })}>
                 <Copy className="h-3 w-3" />
               </CopyText>
             </div>
@@ -384,7 +416,7 @@ function ProjectWorkspacesContent({
         {/* Issues */}
         {summary.issues.length > 0 ? (
           <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-            <span className="font-medium text-muted-foreground/70">Issues</span>
+            <span className="font-medium text-muted-foreground/70">{textFor(uiLanguage, { en: "Issues", "zh-CN": "任务" })}</span>
             {visibleIssues.map((issue) => (
               <IssuesQuicklook key={issue.id} issue={issue}>
                 <Link
@@ -397,7 +429,7 @@ function ProjectWorkspacesContent({
             ))}
             {hiddenIssueCount > 0 ? (
               <Link to={workspaceHref} className="hover:text-foreground hover:underline">
-                +{hiddenIssueCount} more
+                +{hiddenIssueCount} {textFor(uiLanguage, { en: "more", "zh-CN": "更多" })}
               </Link>
             ) : null}
           </div>
@@ -415,7 +447,7 @@ function ProjectWorkspacesContent({
         {cleanupFailedSummaries.length > 0 ? (
           <div className="space-y-2">
             <div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-              Cleanup attention needed
+              {textFor(uiLanguage, { en: "Cleanup attention needed", "zh-CN": "需要关注清理状态" })}
             </div>
             <div className="overflow-hidden rounded-xl border border-amber-500/20 bg-amber-500/5">
               {cleanupFailedSummaries.map(renderSummaryRow)}
@@ -453,6 +485,7 @@ export function ProjectDetail() {
     filter?: string;
   }>();
   const { companies, selectedCompanyId, setSelectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { closePanel } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
   const { pushToast } = useToast();
@@ -570,17 +603,19 @@ export function ProjectDetail() {
       ),
     onSuccess: (updatedProject, archived) => {
       invalidateProject();
-      const name = updatedProject?.name ?? project?.name ?? "Project";
+      const name = updatedProject?.name ?? project?.name ?? textFor(uiLanguage, { en: "Project", "zh-CN": "项目" });
       if (archived) {
-        pushToast({ title: `"${name}" has been archived`, tone: "success" });
+        pushToast({ title: textFor(uiLanguage, { en: `"${name}" has been archived`, "zh-CN": `“${name}” 已归档` }), tone: "success" });
         navigate("/dashboard");
       } else {
-        pushToast({ title: `"${name}" has been unarchived`, tone: "success" });
+        pushToast({ title: textFor(uiLanguage, { en: `"${name}" has been unarchived`, "zh-CN": `“${name}” 已取消归档` }), tone: "success" });
       }
     },
     onError: (_, archived) => {
       pushToast({
-        title: archived ? "Failed to archive project" : "Failed to unarchive project",
+        title: archived
+          ? textFor(uiLanguage, { en: "Failed to archive project", "zh-CN": "归档项目失败" })
+          : textFor(uiLanguage, { en: "Failed to unarchive project", "zh-CN": "取消归档项目失败" }),
         tone: "error",
       });
     },
@@ -588,7 +623,7 @@ export function ProjectDetail() {
 
   const uploadImage = useMutation({
     mutationFn: async (file: File) => {
-      if (!resolvedCompanyId) throw new Error("No company selected");
+      if (!resolvedCompanyId) throw new Error(textFor(uiLanguage, { en: "No company selected", "zh-CN": "未选择公司" }));
       return assetsApi.uploadImage(resolvedCompanyId, file, `projects/${projectLookupRef || "draft"}`);
     },
   });
@@ -603,10 +638,10 @@ export function ProjectDetail() {
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: "Projects", href: "/projects" },
-      { label: project?.name ?? routeProjectRef ?? "Project" },
+      { label: textFor(uiLanguage, { en: "Projects", "zh-CN": "项目" }), href: "/projects" },
+      { label: project?.name ?? routeProjectRef ?? textFor(uiLanguage, { en: "Project", "zh-CN": "项目" }) },
     ]);
-  }, [setBreadcrumbs, project, routeProjectRef]);
+  }, [setBreadcrumbs, project, routeProjectRef, uiLanguage]);
 
   useEffect(() => {
     if (!project) return;
@@ -700,7 +735,7 @@ export function ProjectDetail() {
       companyId: resolvedCompanyId ?? "",
       scopeType: "project",
       scopeId: project?.id ?? routeProjectRef,
-      scopeName: project?.name ?? "Project",
+      scopeName: project?.name ?? textFor(uiLanguage, { en: "Project", "zh-CN": "项目" }),
       metric: "billed_cents",
       windowKind: "lifetime",
       amount: 0,
@@ -817,7 +852,7 @@ export function ProjectDetail() {
           {project.pauseReason === "budget" ? (
             <div className="inline-flex items-center gap-2 rounded-full border border-red-500/30 bg-red-500/10 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-red-200">
               <span className="h-2 w-2 rounded-full bg-red-400" />
-              Paused by budget hard stop
+              {textFor(uiLanguage, { en: "Paused by budget hard stop", "zh-CN": "因预算硬停止而暂停" })}
             </div>
           ) : null}
         </div>
@@ -857,11 +892,11 @@ export function ProjectDetail() {
       <Tabs value={activeTab ?? "list"} onValueChange={(value) => handleTabChange(value as ProjectTab)}>
         <PageTabBar
           items={[
-            { value: "list", label: "Issues" },
-            { value: "overview", label: "Overview" },
-            ...(showWorkspacesTab ? [{ value: "workspaces", label: "Workspaces" }] : []),
-            { value: "configuration", label: "Configuration" },
-            { value: "budget", label: "Budget" },
+            { value: "list", label: textFor(uiLanguage, { en: "Issues", "zh-CN": "任务" }) },
+            { value: "overview", label: textFor(uiLanguage, { en: "Overview", "zh-CN": "总览" }) },
+            ...(showWorkspacesTab ? [{ value: "workspaces", label: textFor(uiLanguage, { en: "Workspaces", "zh-CN": "工作区" }) }] : []),
+            { value: "configuration", label: textFor(uiLanguage, { en: "Configuration", "zh-CN": "配置" }) },
+            { value: "budget", label: textFor(uiLanguage, { en: "Budget", "zh-CN": "预算" }) },
             ...pluginTabItems.map((item) => ({
               value: item.value,
               label: item.label,
@@ -901,7 +936,7 @@ export function ProjectDetail() {
             />
           )
         ) : (
-          <p className="text-sm text-muted-foreground">Loading workspaces...</p>
+          <p className="text-sm text-muted-foreground">{textFor(uiLanguage, { en: "Loading workspaces...", "zh-CN": "正在加载工作区..." })}</p>
         )
       ) : null}
 

--- a/ui/src/pages/Projects.tsx
+++ b/ui/src/pages/Projects.tsx
@@ -4,6 +4,7 @@ import { projectsApi } from "../api/projects";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { queryKeys } from "../lib/queryKeys";
 import { EntityRow } from "../components/EntityRow";
 import { StatusBadge } from "../components/StatusBadge";
@@ -12,15 +13,35 @@ import { PageSkeleton } from "../components/PageSkeleton";
 import { formatDate, projectUrl } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Hexagon, Plus } from "lucide-react";
+import { textFor } from "../lib/ui-language";
 
 export function Projects() {
   const { selectedCompanyId } = useCompany();
+  const { uiLanguage } = useGeneralSettings();
   const { openNewProject } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = {
+    projects: textFor(uiLanguage, {
+      en: "Projects",
+      "zh-CN": "项目",
+    }),
+    selectCompany: textFor(uiLanguage, {
+      en: "Select a company to view projects.",
+      "zh-CN": "请先选择公司以查看项目。",
+    }),
+    addProject: textFor(uiLanguage, {
+      en: "Add Project",
+      "zh-CN": "新建项目",
+    }),
+    noProjects: textFor(uiLanguage, {
+      en: "No projects yet.",
+      "zh-CN": "还没有项目。",
+    }),
+  };
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Projects" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy.projects }]);
+  }, [copy.projects, setBreadcrumbs]);
 
   const { data: allProjects, isLoading, error } = useQuery({
     queryKey: queryKeys.projects.list(selectedCompanyId!),
@@ -33,7 +54,7 @@ export function Projects() {
   );
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Hexagon} message="Select a company to view projects." />;
+    return <EmptyState icon={Hexagon} message={copy.selectCompany} />;
   }
 
   if (isLoading) {
@@ -45,7 +66,7 @@ export function Projects() {
       <div className="flex items-center justify-end">
         <Button size="sm" variant="outline" onClick={openNewProject}>
           <Plus className="h-4 w-4 mr-1" />
-          Add Project
+          {copy.addProject}
         </Button>
       </div>
 
@@ -54,8 +75,8 @@ export function Projects() {
       {!isLoading && projects.length === 0 && (
         <EmptyState
           icon={Hexagon}
-          message="No projects yet."
-          action="Add Project"
+          message={copy.noProjects}
+          action={copy.addProject}
           onAction={openNewProject}
         />
       )}

--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -23,10 +23,12 @@ import { agentsApi } from "../api/agents";
 import { projectsApi } from "../api/projects";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { useToast } from "../context/ToastContext";
 import { queryKeys } from "../lib/queryKeys";
 import { buildRoutineTriggerPatch } from "../lib/routine-trigger-patch";
 import { timeAgo } from "../lib/timeAgo";
+import { textFor, type UiLanguage } from "../lib/ui-language";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
@@ -103,6 +105,71 @@ function getRoutineTabFromSearch(search: string): RoutineTab {
   return isRoutineTab(tab) ? tab : "triggers";
 }
 
+function humanizeToken(value: string) {
+  return value.replaceAll("_", " ");
+}
+
+function routineStatusLabel(status: string, uiLanguage: UiLanguage) {
+  const labels: Record<string, { en: string; "zh-CN": string }> = {
+    active: { en: "Active", "zh-CN": "运行中" },
+    paused: { en: "Paused", "zh-CN": "已暂停" },
+    archived: { en: "Archived", "zh-CN": "已归档" },
+    queued: { en: "Queued", "zh-CN": "排队中" },
+    running: { en: "Running", "zh-CN": "运行中" },
+    succeeded: { en: "Succeeded", "zh-CN": "已成功" },
+    failed: { en: "Failed", "zh-CN": "失败" },
+    timed_out: { en: "Timed out", "zh-CN": "超时" },
+    cancelled: { en: "Cancelled", "zh-CN": "已取消" },
+  };
+  return textFor(uiLanguage, labels[status] ?? { en: humanizeToken(status), "zh-CN": humanizeToken(status) });
+}
+
+function triggerKindLabel(kind: string, uiLanguage: UiLanguage) {
+  const labels: Record<string, { en: string; "zh-CN": string }> = {
+    schedule: { en: "Schedule", "zh-CN": "定时" },
+    webhook: { en: "Webhook", "zh-CN": "Webhook" },
+  };
+  return textFor(uiLanguage, labels[kind] ?? { en: humanizeToken(kind), "zh-CN": humanizeToken(kind) });
+}
+
+function routineRunSourceLabel(source: string, uiLanguage: UiLanguage) {
+  const labels: Record<string, { en: string; "zh-CN": string }> = {
+    schedule: { en: "Schedule", "zh-CN": "定时" },
+    webhook: { en: "Webhook", "zh-CN": "Webhook" },
+    manual: { en: "Manual", "zh-CN": "手动" },
+    on_demand: { en: "On-demand", "zh-CN": "按需" },
+    api: { en: "API", "zh-CN": "API" },
+  };
+  return textFor(uiLanguage, labels[source] ?? { en: humanizeToken(source), "zh-CN": humanizeToken(source) });
+}
+
+function signingModeLabel(mode: string, uiLanguage: UiLanguage) {
+  const labels: Record<string, { en: string; "zh-CN": string }> = {
+    bearer: { en: "Bearer token", "zh-CN": "Bearer 令牌" },
+    hmac_sha256: { en: "HMAC SHA-256", "zh-CN": "HMAC SHA-256" },
+    github_hmac: { en: "GitHub HMAC", "zh-CN": "GitHub HMAC" },
+    none: { en: "None", "zh-CN": "无认证" },
+  };
+  return textFor(uiLanguage, labels[mode] ?? { en: humanizeToken(mode), "zh-CN": humanizeToken(mode) });
+}
+
+function concurrencyPolicyLabel(policy: string, uiLanguage: UiLanguage) {
+  const labels: Record<string, { en: string; "zh-CN": string }> = {
+    coalesce_if_active: { en: "Coalesce if active", "zh-CN": "运行中时合并" },
+    always_enqueue: { en: "Always enqueue", "zh-CN": "始终入队" },
+    skip_if_active: { en: "Skip if active", "zh-CN": "运行中时跳过" },
+  };
+  return textFor(uiLanguage, labels[policy] ?? { en: humanizeToken(policy), "zh-CN": humanizeToken(policy) });
+}
+
+function catchUpPolicyLabel(policy: string, uiLanguage: UiLanguage) {
+  const labels: Record<string, { en: string; "zh-CN": string }> = {
+    skip_missed: { en: "Skip missed windows", "zh-CN": "跳过错过窗口" },
+    enqueue_missed_with_cap: { en: "Enqueue missed windows", "zh-CN": "补跑错过窗口" },
+  };
+  return textFor(uiLanguage, labels[policy] ?? { en: humanizeToken(policy), "zh-CN": humanizeToken(policy) });
+}
+
 function formatActivityDetailValue(value: unknown): string {
   if (value === null) return "null";
   if (typeof value === "string") return value;
@@ -134,6 +201,7 @@ function TriggerEditor({
   onRotate: (id: string) => void;
   onDelete: (id: string) => void;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const [draft, setDraft] = useState({
     label: trigger.label ?? "",
     cronExpression: trigger.cronExpression ?? "",
@@ -150,25 +218,38 @@ function TriggerEditor({
     });
   }, [trigger]);
 
+  const copy = {
+    next: textFor(uiLanguage, { en: "Next", "zh-CN": "下次" }),
+    webhook: textFor(uiLanguage, { en: "Webhook", "zh-CN": "Webhook" }),
+    api: textFor(uiLanguage, { en: "API", "zh-CN": "API" }),
+    label: textFor(uiLanguage, { en: "Label", "zh-CN": "名称" }),
+    schedule: textFor(uiLanguage, { en: "Schedule", "zh-CN": "定时" }),
+    signingMode: textFor(uiLanguage, { en: "Signing mode", "zh-CN": "签名模式" }),
+    replayWindow: textFor(uiLanguage, { en: "Replay window (seconds)", "zh-CN": "重放窗口（秒）" }),
+    last: textFor(uiLanguage, { en: "Last", "zh-CN": "最近" }),
+    rotateSecret: textFor(uiLanguage, { en: "Rotate secret", "zh-CN": "轮换密钥" }),
+    saveTrigger: textFor(uiLanguage, { en: "Save trigger", "zh-CN": "保存触发器" }),
+  };
+
   return (
     <div className="rounded-lg border border-border p-4 space-y-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 text-sm font-medium">
           {trigger.kind === "schedule" ? <Clock3 className="h-3.5 w-3.5" /> : trigger.kind === "webhook" ? <Webhook className="h-3.5 w-3.5" /> : <Zap className="h-3.5 w-3.5" />}
-          {trigger.label ?? trigger.kind}
+          {trigger.label ?? triggerKindLabel(trigger.kind, uiLanguage)}
         </div>
         <span className="text-xs text-muted-foreground">
           {trigger.kind === "schedule" && trigger.nextRunAt
-            ? `Next: ${new Date(trigger.nextRunAt).toLocaleString()}`
+            ? `${copy.next}: ${new Date(trigger.nextRunAt).toLocaleString(uiLanguage === "zh-CN" ? "zh-CN" : "en-US")}`
             : trigger.kind === "webhook"
-              ? "Webhook"
-              : "API"}
+              ? copy.webhook
+              : copy.api}
         </span>
       </div>
 
       <div className="grid gap-3 md:grid-cols-2">
         <div className="space-y-1.5">
-          <Label className="text-xs">Label</Label>
+          <Label className="text-xs">{copy.label}</Label>
           <Input
             value={draft.label}
             onChange={(event) => setDraft((current) => ({ ...current, label: event.target.value }))}
@@ -176,7 +257,7 @@ function TriggerEditor({
         </div>
         {trigger.kind === "schedule" && (
           <div className="md:col-span-2 space-y-1.5">
-            <Label className="text-xs">Schedule</Label>
+            <Label className="text-xs">{copy.schedule}</Label>
             <ScheduleEditor
               value={draft.cronExpression}
               onChange={(cronExpression) => setDraft((current) => ({ ...current, cronExpression }))}
@@ -186,7 +267,7 @@ function TriggerEditor({
         {trigger.kind === "webhook" && (
           <>
             <div className="space-y-1.5">
-              <Label className="text-xs">Signing mode</Label>
+              <Label className="text-xs">{copy.signingMode}</Label>
               <Select
                 value={draft.signingMode}
                 onValueChange={(signingMode) => setDraft((current) => ({ ...current, signingMode }))}
@@ -196,14 +277,14 @@ function TriggerEditor({
                 </SelectTrigger>
                 <SelectContent>
                   {signingModes.map((mode) => (
-                    <SelectItem key={mode} value={mode}>{mode}</SelectItem>
+                    <SelectItem key={mode} value={mode}>{signingModeLabel(mode, uiLanguage)}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>
             </div>
             {!SIGNING_MODES_WITHOUT_REPLAY_WINDOW.has(draft.signingMode) && (
               <div className="space-y-1.5">
-                <Label className="text-xs">Replay window (seconds)</Label>
+                <Label className="text-xs">{copy.replayWindow}</Label>
                 <Input
                   value={draft.replayWindowSec}
                   onChange={(event) => setDraft((current) => ({ ...current, replayWindowSec: event.target.value }))}
@@ -215,12 +296,12 @@ function TriggerEditor({
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
-        {trigger.lastResult && <span className="text-xs text-muted-foreground">Last: {trigger.lastResult}</span>}
+        {trigger.lastResult && <span className="text-xs text-muted-foreground">{copy.last}: {trigger.lastResult}</span>}
         <div className="ml-auto flex items-center gap-2">
           {trigger.kind === "webhook" && (
             <Button variant="outline" size="sm" onClick={() => onRotate(trigger.id)}>
               <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-              Rotate secret
+              {copy.rotateSecret}
             </Button>
           )}
           <Button
@@ -229,7 +310,7 @@ function TriggerEditor({
             onClick={() => onSave(trigger.id, buildRoutineTriggerPatch(trigger, draft, getLocalTimezone()))}
           >
             <Save className="mr-1.5 h-3.5 w-3.5" />
-            Save trigger
+            {copy.saveTrigger}
           </Button>
           <Button
             variant="ghost"
@@ -249,6 +330,7 @@ export function RoutineDetail() {
   const { routineId } = useParams<{ routineId: string }>();
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const { uiLanguage } = useGeneralSettings();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
@@ -287,6 +369,122 @@ export function RoutineDetail() {
     variables: [],
   });
   const activeTab = useMemo(() => getRoutineTabFromSearch(location.search), [location.search]);
+  const concurrencyPolicyDescriptionsForLanguage: Record<string, string> = {
+    coalesce_if_active: textFor(uiLanguage, {
+      en: "Keep one follow-up run queued while an active run is still working.",
+      "zh-CN": "如果已有运行正在执行，只保留一个后续待运行任务。",
+    }),
+    always_enqueue: textFor(uiLanguage, {
+      en: "Queue every trigger occurrence, even if several runs stack up.",
+      "zh-CN": "每次触发都入队，即使已经堆积了多个运行。",
+    }),
+    skip_if_active: textFor(uiLanguage, {
+      en: "Drop overlapping trigger occurrences while the routine is already active.",
+      "zh-CN": "当例行任务已在运行时，丢弃重叠的触发。",
+    }),
+  };
+  const catchUpPolicyDescriptionsForLanguage: Record<string, string> = {
+    skip_missed: textFor(uiLanguage, {
+      en: "Ignore schedule windows that were missed while the routine or scheduler was paused.",
+      "zh-CN": "在例行任务或调度器暂停期间错过的时间窗口将被忽略。",
+    }),
+    enqueue_missed_with_cap: textFor(uiLanguage, {
+      en: "Catch up missed schedule windows in capped batches after recovery.",
+      "zh-CN": "恢复后按上限分批补跑错过的时间窗口。",
+    }),
+  };
+  const signingModeDescriptionsForLanguage: Record<string, string> = {
+    bearer: textFor(uiLanguage, {
+      en: "Expect a shared bearer token in the Authorization header.",
+      "zh-CN": "要求在 Authorization 请求头中提供共享 Bearer 令牌。",
+    }),
+    hmac_sha256: textFor(uiLanguage, {
+      en: "Expect an HMAC SHA-256 signature over the request using the shared secret.",
+      "zh-CN": "要求使用共享密钥对请求进行 HMAC SHA-256 签名。",
+    }),
+    github_hmac: textFor(uiLanguage, {
+      en: "Accept GitHub-style X-Hub-Signature-256 header (HMAC over raw body, no timestamp).",
+      "zh-CN": "接受 GitHub 风格的 X-Hub-Signature-256 请求头（对原始请求体做 HMAC，无时间戳）。",
+    }),
+    none: textFor(uiLanguage, {
+      en: "No authentication — the webhook URL itself acts as a shared secret.",
+      "zh-CN": "不做认证，Webhook URL 本身作为共享密钥。",
+    }),
+  };
+  const copy = {
+    routines: textFor(uiLanguage, { en: "Routines", "zh-CN": "例行任务" }),
+    copied: textFor(uiLanguage, { en: "copied", "zh-CN": "已复制" }),
+    failedToCopy: textFor(uiLanguage, { en: "Failed to copy", "zh-CN": "复制失败" }),
+    clipboardDenied: textFor(uiLanguage, { en: "Clipboard access was denied.", "zh-CN": "没有剪贴板访问权限。" }),
+    failedToSaveRoutine: textFor(uiLanguage, { en: "Failed to save routine", "zh-CN": "保存例行任务失败" }),
+    routineSaveError: textFor(uiLanguage, { en: "Paperclip could not save the routine.", "zh-CN": "Paperclip 无法保存该例行任务。" }),
+    routineRunStarted: textFor(uiLanguage, { en: "Routine run started", "zh-CN": "例行任务已开始运行" }),
+    routineRunFailed: textFor(uiLanguage, { en: "Routine run failed", "zh-CN": "例行任务运行失败" }),
+    routineRunError: textFor(uiLanguage, { en: "Paperclip could not start the routine run.", "zh-CN": "Paperclip 无法启动该例行任务运行。" }),
+    routineSaved: textFor(uiLanguage, { en: "Routine saved", "zh-CN": "例行任务已保存" }),
+    automationPaused: textFor(uiLanguage, { en: "Automation paused.", "zh-CN": "自动触发已暂停。" }),
+    automationEnabled: textFor(uiLanguage, { en: "Automation enabled.", "zh-CN": "自动触发已启用。" }),
+    failedToUpdateRoutine: textFor(uiLanguage, { en: "Failed to update routine", "zh-CN": "更新例行任务失败" }),
+    routineUpdateError: textFor(uiLanguage, { en: "Paperclip could not update the routine.", "zh-CN": "Paperclip 无法更新该例行任务。" }),
+    webhookTriggerCreated: textFor(uiLanguage, { en: "Webhook trigger created", "zh-CN": "Webhook 触发器已创建" }),
+    triggerAdded: textFor(uiLanguage, { en: "Trigger added", "zh-CN": "触发器已添加" }),
+    routineScheduleSaved: textFor(uiLanguage, { en: "The routine schedule was saved.", "zh-CN": "例行任务调度已保存。" }),
+    failedToAddTrigger: textFor(uiLanguage, { en: "Failed to add trigger", "zh-CN": "添加触发器失败" }),
+    triggerCreateError: textFor(uiLanguage, { en: "Paperclip could not create the trigger.", "zh-CN": "Paperclip 无法创建该触发器。" }),
+    triggerSaved: textFor(uiLanguage, { en: "Trigger saved", "zh-CN": "触发器已保存" }),
+    triggerUpdateSaved: textFor(uiLanguage, { en: "The routine cadence update was saved.", "zh-CN": "例行任务节奏更新已保存。" }),
+    failedToUpdateTrigger: textFor(uiLanguage, { en: "Failed to update trigger", "zh-CN": "更新触发器失败" }),
+    triggerUpdateError: textFor(uiLanguage, { en: "Paperclip could not update the trigger.", "zh-CN": "Paperclip 无法更新该触发器。" }),
+    triggerDeleted: textFor(uiLanguage, { en: "Trigger deleted", "zh-CN": "触发器已删除" }),
+    failedToDeleteTrigger: textFor(uiLanguage, { en: "Failed to delete trigger", "zh-CN": "删除触发器失败" }),
+    triggerDeleteError: textFor(uiLanguage, { en: "Paperclip could not delete the trigger.", "zh-CN": "Paperclip 无法删除该触发器。" }),
+    webhookSecretRotated: textFor(uiLanguage, { en: "Webhook secret rotated", "zh-CN": "Webhook 密钥已轮换" }),
+    failedToRotateWebhookSecret: textFor(uiLanguage, { en: "Failed to rotate webhook secret", "zh-CN": "轮换 Webhook 密钥失败" }),
+    webhookSecretRotateError: textFor(uiLanguage, { en: "Paperclip could not rotate the webhook secret.", "zh-CN": "Paperclip 无法轮换该 Webhook 密钥。" }),
+    selectCompany: textFor(uiLanguage, { en: "Select a company to view routines.", "zh-CN": "请选择一个公司以查看例行任务。" }),
+    routineNotFound: textFor(uiLanguage, { en: "Routine not found", "zh-CN": "未找到该例行任务" }),
+    archived: textFor(uiLanguage, { en: "Archived", "zh-CN": "已归档" }),
+    active: textFor(uiLanguage, { en: "Active", "zh-CN": "运行中" }),
+    paused: textFor(uiLanguage, { en: "Paused", "zh-CN": "已暂停" }),
+    routineTitle: textFor(uiLanguage, { en: "Routine title", "zh-CN": "例行任务标题" }),
+    pauseAuto: textFor(uiLanguage, { en: "Pause automatic triggers", "zh-CN": "暂停自动触发" }),
+    enableAuto: textFor(uiLanguage, { en: "Enable automatic triggers", "zh-CN": "启用自动触发" }),
+    saveNow: textFor(uiLanguage, { en: "Save this now. Paperclip will not show the secret value again.", "zh-CN": "请现在保存。Paperclip 不会再次显示该密钥值。" }),
+    webhookUrl: textFor(uiLanguage, { en: "Webhook URL", "zh-CN": "Webhook URL" }),
+    webhookSecret: textFor(uiLanguage, { en: "Webhook secret", "zh-CN": "Webhook 密钥" }),
+    url: textFor(uiLanguage, { en: "URL", "zh-CN": "URL" }),
+    secret: textFor(uiLanguage, { en: "Secret", "zh-CN": "密钥" }),
+    for: textFor(uiLanguage, { en: "For", "zh-CN": "分配给" }),
+    assignee: textFor(uiLanguage, { en: "Assignee", "zh-CN": "负责人" }),
+    noAssignee: textFor(uiLanguage, { en: "No assignee", "zh-CN": "未分配负责人" }),
+    searchAssignees: textFor(uiLanguage, { en: "Search assignees...", "zh-CN": "搜索负责人..." }),
+    noAssigneesFound: textFor(uiLanguage, { en: "No assignees found.", "zh-CN": "未找到负责人。" }),
+    in: textFor(uiLanguage, { en: "in", "zh-CN": "归属项目" }),
+    project: textFor(uiLanguage, { en: "Project", "zh-CN": "项目" }),
+    noProject: textFor(uiLanguage, { en: "No project", "zh-CN": "无项目" }),
+    searchProjects: textFor(uiLanguage, { en: "Search projects...", "zh-CN": "搜索项目..." }),
+    noProjectsFound: textFor(uiLanguage, { en: "No projects found.", "zh-CN": "未找到项目。" }),
+    addInstructions: textFor(uiLanguage, { en: "Add instructions...", "zh-CN": "添加说明..." }),
+    advancedDelivery: textFor(uiLanguage, { en: "Advanced delivery settings", "zh-CN": "高级投递设置" }),
+    concurrency: textFor(uiLanguage, { en: "Concurrency", "zh-CN": "并发策略" }),
+    catchUp: textFor(uiLanguage, { en: "Catch-up", "zh-CN": "补跑策略" }),
+    unsavedChanges: textFor(uiLanguage, { en: "Unsaved changes", "zh-CN": "有未保存更改" }),
+    saveRoutine: textFor(uiLanguage, { en: "Save routine", "zh-CN": "保存例行任务" }),
+    triggers: textFor(uiLanguage, { en: "Triggers", "zh-CN": "触发器" }),
+    runs: textFor(uiLanguage, { en: "Runs", "zh-CN": "运行记录" }),
+    activity: textFor(uiLanguage, { en: "Activity", "zh-CN": "活动" }),
+    addTrigger: textFor(uiLanguage, { en: "Add trigger", "zh-CN": "添加触发器" }),
+    kind: textFor(uiLanguage, { en: "Kind", "zh-CN": "类型" }),
+    comingSoon: textFor(uiLanguage, { en: "COMING SOON", "zh-CN": "即将推出" }),
+    schedule: textFor(uiLanguage, { en: "Schedule", "zh-CN": "定时" }),
+    signingMode: textFor(uiLanguage, { en: "Signing mode", "zh-CN": "签名模式" }),
+    replayWindow: textFor(uiLanguage, { en: "Replay window (seconds)", "zh-CN": "重放窗口（秒）" }),
+    adding: textFor(uiLanguage, { en: "Adding...", "zh-CN": "添加中..." }),
+    addTriggerButton: textFor(uiLanguage, { en: "Add trigger", "zh-CN": "添加触发器" }),
+    noTriggers: textFor(uiLanguage, { en: "No triggers configured yet.", "zh-CN": "还没有配置触发器。" }),
+    noRuns: textFor(uiLanguage, { en: "No runs yet.", "zh-CN": "还没有运行记录。" }),
+    noActivity: textFor(uiLanguage, { en: "No activity yet.", "zh-CN": "还没有活动记录。" }),
+  };
 
   const { data: routine, isLoading, error } = useQuery({
     queryKey: queryKeys.routines.detail(routineId!),
@@ -371,7 +569,7 @@ export function RoutineDetail() {
 
   useEffect(() => {
     if (!routine) return;
-    setBreadcrumbs([{ label: "Routines", href: "/routines" }, { label: routine.title }]);
+    setBreadcrumbs([{ label: copy.routines, href: "/routines" }, { label: routine.title }]);
     if (!routineDefaults) return;
 
     const changedRoutine = hydratedRoutineIdRef.current !== routine.id;
@@ -379,7 +577,7 @@ export function RoutineDetail() {
       setEditDraft(routineDefaults);
       hydratedRoutineIdRef.current = routine.id;
     }
-  }, [routine, routineDefaults, isEditDirty, setBreadcrumbs]);
+  }, [copy.routines, routine, routineDefaults, isEditDirty, setBreadcrumbs]);
 
   useEffect(() => {
     autoResizeTextarea(titleInputRef.current);
@@ -388,11 +586,11 @@ export function RoutineDetail() {
   const copySecretValue = async (label: string, value: string) => {
     try {
       await navigator.clipboard.writeText(value);
-      pushToast({ title: `${label} copied`, tone: "success" });
+      pushToast({ title: `${label}${uiLanguage === "zh-CN" ? "已复制" : ` ${copy.copied}`}`, tone: "success" });
     } catch (error) {
       pushToast({
-        title: `Failed to copy ${label.toLowerCase()}`,
-        body: error instanceof Error ? error.message : "Clipboard access was denied.",
+        title: uiLanguage === "zh-CN" ? `${copy.failedToCopy}${label}` : `${copy.failedToCopy} ${label.toLowerCase()}`,
+        body: error instanceof Error ? error.message : copy.clipboardDenied,
         tone: "error",
       });
     }
@@ -432,8 +630,8 @@ export function RoutineDetail() {
     },
     onError: (error) => {
       pushToast({
-        title: "Failed to save routine",
-        body: error instanceof Error ? error.message : "Paperclip could not save the routine.",
+        title: copy.failedToSaveRoutine,
+        body: error instanceof Error ? error.message : copy.routineSaveError,
         tone: "error",
       });
     },
@@ -450,9 +648,9 @@ export function RoutineDetail() {
         ...(data?.executionWorkspaceSettings !== undefined
           ? { executionWorkspaceSettings: data.executionWorkspaceSettings }
           : {}),
-      }),
+    }),
     onSuccess: async () => {
-      pushToast({ title: "Routine run started", tone: "success" });
+      pushToast({ title: copy.routineRunStarted, tone: "success" });
       setRunVariablesOpen(false);
       setActiveTab("runs");
       await Promise.all([
@@ -464,8 +662,8 @@ export function RoutineDetail() {
     },
     onError: (error) => {
       pushToast({
-        title: "Routine run failed",
-        body: error instanceof Error ? error.message : "Paperclip could not start the routine run.",
+        title: copy.routineRunFailed,
+        body: error instanceof Error ? error.message : copy.routineRunError,
         tone: "error",
       });
     },
@@ -475,8 +673,8 @@ export function RoutineDetail() {
     mutationFn: (status: string) => routinesApi.update(routineId!, { status }),
     onSuccess: async (_data, status) => {
       pushToast({
-        title: "Routine saved",
-        body: status === "paused" ? "Automation paused." : "Automation enabled.",
+        title: copy.routineSaved,
+        body: status === "paused" ? copy.automationPaused : copy.automationEnabled,
         tone: "success",
       });
       await Promise.all([
@@ -486,8 +684,8 @@ export function RoutineDetail() {
     },
     onError: (error) => {
       pushToast({
-        title: "Failed to update routine",
-        body: error instanceof Error ? error.message : "Paperclip could not update the routine.",
+        title: copy.failedToUpdateRoutine,
+        body: error instanceof Error ? error.message : copy.routineUpdateError,
         tone: "error",
       });
     },
@@ -514,14 +712,14 @@ export function RoutineDetail() {
     onSuccess: async (result) => {
       if (result.secretMaterial) {
         setSecretMessage({
-          title: "Webhook trigger created",
+          title: copy.webhookTriggerCreated,
           webhookUrl: result.secretMaterial.webhookUrl,
           webhookSecret: result.secretMaterial.webhookSecret,
         });
       } else {
         pushToast({
-          title: "Trigger added",
-          body: "The routine schedule was saved.",
+          title: copy.triggerAdded,
+          body: copy.routineScheduleSaved,
           tone: "success",
         });
       }
@@ -533,8 +731,8 @@ export function RoutineDetail() {
     },
     onError: (error) => {
       pushToast({
-        title: "Failed to add trigger",
-        body: error instanceof Error ? error.message : "Paperclip could not create the trigger.",
+        title: copy.failedToAddTrigger,
+        body: error instanceof Error ? error.message : copy.triggerCreateError,
         tone: "error",
       });
     },
@@ -544,8 +742,8 @@ export function RoutineDetail() {
     mutationFn: ({ id, patch }: { id: string; patch: Record<string, unknown> }) => routinesApi.updateTrigger(id, patch),
     onSuccess: async () => {
       pushToast({
-        title: "Trigger saved",
-        body: "The routine cadence update was saved.",
+        title: copy.triggerSaved,
+        body: copy.triggerUpdateSaved,
         tone: "success",
       });
       await Promise.all([
@@ -556,8 +754,8 @@ export function RoutineDetail() {
     },
     onError: (error) => {
       pushToast({
-        title: "Failed to update trigger",
-        body: error instanceof Error ? error.message : "Paperclip could not update the trigger.",
+        title: copy.failedToUpdateTrigger,
+        body: error instanceof Error ? error.message : copy.triggerUpdateError,
         tone: "error",
       });
     },
@@ -567,7 +765,7 @@ export function RoutineDetail() {
     mutationFn: (id: string) => routinesApi.deleteTrigger(id),
     onSuccess: async () => {
       pushToast({
-        title: "Trigger deleted",
+        title: copy.triggerDeleted,
         tone: "success",
       });
       await Promise.all([
@@ -578,8 +776,8 @@ export function RoutineDetail() {
     },
     onError: (error) => {
       pushToast({
-        title: "Failed to delete trigger",
-        body: error instanceof Error ? error.message : "Paperclip could not delete the trigger.",
+        title: copy.failedToDeleteTrigger,
+        body: error instanceof Error ? error.message : copy.triggerDeleteError,
         tone: "error",
       });
     },
@@ -589,7 +787,7 @@ export function RoutineDetail() {
     mutationFn: (id: string): Promise<RotateRoutineTriggerResponse> => routinesApi.rotateTriggerSecret(id),
     onSuccess: async (result) => {
       setSecretMessage({
-        title: "Webhook secret rotated",
+        title: copy.webhookSecretRotated,
         webhookUrl: result.secretMaterial.webhookUrl,
         webhookSecret: result.secretMaterial.webhookSecret,
       });
@@ -600,8 +798,8 @@ export function RoutineDetail() {
     },
     onError: (error) => {
       pushToast({
-        title: "Failed to rotate webhook secret",
-        body: error instanceof Error ? error.message : "Paperclip could not rotate the webhook secret.",
+        title: copy.failedToRotateWebhookSecret,
+        body: error instanceof Error ? error.message : copy.webhookSecretRotateError,
         tone: "error",
       });
     },
@@ -641,7 +839,7 @@ export function RoutineDetail() {
   const currentProject = editDraft.projectId ? projectById.get(editDraft.projectId) ?? null : null;
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Repeat} message="Select a company to view routines." />;
+    return <EmptyState icon={Repeat} message={copy.selectCompany} />;
   }
 
   if (isLoading) {
@@ -651,7 +849,7 @@ export function RoutineDetail() {
   if (error || !routine) {
     return (
       <p className="pt-6 text-sm text-destructive">
-        {error instanceof Error ? error.message : "Routine not found"}
+        {error instanceof Error ? error.message : copy.routineNotFound}
       </p>
     );
   }
@@ -664,7 +862,7 @@ export function RoutineDetail() {
     isolatedWorkspacesEnabled: experimentalSettings?.enableIsolatedWorkspaces === true,
   });
   const automationToggleDisabled = updateRoutineStatus.isPending || routine.status === "archived";
-  const automationLabel = routine.status === "archived" ? "Archived" : automationEnabled ? "Active" : "Paused";
+  const automationLabel = routine.status === "archived" ? copy.archived : automationEnabled ? copy.active : copy.paused;
   const automationLabelClassName = routine.status === "archived"
     ? "text-muted-foreground"
     : automationEnabled
@@ -678,7 +876,7 @@ export function RoutineDetail() {
         <textarea
           ref={titleInputRef}
           className="flex-1 min-w-0 resize-none overflow-hidden bg-transparent text-xl font-bold outline-none placeholder:text-muted-foreground/50"
-          placeholder="Routine title"
+          placeholder={copy.routineTitle}
           rows={1}
           value={editDraft.title}
           onChange={(event) => {
@@ -721,7 +919,7 @@ export function RoutineDetail() {
             checked={automationEnabled}
             onCheckedChange={() => updateRoutineStatus.mutate(automationEnabled ? "paused" : "active")}
             disabled={automationToggleDisabled}
-            aria-label={automationEnabled ? "Pause automatic triggers" : "Enable automatic triggers"}
+            aria-label={automationEnabled ? copy.pauseAuto : copy.enableAuto}
           />
           <span className={`min-w-[3.75rem] text-sm font-medium ${automationLabelClassName}`}>
             {automationLabel}
@@ -734,21 +932,21 @@ export function RoutineDetail() {
         <div className="rounded-lg border border-blue-500/30 bg-blue-500/5 p-4 space-y-3 text-sm">
           <div>
             <p className="font-medium">{secretMessage.title}</p>
-            <p className="text-xs text-muted-foreground">Save this now. Paperclip will not show the secret value again.</p>
+            <p className="text-xs text-muted-foreground">{copy.saveNow}</p>
           </div>
           <div className="space-y-2">
             <div className="flex items-center gap-2">
               <Input value={secretMessage.webhookUrl} readOnly className="flex-1" />
-              <Button variant="outline" size="sm" onClick={() => copySecretValue("Webhook URL", secretMessage.webhookUrl)}>
+              <Button variant="outline" size="sm" onClick={() => copySecretValue(copy.webhookUrl, secretMessage.webhookUrl)}>
                 <Copy className="h-3.5 w-3.5 mr-1" />
-                URL
+                {copy.url}
               </Button>
             </div>
             <div className="flex items-center gap-2">
               <Input value={secretMessage.webhookSecret} readOnly className="flex-1" />
-              <Button variant="outline" size="sm" onClick={() => copySecretValue("Webhook secret", secretMessage.webhookSecret)}>
+              <Button variant="outline" size="sm" onClick={() => copySecretValue(copy.webhookSecret, secretMessage.webhookSecret)}>
                 <Copy className="h-3.5 w-3.5 mr-1" />
-                Secret
+                {copy.secret}
               </Button>
             </div>
           </div>
@@ -758,15 +956,15 @@ export function RoutineDetail() {
       {/* Assignment row */}
       <div className="overflow-x-auto overscroll-x-contain">
         <div className="inline-flex min-w-full flex-wrap items-center gap-2 text-sm text-muted-foreground sm:min-w-max sm:flex-nowrap">
-          <span>For</span>
+          <span>{copy.for}</span>
           <InlineEntitySelector
             ref={assigneeSelectorRef}
             value={editDraft.assigneeAgentId}
             options={assigneeOptions}
-            placeholder="Assignee"
-            noneLabel="No assignee"
-            searchPlaceholder="Search assignees..."
-            emptyMessage="No assignees found."
+            placeholder={copy.assignee}
+            noneLabel={copy.noAssignee}
+            searchPlaceholder={copy.searchAssignees}
+            emptyMessage={copy.noAssigneesFound}
             onChange={(assigneeAgentId) => {
               if (assigneeAgentId) trackRecentAssignee(assigneeAgentId);
               setEditDraft((current) => ({ ...current, assigneeAgentId }));
@@ -789,7 +987,7 @@ export function RoutineDetail() {
                   <span className="truncate">{option.label}</span>
                 )
               ) : (
-                <span className="text-muted-foreground">Assignee</span>
+                <span className="text-muted-foreground">{copy.assignee}</span>
               )
             }
             renderOption={(option) => {
@@ -803,15 +1001,15 @@ export function RoutineDetail() {
               );
             }}
           />
-          <span>in</span>
+          <span>{copy.in}</span>
           <InlineEntitySelector
             ref={projectSelectorRef}
             value={editDraft.projectId}
             options={projectOptions}
-            placeholder="Project"
-            noneLabel="No project"
-            searchPlaceholder="Search projects..."
-            emptyMessage="No projects found."
+            placeholder={copy.project}
+            noneLabel={copy.noProject}
+            searchPlaceholder={copy.searchProjects}
+            emptyMessage={copy.noProjectsFound}
             onChange={(projectId) => setEditDraft((current) => ({ ...current, projectId }))}
             onConfirm={() => descriptionEditorRef.current?.focus()}
             renderTriggerValue={(option) =>
@@ -824,7 +1022,7 @@ export function RoutineDetail() {
                   <span className="truncate">{option.label}</span>
                 </>
               ) : (
-                <span className="text-muted-foreground">Project</span>
+                <span className="text-muted-foreground">{copy.project}</span>
               )
             }
             renderOption={(option) => {
@@ -849,7 +1047,7 @@ export function RoutineDetail() {
         ref={descriptionEditorRef}
         value={editDraft.description}
         onChange={(description) => setEditDraft((current) => ({ ...current, description }))}
-        placeholder="Add instructions..."
+        placeholder={copy.addInstructions}
         bordered={false}
         contentClassName="min-h-[120px] text-[15px] leading-7"
         onSubmit={() => {
@@ -869,13 +1067,13 @@ export function RoutineDetail() {
       {/* Advanced delivery settings */}
       <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
         <CollapsibleTrigger className="flex w-full items-center justify-between text-left">
-          <span className="text-sm font-medium">Advanced delivery settings</span>
+          <span className="text-sm font-medium">{copy.advancedDelivery}</span>
           {advancedOpen ? <ChevronDown className="h-4 w-4 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 text-muted-foreground" />}
         </CollapsibleTrigger>
         <CollapsibleContent className="pt-3">
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Concurrency</p>
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{copy.concurrency}</p>
               <Select
                 value={editDraft.concurrencyPolicy}
                 onValueChange={(concurrencyPolicy) => setEditDraft((current) => ({ ...current, concurrencyPolicy }))}
@@ -885,14 +1083,14 @@ export function RoutineDetail() {
                 </SelectTrigger>
                 <SelectContent>
                   {concurrencyPolicies.map((value) => (
-                    <SelectItem key={value} value={value}>{value.replaceAll("_", " ")}</SelectItem>
+                    <SelectItem key={value} value={value}>{concurrencyPolicyLabel(value, uiLanguage)}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-              <p className="text-xs text-muted-foreground">{concurrencyPolicyDescriptions[editDraft.concurrencyPolicy]}</p>
+              <p className="text-xs text-muted-foreground">{concurrencyPolicyDescriptionsForLanguage[editDraft.concurrencyPolicy]}</p>
             </div>
             <div className="space-y-2">
-              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Catch-up</p>
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{copy.catchUp}</p>
               <Select
                 value={editDraft.catchUpPolicy}
                 onValueChange={(catchUpPolicy) => setEditDraft((current) => ({ ...current, catchUpPolicy }))}
@@ -902,11 +1100,11 @@ export function RoutineDetail() {
                 </SelectTrigger>
                 <SelectContent>
                   {catchUpPolicies.map((value) => (
-                    <SelectItem key={value} value={value}>{value.replaceAll("_", " ")}</SelectItem>
+                    <SelectItem key={value} value={value}>{catchUpPolicyLabel(value, uiLanguage)}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-              <p className="text-xs text-muted-foreground">{catchUpPolicyDescriptions[editDraft.catchUpPolicy]}</p>
+              <p className="text-xs text-muted-foreground">{catchUpPolicyDescriptionsForLanguage[editDraft.catchUpPolicy]}</p>
             </div>
           </div>
         </CollapsibleContent>
@@ -915,7 +1113,7 @@ export function RoutineDetail() {
       {/* Save bar */}
       <div className="flex items-center justify-between">
         {isEditDirty ? (
-          <span className="text-xs text-amber-600">Unsaved changes</span>
+          <span className="text-xs text-amber-600">{copy.unsavedChanges}</span>
         ) : (
           <span />
         )}
@@ -924,7 +1122,7 @@ export function RoutineDetail() {
           disabled={saveRoutine.isPending || !editDraft.title.trim() || !editDraft.projectId || !editDraft.assigneeAgentId}
         >
           <Save className="mr-2 h-4 w-4" />
-          Save routine
+          {copy.saveRoutine}
         </Button>
       </div>
 
@@ -935,26 +1133,26 @@ export function RoutineDetail() {
         <TabsList variant="line" className="w-full justify-start gap-1">
           <TabsTrigger value="triggers" className="gap-1.5">
             <Clock3 className="h-3.5 w-3.5" />
-            Triggers
+            {copy.triggers}
           </TabsTrigger>
           <TabsTrigger value="runs" className="gap-1.5">
             <Play className="h-3.5 w-3.5" />
-            Runs
+            {copy.runs}
             {hasLiveRun && <span className="h-2 w-2 rounded-full bg-blue-500 animate-pulse" />}
           </TabsTrigger>
-<TabsTrigger value="activity" className="gap-1.5">
+          <TabsTrigger value="activity" className="gap-1.5">
             <ActivityIcon className="h-3.5 w-3.5" />
-            Activity
+            {copy.activity}
           </TabsTrigger>
         </TabsList>
 
         <TabsContent value="triggers" className="space-y-4">
           {/* Add trigger form */}
           <div className="rounded-lg border border-border p-4 space-y-3">
-            <p className="text-sm font-medium">Add trigger</p>
+            <p className="text-sm font-medium">{copy.addTrigger}</p>
             <div className="grid gap-3 md:grid-cols-2">
               <div className="space-y-1.5">
-                <Label className="text-xs">Kind</Label>
+                <Label className="text-xs">{copy.kind}</Label>
                 <Select value={newTrigger.kind} onValueChange={(kind) => setNewTrigger((current) => ({ ...current, kind }))}>
                   <SelectTrigger>
                     <SelectValue />
@@ -962,7 +1160,7 @@ export function RoutineDetail() {
                   <SelectContent>
                     {triggerKinds.map((kind) => (
                       <SelectItem key={kind} value={kind} disabled={kind === "webhook"}>
-                        {kind}{kind === "webhook" ? " — COMING SOON" : ""}
+                        {triggerKindLabel(kind, uiLanguage)}{kind === "webhook" ? ` - ${copy.comingSoon}` : ""}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -970,7 +1168,7 @@ export function RoutineDetail() {
               </div>
               {newTrigger.kind === "schedule" && (
                 <div className="md:col-span-2 space-y-1.5">
-                  <Label className="text-xs">Schedule</Label>
+                  <Label className="text-xs">{copy.schedule}</Label>
                   <ScheduleEditor
                     value={newTrigger.cronExpression}
                     onChange={(cronExpression) => setNewTrigger((current) => ({ ...current, cronExpression }))}
@@ -980,22 +1178,22 @@ export function RoutineDetail() {
               {newTrigger.kind === "webhook" && (
                 <>
                   <div className="space-y-1.5">
-                    <Label className="text-xs">Signing mode</Label>
+                    <Label className="text-xs">{copy.signingMode}</Label>
                     <Select value={newTrigger.signingMode} onValueChange={(signingMode) => setNewTrigger((current) => ({ ...current, signingMode }))}>
                       <SelectTrigger>
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
                         {signingModes.map((mode) => (
-                          <SelectItem key={mode} value={mode}>{mode}</SelectItem>
+                          <SelectItem key={mode} value={mode}>{signingModeLabel(mode, uiLanguage)}</SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
-                    <p className="text-xs text-muted-foreground">{signingModeDescriptions[newTrigger.signingMode]}</p>
+                    <p className="text-xs text-muted-foreground">{signingModeDescriptionsForLanguage[newTrigger.signingMode]}</p>
                   </div>
                   {!SIGNING_MODES_WITHOUT_REPLAY_WINDOW.has(newTrigger.signingMode) && (
                     <div className="space-y-1.5">
-                      <Label className="text-xs">Replay window (seconds)</Label>
+                      <Label className="text-xs">{copy.replayWindow}</Label>
                       <Input value={newTrigger.replayWindowSec} onChange={(event) => setNewTrigger((current) => ({ ...current, replayWindowSec: event.target.value }))} />
                     </div>
                   )}
@@ -1004,14 +1202,14 @@ export function RoutineDetail() {
             </div>
             <div className="flex items-center justify-end">
               <Button size="sm" onClick={() => createTrigger.mutate()} disabled={createTrigger.isPending}>
-                {createTrigger.isPending ? "Adding..." : "Add trigger"}
+                {createTrigger.isPending ? copy.adding : copy.addTriggerButton}
               </Button>
             </div>
           </div>
 
           {/* Existing triggers */}
           {routine.triggers.length === 0 ? (
-            <p className="text-xs text-muted-foreground">No triggers configured yet.</p>
+            <p className="text-xs text-muted-foreground">{copy.noTriggers}</p>
           ) : (
             <div className="space-y-3">
               {routine.triggers.map((trigger) => (
@@ -1032,15 +1230,15 @@ export function RoutineDetail() {
             <LiveRunWidget issueId={activeIssueId} companyId={routine.companyId} />
           )}
           {(routineRuns ?? []).length === 0 ? (
-            <p className="text-xs text-muted-foreground">No runs yet.</p>
+            <p className="text-xs text-muted-foreground">{copy.noRuns}</p>
           ) : (
             <div className="border border-border rounded-lg divide-y divide-border">
               {(routineRuns ?? []).map((run) => (
                 <div key={run.id} className="flex items-center justify-between px-3 py-2 text-sm">
                   <div className="flex items-center gap-2 min-w-0">
-                    <Badge variant="outline" className="shrink-0">{run.source}</Badge>
+                    <Badge variant="outline" className="shrink-0">{routineRunSourceLabel(run.source, uiLanguage)}</Badge>
                     <Badge variant={run.status === "failed" ? "destructive" : "secondary"} className="shrink-0">
-                      {run.status.replaceAll("_", " ")}
+                      {routineStatusLabel(run.status, uiLanguage)}
                     </Badge>
                     {run.trigger && (
                       <span className="text-muted-foreground truncate">{run.trigger.label ?? run.trigger.kind}</span>
@@ -1060,7 +1258,7 @@ export function RoutineDetail() {
 
         <TabsContent value="activity">
           {(activity ?? []).length === 0 ? (
-            <p className="text-xs text-muted-foreground">No activity yet.</p>
+            <p className="text-xs text-muted-foreground">{copy.noActivity}</p>
           ) : (
             <div className="border border-border rounded-lg divide-y divide-border">
               {(activity ?? []).map((event) => (

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -10,11 +10,13 @@ import { issuesApi } from "../api/issues";
 import { heartbeatsApi } from "../api/heartbeats";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { useToast } from "../context/ToastContext";
 import { queryKeys } from "../lib/queryKeys";
 import { groupBy } from "../lib/groupBy";
 import { createIssueDetailLocationState } from "../lib/issueDetailBreadcrumb";
 import { getRecentAssigneeIds, sortAgentsByRecency, trackRecentAssignee } from "../lib/recent-assignees";
+import { readStoredUiLanguage, textFor, type UiLanguage } from "../lib/ui-language";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { EmptyState } from "../components/EmptyState";
 import { IssuesList } from "../components/IssuesList";
@@ -53,15 +55,23 @@ import type { RoutineListItem, RoutineVariable } from "@paperclipai/shared";
 
 const concurrencyPolicies = ["coalesce_if_active", "always_enqueue", "skip_if_active"];
 const catchUpPolicies = ["skip_missed", "enqueue_missed_with_cap"];
-const concurrencyPolicyDescriptions: Record<string, string> = {
-  coalesce_if_active: "If a run is already active, keep just one follow-up run queued.",
-  always_enqueue: "Queue every trigger occurrence, even if the routine is already running.",
-  skip_if_active: "Drop new trigger occurrences while a run is still active.",
-};
-const catchUpPolicyDescriptions: Record<string, string> = {
-  skip_missed: "Ignore windows that were missed while the scheduler or routine was paused.",
-  enqueue_missed_with_cap: "Catch up missed schedule windows in capped batches after recovery.",
-};
+
+function routineStatusLabel(value: string | null | undefined, uiLanguage: UiLanguage) {
+  if (!value) return null;
+  const labels: Record<string, { en: string; zh: string }> = {
+    active: { en: "active", zh: "运行中" },
+    paused: { en: "paused", zh: "已暂停" },
+    archived: { en: "archived", zh: "已归档" },
+    queued: { en: "queued", zh: "排队中" },
+    running: { en: "running", zh: "运行中" },
+    succeeded: { en: "succeeded", zh: "已成功" },
+    failed: { en: "failed", zh: "失败" },
+    timed_out: { en: "timed out", zh: "超时" },
+  };
+  const label = labels[value];
+  if (label) return uiLanguage === "zh-CN" ? label.zh : label.en;
+  return value.replaceAll("_", " ");
+}
 
 function autoResizeTextarea(element: HTMLTextAreaElement | null) {
   if (!element) return;
@@ -70,8 +80,9 @@ function autoResizeTextarea(element: HTMLTextAreaElement | null) {
 }
 
 function formatLastRunTimestamp(value: Date | string | null | undefined) {
-  if (!value) return "Never";
-  return new Date(value).toLocaleString();
+  const uiLanguage = readStoredUiLanguage();
+  if (!value) return textFor(uiLanguage, { en: "Never", "zh-CN": "从未运行" });
+  return new Date(value).toLocaleString(uiLanguage === "zh-CN" ? "zh-CN" : "en-US");
 }
 
 function nextRoutineStatus(currentStatus: string, enabled: boolean) {
@@ -112,17 +123,13 @@ function saveRoutineViewState(key: string, state: RoutineViewState) {
   localStorage.setItem(key, JSON.stringify(state));
 }
 
-function formatRoutineRunStatus(value: string | null | undefined) {
-  if (!value) return null;
-  return value.replaceAll("_", " ");
-}
-
 export function buildRoutineGroups(
   routines: RoutineListItem[],
   groupByValue: RoutineGroupBy,
   projectById: Map<string, { name: string }>,
   agentById: Map<string, { name: string }>,
 ): RoutineGroup[] {
+  const uiLanguage = readStoredUiLanguage();
   if (groupByValue === "none") {
     return [{ key: "__all", label: null, items: routines }];
   }
@@ -131,13 +138,19 @@ export function buildRoutineGroups(
     const groups = groupBy(routines, (routine) => routine.projectId ?? "__no_project");
     return Object.keys(groups)
       .sort((left, right) => {
-        const leftLabel = left === "__no_project" ? "No project" : (projectById.get(left)?.name ?? "Unknown project");
-        const rightLabel = right === "__no_project" ? "No project" : (projectById.get(right)?.name ?? "Unknown project");
+        const leftLabel = left === "__no_project"
+          ? textFor(uiLanguage, { en: "No project", "zh-CN": "无项目" })
+          : (projectById.get(left)?.name ?? textFor(uiLanguage, { en: "Unknown project", "zh-CN": "未知项目" }));
+        const rightLabel = right === "__no_project"
+          ? textFor(uiLanguage, { en: "No project", "zh-CN": "无项目" })
+          : (projectById.get(right)?.name ?? textFor(uiLanguage, { en: "Unknown project", "zh-CN": "未知项目" }));
         return leftLabel.localeCompare(rightLabel);
       })
       .map((key) => ({
         key,
-        label: key === "__no_project" ? "No project" : (projectById.get(key)?.name ?? "Unknown project"),
+        label: key === "__no_project"
+          ? textFor(uiLanguage, { en: "No project", "zh-CN": "无项目" })
+          : (projectById.get(key)?.name ?? textFor(uiLanguage, { en: "Unknown project", "zh-CN": "未知项目" })),
         items: groups[key]!,
       }));
   }
@@ -145,13 +158,19 @@ export function buildRoutineGroups(
   const groups = groupBy(routines, (routine) => routine.assigneeAgentId ?? "__unassigned");
   return Object.keys(groups)
     .sort((left, right) => {
-      const leftLabel = left === "__unassigned" ? "Unassigned" : (agentById.get(left)?.name ?? "Unknown agent");
-      const rightLabel = right === "__unassigned" ? "Unassigned" : (agentById.get(right)?.name ?? "Unknown agent");
+      const leftLabel = left === "__unassigned"
+        ? textFor(uiLanguage, { en: "Unassigned", "zh-CN": "未分配" })
+        : (agentById.get(left)?.name ?? textFor(uiLanguage, { en: "Unknown agent", "zh-CN": "未知智能体" }));
+      const rightLabel = right === "__unassigned"
+        ? textFor(uiLanguage, { en: "Unassigned", "zh-CN": "未分配" })
+        : (agentById.get(right)?.name ?? textFor(uiLanguage, { en: "Unknown agent", "zh-CN": "未知智能体" }));
       return leftLabel.localeCompare(rightLabel);
     })
     .map((key) => ({
       key,
-      label: key === "__unassigned" ? "Unassigned" : (agentById.get(key)?.name ?? "Unknown agent"),
+      label: key === "__unassigned"
+        ? textFor(uiLanguage, { en: "Unassigned", "zh-CN": "未分配" })
+        : (agentById.get(key)?.name ?? textFor(uiLanguage, { en: "Unknown agent", "zh-CN": "未知智能体" })),
       items: groups[key]!,
     }));
 }
@@ -181,11 +200,29 @@ function RoutineListRow({
   onToggleEnabled: (routine: RoutineListItem, enabled: boolean) => void;
   onToggleArchived: (routine: RoutineListItem) => void;
 }) {
+  const { uiLanguage } = useGeneralSettings();
   const enabled = routine.status === "active";
   const isArchived = routine.status === "archived";
   const isStatusPending = statusMutationRoutineId === routine.id;
   const project = routine.projectId ? projectById.get(routine.projectId) ?? null : null;
   const agent = routine.assigneeAgentId ? agentById.get(routine.assigneeAgentId) ?? null : null;
+  const copy = {
+    archived: textFor(uiLanguage, { en: "archived", "zh-CN": "已归档" }),
+    paused: textFor(uiLanguage, { en: "paused", "zh-CN": "已暂停" }),
+    unknownProject: textFor(uiLanguage, { en: "Unknown project", "zh-CN": "未知项目" }),
+    unknownAgent: textFor(uiLanguage, { en: "Unknown agent", "zh-CN": "未知智能体" }),
+    archivedState: textFor(uiLanguage, { en: "Archived", "zh-CN": "已归档" }),
+    on: textFor(uiLanguage, { en: "On", "zh-CN": "开" }),
+    off: textFor(uiLanguage, { en: "Off", "zh-CN": "关" }),
+    moreActions: textFor(uiLanguage, { en: "More actions for", "zh-CN": "更多操作：" }),
+    edit: textFor(uiLanguage, { en: "Edit", "zh-CN": "编辑" }),
+    running: textFor(uiLanguage, { en: "Running...", "zh-CN": "运行中..." }),
+    runNow: textFor(uiLanguage, { en: "Run now", "zh-CN": "立即运行" }),
+    pause: textFor(uiLanguage, { en: "Pause", "zh-CN": "暂停" }),
+    enable: textFor(uiLanguage, { en: "Enable", "zh-CN": "启用" }),
+    restore: textFor(uiLanguage, { en: "Restore", "zh-CN": "恢复" }),
+    archive: textFor(uiLanguage, { en: "Archive", "zh-CN": "归档" }),
+  };
 
   return (
     <div
@@ -197,7 +234,7 @@ function RoutineListRow({
           <span className="truncate text-sm font-medium">{routine.title}</span>
           {(isArchived || routine.status === "paused") ? (
             <span className="text-xs text-muted-foreground">
-              {isArchived ? "archived" : "paused"}
+              {isArchived ? copy.archived : copy.paused}
             </span>
           ) : null}
         </div>
@@ -207,15 +244,15 @@ function RoutineListRow({
               className="h-2.5 w-2.5 shrink-0 rounded-sm"
               style={{ backgroundColor: project?.color ?? "#64748b" }}
             />
-            <span>{project?.name ?? "Unknown project"}</span>
+            <span>{project?.name ?? copy.unknownProject}</span>
           </span>
           <span className="flex items-center gap-2">
             {agent?.icon ? <AgentIcon icon={agent.icon} className="h-3.5 w-3.5 shrink-0" /> : null}
-            <span>{agent?.name ?? "Unknown agent"}</span>
+            <span>{agent?.name ?? copy.unknownAgent}</span>
           </span>
           <span>
             {formatLastRunTimestamp(routine.lastRun?.triggeredAt)}
-            {routine.lastRun ? ` · ${formatRoutineRunStatus(routine.lastRun.status)}` : ""}
+            {routine.lastRun ? ` · ${routineStatusLabel(routine.lastRun.status, uiLanguage)}` : ""}
           </span>
         </div>
       </div>
@@ -227,41 +264,43 @@ function RoutineListRow({
             checked={enabled}
             onCheckedChange={() => onToggleEnabled(routine, enabled)}
             disabled={isStatusPending || isArchived}
-            aria-label={enabled ? `Disable ${routine.title}` : `Enable ${routine.title}`}
+            aria-label={enabled
+              ? `${textFor(uiLanguage, { en: "Disable", "zh-CN": "停用" })} ${routine.title}`
+              : `${textFor(uiLanguage, { en: "Enable", "zh-CN": "启用" })} ${routine.title}`}
           />
           <span className="w-12 text-xs text-muted-foreground">
-            {isArchived ? "Archived" : enabled ? "On" : "Off"}
+            {isArchived ? copy.archivedState : enabled ? copy.on : copy.off}
           </span>
         </div>
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon-sm" aria-label={`More actions for ${routine.title}`}>
+            <Button variant="ghost" size="icon-sm" aria-label={`${copy.moreActions} ${routine.title}`}>
               <MoreHorizontal className="h-4 w-4" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem onClick={() => onNavigate(routine.id)}>
-              Edit
+              {copy.edit}
             </DropdownMenuItem>
             <DropdownMenuItem
               disabled={runningRoutineId === routine.id || isArchived}
               onClick={() => onRunNow(routine)}
             >
-              {runningRoutineId === routine.id ? "Running..." : "Run now"}
+              {runningRoutineId === routine.id ? copy.running : copy.runNow}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={() => onToggleEnabled(routine, enabled)}
               disabled={isStatusPending || isArchived}
             >
-              {enabled ? "Pause" : "Enable"}
+              {enabled ? copy.pause : copy.enable}
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => onToggleArchived(routine)}
               disabled={isStatusPending}
             >
-              {routine.status === "archived" ? "Restore" : "Archive"}
+              {routine.status === "archived" ? copy.restore : copy.archive}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -273,6 +312,7 @@ function RoutineListRow({
 export function Routines() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const { uiLanguage } = useGeneralSettings();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -310,10 +350,93 @@ export function Routines() {
     ? `paperclip:routines-view:${selectedCompanyId}`
     : "paperclip:routines-view";
   const [routineViewState, setRoutineViewState] = useState<RoutineViewState>(() => getRoutineViewState(routineViewStateKey));
+  const concurrencyPolicyDescriptions: Record<string, string> = {
+    coalesce_if_active: textFor(uiLanguage, {
+      en: "If a run is already active, keep just one follow-up run queued.",
+      "zh-CN": "如果当前已有运行在进行中，只保留一个后续待运行任务。",
+    }),
+    always_enqueue: textFor(uiLanguage, {
+      en: "Queue every trigger occurrence, even if the routine is already running.",
+      "zh-CN": "即使例行任务已经在运行，也将每次触发都加入队列。",
+    }),
+    skip_if_active: textFor(uiLanguage, {
+      en: "Drop new trigger occurrences while a run is still active.",
+      "zh-CN": "当已有运行处于活动状态时，忽略新的触发。",
+    }),
+  };
+  const catchUpPolicyDescriptions: Record<string, string> = {
+    skip_missed: textFor(uiLanguage, {
+      en: "Ignore windows that were missed while the scheduler or routine was paused.",
+      "zh-CN": "忽略调度器或例行任务暂停期间错过的时间窗口。",
+    }),
+    enqueue_missed_with_cap: textFor(uiLanguage, {
+      en: "Catch up missed schedule windows in capped batches after recovery.",
+      "zh-CN": "恢复后按上限批量补跑错过的调度窗口。",
+    }),
+  };
+  const concurrencyPolicyLabels: Record<string, string> = {
+    coalesce_if_active: textFor(uiLanguage, { en: "Coalesce if active", "zh-CN": "活动时合并" }),
+    always_enqueue: textFor(uiLanguage, { en: "Always enqueue", "zh-CN": "始终排队" }),
+    skip_if_active: textFor(uiLanguage, { en: "Skip if active", "zh-CN": "活动时跳过" }),
+  };
+  const catchUpPolicyLabels: Record<string, string> = {
+    skip_missed: textFor(uiLanguage, { en: "Skip missed", "zh-CN": "跳过错过的" }),
+    enqueue_missed_with_cap: textFor(uiLanguage, { en: "Enqueue missed with cap", "zh-CN": "按上限补入队列" }),
+  };
+  const copy = {
+    routines: textFor(uiLanguage, { en: "Routines", "zh-CN": "例行任务" }),
+    beta: textFor(uiLanguage, { en: "Beta", "zh-CN": "测试版" }),
+    pageDescription: textFor(uiLanguage, {
+      en: "Recurring work definitions that materialize into auditable execution issues.",
+      "zh-CN": "定义可重复执行的工作，并将其转化为可审计的执行任务。",
+    }),
+    createRoutine: textFor(uiLanguage, { en: "Create routine", "zh-CN": "新建例行任务" }),
+    recentRuns: textFor(uiLanguage, { en: "Recent Runs", "zh-CN": "最近运行" }),
+    routineCount: (count: number) => uiLanguage === "zh-CN" ? `${count} 个例行任务` : `${count} routine${count === 1 ? "" : "s"}`,
+    group: textFor(uiLanguage, { en: "Group", "zh-CN": "分组" }),
+    project: textFor(uiLanguage, { en: "Project", "zh-CN": "项目" }),
+    agent: textFor(uiLanguage, { en: "Agent", "zh-CN": "智能体" }),
+    none: textFor(uiLanguage, { en: "None", "zh-CN": "无" }),
+    newRoutine: textFor(uiLanguage, { en: "New routine", "zh-CN": "新建例行任务" }),
+    createHint: textFor(uiLanguage, {
+      en: "Define the recurring work first. Trigger setup comes next on the detail page.",
+      "zh-CN": "先定义重复执行的工作内容，触发器设置稍后在详情页完成。",
+    }),
+    cancel: textFor(uiLanguage, { en: "Cancel", "zh-CN": "取消" }),
+    routineTitle: textFor(uiLanguage, { en: "Routine title", "zh-CN": "例行任务标题" }),
+    for: textFor(uiLanguage, { en: "For", "zh-CN": "分配给" }),
+    assignee: textFor(uiLanguage, { en: "Assignee", "zh-CN": "负责人" }),
+    noAssignee: textFor(uiLanguage, { en: "No assignee", "zh-CN": "未分配" }),
+    searchAssignees: textFor(uiLanguage, { en: "Search assignees...", "zh-CN": "搜索负责人..." }),
+    noAssigneesFound: textFor(uiLanguage, { en: "No assignees found.", "zh-CN": "未找到负责人。" }),
+    in: textFor(uiLanguage, { en: "in", "zh-CN": "在" }),
+    noProject: textFor(uiLanguage, { en: "No project", "zh-CN": "无项目" }),
+    searchProjects: textFor(uiLanguage, { en: "Search projects...", "zh-CN": "搜索项目..." }),
+    noProjectsFound: textFor(uiLanguage, { en: "No projects found.", "zh-CN": "未找到项目。" }),
+    addInstructions: textFor(uiLanguage, { en: "Add instructions...", "zh-CN": "补充说明..." }),
+    advancedSettings: textFor(uiLanguage, { en: "Advanced delivery settings", "zh-CN": "高级投递设置" }),
+    advancedHint: textFor(uiLanguage, {
+      en: "Keep policy controls secondary to the work definition.",
+      "zh-CN": "策略控制项应作为工作定义的补充设置。",
+    }),
+    concurrency: textFor(uiLanguage, { en: "Concurrency", "zh-CN": "并发" }),
+    catchUp: textFor(uiLanguage, { en: "Catch-up", "zh-CN": "补跑" }),
+    footerHint: textFor(uiLanguage, {
+      en: "After creation, Paperclip takes you straight to trigger setup for schedules, webhooks, or internal runs.",
+      "zh-CN": "创建后，Paperclip 会直接带你进入触发器设置页面，可配置定时、Webhook 或内部运行。",
+    }),
+    creating: textFor(uiLanguage, { en: "Creating...", "zh-CN": "创建中..." }),
+    failedToCreateRoutine: textFor(uiLanguage, { en: "Failed to create routine", "zh-CN": "创建例行任务失败" }),
+    failedToLoadRoutines: textFor(uiLanguage, { en: "Failed to load routines", "zh-CN": "加载例行任务失败" }),
+    noRoutinesYet: textFor(uiLanguage, {
+      en: "No routines yet. Use Create routine to define the first recurring workflow.",
+      "zh-CN": "还没有例行任务。点击“新建例行任务”来定义第一个重复工作流。",
+    }),
+  };
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Routines" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy.routines }]);
+  }, [copy.routines, setBreadcrumbs]);
 
   useEffect(() => {
     setRoutineViewState(getRoutineViewState(routineViewStateKey));
@@ -376,8 +499,8 @@ export function Routines() {
       setAdvancedOpen(false);
       await queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) });
       pushToast({
-        title: "Routine created",
-        body: "Add the first trigger to turn it into a live workflow.",
+        title: textFor(uiLanguage, { en: "Routine created", "zh-CN": "例行任务已创建" }),
+        body: textFor(uiLanguage, { en: "Add the first trigger to turn it into a live workflow.", "zh-CN": "接下来添加第一个触发器，让它成为可运行的工作流。" }),
         tone: "success",
       });
       navigate(`/routines/${routine.id}?tab=triggers`);
@@ -407,8 +530,8 @@ export function Routines() {
     },
     onError: (mutationError) => {
       pushToast({
-        title: "Failed to update routine",
-        body: mutationError instanceof Error ? mutationError.message : "Paperclip could not update the routine.",
+        title: textFor(uiLanguage, { en: "Failed to update routine", "zh-CN": "更新例行任务失败" }),
+        body: mutationError instanceof Error ? mutationError.message : textFor(uiLanguage, { en: "Paperclip could not update the routine.", "zh-CN": "Paperclip 无法更新这个例行任务。" }),
         tone: "error",
       });
     },
@@ -440,8 +563,8 @@ export function Routines() {
     },
     onError: (mutationError) => {
       pushToast({
-        title: "Routine run failed",
-        body: mutationError instanceof Error ? mutationError.message : "Paperclip could not start the routine run.",
+        title: textFor(uiLanguage, { en: "Routine run failed", "zh-CN": "例行任务运行失败" }),
+        body: mutationError instanceof Error ? mutationError.message : textFor(uiLanguage, { en: "Paperclip could not start the routine run.", "zh-CN": "Paperclip 无法启动这次例行任务运行。" }),
         tone: "error",
       });
     },
@@ -491,11 +614,11 @@ export function Routines() {
   const recentRunsIssueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(
-        "Recent Runs",
+        copy.recentRuns,
         buildRoutinesTabHref("runs"),
         "issues",
       ),
-    [],
+    [copy.recentRuns],
   );
   const runDialogProject = runDialogRoutine?.projectId ? projectById.get(runDialogRoutine.projectId) ?? null : null;
   const currentAssignee = draft.assigneeAgentId ? agentById.get(draft.assigneeAgentId) ?? null : null;
@@ -545,7 +668,7 @@ export function Routines() {
   }
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Repeat} message="Select a company to view routines." />;
+    return <EmptyState icon={Repeat} message={textFor(uiLanguage, { en: "Select a company to view routines.", "zh-CN": "请先选择公司以查看例行任务。" })} />;
   }
 
   if (isLoading) {
@@ -557,16 +680,16 @@ export function Routines() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div className="space-y-1">
           <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
-            Routines
-            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">Beta</span>
+            {copy.routines}
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">{copy.beta}</span>
           </h1>
           <p className="text-sm text-muted-foreground">
-            Recurring work definitions that materialize into auditable execution issues.
+            {copy.pageDescription}
           </p>
         </div>
         <Button onClick={() => setComposerOpen(true)}>
           <Plus className="mr-2 h-4 w-4" />
-          Create routine
+          {copy.createRoutine}
         </Button>
       </div>
 
@@ -576,28 +699,28 @@ export function Routines() {
           value={activeTab}
           onValueChange={handleTabChange}
           items={[
-            { value: "routines", label: "Routines" },
-            { value: "runs", label: "Recent Runs" },
+            { value: "routines", label: copy.routines },
+            { value: "runs", label: copy.recentRuns },
           ]}
         />
         <TabsContent value="routines" className="space-y-4">
           <div className="flex items-center justify-between gap-3">
             <p className="text-sm text-muted-foreground">
-              {(routines ?? []).length} routine{(routines ?? []).length === 1 ? "" : "s"}
+              {copy.routineCount((routines ?? []).length)}
             </p>
             <Popover>
               <PopoverTrigger asChild>
                 <Button variant="ghost" size="sm" className="text-xs">
                   <Layers className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
-                  <span className="hidden sm:inline">Group</span>
+                  <span className="hidden sm:inline">{copy.group}</span>
                 </Button>
               </PopoverTrigger>
               <PopoverContent align="end" className="w-44 p-0">
                 <div className="p-2 space-y-0.5">
                   {([
-                    ["project", "Project"],
-                    ["assignee", "Agent"],
-                    ["none", "None"],
+                    ["project", copy.project],
+                    ["assignee", copy.agent],
+                    ["none", copy.none],
                   ] as const).map(([value, label]) => (
                     <button
                       key={value}
@@ -646,9 +769,9 @@ export function Routines() {
         >
           <div className="shrink-0 flex flex-wrap items-center justify-between gap-3 border-b border-border/60 px-5 py-3">
             <div>
-              <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">New routine</p>
+              <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">{copy.newRoutine}</p>
               <p className="text-sm text-muted-foreground">
-                Define the recurring work first. Trigger setup comes next on the detail page.
+                {copy.createHint}
               </p>
             </div>
             <Button
@@ -660,7 +783,7 @@ export function Routines() {
               }}
               disabled={createRoutine.isPending}
             >
-              Cancel
+              {copy.cancel}
             </Button>
           </div>
 
@@ -669,7 +792,7 @@ export function Routines() {
               <textarea
                 ref={titleInputRef}
                 className="w-full resize-none overflow-hidden bg-transparent text-xl font-semibold outline-none placeholder:text-muted-foreground/50"
-                placeholder="Routine title"
+                placeholder={copy.routineTitle}
                 rows={1}
                 value={draft.title}
                 onChange={(event) => {
@@ -702,15 +825,15 @@ export function Routines() {
             <div className="px-5 pb-3">
               <div className="overflow-x-auto overscroll-x-contain">
                 <div className="inline-flex min-w-full flex-wrap items-center gap-2 text-sm text-muted-foreground sm:min-w-max sm:flex-nowrap">
-                  <span>For</span>
+                  <span>{copy.for}</span>
                   <InlineEntitySelector
                     ref={assigneeSelectorRef}
                     value={draft.assigneeAgentId}
                     options={assigneeOptions}
-                    placeholder="Assignee"
-                    noneLabel="No assignee"
-                    searchPlaceholder="Search assignees..."
-                    emptyMessage="No assignees found."
+                    placeholder={copy.assignee}
+                    noneLabel={copy.noAssignee}
+                    searchPlaceholder={copy.searchAssignees}
+                    emptyMessage={copy.noAssigneesFound}
                     onChange={(assigneeAgentId) => {
                       if (assigneeAgentId) trackRecentAssignee(assigneeAgentId);
                       setDraft((current) => ({ ...current, assigneeAgentId }));
@@ -733,7 +856,7 @@ export function Routines() {
                           <span className="truncate">{option.label}</span>
                         )
                       ) : (
-                        <span className="text-muted-foreground">Assignee</span>
+                        <span className="text-muted-foreground">{copy.assignee}</span>
                       )
                     }
                     renderOption={(option) => {
@@ -747,15 +870,15 @@ export function Routines() {
                       );
                     }}
                   />
-                  <span>in</span>
+                  <span>{copy.in}</span>
                   <InlineEntitySelector
                     ref={projectSelectorRef}
                     value={draft.projectId}
                     options={projectOptions}
-                    placeholder="Project"
-                    noneLabel="No project"
-                    searchPlaceholder="Search projects..."
-                    emptyMessage="No projects found."
+                    placeholder={copy.project}
+                    noneLabel={copy.noProject}
+                    searchPlaceholder={copy.searchProjects}
+                    emptyMessage={copy.noProjectsFound}
                     onChange={(projectId) => setDraft((current) => ({ ...current, projectId }))}
                     onConfirm={() => descriptionEditorRef.current?.focus()}
                     renderTriggerValue={(option) =>
@@ -768,7 +891,7 @@ export function Routines() {
                           <span className="truncate">{option.label}</span>
                         </>
                       ) : (
-                        <span className="text-muted-foreground">Project</span>
+                        <span className="text-muted-foreground">{copy.project}</span>
                       )
                     }
                     renderOption={(option) => {
@@ -794,7 +917,7 @@ export function Routines() {
                 ref={descriptionEditorRef}
                 value={draft.description}
                 onChange={(description) => setDraft((current) => ({ ...current, description }))}
-                placeholder="Add instructions..."
+                placeholder={copy.addInstructions}
                 bordered={false}
                 contentClassName="min-h-[160px] text-sm text-muted-foreground"
                 onSubmit={() => {
@@ -818,15 +941,15 @@ export function Routines() {
               <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
                 <CollapsibleTrigger className="flex w-full items-center justify-between text-left">
                   <div>
-                    <p className="text-sm font-medium">Advanced delivery settings</p>
-                    <p className="text-sm text-muted-foreground">Keep policy controls secondary to the work definition.</p>
+                    <p className="text-sm font-medium">{copy.advancedSettings}</p>
+                    <p className="text-sm text-muted-foreground">{copy.advancedHint}</p>
                   </div>
                   {advancedOpen ? <ChevronDown className="h-4 w-4 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 text-muted-foreground" />}
                 </CollapsibleTrigger>
                 <CollapsibleContent className="pt-3">
                   <div className="grid gap-4 md:grid-cols-2">
                     <div className="space-y-2">
-                      <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Concurrency</p>
+                      <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{copy.concurrency}</p>
                       <Select
                         value={draft.concurrencyPolicy}
                         onValueChange={(concurrencyPolicy) => setDraft((current) => ({ ...current, concurrencyPolicy }))}
@@ -836,14 +959,14 @@ export function Routines() {
                         </SelectTrigger>
                         <SelectContent>
                           {concurrencyPolicies.map((value) => (
-                            <SelectItem key={value} value={value}>{value.replaceAll("_", " ")}</SelectItem>
+                            <SelectItem key={value} value={value}>{concurrencyPolicyLabels[value]}</SelectItem>
                           ))}
                         </SelectContent>
                       </Select>
                       <p className="text-xs text-muted-foreground">{concurrencyPolicyDescriptions[draft.concurrencyPolicy]}</p>
                     </div>
                     <div className="space-y-2">
-                      <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Catch-up</p>
+                      <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{copy.catchUp}</p>
                       <Select
                         value={draft.catchUpPolicy}
                         onValueChange={(catchUpPolicy) => setDraft((current) => ({ ...current, catchUpPolicy }))}
@@ -853,7 +976,7 @@ export function Routines() {
                         </SelectTrigger>
                         <SelectContent>
                           {catchUpPolicies.map((value) => (
-                            <SelectItem key={value} value={value}>{value.replaceAll("_", " ")}</SelectItem>
+                            <SelectItem key={value} value={value}>{catchUpPolicyLabels[value]}</SelectItem>
                           ))}
                         </SelectContent>
                       </Select>
@@ -867,7 +990,7 @@ export function Routines() {
 
           <div className="shrink-0 flex flex-col gap-3 border-t border-border/60 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="text-sm text-muted-foreground">
-              After creation, Paperclip takes you straight to trigger setup for schedules, webhooks, or internal runs.
+              {copy.footerHint}
             </div>
             <div className="flex flex-col gap-2 sm:items-end">
               <Button
@@ -880,11 +1003,11 @@ export function Routines() {
                 }
               >
                 <Plus className="mr-2 h-4 w-4" />
-                {createRoutine.isPending ? "Creating..." : "Create routine"}
+                {createRoutine.isPending ? copy.creating : copy.createRoutine}
               </Button>
               {createRoutine.isError ? (
                 <p className="text-sm text-destructive">
-                  {createRoutine.error instanceof Error ? createRoutine.error.message : "Failed to create routine"}
+                  {createRoutine.error instanceof Error ? createRoutine.error.message : copy.failedToCreateRoutine}
                 </p>
               ) : null}
             </div>
@@ -895,7 +1018,7 @@ export function Routines() {
       {error ? (
         <Card>
           <CardContent className="pt-6 text-sm text-destructive">
-            {error instanceof Error ? error.message : "Failed to load routines"}
+            {error instanceof Error ? error.message : copy.failedToLoadRoutines}
           </CardContent>
         </Card>
       ) : null}
@@ -906,7 +1029,7 @@ export function Routines() {
             <div className="py-12">
               <EmptyState
                 icon={Repeat}
-                message="No routines yet. Use Create routine to define the first recurring workflow."
+                message={copy.noRoutinesYet}
               />
             </div>
           ) : (


### PR DESCRIPTION
## Summary
- add shared zh-CN UI language plumbing and persist/read the selected language across the board UI
- localize the remaining frontend surfaces called out in review: costs, activity, new issue, onboarding, and project configuration
- clean up shared inline editor / status / workspace labels so nested configuration screens stop leaking English strings

## Verification
- pnpm --filter @paperclipai/ui build
- Playwright smoke checks on `/WIL/activity`, `/WIL/costs`, `/WIL/onboarding`, new issue dialog, and `/WIL/projects/onboarding/configuration`
