### PR TITLE
fix: disable io_uring in all spawned processes to prevent D-state hangs on Linux 6.8

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -949,6 +949,12 @@ export async function runChildProcess(
       delete rawMerged[key];
     }
 
+    // Disable io_uring in spawned processes to prevent D-state zombie processes
+    // on Linux kernel 6.8 where io_uring cleanup can hang indefinitely after SIGKILL.
+    // Without this, killed claude processes accumulate as unkillable D-state zombies,
+    // fill swap, and cause Paperclip to deadlock treating them as alive.
+    rawMerged["UV_USE_IO_URING"] = "0";
+
     const mergedEnv = ensurePathInEnv(rawMerged);
     void resolveSpawnTarget(command, args, opts.cwd, mergedEnv)
       .then((target) => {

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -614,6 +614,8 @@ export function createPluginWorkerHandle(
       PAPERCLIP_PLUGIN_ID: pluginId,
       NODE_ENV: process.env.NODE_ENV ?? "production",
       TZ: process.env.TZ ?? "UTC",
+      // Disable io_uring to prevent D-state zombie processes on Linux kernel 6.8.
+      UV_USE_IO_URING: "0",
     };
 
     const child = fork(options.entrypointPath, [], {

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -459,7 +459,8 @@ async function executeProcess(input: {
     const child = spawn(input.command, input.args, {
       cwd: input.cwd,
       stdio: ["ignore", "pipe", "pipe"],
-      env: input.env ?? process.env,
+      // Disable io_uring to prevent D-state zombie processes on Linux kernel 6.8.
+      env: { ...(input.env ?? process.env), UV_USE_IO_URING: "0" },
     });
     const stdout = createProcessOutputCapture(input.maxStdoutBytes ?? DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES);
     const stderr = createProcessOutputCapture(input.maxStderrBytes ?? DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES);
@@ -1639,7 +1640,8 @@ async function startLocalRuntimeService(input: {
   const shell = resolveShell();
   const child = spawn(shell, ["-lc", command], {
     cwd: serviceCwd,
-    env,
+    // Disable io_uring to prevent D-state zombie processes on Linux kernel 6.8.
+    env: { ...env, UV_USE_IO_URING: "0" },
     detached: process.platform !== "win32",
     stdio: ["ignore", "pipe", "pipe"],
   });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and spawns many child processes: agent runners (claude, codex, gemini, etc.), MCP servers, and plugin workers
> - All spawned processes are terminated via SIGKILL on timeout or cancellation
> - On Linux kernel 6.8 (Ubuntu 24.04 LTS), there is a regression where `io_uring_exit()` blocks indefinitely after SIGKILL
> - Node.js/libuv uses `io_uring` by default on Linux, so every spawned process is affected
> - The killed processes enter D-state (uninterruptible sleep), accumulate as unkillable `iou-sqp-*` kernel threads, and fill RAM/swap
> - `process.kill(pid, 0)` succeeds on D-state processes → Paperclip believes old agents are still alive and locks their workspaces
> - Over hours this causes OOM crashes and makes `systemd` unable to stop/restart the service without a full reboot
> - This pull request injects `UV_USE_IO_URING=0` into every spawned child process environment across all Paperclip spawn points
> - The benefit is that processes exit cleanly on SIGKILL; no D-state accumulation, no workspace deadlock, no service shutdown hang

## What Changed

- `packages/adapter-utils/src/server-utils.ts`: added `UV_USE_IO_URING=0` to the merged env in `runChildProcess()`, covering all agent adapter executions (claude, codex, opencode, gemini, cursor, etc.)
- `server/src/services/plugin-worker-manager.ts`: added `UV_USE_IO_URING=0` to the controlled env object in the plugin worker fork
- `server/src/services/workspace-runtime.ts` (`executeProcess`): spread `UV_USE_IO_URING=0` into the spawn env for git and utility process calls
- `server/src/services/workspace-runtime.ts` (runtime service spawn): spread `UV_USE_IO_URING=0` into the MCP server spawn env (firebase, playwright, mongodb, aikido, nimble, chrome-devtools, etc.)

## Verification

Applied on a production server running Ubuntu 24.04 (kernel 6.8), operated for 24+ hours after applying both commits:

```bash
# All spawned claude processes carry the flag
ps aux | grep " claude$" | awk '{print $2}' | while read pid; do
  tr '\0' '\n' < /proc/$pid/environ | grep UV_USE_IO_URING
done
# → UV_USE_IO_URING=0  (for each process)

# No D-state processes
ps aux | awk '$8=="D"' | wc -l
# → 0

# Swap usage
free -h | grep Подкачка
# → 0B used out of 1.9GiB
```

- Zero D-state processes accumulated
- Swap remains at 0 between restarts
- `systemctl restart paperclip` completes cleanly without hanging

## Risks

- **Low risk.** The change is purely additive — `UV_USE_IO_URING=0` is injected into child process environments only. Parent process behavior is unchanged.
- `UV_USE_IO_URING` is a Linux-only libuv env var; it is silently ignored on macOS and Windows.
- On Linux kernels that do not use io_uring (< 6.x), the variable is accepted but has no effect since io_uring is not active.
- On Linux kernel ≥ 6.9 where the regression is presumably fixed upstream, the variable is harmless.
- Paperclip requires Node ≥ 18, and `UV_USE_IO_URING` has been a stable libuv knob since libuv 1.45 (Node 18), so the env var is always honoured on supported Node versions.
- No behavior changes on non-Linux platforms or unaffected kernel versions.

## Model Used

- **Provider:** Anthropic  
- **Model:** Claude Sonnet 4.6 (`claude-sonnet-4-6`)  
- **Mode:** Tool use / agentic (Claude Code CLI)  
- Both commits were produced with Claude Code assistance, with human review and testing on the affected server

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable — no tests needed (env var injection, verified in prod)
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [ ] I have updated relevant documentation to reflect my changes — N/A
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge