### PR TITLE
Engineer Agent: bug fixes for executionRunId locking, blocked status validation, and OpenClaw gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tmp-*
 cli/tmp/
 
 # Scratch/seed scripts (but not scripts/ dir)
+run-*.sh
 check-*.mjs
 !scripts/check-*.mjs
 new-agent*.json

--- a/cli/src/commands/heartbeat-run.ts
+++ b/cli/src/commands/heartbeat-run.ts
@@ -254,7 +254,7 @@ export async function heartbeatRun(opts: HeartbeatRunOptions): Promise<void> {
     }
 
     const logResult = await api.get<{ content: string; nextOffset?: number }>(
-      `/api/heartbeat-runs/${activeRunId}/log?offset=${logOffset}&limitBytes=16384`,
+      `/heartbeat-runs/${activeRunId}/log?offset=${logOffset}&limitBytes=16384`,
       { ignoreNotFound: true },
     );
     if (logResult && logResult.content) {

--- a/cli/src/commands/heartbeat-run.ts
+++ b/cli/src/commands/heartbeat-run.ts
@@ -254,7 +254,7 @@ export async function heartbeatRun(opts: HeartbeatRunOptions): Promise<void> {
     }
 
     const logResult = await api.get<{ content: string; nextOffset?: number }>(
-      `/heartbeat-runs/${activeRunId}/log?offset=${logOffset}&limitBytes=16384`,
+      `/api/heartbeat-runs/${activeRunId}/log?offset=${logOffset}&limitBytes=16384`,
       { ignoreNotFound: true },
     );
     if (logResult && logResult.content) {

--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -55,6 +55,18 @@ The agent request is built as:
   - all `payloadTemplate` fields merged in
   - `agentId` from config if set and not already in template
 
+## Paperclip API Key Path
+
+By default the wake text tells the remote OpenClaw run to load `PAPERCLIP_API_KEY`
+from `~/.openclaw/workspace/paperclip-claimed-api-key.json`.
+
+For multi-company deployments, set:
+
+- `paperclipApiKeyPath` in adapter config
+
+This lets each OpenClaw gateway agent read a company-scoped claimed API key file
+instead of sharing one global path.
+
 ## Timeouts
 
 - `timeoutSec` controls adapter-level request budget

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -41,11 +41,10 @@ Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run
 - sessionKey (string, optional): fixed session key when strategy=fixed (default paperclip)
 
-Standard outbound payload additions:
-- paperclip (object): standardized Paperclip context added to every gateway agent request
-- paperclip.workspace (object, optional): resolved execution workspace for this run
-- paperclip.workspaces (array, optional): additional workspace hints Paperclip exposed to the run
-- paperclip.workspaceRuntime (object, optional): reserved workspace runtime metadata when explicitly supplied outside normal heartbeat execution
+Standard outbound message additions:
+- A \`## Paperclip Standard Context\` JSON block is appended to the gateway message body.
+- This carries the standardized Paperclip context that older adapter builds tried to send as a top-level \`paperclip\` request property.
+- Workspace/runtime hints are therefore preserved in-band without relying on gateway schema extensions.
 
 Standard result metadata supported:
 - meta.runtimeServices (array, optional): normalized adapter-managed runtime service reports

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -36,6 +36,7 @@ Request behavior fields:
 - waitTimeoutMs (number, optional): agent.wait timeout override (default timeoutSec * 1000)
 - autoPairOnFirstConnect (boolean, optional): on first "pairing required", attempt device.pair.list/device.pair.approve via shared auth, then retry once (default true)
 - paperclipApiUrl (string, optional): absolute Paperclip base URL advertised in wake text
+- paperclipApiKeyPath (string, optional): path the remote OpenClaw run should read for PAPERCLIP_API_KEY (default ~/.openclaw/workspace/paperclip-claimed-api-key.json)
 
 Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1105,8 +1105,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
-  const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
+  const standardWakeJson = JSON.stringify(
+    buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate),
+  );
+  const wakeMessage = appendWakeText(wakeText, `## Paperclip Standard Context\n\n${standardWakeJson}`);
+  const message = templateMessage ? appendWakeText(templateMessage, wakeMessage) : wakeMessage;
 
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
@@ -1115,7 +1118,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  delete agentParams.paperclip;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -29,6 +29,8 @@ type WakePayload = {
   issueIds: string[];
 };
 
+const DEFAULT_PAPERCLIP_API_KEY_PATH = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+
 type GatewayDeviceIdentity = {
   deviceId: string;
   publicKeyRawBase64Url: string;
@@ -343,11 +345,13 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
 }
 
 function buildWakeText(
+  config: Record<string, unknown>,
   payload: WakePayload,
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,
 ): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+  const claimedApiKeyPath =
+    nonEmpty(config.paperclipApiKeyPath) ?? DEFAULT_PAPERCLIP_API_KEY_PATH;
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -1088,6 +1092,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const structuredWakePrompt = renderPaperclipWakePrompt(ctx.context.paperclipWake);
   const structuredWakeJson = stringifyPaperclipWakePayload(ctx.context.paperclipWake);
   const wakeText = buildWakeText(
+    parseObject(ctx.config),
     wakePayload,
     paperclipEnv,
     structuredWakeJson

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -502,12 +502,10 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
-      expect(payload?.paperclip).toMatchObject({
-        wake: {
-          latestCommentId: "comment-2",
-          commentIds: ["comment-1", "comment-2"],
-        },
-      });
+      expect(payload?.paperclip).toBeUndefined();
+      expect(String(payload?.message ?? "")).toContain("## Paperclip Standard Context");
+      expect(String(payload?.message ?? "")).toContain('"latestCommentId":"comment-2"');
+      expect(String(payload?.message ?? "")).toContain('"commentIds":["comment-1","comment-2"]');
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
     } finally {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import type { BillingType, ExecutionWorkspace, ExecutionWorkspaceConfig } from "@paperclipai/shared";
 import {
@@ -1980,6 +1980,29 @@ export function heartbeatService(db: Db) {
     });
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
+
+    // Lazy locking: stamp executionRunId now that the run is actually running,
+    // not at queue time. Guard is idempotent — safe if called more than once.
+    const claimedIssueId = readNonEmptyString(parseObject(claimed.contextSnapshot).issueId);
+    if (claimedIssueId) {
+      const claimedAgent = await getAgent(claimed.agentId);
+      await db
+        .update(issues)
+        .set({
+          executionRunId: claimed.id,
+          executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
+          executionLockedAt: claimedAt,
+          updatedAt: claimedAt,
+        })
+        .where(
+          and(
+            eq(issues.id, claimedIssueId),
+            eq(issues.companyId, claimed.companyId),
+            or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
+          ),
+        );
+    }
+
     return claimed;
   }
 
@@ -3695,15 +3718,9 @@ export function heartbeatService(db: Db) {
           })
           .where(eq(agentWakeupRequests.id, wakeupRequest.id));
 
-        await tx
-          .update(issues)
-          .set({
-            executionRunId: newRun.id,
-            executionAgentNameKey: agentNameKey,
-            executionLockedAt: new Date(),
-            updatedAt: new Date(),
-          })
-          .where(eq(issues.id, issue.id));
+        // executionRunId is NOT stamped here (enqueueWakeup queues the run but
+        // doesn't start it). It will be stamped in claimQueuedRun() once the run
+        // transitions to "running" — lazy locking prevents stale locks on queued runs.
 
         return { kind: "queued" as const, run: newRun };
       });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1573,15 +1573,37 @@ export function issueService(db: Db) {
         assertTransition(existing.status, issueData.status);
       }
 
+      const normalizedIssueData = { ...issueData };
+
+      if (
+        normalizedIssueData.assigneeAgentId !== undefined &&
+        normalizedIssueData.assigneeAgentId !== null &&
+        normalizedIssueData.assigneeUserId === undefined
+      ) {
+        normalizedIssueData.assigneeUserId = null;
+      }
+
+      if (
+        normalizedIssueData.assigneeUserId !== undefined &&
+        normalizedIssueData.assigneeUserId !== null &&
+        normalizedIssueData.assigneeAgentId === undefined
+      ) {
+        normalizedIssueData.assigneeAgentId = null;
+      }
+
       const patch: Partial<typeof issues.$inferInsert> = {
-        ...issueData,
+        ...normalizedIssueData,
         updatedAt: new Date(),
       };
 
       const nextAssigneeAgentId =
-        issueData.assigneeAgentId !== undefined ? issueData.assigneeAgentId : existing.assigneeAgentId;
+        normalizedIssueData.assigneeAgentId !== undefined
+          ? normalizedIssueData.assigneeAgentId
+          : existing.assigneeAgentId;
       const nextAssigneeUserId =
-        issueData.assigneeUserId !== undefined ? issueData.assigneeUserId : existing.assigneeUserId;
+        normalizedIssueData.assigneeUserId !== undefined
+          ? normalizedIssueData.assigneeUserId
+          : existing.assigneeUserId;
 
       if (nextAssigneeAgentId && nextAssigneeUserId) {
         throw unprocessable("Issue can only have one assignee");
@@ -1589,17 +1611,22 @@ export function issueService(db: Db) {
       if (patch.status === "in_progress" && !nextAssigneeAgentId && !nextAssigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
-      if (issueData.assigneeAgentId) {
-        await assertAssignableAgent(existing.companyId, issueData.assigneeAgentId);
+      if (normalizedIssueData.assigneeAgentId) {
+        await assertAssignableAgent(existing.companyId, normalizedIssueData.assigneeAgentId);
       }
-      if (issueData.assigneeUserId) {
-        await assertAssignableUser(existing.companyId, issueData.assigneeUserId);
+      if (normalizedIssueData.assigneeUserId) {
+        await assertAssignableUser(existing.companyId, normalizedIssueData.assigneeUserId);
       }
-      const nextProjectId = issueData.projectId !== undefined ? issueData.projectId : existing.projectId;
+      const nextProjectId =
+        normalizedIssueData.projectId !== undefined ? normalizedIssueData.projectId : existing.projectId;
       const nextProjectWorkspaceId =
-        issueData.projectWorkspaceId !== undefined ? issueData.projectWorkspaceId : existing.projectWorkspaceId;
+        normalizedIssueData.projectWorkspaceId !== undefined
+          ? normalizedIssueData.projectWorkspaceId
+          : existing.projectWorkspaceId;
       const nextExecutionWorkspaceId =
-        issueData.executionWorkspaceId !== undefined ? issueData.executionWorkspaceId : existing.executionWorkspaceId;
+        normalizedIssueData.executionWorkspaceId !== undefined
+          ? normalizedIssueData.executionWorkspaceId
+          : existing.executionWorkspaceId;
       if (nextProjectWorkspaceId) {
         await assertValidProjectWorkspace(existing.companyId, nextProjectId, nextProjectWorkspaceId);
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1573,6 +1573,14 @@ export function issueService(db: Db) {
         assertTransition(existing.status, issueData.status);
       }
 
+      if (
+        issueData.status === "blocked" &&
+        existing.status !== "blocked" &&
+        (blockedByIssueIds === undefined || blockedByIssueIds.length === 0)
+      ) {
+        throw unprocessable("Issues set to blocked status must have at least one blocker in blockedByIssueIds");
+      }
+
       const normalizedIssueData = { ...issueData };
 
       if (

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1651,12 +1651,19 @@ export function issueService(db: Db) {
       }
       if (issueData.status && issueData.status !== "in_progress") {
         patch.checkoutRunId = null;
+        if (issueData.status !== "done") {
+          patch.executionRunId = null;
+          patch.executionLockedAt = null;
+        }
       }
       if (
         (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
         (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
       ) {
         patch.checkoutRunId = null;
+        // Clear execution lock on reassignment, matching checkoutRunId clear
+        patch.executionRunId = null;
+        patch.executionLockedAt = null;
       }
 
       return db.transaction(async (tx) => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1578,7 +1578,7 @@ export function issueService(db: Db) {
       if (
         normalizedIssueData.assigneeAgentId !== undefined &&
         normalizedIssueData.assigneeAgentId !== null &&
-        normalizedIssueData.assigneeUserId === undefined
+        normalizedIssueData.assigneeUserId == null
       ) {
         normalizedIssueData.assigneeUserId = null;
       }


### PR DESCRIPTION
## Summary

Bug fixes for Paperclip core addressing executionRunId locking, status validation, and OpenClaw gateway configuration:

- **executionRunId lazy locking**: Stamp executionRunId at claim time (run start), not queue time, preventing stale locks on queued runs
- **executionRunId cleanup on done**: Preserve executionRunId when transitioning to done status so releaseIssueExecutionAndPromote can promote deferred wakeups  
- **blocked status validation**: Require non-empty blockedByIssueIds when transitioning to blocked status
- **OpenClaw gateway paperclipApiKeyPath**: Support configurable API key path for multi-company deployments

## Commits

- `b080f84b` Fix heartbeat run log polling path
- `70a7bef1` Add paperclipApiKeyPath config for multi-company OpenClaw deployments
- `fcf7b508` Validate blocked status requires non-empty blockedByIssueIds
- `3dd016ea` Fix issue reassignment when stale assigneeUserId is null
- `7b57aa92` Normalize issue assignee handoff patches
- `32259ee0` Fix OpenClaw gateway adapter payload shape

## Testing

- QA regression issue: MAX-1712