### PR TITLE
fix(process-adapter): inject PAPERCLIP_RUN_ID and auth token env

### DIFF
--- a/server/src/__tests__/process-adapter-execute.test.ts
+++ b/server/src/__tests__/process-adapter-execute.test.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { execute } from "../adapters/process/execute.js";
+
+async function writeEnvCaptureScript(scriptPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const payload = {
+  PAPERCLIP_AGENT_ID: process.env.PAPERCLIP_AGENT_ID ?? null,
+  PAPERCLIP_COMPANY_ID: process.env.PAPERCLIP_COMPANY_ID ?? null,
+  PAPERCLIP_API_URL: process.env.PAPERCLIP_API_URL ?? null,
+  PAPERCLIP_RUN_ID: process.env.PAPERCLIP_RUN_ID ?? null,
+  PAPERCLIP_API_KEY: process.env.PAPERCLIP_API_KEY ?? null
+};
+fs.writeFileSync(process.argv[2], JSON.stringify(payload), "utf8");
+`;
+  await fs.writeFile(scriptPath, script, "utf8");
+  await fs.chmod(scriptPath, 0o755);
+}
+
+describe("process adapter execute", () => {
+  it("injects PAPERCLIP_RUN_ID and PAPERCLIP_API_KEY from authToken by default", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-execute-"));
+    const scriptPath = path.join(root, "capture.js");
+    const capturePath = path.join(root, "capture.json");
+    await writeEnvCaptureScript(scriptPath);
+
+    try {
+      const result = await execute({
+        runId: "run-123",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Process Agent",
+          adapterType: "process",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: process.execPath,
+          args: [scriptPath, capturePath],
+          cwd: root,
+          env: {},
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+        onMeta: async () => {},
+      } as any);
+
+      expect(result.errorMessage).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+
+      const payload = JSON.parse(await fs.readFile(capturePath, "utf8")) as Record<string, string | null>;
+      expect(payload.PAPERCLIP_AGENT_ID).toBe("agent-1");
+      expect(payload.PAPERCLIP_COMPANY_ID).toBe("company-1");
+      expect(payload.PAPERCLIP_RUN_ID).toBe("run-123");
+      expect(payload.PAPERCLIP_API_KEY).toBe("run-jwt-token");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves explicit PAPERCLIP_API_KEY override from adapter config", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-execute-explicit-key-"));
+    const scriptPath = path.join(root, "capture.js");
+    const capturePath = path.join(root, "capture.json");
+    await writeEnvCaptureScript(scriptPath);
+
+    try {
+      const result = await execute({
+        runId: "run-456",
+        agent: {
+          id: "agent-2",
+          companyId: "company-2",
+          name: "Process Agent",
+          adapterType: "process",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: process.execPath,
+          args: [scriptPath, capturePath],
+          cwd: root,
+          env: {
+            PAPERCLIP_API_KEY: "manual-agent-key",
+          },
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+        onMeta: async () => {},
+      } as any);
+
+      expect(result.errorMessage).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+
+      const payload = JSON.parse(await fs.readFile(capturePath, "utf8")) as Record<string, string | null>;
+      expect(payload.PAPERCLIP_RUN_ID).toBe("run-456");
+      expect(payload.PAPERCLIP_API_KEY).toBe("manual-agent-key");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/__tests__/process-adapter-execute.test.ts
+++ b/server/src/__tests__/process-adapter-execute.test.ts
@@ -114,4 +114,52 @@ describe("process adapter execute", () => {
       await fs.rm(root, { recursive: true, force: true });
     }
   });
+
+  it("keeps injected auth token and canonical run id when config env uses empty or stale values", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-execute-empty-key-"));
+    const scriptPath = path.join(root, "capture.js");
+    const capturePath = path.join(root, "capture.json");
+    await writeEnvCaptureScript(scriptPath);
+
+    try {
+      const result = await execute({
+        runId: "run-789",
+        agent: {
+          id: "agent-3",
+          companyId: "company-3",
+          name: "Process Agent",
+          adapterType: "process",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: process.execPath,
+          args: [scriptPath, capturePath],
+          cwd: root,
+          env: {
+            PAPERCLIP_API_KEY: "",
+            PAPERCLIP_RUN_ID: "stale-run-id",
+          },
+        },
+        context: {},
+        authToken: "fallback-run-token",
+        onLog: async () => {},
+        onMeta: async () => {},
+      } as any);
+
+      expect(result.errorMessage).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+
+      const payload = JSON.parse(await fs.readFile(capturePath, "utf8")) as Record<string, string | null>;
+      expect(payload.PAPERCLIP_RUN_ID).toBe("run-789");
+      expect(payload.PAPERCLIP_API_KEY).toBe("fallback-run-token");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -12,14 +12,20 @@ import {
 } from "../utils.js";
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { runId, agent, config, onLog, onMeta } = ctx;
+  const { runId, agent, config, onLog, onMeta, authToken } = ctx;
   const command = asString(config.command, "");
   if (!command) throw new Error("Process adapter missing command");
 
   const args = asStringArray(config.args);
   const cwd = asString(config.cwd, process.cwd());
   const envConfig = parseObject(config.env);
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+  if (!hasExplicitApiKey && typeof authToken === "string" && authToken.trim().length > 0) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;
   }

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -22,12 +22,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  for (const [k, v] of Object.entries(envConfig)) {
+    if (typeof v === "string") env[k] = v;
+  }
   env.PAPERCLIP_RUN_ID = runId;
   if (!hasExplicitApiKey && typeof authToken === "string" && authToken.trim().length > 0) {
     env.PAPERCLIP_API_KEY = authToken;
-  }
-  for (const [k, v] of Object.entries(envConfig)) {
-    if (typeof v === "string") env[k] = v;
   }
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
   const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and adapters, so adapter env wiring has to preserve the server's canonical execution context.
> - This PR is in the process adapter path that spawns external commands on behalf of an agent run.
> - The goal of #3381 is to inject `PAPERCLIP_RUN_ID` and an auth-token-backed `PAPERCLIP_API_KEY` so subprocesses can authenticate and correlate logs.
> - Greptile caught that the adapter merged `config.env` after the injected values, which let empty or stale config values silently erase the canonical run env.
> - That means a user-supplied empty `PAPERCLIP_API_KEY` or stale `PAPERCLIP_RUN_ID` could break the very fallback this PR was trying to add.
> - This pull request keeps `config.env` support, but restores canonical precedence for the injected run id and auth-token fallback.
> - The benefit is that process adapters stay authenticated and correctly bound to the active run even when config env contains blank or stale keys.

## What Changed

- Apply `config.env` first in `server/src/adapters/process/execute.ts`, then write the canonical `PAPERCLIP_RUN_ID` and auth-token fallback so they win over empty or stale config entries.
- Add a regression test covering `PAPERCLIP_API_KEY: ""` plus a stale `PAPERCLIP_RUN_ID` in adapter config.
- Keep the existing explicit non-empty API key override behavior unchanged.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm test:run server/src/__tests__/process-adapter-execute.test.ts`

## Risks

- Low risk. Scope is limited to process-adapter env assembly.
- The only behavioral change is precedence: canonical run env now correctly overrides empty or stale config values, while explicit non-empty API keys still win.

## Model Used

- OpenAI Codex, GPT-5-based coding agent in Codex CLI with tool use and code execution in this workspace.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
