### PR TITLE
fix(server): make Slack webhooks verify and respond correctly

### DIFF
--- a/server/src/__tests__/plugin-webhook-routes.test.ts
+++ b/server/src/__tests__/plugin-webhook-routes.test.ts
@@ -1,0 +1,138 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRegistry = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getByKey: vi.fn(),
+  list: vi.fn(),
+}));
+
+const mockWorkerManager = vi.hoisted(() => ({
+  call: vi.fn(),
+}));
+
+function registerRouteMocks() {
+  vi.doMock("../services/plugin-registry.js", () => ({
+    pluginRegistryService: () => mockRegistry,
+  }));
+  vi.doMock("../services/plugin-lifecycle.js", () => ({
+    pluginLifecycleManager: () => ({}) as unknown,
+  }));
+  vi.doMock("../services/plugin-loader.js", () => ({
+    pluginLoader: () => ({}) as unknown,
+    getPluginUiContributionMetadata: vi.fn(),
+  }));
+  vi.doMock("../services/activity-log.js", () => ({
+    logActivity: vi.fn(),
+  }));
+  vi.doMock("../services/live-events.js", () => ({
+    publishGlobalLiveEvent: vi.fn(),
+  }));
+  vi.doMock("../services/plugin-config-validator.js", () => ({
+    validateInstanceConfig: vi.fn(),
+  }));
+}
+
+async function createApp() {
+  const [{ pluginRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/plugins.js"),
+    import("../middleware/index.js"),
+  ]);
+
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = {
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: ["company-1"],
+    } as any;
+    next();
+  });
+  app.use(
+    "/api",
+    pluginRoutes(
+      {
+        insert: vi.fn(() => ({
+          values: vi.fn(() => ({
+            returning: vi.fn().mockResolvedValue([{ id: "delivery-1" }]),
+          })),
+        })),
+        update: vi.fn(() => ({
+          set: vi.fn(() => ({
+            where: vi.fn().mockResolvedValue(undefined),
+          })),
+        })),
+      } as any,
+      {} as any,
+      undefined,
+      { workerManager: mockWorkerManager as any },
+    ),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+describe("plugin webhook routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    registerRouteMocks();
+    mockRegistry.getById.mockResolvedValue({
+      id: "plugin-1",
+      status: "ready",
+      manifestJson: {
+        capabilities: ["webhooks.receive"],
+        webhooks: [
+          { endpointKey: "slash-command", displayName: "Slash commands" },
+          { endpointKey: "slack-events", displayName: "Slack events" },
+          { endpointKey: "slack-interactivity", displayName: "Slack interactivity" },
+        ],
+      },
+    });
+    mockRegistry.getByKey.mockResolvedValue(null);
+    mockWorkerManager.call.mockResolvedValue(undefined);
+  });
+
+  it("returns an empty 200 response for Slack slash commands", async () => {
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/plugins/plugin-1/webhooks/slash-command")
+      .set("x-slack-signature", "v0=fake-signature")
+      .set("x-slack-request-timestamp", "1234567890")
+      .type("form")
+      .send({
+        command: "/clip",
+        text: "help",
+        channel_id: "C123",
+        user_id: "U123",
+        response_url: "https://example.com/response",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.text).toBe("");
+    expect(mockWorkerManager.call).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes through the Slack url_verification challenge without calling the worker", async () => {
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/plugins/plugin-1/webhooks/slack-events")
+      .set("x-slack-signature", "v0=fake-signature")
+      .set("x-slack-request-timestamp", "1234567890")
+      .send({
+        type: "url_verification",
+        challenge: "challenge-123",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ challenge: "challenge-123" });
+    expect(mockWorkerManager.call).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/plugin-webhook-routes.test.ts
+++ b/server/src/__tests__/plugin-webhook-routes.test.ts
@@ -41,8 +41,17 @@ async function createApp() {
   ]);
 
   const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use(express.json());
+  app.use(express.urlencoded({
+    extended: false,
+    verify: (req, _res, buf) => {
+      (req as unknown as { rawBody: Buffer }).rawBody = buf;
+    },
+  }));
+  app.use(express.json({
+    verify: (req, _res, buf) => {
+      (req as unknown as { rawBody: Buffer }).rawBody = buf;
+    },
+  }));
   app.use((req, _res, next) => {
     req.actor = {
       type: "board",
@@ -117,6 +126,14 @@ describe("plugin webhook routes", () => {
     expect(res.status).toBe(200);
     expect(res.text).toBe("");
     expect(mockWorkerManager.call).toHaveBeenCalledTimes(1);
+    expect(mockWorkerManager.call).toHaveBeenCalledWith(
+      "plugin-1",
+      "handleWebhook",
+      expect.objectContaining({
+        endpointKey: "slash-command",
+        rawBody: expect.stringContaining("command=%2Fclip"),
+      }),
+    );
   });
 
   it("passes through the Slack url_verification challenge without calling the worker", async () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -89,6 +89,15 @@ export async function createApp(
 ) {
   const app = express();
 
+  app.use(express.urlencoded({
+    extended: false,
+    // Slack slash commands and interactivity post as application/x-www-form-urlencoded.
+    // Preserve the exact raw bytes for HMAC verification before parsing.
+    limit: "10mb",
+    verify: (req, _res, buf) => {
+      (req as unknown as { rawBody: Buffer }).rawBody = buf;
+    },
+  }));
   app.use(express.json({
     // Company import/export payloads can inline full portable packages.
     limit: "10mb",

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -1886,7 +1886,10 @@ export function pluginRoutes(
    * endpoints must be publicly accessible for external callers. Signature
    * verification is the plugin's responsibility.
    *
-   * Response: `{ deliveryId: string, status: string }`
+   * Response: `{ deliveryId: string, status: string }` for generic webhooks.
+   * Slack-compatible responses are returned for signed Slack requests:
+   * - empty `200 OK` for slash commands and interactivity
+   * - `{ challenge }` for Slack Events `url_verification`
    * Errors:
    * - 404 if plugin not found or endpointKey not declared
    * - 400 if plugin is not in ready state or lacks webhooks.receive capability
@@ -1953,13 +1956,26 @@ export function pluginRoutes(
       }
     }
 
-    // Use the raw buffer stashed by the express.json() `verify` callback.
+    // Use the raw buffer stashed by the express.json() or express.urlencoded() `verify` callback.
     // This preserves the exact bytes the provider signed, whereas
     // JSON.stringify(req.body) would re-serialize and break HMAC verification.
     const stashedRaw = (req as unknown as { rawBody?: Buffer }).rawBody;
     const rawBody = stashedRaw ? stashedRaw.toString("utf-8") : "";
     const parsedBody = req.body as unknown;
     const payload = (req.body as Record<string, unknown> | undefined) ?? {};
+    const slackSignature = rawHeaders["x-slack-signature"];
+    const slackRequestTimestamp = rawHeaders["x-slack-request-timestamp"];
+    const isSlackWebhook = typeof slackSignature === "string" && typeof slackRequestTimestamp === "string";
+    const slackEventType =
+      parsedBody && typeof parsedBody === "object" && "type" in parsedBody
+        ? parsedBody.type
+        : undefined;
+    const slackChallenge =
+      parsedBody && typeof parsedBody === "object" && "challenge" in parsedBody
+        ? parsedBody.challenge
+        : undefined;
+    const isSlackUrlVerification =
+      isSlackWebhook && slackEventType === "url_verification" && typeof slackChallenge === "string";
 
     // Step 6: Record the delivery in the database
     const startedAt = new Date();
@@ -1974,6 +1990,22 @@ export function pluginRoutes(
         startedAt,
       })
       .returning({ id: pluginWebhookDeliveries.id });
+
+    if (isSlackUrlVerification) {
+      const finishedAt = new Date();
+      const durationMs = finishedAt.getTime() - startedAt.getTime();
+      await db
+        .update(pluginWebhookDeliveries)
+        .set({
+          status: "success",
+          durationMs,
+          finishedAt,
+        })
+        .where(eq(pluginWebhookDeliveries.id, delivery.id));
+
+      res.status(200).json({ challenge: slackChallenge });
+      return;
+    }
 
     // Step 7: Dispatch to the worker via handleWebhook RPC
     try {
@@ -1996,6 +2028,11 @@ export function pluginRoutes(
           finishedAt,
         })
         .where(eq(pluginWebhookDeliveries.id, delivery.id));
+
+      if (isSlackWebhook) {
+        res.status(200).end();
+        return;
+      }
 
       res.status(200).json({
         deliveryId: delivery.id,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Plugins extend Paperclip with inbound webhook integrations for third-party systems like Slack
> - Slack webhook flows rely on two host-level guarantees: the exact signed request body must be preserved for HMAC verification, and the HTTP response must match Slack's protocol
> - The server only preserved `req.rawBody` through `express.json({ verify })`, which misses Slack's form-encoded slash-command and interactivity payloads
> - The webhook route also returned Paperclip's generic delivery ACK JSON on success, and the Slack Events `url_verification` challenge depended on the worker succeeding first
> - That combination can break Slack signature verification, return the wrong success body to Slack, and fail URL verification when the worker is unavailable
> - This pull request preserves raw bytes for urlencoded payloads, short-circuits Slack `url_verification` before worker dispatch, and returns Slack-compatible success responses for signed Slack requests
> - The benefit is that Slack integrations can authenticate and complete webhook setup reliably without plugin-specific workarounds in the host response path

## What Changed

- Added `express.urlencoded({ verify })` raw-body capture in `server/src/app.ts` so form-encoded Slack payloads preserve the exact signed bytes
- Updated the plugin webhook route to detect Slack requests via Slack signature headers rather than hardcoded endpoint-key names
- Short-circuited Slack Events `url_verification` to return `{ "challenge": "..." }` before worker dispatch, while still recording a successful delivery
- Returned an empty `200 OK` for other signed Slack webhook successes instead of Paperclip's generic delivery ACK JSON
- Added route tests covering slash-command success responses and `url_verification` short-circuit behavior

## Verification

- `pnpm test:run server/src/__tests__/plugin-webhook-routes.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- Manual reproduction against a local Paperclip instance with the Slack plugin installed:
  - signed slash-command requests reached the webhook route with the original raw body preserved
  - successful slash-command responses returned an empty `200 OK` instead of the generic delivery ACK JSON
  - Slack Events `url_verification` could be satisfied from the host route without depending on worker startup timing

## Risks

- Low risk, the response shaping only applies to requests that include Slack's signature headers
- Non-Slack plugin webhooks continue to receive the existing Paperclip delivery ACK JSON
- Signed Slack event callbacks now also get an empty `200 OK` after worker success, which is Slack-compatible but slightly changes the previous host response body for those requests

## Model Used

- OpenAI Codex GPT-5.4 via OpenClaw (`openai-codex/gpt-5.4`)
- High thinking mode enabled in the OpenClaw runtime
- Tool-assisted workflow using local shell, file editing, git, and GitHub CLI
- Context window size not explicitly surfaced by the runtime

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
