### PR TITLE
Harden authenticated mode secret handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 DATABASE_URL=postgres://paperclip:paperclip@localhost:5432/paperclip
 PORT=3100
 SERVE_UI=false
-BETTER_AUTH_SECRET=paperclip-dev-secret
+BETTER_AUTH_SECRET=<generate-with-openssl-rand-hex-32>

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -67,11 +67,13 @@ export function deriveAuthTrustedOrigins(config: Config): string[] {
 
 export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?: string[]): BetterAuthInstance {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
-  const secret = process.env.BETTER_AUTH_SECRET ?? process.env.PAPERCLIP_AGENT_JWT_SECRET;
+  const secret =
+    process.env.BETTER_AUTH_SECRET?.trim() ??
+    process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim() ??
+    "";
   if (!secret) {
     throw new Error(
-      "BETTER_AUTH_SECRET (or PAPERCLIP_AGENT_JWT_SECRET) must be set. " +
-      "For local development, set BETTER_AUTH_SECRET=paperclip-dev-secret in your .env file.",
+      "BETTER_AUTH_SECRET or PAPERCLIP_AGENT_JWT_SECRET must be set for authenticated mode",
     );
   }
   const effectiveTrustedOrigins = trustedOrigins ?? deriveAuthTrustedOrigins(config);


### PR DESCRIPTION
## Summary\n- Remove the authenticated-mode hint that recommends a fixed development auth secret.\n- Trim auth secret env values before use and fail clearly when neither BETTER_AUTH_SECRET nor PAPERCLIP_AGENT_JWT_SECRET is configured.\n- Update .env.example to require generating a unique auth secret.\n\n## Verification\n- pnpm install --frozen-lockfile\n- pnpm -r typecheck\n- pnpm test:run\n- pnpm build\n- git diff --check\n\nNote: node scripts/check-forbidden-tokens.mjs currently reports pre-existing tracked strings on clean master, so it was not a useful gate for this focused branch.