### PR TITLE
fix(openclaw-gateway): honor claimedApiKeyPath in wake context

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveSessionKey } from "./execute.js";
+import { execute, resolveSessionKey } from "./execute.js";
 
 describe("resolveSessionKey", () => {
   it("prefixes run-scoped session keys with the configured agent", () => {
@@ -48,5 +48,34 @@ describe("resolveSessionKey", () => {
         issueId: null,
       }),
     ).toBe("agent:meridian:paperclip");
+  });
+
+  it("uses the configured claimed api key path in the wake payload", async () => {
+    let stdout = "";
+    const result = await execute({
+      config: {
+        url: "ws://127.0.0.1:18789",
+        headers: {
+          "x-openclaw-token": "gateway-token-1234567890",
+        },
+        claimedApiKeyPath: "/tmp/custom-paperclip-key.json",
+      },
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Meridian",
+      },
+      context: {},
+      onMeta: async () => undefined,
+      onLog: async (stream: string, chunk: string) => {
+        if (stream === "stdout") stdout += chunk;
+      },
+    } as any);
+
+    expect(result.errorCode).toBe("openclaw_gateway_connection_failed");
+    expect(result.errorMessage).toContain("ws://127.0.0.1:18789");
+    expect(stdout).toContain("PAPERCLIP_CLAIMED_API_KEY_PATH=/tmp/custom-paperclip-key.json");
+    expect(stdout).toContain("Load PAPERCLIP_API_KEY from /tmp/custom-paperclip-key.json");
   });
 });

--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -78,4 +78,32 @@ describe("resolveSessionKey", () => {
     expect(stdout).toContain("PAPERCLIP_CLAIMED_API_KEY_PATH=/tmp/custom-paperclip-key.json");
     expect(stdout).toContain("Load PAPERCLIP_API_KEY from /tmp/custom-paperclip-key.json");
   });
+
+  it("does not inject PAPERCLIP_CLAIMED_API_KEY_PATH when it is not configured", async () => {
+    let stdout = "";
+    const result = await execute({
+      config: {
+        url: "ws://127.0.0.1:18789",
+        headers: {
+          "x-openclaw-token": "gateway-token-1234567890",
+        },
+      },
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Meridian",
+      },
+      context: {},
+      onMeta: async () => undefined,
+      onLog: async (stream: string, chunk: string) => {
+        if (stream === "stdout") stdout += chunk;
+      },
+    } as any);
+
+    expect(result.errorCode).toBe("openclaw_gateway_connection_failed");
+    expect(result.errorMessage).toContain("ws://127.0.0.1:18789");
+    expect(stdout).not.toContain("PAPERCLIP_CLAIMED_API_KEY_PATH=");
+    expect(stdout).toContain("Load PAPERCLIP_API_KEY from ~/.openclaw/workspace/paperclip-claimed-api-key.json");
+  });
 });

--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { execute, resolveSessionKey } from "./execute.js";
+import { buildPaperclipEnvForWake, buildWakeText, execute, resolveSessionKey } from "./execute.js";
 
 describe("resolveSessionKey", () => {
   it("prefixes run-scoped session keys with the configured agent", () => {
@@ -50,9 +50,8 @@ describe("resolveSessionKey", () => {
     ).toBe("agent:meridian:paperclip");
   });
 
-  it("uses the configured claimed api key path in the wake payload", async () => {
-    let stdout = "";
-    const result = await execute({
+  it("uses the configured claimed api key path in the wake text and env", async () => {
+    const ctx = {
       config: {
         url: "ws://127.0.0.1:18789",
         headers: {
@@ -68,20 +67,31 @@ describe("resolveSessionKey", () => {
       },
       context: {},
       onMeta: async () => undefined,
-      onLog: async (stream: string, chunk: string) => {
-        if (stream === "stdout") stdout += chunk;
-      },
-    } as any);
+      onLog: async () => undefined,
+    } as any;
+    const wakePayload = {
+      runId: "run-123",
+      agentId: "agent-123",
+      companyId: "company-123",
+      taskId: null,
+      issueId: null,
+      wakeReason: null,
+      wakeCommentId: null,
+      approvalId: null,
+      approvalStatus: null,
+      issueIds: [],
+    };
 
-    expect(result.errorCode).toBe("openclaw_gateway_connection_failed");
-    expect(result.errorMessage).toContain("ws://127.0.0.1:18789");
-    expect(stdout).toContain("PAPERCLIP_CLAIMED_API_KEY_PATH=/tmp/custom-paperclip-key.json");
-    expect(stdout).toContain("Load PAPERCLIP_API_KEY from /tmp/custom-paperclip-key.json");
+    const env = buildPaperclipEnvForWake(ctx, wakePayload);
+    const wakeText = buildWakeText(wakePayload, env, "");
+
+    expect(env.PAPERCLIP_CLAIMED_API_KEY_PATH).toBe("/tmp/custom-paperclip-key.json");
+    expect(wakeText).toContain("PAPERCLIP_CLAIMED_API_KEY_PATH=/tmp/custom-paperclip-key.json");
+    expect(wakeText).toContain("Load PAPERCLIP_API_KEY from /tmp/custom-paperclip-key.json");
   });
 
   it("does not inject PAPERCLIP_CLAIMED_API_KEY_PATH when it is not configured", async () => {
-    let stdout = "";
-    const result = await execute({
+    const ctx = {
       config: {
         url: "ws://127.0.0.1:18789",
         headers: {
@@ -96,14 +106,26 @@ describe("resolveSessionKey", () => {
       },
       context: {},
       onMeta: async () => undefined,
-      onLog: async (stream: string, chunk: string) => {
-        if (stream === "stdout") stdout += chunk;
-      },
-    } as any);
+      onLog: async () => undefined,
+    } as any;
+    const wakePayload = {
+      runId: "run-123",
+      agentId: "agent-123",
+      companyId: "company-123",
+      taskId: null,
+      issueId: null,
+      wakeReason: null,
+      wakeCommentId: null,
+      approvalId: null,
+      approvalStatus: null,
+      issueIds: [],
+    };
 
-    expect(result.errorCode).toBe("openclaw_gateway_connection_failed");
-    expect(result.errorMessage).toContain("ws://127.0.0.1:18789");
-    expect(stdout).not.toContain("PAPERCLIP_CLAIMED_API_KEY_PATH=");
-    expect(stdout).toContain("Load PAPERCLIP_API_KEY from ~/.openclaw/workspace/paperclip-claimed-api-key.json");
+    const env = buildPaperclipEnvForWake(ctx, wakePayload);
+    const wakeText = buildWakeText(wakePayload, env, "");
+
+    expect(env.PAPERCLIP_CLAIMED_API_KEY_PATH).toBeUndefined();
+    expect(wakeText).not.toContain("PAPERCLIP_CLAIMED_API_KEY_PATH=");
+    expect(wakeText).toContain("Load PAPERCLIP_API_KEY from ~/.openclaw/workspace/paperclip-claimed-api-key.json");
   });
 });

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -332,8 +332,8 @@ function resolvePaperclipApiUrlOverride(value: unknown): string | null {
 
 const DEFAULT_CLAIMED_API_KEY_PATH = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
 
-function resolveClaimedApiKeyPath(value: unknown): string {
-  return nonEmpty(value) ?? DEFAULT_CLAIMED_API_KEY_PATH;
+function resolveClaimedApiKeyPath(value: unknown): string | null {
+  return nonEmpty(value) ?? null;
 }
 
 function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: WakePayload): Record<string, string> {

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -338,6 +338,7 @@ function resolveClaimedApiKeyPath(value: unknown): string {
 
 function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: WakePayload): Record<string, string> {
   const paperclipApiUrlOverride = resolvePaperclipApiUrlOverride(ctx.config.paperclipApiUrl);
+  const claimedApiKeyPathOverride = resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath);
   const paperclipEnv: Record<string, string> = {
     ...buildPaperclipEnv(ctx.agent),
     PAPERCLIP_RUN_ID: ctx.runId,
@@ -345,6 +346,9 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
 
   if (paperclipApiUrlOverride) {
     paperclipEnv.PAPERCLIP_API_URL = paperclipApiUrlOverride;
+  }
+  if (claimedApiKeyPathOverride) {
+    paperclipEnv.PAPERCLIP_CLAIMED_API_KEY_PATH = claimedApiKeyPathOverride;
   }
   if (wakePayload.taskId) paperclipEnv.PAPERCLIP_TASK_ID = wakePayload.taskId;
   if (wakePayload.wakeReason) paperclipEnv.PAPERCLIP_WAKE_REASON = wakePayload.wakeReason;
@@ -363,12 +367,14 @@ function buildWakeText(
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,
 ): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+  const claimedApiKeyPath =
+    paperclipEnv.PAPERCLIP_CLAIMED_API_KEY_PATH ?? DEFAULT_CLAIMED_API_KEY_PATH;
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
     "PAPERCLIP_COMPANY_ID",
     "PAPERCLIP_API_URL",
+    "PAPERCLIP_CLAIMED_API_KEY_PATH",
     "PAPERCLIP_TASK_ID",
     "PAPERCLIP_WAKE_REASON",
     "PAPERCLIP_WAKE_COMMENT_ID",

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -336,7 +336,7 @@ function resolveClaimedApiKeyPath(value: unknown): string | null {
   return nonEmpty(value) ?? null;
 }
 
-function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: WakePayload): Record<string, string> {
+export function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: WakePayload): Record<string, string> {
   const paperclipApiUrlOverride = resolvePaperclipApiUrlOverride(ctx.config.paperclipApiUrl);
   const claimedApiKeyPathOverride = resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath);
   const paperclipEnv: Record<string, string> = {
@@ -362,7 +362,7 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
   return paperclipEnv;
 }
 
-function buildWakeText(
+export function buildWakeText(
   payload: WakePayload,
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -225,6 +225,11 @@ describe("heartbeat comment wake batching", () => {
   }, 45_000);
 
   afterAll(async () => {
+    await (db as
+      | (ReturnType<typeof createDb> & {
+          $client?: { end?: (opts?: { timeout?: number }) => Promise<void> };
+        })
+      | undefined)?.$client?.end?.({ timeout: 5 }).catch(() => undefined);
     await instance?.stop();
     if (dataDir) {
       fs.rmSync(dataDir, { recursive: true, force: true });

--- a/server/src/__tests__/invite-accept-gateway-defaults.test.ts
+++ b/server/src/__tests__/invite-accept-gateway-defaults.test.ts
@@ -116,4 +116,31 @@ describe("normalizeAgentDefaultsForJoin (openclaw_gateway)", () => {
     expect(normalized.normalized?.disableDeviceAuth).toBe(true);
     expect(normalized.normalized?.devicePrivateKeyPem).toBeUndefined();
   });
+
+  it("preserves claimedApiKeyPath when provided", () => {
+    const normalized = normalizeAgentDefaultsForJoin({
+      adapterType: "openclaw_gateway",
+      defaultsPayload: {
+        url: "ws://127.0.0.1:18789",
+        headers: {
+          "x-openclaw-token": "gateway-token-1234567890",
+        },
+        claimedApiKeyPath: "/tmp/custom-paperclip-key.json",
+      },
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    });
+
+    expect(normalized.fatalErrors).toEqual([]);
+    expect(normalized.normalized?.claimedApiKeyPath).toBe("/tmp/custom-paperclip-key.json");
+    expect(normalized.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "openclaw_gateway_claimed_api_key_path_configured",
+        }),
+      ]),
+    );
+  });
 });

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1052,11 +1052,11 @@ function buildInviteOnboardingManifest(
         "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ~/.openclaw/workspace/paperclip-claimed-api-key.json and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).",
       inviteMessage: extractInviteMessage(invite),
       recommendedAdapterType: "openclaw_gateway",
-        requiredFields: {
-          requestType: "agent",
-          agentName: "Display name for this agent",
-          adapterType: "Use 'openclaw_gateway' for OpenClaw Gateway agents",
-          capabilities: "Optional capability summary",
+      requiredFields: {
+        requestType: "agent",
+        agentName: "Display name for this agent",
+        adapterType: "Use 'openclaw_gateway' for OpenClaw Gateway agents",
+        capabilities: "Optional capability summary",
         agentDefaultsPayload:
           "Adapter config for OpenClaw gateway. MUST include url (ws:// or wss://) and headers.x-openclaw-token (or legacy x-openclaw-auth). Optional fields: paperclipApiUrl, claimedApiKeyPath, waitTimeoutMs, sessionKeyStrategy, sessionKey, role, scopes, disableDeviceAuth, devicePrivateKeyPem."
       },

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1226,14 +1226,14 @@ export function buildInviteOnboardingTextDocument(
       "agentName": "My OpenClaw Agent",
       "adapterType": "openclaw_gateway",
       "capabilities": "Optional summary",
-        "agentDefaultsPayload": {
-          "url": "wss://your-openclaw-gateway.example",
-          "paperclipApiUrl": "https://paperclip-hostname-your-agent-can-reach:3100",
-          "claimedApiKeyPath": "~/.openclaw/workspace/paperclip-claimed-api-key.json",
-          "headers": { "x-openclaw-token": "replace-me" },
-          "waitTimeoutMs": 120000,
-          "sessionKeyStrategy": "issue",
-          "role": "operator",
+      "agentDefaultsPayload": {
+        "url": "wss://your-openclaw-gateway.example",
+        "paperclipApiUrl": "https://paperclip-hostname-your-agent-can-reach:3100",
+        "claimedApiKeyPath": "~/.openclaw/workspace/paperclip-claimed-api-key.json",
+        "headers": { "x-openclaw-token": "replace-me" },
+        "waitTimeoutMs": 120000,
+        "sessionKeyStrategy": "issue",
+        "role": "operator",
         "scopes": ["operator.admin"]
       }
     }

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -851,6 +851,19 @@ export function normalizeAgentDefaultsForJoin(input: {
     }
   }
 
+  const claimedApiKeyPath =
+    typeof defaults.claimedApiKeyPath === "string"
+      ? defaults.claimedApiKeyPath.trim()
+      : "";
+  if (claimedApiKeyPath) {
+    normalized.claimedApiKeyPath = claimedApiKeyPath;
+    diagnostics.push({
+      code: "openclaw_gateway_claimed_api_key_path_configured",
+      level: "info",
+      message: `claimedApiKeyPath set to ${claimedApiKeyPath}`,
+    });
+  }
+
   return { normalized, diagnostics, fatalErrors };
 }
 
@@ -1039,13 +1052,13 @@ function buildInviteOnboardingManifest(
         "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ~/.openclaw/workspace/paperclip-claimed-api-key.json and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).",
       inviteMessage: extractInviteMessage(invite),
       recommendedAdapterType: "openclaw_gateway",
-      requiredFields: {
-        requestType: "agent",
-        agentName: "Display name for this agent",
-        adapterType: "Use 'openclaw_gateway' for OpenClaw Gateway agents",
-        capabilities: "Optional capability summary",
+        requiredFields: {
+          requestType: "agent",
+          agentName: "Display name for this agent",
+          adapterType: "Use 'openclaw_gateway' for OpenClaw Gateway agents",
+          capabilities: "Optional capability summary",
         agentDefaultsPayload:
-          "Adapter config for OpenClaw gateway. MUST include url (ws:// or wss://) and headers.x-openclaw-token (or legacy x-openclaw-auth). Optional fields: paperclipApiUrl, waitTimeoutMs, sessionKeyStrategy, sessionKey, role, scopes, disableDeviceAuth, devicePrivateKeyPem."
+          "Adapter config for OpenClaw gateway. MUST include url (ws:// or wss://) and headers.x-openclaw-token (or legacy x-openclaw-auth). Optional fields: paperclipApiUrl, claimedApiKeyPath, waitTimeoutMs, sessionKeyStrategy, sessionKey, role, scopes, disableDeviceAuth, devicePrivateKeyPem."
       },
       registrationEndpoint: {
         method: "POST",
@@ -1213,13 +1226,14 @@ export function buildInviteOnboardingTextDocument(
       "agentName": "My OpenClaw Agent",
       "adapterType": "openclaw_gateway",
       "capabilities": "Optional summary",
-      "agentDefaultsPayload": {
-        "url": "wss://your-openclaw-gateway.example",
-        "paperclipApiUrl": "https://paperclip-hostname-your-agent-can-reach:3100",
-        "headers": { "x-openclaw-token": "replace-me" },
-        "waitTimeoutMs": 120000,
-        "sessionKeyStrategy": "issue",
-        "role": "operator",
+        "agentDefaultsPayload": {
+          "url": "wss://your-openclaw-gateway.example",
+          "paperclipApiUrl": "https://paperclip-hostname-your-agent-can-reach:3100",
+          "claimedApiKeyPath": "~/.openclaw/workspace/paperclip-claimed-api-key.json",
+          "headers": { "x-openclaw-token": "replace-me" },
+          "waitTimeoutMs": 120000,
+          "sessionKeyStrategy": "issue",
+          "role": "operator",
         "scopes": ["operator.admin"]
       }
     }


### PR DESCRIPTION
## Why

`claimedApiKeyPath` is already documented and surfaced in the OpenClaw Gateway configuration, but upstream currently drops it during join/default normalization and ignores it when composing the wake env and wake text.

That creates a real runtime mismatch: per-agent claimed-key auth looks supported, but agents still fall back to the hardcoded default path unless downstreams patch Paperclip at runtime.

This change fixes that mismatch directly in upstream Paperclip.

## What changed

- preserve `claimedApiKeyPath` in `normalizeAgentDefaultsForJoin`
- include it in the OpenClaw Gateway onboarding and help text
- emit `PAPERCLIP_CLAIMED_API_KEY_PATH` in the wake env when configured
- make the wake instructions load the token from the configured path instead of always hardcoding the default path
- add coverage for join normalization and configured wake-path behavior

## Why this belongs upstream

This is not deployment-specific behavior. It fixes an inconsistency in an already documented adapter option. If Paperclip exposes `claimedApiKeyPath`, the adapter should actually honor it.

## Opt-in / behavior

This is not a default behavior change.

If `claimedApiKeyPath` is not set, behavior remains unchanged and the existing default path is still used.

The new behavior only applies when an operator explicitly configures `claimedApiKeyPath`.

## Validation

- `server/src/__tests__/invite-accept-gateway-defaults.test.ts`
- `packages/adapters/openclaw-gateway` typecheck
