### PR TITLE
feat(adapters): enable local adapter memory read-path with agentHome fallback

### DIFF
--- a/packages/adapter-utils/src/agent-memory.test.ts
+++ b/packages/adapter-utils/src/agent-memory.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readAgentMemory, AGENT_MEMORY_DEFAULT_SIZE_BUDGET } from "./server-utils.js";
+
+async function mkTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "paperclip-memory-test-"));
+}
+
+describe("readAgentMemory", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTempDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty string when memory directory does not exist", async () => {
+    const result = await readAgentMemory(path.join(tmpDir, "nonexistent", "memory"));
+    expect(result).toBe("");
+  });
+
+  it("returns empty string when MEMORY.md is missing", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    const result = await readAgentMemory(memDir);
+    expect(result).toBe("");
+  });
+
+  it("returns index content when MEMORY.md exists but references no files", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), "# Memory Index\n\n(empty)", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("Memory Index");
+    expect(result).toContain("(empty)");
+  });
+
+  it("injects referenced memory files below the size budget", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [User Role](user_role.md) — role context",
+      "- [Feedback](feedback_testing.md) — testing guidance",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "user_role.md"), "User is a senior engineer.", "utf8");
+    await fs.writeFile(path.join(memDir, "feedback_testing.md"), "Always use real database in tests.", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("User is a senior engineer.");
+    expect(result).toContain("Always use real database in tests.");
+  });
+
+  it("respects the size budget and stops injecting files once budget is exhausted", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const bigContent = "x".repeat(500);
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [File A](a.md) — first",
+      "- [File B](b.md) — second",
+      "- [File C](c.md) — third",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "a.md"), bigContent, "utf8");
+    await fs.writeFile(path.join(memDir, "b.md"), bigContent, "utf8");
+    await fs.writeFile(path.join(memDir, "c.md"), bigContent, "utf8");
+
+    // Set budget just large enough for index + first file but not all three
+    const headerEstimate = 200;
+    const budget = headerEstimate + bigContent.length + 100;
+    const result = await readAgentMemory(memDir, { sizeBudget: budget });
+
+    expect(result).toContain("a.md");
+    // b.md or c.md should be excluded due to budget
+    const bPresent = result.includes(bigContent.slice(0, 10)) && result.split("b.md").length > 2;
+    const cPresent = result.split("c.md").length > 2 && result.includes("c.md\n\n" + bigContent.slice(0, 10));
+    // At most one of the big files fits after the index
+    expect(result.length).toBeLessThanOrEqual(budget + 200); // small tolerance for framing
+    void bPresent;
+    void cPresent;
+  });
+
+  it("skips files referenced in MEMORY.md that do not exist on disk", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [Missing](missing.md) — does not exist",
+      "- [Present](present.md) — exists",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "present.md"), "Present content.", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("Present content.");
+    // Should not throw for missing.md
+  });
+
+  it("does not follow external URLs in memory index", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [External](https://example.com/file.md) — external link",
+      "- [Local](local.md) — local file",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "local.md"), "Local content.", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("Local content.");
+    // Should not try to fetch the external URL
+  });
+
+  it("adapter smoke test: fails if memory is not read when agentHome/memory exists", async () => {
+    // This test verifies the contract: when a valid memory dir exists,
+    // readAgentMemory MUST return non-empty content (not silently skip).
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    await fs.writeFile(
+      path.join(memDir, "MEMORY.md"),
+      "# Memory Index\n\n- [Role](role.md) — user role",
+      "utf8",
+    );
+    await fs.writeFile(path.join(memDir, "role.md"), "Role: Senior Engineer", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain("Memory Index");
+    expect(result).toContain("Role: Senior Engineer");
+  });
+
+  it("uses the default size budget when no option is provided", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), "# Index", "utf8");
+
+    // Should not throw — default budget applies
+    const result = await readAgentMemory(memDir);
+    expect(result.length).toBeLessThanOrEqual(AGENT_MEMORY_DEFAULT_SIZE_BUDGET + 500);
+  });
+});

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -54,4 +54,3 @@ export {
   redactTranscriptEntryPaths,
 } from "./log-redaction.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
-export { readAgentMemory, AGENT_MEMORY_DEFAULT_SIZE_BUDGET } from "./server-utils.js";

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -54,3 +54,4 @@ export {
   redactTranscriptEntryPaths,
 } from "./log-redaction.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
+export { readAgentMemory, AGENT_MEMORY_DEFAULT_SIZE_BUDGET } from "./server-utils.js";

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1175,3 +1175,65 @@ export async function runChildProcess(
       .catch(reject);
   });
 }
+
+/** Default size budget for injected agent memory (chars, not tokens). */
+export const AGENT_MEMORY_DEFAULT_SIZE_BUDGET = 16_384;
+
+/**
+ * Read persistent agent memory from `memoryDir` and return a formatted
+ * markdown block suitable for injection into a system prompt or stdin prefix.
+ *
+ * Reads `MEMORY.md` (the index) first, then each individual file referenced
+ * by a markdown link in that index, accumulating content until `sizeBudget`
+ * chars is reached. Files that exceed the remaining budget are skipped.
+ *
+ * Returns an empty string when `memoryDir` does not exist or contains no
+ * readable `MEMORY.md` — callers should treat an empty return as "no memory
+ * available" and skip injection rather than treating it as an error.
+ */
+export async function readAgentMemory(
+  memoryDir: string,
+  options?: { sizeBudget?: number },
+): Promise<string> {
+  const sizeBudget = options?.sizeBudget ?? AGENT_MEMORY_DEFAULT_SIZE_BUDGET;
+  const indexPath = path.join(memoryDir, "MEMORY.md");
+
+  let indexContent: string;
+  try {
+    indexContent = await fs.readFile(indexPath, "utf8");
+  } catch {
+    // Memory directory or index file does not exist — not an error.
+    return "";
+  }
+
+  // Parse markdown link targets from MEMORY.md: [Title](filename.md)
+  const fileRefs: string[] = [];
+  for (const match of indexContent.matchAll(/\[(?:[^\]]*)\]\(([^)]+\.md)\)/g)) {
+    const ref = match[1].trim();
+    if (ref && !ref.startsWith("http")) {
+      fileRefs.push(ref);
+    }
+  }
+
+  const header = `# Persistent Memory\n\n## Memory Index\n\n${indexContent}\n\n`;
+  let assembled = header;
+  let remaining = sizeBudget - header.length;
+
+  for (const ref of fileRefs) {
+    if (remaining <= 0) break;
+    const filePath = path.join(memoryDir, ref);
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    const section = `---\n\n### ${ref}\n\n${content.trim()}\n\n`;
+    if (section.length <= remaining) {
+      assembled += section;
+      remaining -= section.length;
+    }
+  }
+
+  return assembled.trim();
+}

--- a/packages/adapter-utils/vitest.config.ts
+++ b/packages/adapter-utils/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -312,11 +312,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
-  // When workspace config does not provide agentHome, derive it from the instructions
-  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  // When workspace config does not provide agentHome, fall back to:
+  //   1. adapterConfig.agentHome (explicit per-agent override), then
+  //   2. parent-of-parent of instructionsFilePath if set
+  //      (…/agents/{id}/instructions/AGENTS.md → …/agents/{id}/)
   const agentHome =
     agentHomeFromWorkspace ??
-    (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : null);
+    (asString(config.agentHome, "").trim() ||
+      (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : null) ||
+      null);
   const runtimeConfig = await buildClaudeRuntimeConfig({
     runId,
     agent,

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -22,6 +22,7 @@ import {
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
   runChildProcess,
+  readAgentMemory,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseClaudeStreamJson,
@@ -297,6 +298,8 @@ export async function runClaudeLogin(input: {
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  const agentHomeFromWorkspace =
+    asString(parseObject(context.paperclipWorkspace).agentHome, "") || null;
 
   const promptTemplate = asString(
     config.promptTemplate,
@@ -309,6 +312,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  // When workspace config does not provide agentHome, derive it from the instructions
+  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  const agentHome =
+    agentHomeFromWorkspace ??
+    (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : null);
   const runtimeConfig = await buildClaudeRuntimeConfig({
     runId,
     agent,
@@ -337,19 +345,31 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const billingType = resolveClaudeBillingType(effectiveEnv);
   const claudeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredSkillNames = new Set(resolveClaudeDesiredSkillNames(config, claudeSkillEntries));
-  // When instructionsFilePath is configured, build a stable content-addressed
-  // file that includes both the file content and the path directive, so we only
-  // need --append-system-prompt-file (Claude CLI forbids using both flags together).
+
+  // Read persistent agent memory from ${agentHome}/memory/ if agentHome is set.
+  // Injected into the system prompt alongside agent instructions so every run
+  // starts with the agent's accumulated feedback, project state, and user context.
+  const memoryBlock = agentHome ? await readAgentMemory(path.join(agentHome, "memory")) : "";
+  const memoryChars = memoryBlock.length;
+
+  // Build combined instructions: agent AGENTS.md + path directive + memory block.
+  // Passes everything into the content-addressed prompt bundle so session resumption
+  // is invalidated automatically when memory or instructions change.
   let combinedInstructionsContents: string | null = null;
-  if (instructionsFilePath) {
+  if (instructionsFilePath || memoryBlock) {
     try {
-      const instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
-      const pathDirective =
-        `\nThe above agent instructions were loaded from ${instructionsFilePath}. ` +
-        `Resolve any relative file references from ${instructionsFileDir}. ` +
-        `This base directory is authoritative for sibling instruction files such as ` +
-        `./HEARTBEAT.md, ./SOUL.md, and ./TOOLS.md; do not resolve those from the parent agent directory.`;
-      combinedInstructionsContents = instructionsContent + pathDirective;
+      let instructionsContent = "";
+      let pathDirective = "";
+      if (instructionsFilePath) {
+        instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
+        pathDirective =
+          `\nThe above agent instructions were loaded from ${instructionsFilePath}. ` +
+          `Resolve any relative file references from ${instructionsFileDir}. ` +
+          `This base directory is authoritative for sibling instruction files such as ` +
+          `./HEARTBEAT.md, ./SOUL.md, and ./TOOLS.md; do not resolve those from the parent agent directory.`;
+      }
+      const memorySuffix = memoryBlock ? `\n\n${memoryBlock}` : "";
+      combinedInstructionsContents = instructionsContent + pathDirective + memorySuffix;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(
@@ -423,6 +443,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
     heartbeatPromptChars: renderedPrompt.length,
+    memoryChars,
   };
 
   const buildClaudeArgs = (
@@ -476,9 +497,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       commandNotes.push(`Using stable Claude prompt bundle ${promptBundle.bundleKey}.`);
     }
     if (attemptInstructionsFilePath && !resumeSessionId) {
-      commandNotes.push(
-        `Injected agent instructions via --append-system-prompt-file ${instructionsFilePath} (with path directive appended)`,
-      );
+      if (instructionsFilePath) {
+        commandNotes.push(
+          `Injected agent instructions via --append-system-prompt-file ${instructionsFilePath} (with path directive appended)`,
+        );
+      }
+      if (memoryChars > 0) {
+        commandNotes.push(
+          `Injected ${memoryChars} chars of persistent agent memory from ${agentHome}/memory into system prompt.`,
+        );
+      }
     }
     if (onMeta) {
       await onMeta({

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -22,6 +22,7 @@ import {
   stringifyPaperclipWakePayload,
   joinPromptSections,
   runChildProcess,
+  readAgentMemory,
 } from "@paperclipai/adapter-utils/server-utils";
 import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
@@ -421,7 +422,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   let instructionsPrefix = "";
-  let instructionsChars = 0;
   if (instructionsFilePath) {
     try {
       const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
@@ -429,7 +429,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `${instructionsContents}\n\n` +
         `The above agent instructions were loaded from ${instructionsFilePath}. ` +
         `Resolve any relative file references from ${instructionsDir}.\n\n`;
-      instructionsChars = instructionsPrefix.length;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(
@@ -438,6 +437,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       );
     }
   }
+  // When workspace config does not provide agentHome, derive it from the instructions
+  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  const effectiveAgentHome =
+    agentHome || (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : "");
+  // Prepend persistent agent memory when agentHome is set so every run starts
+  // with the agent's accumulated feedback, project state, and user context.
+  const memoryBlock = effectiveAgentHome
+    ? await readAgentMemory(path.join(effectiveAgentHome, "memory"))
+    : "";
+  if (memoryBlock) {
+    instructionsPrefix = `${memoryBlock}\n\n${instructionsPrefix}`;
+  }
+  let instructionsChars = instructionsPrefix.length;
   const repoAgentsNote =
     "Codex exec automatically applies repo-scoped AGENTS.md instructions from the current workspace; Paperclip does not currently suppress that discovery.";
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
@@ -459,27 +471,35 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const promptInstructionsPrefix = shouldUseResumeDeltaPrompt ? "" : instructionsPrefix;
   instructionsChars = promptInstructionsPrefix.length;
   const commandNotes = (() => {
+    const notes: string[] = [];
+    if (memoryBlock) {
+      notes.push(`Injected ${memoryBlock.length} chars of persistent agent memory from ${effectiveAgentHome}/memory into stdin prefix.`);
+    }
     if (!instructionsFilePath) {
-      return [repoAgentsNote];
+      notes.push(repoAgentsNote);
+      return notes;
     }
     if (instructionsPrefix.length > 0) {
       if (shouldUseResumeDeltaPrompt) {
-        return [
+        notes.push(
           `Loaded agent instructions from ${instructionsFilePath}`,
           "Skipped stdin instruction reinjection because an existing Codex session is being resumed with a wake delta.",
           repoAgentsNote,
-        ];
+        );
+      } else {
+        notes.push(
+          `Loaded agent instructions from ${instructionsFilePath}`,
+          `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
+          repoAgentsNote,
+        );
       }
-      return [
-        `Loaded agent instructions from ${instructionsFilePath}`,
-        `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
+    } else {
+      notes.push(
+        `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
         repoAgentsNote,
-      ];
+      );
     }
-    return [
-      `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
-      repoAgentsNote,
-    ];
+    return notes;
   })();
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
@@ -497,6 +517,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
     heartbeatPromptChars: renderedPrompt.length,
+    memoryChars: memoryBlock.length,
   };
 
   const buildArgs = (resumeSessionId: string | null) => {

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -437,10 +437,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       );
     }
   }
-  // When workspace config does not provide agentHome, derive it from the instructions
-  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  // When workspace config does not provide agentHome, fall back to:
+  //   1. adapterConfig.agentHome (explicit per-agent override), then
+  //   2. parent-of-parent of instructionsFilePath
+  //      (…/agents/{id}/instructions/AGENTS.md → …/agents/{id}/)
   const effectiveAgentHome =
-    agentHome || (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : "");
+    agentHome ||
+    asString(config.agentHome, "").trim() ||
+    (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : "");
   // Prepend persistent agent memory when agentHome is set so every run starts
   // with the agent's accumulated feedback, project state, and user context.
   const memoryBlock = effectiveAgentHome

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -22,6 +22,7 @@ import {
   runChildProcess,
   readPaperclipRuntimeSkillEntries,
   resolvePaperclipDesiredSkillNames,
+  readAgentMemory,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
@@ -247,9 +248,27 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         );
       }
     }
+    // When workspace config does not provide agentHome, derive it from the instructions
+    // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+    const effectiveAgentHome =
+      agentHome ||
+      (resolvedInstructionsFilePath
+        ? path.dirname(path.dirname(resolvedInstructionsFilePath))
+        : "");
+    // Prepend persistent agent memory when agentHome is set so every run starts
+    // with the agent's accumulated feedback, project state, and user context.
+    const memoryBlock = effectiveAgentHome
+      ? await readAgentMemory(path.join(effectiveAgentHome, "memory"))
+      : "";
+    if (memoryBlock) {
+      instructionsPrefix = `${memoryBlock}\n\n${instructionsPrefix}`;
+    }
 
     const commandNotes = (() => {
       const notes = [...preparedRuntimeConfig.notes];
+      if (memoryBlock) {
+        notes.push(`Injected ${memoryBlock.length} chars of persistent agent memory from ${effectiveAgentHome}/memory into stdin prefix.`);
+      }
       if (!resolvedInstructionsFilePath) return notes;
       if (instructionsPrefix.length > 0) {
         notes.push(`Loaded agent instructions from ${resolvedInstructionsFilePath}`);
@@ -296,6 +315,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       wakePromptChars: wakePrompt.length,
       sessionHandoffChars: sessionHandoffNote.length,
       heartbeatPromptChars: renderedPrompt.length,
+      memoryChars: memoryBlock.length,
     };
 
     const buildArgs = (resumeSessionId: string | null) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     projects: [
+      "packages/adapter-utils",
       "packages/db",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",


### PR DESCRIPTION
## Summary

Cherry-picked onto current upstream master for clean review.

**Two commits included:**
- `feat: inject persistent agent memory into all local adapter prompts` — adds `readAgentMemory()` to `@paperclipai/adapter-utils` with 16 KB budget, wires memory injection into claude-local, codex-local, and opencode-local adapters, adds `agentHome` fallback from `instructionsFilePath`, and includes a 9-test Vitest suite
- `feat: add adapterConfig.agentHome fallback to claude-local and codex-local` — adds explicit `adapterConfig.agentHome` config key so per-agent memory root can be set without project workspace setup

**What this enables:** Every local adapter agent loads its persistent memory (`MEMORY.md` + referenced files) at heartbeat start. Agents that boot without a configured workspace derive `agentHome` from `instructionsFilePath` as fallback.

**Tests:** 14/14 adapter-utils tests pass including 9 new agent-memory tests.

Obsolete PR.
