### PR TITLE
feat(issues): add opt-in blocked-issue escalation policy

### DIFF
--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -43,6 +43,22 @@ The adapter supports the same session routing model as HTTP OpenClaw mode:
 
 Resolved session key is sent as `agent.sessionKey`.
 
+## Opt-in blocked-issue escalation
+
+You can require explicit unblocker tickets before an OpenClaw-backed agent leaves work in `blocked`.
+
+- set `issueBlockEscalation.enabled=true`
+- set `issueBlockEscalation.targetRole=<role>` such as `cto`
+- optional `issueBlockEscalation.openStatuses=["backlog","todo","in_progress","in_review","blocked"]`
+
+When enabled, a `PATCH /api/issues/:id` transition to `blocked` by that agent will:
+
+- create or reuse a child escalation issue assigned to `targetRole`
+- log the escalation on the parent issue activity stream
+- reject the block transition with `422` if the config is incomplete or the target role does not exist
+
+If the policy is not enabled, blocked transitions behave exactly as before.
+
 ## Payload Mapping
 
 The agent request is built as:

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -42,6 +42,12 @@ Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run
 - sessionKey (string, optional): fixed session key when strategy=fixed (default paperclip)
 
+Issue policy fields:
+- issueBlockEscalation (object, optional): explicit opt-in policy for auto-escalating blocked issues
+  - enabled (boolean, required to activate)
+  - targetRole (string, required when enabled): role that should receive the unblocker issue, for example cto
+  - openStatuses (string[], optional): statuses treated as reusable escalation issues; defaults to backlog,todo,in_progress,in_review,blocked
+
 Standard outbound payload additions:
 - paperclip (object): standardized Paperclip context added to every gateway agent request
 - paperclip.workspace (object, optional): resolved execution workspace for this run

--- a/server/src/__tests__/invite-accept-gateway-defaults.test.ts
+++ b/server/src/__tests__/invite-accept-gateway-defaults.test.ts
@@ -116,4 +116,54 @@ describe("normalizeAgentDefaultsForJoin (openclaw_gateway)", () => {
     expect(normalized.normalized?.disableDeviceAuth).toBe(true);
     expect(normalized.normalized?.devicePrivateKeyPem).toBeUndefined();
   });
+
+  it("preserves enabled blocked-issue escalation config including reusable statuses", () => {
+    const normalized = normalizeAgentDefaultsForJoin({
+      adapterType: "openclaw_gateway",
+      defaultsPayload: {
+        url: "ws://127.0.0.1:18789",
+        headers: {
+          "x-openclaw-token": "gateway-token-1234567890",
+        },
+        issueBlockEscalation: {
+          enabled: true,
+          targetRole: "cto",
+          openStatuses: ["todo", "in_progress"],
+        },
+      },
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    });
+
+    expect(normalized.normalized?.issueBlockEscalation).toEqual({
+      enabled: true,
+      targetRole: "cto",
+      openStatuses: ["todo", "in_progress"],
+    });
+  });
+
+  it("drops blocked-issue escalation config when the opt-in toggle is disabled", () => {
+    const normalized = normalizeAgentDefaultsForJoin({
+      adapterType: "openclaw_gateway",
+      defaultsPayload: {
+        url: "ws://127.0.0.1:18789",
+        headers: {
+          "x-openclaw-token": "gateway-token-1234567890",
+        },
+        issueBlockEscalation: {
+          enabled: false,
+          targetRole: "cto",
+          openStatuses: ["todo", "in_progress"],
+        },
+      },
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    });
+
+    expect(normalized.normalized?.issueBlockEscalation).toBeUndefined();
+  });
 });

--- a/server/src/__tests__/issue-block-escalation-policy.test.ts
+++ b/server/src/__tests__/issue-block-escalation-policy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_BLOCK_ESCALATION_OPEN_STATUSES,
+  parseIssueBlockEscalationConfig,
+} from "../routes/issues.js";
+
+describe("parseIssueBlockEscalationConfig", () => {
+  it("returns null unless the policy is explicitly enabled", () => {
+    expect(parseIssueBlockEscalationConfig(null)).toBeNull();
+    expect(parseIssueBlockEscalationConfig({})).toBeNull();
+    expect(parseIssueBlockEscalationConfig({ enabled: false, targetRole: "cto" })).toBeNull();
+  });
+
+  it("uses default open statuses when the opt-in policy omits them", () => {
+    expect(parseIssueBlockEscalationConfig({ enabled: true, targetRole: "cto" })).toEqual({
+      targetRole: "cto",
+      openStatuses: DEFAULT_BLOCK_ESCALATION_OPEN_STATUSES,
+    });
+  });
+
+  it("preserves explicit target role and reusable statuses", () => {
+    expect(
+      parseIssueBlockEscalationConfig({
+        enabled: "true",
+        targetRole: "qa_tester",
+        openStatuses: ["todo", "in_progress"],
+      }),
+    ).toEqual({
+      targetRole: "qa_tester",
+      openStatuses: "todo,in_progress",
+    });
+  });
+});

--- a/server/src/__tests__/issue-block-escalation-routes.test.ts
+++ b/server/src/__tests__/issue-block-escalation-routes.test.ts
@@ -1,0 +1,198 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  assertCheckoutOwner: vi.fn(),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  getRelationSummaries: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+  list: vi.fn(),
+  create: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  list: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(async () => false),
+    hasPermission: vi.fn(async () => false),
+  }),
+  agentService: () => mockAgentService,
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({
+    getById: vi.fn(async () => null),
+  }),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+  }),
+  goalService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    })),
+    listCompanyIds: vi.fn(async () => ["company-1"]),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: "agent-senior-engineer",
+      companyId: "company-1",
+      runId: null,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue() {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    companyId: "company-1",
+    status: "todo",
+    assigneeAgentId: "agent-senior-engineer",
+    assigneeUserId: null,
+    createdByUserId: "local-board",
+    identifier: "PAP-580",
+    title: "Blocked issue",
+    priority: "medium",
+    projectId: null,
+    goalId: null,
+    parentId: null,
+    requestDepth: 0,
+    executionPolicy: null,
+    executionState: null,
+  };
+}
+
+function makeActorAgent() {
+  return {
+    id: "agent-senior-engineer",
+    companyId: "company-1",
+    role: "senior_engineer",
+    name: "Senior Engineer",
+    title: "Senior Engineer",
+    adapterConfig: {
+      issueBlockEscalation: {
+        enabled: true,
+        targetRole: "cto",
+        openStatuses: ["todo", "in_progress", "blocked"],
+      },
+    },
+  };
+}
+
+describe("issue blocked escalation route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.list.mockResolvedValue([]);
+    mockAgentService.getById.mockResolvedValue(makeActorAgent());
+    mockAgentService.list.mockResolvedValue([
+      { id: "agent-cto", companyId: "company-1", role: "cto", name: "CTO", title: "CTO" },
+    ]);
+  });
+
+  it("does not create an escalation child if the parent update fails", async () => {
+    const issue = makeIssue();
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockRejectedValue(new Error("update failed"));
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${issue.id}`)
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(500);
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.escalated" }),
+    );
+  });
+
+  it("creates the escalation child only after the parent update succeeds", async () => {
+    const issue = makeIssue();
+    const escalationIssue = {
+      ...issue,
+      id: "22222222-2222-4222-8222-222222222222",
+      identifier: "PAP-581",
+      parentId: issue.id,
+      originKind: "issue_escalation",
+      assigneeAgentId: "agent-cto",
+      status: "todo",
+      title: "CTO escalation: PAP-580",
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockResolvedValue({
+      ...issue,
+      status: "blocked",
+      updatedAt: new Date(),
+    });
+    mockIssueService.create.mockResolvedValue(escalationIssue);
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${issue.id}`)
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update.mock.invocationCallOrder[0]).toBeLessThan(
+      mockIssueService.create.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(mockIssueService.list).toHaveBeenCalledWith("company-1", expect.objectContaining({
+      parentId: issue.id,
+      assigneeAgentId: "agent-cto",
+    }));
+    expect(mockIssueService.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        parentId: issue.id,
+        assigneeAgentId: "agent-cto",
+        originKind: "issue_escalation",
+      }),
+    );
+  });
+});

--- a/server/src/__tests__/issue-block-escalation-routes.test.ts
+++ b/server/src/__tests__/issue-block-escalation-routes.test.ts
@@ -19,6 +19,7 @@ const mockIssueService = vi.hoisted(() => ({
 
 const mockAgentService = vi.hoisted(() => ({
   getById: vi.fn(),
+  getByRole: vi.fn(),
   list: vi.fn(),
 }));
 
@@ -131,9 +132,13 @@ describe("issue blocked escalation route", () => {
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
     mockIssueService.list.mockResolvedValue([]);
     mockAgentService.getById.mockResolvedValue(makeActorAgent());
-    mockAgentService.list.mockResolvedValue([
-      { id: "agent-cto", companyId: "company-1", role: "cto", name: "CTO", title: "CTO" },
-    ]);
+    mockAgentService.getByRole.mockResolvedValue({
+      id: "agent-cto",
+      companyId: "company-1",
+      role: "cto",
+      name: "CTO",
+      title: "CTO",
+    });
   });
 
   it("does not create an escalation child if the parent update fails", async () => {
@@ -186,12 +191,58 @@ describe("issue blocked escalation route", () => {
       parentId: issue.id,
       assigneeAgentId: "agent-cto",
     }));
+    expect(mockAgentService.getByRole).toHaveBeenCalledWith("company-1", "cto");
     expect(mockIssueService.create).toHaveBeenCalledWith(
       "company-1",
       expect.objectContaining({
         parentId: issue.id,
         assigneeAgentId: "agent-cto",
         originKind: "issue_escalation",
+      }),
+    );
+  });
+
+  it("does not reuse an unrelated open child issue as the escalation issue", async () => {
+    const issue = makeIssue();
+    const unrelatedChild = {
+      ...issue,
+      id: "33333333-3333-4333-8333-333333333333",
+      identifier: "PAP-582",
+      parentId: issue.id,
+      originKind: "child_request",
+      assigneeAgentId: "agent-cto",
+      status: "todo",
+      title: "Existing CTO follow-up",
+    };
+    const escalationIssue = {
+      ...issue,
+      id: "44444444-4444-4444-8444-444444444444",
+      identifier: "PAP-583",
+      parentId: issue.id,
+      originKind: "issue_escalation",
+      assigneeAgentId: "agent-cto",
+      status: "todo",
+      title: "CTO escalation: PAP-580",
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockResolvedValue({
+      ...issue,
+      status: "blocked",
+      updatedAt: new Date(),
+    });
+    mockIssueService.list.mockResolvedValue([unrelatedChild]);
+    mockIssueService.create.mockResolvedValue(escalationIssue);
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${issue.id}`)
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        originKind: "issue_escalation",
+        assigneeAgentId: "agent-cto",
       }),
     );
   });

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -817,16 +817,11 @@ export function normalizeAgentDefaultsForJoin(input: {
       typeof issueBlockEscalation.targetRole === "string"
         ? issueBlockEscalation.targetRole.trim()
         : "";
-    if (enabled) {
       normalized.issueBlockEscalation = {
         enabled: true,
         ...(targetRole ? { targetRole } : {}),
+        ...(Array.isArray(issueBlockEscalation.openStatuses) ? { openStatuses: issueBlockEscalation.openStatuses } : {}),
       };
-      diagnostics.push({
-        code: "openclaw_gateway_issue_block_escalation_configured",
-        level: "info",
-        message: `issueBlockEscalation enabled${targetRole ? ` for target role ${targetRole}` : ""}`,
-      });
     }
   }
 

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -817,6 +817,7 @@ export function normalizeAgentDefaultsForJoin(input: {
       typeof issueBlockEscalation.targetRole === "string"
         ? issueBlockEscalation.targetRole.trim()
         : "";
+    if (enabled) {
       normalized.issueBlockEscalation = {
         enabled: true,
         ...(targetRole ? { targetRole } : {}),

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -803,6 +803,33 @@ export function normalizeAgentDefaultsForJoin(input: {
     normalized.sessionKey = sessionKey;
   }
 
+  if (
+    defaults.issueBlockEscalation &&
+    typeof defaults.issueBlockEscalation === "object" &&
+    !Array.isArray(defaults.issueBlockEscalation)
+  ) {
+    const issueBlockEscalation = defaults.issueBlockEscalation as Record<string, unknown>;
+    const enabled =
+      issueBlockEscalation.enabled === true ||
+      issueBlockEscalation.enabled === "true" ||
+      issueBlockEscalation.enabled === "1";
+    const targetRole =
+      typeof issueBlockEscalation.targetRole === "string"
+        ? issueBlockEscalation.targetRole.trim()
+        : "";
+    if (enabled) {
+      normalized.issueBlockEscalation = {
+        enabled: true,
+        ...(targetRole ? { targetRole } : {}),
+      };
+      diagnostics.push({
+        code: "openclaw_gateway_issue_block_escalation_configured",
+        level: "info",
+        message: `issueBlockEscalation enabled${targetRole ? ` for target role ${targetRole}` : ""}`,
+      });
+    }
+  }
+
   const role = nonEmptyTrimmedString(defaults.role);
   if (role) {
     normalized.role = role;
@@ -1045,7 +1072,7 @@ function buildInviteOnboardingManifest(
         adapterType: "Use 'openclaw_gateway' for OpenClaw Gateway agents",
         capabilities: "Optional capability summary",
         agentDefaultsPayload:
-          "Adapter config for OpenClaw gateway. MUST include url (ws:// or wss://) and headers.x-openclaw-token (or legacy x-openclaw-auth). Optional fields: paperclipApiUrl, waitTimeoutMs, sessionKeyStrategy, sessionKey, role, scopes, disableDeviceAuth, devicePrivateKeyPem."
+          "Adapter config for OpenClaw gateway. MUST include url (ws:// or wss://) and headers.x-openclaw-token (or legacy x-openclaw-auth). Optional fields: paperclipApiUrl, waitTimeoutMs, sessionKeyStrategy, sessionKey, issueBlockEscalation, role, scopes, disableDeviceAuth, devicePrivateKeyPem."
       },
       registrationEndpoint: {
         method: "POST",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -381,12 +381,10 @@ export function issueRoutes(
     ].join("\n");
   }
 
-  async function ensureRequiredRoleEscalationForBlockedIssue(
+  async function prepareRequiredRoleEscalationForBlockedIssue(
     req: Request,
-    actor: ReturnType<typeof getActorInfo>,
     issue: NonNullable<Awaited<ReturnType<typeof svc.getById>>>,
     nextStatus: unknown,
-    commentBody?: string,
   ) {
     if (nextStatus !== "blocked" || issue.status === "blocked") return null;
     if (req.actor.type !== "agent" || !req.actor.agentId) return null;
@@ -413,10 +411,26 @@ export function issueRoutes(
       );
     }
 
+    return {
+      actorAgent,
+      targetAgent,
+      targetRole: escalationConfig.targetRole,
+      openStatuses: escalationConfig.openStatuses,
+    };
+  }
+
+  async function ensureRequiredRoleEscalationForBlockedIssue(
+    actor: ReturnType<typeof getActorInfo>,
+    issue: NonNullable<Awaited<ReturnType<typeof svc.getById>>>,
+    escalationPlan: NonNullable<Awaited<ReturnType<typeof prepareRequiredRoleEscalationForBlockedIssue>>>,
+    commentBody?: string,
+  ) {
+    const { actorAgent, targetAgent, targetRole, openStatuses } = escalationPlan;
+
     const existingEscalations = await svc.list(issue.companyId, {
       parentId: issue.id,
       assigneeAgentId: targetAgent.id,
-      status: escalationConfig.openStatuses,
+      status: openStatuses,
       includeRoutineExecutions: true,
     });
     const existingEscalation =
@@ -429,8 +443,8 @@ export function issueRoutes(
       parentId: issue.id,
       projectId: issue.projectId ?? null,
       goalId: issue.goalId ?? null,
-      title: buildAutoEscalationTitle(issue, escalationConfig.targetRole),
-      description: buildAutoEscalationDescription(issue, actorAgent, escalationConfig.targetRole, commentBody),
+      title: buildAutoEscalationTitle(issue, targetRole),
+      description: buildAutoEscalationDescription(issue, actorAgent, targetRole, commentBody),
       status: "todo",
       priority: issue.priority === "low" ? "medium" : issue.priority,
       assigneeAgentId: targetAgent.id,
@@ -473,7 +487,7 @@ export function issueRoutes(
         identifier: issue.identifier,
         escalationIssueId: escalationIssue.id,
         escalationIssueIdentifier: escalationIssue.identifier,
-        escalationOwnerRole: escalationConfig.targetRole,
+        escalationOwnerRole: targetRole,
         source: "auto_role_blocker_escalation",
       },
     });
@@ -1604,13 +1618,7 @@ export function issueRoutes(
       }
     }
 
-    const blockerEscalationIssue = await ensureRequiredRoleEscalationForBlockedIssue(
-      req,
-      actor,
-      existing,
-      updateFields.status,
-      commentBody,
-    );
+    const blockerEscalationPlan = await prepareRequiredRoleEscalationForBlockedIssue(req, existing, updateFields.status);
     let issue;
     try {
       if (transition.decision && decisionId) {
@@ -1677,6 +1685,10 @@ export function issueRoutes(
       res.status(404).json({ error: "Issue not found" });
       return;
     }
+    const blockerEscalationIssue =
+      blockerEscalationPlan && issue.status === "blocked"
+        ? await ensureRequiredRoleEscalationForBlockedIssue(actor, issue, blockerEscalationPlan, commentBody)
+        : null;
     let issueResponse: typeof issue & { blockedBy?: unknown; blocks?: unknown } = issue;
     let updatedRelations: Awaited<ReturnType<typeof svc.getRelationSummaries>> | null = null;
     if (issue && Array.isArray(req.body.blockedByIssueIds)) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -401,9 +401,7 @@ export function issueRoutes(
       );
     }
 
-    const targetAgent =
-      (await agentsSvc.list(issue.companyId)).find((candidate) => candidate.role === escalationConfig.targetRole) ??
-      null;
+    const targetAgent = await agentsSvc.getByRole(issue.companyId, escalationConfig.targetRole);
     if (!targetAgent) {
       throw new HttpError(
         422,
@@ -435,7 +433,6 @@ export function issueRoutes(
     });
     const existingEscalation =
       existingEscalations.find((candidate) => candidate.originKind === "issue_escalation") ??
-      existingEscalations[0] ??
       null;
     if (existingEscalation) return existingEscalation;
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -88,6 +88,8 @@ type ExecutionStageWakeContext = {
   allowedActions: string[];
 };
 
+export const DEFAULT_BLOCK_ESCALATION_OPEN_STATUSES = "backlog,todo,in_progress,in_review,blocked";
+
 function executionPrincipalsEqual(
   left: ParsedExecutionState["currentParticipant"] | null,
   right: ParsedExecutionState["currentParticipant"] | null,
@@ -162,6 +164,37 @@ function diffExecutionParticipants(
     participants: nextParticipants,
     addedParticipants: nextParticipants.filter((participant) => !previousByKey.has(activityExecutionParticipantKey(participant))),
     removedParticipants: previousParticipants.filter((participant) => !nextByKey.has(activityExecutionParticipantKey(participant))),
+  };
+}
+
+function parseBooleanFlag(value: unknown) {
+  if (value === true || value === false) return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true" || normalized === "1") return true;
+    if (normalized === "false" || normalized === "0") return false;
+  }
+  return null;
+}
+
+export function parseIssueBlockEscalationConfig(value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const enabled = parseBooleanFlag(record.enabled);
+  if (enabled !== true) return null;
+  const targetRole =
+    typeof record.targetRole === "string" && record.targetRole.trim().length > 0
+      ? record.targetRole.trim()
+      : null;
+  const openStatuses =
+    Array.isArray(record.openStatuses) &&
+    record.openStatuses.every((entry) => typeof entry === "string" && entry.trim().length > 0)
+      ? record.openStatuses.map((entry) => entry.trim()).join(",")
+      : DEFAULT_BLOCK_ESCALATION_OPEN_STATUSES;
+
+  return {
+    targetRole,
+    openStatuses,
   };
 }
 
@@ -314,6 +347,148 @@ export function issueRoutes(
       throw new HttpError(400, `Invalid ${field} query value`);
     }
     return parsed;
+  }
+
+  function buildAutoEscalationTitle(issue: NonNullable<Awaited<ReturnType<typeof svc.getById>>>, targetRole: string) {
+    const reference = issue.identifier?.trim() || issue.title.trim() || issue.id;
+    return `${targetRole.toUpperCase()} escalation: ${reference}`;
+  }
+
+  function buildAutoEscalationDescription(
+    issue: NonNullable<Awaited<ReturnType<typeof svc.getById>>>,
+    actorAgent: { role: string; name: string; title?: string | null },
+    targetRole: string,
+    commentBody?: string,
+  ) {
+    const issueReference = issue.identifier?.trim() || issue.id;
+    const blockerNote = commentBody?.trim() || "No blocker comment was provided.";
+    return [
+      `${actorAgent.title ?? actorAgent.name} attempted to move parent issue ${issueReference} to blocked.`,
+      "",
+      `Parent issue: ${issueReference}`,
+      `Parent title: ${issue.title}`,
+      `Blocked by role: ${actorAgent.role}`,
+      `Escalation target role: ${targetRole}`,
+      `Status transition: ${issue.status} -> blocked`,
+      "",
+      "Blocker evidence:",
+      blockerNote,
+      "",
+      "Required outcome:",
+      "- Reproduce and explain the blocker",
+      `- Decide or implement the fix needed to unblock ${issueReference}`,
+      "- Leave explicit unblock guidance on the parent issue",
+    ].join("\n");
+  }
+
+  async function ensureRequiredRoleEscalationForBlockedIssue(
+    req: Request,
+    actor: ReturnType<typeof getActorInfo>,
+    issue: NonNullable<Awaited<ReturnType<typeof svc.getById>>>,
+    nextStatus: unknown,
+    commentBody?: string,
+  ) {
+    if (nextStatus !== "blocked" || issue.status === "blocked") return null;
+    if (req.actor.type !== "agent" || !req.actor.agentId) return null;
+
+    const actorAgent = await agentsSvc.getById(req.actor.agentId);
+    if (!actorAgent || actorAgent.companyId !== issue.companyId) return null;
+
+    const escalationConfig = parseIssueBlockEscalationConfig(actorAgent.adapterConfig?.issueBlockEscalation);
+    if (!escalationConfig) return null;
+    if (!escalationConfig.targetRole) {
+      throw new HttpError(
+        422,
+        "Cannot move issue to blocked until adapterConfig.issueBlockEscalation.targetRole is configured",
+      );
+    }
+
+    const targetAgent =
+      (await agentsSvc.list(issue.companyId)).find((candidate) => candidate.role === escalationConfig.targetRole) ??
+      null;
+    if (!targetAgent) {
+      throw new HttpError(
+        422,
+        `Cannot move issue to blocked until a ${escalationConfig.targetRole} escalation route exists for this company`,
+      );
+    }
+
+    const existingEscalations = await svc.list(issue.companyId, {
+      parentId: issue.id,
+      assigneeAgentId: targetAgent.id,
+      status: escalationConfig.openStatuses,
+      includeRoutineExecutions: true,
+    });
+    const existingEscalation =
+      existingEscalations.find((candidate) => candidate.originKind === "issue_escalation") ??
+      existingEscalations[0] ??
+      null;
+    if (existingEscalation) return existingEscalation;
+
+    const escalationIssue = await svc.create(issue.companyId, {
+      parentId: issue.id,
+      projectId: issue.projectId ?? null,
+      goalId: issue.goalId ?? null,
+      title: buildAutoEscalationTitle(issue, escalationConfig.targetRole),
+      description: buildAutoEscalationDescription(issue, actorAgent, escalationConfig.targetRole, commentBody),
+      status: "todo",
+      priority: issue.priority === "low" ? "medium" : issue.priority,
+      assigneeAgentId: targetAgent.id,
+      createdByAgentId: actorAgent.id,
+      originKind: "issue_escalation",
+      originId: issue.id,
+      originRunId: actor.runId ?? null,
+      requestDepth: (issue.requestDepth ?? 0) + 1,
+      inheritExecutionWorkspaceFromIssueId: issue.id,
+    });
+
+    await logActivity(db, {
+      companyId: escalationIssue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "issue.created",
+      entityType: "issue",
+      entityId: escalationIssue.id,
+      details: {
+        title: escalationIssue.title,
+        identifier: escalationIssue.identifier,
+        parentIssueId: issue.id,
+        parentIssueIdentifier: issue.identifier,
+        source: "auto_role_blocker_escalation",
+      },
+    });
+
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "issue.escalated",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        identifier: issue.identifier,
+        escalationIssueId: escalationIssue.id,
+        escalationIssueIdentifier: escalationIssue.identifier,
+        escalationOwnerRole: escalationConfig.targetRole,
+        source: "auto_role_blocker_escalation",
+      },
+    });
+
+    void queueIssueAssignmentWakeup({
+      heartbeat,
+      issue: escalationIssue,
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "issue.blocked_auto_escalation",
+      requestedByActorType: actor.actorType,
+      requestedByActorId: actor.actorId,
+    });
+
+    return escalationIssue;
   }
 
   async function runSingleFileUpload(req: Request, res: Response) {
@@ -1429,6 +1604,13 @@ export function issueRoutes(
       }
     }
 
+    const blockerEscalationIssue = await ensureRequiredRoleEscalationForBlockedIssue(
+      req,
+      actor,
+      existing,
+      updateFields.status,
+      commentBody,
+    );
     let issue;
     try {
       if (transition.decision && decisionId) {
@@ -1546,6 +1728,12 @@ export function issueRoutes(
         ...(commentBody ? { source: "comment" } : {}),
         ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus } : {}),
         ...(interruptedRunId ? { interruptedRunId } : {}),
+        ...(blockerEscalationIssue
+          ? {
+              blockerEscalationIssueId: blockerEscalationIssue.id,
+              blockerEscalationIssueIdentifier: blockerEscalationIssue.identifier,
+            }
+          : {}),
         _previous: hasFieldChanges ? previous : undefined,
       },
     });

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -383,6 +383,22 @@ export function agentService(db: Db) {
       return hydrated.map(normalizeAgentRow);
     },
 
+    getByRole: async (companyId: string, role: string, options?: { includeTerminated?: boolean }) => {
+      const conditions = [eq(agents.companyId, companyId), eq(agents.role, role)];
+      if (!options?.includeTerminated) {
+        conditions.push(ne(agents.status, "terminated"));
+      }
+      const row = await db
+        .select()
+        .from(agents)
+        .where(and(...conditions))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (!row) return null;
+      const [hydrated] = await hydrateAgentSpend([row]);
+      return normalizeAgentRow(hydrated);
+    },
+
     getById,
 
     create: async (companyId: string, data: Omit<typeof agents.$inferInsert, "companyId">) => {

--- a/ui/src/adapters/openclaw-gateway/config-fields.test.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OpenClawGatewayConfigFields } from "./config-fields";
+
+vi.mock("../../components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../runtime-json-fields", () => ({
+  PayloadTemplateJsonField: () => null,
+  RuntimeServicesJsonField: () => null,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function renderFields(effValue: Record<string, unknown> | undefined) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const mark = vi.fn();
+
+  act(() => {
+    root.render(
+      <OpenClawGatewayConfigFields
+        mode="edit"
+        isCreate={false}
+        adapterType="openclaw_gateway"
+        values={null}
+        set={null}
+        config={{
+          url: "ws://gateway",
+          headers: {},
+          issueBlockEscalation: {
+            enabled: true,
+            targetRole: "cto",
+          },
+        }}
+        eff={(_group, field, original) => {
+          if (field === "issueBlockEscalation") {
+            return (effValue as typeof original) ?? original;
+          }
+          return original;
+        }}
+        mark={mark}
+        models={[]}
+      />,
+    );
+  });
+
+  return {
+    container,
+    root,
+    mark,
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("OpenClawGatewayConfigFields", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("reflects a disabled issueBlockEscalation overlay instead of stale saved config", () => {
+    const view = renderFields({});
+
+    const toggle = view.container.querySelector('[role="switch"]');
+    expect(toggle?.getAttribute("aria-checked")).toBe("false");
+    expect(view.container.querySelector('input[placeholder="cto"]')).toBeNull();
+
+    view.cleanup();
+  });
+
+  it("reads the targetRole field from the overlay while editing", () => {
+    const view = renderFields({
+      enabled: true,
+      targetRole: "senior_engineer",
+    });
+
+    const targetRoleInput = view.container.querySelector('input[placeholder="cto"]') as HTMLInputElement | null;
+    expect(targetRoleInput?.value).toBe("senior_engineer");
+    expect(view.container.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("true");
+
+    view.cleanup();
+  });
+});

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -100,8 +100,10 @@ export function OpenClawGatewayConfigFields({
     config.issueBlockEscalation && typeof config.issueBlockEscalation === "object" && !Array.isArray(config.issueBlockEscalation)
       ? (config.issueBlockEscalation as Record<string, unknown>)
       : {};
+  const effectiveIssueBlockEscalation =
+    (eff("adapterConfig", "issueBlockEscalation", issueBlockEscalation) as Record<string, unknown> | undefined) ?? {};
   const issueBlockEscalationEnabled = Boolean(
-    (eff("adapterConfig", "issueBlockEscalation", issueBlockEscalation) ?? {}).enabled,
+    effectiveIssueBlockEscalation.enabled,
   );
 
   const setIssueBlockEscalation = (patch: Record<string, unknown>) => {
@@ -270,7 +272,7 @@ export function OpenClawGatewayConfigFields({
           {issueBlockEscalationEnabled && (
             <Field label="Blocked issue escalation target role">
               <DraftInput
-                value={String(issueBlockEscalation.targetRole ?? "cto")}
+                value={String(effectiveIssueBlockEscalation.targetRole ?? issueBlockEscalation.targetRole ?? "cto")}
                 onCommit={(v) => setIssueBlockEscalation({ enabled: true, targetRole: v || "cto" })}
                 immediate
                 className={inputClass}

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -101,7 +101,7 @@ export function OpenClawGatewayConfigFields({
       ? (config.issueBlockEscalation as Record<string, unknown>)
       : {};
   const issueBlockEscalationEnabled = Boolean(
-    eff("adapterConfig", "issueBlockEscalation", issueBlockEscalation).enabled ?? issueBlockEscalation.enabled,
+    (eff("adapterConfig", "issueBlockEscalation", issueBlockEscalation) ?? {}).enabled ?? issueBlockEscalation.enabled,
   );
 
   const setIssueBlockEscalation = (patch: Record<string, unknown>) => {

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -101,7 +101,7 @@ export function OpenClawGatewayConfigFields({
       ? (config.issueBlockEscalation as Record<string, unknown>)
       : {};
   const issueBlockEscalationEnabled = Boolean(
-    (eff("adapterConfig", "issueBlockEscalation", issueBlockEscalation) ?? {}).enabled ?? issueBlockEscalation.enabled,
+    (eff("adapterConfig", "issueBlockEscalation", issueBlockEscalation) ?? {}).enabled,
   );
 
   const setIssueBlockEscalation = (patch: Record<string, unknown>) => {

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -3,6 +3,7 @@ import { Eye, EyeOff } from "lucide-react";
 import type { AdapterConfigFieldsProps } from "../types";
 import {
   Field,
+  ToggleField,
   DraftInput,
   help,
 } from "../../components/agent-config-primitives";
@@ -95,6 +96,29 @@ export function OpenClawGatewayConfigFields({
     "sessionKeyStrategy",
     String(config.sessionKeyStrategy ?? "fixed"),
   );
+  const issueBlockEscalation =
+    config.issueBlockEscalation && typeof config.issueBlockEscalation === "object" && !Array.isArray(config.issueBlockEscalation)
+      ? (config.issueBlockEscalation as Record<string, unknown>)
+      : {};
+  const issueBlockEscalationEnabled = Boolean(
+    eff("adapterConfig", "issueBlockEscalation", issueBlockEscalation).enabled ?? issueBlockEscalation.enabled,
+  );
+
+  const setIssueBlockEscalation = (patch: Record<string, unknown>) => {
+    const current =
+      config.issueBlockEscalation && typeof config.issueBlockEscalation === "object" && !Array.isArray(config.issueBlockEscalation)
+        ? (config.issueBlockEscalation as Record<string, unknown>)
+        : {};
+    const next = {
+      ...current,
+      ...patch,
+    };
+    if (next.enabled !== true) {
+      mark("adapterConfig", "issueBlockEscalation", undefined);
+      return;
+    }
+    mark("adapterConfig", "issueBlockEscalation", next);
+  };
 
   return (
     <>
@@ -233,6 +257,27 @@ export function OpenClawGatewayConfigFields({
               placeholder="120000"
             />
           </Field>
+
+          <ToggleField
+            label="Auto-escalate blocked issues"
+            hint="Explicit opt-in. When enabled, moving an issue to blocked auto-creates or reuses an escalation issue for the target role."
+            checked={issueBlockEscalationEnabled}
+            onChange={(enabled) =>
+              setIssueBlockEscalation(enabled ? { enabled: true, targetRole: "cto" } : { enabled: false })
+            }
+          />
+
+          {issueBlockEscalationEnabled && (
+            <Field label="Blocked issue escalation target role">
+              <DraftInput
+                value={String(issueBlockEscalation.targetRole ?? "cto")}
+                onCommit={(v) => setIssueBlockEscalation({ enabled: true, targetRole: v || "cto" })}
+                immediate
+                className={inputClass}
+                placeholder="cto"
+              />
+            </Field>
+          )}
 
           <Field label="Device auth">
             <div className="text-xs text-muted-foreground leading-relaxed">


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - One important part of that orchestration is issue-driven execution, where agents pick up work from issues and report status back into the issue system.
> - A current failure mode in that flow is that an agent can move an issue to `blocked` and then no explicit follow-up work is guaranteed to exist to unblock it.
> - That means technically fixable work can stall in a passive blocked state instead of producing a concrete escalation path.
> - OpenClaw Gateway agents already carry adapter-specific execution policy, so this is the right layer to express an opt-in blocked-issue escalation rule.
> - This pull request adds an explicit `issueBlockEscalation` policy surface, preserves it through gateway normalization, and enforces it when a blocked transition is attempted.
> - The benefit is that operators can opt into a stricter governance model where blocked work automatically creates or reuses a child escalation issue for the right role instead of silently stalling.

## What Changed

- Added `issueBlockEscalation` documentation to the OpenClaw Gateway adapter docs and config schema.
- Preserved the `issueBlockEscalation` config through `normalizeAgentDefaultsForJoin`, while keeping the feature fully opt-in.
- Added parsing and validation helpers in `server/src/routes/issues.ts` for the blocked-issue escalation policy.
- Enforced the policy during `PATCH /api/issues/:id` blocked transitions so a child escalation issue is created or reused for the configured target role.
- Ensured escalation creation happens only after the parent issue update succeeds, to avoid orphaned child issues.
- Logged escalation activity onto the parent issue and queued an assignment wakeup for the created escalation issue.
- Added tests for config normalization, policy parsing, and route behavior.
- Added UI controls to the OpenClaw Gateway config form for enabling blocked-issue auto-escalation and choosing the target role.

## Verification

- Ran:
  - `PAPERCLIP_HOME=/tmp/paperclip-ci-home corepack pnpm test:run server/src/__tests__/issue-block-escalation-policy.test.ts server/src/__tests__/invite-accept-gateway-defaults.test.ts server/src/__tests__/issue-block-escalation-routes.test.ts`
- Verified route behavior in tests:
  - escalation child is not created when the parent update fails
  - escalation child is created only after the parent update succeeds
  - disabled opt-in config is dropped during normalization
  - enabled opt-in config preserves `targetRole` and reusable statuses
- UI change:
  - config form now exposes an explicit toggle plus target-role field for blocked-issue escalation
- Screenshots:
  - Before/after screenshots are still required for the UI change and should be added before merge

## Risks

- Medium risk in issue lifecycle behavior because this changes blocked transitions when the policy is explicitly enabled.
- Misconfigured enabled policies now fail closed with `422`, which is intentional but may surface new operator-facing errors if setup is incomplete.
- The route behavior depends on correct target-role mapping inside a company; if the target role is absent, the blocked transition is rejected.
- Low risk to existing deployments that do not opt into `issueBlockEscalation`, because behavior remains unchanged when the policy is unset.

## Model Used

- OpenAI GPT-5 Codex via Codex desktop agent tooling
- Tool-assisted coding workflow with repository inspection, patching, local test execution, and GitHub connector usage
- Reasoning mode: default Codex agent reasoning/tool-use workflow in a long-context coding session

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer co



Before
<img width="1440" height="1800" alt="pr-3369-before" src="https://github.com/user-attachments/assets/baa1d8d6-f268-469f-b6da-58686b1652aa" />

After
<img width="1440" height="1800" alt="pr-3369-after" src="https://github.com/user-attachments/assets/266bd7ae-0613-4e6b-8f5a-626d83128ad6" />
