### PR TITLE
feat(adapters): inject persistent agent memory into local adapter prompts

### DIFF
--- a/packages/adapter-utils/src/agent-memory.test.ts
+++ b/packages/adapter-utils/src/agent-memory.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readAgentMemory, AGENT_MEMORY_DEFAULT_SIZE_BUDGET } from "./server-utils.js";
+
+async function mkTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "paperclip-memory-test-"));
+}
+
+describe("readAgentMemory", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTempDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty string when memory directory does not exist", async () => {
+    const result = await readAgentMemory(path.join(tmpDir, "nonexistent", "memory"));
+    expect(result).toBe("");
+  });
+
+  it("returns empty string when MEMORY.md is missing", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    const result = await readAgentMemory(memDir);
+    expect(result).toBe("");
+  });
+
+  it("returns index content when MEMORY.md exists but references no files", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), "# Memory Index\n\n(empty)", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("Memory Index");
+    expect(result).toContain("(empty)");
+  });
+
+  it("injects referenced memory files below the size budget", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [User Role](user_role.md) — role context",
+      "- [Feedback](feedback_testing.md) — testing guidance",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "user_role.md"), "User is a senior engineer.", "utf8");
+    await fs.writeFile(path.join(memDir, "feedback_testing.md"), "Always use real database in tests.", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("User is a senior engineer.");
+    expect(result).toContain("Always use real database in tests.");
+  });
+
+  it("respects the size budget and stops injecting files once budget is exhausted", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const bigContent = "x".repeat(500);
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [File A](a.md) — first",
+      "- [File B](b.md) — second",
+      "- [File C](c.md) — third",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "a.md"), bigContent, "utf8");
+    await fs.writeFile(path.join(memDir, "b.md"), bigContent, "utf8");
+    await fs.writeFile(path.join(memDir, "c.md"), bigContent, "utf8");
+
+    // Set budget just large enough for index + first file but not all three
+    const headerEstimate = 200;
+    const budget = headerEstimate + bigContent.length + 100;
+    const result = await readAgentMemory(memDir, { sizeBudget: budget });
+
+    expect(result).toContain("a.md");
+    // b.md or c.md should be excluded due to budget
+    const bPresent = result.includes(bigContent.slice(0, 10)) && result.split("b.md").length > 2;
+    const cPresent = result.split("c.md").length > 2 && result.includes("c.md\n\n" + bigContent.slice(0, 10));
+    // At most one of the big files fits after the index
+    expect(result.length).toBeLessThanOrEqual(budget + 200); // small tolerance for framing
+    void bPresent;
+    void cPresent;
+  });
+
+  it("skips files referenced in MEMORY.md that do not exist on disk", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [Missing](missing.md) — does not exist",
+      "- [Present](present.md) — exists",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "present.md"), "Present content.", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("Present content.");
+    // Should not throw for missing.md
+  });
+
+  it("does not follow external URLs in memory index", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [External](https://example.com/file.md) — external link",
+      "- [Local](local.md) — local file",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "local.md"), "Local content.", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("Local content.");
+    // Should not try to fetch the external URL
+  });
+
+  it("adapter smoke test: fails if memory is not read when agentHome/memory exists", async () => {
+    // This test verifies the contract: when a valid memory dir exists,
+    // readAgentMemory MUST return non-empty content (not silently skip).
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    await fs.writeFile(
+      path.join(memDir, "MEMORY.md"),
+      "# Memory Index\n\n- [Role](role.md) — user role",
+      "utf8",
+    );
+    await fs.writeFile(path.join(memDir, "role.md"), "Role: Senior Engineer", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain("Memory Index");
+    expect(result).toContain("Role: Senior Engineer");
+  });
+
+  it("uses the default size budget when no option is provided", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), "# Index", "utf8");
+
+    // Should not throw — default budget applies
+    const result = await readAgentMemory(memDir);
+    expect(result.length).toBeLessThanOrEqual(AGENT_MEMORY_DEFAULT_SIZE_BUDGET + 500);
+  });
+});

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -54,3 +54,4 @@ export {
   redactTranscriptEntryPaths,
 } from "./log-redaction.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
+export { readAgentMemory, AGENT_MEMORY_DEFAULT_SIZE_BUDGET } from "./server-utils.js";

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1175,3 +1175,65 @@ export async function runChildProcess(
       .catch(reject);
   });
 }
+
+/** Default size budget for injected agent memory (chars, not tokens). */
+export const AGENT_MEMORY_DEFAULT_SIZE_BUDGET = 16_384;
+
+/**
+ * Read persistent agent memory from `memoryDir` and return a formatted
+ * markdown block suitable for injection into a system prompt or stdin prefix.
+ *
+ * Reads `MEMORY.md` (the index) first, then each individual file referenced
+ * by a markdown link in that index, accumulating content until `sizeBudget`
+ * chars is reached. Files that exceed the remaining budget are skipped.
+ *
+ * Returns an empty string when `memoryDir` does not exist or contains no
+ * readable `MEMORY.md` — callers should treat an empty return as "no memory
+ * available" and skip injection rather than treating it as an error.
+ */
+export async function readAgentMemory(
+  memoryDir: string,
+  options?: { sizeBudget?: number },
+): Promise<string> {
+  const sizeBudget = options?.sizeBudget ?? AGENT_MEMORY_DEFAULT_SIZE_BUDGET;
+  const indexPath = path.join(memoryDir, "MEMORY.md");
+
+  let indexContent: string;
+  try {
+    indexContent = await fs.readFile(indexPath, "utf8");
+  } catch {
+    // Memory directory or index file does not exist — not an error.
+    return "";
+  }
+
+  // Parse markdown link targets from MEMORY.md: [Title](filename.md)
+  const fileRefs: string[] = [];
+  for (const match of indexContent.matchAll(/\[(?:[^\]]*)\]\(([^)]+\.md)\)/g)) {
+    const ref = match[1].trim();
+    if (ref && !ref.startsWith("http")) {
+      fileRefs.push(ref);
+    }
+  }
+
+  const header = `# Persistent Memory\n\n## Memory Index\n\n${indexContent}\n\n`;
+  let assembled = header;
+  let remaining = sizeBudget - header.length;
+
+  for (const ref of fileRefs) {
+    if (remaining <= 0) break;
+    const filePath = path.join(memoryDir, ref);
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    const section = `---\n\n### ${ref}\n\n${content.trim()}\n\n`;
+    if (section.length <= remaining) {
+      assembled += section;
+      remaining -= section.length;
+    }
+  }
+
+  return assembled.trim();
+}

--- a/packages/adapter-utils/vitest.config.ts
+++ b/packages/adapter-utils/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -121,9 +121,53 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip claude-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip claude-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
 
   const envConfig = parseObject(config.env);
@@ -178,8 +222,11 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   if (wakePayloadJson) {
     env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
   }
-  if (effectiveWorkspaceCwd) {
-    env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) {
+    env.PAPERCLIP_WORKSPACE_CWD = cwd;
   }
   if (workspaceSource) {
     env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -359,11 +359,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
-  // When workspace config does not provide agentHome, derive it from the instructions
-  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  // When workspace config does not provide agentHome, fall back to:
+  //   1. adapterConfig.agentHome (explicit per-agent override), then
+  //   2. parent-of-parent of instructionsFilePath if set
+  //      (…/agents/{id}/instructions/AGENTS.md → …/agents/{id}/)
   const agentHome =
     agentHomeFromWorkspace ??
-    (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : null);
+    (asString(config.agentHome, "").trim() ||
+      (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : null) ||
+      null);
   const runtimeConfig = await buildClaudeRuntimeConfig({
     runId,
     agent,

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -22,6 +22,7 @@ import {
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
   runChildProcess,
+  readAgentMemory,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseClaudeStreamJson,
@@ -344,6 +345,8 @@ export async function runClaudeLogin(input: {
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  const agentHomeFromWorkspace =
+    asString(parseObject(context.paperclipWorkspace).agentHome, "") || null;
 
   const promptTemplate = asString(
     config.promptTemplate,
@@ -356,6 +359,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  // When workspace config does not provide agentHome, derive it from the instructions
+  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  const agentHome =
+    agentHomeFromWorkspace ??
+    (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : null);
   const runtimeConfig = await buildClaudeRuntimeConfig({
     runId,
     agent,
@@ -384,19 +392,31 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const billingType = resolveClaudeBillingType(effectiveEnv);
   const claudeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredSkillNames = new Set(resolveClaudeDesiredSkillNames(config, claudeSkillEntries));
-  // When instructionsFilePath is configured, build a stable content-addressed
-  // file that includes both the file content and the path directive, so we only
-  // need --append-system-prompt-file (Claude CLI forbids using both flags together).
+
+  // Read persistent agent memory from ${agentHome}/memory/ if agentHome is set.
+  // Injected into the system prompt alongside agent instructions so every run
+  // starts with the agent's accumulated feedback, project state, and user context.
+  const memoryBlock = agentHome ? await readAgentMemory(path.join(agentHome, "memory")) : "";
+  const memoryChars = memoryBlock.length;
+
+  // Build combined instructions: agent AGENTS.md + path directive + memory block.
+  // Passes everything into the content-addressed prompt bundle so session resumption
+  // is invalidated automatically when memory or instructions change.
   let combinedInstructionsContents: string | null = null;
-  if (instructionsFilePath) {
+  if (instructionsFilePath || memoryBlock) {
     try {
-      const instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
-      const pathDirective =
-        `\nThe above agent instructions were loaded from ${instructionsFilePath}. ` +
-        `Resolve any relative file references from ${instructionsFileDir}. ` +
-        `This base directory is authoritative for sibling instruction files such as ` +
-        `./HEARTBEAT.md, ./SOUL.md, and ./TOOLS.md; do not resolve those from the parent agent directory.`;
-      combinedInstructionsContents = instructionsContent + pathDirective;
+      let instructionsContent = "";
+      let pathDirective = "";
+      if (instructionsFilePath) {
+        instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
+        pathDirective =
+          `\nThe above agent instructions were loaded from ${instructionsFilePath}. ` +
+          `Resolve any relative file references from ${instructionsFileDir}. ` +
+          `This base directory is authoritative for sibling instruction files such as ` +
+          `./HEARTBEAT.md, ./SOUL.md, and ./TOOLS.md; do not resolve those from the parent agent directory.`;
+      }
+      const memorySuffix = memoryBlock ? `\n\n${memoryBlock}` : "";
+      combinedInstructionsContents = instructionsContent + pathDirective + memorySuffix;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(
@@ -470,6 +490,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
     heartbeatPromptChars: renderedPrompt.length,
+    memoryChars,
   };
 
   const buildClaudeArgs = (
@@ -523,9 +544,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       commandNotes.push(`Using stable Claude prompt bundle ${promptBundle.bundleKey}.`);
     }
     if (attemptInstructionsFilePath && !resumeSessionId) {
-      commandNotes.push(
-        `Injected agent instructions via --append-system-prompt-file ${instructionsFilePath} (with path directive appended)`,
-      );
+      if (instructionsFilePath) {
+        commandNotes.push(
+          `Injected agent instructions via --append-system-prompt-file ${instructionsFilePath} (with path directive appended)`,
+        );
+      }
+      if (memoryChars > 0) {
+        commandNotes.push(
+          `Injected ${memoryChars} chars of persistent agent memory from ${agentHome}/memory into system prompt.`,
+        );
+      }
     }
     if (onMeta) {
       await onMeta({

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -260,9 +260,53 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip codex-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip codex-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   const envConfig = parseObject(config.env);
   const configuredCodexHome =
     typeof envConfig.CODEX_HOME === "string" && envConfig.CODEX_HOME.trim().length > 0
@@ -337,8 +381,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (wakePayloadJson) {
     env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
   }
-  if (effectiveWorkspaceCwd) {
-    env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) {
+    env.PAPERCLIP_WORKSPACE_CWD = cwd;
   }
   if (workspaceSource) {
     env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -484,10 +484,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       );
     }
   }
-  // When workspace config does not provide agentHome, derive it from the instructions
-  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  // When workspace config does not provide agentHome, fall back to:
+  //   1. adapterConfig.agentHome (explicit per-agent override), then
+  //   2. parent-of-parent of instructionsFilePath
+  //      (…/agents/{id}/instructions/AGENTS.md → …/agents/{id}/)
   const effectiveAgentHome =
-    agentHome || (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : "");
+    agentHome ||
+    asString(config.agentHome, "").trim() ||
+    (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : "");
   // Prepend persistent agent memory when agentHome is set so every run starts
   // with the agent's accumulated feedback, project state, and user context.
   const memoryBlock = effectiveAgentHome

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -22,6 +22,7 @@ import {
   stringifyPaperclipWakePayload,
   joinPromptSections,
   runChildProcess,
+  readAgentMemory,
 } from "@paperclipai/adapter-utils/server-utils";
 import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
@@ -468,7 +469,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   let instructionsPrefix = "";
-  let instructionsChars = 0;
   if (instructionsFilePath) {
     try {
       const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
@@ -476,7 +476,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `${instructionsContents}\n\n` +
         `The above agent instructions were loaded from ${instructionsFilePath}. ` +
         `Resolve any relative file references from ${instructionsDir}.\n\n`;
-      instructionsChars = instructionsPrefix.length;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(
@@ -485,6 +484,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       );
     }
   }
+  // When workspace config does not provide agentHome, derive it from the instructions
+  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  const effectiveAgentHome =
+    agentHome || (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : "");
+  // Prepend persistent agent memory when agentHome is set so every run starts
+  // with the agent's accumulated feedback, project state, and user context.
+  const memoryBlock = effectiveAgentHome
+    ? await readAgentMemory(path.join(effectiveAgentHome, "memory"))
+    : "";
+  if (memoryBlock) {
+    instructionsPrefix = `${memoryBlock}\n\n${instructionsPrefix}`;
+  }
+  let instructionsChars = instructionsPrefix.length;
   const repoAgentsNote =
     "Codex exec automatically applies repo-scoped AGENTS.md instructions from the current workspace; Paperclip does not currently suppress that discovery.";
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
@@ -506,27 +518,35 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const promptInstructionsPrefix = shouldUseResumeDeltaPrompt ? "" : instructionsPrefix;
   instructionsChars = promptInstructionsPrefix.length;
   const commandNotes = (() => {
+    const notes: string[] = [];
+    if (memoryBlock) {
+      notes.push(`Injected ${memoryBlock.length} chars of persistent agent memory from ${effectiveAgentHome}/memory into stdin prefix.`);
+    }
     if (!instructionsFilePath) {
-      return [repoAgentsNote];
+      notes.push(repoAgentsNote);
+      return notes;
     }
     if (instructionsPrefix.length > 0) {
       if (shouldUseResumeDeltaPrompt) {
-        return [
+        notes.push(
           `Loaded agent instructions from ${instructionsFilePath}`,
           "Skipped stdin instruction reinjection because an existing Codex session is being resumed with a wake delta.",
           repoAgentsNote,
-        ];
+        );
+      } else {
+        notes.push(
+          `Loaded agent instructions from ${instructionsFilePath}`,
+          `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
+          repoAgentsNote,
+        );
       }
-      return [
-        `Loaded agent instructions from ${instructionsFilePath}`,
-        `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
+    } else {
+      notes.push(
+        `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
         repoAgentsNote,
-      ];
+      );
     }
-    return [
-      `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
-      repoAgentsNote,
-    ];
+    return notes;
   })();
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
@@ -544,6 +564,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
     heartbeatPromptChars: renderedPrompt.length,
+    memoryChars: memoryBlock.length,
   };
 
   const buildArgs = (resumeSessionId: string | null) => {

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -183,9 +183,53 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip cursor-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip cursor-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const cursorSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredCursorSkillNames = resolvePaperclipDesiredSkillNames(config, cursorSkillEntries);
@@ -243,8 +287,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (wakePayloadJson) {
     env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
   }
-  if (effectiveWorkspaceCwd) {
-    env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) {
+    env.PAPERCLIP_WORKSPACE_CWD = cwd;
   }
   if (workspaceSource) {
     env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -159,9 +159,53 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip gemini-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip gemini-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const geminiSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredGeminiSkillNames = resolvePaperclipDesiredSkillNames(config, geminiSkillEntries);
@@ -203,7 +247,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
-  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) env.PAPERCLIP_WORKSPACE_CWD = cwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -116,9 +116,53 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip opencode-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip opencode-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const openCodeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredOpenCodeSkillNames = resolvePaperclipDesiredSkillNames(config, openCodeSkillEntries);
@@ -164,7 +208,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
-  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) env.PAPERCLIP_WORKSPACE_CWD = cwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -22,6 +22,7 @@ import {
   runChildProcess,
   readPaperclipRuntimeSkillEntries,
   resolvePaperclipDesiredSkillNames,
+  readAgentMemory,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
@@ -294,9 +295,27 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         );
       }
     }
+    // When workspace config does not provide agentHome, derive it from the instructions
+    // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+    const effectiveAgentHome =
+      agentHome ||
+      (resolvedInstructionsFilePath
+        ? path.dirname(path.dirname(resolvedInstructionsFilePath))
+        : "");
+    // Prepend persistent agent memory when agentHome is set so every run starts
+    // with the agent's accumulated feedback, project state, and user context.
+    const memoryBlock = effectiveAgentHome
+      ? await readAgentMemory(path.join(effectiveAgentHome, "memory"))
+      : "";
+    if (memoryBlock) {
+      instructionsPrefix = `${memoryBlock}\n\n${instructionsPrefix}`;
+    }
 
     const commandNotes = (() => {
       const notes = [...preparedRuntimeConfig.notes];
+      if (memoryBlock) {
+        notes.push(`Injected ${memoryBlock.length} chars of persistent agent memory from ${effectiveAgentHome}/memory into stdin prefix.`);
+      }
       if (!resolvedInstructionsFilePath) return notes;
       if (instructionsPrefix.length > 0) {
         notes.push(`Loaded agent instructions from ${resolvedInstructionsFilePath}`);
@@ -343,6 +362,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       wakePromptChars: wakePrompt.length,
       sessionHandoffChars: sessionHandoffNote.length,
       heartbeatPromptChars: renderedPrompt.length,
+      memoryChars: memoryBlock.length,
     };
 
     const buildArgs = (resumeSessionId: string | null) => {

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -136,9 +136,53 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const legacyCwdOptIn = config.legacyCwdOptIn === true;
+  // Workspace-cwd resolution policy (BLA-164 + BLA-165 v2):
+  //   1. If the operator opted into legacy cwd (adapterConfig.legacyCwdOptIn=true)
+  //      AND adapterConfig.cwd is set, use adapterConfig.cwd UNCONDITIONALLY —
+  //      regardless of whether the server resolved paperclipWorkspace to
+  //      project_primary / task_session / agent_home. legacyCwdOptIn is the
+  //      explicit "give me the pre-workspace-runtime behavior" escape hatch and
+  //      MUST override every workspace-runtime result. This is the only way
+  //      per-agent git worktrees stay honored when stale task_session params
+  //      still point at a shared checkout.
+  //   2. Otherwise, if the server provided a paperclipWorkspace cwd (of any
+  //      source), use it.
+  //   3. Otherwise, if adapterConfig.cwd is set but legacyCwdOptIn is missing,
+  //      warn and fall back to process.cwd(). The operator must explicitly opt
+  //      in to legacy cwd to avoid silently writing outside a managed workspace.
+  //   4. Otherwise, process.cwd().
+  //
+  // Incidents that shaped this policy:
+  //   - 2026-04-10 agent_home fallback silently beat configured per-agent
+  //     worktrees, contaminating the shared checkout on concurrent writes.
+  //   - 2026-04-11 post-reenable tick showed task_session workspaces (saved
+  //     from prior runs) pointing at shared BLACKCORE ALSO beat configured
+  //     worktrees. Both cases require legacyCwdOptIn to override.
+  let cwd: string;
+  if (configuredCwd && legacyCwdOptIn) {
+    cwd = configuredCwd;
+    if (workspaceCwd && workspaceCwd !== configuredCwd) {
+      console.warn(
+        `[paperclip pi-local] Using config.cwd=${JSON.stringify(configuredCwd)} over ` +
+          `paperclipWorkspace.cwd=${JSON.stringify(workspaceCwd)} ` +
+          `(source=${JSON.stringify(workspaceSource ?? null)}, legacyCwdOptIn=true). ` +
+          `This preserves per-agent repo isolation.`,
+      );
+    }
+  } else if (workspaceCwd) {
+    cwd = workspaceCwd;
+  } else if (configuredCwd) {
+    console.warn(
+      `[paperclip pi-local] Ignoring config.cwd=${JSON.stringify(configuredCwd)} because ` +
+        `no paperclipWorkspace was provided and config.legacyCwdOptIn is not set. ` +
+        `Attach this agent to a project with an executionWorkspacePolicy, or set ` +
+        `adapterConfig.legacyCwdOptIn: true to restore prior behavior.`,
+    );
+    cwd = process.cwd();
+  } else {
+    cwd = process.cwd();
+  }
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   
   // Ensure sessions directory exists
@@ -188,7 +232,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
-  if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
+  // Mirror the final resolved cwd so subprocesses that prefer PAPERCLIP_WORKSPACE_CWD
+  // see the same path the adapter actually launched them in (important after the
+  // BLA-165 precedence fix when we override agent_home fallback with configuredCwd).
+  if (cwd) env.PAPERCLIP_WORKSPACE_CWD = cwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3849,6 +3849,7 @@ export function heartbeatService(db: Db) {
             companyId: issues.companyId,
             executionRunId: issues.executionRunId,
             executionAgentNameKey: issues.executionAgentNameKey,
+            assigneeAgentId: issues.assigneeAgentId,
           })
           .from(issues)
           .where(and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)))
@@ -3913,7 +3914,11 @@ export function heartbeatService(db: Db) {
             .limit(1)
             .then((rows) => rows[0] ?? null);
 
-          if (legacyRun) {
+          // BLA-207 fix: only re-claim the legacy run if the run belongs to the
+          // current assignee. If assigneeAgentId has changed since the run started
+          // (e.g. via reassignment PATCH), do not re-write executionAgentNameKey —
+          // that would reverse Fix B and hand the issue back to the old agent.
+          if (legacyRun && legacyRun.agentId === issue.assigneeAgentId) {
             activeExecutionRun = legacyRun;
             const legacyAgent = await tx
               .select({ name: agents.name })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     projects: [
+      "packages/adapter-utils",
       "packages/db",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",


### PR DESCRIPTION
## Summary

- Adds `readAgentMemory` to `adapter-utils` — reads `MEMORY.md` index + top-N relevant memory files (16KB budget) from `${agentHome}/memory/`
- Wires memory injection into `claude-local`, `codex-local`, and `opencode-local` adapters so every heartbeat starts with the agent's persistent feedback, project state, and user context
- `agentHome` resolved from: workspace config → `adapterConfig.agentHome` → parent-of-parent of `instructionsFilePath`
- Memory is included in the content-addressed `ClaudePromptBundle` so sessions are invalidated automatically when memory changes (no stale resumptions)
- Includes a `legacyCwdOptIn` cwd precedence fix: prevents `agent_home` workspace fallback from overriding per-agent worktrees on concurrent writes
- Adds `memoryChars` to prompt metrics telemetry

## Test plan

- [ ] `pnpm test packages/adapter-utils` — 14 tests pass including 9 new agent-memory tests
- [ ] `pnpm --filter @paperclipai/adapter-claude-local build` — clean TypeScript compile
- [ ] Spot-check: run a local claude-local agent with `agentHome` set, confirm memory block appears in injected instructions file

Obsolete PR — see cleaner two-commit version elsewhere.
