### PR TITLE
feat: impute API-equivalent cost for subscription-included runs

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -410,8 +410,51 @@ function resolveLedgerBiller(result: AdapterExecutionResult): string {
   return readNonEmptyString(result.biller) ?? readNonEmptyString(result.provider) ?? "unknown";
 }
 
-function normalizeBilledCostCents(costUsd: number | null | undefined, billingType: BillingType): number {
-  if (billingType === "subscription_included") return 0;
+/**
+ * Anthropic API-equivalent pricing per million tokens (USD).
+ * Used to impute a dollar cost for subscription-included runs so the UI
+ * shows what the usage *would* cost at standard API rates.
+ */
+const ANTHROPIC_PRICING_PER_MTOK: Record<string, { input: number; cachedInput: number; output: number }> = {
+  "claude-opus-4-6":           { input: 15,  cachedInput: 1.50, output: 75 },
+  "claude-sonnet-4-6":         { input: 3,   cachedInput: 0.30, output: 15 },
+  "claude-haiku-4-6":          { input: 0.80, cachedInput: 0.08, output: 4 },
+  "claude-sonnet-4-5-20250929": { input: 3,   cachedInput: 0.30, output: 15 },
+  "claude-haiku-4-5-20251001":  { input: 0.80, cachedInput: 0.08, output: 4 },
+};
+
+function estimateCostCentsFromTokens(
+  model: string,
+  inputTokens: number,
+  cachedInputTokens: number,
+  outputTokens: number,
+): number {
+  const pricing = ANTHROPIC_PRICING_PER_MTOK[model];
+  if (!pricing) return 0;
+  const cost =
+    (inputTokens / 1_000_000) * pricing.input +
+    (cachedInputTokens / 1_000_000) * pricing.cachedInput +
+    (outputTokens / 1_000_000) * pricing.output;
+  return Math.max(0, Math.round(cost * 100));
+}
+
+function normalizeBilledCostCents(
+  costUsd: number | null | undefined,
+  billingType: BillingType,
+  tokenEstimate?: { model: string; inputTokens: number; cachedInputTokens: number; outputTokens: number },
+): number {
+  if (billingType === "subscription_included") {
+    // Impute API-equivalent cost from token counts so the UI shows real usage cost
+    if (tokenEstimate) {
+      return estimateCostCentsFromTokens(
+        tokenEstimate.model,
+        tokenEstimate.inputTokens,
+        tokenEstimate.cachedInputTokens,
+        tokenEstimate.outputTokens,
+      );
+    }
+    return 0;
+  }
   if (typeof costUsd !== "number" || !Number.isFinite(costUsd)) return 0;
   return Math.max(0, Math.round(costUsd * 100));
 }
@@ -2455,7 +2498,13 @@ export function heartbeatService(db: Db) {
     const outputTokens = usage?.outputTokens ?? 0;
     const cachedInputTokens = usage?.cachedInputTokens ?? 0;
     const billingType = normalizeLedgerBillingType(result.billingType);
-    const additionalCostCents = normalizeBilledCostCents(result.costUsd, billingType);
+    const model = result.model ?? "unknown";
+    const additionalCostCents = normalizeBilledCostCents(result.costUsd, billingType, {
+      model,
+      inputTokens,
+      cachedInputTokens,
+      outputTokens,
+    });
     const hasTokenUsage = inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0;
     const provider = result.provider ?? "unknown";
     const biller = resolveLedgerBiller(result);
@@ -2487,7 +2536,7 @@ export function heartbeatService(db: Db) {
         provider,
         biller,
         billingType,
-        model: result.model ?? "unknown",
+        model,
         inputTokens,
         cachedInputTokens,
         outputTokens,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -430,7 +430,10 @@ function estimateCostCentsFromTokens(
   outputTokens: number,
 ): number {
   const pricing = ANTHROPIC_PRICING_PER_MTOK[model];
-  if (!pricing) return 0;
+  if (!pricing) {
+    logger.warn({ model }, "no pricing entry for model; cost will be reported as 0");
+    return 0;
+  }
   const cost =
     (inputTokens / 1_000_000) * pricing.input +
     (cachedInputTokens / 1_000_000) * pricing.cachedInput +


### PR DESCRIPTION
## Summary

- Subscription-included runs previously hard-coded `cost_cents=0`, making the UI show $0.00 for all agents even though tokens were being consumed
- Added Anthropic API pricing map (`ANTHROPIC_PRICING_PER_MTOK`) and `estimateCostCentsFromTokens()` to calculate API-equivalent costs from token counts
- Modified `normalizeBilledCostCents()` to impute costs for `subscription_included` billing type instead of returning 0
- Agent dashboards, Costs page, and budget views now reflect real usage costs

## Thinking Path

The pricing map is intentionally static and scoped to Anthropic models. Imputing costs live from a provider API would:
- Couple every heartbeat to an extra network round-trip with its own failure mode
- Require credentials we do not store for subscription-only customers
- Still be based on the same list prices anyway

A static table keeps the cost path deterministic and auditable; the follow-up work when prices change is a one-line map edit, not a service rewire. A warning log surfaces gaps when a new model appears.

## Risks

- **Pricing drift**: if Anthropic raises list prices and the map is not updated, imputed cost under-reports real API-equivalent spend. Mitigated by the warning log for unknown models; price-update drift still needs manual review each quarter.
- **False precision**: imputed cost is a *list-price* estimate, not a billed amount — subscription customers pay a flat fee regardless. Anyone using this number for accounting should be aware it is an estimate, not an invoice line.
- **Scope**: covers Anthropic Claude models only. Non-Anthropic subscription runs (if/when added) will continue to report 0 until the map is extended.

## Model Used

Claude Opus 4.6 (claude-opus-4-6).

## Checklist

- [x] Tests pass locally (costs-service, heartbeat-run-summary, heartbeat-workspace-session, heartbeat-project-env)
- [x] TypeScript compiles clean
- [x] No breaking changes to the adapter contract
- [x] Warning log for unknown models (addresses greptile P2 feedback)
- [x] PR scope is a single file (heartbeat.ts) — no unrelated changes bundled

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] `costs-service.test.ts` — 8/8 passed
- [x] `heartbeat-run-summary.test.ts` — 5/5 passed
- [x] `heartbeat-workspace-session.test.ts` — 33/33 passed
- [x] `heartbeat-project-env.test.ts` — 2/2 passed
- [ ] Verify agent dashboard shows non-zero "Total cost" after new runs
- [ ] Verify Costs page aggregates show correct per-agent and per-model breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)