### PR TITLE
feat(budgets): add opt-in calendar_day_utc windows

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -292,7 +292,7 @@ export type BudgetScopeType = (typeof BUDGET_SCOPE_TYPES)[number];
 export const BUDGET_METRICS = ["billed_cents"] as const;
 export type BudgetMetric = (typeof BUDGET_METRICS)[number];
 
-export const BUDGET_WINDOW_KINDS = ["calendar_month_utc", "lifetime"] as const;
+export const BUDGET_WINDOW_KINDS = ["calendar_day_utc", "calendar_month_utc", "lifetime"] as const;
 export type BudgetWindowKind = (typeof BUDGET_WINDOW_KINDS)[number];
 
 export const BUDGET_THRESHOLD_TYPES = ["soft", "hard"] as const;

--- a/server/src/__tests__/budgets-service.test.ts
+++ b/server/src/__tests__/budgets-service.test.ts
@@ -352,8 +352,8 @@ describe("budgetService", () => {
     }]);
     dbStub.queueUpdate([]);
 
-    const service = budgetService(dbStub.db as any);
-    await service.evaluateCostEvent({
+    const cancelWorkForScope = vi.fn().mockResolvedValue(undefined);
+    const service = budgetService(dbStub.db as any, { cancelWorkForScope });
       companyId: "company-1",
       agentId: "agent-1",
       projectId: null,

--- a/server/src/__tests__/budgets-service.test.ts
+++ b/server/src/__tests__/budgets-service.test.ts
@@ -308,4 +308,67 @@ describe("budgetService", () => {
       }),
     );
   });
+
+  it("uses calendar_day_utc windows when creating hard-stop incidents", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-11T13:45:00.000Z"));
+
+    const policy = {
+      id: "policy-day-1",
+      companyId: "company-1",
+      scopeType: "agent",
+      scopeId: "agent-1",
+      metric: "billed_cents",
+      windowKind: "calendar_day_utc",
+      amount: 100,
+      warnPercent: 80,
+      hardStopEnabled: true,
+      notifyEnabled: false,
+      isActive: true,
+    };
+
+    const dbStub = createDbStub([
+      [policy],
+      [{ total: 150 }],
+      [],
+      [{
+        companyId: "company-1",
+        name: "Budget Agent",
+        status: "running",
+        pauseReason: null,
+      }],
+    ]);
+
+    dbStub.queueInsert([{
+      id: "approval-1",
+      companyId: "company-1",
+      status: "pending",
+    }]);
+    dbStub.queueInsert([{
+      id: "incident-1",
+      companyId: "company-1",
+      policyId: "policy-day-1",
+      approvalId: "approval-1",
+    }]);
+    dbStub.queueUpdate([]);
+
+    const service = budgetService(dbStub.db as any);
+    await service.evaluateCostEvent({
+      companyId: "company-1",
+      agentId: "agent-1",
+      projectId: null,
+    } as any);
+
+    expect(dbStub.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          windowKind: "calendar_day_utc",
+          windowStart: "2026-04-11T00:00:00.000Z",
+          windowEnd: "2026-04-12T00:00:00.000Z",
+        }),
+      }),
+    );
+
+    vi.useRealTimers();
+  });
 });

--- a/server/src/__tests__/budgets-service.test.ts
+++ b/server/src/__tests__/budgets-service.test.ts
@@ -312,63 +312,65 @@ describe("budgetService", () => {
   it("uses calendar_day_utc windows when creating hard-stop incidents", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-11T13:45:00.000Z"));
-
-    const policy = {
-      id: "policy-day-1",
-      companyId: "company-1",
-      scopeType: "agent",
-      scopeId: "agent-1",
-      metric: "billed_cents",
-      windowKind: "calendar_day_utc",
-      amount: 100,
-      warnPercent: 80,
-      hardStopEnabled: true,
-      notifyEnabled: false,
-      isActive: true,
-    };
-
-    const dbStub = createDbStub([
-      [policy],
-      [{ total: 150 }],
-      [],
-      [{
+    try {
+      const policy = {
+        id: "policy-day-1",
         companyId: "company-1",
-        name: "Budget Agent",
-        status: "running",
-        pauseReason: null,
-      }],
-    ]);
+        scopeType: "agent",
+        scopeId: "agent-1",
+        metric: "billed_cents",
+        windowKind: "calendar_day_utc",
+        amount: 100,
+        warnPercent: 80,
+        hardStopEnabled: true,
+        notifyEnabled: false,
+        isActive: true,
+      };
 
-    dbStub.queueInsert([{
-      id: "approval-1",
-      companyId: "company-1",
-      status: "pending",
-    }]);
-    dbStub.queueInsert([{
-      id: "incident-1",
-      companyId: "company-1",
-      policyId: "policy-day-1",
-      approvalId: "approval-1",
-    }]);
-    dbStub.queueUpdate([]);
+      const dbStub = createDbStub([
+        [policy],
+        [{ total: 150 }],
+        [],
+        [{
+          companyId: "company-1",
+          name: "Budget Agent",
+          status: "running",
+          pauseReason: null,
+        }],
+      ]);
 
-    const cancelWorkForScope = vi.fn().mockResolvedValue(undefined);
-    const service = budgetService(dbStub.db as any, { cancelWorkForScope });
-      companyId: "company-1",
-      agentId: "agent-1",
-      projectId: null,
-    } as any);
+      dbStub.queueInsert([{
+        id: "approval-1",
+        companyId: "company-1",
+        status: "pending",
+      }]);
+      dbStub.queueInsert([{
+        id: "incident-1",
+        companyId: "company-1",
+        policyId: "policy-day-1",
+        approvalId: "approval-1",
+      }]);
+      dbStub.queueUpdate([]);
 
-    expect(dbStub.insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        payload: expect.objectContaining({
-          windowKind: "calendar_day_utc",
-          windowStart: "2026-04-11T00:00:00.000Z",
-          windowEnd: "2026-04-12T00:00:00.000Z",
+      const cancelWorkForScope = vi.fn().mockResolvedValue(undefined);
+      const service = budgetService(dbStub.db as any, { cancelWorkForScope });
+      await service.evaluateCostEvent({
+        companyId: "company-1",
+        agentId: "agent-1",
+        projectId: null,
+      } as any);
+
+      expect(dbStub.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            windowKind: "calendar_day_utc",
+            windowStart: "2026-04-11T00:00:00.000Z",
+            windowEnd: "2026-04-12T00:00:00.000Z",
+          }),
         }),
-      }),
-    );
-
-    vi.useRealTimers();
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -52,12 +52,24 @@ function currentUtcMonthWindow(now = new Date()) {
   return { start, end };
 }
 
+function currentUtcDayWindow(now = new Date()) {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const day = now.getUTCDate();
+  const start = new Date(Date.UTC(year, month, day, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(year, month, day + 1, 0, 0, 0, 0));
+  return { start, end };
+}
+
 function resolveWindow(windowKind: BudgetWindowKind, now = new Date()) {
   if (windowKind === "lifetime") {
     return {
       start: new Date(Date.UTC(1970, 0, 1, 0, 0, 0, 0)),
       end: new Date(Date.UTC(9999, 0, 1, 0, 0, 0, 0)),
     };
+  }
+  if (windowKind === "calendar_day_utc") {
+    return currentUtcDayWindow(now);
   }
   return currentUtcMonthWindow(now);
 }
@@ -149,7 +161,7 @@ async function computeObservedAmount(
   if (policy.scopeType === "agent") conditions.push(eq(costEvents.agentId, policy.scopeId));
   if (policy.scopeType === "project") conditions.push(eq(costEvents.projectId, policy.scopeId));
   const { start, end } = resolveWindow(policy.windowKind as BudgetWindowKind);
-  if (policy.windowKind === "calendar_month_utc") {
+  if (policy.windowKind !== "lifetime") {
     conditions.push(gte(costEvents.occurredAt, start));
     conditions.push(lt(costEvents.occurredAt, end));
   }


### PR DESCRIPTION
## Thinking Path

- Paperclip already supports multiple budget window kinds, but the current set is too coarse for some operational policies.
- Daily UTC caps are a real control mechanism for AI-agent budgets because they let operators constrain spend at the same cadence they monitor incidents and platform burn.
- The existing budget service already resolves a time window before evaluating spend, so the clean upstream change is to add one more explicit window kind rather than introducing downstream-only overrides.
- This should stay opt-in. Existing installs that use monthly or lifetime windows should not change behavior.
- The implementation therefore adds `calendar_day_utc` to the supported window kinds, resolves the UTC day boundary in the budget service, and verifies the new behavior with tests.

## What Changed

- Added `calendar_day_utc` to the supported budget window kinds.
- Added UTC day window resolution logic in the budget service.
- Applied the resolved UTC day window to spend evaluation for non-lifetime policies.
- Added test coverage for daily window boundary behavior.

## Why this belongs upstream

Daily spend caps are a general operational budgeting feature, not a deployment-specific customization. Paperclip already models budget windows explicitly, so adding `calendar_day_utc` upstream keeps the capability in the core policy model instead of forcing downstream runtime patches.

## Opt-in / Behavior

This change is fully additive.

The default remains `calendar_month_utc`. No existing policy changes behavior unless it explicitly uses:

```json
{
  "windowKind": "calendar_day_utc"
}
