### PR TITLE
fix(server): preserve Slack webhook bodies and return Slack-compatible responses

### DIFF
--- a/server/src/__tests__/plugin-webhook-routes.test.ts
+++ b/server/src/__tests__/plugin-webhook-routes.test.ts
@@ -1,0 +1,132 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRegistry = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getByKey: vi.fn(),
+  list: vi.fn(),
+}));
+
+const mockWorkerManager = vi.hoisted(() => ({
+  call: vi.fn(),
+}));
+
+function registerRouteMocks() {
+  vi.doMock("../services/plugin-registry.js", () => ({
+    pluginRegistryService: () => mockRegistry,
+  }));
+  vi.doMock("../services/plugin-lifecycle.js", () => ({
+    pluginLifecycleManager: () => ({}) as unknown,
+  }));
+  vi.doMock("../services/plugin-loader.js", () => ({
+    pluginLoader: () => ({}) as unknown,
+    getPluginUiContributionMetadata: vi.fn(),
+  }));
+  vi.doMock("../services/activity-log.js", () => ({
+    logActivity: vi.fn(),
+  }));
+  vi.doMock("../services/live-events.js", () => ({
+    publishGlobalLiveEvent: vi.fn(),
+  }));
+  vi.doMock("../services/plugin-config-validator.js", () => ({
+    validateInstanceConfig: vi.fn(),
+  }));
+}
+
+async function createApp() {
+  const [{ pluginRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/plugins.js"),
+    import("../middleware/index.js"),
+  ]);
+
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = {
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: ["company-1"],
+    } as any;
+    next();
+  });
+  app.use(
+    "/api",
+    pluginRoutes(
+      {
+        insert: vi.fn(() => ({
+          values: vi.fn(() => ({
+            returning: vi.fn().mockResolvedValue([{ id: "delivery-1" }]),
+          })),
+        })),
+        update: vi.fn(() => ({
+          set: vi.fn(() => ({
+            where: vi.fn().mockResolvedValue(undefined),
+          })),
+        })),
+      } as any,
+      {} as any,
+      undefined,
+      { workerManager: mockWorkerManager as any },
+    ),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+describe("plugin webhook routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    registerRouteMocks();
+    mockRegistry.getById.mockResolvedValue({
+      id: "plugin-1",
+      status: "ready",
+      manifestJson: {
+        capabilities: ["webhooks.receive"],
+        webhooks: [
+          { endpointKey: "slash-command" },
+          { endpointKey: "slack-events" },
+          { endpointKey: "slack-interactivity" },
+        ],
+      },
+    });
+    mockRegistry.getByKey.mockResolvedValue(null);
+    mockWorkerManager.call.mockResolvedValue(undefined);
+  });
+
+  it("returns an empty 200 response for Slack slash commands", async () => {
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/plugins/plugin-1/webhooks/slash-command")
+      .type("form")
+      .send({
+        command: "/clip",
+        text: "help",
+        channel_id: "C123",
+        user_id: "U123",
+        response_url: "https://example.com/response",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.text).toBe("");
+  });
+
+  it("passes through the Slack url_verification challenge", async () => {
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/plugins/plugin-1/webhooks/slack-events")
+      .send({
+        type: "url_verification",
+        challenge: "challenge-123",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ challenge: "challenge-123" });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -89,6 +89,15 @@ export async function createApp(
 ) {
   const app = express();
 
+  app.use(express.urlencoded({
+    extended: false,
+    // Slack slash commands and interactivity post as application/x-www-form-urlencoded.
+    // Preserve the exact raw bytes for HMAC verification before parsing.
+    limit: "10mb",
+    verify: (req, _res, buf) => {
+      (req as unknown as { rawBody: Buffer }).rawBody = buf;
+    },
+  }));
   app.use(express.json({
     // Company import/export payloads can inline full portable packages.
     limit: "10mb",

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -1997,6 +1997,27 @@ export function pluginRoutes(
         })
         .where(eq(pluginWebhookDeliveries.id, delivery.id));
 
+      const slackEventType =
+        parsedBody && typeof parsedBody === "object" && "type" in parsedBody
+          ? parsedBody.type
+          : undefined;
+
+      if (endpointKey === "slash-command" || endpointKey === "slack-interactivity") {
+        res.status(200).end();
+        return;
+      }
+
+      if (endpointKey === "slack-events" && slackEventType === "url_verification") {
+        const challenge =
+          parsedBody && typeof parsedBody === "object" && "challenge" in parsedBody
+            ? parsedBody.challenge
+            : undefined;
+        if (typeof challenge === "string") {
+          res.status(200).json({ challenge });
+          return;
+        }
+      }
+
       res.status(200).json({
         deliveryId: delivery.id,
         status: "success",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - One way it extends behavior is through plugins that receive inbound webhooks from third-party systems
> - The Slack plugin depends on webhook delivery for slash commands, interactivity, and Slack Events verification
> - Slack signs its slash-command and interactivity payloads as `application/x-www-form-urlencoded`, and expects webhook responses that match Slack's own protocol
> - The server was only preserving `req.rawBody` through `express.json({ verify })`, and it always returned Paperclip's generic delivery ACK JSON after successful webhook dispatch
> - That combination breaks Slack signature verification for form-encoded requests and returns an incompatible response shape for slash commands and `url_verification`
> - This pull request preserves raw bytes for urlencoded webhook bodies and returns Slack-compatible success responses for Slack webhook endpoints
> - The benefit is that Slack integrations can authenticate and complete webhook flows correctly without changing plugin behavior or adding special-case workarounds in the plugin itself

## What Changed

- Added `express.urlencoded({ verify })` raw-body capture in `server/src/app.ts` so `application/x-www-form-urlencoded` webhook payloads preserve the exact bytes Slack signed
- Updated `POST /api/plugins/:pluginId/webhooks/:endpointKey` in `server/src/routes/plugins.ts` to return an empty `200 OK` for `slash-command` and `slack-interactivity`
- Updated the same route to pass through Slack `url_verification` challenges on `slack-events` by returning `{ "challenge": "..." }`
- Added route tests covering the empty slash-command response and `url_verification` challenge pass-through

## Verification

- `pnpm test:run server/src/__tests__/plugin-webhook-routes.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- Manual reproduction against a local Paperclip instance with the Slack plugin installed:
  - slash-command webhook accepted a real form-encoded request after preserving raw bytes
  - slash-command HTTP response changed from Paperclip ACK JSON to an empty `200 OK`
  - Slack Events `url_verification` behavior was validated at the route level with the added test coverage

## Risks

- Low risk, this only changes webhook response behavior for the Slack-specific endpoint keys `slash-command`, `slack-interactivity`, and `slack-events` when the payload is a Slack `url_verification`
- Other plugin webhooks continue to receive the existing Paperclip delivery ACK JSON
- `express.urlencoded()` runs before `express.json()`, but only for urlencoded payloads, which is required to preserve Slack's signed body bytes

## Model Used

- OpenAI Codex GPT-5.4 via OpenClaw (`openai-codex/gpt-5.4`)
- High thinking mode enabled in the OpenClaw runtime
- Tool-assisted workflow using local shell, file editing, git, and GitHub CLI
- Context window size not explicitly surfaced by the runtime

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
