### PR TITLE
fix(adapters): honor legacyCwdOptIn over all workspace sources

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -138,9 +138,53 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip claude-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip claude-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
 
   const envConfig = parseObject(config.env);
@@ -195,8 +239,11 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   if (wakePayloadJson) {
     env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
   }
-  if (effectiveWorkspaceCwd) {
-    env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) {
+    env.PAPERCLIP_WORKSPACE_CWD = cwd;
   }
   if (workspaceSource) {
     env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -260,9 +260,53 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip codex-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip codex-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   const envConfig = parseObject(config.env);
   const configuredCodexHome =
     typeof envConfig.CODEX_HOME === "string" && envConfig.CODEX_HOME.trim().length > 0
@@ -337,8 +381,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (wakePayloadJson) {
     env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
   }
-  if (effectiveWorkspaceCwd) {
-    env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) {
+    env.PAPERCLIP_WORKSPACE_CWD = cwd;
   }
   if (workspaceSource) {
     env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -183,9 +183,53 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip cursor-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip cursor-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const cursorSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredCursorSkillNames = resolvePaperclipDesiredSkillNames(config, cursorSkillEntries);
@@ -243,8 +287,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (wakePayloadJson) {
     env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
   }
-  if (effectiveWorkspaceCwd) {
-    env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) {
+    env.PAPERCLIP_WORKSPACE_CWD = cwd;
   }
   if (workspaceSource) {
     env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -159,9 +159,53 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip gemini-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip gemini-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const geminiSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredGeminiSkillNames = resolvePaperclipDesiredSkillNames(config, geminiSkillEntries);
@@ -203,7 +247,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
-  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) env.PAPERCLIP_WORKSPACE_CWD = cwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -116,9 +116,53 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip opencode-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip opencode-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const openCodeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredOpenCodeSkillNames = resolvePaperclipDesiredSkillNames(config, openCodeSkillEntries);
@@ -164,7 +208,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
-  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) env.PAPERCLIP_WORKSPACE_CWD = cwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -136,9 +136,53 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip pi-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip pi-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   
   // Ensure sessions directory exists
@@ -188,7 +232,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
-  if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) env.PAPERCLIP_WORKSPACE_CWD = cwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;


### PR DESCRIPTION
## Summary
Replaces the v1 precedence rule (which only overrode `agent_home` fallback) with a policy where `adapterConfig.cwd + legacyCwdOptIn=true` takes precedence over **every** `paperclipWorkspace` source: `project_primary`, `task_session`, and `agent_home`. This is the explicit "give me the pre-workspace-runtime behavior" escape hatch and must override every workspace-runtime result so per-agent git worktrees stay honored when stale `task_session` params still point at a shared checkout.

Applied identically to `claude-local`, `codex-local`, `cursor-local`, `gemini-local`, `opencode-local`, and `pi-local`.

## Why
Two separate failure modes shaped this policy:

1. **`agent_home` fallback silently beat configured per-agent worktrees**, contaminating a shared checkout on concurrent writes.
2. **Stale `task_session` workspaces** (saved from prior runs via `agentTaskSessions.sessionParamsJson.cwd`) pointing at the shared checkout ALSO beat configured worktrees. The v1 fix only handled `agent_home`, so `task_session` slipped through.

Both cases require `legacyCwdOptIn` to unconditionally override.

## What changed
- **Precedence rule** (all 6 adapters): `configuredCwd && legacyCwdOptIn` wins unconditionally over any `workspaceCwd` regardless of `workspaceSource`. When they differ, emit a `console.warn` so operators can trace why a run landed where it did.
- **No-opt-in safety**: if `configuredCwd` is set but `legacyCwdOptIn` is missing, warn and fall back to `process.cwd()` instead of silently writing outside a managed workspace.
- **`PAPERCLIP_WORKSPACE_CWD` env mirror**: previously only set when `effectiveWorkspaceCwd` was non-empty — now always mirrors the final resolved `cwd`, so subprocesses that prefer this env var see the same path the adapter launched them in.

## Test plan
- [ ] Wake a `claude_local` agent via `source=on_demand` with `adapterConfig.cwd` set and `legacyCwdOptIn: true`, confirm the run lands in the configured cwd
- [ ] Wake the same agent via `source=timer` with stale `agentTaskSessions.sessionParamsJson.cwd` pointing elsewhere, confirm the run still lands in the configured cwd (task_session overridden)
- [ ] Set `adapterConfig.cwd` without `legacyCwdOptIn`, confirm warning fires and run falls back to `process.cwd()` (not the configured cwd)
- [ ] Verify `PAPERCLIP_WORKSPACE_CWD` env var in the subprocess matches the adapter's resolved cwd
- [ ] Repeat the above matrix for `codex_local`, `cursor_local`, `gemini_local`, `opencode_local`, `pi_local`

Obsolete PR.
