### PR TITLE
feat(ui,adapter): add MCP server configuration for claude_local agents

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -366,6 +366,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
   const effectiveInstructionsFilePath = promptBundle.instructionsFilePath ?? undefined;
 
+  let mcpConfigPath: string | null = null;
+  const rawMcpServers = config.mcpServers;
+  if (rawMcpServers && typeof rawMcpServers === "object" && Object.keys(rawMcpServers).length > 0) {
+    mcpConfigPath = path.join(promptBundle.addDir, "mcp-config.json");
+    await fs.writeFile(
+      mcpConfigPath,
+      JSON.stringify({ mcpServers: rawMcpServers }, null, 2),
+      "utf-8",
+    );
+  }
+
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
   const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
@@ -448,6 +459,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--append-system-prompt-file", attemptInstructionsFilePath);
     }
     args.push("--add-dir", promptBundle.addDir);
+    if (mcpConfigPath) args.push("--mcp-config", mcpConfigPath);
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };

--- a/packages/adapters/claude-local/vitest.config.ts
+++ b/packages/adapters/claude-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/ui/src/components/McpServersEditor.test.ts
+++ b/ui/src/components/McpServersEditor.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectTransport,
+  fromRows,
+  toRows,
+  type McpServersMap,
+} from "./McpServersEditor";
+
+describe("detectTransport", () => {
+  it("returns 'stdio' when no type field is present", () => {
+    expect(detectTransport({ command: "node", args: [] })).toBe("stdio");
+  });
+
+  it("returns 'sse' for type sse", () => {
+    expect(detectTransport({ type: "sse", url: "http://localhost/sse" })).toBe("sse");
+  });
+
+  it("returns 'http' for type http", () => {
+    expect(detectTransport({ type: "http", url: "http://localhost/mcp" })).toBe("http");
+  });
+
+  it("maps legacy type 'url' to 'http'", () => {
+    expect(detectTransport({ type: "url", url: "http://localhost/mcp" })).toBe("http");
+  });
+
+  it("returns 'stdio' for unknown type values", () => {
+    expect(detectTransport({ type: "unknown" })).toBe("stdio");
+  });
+});
+
+describe("toRows", () => {
+  it("returns empty array for undefined", () => {
+    expect(toRows(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for empty object", () => {
+    expect(toRows({} as McpServersMap)).toEqual([]);
+  });
+
+  it("parses a stdio server", () => {
+    const servers: McpServersMap = {
+      "my-server": { command: "node", args: ["server.js", "--stdio"] },
+    };
+    const rows = toRows(servers);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe("my-server");
+    expect(rows[0].transport).toBe("stdio");
+    expect(rows[0].command).toBe("node");
+    expect(rows[0].args).toBe("server.js, --stdio");
+  });
+
+  it("parses an SSE server", () => {
+    const servers: McpServersMap = {
+      "sse-server": { type: "sse", url: "http://localhost:3099/sse" },
+    };
+    const rows = toRows(servers);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe("sse-server");
+    expect(rows[0].transport).toBe("sse");
+    expect(rows[0].url).toBe("http://localhost:3099/sse");
+  });
+
+  it("parses an HTTP streamable server", () => {
+    const servers: McpServersMap = {
+      "http-server": { type: "http", url: "http://localhost:3099/mcp" },
+    };
+    const rows = toRows(servers);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].transport).toBe("http");
+    expect(rows[0].url).toBe("http://localhost:3099/mcp");
+  });
+
+  it("parses env vars and adds trailing empty row", () => {
+    const servers: McpServersMap = {
+      "with-env": {
+        command: "node",
+        args: [],
+        env: { API_KEY: "secret", DEBUG: "true" },
+      },
+    };
+    const rows = toRows(servers);
+    expect(rows[0].envRows).toHaveLength(3); // 2 real + 1 trailing empty
+    expect(rows[0].envRows[0]).toEqual({ key: "API_KEY", value: "secret" });
+    expect(rows[0].envRows[1]).toEqual({ key: "DEBUG", value: "true" });
+    expect(rows[0].envRows[2]).toEqual({ key: "", value: "" });
+  });
+});
+
+describe("fromRows", () => {
+  it("returns undefined for empty rows", () => {
+    expect(fromRows([])).toBeUndefined();
+  });
+
+  it("skips rows with empty names", () => {
+    const rows = toRows(undefined);
+    // Add a row with no name
+    rows.push({
+      uid: "test",
+      name: "  ",
+      transport: "stdio",
+      command: "node",
+      args: "",
+      url: "",
+      envRows: [{ key: "", value: "" }],
+      open: true,
+    });
+    expect(fromRows(rows)).toBeUndefined();
+  });
+
+  it("serializes a stdio server correctly", () => {
+    const rows = [{
+      uid: "1",
+      name: "my-server",
+      transport: "stdio" as const,
+      command: "npx",
+      args: "ts-node, server.ts, --stdio",
+      url: "",
+      envRows: [{ key: "", value: "" }],
+      open: true,
+    }];
+    const result = fromRows(rows);
+    expect(result).toEqual({
+      "my-server": {
+        command: "npx",
+        args: ["ts-node", "server.ts", "--stdio"],
+      },
+    });
+  });
+
+  it("serializes an SSE server with type 'sse'", () => {
+    const rows = [{
+      uid: "1",
+      name: "sse-server",
+      transport: "sse" as const,
+      command: "",
+      args: "",
+      url: "http://localhost:3099/sse",
+      envRows: [{ key: "", value: "" }],
+      open: true,
+    }];
+    const result = fromRows(rows);
+    expect(result).toEqual({
+      "sse-server": {
+        type: "sse",
+        url: "http://localhost:3099/sse",
+      },
+    });
+  });
+
+  it("serializes HTTP streamable server with type 'http' (not 'url')", () => {
+    const rows = [{
+      uid: "1",
+      name: "http-server",
+      transport: "http" as const,
+      command: "",
+      args: "",
+      url: "http://localhost:3099/mcp",
+      envRows: [{ key: "", value: "" }],
+      open: true,
+    }];
+    const result = fromRows(rows);
+    expect(result).toEqual({
+      "http-server": {
+        type: "http",
+        url: "http://localhost:3099/mcp",
+      },
+    });
+    // Must NOT produce type: "url" — Claude Code rejects it
+    expect((result as Record<string, Record<string, unknown>>)["http-server"].type).toBe("http");
+  });
+
+  it("includes env vars only when non-empty", () => {
+    const rows = [{
+      uid: "1",
+      name: "with-env",
+      transport: "stdio" as const,
+      command: "node",
+      args: "server.js",
+      url: "",
+      envRows: [
+        { key: "API_KEY", value: "secret" },
+        { key: "", value: "" }, // trailing empty — should be ignored
+      ],
+      open: true,
+    }];
+    const result = fromRows(rows)!;
+    expect(result["with-env"]).toEqual({
+      command: "node",
+      args: ["server.js"],
+      env: { API_KEY: "secret" },
+    });
+  });
+
+  it("omits env when all rows are empty", () => {
+    const rows = [{
+      uid: "1",
+      name: "no-env",
+      transport: "sse" as const,
+      command: "",
+      args: "",
+      url: "http://localhost/sse",
+      envRows: [{ key: "", value: "" }],
+      open: true,
+    }];
+    const result = fromRows(rows)!;
+    expect(result["no-env"]).toEqual({ type: "sse", url: "http://localhost/sse" });
+    expect("env" in result["no-env"]).toBe(false);
+  });
+
+  it("round-trips a mixed config correctly", () => {
+    const original: McpServersMap = {
+      "stdio-server": { command: "node", args: ["index.js"], env: { PORT: "8080" } },
+      "sse-server": { type: "sse", url: "http://localhost:4000/sse" },
+      "http-server": { type: "http", url: "http://localhost:5000/mcp" },
+    };
+    const rows = toRows(original);
+    const result = fromRows(rows);
+    expect(result).toEqual(original);
+  });
+});

--- a/ui/src/components/McpServersEditor.test.ts
+++ b/ui/src/components/McpServersEditor.test.ts
@@ -166,7 +166,7 @@ describe("fromRows", () => {
       },
     });
     // Must NOT produce type: "url" — Claude Code rejects it
-    expect((result as Record<string, Record<string, unknown>>)["http-server"].type).toBe("http");
+    expect((result as unknown as Record<string, Record<string, unknown>>)["http-server"].type).toBe("http");
   });
 
   it("includes env vars only when non-empty", () => {

--- a/ui/src/components/McpServersEditor.test.ts
+++ b/ui/src/components/McpServersEditor.test.ts
@@ -46,7 +46,7 @@ describe("toRows", () => {
     expect(rows[0].name).toBe("my-server");
     expect(rows[0].transport).toBe("stdio");
     expect(rows[0].command).toBe("node");
-    expect(rows[0].args).toBe("server.js, --stdio");
+    expect(rows[0].args).toBe("server.js\n--stdio");
   });
 
   it("parses an SSE server", () => {
@@ -91,6 +91,43 @@ describe("fromRows", () => {
     expect(fromRows([])).toBeUndefined();
   });
 
+  it("skips stdio rows with empty command", () => {
+    const rows = [{
+      uid: "1",
+      name: "broken",
+      transport: "stdio" as const,
+      command: "  ",
+      args: "",
+      url: "",
+      envRows: [{ key: "", value: "" }],
+      open: true,
+    }];
+    expect(fromRows(rows)).toBeUndefined();
+  });
+
+  it("skips network rows with empty url", () => {
+    const rows = [{
+      uid: "1",
+      name: "broken-sse",
+      transport: "sse" as const,
+      command: "",
+      args: "",
+      url: "",
+      envRows: [{ key: "", value: "" }],
+      open: true,
+    }, {
+      uid: "2",
+      name: "broken-http",
+      transport: "http" as const,
+      command: "",
+      args: "",
+      url: "  ",
+      envRows: [{ key: "", value: "" }],
+      open: true,
+    }];
+    expect(fromRows(rows)).toBeUndefined();
+  });
+
   it("skips rows with empty names", () => {
     const rows = toRows(undefined);
     // Add a row with no name
@@ -113,7 +150,7 @@ describe("fromRows", () => {
       name: "my-server",
       transport: "stdio" as const,
       command: "npx",
-      args: "ts-node, server.ts, --stdio",
+      args: "ts-node\nserver.ts\n--stdio",
       url: "",
       envRows: [{ key: "", value: "" }],
       open: true,
@@ -205,6 +242,24 @@ describe("fromRows", () => {
     const result = fromRows(rows)!;
     expect(result["no-env"]).toEqual({ type: "sse", url: "http://localhost/sse" });
     expect("env" in result["no-env"]).toBe(false);
+  });
+
+  it("preserves commas inside arguments", () => {
+    const rows = [{
+      uid: "1",
+      name: "comma-args",
+      transport: "stdio" as const,
+      command: "node",
+      args: "/tmp/my,folder\n--config=a,b",
+      url: "",
+      envRows: [{ key: "", value: "" }],
+      open: true,
+    }];
+    const result = fromRows(rows)!;
+    expect(result["comma-args"]).toEqual({
+      command: "node",
+      args: ["/tmp/my,folder", "--config=a,b"],
+    });
   });
 
   it("round-trips a mixed config correctly", () => {

--- a/ui/src/components/McpServersEditor.tsx
+++ b/ui/src/components/McpServersEditor.tsx
@@ -1,0 +1,435 @@
+import { useState, useEffect, useRef } from "react";
+import { Plus, Trash2, ChevronDown, ChevronRight, Server } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "../lib/utils";
+import { HintIcon } from "./agent-config-primitives";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+const selectClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-background outline-none text-sm font-mono";
+
+/* ---- Types ---- */
+
+export type McpTransportType = "stdio" | "sse" | "http";
+
+export interface McpServerEntryStdio {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+export interface McpServerEntryNetwork {
+  type: "sse" | "http";
+  url: string;
+  env?: Record<string, string>;
+}
+
+export type McpServerEntry = McpServerEntryStdio | McpServerEntryNetwork;
+
+export type McpServersMap = Record<string, McpServerEntry>;
+
+/* ---- Internal row helpers ---- */
+
+interface ServerRow {
+  uid: string;
+  name: string;
+  transport: McpTransportType;
+  command: string;
+  args: string;
+  url: string;
+  envRows: { key: string; value: string }[];
+  open: boolean;
+}
+
+let nextUid = 1;
+function uid() {
+  return `mcp-${nextUid++}`;
+}
+
+export function detectTransport(entry: Record<string, unknown>): McpTransportType {
+  if (entry.type === "sse") return "sse";
+  if (entry.type === "http" || entry.type === "url") return "http";
+  return "stdio";
+}
+
+export function toRows(servers: McpServersMap | undefined): ServerRow[] {
+  if (!servers || typeof servers !== "object") return [];
+  return Object.entries(servers).map(([name, entry]) => {
+    const raw = entry as unknown as Record<string, unknown>;
+    const transport = detectTransport(raw);
+    const envObj = (raw.env ?? {}) as Record<string, string>;
+    const envEntries = Object.entries(envObj).map(([key, value]) => ({ key, value }));
+    return {
+      uid: uid(),
+      name,
+      transport,
+      command: typeof raw.command === "string" ? raw.command : "",
+      args: Array.isArray(raw.args) ? (raw.args as string[]).join(", ") : "",
+      url: typeof raw.url === "string" ? raw.url : "",
+      envRows: [...envEntries, { key: "", value: "" }],
+      open: true,
+    };
+  });
+}
+
+export function fromRows(rows: ServerRow[]): McpServersMap | undefined {
+  const map: McpServersMap = {};
+  for (const row of rows) {
+    const name = row.name.trim();
+    if (!name) continue;
+    const env: Record<string, string> = {};
+    for (const e of row.envRows) {
+      const k = e.key.trim();
+      if (k) env[k] = e.value;
+    }
+    const hasEnv = Object.keys(env).length > 0;
+
+    if (row.transport === "sse" || row.transport === "http") {
+      map[name] = {
+        type: row.transport,
+        url: row.url,
+        ...(hasEnv ? { env } : {}),
+      };
+    } else {
+      const args = row.args
+        .split(",")
+        .map((a) => a.trim())
+        .filter(Boolean);
+      map[name] = {
+        command: row.command,
+        args,
+        ...(hasEnv ? { env } : {}),
+      };
+    }
+  }
+  return Object.keys(map).length > 0 ? map : undefined;
+}
+
+const TRANSPORT_OPTIONS: { value: McpTransportType; label: string; hint: string }[] = [
+  { value: "stdio", label: "stdio", hint: "Spawn a local process (command + args)" },
+  { value: "sse", label: "SSE", hint: "Connect to a running server via Server-Sent Events" },
+  { value: "http", label: "HTTP (streamable)", hint: "Connect to a running server via streamable HTTP" },
+];
+
+/* ---- Component ---- */
+
+export function McpServersEditor({
+  value,
+  onChange,
+}: {
+  value: McpServersMap | undefined;
+  onChange: (servers: McpServersMap | undefined) => void;
+}) {
+  const [rows, setRows] = useState<ServerRow[]>(() => toRows(value));
+  const valueRef = useRef(value);
+  const emittingRef = useRef(false);
+
+  useEffect(() => {
+    if (emittingRef.current) {
+      emittingRef.current = false;
+      valueRef.current = value;
+      return;
+    }
+    if (value !== valueRef.current) {
+      valueRef.current = value;
+      setRows(toRows(value));
+    }
+  }, [value]);
+
+  function emit(nextRows: ServerRow[]) {
+    emittingRef.current = true;
+    onChange(fromRows(nextRows));
+  }
+
+  function updateRow(index: number, patch: Partial<ServerRow>) {
+    const next = rows.map((r, i) => (i === index ? { ...r, ...patch } : r));
+    setRows(next);
+    emit(next);
+  }
+
+  function removeRow(index: number) {
+    const next = rows.filter((_, i) => i !== index);
+    setRows(next);
+    emit(next);
+  }
+
+  function addServer() {
+    const next = [
+      ...rows,
+      {
+        uid: uid(),
+        name: "",
+        transport: "stdio" as McpTransportType,
+        command: "",
+        args: "",
+        url: "",
+        envRows: [{ key: "", value: "" }],
+        open: true,
+      },
+    ];
+    setRows(next);
+  }
+
+  function updateEnvRow(
+    serverIndex: number,
+    envIndex: number,
+    patch: { key?: string; value?: string },
+  ) {
+    const server = rows[serverIndex];
+    const envRows = server.envRows.map((e, i) =>
+      i === envIndex ? { ...e, ...patch } : e,
+    );
+    const last = envRows[envRows.length - 1];
+    if (last && (last.key || last.value)) {
+      envRows.push({ key: "", value: "" });
+    }
+    const next = rows.map((r, i) =>
+      i === serverIndex ? { ...r, envRows } : r,
+    );
+    setRows(next);
+    emit(next);
+  }
+
+  function removeEnvRow(serverIndex: number, envIndex: number) {
+    const server = rows[serverIndex];
+    let envRows = server.envRows.filter((_, i) => i !== envIndex);
+    const last = envRows[envRows.length - 1];
+    if (!last || last.key || last.value) {
+      envRows.push({ key: "", value: "" });
+    }
+    const next = rows.map((r, i) =>
+      i === serverIndex ? { ...r, envRows } : r,
+    );
+    setRows(next);
+    emit(next);
+  }
+
+  function headerSubtitle(row: ServerRow): string {
+    if (row.transport === "stdio") return row.command || "";
+    return row.url || "";
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.length === 0 && (
+        <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center">
+          <Server className="mx-auto h-8 w-8 text-muted-foreground/30 mb-2" />
+          <p className="text-sm text-muted-foreground/60">
+            No MCP servers configured
+          </p>
+          <p className="text-xs text-muted-foreground/40 mt-1">
+            Add MCP servers to give this agent access to external tools and data
+            sources.
+          </p>
+        </div>
+      )}
+
+      {rows.map((row, index) => (
+        <div
+          key={row.uid}
+          className="rounded-lg border border-border overflow-hidden"
+        >
+          {/* Header */}
+          <button
+            type="button"
+            className="flex items-center gap-2 w-full px-3 py-2 text-left hover:bg-accent/30 transition-colors"
+            onClick={() => updateRow(index, { open: !row.open })}
+          >
+            {row.open ? (
+              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            )}
+            <Server className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="text-sm font-medium truncate">
+              {row.name || (
+                <span className="text-muted-foreground/40 italic">
+                  unnamed server
+                </span>
+              )}
+            </span>
+            <span className="ml-auto text-xs text-muted-foreground/50 font-mono truncate max-w-[200px]">
+              {headerSubtitle(row)}
+            </span>
+            <button
+              type="button"
+              className="shrink-0 p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
+              onClick={(e) => {
+                e.stopPropagation();
+                removeRow(index);
+              }}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </button>
+
+          {/* Body */}
+          {row.open && (
+            <div className="px-3 pb-3 pt-1 space-y-3 border-t border-border">
+              {/* Server name */}
+              <div>
+                <label className="text-xs text-muted-foreground flex items-center gap-1.5 mb-1">
+                  Server name
+                  <HintIcon text="Unique identifier for this MCP server. Used in Claude Code's MCP config." />
+                </label>
+                <input
+                  className={inputClass}
+                  placeholder="e.g. my-mcp-server"
+                  value={row.name}
+                  onChange={(e) => updateRow(index, { name: e.target.value })}
+                />
+              </div>
+
+              {/* Transport type */}
+              <div>
+                <label className="text-xs text-muted-foreground flex items-center gap-1.5 mb-1">
+                  Transport
+                  <HintIcon text="How Claude Code connects to this MCP server. stdio spawns a local process; SSE and HTTP connect to a running server." />
+                </label>
+                <select
+                  className={selectClass}
+                  value={row.transport}
+                  onChange={(e) =>
+                    updateRow(index, {
+                      transport: e.target.value as McpTransportType,
+                    })
+                  }
+                >
+                  {TRANSPORT_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* stdio fields */}
+              {row.transport === "stdio" && (
+                <>
+                  <div>
+                    <label className="text-xs text-muted-foreground flex items-center gap-1.5 mb-1">
+                      Command
+                      <HintIcon text="The executable to run the MCP server (e.g. npx, node, python, uvx)." />
+                    </label>
+                    <input
+                      className={inputClass}
+                      placeholder="e.g. node"
+                      value={row.command}
+                      onChange={(e) =>
+                        updateRow(index, { command: e.target.value })
+                      }
+                    />
+                  </div>
+                  <div>
+                    <label className="text-xs text-muted-foreground flex items-center gap-1.5 mb-1">
+                      Arguments
+                      <HintIcon text="Comma-separated arguments passed to the command." />
+                    </label>
+                    <input
+                      className={inputClass}
+                      placeholder="e.g. /path/to/server.js, --stdio"
+                      value={row.args}
+                      onChange={(e) =>
+                        updateRow(index, { args: e.target.value })
+                      }
+                    />
+                  </div>
+                </>
+              )}
+
+              {/* SSE / URL fields */}
+              {(row.transport === "sse" || row.transport === "http") && (
+                <div>
+                  <label className="text-xs text-muted-foreground flex items-center gap-1.5 mb-1">
+                    URL
+                    <HintIcon
+                      text={
+                        row.transport === "sse"
+                          ? "The SSE endpoint URL of the running MCP server (e.g. http://localhost:3099/sse)."
+                          : "The HTTP endpoint URL of the running MCP server (e.g. http://localhost:3099/mcp)."
+                      }
+                    />
+                  </label>
+                  <input
+                    className={inputClass}
+                    placeholder={
+                      row.transport === "sse"
+                        ? "e.g. http://localhost:3099/sse"
+                        : "e.g. http://localhost:3099/mcp"
+                    }
+                    value={row.url}
+                    onChange={(e) => updateRow(index, { url: e.target.value })}
+                  />
+                </div>
+              )}
+
+              {/* Env vars (all transport types) */}
+              <div>
+                <label className="text-xs text-muted-foreground flex items-center gap-1.5 mb-1">
+                  Environment variables
+                  <HintIcon text="Environment variables passed to this MCP server process." />
+                </label>
+                <div className="space-y-1.5">
+                  {row.envRows.map((envRow, envIndex) => {
+                    const isTrailing =
+                      envIndex === row.envRows.length - 1 &&
+                      !envRow.key &&
+                      !envRow.value;
+                    return (
+                      <div key={envIndex} className="flex items-center gap-1.5">
+                        <input
+                          className={cn(inputClass, "flex-[2]")}
+                          placeholder="KEY"
+                          value={envRow.key}
+                          onChange={(e) =>
+                            updateEnvRow(index, envIndex, {
+                              key: e.target.value,
+                            })
+                          }
+                        />
+                        <input
+                          className={cn(inputClass, "flex-[3]")}
+                          placeholder="value"
+                          value={envRow.value}
+                          onChange={(e) =>
+                            updateEnvRow(index, envIndex, {
+                              value: e.target.value,
+                            })
+                          }
+                        />
+                        {!isTrailing ? (
+                          <button
+                            type="button"
+                            className="shrink-0 p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
+                            onClick={() => removeEnvRow(index, envIndex)}
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </button>
+                        ) : (
+                          <div className="w-[26px] shrink-0" />
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="w-full"
+        onClick={addServer}
+      >
+        <Plus className="h-3.5 w-3.5 mr-1.5" />
+        Add MCP Server
+      </Button>
+    </div>
+  );
+}

--- a/ui/src/components/McpServersEditor.tsx
+++ b/ui/src/components/McpServersEditor.tsx
@@ -66,7 +66,7 @@ export function toRows(servers: McpServersMap | undefined): ServerRow[] {
       name,
       transport,
       command: typeof raw.command === "string" ? raw.command : "",
-      args: Array.isArray(raw.args) ? (raw.args as string[]).join(", ") : "",
+      args: Array.isArray(raw.args) ? (raw.args as string[]).join("\n") : "",
       url: typeof raw.url === "string" ? raw.url : "",
       envRows: [...envEntries, { key: "", value: "" }],
       open: true,
@@ -87,14 +87,16 @@ export function fromRows(rows: ServerRow[]): McpServersMap | undefined {
     const hasEnv = Object.keys(env).length > 0;
 
     if (row.transport === "sse" || row.transport === "http") {
+      if (!row.url.trim()) continue;
       map[name] = {
         type: row.transport,
         url: row.url,
         ...(hasEnv ? { env } : {}),
       };
     } else {
+      if (!row.command.trim()) continue;
       const args = row.args
-        .split(",")
+        .split("\n")
         .map((a) => a.trim())
         .filter(Boolean);
       map[name] = {
@@ -170,6 +172,7 @@ export function McpServersEditor({
       },
     ];
     setRows(next);
+    emit(next);
   }
 
   function updateEnvRow(
@@ -325,11 +328,12 @@ export function McpServersEditor({
                   <div>
                     <label className="text-xs text-muted-foreground flex items-center gap-1.5 mb-1">
                       Arguments
-                      <HintIcon text="Comma-separated arguments passed to the command." />
+                      <HintIcon text="One argument per line. Passed to the command in order." />
                     </label>
-                    <input
-                      className={inputClass}
-                      placeholder="e.g. /path/to/server.js, --stdio"
+                    <textarea
+                      className={cn(inputClass, "resize-y min-h-[2.25rem]")}
+                      rows={Math.max(2, row.args.split("\n").length)}
+                      placeholder={"e.g.\n/path/to/server.js\n--stdio"}
                       value={row.args}
                       onChange={(e) =>
                         updateRow(index, { args: e.target.value })

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -38,6 +38,7 @@ import { Identity } from "../components/Identity";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { RunButton, PauseResumeButton } from "../components/AgentActionButtons";
 import { BudgetPolicyCard } from "../components/BudgetPolicyCard";
+import { McpServersEditor, type McpServersMap } from "../components/McpServersEditor";
 import { PackageFileTree, buildFileTree } from "../components/PackageFileTree";
 import { ScrollToBottom } from "../components/ScrollToBottom";
 import { formatCents, formatDate, relativeTime, formatTokens, visibleRunCostUsd } from "../lib/utils";
@@ -223,12 +224,13 @@ function scrollToContainerBottom(container: ScrollContainer, behavior: ScrollBeh
   container.scrollTo({ top: container.scrollHeight, behavior });
 }
 
-type AgentDetailView = "dashboard" | "instructions" | "configuration" | "skills" | "runs" | "budget";
+type AgentDetailView = "dashboard" | "instructions" | "configuration" | "skills" | "mcp" | "runs" | "budget";
 
 function parseAgentDetailView(value: string | null): AgentDetailView {
   if (value === "instructions" || value === "prompts") return "instructions";
   if (value === "configure" || value === "configuration") return "configuration";
   if (value === "skills") return "skills";
+  if (value === "mcp") return "mcp";
   if (value === "budget") return "budget";
   if (value === "runs") return value;
   return "dashboard";
@@ -744,11 +746,13 @@ export function AgentDetail() {
           ? "configuration"
           : activeView === "skills"
             ? "skills"
-            : activeView === "runs"
-              ? "runs"
-              : activeView === "budget"
-                ? "budget"
-              : "dashboard";
+            : activeView === "mcp"
+              ? "mcp"
+              : activeView === "runs"
+                ? "runs"
+                : activeView === "budget"
+                  ? "budget"
+                : "dashboard";
     if (routeAgentRef !== canonicalAgentRef || urlTab !== canonicalTab) {
       navigate(`/agents/${canonicalAgentRef}/${canonicalTab}`, { replace: true });
       return;
@@ -1008,6 +1012,9 @@ export function AgentDetail() {
               { value: "dashboard", label: "Dashboard" },
               { value: "instructions", label: "Instructions" },
               { value: "skills", label: "Skills" },
+              ...(agent.adapterType === "claude_local"
+                ? [{ value: "mcp", label: "MCP Servers" }]
+                : []),
               { value: "configuration", label: "Configuration" },
               { value: "runs", label: "Runs" },
               { value: "budget", label: "Budget" },
@@ -1119,6 +1126,13 @@ export function AgentDetail() {
 
       {activeView === "skills" && (
         <AgentSkillsTab
+          agent={agent}
+          companyId={resolvedCompanyId ?? undefined}
+        />
+      )}
+
+      {activeView === "mcp" && agent.adapterType === "claude_local" && (
+        <McpServersTab
           agent={agent}
           companyId={resolvedCompanyId ?? undefined}
         />
@@ -2412,6 +2426,101 @@ function PromptEditorSkeleton() {
     <div className="space-y-3">
       <Skeleton className="h-10 w-full" />
       <Skeleton className="h-[420px] w-full" />
+    </div>
+  );
+}
+
+/* ---- MCP Servers Tab (claude_local only) ---- */
+
+function McpServersTab({
+  agent,
+  companyId,
+}: {
+  agent: AgentDetailRecord;
+  companyId: string | undefined;
+}) {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+  const lastAgentRef = useRef(agent);
+  const [awaitingRefresh, setAwaitingRefresh] = useState(false);
+  const [localServers, setLocalServers] = useState<McpServersMap | undefined>(
+    () => (agent.adapterConfig?.mcpServers ?? undefined) as McpServersMap | undefined,
+  );
+  const [dirty, setDirty] = useState(false);
+
+  // Sync when agent data refreshes from server (after save or external change)
+  useEffect(() => {
+    if (agent !== lastAgentRef.current) {
+      lastAgentRef.current = agent;
+      setLocalServers((agent.adapterConfig?.mcpServers ?? undefined) as McpServersMap | undefined);
+      setDirty(false);
+      setAwaitingRefresh(false);
+    }
+  }, [agent]);
+
+  const updateMcp = useMutation({
+    mutationFn: (servers: McpServersMap | undefined) =>
+      agentsApi.update(
+        agent.id,
+        {
+          adapterConfig: {
+            ...agent.adapterConfig,
+            mcpServers: servers ?? null,
+          },
+        },
+        companyId,
+      ),
+    onMutate: () => setAwaitingRefresh(true),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.id) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.urlKey) });
+    },
+    onError: (err) => {
+      setAwaitingRefresh(false);
+      pushToast({
+        title: "Failed to save MCP servers",
+        body: err instanceof Error ? err.message : "Unknown error",
+        tone: "error",
+      });
+    },
+  });
+
+  const isSaving = updateMcp.isPending || awaitingRefresh;
+
+  const handleChange = (servers: McpServersMap | undefined) => {
+    setLocalServers(servers);
+    setDirty(true);
+  };
+
+  const handleCancel = () => {
+    setLocalServers((agent.adapterConfig?.mcpServers ?? undefined) as McpServersMap | undefined);
+    setDirty(false);
+  };
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-medium">MCP Servers</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Configure Model Context Protocol servers that this agent can use during runs.
+            Each server provides additional tools and data sources to Claude Code via <code className="text-[11px] bg-muted px-1 rounded">--mcp-config</code>.
+          </p>
+        </div>
+      </div>
+
+      <McpServersEditor value={localServers} onChange={handleChange} />
+
+      {dirty && (
+        <div className="flex items-center gap-2 pt-1">
+          <Button size="sm" onClick={() => updateMcp.mutate(localServers)} disabled={isSaving}>
+            {isSaving ? "Saving..." : "Save changes"}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={handleCancel} disabled={isSaving}>
+            Cancel
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     projects: [
       "packages/db",
+      "packages/adapters/claude-local",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",
       "server",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - There are many types of adapters for each LLM model provider, including the claude_local adapter which runs Claude Code
> - Claude Code supports MCP (Model Context Protocol) servers that provide external tools and data sources to agents
> - But there was no way to configure MCP servers for claude_local agents through the Paperclip UI
> - So users had to manually manage MCP config outside of Paperclip, which is error-prone and breaks the "zero-human" workflow
> - This pull request adds per-agent MCP server configuration with a dedicated UI tab and backend wiring via `--mcp-config`
> - The benefit is that users can now manage MCP servers directly from the agent detail page, and agents get the configured tools at runtime without any manual setup

## What Changed

- **New `McpServersEditor` component** (`ui/src/components/McpServersEditor.tsx`): A form editor supporting stdio, SSE, and HTTP (streamable) transport types, with environment variable management. Includes pure helper functions (`toRows`, `fromRows`, `detectTransport`) for converting between the API map format and the UI row format.
- **New "MCP Servers" tab on agent detail page** (`ui/src/pages/AgentDetail.tsx`): Adds an `McpServersTab` that appears only for `claude_local` agents. It persists the MCP config via `agentsApi.update` into `adapterConfig.mcpServers`.
- **Backend adapter wiring** (`packages/adapters/claude-local/src/server/execute.ts`): Reads `config.mcpServers`, writes an `mcp-config.json` file into the skills directory, and passes `--mcp-config <path>` to the Claude Code CLI.
- **Tests** (`ui/src/components/McpServersEditor.test.ts`): 19 unit tests covering `detectTransport`, `toRows`, `fromRows`, and round-trip serialization for all transport types and edge cases.
- **Vitest config** (`packages/adapters/claude-local/vitest.config.ts`, `vitest.config.ts`): Added vitest project config for the claude-local adapter package.

Before:
<img width="1129" height="197" alt="Captura de Tela 2026-04-10 às 20 03 05" src="https://github.com/user-attachments/assets/0bd0c0f1-7846-46c4-830e-b0b7b355a52e" />

After:
<img width="1145" height="472" alt="image" src="https://github.com/user-attachments/assets/957a6e86-75de-4d8c-ad02-f5f32dcc662e" />
<img width="1136" height="573" alt="Captura de Tela 2026-04-10 às 20 02 41" src="https://github.com/user-attachments/assets/b8408045-e44c-48bf-9e57-e945bf784dd9" />


## Verification

- All 19 new unit tests pass: `npx vitest run ui/src/components/McpServersEditor.test.ts`
- Manual testing:
  1. Navigate to a claude_local agent's detail page
  2. Confirm the "MCP Servers" tab only appears for claude_local agents (not other adapter types)
  3. Add a stdio server (e.g. name: `my-server`, command: `npx`, args: `@modelcontextprotocol/server-filesystem, /tmp`)
  4. Add an SSE server and an HTTP server to verify transport switching
  5. Add environment variables and verify trailing-row auto-append behavior
  6. Save and confirm the config persists on page reload
  7. Verify the adapter writes `mcp-config.json` and passes `--mcp-config` to Claude Code during a run

## Risks

- **Low risk.** The MCP Servers tab is gated behind `agent.adapterType === "claude_local"`, so no other adapter types are affected. The backend change only adds an optional `--mcp-config` flag when MCP servers are configured — if none are configured, the execution path is unchanged. The new component is self-contained with no changes to existing shared components.

## Model Used

Anthropic Claude Opus 4.6 (`claude-opus-4-6`) — 1M context window, with tool use (Claude Code CLI).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge