### PR TITLE
Fix heartbeat resume when timer wakes fall back to synthetic scope

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -361,6 +361,22 @@ describe("recoverTimerWakeTaskScope", () => {
       }),
     ).toBeNull();
   });
+
+  it("recovers null task keys from scheduler timer wakes", () => {
+    expect(
+      recoverTimerWakeTaskScope({
+        currentTaskKey: null,
+        lastRunContextSnapshot: {
+          issueId: "issue-456",
+          taskId: "issue-456",
+        },
+      }),
+    ).toEqual({
+      taskKey: "issue-456",
+      issueId: "issue-456",
+      taskId: "issue-456",
+    });
+  });
 });
 
 describe("comment wake batching", () => {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -13,6 +13,7 @@ import {
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
   resolveRuntimeSessionParamsForWorkspace,
+  recoverTimerWakeTaskScope,
   stripWorkspaceRuntimeFromExecutionRunConfig,
   shouldResetTaskSessionForWake,
   type ResolvedWorkspaceForRun,
@@ -330,6 +331,35 @@ describe("deriveTaskKeyWithHeartbeatFallback", () => {
 
   it("returns null for empty context", () => {
     expect(deriveTaskKeyWithHeartbeatFallback({}, null)).toBeNull();
+  });
+});
+
+describe("recoverTimerWakeTaskScope", () => {
+  it("recovers the last run issue scope for timer wakes that only have heartbeat context", () => {
+    expect(
+      recoverTimerWakeTaskScope({
+        currentTaskKey: "__heartbeat__",
+        lastRunContextSnapshot: {
+          issueId: "issue-123",
+          taskId: "issue-123",
+        },
+      }),
+    ).toEqual({
+      taskKey: "issue-123",
+      issueId: "issue-123",
+      taskId: "issue-123",
+    });
+  });
+
+  it("leaves non-heartbeat wakes unchanged", () => {
+    expect(
+      recoverTimerWakeTaskScope({
+        currentTaskKey: "issue-123",
+        lastRunContextSnapshot: {
+          issueId: "issue-123",
+        },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1216,7 +1216,7 @@ export function recoverTimerWakeTaskScope(input: {
 }) {
   // Timer wakes inherit the last real task scope so they resume the same
   // saved session instead of falling back to the synthetic heartbeat bucket.
-  if (input.currentTaskKey !== HEARTBEAT_TASK_KEY) return null;
+  if (input.currentTaskKey !== null && input.currentTaskKey !== HEARTBEAT_TASK_KEY) return null;
 
   const recoveredTaskKey = deriveTaskKey(input.lastRunContextSnapshot, null);
   if (!recoveredTaskKey || recoveredTaskKey === HEARTBEAT_TASK_KEY) return null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1210,6 +1210,26 @@ export function deriveTaskKeyWithHeartbeatFallback(
   return null;
 }
 
+export function recoverTimerWakeTaskScope(input: {
+  currentTaskKey: string | null;
+  lastRunContextSnapshot: Record<string, unknown> | null | undefined;
+}) {
+  // Timer wakes inherit the last real task scope so they resume the same
+  // saved session instead of falling back to the synthetic heartbeat bucket.
+  if (input.currentTaskKey !== HEARTBEAT_TASK_KEY) return null;
+
+  const recoveredTaskKey = deriveTaskKey(input.lastRunContextSnapshot, null);
+  if (!recoveredTaskKey || recoveredTaskKey === HEARTBEAT_TASK_KEY) return null;
+
+  return {
+    taskKey: recoveredTaskKey,
+    issueId: readNonEmptyString(input.lastRunContextSnapshot?.issueId),
+    taskId:
+      readNonEmptyString(input.lastRunContextSnapshot?.taskId) ??
+      readNonEmptyString(input.lastRunContextSnapshot?.issueId),
+  };
+}
+
 export function shouldResetTaskSessionForWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
@@ -6251,7 +6271,7 @@ export function heartbeatService(db: Db) {
     const {
       contextSnapshot: enrichedContextSnapshot,
       issueIdFromPayload,
-      taskKey,
+      taskKey: initialTaskKey,
       wakeCommentId,
     } = enrichWakeContextSnapshot({
       contextSnapshot,
@@ -6261,9 +6281,34 @@ export function heartbeatService(db: Db) {
       payload,
     });
     let issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload;
+    let taskKey = initialTaskKey;
 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");
+
+    if (source === "timer") {
+      const runtimeState = await getRuntimeState(agent.id);
+      const lastRunId = readNonEmptyString(runtimeState?.lastRunId);
+      const lastRun = lastRunId ? await getRun(lastRunId) : null;
+      const recoveredTaskScope = recoverTimerWakeTaskScope({
+        currentTaskKey: taskKey,
+        lastRunContextSnapshot: lastRun ? parseObject(lastRun.contextSnapshot) : null,
+      });
+      if (recoveredTaskScope) {
+        taskKey = recoveredTaskScope.taskKey;
+        if (!readNonEmptyString(enrichedContextSnapshot.issueId) && recoveredTaskScope.issueId) {
+          enrichedContextSnapshot.issueId = recoveredTaskScope.issueId;
+        }
+        if (!readNonEmptyString(enrichedContextSnapshot.taskId) && recoveredTaskScope.taskId) {
+          enrichedContextSnapshot.taskId = recoveredTaskScope.taskId;
+        }
+        if (!readNonEmptyString(enrichedContextSnapshot.taskKey)) {
+          enrichedContextSnapshot.taskKey = recoveredTaskScope.taskKey;
+        }
+        issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueId;
+      }
+    }
+
     const explicitResumeSession = await resolveExplicitResumeSessionOverride(agent, payload, taskKey);
     if (explicitResumeSession) {
       enrichedContextSnapshot.resumeFromRunId = explicitResumeSession.resumeFromRunId;


### PR DESCRIPTION
## Thinking Path

> - Paperclip keeps long-running AI agents alive through heartbeat-driven wakeups and per-task session persistence.
> - Gemini local agents reuse saved session ids and workspace context across wakes.
> - Timer wakes were being assigned the synthetic `__heartbeat__` task scope when no explicit task key was present.
> - That synthetic scope prevented Paperclip from recovering the real issue-bound task session on re-trigger.
> - The result was that Gemini resumed from the fallback agent-home workspace and rejected the stale session id.
> - This pull request restores the real task scope for timer wakes so the saved session and workspace remain aligned.
> - The benefit is that Gemini local heartbeats can resume reliably instead of failing with `Invalid session identifier`.

## What Changed

- Added `recoverTimerWakeTaskScope` in `server/src/services/heartbeat.ts` to recover the last real task scope for timer wakes from the agent’s last run.
- Updated timer wake handling to use the recovered issue/task scope before building session resume parameters.
- Added regression coverage in `server/src/__tests__/heartbeat-workspace-session.test.ts` for recovering the task scope from `__heartbeat__`.

## Verification

- `pnpm -C server exec vitest run src/__tests__/heartbeat-workspace-session.test.ts`
- `pnpm -C server exec vitest run src/__tests__/gemini-local-adapter.test.ts`
- `pnpm -r typecheck`
- `pnpm build`
- Manual heartbeat re-trigger for Ernest now stays on the project workspace and no longer falls back to the agent-home workspace.

## Risks

- Low risk. The change only affects timer wakes that would otherwise fall back to the synthetic heartbeat scope.
- The main behavioral shift is that timer-driven resumes now reuse the last real task scope when it is recoverable.
- If the last run context is missing or not issue-scoped, the existing fallback behavior remains unchanged.

## Model Used

- OpenAI GPT-5 (Codex), tool-using coding agent with local repository access and shell execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes or confirmed none was needed
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
