### PR TITLE
Change default invite TTL from 10 minutes to 72 hours

### DIFF
--- a/docs/adapters/codex-local.md
+++ b/docs/adapters/codex-local.md
@@ -20,6 +20,7 @@ The `codex_local` adapter runs OpenAI's Codex CLI locally. It supports session p
 | `env` | object | No | Environment variables (supports secret refs) |
 | `timeoutSec` | number | No | Process timeout (0 = no timeout) |
 | `graceSec` | number | No | Grace period before force-kill |
+| `fastMode` | boolean | No | Enables Codex Fast mode. Currently supported on `gpt-5.4` only and burns credits faster |
 | `dangerouslyBypassApprovalsAndSandbox` | boolean | No | Skip safety checks (dev only) |
 
 ## Session Persistence
@@ -29,6 +30,16 @@ Codex uses `previous_response_id` for session continuity. The adapter serializes
 ## Skills Injection
 
 The adapter symlinks Paperclip skills into the global Codex skills directory (`~/.codex/skills`). Existing user skills are not overwritten.
+
+## Fast Mode
+
+When `fastMode` is enabled, Paperclip adds Codex config overrides equivalent to:
+
+```sh
+-c 'service_tier="fast"' -c 'features.fast_mode=true'
+```
+
+Paperclip currently applies that only when the selected model is `gpt-5.4`. On other models, the toggle is preserved in config but ignored at execution time to avoid unsupported runs.
 
 When Paperclip is running inside a managed worktree instance (`PAPERCLIP_IN_WORKTREE=true`), the adapter instead uses a worktree-isolated `CODEX_HOME` under the Paperclip instance so Codex skills, sessions, logs, and other runtime state do not leak across checkouts. It seeds that isolated home from the user's main Codex home for shared auth/config continuity.
 

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -372,6 +372,7 @@ export interface CreateConfigValues {
   chrome: boolean;
   dangerouslySkipPermissions: boolean;
   search: boolean;
+  fastMode: boolean;
   dangerouslyBypassSandbox: boolean;
   command: string;
   args: string;

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -2,6 +2,14 @@ export const type = "codex_local";
 export const label = "Codex (local)";
 export const DEFAULT_CODEX_LOCAL_MODEL = "gpt-5.3-codex";
 export const DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX = true;
+export const CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS = ["gpt-5.4"] as const;
+
+export function isCodexLocalFastModeSupported(model: string | null | undefined): boolean {
+  const normalizedModel = typeof model === "string" ? model.trim() : "";
+  return CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS.includes(
+    normalizedModel as (typeof CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS)[number],
+  );
+}
 
 export const models = [
   { id: "gpt-5.4", label: "gpt-5.4" },
@@ -27,6 +35,7 @@ Core fields:
 - modelReasoningEffort (string, optional): reasoning effort override (minimal|low|medium|high|xhigh) passed via -c model_reasoning_effort=...
 - promptTemplate (string, optional): run prompt template
 - search (boolean, optional): run codex with --search
+- fastMode (boolean, optional): enable Codex Fast mode; currently supported on GPT-5.4 only and consumes credits faster
 - dangerouslyBypassApprovalsAndSandbox (boolean, optional): run with bypass flag
 - command (string, optional): defaults to "codex"
 - extraArgs (string[], optional): additional CLI args
@@ -45,5 +54,6 @@ Notes:
 - Paperclip injects desired local skills into the effective CODEX_HOME/skills/ directory at execution time so Codex can discover "$paperclip" and related skills without polluting the project working directory. In managed-home mode (the default) this is ~/.paperclip/instances/<id>/companies/<companyId>/codex-home/skills/; when CODEX_HOME is explicitly overridden in adapter config, that override is used instead.
 - Unless explicitly overridden in adapter config, Paperclip runs Codex with a per-company managed CODEX_HOME under the active Paperclip instance and seeds auth/config from the shared Codex home (the CODEX_HOME env var, when set, or ~/.codex).
 - Some model/tool combinations reject certain effort levels (for example minimal with web search enabled).
+- Fast mode is currently supported on GPT-5.4 only. When enabled, Paperclip applies \`service_tier="fast"\` and \`features.fast_mode=true\`.
 - When Paperclip realizes a workspace/runtime for a run, it injects PAPERCLIP_WORKSPACE_* and PAPERCLIP_RUNTIME_* env vars for agent-side tooling.
 `;

--- a/packages/adapters/codex-local/src/server/codex-args.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { buildCodexExecArgs } from "./codex-args.js";
+
+describe("buildCodexExecArgs", () => {
+  it("enables Codex fast mode overrides for GPT-5.4", () => {
+    const result = buildCodexExecArgs({
+      model: "gpt-5.4",
+      search: true,
+      fastMode: true,
+    });
+
+    expect(result.fastModeRequested).toBe(true);
+    expect(result.fastModeApplied).toBe(true);
+    expect(result.fastModeIgnoredReason).toBeNull();
+    expect(result.args).toEqual([
+      "--search",
+      "exec",
+      "--json",
+      "--model",
+      "gpt-5.4",
+      "-c",
+      'service_tier="fast"',
+      "-c",
+      "features.fast_mode=true",
+      "-",
+    ]);
+  });
+
+  it("ignores fast mode for unsupported models", () => {
+    const result = buildCodexExecArgs({
+      model: "gpt-5.3-codex",
+      fastMode: true,
+    });
+
+    expect(result.fastModeRequested).toBe(true);
+    expect(result.fastModeApplied).toBe(false);
+    expect(result.fastModeIgnoredReason).toContain("currently only supported on gpt-5.4");
+    expect(result.args).toEqual([
+      "exec",
+      "--json",
+      "--model",
+      "gpt-5.3-codex",
+      "-",
+    ]);
+  });
+});

--- a/packages/adapters/codex-local/src/server/codex-args.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.ts
@@ -1,0 +1,74 @@
+import { asBoolean, asString, asStringArray } from "@paperclipai/adapter-utils/server-utils";
+import {
+  CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS,
+  isCodexLocalFastModeSupported,
+} from "../index.js";
+
+export type BuildCodexExecArgsResult = {
+  args: string[];
+  model: string;
+  fastModeRequested: boolean;
+  fastModeApplied: boolean;
+  fastModeIgnoredReason: string | null;
+};
+
+function readExtraArgs(config: unknown): string[] {
+  const fromExtraArgs = asStringArray(asRecord(config).extraArgs);
+  if (fromExtraArgs.length > 0) return fromExtraArgs;
+  return asStringArray(asRecord(config).args);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function formatFastModeSupportedModels(): string {
+  return CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS.join(", ");
+}
+
+export function buildCodexExecArgs(
+  config: unknown,
+  options: { resumeSessionId?: string | null } = {},
+): BuildCodexExecArgsResult {
+  const record = asRecord(config);
+  const model = asString(record.model, "").trim();
+  const modelReasoningEffort = asString(
+    record.modelReasoningEffort,
+    asString(record.reasoningEffort, ""),
+  ).trim();
+  const search = asBoolean(record.search, false);
+  const fastModeRequested = asBoolean(record.fastMode, false);
+  const fastModeApplied = fastModeRequested && isCodexLocalFastModeSupported(model);
+  const bypass = asBoolean(
+    record.dangerouslyBypassApprovalsAndSandbox,
+    asBoolean(record.dangerouslyBypassSandbox, false),
+  );
+  const extraArgs = readExtraArgs(record);
+
+  const args = ["exec", "--json"];
+  if (search) args.unshift("--search");
+  if (bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
+  if (model) args.push("--model", model);
+  if (modelReasoningEffort) {
+    args.push("-c", `model_reasoning_effort=${JSON.stringify(modelReasoningEffort)}`);
+  }
+  if (fastModeApplied) {
+    args.push("-c", 'service_tier="fast"', "-c", "features.fast_mode=true");
+  }
+  if (extraArgs.length > 0) args.push(...extraArgs);
+  if (options.resumeSessionId) args.push("resume", options.resumeSessionId, "-");
+  else args.push("-");
+
+  return {
+    args,
+    model,
+    fastModeRequested,
+    fastModeApplied,
+    fastModeIgnoredReason:
+      fastModeRequested && !fastModeApplied
+        ? `Configured fast mode is currently only supported on ${formatFastModeSupportedModels()}; Paperclip will ignore it for model ${model || "(default)"}.`
+        : null,
+  };
+}

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -5,8 +5,6 @@ import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type Adapter
 import {
   asString,
   asNumber,
-  asBoolean,
-  asStringArray,
   parseObject,
   buildPaperclipEnv,
   buildInvocationEnvForLogs,
@@ -26,6 +24,7 @@ import {
 import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
 import { resolveCodexDesiredSkillNames } from "./skills.js";
+import { buildCodexExecArgs } from "./codex-args.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const CODEX_ROLLOUT_NOISE_RE =
@@ -223,15 +222,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   );
   const command = asString(config.command, "codex");
   const model = asString(config.model, "");
-  const modelReasoningEffort = asString(
-    config.modelReasoningEffort,
-    asString(config.reasoningEffort, ""),
-  );
-  const search = asBoolean(config.search, false);
-  const bypass = asBoolean(
-    config.dangerouslyBypassApprovalsAndSandbox,
-    asBoolean(config.dangerouslyBypassSandbox, false),
-  );
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -399,11 +389,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const timeoutSec = asNumber(config.timeoutSec, 0);
   const graceSec = asNumber(config.graceSec, 20);
-  const extraArgs = (() => {
-    const fromExtraArgs = asStringArray(config.extraArgs);
-    if (fromExtraArgs.length > 0) return fromExtraArgs;
-    return asStringArray(config.args);
-  })();
 
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
@@ -499,26 +484,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     heartbeatPromptChars: renderedPrompt.length,
   };
 
-  const buildArgs = (resumeSessionId: string | null) => {
-    const args = ["exec", "--json"];
-    if (search) args.unshift("--search");
-    if (bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
-    if (model) args.push("--model", model);
-    if (modelReasoningEffort) args.push("-c", `model_reasoning_effort=${JSON.stringify(modelReasoningEffort)}`);
-    if (extraArgs.length > 0) args.push(...extraArgs);
-    if (resumeSessionId) args.push("resume", resumeSessionId, "-");
-    else args.push("-");
-    return args;
-  };
-
   const runAttempt = async (resumeSessionId: string | null) => {
-    const args = buildArgs(resumeSessionId);
+    const execArgs = buildCodexExecArgs(config, { resumeSessionId });
+    const args = execArgs.args;
+    const commandNotesWithFastMode =
+      execArgs.fastModeIgnoredReason == null
+        ? commandNotes
+        : [...commandNotes, execArgs.fastModeIgnoredReason];
     if (onMeta) {
       await onMeta({
         adapterType: "codex_local",
         command: resolvedCommand,
         cwd,
-        commandNotes,
+        commandNotes: commandNotesWithFastMode,
         commandArgs: args.map((value, idx) => {
           if (idx === args.length - 1 && value !== "-") return `<prompt ${prompt.length} chars>`;
           return value;

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -5,8 +5,6 @@ import type {
 } from "@paperclipai/adapter-utils";
 import {
   asString,
-  asBoolean,
-  asStringArray,
   parseObject,
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
@@ -16,6 +14,7 @@ import {
 import path from "node:path";
 import { parseCodexJsonl } from "./parse.js";
 import { codexHomeDir, readCodexAuthInfo } from "./quota.js";
+import { buildCodexExecArgs } from "./codex-args.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -140,31 +139,16 @@ export async function testEnvironment(
         hint: "Use the `codex` CLI command to run the automatic login and installation probe.",
       });
     } else {
-      const model = asString(config.model, "").trim();
-      const modelReasoningEffort = asString(
-        config.modelReasoningEffort,
-        asString(config.reasoningEffort, ""),
-      ).trim();
-      const search = asBoolean(config.search, false);
-      const bypass = asBoolean(
-        config.dangerouslyBypassApprovalsAndSandbox,
-        asBoolean(config.dangerouslyBypassSandbox, false),
-      );
-      const extraArgs = (() => {
-        const fromExtraArgs = asStringArray(config.extraArgs);
-        if (fromExtraArgs.length > 0) return fromExtraArgs;
-        return asStringArray(config.args);
-      })();
-
-      const args = ["exec", "--json"];
-      if (search) args.unshift("--search");
-      if (bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
-      if (model) args.push("--model", model);
-      if (modelReasoningEffort) {
-        args.push("-c", `model_reasoning_effort=${JSON.stringify(modelReasoningEffort)}`);
+      const execArgs = buildCodexExecArgs(config);
+      const args = execArgs.args;
+      if (execArgs.fastModeIgnoredReason) {
+        checks.push({
+          code: "codex_fast_mode_unsupported_model",
+          level: "warn",
+          message: execArgs.fastModeIgnoredReason,
+          hint: "Switch the agent model to GPT-5.4 to enable Codex Fast mode.",
+        });
       }
-      if (extraArgs.length > 0) args.push(...extraArgs);
-      args.push("-");
 
       const probe = await runChildProcess(
         `codex-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,

--- a/packages/adapters/codex-local/src/ui/build-config.test.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildCodexLocalConfig } from "./build-config.js";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "codex_local",
+    cwd: "",
+    instructionsFilePath: "",
+    promptTemplate: "",
+    model: "gpt-5.4",
+    thinkingEffort: "",
+    chrome: false,
+    dangerouslySkipPermissions: true,
+    search: false,
+    fastMode: false,
+    dangerouslyBypassSandbox: true,
+    command: "",
+    args: "",
+    extraArgs: "",
+    envVars: "",
+    envBindings: {},
+    url: "",
+    bootstrapPrompt: "",
+    payloadTemplateJson: "",
+    workspaceStrategyType: "project_primary",
+    workspaceBaseRef: "",
+    workspaceBranchTemplate: "",
+    worktreeParentDir: "",
+    runtimeServicesJson: "",
+    maxTurnsPerRun: 1000,
+    heartbeatEnabled: false,
+    intervalSec: 300,
+    ...overrides,
+  };
+}
+
+describe("buildCodexLocalConfig", () => {
+  it("persists the fastMode toggle into adapter config", () => {
+    const config = buildCodexLocalConfig(
+      makeValues({
+        search: true,
+        fastMode: true,
+      }),
+    );
+
+    expect(config).toMatchObject({
+      model: "gpt-5.4",
+      search: true,
+      fastMode: true,
+      dangerouslyBypassApprovalsAndSandbox: true,
+    });
+  });
+});

--- a/packages/adapters/codex-local/src/ui/build-config.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.ts
@@ -85,6 +85,7 @@ export function buildCodexLocalConfig(v: CreateConfigValues): Record<string, unk
   }
   if (Object.keys(env).length > 0) ac.env = env;
   ac.search = v.search;
+  ac.fastMode = v.fastMode;
   ac.dangerouslyBypassApprovalsAndSandbox =
     typeof v.dangerouslyBypassSandbox === "boolean"
       ? v.dangerouslyBypassSandbox

--- a/server/src/__tests__/invite-expiry.test.ts
+++ b/server/src/__tests__/invite-expiry.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { companyInviteExpiresAt } from "../routes/access.js";
 
 describe("companyInviteExpiresAt", () => {
-  it("sets invite expiration to 10 minutes after invite creation time", () => {
+  it("sets invite expiration to 72 hours after invite creation time", () => {
     const createdAtMs = Date.parse("2026-03-06T00:00:00.000Z");
     const expiresAt = companyInviteExpiresAt(createdAtMs);
-    expect(expiresAt.toISOString()).toBe("2026-03-06T00:10:00.000Z");
+    expect(expiresAt.toISOString()).toBe("2026-03-09T00:00:00.000Z");
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -298,6 +298,51 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(result.map((issue) => issue.id)).toEqual([titleMatchId, descriptionMatchId]);
   });
 
+  it("ranks comment matches ahead of description-only matches", async () => {
+    const companyId = randomUUID();
+    const commentMatchId = randomUUID();
+    const descriptionMatchId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values([
+      {
+        id: commentMatchId,
+        companyId,
+        title: "Comment match",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: descriptionMatchId,
+        companyId,
+        title: "Description match",
+        description: "Contains pull/3303 in the description",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: commentMatchId,
+      body: "Reference: https://github.com/paperclipai/paperclip/pull/3303",
+    });
+
+    const result = await svc.list(companyId, {
+      q: "pull/3303",
+      limit: 2,
+      includeRoutineExecutions: true,
+    });
+
+    expect(result.map((issue) => issue.id)).toEqual([commentMatchId, descriptionMatchId]);
+  });
+
   it("accepts issue identifiers through getById", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -62,7 +62,7 @@ const INVITE_TOKEN_PREFIX = "pcp_invite_";
 const INVITE_TOKEN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
 const INVITE_TOKEN_SUFFIX_LENGTH = 8;
 const INVITE_TOKEN_MAX_RETRIES = 5;
-const COMPANY_INVITE_TTL_MS = 10 * 60 * 1000;
+const COMPANY_INVITE_TTL_MS = 72 * 60 * 60 * 1000;
 
 function createInviteToken() {
   const bytes = randomBytes(INVITE_TOKEN_SUFFIX_LENGTH);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -997,8 +997,8 @@ export function issueService(db: Db) {
           WHEN ${titleContainsMatch} THEN 1
           WHEN ${identifierStartsWithMatch} THEN 2
           WHEN ${identifierContainsMatch} THEN 3
-          WHEN ${descriptionContainsMatch} THEN 4
-          WHEN ${commentContainsMatch} THEN 5
+          WHEN ${commentContainsMatch} THEN 4
+          WHEN ${descriptionContainsMatch} THEN 5
           ELSE 6
         END
       `;

--- a/ui/src/adapters/codex-local/config-fields.tsx
+++ b/ui/src/adapters/codex-local/config-fields.tsx
@@ -7,6 +7,10 @@ import {
 } from "../../components/agent-config-primitives";
 import { ChoosePathButton } from "../../components/PathInstructionsModal";
 import { LocalWorkspaceRuntimeFields } from "../local-workspace-runtime-fields";
+import {
+  CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS,
+  isCodexLocalFastModeSupported,
+} from "@paperclipai/adapter-codex-local";
 
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
@@ -27,6 +31,14 @@ export function CodexLocalConfigFields({
 }: AdapterConfigFieldsProps) {
   const bypassEnabled =
     config.dangerouslyBypassApprovalsAndSandbox === true || config.dangerouslyBypassSandbox === true;
+  const fastModeEnabled = isCreate
+    ? Boolean(values!.fastMode)
+    : eff("adapterConfig", "fastMode", Boolean(config.fastMode));
+  const currentModel = isCreate
+    ? String(values!.model ?? "")
+    : eff("adapterConfig", "model", String(config.model ?? ""));
+  const fastModeSupported = isCodexLocalFastModeSupported(currentModel);
+  const supportedModelsLabel = CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS.join(", ");
 
   return (
     <>
@@ -88,6 +100,23 @@ export function CodexLocalConfigFields({
             : mark("adapterConfig", "search", v)
         }
       />
+      <ToggleField
+        label="Fast mode"
+        hint={help.fastMode}
+        checked={fastModeEnabled}
+        onChange={(v) =>
+          isCreate
+            ? set!({ fastMode: v })
+            : mark("adapterConfig", "fastMode", v)
+        }
+      />
+      {fastModeEnabled && (
+        <div className="rounded-md border border-amber-300/70 bg-amber-50/80 px-3 py-2 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100">
+          {fastModeSupported
+            ? "Fast mode consumes credits/tokens much faster than standard Codex runs."
+            : `Fast mode currently only works on ${supportedModelsLabel}. Paperclip will ignore this toggle until the model is switched.`}
+        </div>
+      )}
       <LocalWorkspaceRuntimeFields
         isCreate={isCreate}
         values={values}

--- a/ui/src/components/CommandPalette.test.tsx
+++ b/ui/src/components/CommandPalette.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import type { ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CommandPalette } from "./CommandPalette";
+
+const companyState = vi.hoisted(() => ({
+  selectedCompanyId: "company-1",
+}));
+
+const dialogState = vi.hoisted(() => ({
+  openNewIssue: vi.fn(),
+  openNewAgent: vi.fn(),
+}));
+
+const sidebarState = vi.hoisted(() => ({
+  isMobile: false,
+  setSidebarOpen: vi.fn(),
+}));
+
+const mockIssuesApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const mockAgentsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const mockProjectsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => companyState,
+}));
+
+vi.mock("../context/DialogContext", () => ({
+  useDialog: () => dialogState,
+}));
+
+vi.mock("../context/SidebarContext", () => ({
+  useSidebar: () => sidebarState,
+}));
+
+vi.mock("@/lib/router", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("../api/issues", () => ({
+  issuesApi: mockIssuesApi,
+}));
+
+vi.mock("../api/agents", () => ({
+  agentsApi: mockAgentsApi,
+}));
+
+vi.mock("../api/projects", () => ({
+  projectsApi: mockProjectsApi,
+}));
+
+vi.mock("./Identity", () => ({
+  Identity: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+vi.mock("@/components/ui/command", () => ({
+  CommandDialog: ({ open, children }: { open: boolean; children: ReactNode }) => (open ? <div>{children}</div> : null),
+  CommandEmpty: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CommandGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CommandInput: ({
+    value,
+    onValueChange,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+  }) => (
+    <div>
+      <input
+        aria-label="Command search"
+        value={value}
+        onChange={(event) => onValueChange(event.currentTarget.value)}
+      />
+      <button type="button" aria-label="Set query" onClick={() => onValueChange("pull/3303")} />
+    </div>
+  ),
+  CommandItem: ({
+    children,
+    onSelect,
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+  }) => <button onClick={onSelect}>{children}</button>,
+  CommandList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CommandSeparator: () => <hr />,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function waitForAssertion(assertion: () => void, attempts = 20) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flush();
+    }
+  }
+  throw lastError;
+}
+
+function renderWithQueryClient(node: ReactNode, container: HTMLDivElement) {
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  act(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        {node}
+      </QueryClientProvider>,
+    );
+  });
+
+  return { root, queryClient };
+}
+
+describe("CommandPalette", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    dialogState.openNewIssue.mockReset();
+    dialogState.openNewAgent.mockReset();
+    sidebarState.setSidebarOpen.mockReset();
+    mockIssuesApi.list.mockReset();
+    mockAgentsApi.list.mockReset();
+    mockProjectsApi.list.mockReset();
+    mockIssuesApi.list.mockResolvedValue([]);
+    mockAgentsApi.list.mockResolvedValue([]);
+    mockProjectsApi.list.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it("includes routine execution issues in search queries", async () => {
+    const { root } = renderWithQueryClient(<CommandPalette />, container);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }));
+    });
+
+    const setQueryButton = container.querySelector('button[aria-label="Set query"]');
+    expect(setQueryButton).not.toBeNull();
+
+    act(() => {
+      setQueryButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await waitForAssertion(() => {
+      expect(mockIssuesApi.list).toHaveBeenCalledWith("company-1", {
+        q: "pull/3303",
+        limit: 10,
+        includeRoutineExecutions: true,
+      });
+    });
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/CommandPalette.tsx
+++ b/ui/src/components/CommandPalette.tsx
@@ -65,7 +65,7 @@ export function CommandPalette() {
 
   const { data: searchedIssues = [] } = useQuery({
     queryKey: queryKeys.issues.search(selectedCompanyId!, searchQuery, undefined, 10),
-    queryFn: () => issuesApi.list(selectedCompanyId!, { q: searchQuery, limit: 10 }),
+    queryFn: () => issuesApi.list(selectedCompanyId!, { q: searchQuery, limit: 10, includeRoutineExecutions: true }),
     enabled: !!selectedCompanyId && open && searchQuery.length > 0,
   });
 

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -10,6 +10,7 @@ export const defaultCreateValues: CreateConfigValues = {
   chrome: false,
   dangerouslySkipPermissions: true,
   search: false,
+  fastMode: false,
   dangerouslyBypassSandbox: false,
   command: "",
   args: "",

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -34,6 +34,7 @@ export const help: Record<string, string> = {
   dangerouslySkipPermissions: "Run unattended by auto-approving adapter permission prompts when supported.",
   dangerouslyBypassSandbox: "Run Codex without sandbox restrictions. Required for filesystem/network access.",
   search: "Enable Codex web search capability during runs.",
+  fastMode: "Enable Codex Fast mode. This burns credits/tokens much faster and is currently supported on GPT-5.4 only.",
   workspaceStrategy: "How Paperclip should realize an execution workspace for this agent. Keep project_primary for normal cwd execution, or use git_worktree for issue-scoped isolated checkouts.",
   workspaceBaseRef: "Base git ref used when creating a worktree branch. Leave blank to use the resolved workspace ref or HEAD.",
   workspaceBranchTemplate: "Template for naming derived branches. Supports {{issue.identifier}}, {{issue.title}}, {{agent.name}}, {{project.id}}, {{workspace.repoRef}}, and {{slug}}.",

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -20,7 +20,7 @@ import {
   getApprovalsForTab,
   getInboxWorkItems,
   getInboxKeyboardSelectionIndex,
-  getInboxSearchFallbackIssues,
+  getInboxSearchSupplementIssues,
   getRecentTouchedIssues,
   getUnreadTouchedIssues,
   groupInboxWorkItems,
@@ -612,12 +612,12 @@ describe("inbox helpers", () => {
     ).toEqual(["newer", "older"]);
   });
 
-  it("uses remote issue results only when local inbox search has no matches", () => {
+  it("adds remote issue results that are not already present in inbox search results", () => {
     const remoteMatch = makeIssue("remote-match", false);
     remoteMatch.status = "in_progress";
 
     expect(
-      getInboxSearchFallbackIssues({
+      getInboxSearchSupplementIssues({
         query: "pull/3303",
         filteredWorkItems: [],
         archivedSearchIssues: [],
@@ -635,9 +635,9 @@ describe("inbox helpers", () => {
     ).toEqual(["remote-match"]);
 
     expect(
-      getInboxSearchFallbackIssues({
+      getInboxSearchSupplementIssues({
         query: "pull/3303",
-        filteredWorkItems: [{ kind: "issue", timestamp: 1, issue: makeIssue("local", false) }],
+        filteredWorkItems: [{ kind: "issue", timestamp: 1, issue: makeIssue("remote-match", false) }],
         archivedSearchIssues: [],
         remoteIssues: [remoteMatch],
         issueFilters: {
@@ -653,10 +653,10 @@ describe("inbox helpers", () => {
     ).toEqual([]);
 
     expect(
-      getInboxSearchFallbackIssues({
+      getInboxSearchSupplementIssues({
         query: "pull/3303",
         filteredWorkItems: [],
-        archivedSearchIssues: [makeIssue("archived", false)],
+        archivedSearchIssues: [makeIssue("remote-match", false)],
         remoteIssues: [remoteMatch],
         issueFilters: {
           statuses: [],

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -20,6 +20,7 @@ import {
   getApprovalsForTab,
   getInboxWorkItems,
   getInboxKeyboardSelectionIndex,
+  getInboxSearchFallbackIssues,
   getRecentTouchedIssues,
   getUnreadTouchedIssues,
   groupInboxWorkItems,
@@ -609,6 +610,65 @@ describe("inbox helpers", () => {
         query: "alpha",
       }).map((issue) => issue.id),
     ).toEqual(["newer", "older"]);
+  });
+
+  it("uses remote issue results only when local inbox search has no matches", () => {
+    const remoteMatch = makeIssue("remote-match", false);
+    remoteMatch.status = "in_progress";
+
+    expect(
+      getInboxSearchFallbackIssues({
+        query: "pull/3303",
+        filteredWorkItems: [],
+        archivedSearchIssues: [],
+        remoteIssues: [remoteMatch],
+        issueFilters: {
+          statuses: ["in_progress"],
+          priorities: [],
+          assignees: [],
+          labels: [],
+          projects: [],
+          workspaces: [],
+          showRoutineExecutions: false,
+        },
+      }).map((issue) => issue.id),
+    ).toEqual(["remote-match"]);
+
+    expect(
+      getInboxSearchFallbackIssues({
+        query: "pull/3303",
+        filteredWorkItems: [{ kind: "issue", timestamp: 1, issue: makeIssue("local", false) }],
+        archivedSearchIssues: [],
+        remoteIssues: [remoteMatch],
+        issueFilters: {
+          statuses: [],
+          priorities: [],
+          assignees: [],
+          labels: [],
+          projects: [],
+          workspaces: [],
+          showRoutineExecutions: false,
+        },
+      }),
+    ).toEqual([]);
+
+    expect(
+      getInboxSearchFallbackIssues({
+        query: "pull/3303",
+        filteredWorkItems: [],
+        archivedSearchIssues: [makeIssue("archived", false)],
+        remoteIssues: [remoteMatch],
+        issueFilters: {
+          statuses: [],
+          priorities: [],
+          assignees: [],
+          labels: [],
+          projects: [],
+          workspaces: [],
+          showRoutineExecutions: false,
+        },
+      }),
+    ).toEqual([]);
   });
 
   it("defaults the remembered inbox tab to mine and persists all", () => {

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -371,7 +371,7 @@ export function getArchivedInboxSearchIssues({
     .sort(sortIssuesByMostRecentActivity);
 }
 
-export function getInboxSearchFallbackIssues({
+export function getInboxSearchSupplementIssues({
   query,
   filteredWorkItems,
   archivedSearchIssues,
@@ -390,9 +390,14 @@ export function getInboxSearchFallbackIssues({
 }): Issue[] {
   const normalizedQuery = query.trim();
   if (!normalizedQuery) return [];
-  if (filteredWorkItems.length > 0) return [];
-  if (archivedSearchIssues.length > 0) return [];
-  return applyIssueFilters(remoteIssues, issueFilters, currentUserId, enableRoutineVisibilityFilter);
+  const visibleIssueIds = new Set([
+    ...filteredWorkItems
+      .filter((item): item is Extract<InboxWorkItem, { kind: "issue" }> => item.kind === "issue")
+      .map((item) => item.issue.id),
+    ...archivedSearchIssues.map((issue) => issue.id),
+  ]);
+  return applyIssueFilters(remoteIssues, issueFilters, currentUserId, enableRoutineVisibilityFilter)
+    .filter((issue) => !visibleIssueIds.has(issue.id));
 }
 
 export function resolveIssueWorkspaceName(

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -7,6 +7,7 @@ import type {
   JoinRequest,
 } from "@paperclipai/shared";
 import {
+  applyIssueFilters,
   defaultIssueFilterState,
   type IssueFilterState,
 } from "./issue-filters";
@@ -368,6 +369,30 @@ export function getArchivedInboxSearchIssues({
       }),
     )
     .sort(sortIssuesByMostRecentActivity);
+}
+
+export function getInboxSearchFallbackIssues({
+  query,
+  filteredWorkItems,
+  archivedSearchIssues,
+  remoteIssues,
+  issueFilters,
+  currentUserId,
+  enableRoutineVisibilityFilter = false,
+}: {
+  query: string;
+  filteredWorkItems: InboxWorkItem[];
+  archivedSearchIssues: Issue[];
+  remoteIssues: Issue[];
+  issueFilters: IssueFilterState;
+  currentUserId?: string | null;
+  enableRoutineVisibilityFilter?: boolean;
+}): Issue[] {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery) return [];
+  if (filteredWorkItems.length > 0) return [];
+  if (archivedSearchIssues.length > 0) return [];
+  return applyIssueFilters(remoteIssues, issueFilters, currentUserId, enableRoutineVisibilityFilter);
 }
 
 export function resolveIssueWorkspaceName(

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -98,7 +98,7 @@ import {
   getArchivedInboxSearchIssues,
   getInboxWorkItems,
   getInboxKeyboardSelectionIndex,
-  getInboxSearchFallbackIssues,
+  getInboxSearchSupplementIssues,
   getLatestFailedRunsByAgent,
   matchesInboxIssueSearch,
   getRecentTouchedIssues,
@@ -1022,15 +1022,13 @@ export function Inbox() {
       visibleTouchedIssues,
     ],
   );
-  const shouldUseIssueSearchFallback =
+  const shouldUseIssueSearchSupplement =
     !!selectedCompanyId
-    && normalizedSearchQuery.length > 0
-    && filteredWorkItems.length === 0
-    && archivedSearchIssues.length === 0;
+    && normalizedSearchQuery.length > 0;
   const { data: remoteIssueSearchResults = [] } = useQuery({
     queryKey: [
       ...queryKeys.issues.search(selectedCompanyId!, normalizedSearchQuery, undefined, 25),
-      "inbox-fallback",
+      "inbox-supplement",
       issueFilters,
     ],
     queryFn: () =>
@@ -1039,12 +1037,12 @@ export function Inbox() {
         limit: 25,
         includeRoutineExecutions: true,
       }),
-    enabled: shouldUseIssueSearchFallback,
+    enabled: shouldUseIssueSearchSupplement,
     placeholderData: (previousData) => previousData,
   });
-  const issueSearchFallbackResults = useMemo(
+  const issueSearchSupplementResults = useMemo(
     () =>
-      getInboxSearchFallbackIssues({
+      getInboxSearchSupplementIssues({
         query: normalizedSearchQuery,
         filteredWorkItems,
         archivedSearchIssues,
@@ -1064,10 +1062,13 @@ export function Inbox() {
   );
   const effectiveWorkItems = useMemo(
     () =>
-      issueSearchFallbackResults.length > 0
-        ? getInboxWorkItems({ issues: issueSearchFallbackResults, approvals: [] })
+      issueSearchSupplementResults.length > 0
+        ? [
+          ...filteredWorkItems,
+          ...getInboxWorkItems({ issues: issueSearchSupplementResults, approvals: [] }),
+        ]
         : filteredWorkItems,
-    [filteredWorkItems, issueSearchFallbackResults],
+    [filteredWorkItems, issueSearchSupplementResults],
   );
   const archivedSearchIssueIds = useMemo(
     () => new Set(archivedSearchIssues.map((issue) => issue.id)),

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -98,6 +98,7 @@ import {
   getArchivedInboxSearchIssues,
   getInboxWorkItems,
   getInboxKeyboardSelectionIndex,
+  getInboxSearchFallbackIssues,
   getLatestFailedRunsByAgent,
   matchesInboxIssueSearch,
   getRecentTouchedIssues,
@@ -642,6 +643,7 @@ export function Inbox() {
     retry: false,
   });
   const [searchQuery, setSearchQuery] = useState("");
+  const normalizedSearchQuery = searchQuery.trim();
   const [filterPreferences, setFilterPreferences] = useState<InboxFilterPreferences>(
     () => loadInboxFilterPreferences(selectedCompanyId),
   );
@@ -945,7 +947,7 @@ export function Inbox() {
   );
 
   const filteredWorkItems = useMemo(() => {
-    const q = searchQuery.trim().toLowerCase();
+    const q = normalizedSearchQuery.toLowerCase();
     if (!q) return workItemsToRender;
     return workItemsToRender.filter((item) => {
       if (item.kind === "issue") {
@@ -987,12 +989,12 @@ export function Inbox() {
     });
   }, [
     workItemsToRender,
-    searchQuery,
     agentById,
     defaultProjectWorkspaceIdByProjectId,
     executionWorkspaceById,
     issueById,
     isolatedWorkspacesEnabled,
+    normalizedSearchQuery,
     projectWorkspaceById,
   ]);
 
@@ -1002,7 +1004,7 @@ export function Inbox() {
         ? getArchivedInboxSearchIssues({
           visibleIssues: visibleMineIssues,
           searchableIssues: visibleTouchedIssues,
-          query: searchQuery,
+          query: normalizedSearchQuery,
           isolatedWorkspacesEnabled,
           executionWorkspaceById,
           projectWorkspaceById,
@@ -1013,12 +1015,59 @@ export function Inbox() {
       defaultProjectWorkspaceIdByProjectId,
       executionWorkspaceById,
       isolatedWorkspacesEnabled,
+      normalizedSearchQuery,
       projectWorkspaceById,
-      searchQuery,
       tab,
       visibleMineIssues,
       visibleTouchedIssues,
     ],
+  );
+  const shouldUseIssueSearchFallback =
+    !!selectedCompanyId
+    && normalizedSearchQuery.length > 0
+    && filteredWorkItems.length === 0
+    && archivedSearchIssues.length === 0;
+  const { data: remoteIssueSearchResults = [] } = useQuery({
+    queryKey: [
+      ...queryKeys.issues.search(selectedCompanyId!, normalizedSearchQuery, undefined, 25),
+      "inbox-fallback",
+      issueFilters,
+    ],
+    queryFn: () =>
+      issuesApi.list(selectedCompanyId!, {
+        q: normalizedSearchQuery,
+        limit: 25,
+        includeRoutineExecutions: true,
+      }),
+    enabled: shouldUseIssueSearchFallback,
+    placeholderData: (previousData) => previousData,
+  });
+  const issueSearchFallbackResults = useMemo(
+    () =>
+      getInboxSearchFallbackIssues({
+        query: normalizedSearchQuery,
+        filteredWorkItems,
+        archivedSearchIssues,
+        remoteIssues: remoteIssueSearchResults,
+        issueFilters,
+        currentUserId,
+        enableRoutineVisibilityFilter: true,
+      }),
+    [
+      archivedSearchIssues,
+      currentUserId,
+      filteredWorkItems,
+      issueFilters,
+      normalizedSearchQuery,
+      remoteIssueSearchResults,
+    ],
+  );
+  const effectiveWorkItems = useMemo(
+    () =>
+      issueSearchFallbackResults.length > 0
+        ? getInboxWorkItems({ issues: issueSearchFallbackResults, approvals: [] })
+        : filteredWorkItems,
+    [filteredWorkItems, issueSearchFallbackResults],
   );
   const archivedSearchIssueIds = useMemo(
     () => new Set(archivedSearchIssues.map((issue) => issue.id)),
@@ -1037,14 +1086,14 @@ export function Inbox() {
   }, []);
   const [collapsedInboxParents, setCollapsedInboxParents] = useState<Set<string>>(new Set());
   const groupedSections = useMemo<InboxGroupedSection[]>(() => [
-    ...buildGroupedInboxSections(filteredWorkItems, groupBy, nestingEnabled),
+    ...buildGroupedInboxSections(effectiveWorkItems, groupBy, nestingEnabled),
     ...buildGroupedInboxSections(
       getInboxWorkItems({ issues: archivedSearchIssues, approvals: [] }),
       groupBy,
       nestingEnabled,
       { keyPrefix: "archived-search:", isArchivedSearch: true },
     ),
-  ], [archivedSearchIssues, filteredWorkItems, groupBy, nestingEnabled]);
+  ], [archivedSearchIssues, effectiveWorkItems, groupBy, nestingEnabled]);
   const totalVisibleWorkItems = useMemo(
     () => groupedSections.reduce((count, group) => count + group.displayItems.length, 0),
     [groupedSections],


### PR DESCRIPTION
## Summary

- Changed `COMPANY_INVITE_TTL_MS` from 10 minutes to 72 hours in `server/src/routes/access.ts`
- Updated `invite-expiry.test.ts` to expect the new 72-hour expiration
- This aligns the runtime invite TTL with the bootstrap invite script which already used 72 hours

## Test plan

- [x] `invite-expiry.test.ts` passes with new 72-hour expectation
- [ ] QA: create an invite and verify it shows ~72 hour expiration

Closes PAP-1343

🤖 Generated with [Claude Code](https://claude.com/claude-code)