### PR TITLE
fix(logger): redact cookies from server log

### DIFF
--- a/server/src/__tests__/logger-redaction-config.test.ts
+++ b/server/src/__tests__/logger-redaction-config.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockTransport = vi.hoisted(() => vi.fn(() => ({ write: vi.fn() })));
+const mockPino = vi.hoisted(() => {
+  const fn = vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    child: vi.fn(),
+  }));
+  (fn as any).transport = mockTransport;
+  return fn;
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, mkdirSync: vi.fn() };
+});
+
+vi.mock("pino", () => ({
+  default: mockPino,
+}));
+vi.mock("pino-http", () => ({
+  pinoHttp: vi.fn(() => vi.fn()),
+}));
+vi.mock("../config-file.js", () => ({
+  readConfigFile: vi.fn(() => null),
+}));
+vi.mock("../home-paths.js", () => ({
+  resolveHomeAwarePath: vi.fn((p: string) => p),
+  resolveDefaultLogsDir: vi.fn(() => "/tmp/paperclip-test-logs"),
+}));
+
+describe("logger request redaction config", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockTransport.mockClear();
+    mockPino.mockClear();
+  });
+
+  it("redacts cookie headers and keeps req/res out of both pretty transports", async () => {
+    await import("../middleware/logger.js");
+
+    expect(mockPino).toHaveBeenCalledOnce();
+    const [config] = mockPino.mock.calls[0] as [{ redact?: string[] }];
+    expect(config.redact).toEqual(
+      expect.arrayContaining(["req.headers.authorization", "req.headers.cookie"]),
+    );
+
+    expect(mockTransport).toHaveBeenCalledOnce();
+    const { targets } = mockTransport.mock.calls[0][0] as {
+      targets: Array<{ options: Record<string, unknown> }>;
+    };
+    for (const target of targets) {
+      expect(target.options.ignore).toBe("pid,hostname,req,res,responseTime");
+    }
+  });
+});

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -25,20 +25,21 @@ const sharedOpts = {
   ignore: "pid,hostname",
   singleLine: true,
 };
+const requestIgnoreFields = "pid,hostname,req,res,responseTime";
 
 export const logger = pino({
   level: "debug",
-  redact: ["req.headers.authorization"],
+  redact: ["req.headers.authorization", "req.headers.cookie"],
 }, pino.transport({
   targets: [
     {
       target: "pino-pretty",
-      options: { ...sharedOpts, ignore: "pid,hostname,req,res,responseTime", colorize: true, destination: 1 },
+      options: { ...sharedOpts, ignore: requestIgnoreFields, colorize: true, destination: 1 },
       level: "info",
     },
     {
       target: "pino-pretty",
-      options: { ...sharedOpts, colorize: false, destination: logFile, mkdir: true },
+      options: { ...sharedOpts, ignore: requestIgnoreFields, colorize: false, destination: logFile, mkdir: true },
       level: "debug",
     },
   ],


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs a local multi-agent server, so request logging sits on the hot path for every dashboard and API action.
> - This PR is in the server logger middleware that writes the long-lived `server.log` file operators inspect for debugging.
> - Issue #3338 showed that the file transport was still logging the full `req` object, including plaintext `Cookie` headers that contain session tokens.
> - The existing logger only redacted `req.headers.authorization`, and only the stdout transport ignored `req`/`res`, so disk logs kept growing with sensitive cookie data.
> - That is both a security problem and an operational problem because the repeated request dump bloats `server.log` and slows the dashboard.
> - This pull request makes the file transport match stdout by excluding `req`/`res`, and adds `req.headers.cookie` to the redact list as defense in depth.
> - The benefit is smaller logs and no plaintext cookie/session token leakage in normal request logging.

## What Changed

- Add `req.headers.cookie` to the logger redact list.
- Reuse the same `ignore` field set for both pretty transports so the file logger no longer writes whole `req`/`res` payloads to disk.
- Add a logger configuration regression test that locks both behaviors in place.

## Verification

- `pnpm test:run server/src/__tests__/logger-redaction-config.test.ts server/src/__tests__/logger-tz.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

Closes #3338

## Risks

- Low risk. This only changes logger redaction and field filtering.
- The main behavior change is that `server.log` no longer includes full `req`/`res` objects on normal request lines; top-level custom error props remain available for error debugging.

## Model Used

- OpenAI Codex, GPT-5-based coding agent in Codex CLI with tool use and local code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
