### PR TITLE
fix(heartbeat): guard deferred promotion against reassigned issues

### DIFF
--- a/packages/adapter-utils/src/agent-memory.test.ts
+++ b/packages/adapter-utils/src/agent-memory.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readAgentMemory, AGENT_MEMORY_DEFAULT_SIZE_BUDGET } from "./server-utils.js";
+
+async function mkTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "paperclip-memory-test-"));
+}
+
+describe("readAgentMemory", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTempDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty string when memory directory does not exist", async () => {
+    const result = await readAgentMemory(path.join(tmpDir, "nonexistent", "memory"));
+    expect(result).toBe("");
+  });
+
+  it("returns empty string when MEMORY.md is missing", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    const result = await readAgentMemory(memDir);
+    expect(result).toBe("");
+  });
+
+  it("returns index content when MEMORY.md exists but references no files", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), "# Memory Index\n\n(empty)", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("Memory Index");
+    expect(result).toContain("(empty)");
+  });
+
+  it("injects referenced memory files below the size budget", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [User Role](user_role.md) — role context",
+      "- [Feedback](feedback_testing.md) — testing guidance",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "user_role.md"), "User is a senior engineer.", "utf8");
+    await fs.writeFile(path.join(memDir, "feedback_testing.md"), "Always use real database in tests.", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("User is a senior engineer.");
+    expect(result).toContain("Always use real database in tests.");
+  });
+
+  it("respects the size budget and stops injecting files once budget is exhausted", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const bigContent = "x".repeat(500);
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [File A](a.md) — first",
+      "- [File B](b.md) — second",
+      "- [File C](c.md) — third",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "a.md"), bigContent, "utf8");
+    await fs.writeFile(path.join(memDir, "b.md"), bigContent, "utf8");
+    await fs.writeFile(path.join(memDir, "c.md"), bigContent, "utf8");
+
+    // Set budget just large enough for index + first file but not all three
+    const headerEstimate = 200;
+    const budget = headerEstimate + bigContent.length + 100;
+    const result = await readAgentMemory(memDir, { sizeBudget: budget });
+
+    expect(result).toContain("a.md");
+    // b.md or c.md should be excluded due to budget
+    const bPresent = result.includes(bigContent.slice(0, 10)) && result.split("b.md").length > 2;
+    const cPresent = result.split("c.md").length > 2 && result.includes("c.md\n\n" + bigContent.slice(0, 10));
+    // At most one of the big files fits after the index
+    expect(result.length).toBeLessThanOrEqual(budget + 200); // small tolerance for framing
+    void bPresent;
+    void cPresent;
+  });
+
+  it("skips files referenced in MEMORY.md that do not exist on disk", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [Missing](missing.md) — does not exist",
+      "- [Present](present.md) — exists",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "present.md"), "Present content.", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("Present content.");
+    // Should not throw for missing.md
+  });
+
+  it("does not follow external URLs in memory index", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+
+    const indexContent = [
+      "# Memory Index",
+      "",
+      "- [External](https://example.com/file.md) — external link",
+      "- [Local](local.md) — local file",
+    ].join("\n");
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), indexContent, "utf8");
+    await fs.writeFile(path.join(memDir, "local.md"), "Local content.", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result).toContain("Local content.");
+    // Should not try to fetch the external URL
+  });
+
+  it("adapter smoke test: fails if memory is not read when agentHome/memory exists", async () => {
+    // This test verifies the contract: when a valid memory dir exists,
+    // readAgentMemory MUST return non-empty content (not silently skip).
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    await fs.writeFile(
+      path.join(memDir, "MEMORY.md"),
+      "# Memory Index\n\n- [Role](role.md) — user role",
+      "utf8",
+    );
+    await fs.writeFile(path.join(memDir, "role.md"), "Role: Senior Engineer", "utf8");
+
+    const result = await readAgentMemory(memDir);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain("Memory Index");
+    expect(result).toContain("Role: Senior Engineer");
+  });
+
+  it("uses the default size budget when no option is provided", async () => {
+    const memDir = path.join(tmpDir, "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    await fs.writeFile(path.join(memDir, "MEMORY.md"), "# Index", "utf8");
+
+    // Should not throw — default budget applies
+    const result = await readAgentMemory(memDir);
+    expect(result.length).toBeLessThanOrEqual(AGENT_MEMORY_DEFAULT_SIZE_BUDGET + 500);
+  });
+});

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -54,4 +54,3 @@ export {
   redactTranscriptEntryPaths,
 } from "./log-redaction.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
-export { readAgentMemory, AGENT_MEMORY_DEFAULT_SIZE_BUDGET } from "./server-utils.js";

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -54,3 +54,4 @@ export {
   redactTranscriptEntryPaths,
 } from "./log-redaction.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
+export { readAgentMemory, AGENT_MEMORY_DEFAULT_SIZE_BUDGET } from "./server-utils.js";

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1189,3 +1189,65 @@ export async function runChildProcess(
       .catch(reject);
   });
 }
+
+/** Default size budget for injected agent memory (chars, not tokens). */
+export const AGENT_MEMORY_DEFAULT_SIZE_BUDGET = 16_384;
+
+/**
+ * Read persistent agent memory from `memoryDir` and return a formatted
+ * markdown block suitable for injection into a system prompt or stdin prefix.
+ *
+ * Reads `MEMORY.md` (the index) first, then each individual file referenced
+ * by a markdown link in that index, accumulating content until `sizeBudget`
+ * chars is reached. Files that exceed the remaining budget are skipped.
+ *
+ * Returns an empty string when `memoryDir` does not exist or contains no
+ * readable `MEMORY.md` — callers should treat an empty return as "no memory
+ * available" and skip injection rather than treating it as an error.
+ */
+export async function readAgentMemory(
+  memoryDir: string,
+  options?: { sizeBudget?: number },
+): Promise<string> {
+  const sizeBudget = options?.sizeBudget ?? AGENT_MEMORY_DEFAULT_SIZE_BUDGET;
+  const indexPath = path.join(memoryDir, "MEMORY.md");
+
+  let indexContent: string;
+  try {
+    indexContent = await fs.readFile(indexPath, "utf8");
+  } catch {
+    // Memory directory or index file does not exist — not an error.
+    return "";
+  }
+
+  // Parse markdown link targets from MEMORY.md: [Title](filename.md)
+  const fileRefs: string[] = [];
+  for (const match of indexContent.matchAll(/\[(?:[^\]]*)\]\(([^)]+\.md)\)/g)) {
+    const ref = match[1].trim();
+    if (ref && !ref.startsWith("http")) {
+      fileRefs.push(ref);
+    }
+  }
+
+  const header = `# Persistent Memory\n\n## Memory Index\n\n${indexContent}\n\n`;
+  let assembled = header;
+  let remaining = sizeBudget - header.length;
+
+  for (const ref of fileRefs) {
+    if (remaining <= 0) break;
+    const filePath = path.join(memoryDir, ref);
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    const section = `---\n\n### ${ref}\n\n${content.trim()}\n\n`;
+    if (section.length <= remaining) {
+      assembled += section;
+      remaining -= section.length;
+    }
+  }
+
+  return assembled.trim();
+}

--- a/packages/adapter-utils/vitest.config.ts
+++ b/packages/adapter-utils/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -312,11 +312,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
-  // When workspace config does not provide agentHome, derive it from the instructions
-  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  // When workspace config does not provide agentHome, fall back to:
+  //   1. adapterConfig.agentHome (explicit per-agent override), then
+  //   2. parent-of-parent of instructionsFilePath if set
+  //      (…/agents/{id}/instructions/AGENTS.md → …/agents/{id}/)
   const agentHome =
     agentHomeFromWorkspace ??
-    (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : null);
+    (asString(config.agentHome, "").trim() ||
+      (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : null) ||
+      null);
   const runtimeConfig = await buildClaudeRuntimeConfig({
     runId,
     agent,

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -22,6 +22,7 @@ import {
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
   runChildProcess,
+  readAgentMemory,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseClaudeStreamJson,
@@ -297,6 +298,8 @@ export async function runClaudeLogin(input: {
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  const agentHomeFromWorkspace =
+    asString(parseObject(context.paperclipWorkspace).agentHome, "") || null;
 
   const promptTemplate = asString(
     config.promptTemplate,
@@ -309,6 +312,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  // When workspace config does not provide agentHome, derive it from the instructions
+  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  const agentHome =
+    agentHomeFromWorkspace ??
+    (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : null);
   const runtimeConfig = await buildClaudeRuntimeConfig({
     runId,
     agent,
@@ -337,19 +345,31 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const billingType = resolveClaudeBillingType(effectiveEnv);
   const claudeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredSkillNames = new Set(resolveClaudeDesiredSkillNames(config, claudeSkillEntries));
-  // When instructionsFilePath is configured, build a stable content-addressed
-  // file that includes both the file content and the path directive, so we only
-  // need --append-system-prompt-file (Claude CLI forbids using both flags together).
+
+  // Read persistent agent memory from ${agentHome}/memory/ if agentHome is set.
+  // Injected into the system prompt alongside agent instructions so every run
+  // starts with the agent's accumulated feedback, project state, and user context.
+  const memoryBlock = agentHome ? await readAgentMemory(path.join(agentHome, "memory")) : "";
+  const memoryChars = memoryBlock.length;
+
+  // Build combined instructions: agent AGENTS.md + path directive + memory block.
+  // Passes everything into the content-addressed prompt bundle so session resumption
+  // is invalidated automatically when memory or instructions change.
   let combinedInstructionsContents: string | null = null;
-  if (instructionsFilePath) {
+  if (instructionsFilePath || memoryBlock) {
     try {
-      const instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
-      const pathDirective =
-        `\nThe above agent instructions were loaded from ${instructionsFilePath}. ` +
-        `Resolve any relative file references from ${instructionsFileDir}. ` +
-        `This base directory is authoritative for sibling instruction files such as ` +
-        `./HEARTBEAT.md, ./SOUL.md, and ./TOOLS.md; do not resolve those from the parent agent directory.`;
-      combinedInstructionsContents = instructionsContent + pathDirective;
+      let instructionsContent = "";
+      let pathDirective = "";
+      if (instructionsFilePath) {
+        instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
+        pathDirective =
+          `\nThe above agent instructions were loaded from ${instructionsFilePath}. ` +
+          `Resolve any relative file references from ${instructionsFileDir}. ` +
+          `This base directory is authoritative for sibling instruction files such as ` +
+          `./HEARTBEAT.md, ./SOUL.md, and ./TOOLS.md; do not resolve those from the parent agent directory.`;
+      }
+      const memorySuffix = memoryBlock ? `\n\n${memoryBlock}` : "";
+      combinedInstructionsContents = instructionsContent + pathDirective + memorySuffix;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(
@@ -423,6 +443,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
     heartbeatPromptChars: renderedPrompt.length,
+    memoryChars,
   };
 
   const buildClaudeArgs = (
@@ -476,9 +497,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       commandNotes.push(`Using stable Claude prompt bundle ${promptBundle.bundleKey}.`);
     }
     if (attemptInstructionsFilePath && !resumeSessionId) {
-      commandNotes.push(
-        `Injected agent instructions via --append-system-prompt-file ${instructionsFilePath} (with path directive appended)`,
-      );
+      if (instructionsFilePath) {
+        commandNotes.push(
+          `Injected agent instructions via --append-system-prompt-file ${instructionsFilePath} (with path directive appended)`,
+        );
+      }
+      if (memoryChars > 0) {
+        commandNotes.push(
+          `Injected ${memoryChars} chars of persistent agent memory from ${agentHome}/memory into system prompt.`,
+        );
+      }
     }
     if (onMeta) {
       await onMeta({

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -422,10 +422,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       );
     }
   }
-  // When workspace config does not provide agentHome, derive it from the instructions
-  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  // When workspace config does not provide agentHome, fall back to:
+  //   1. adapterConfig.agentHome (explicit per-agent override), then
+  //   2. parent-of-parent of instructionsFilePath
+  //      (…/agents/{id}/instructions/AGENTS.md → …/agents/{id}/)
   const effectiveAgentHome =
-    agentHome || (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : "");
+    agentHome ||
+    asString(config.agentHome, "").trim() ||
+    (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : "");
   // Prepend persistent agent memory when agentHome is set so every run starts
   // with the agent's accumulated feedback, project state, and user context.
   const memoryBlock = effectiveAgentHome

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -20,6 +20,7 @@ import {
   stringifyPaperclipWakePayload,
   joinPromptSections,
   runChildProcess,
+  readAgentMemory,
 } from "@paperclipai/adapter-utils/server-utils";
 import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
@@ -406,7 +407,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   let instructionsPrefix = "";
-  let instructionsChars = 0;
   if (instructionsFilePath) {
     try {
       const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
@@ -414,7 +414,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `${instructionsContents}\n\n` +
         `The above agent instructions were loaded from ${instructionsFilePath}. ` +
         `Resolve any relative file references from ${instructionsDir}.\n\n`;
-      instructionsChars = instructionsPrefix.length;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(
@@ -423,6 +422,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       );
     }
   }
+  // When workspace config does not provide agentHome, derive it from the instructions
+  // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+  const effectiveAgentHome =
+    agentHome || (instructionsFilePath ? path.dirname(path.dirname(instructionsFilePath)) : "");
+  // Prepend persistent agent memory when agentHome is set so every run starts
+  // with the agent's accumulated feedback, project state, and user context.
+  const memoryBlock = effectiveAgentHome
+    ? await readAgentMemory(path.join(effectiveAgentHome, "memory"))
+    : "";
+  if (memoryBlock) {
+    instructionsPrefix = `${memoryBlock}\n\n${instructionsPrefix}`;
+  }
+  let instructionsChars = instructionsPrefix.length;
   const repoAgentsNote =
     "Codex exec automatically applies repo-scoped AGENTS.md instructions from the current workspace; Paperclip does not currently suppress that discovery.";
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
@@ -444,27 +456,35 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const promptInstructionsPrefix = shouldUseResumeDeltaPrompt ? "" : instructionsPrefix;
   instructionsChars = promptInstructionsPrefix.length;
   const commandNotes = (() => {
+    const notes: string[] = [];
+    if (memoryBlock) {
+      notes.push(`Injected ${memoryBlock.length} chars of persistent agent memory from ${effectiveAgentHome}/memory into stdin prefix.`);
+    }
     if (!instructionsFilePath) {
-      return [repoAgentsNote];
+      notes.push(repoAgentsNote);
+      return notes;
     }
     if (instructionsPrefix.length > 0) {
       if (shouldUseResumeDeltaPrompt) {
-        return [
+        notes.push(
           `Loaded agent instructions from ${instructionsFilePath}`,
           "Skipped stdin instruction reinjection because an existing Codex session is being resumed with a wake delta.",
           repoAgentsNote,
-        ];
+        );
+      } else {
+        notes.push(
+          `Loaded agent instructions from ${instructionsFilePath}`,
+          `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
+          repoAgentsNote,
+        );
       }
-      return [
-        `Loaded agent instructions from ${instructionsFilePath}`,
-        `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
+    } else {
+      notes.push(
+        `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
         repoAgentsNote,
-      ];
+      );
     }
-    return [
-      `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
-      repoAgentsNote,
-    ];
+    return notes;
   })();
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
@@ -482,6 +502,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
     heartbeatPromptChars: renderedPrompt.length,
+    memoryChars: memoryBlock.length,
   };
 
   const runAttempt = async (resumeSessionId: string | null) => {

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -22,6 +22,7 @@ import {
   runChildProcess,
   readPaperclipRuntimeSkillEntries,
   resolvePaperclipDesiredSkillNames,
+  readAgentMemory,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
@@ -247,9 +248,27 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         );
       }
     }
+    // When workspace config does not provide agentHome, derive it from the instructions
+    // file path: …/agents/{id}/instructions/AGENTS.md → …/agents/{id}/
+    const effectiveAgentHome =
+      agentHome ||
+      (resolvedInstructionsFilePath
+        ? path.dirname(path.dirname(resolvedInstructionsFilePath))
+        : "");
+    // Prepend persistent agent memory when agentHome is set so every run starts
+    // with the agent's accumulated feedback, project state, and user context.
+    const memoryBlock = effectiveAgentHome
+      ? await readAgentMemory(path.join(effectiveAgentHome, "memory"))
+      : "";
+    if (memoryBlock) {
+      instructionsPrefix = `${memoryBlock}\n\n${instructionsPrefix}`;
+    }
 
     const commandNotes = (() => {
       const notes = [...preparedRuntimeConfig.notes];
+      if (memoryBlock) {
+        notes.push(`Injected ${memoryBlock.length} chars of persistent agent memory from ${effectiveAgentHome}/memory into stdin prefix.`);
+      }
       if (!resolvedInstructionsFilePath) return notes;
       if (instructionsPrefix.length > 0) {
         notes.push(`Loaded agent instructions from ${resolvedInstructionsFilePath}`);
@@ -296,6 +315,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       wakePromptChars: wakePrompt.length,
       sessionHandoffChars: sessionHandoffNote.length,
       heartbeatPromptChars: renderedPrompt.length,
+      memoryChars: memoryBlock.length,
     };
 
     const buildArgs = (resumeSessionId: string | null) => {

--- a/server/src/__tests__/heartbeat-ownership-transition.test.ts
+++ b/server/src/__tests__/heartbeat-ownership-transition.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Regression tests for BLA-206 and BLA-207 — heartbeat ownership transitions.
+ *
+ * BLA-207: After an issue is reassigned from agent A to agent B, agent A's
+ *   orphaned run completing must NOT re-claim the issue via stale deferred
+ *   wakeup promotion. assigneeAgentId is the authoritative ownership signal.
+ *
+ * BLA-206: A deferred wakeup queued by agent A (e.g. EPM scavenging) must
+ *   not be promoted into execution if the issue's assigneeAgentId has since
+ *   been set to a different agent.
+ *
+ * Both are fixed in releaseIssueExecutionAndPromote (heartbeat.ts) by reading
+ * assigneeAgentId from the issue row and skipping any deferred request whose
+ * agentId does not match.
+ */
+
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { runningProcesses } from "../adapters/index.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat ownership tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat ownership transitions (BLA-206 / BLA-207)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-ownership-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    runningProcesses.clear();
+    await db.delete(issues);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    runningProcesses.clear();
+    await tempDb?.cleanup();
+  });
+
+  async function seedTwoAgents() {
+    const companyId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Test Company",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const agentAId = randomUUID();
+    const agentBId = randomUUID();
+
+    await db.insert(agents).values([
+      {
+        id: agentAId,
+        companyId,
+        name: "Agent Alpha",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: agentBId,
+        companyId,
+        name: "Agent Beta",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    return { companyId, issuePrefix, agentAId, agentBId };
+  }
+
+  /**
+   * BLA-207 regression: assign issue to agent A → checkout by agent A → issue
+   * reassigned to agent B → agent A's orphaned run is reaped →
+   * agent A's deferred wakeup MUST NOT be promoted (assigneeAgentId stays B).
+   */
+  it("BLA-207: reaping agent A run does not promote its deferred wakeup when issue was reassigned to agent B", async () => {
+    const { companyId, issuePrefix, agentAId, agentBId } = await seedTwoAgents();
+
+    const issueId = randomUUID();
+    const runAId = randomUUID();
+    const wakeupAId = randomUUID();
+    const deferredWakeupAId = randomUUID();
+    const now = new Date("2026-01-01T00:00:00.000Z");
+
+    // Active wakeup / run for agent A that holds execution lock on the issue
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupAId,
+      companyId,
+      agentId: agentAId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      status: "claimed",
+      runId: runAId,
+      claimedAt: now,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runAId,
+      companyId,
+      agentId: agentAId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId: wakeupAId,
+      contextSnapshot: { issueId },
+      // Non-zero dead PID so reapOrphanedRuns picks this up as a lost process.
+      // processLossRetryCount=1 bypasses the one-retry grace path so
+      // releaseIssueExecutionAndPromote is invoked directly.
+      processPid: 999_999_999,
+      processLossRetryCount: 1,
+      startedAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Ownership transition test issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentAId,
+      checkoutRunId: runAId,
+      executionRunId: runAId,
+      executionAgentNameKey: "agent alpha",
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    // A deferred wakeup for agent A is already queued (e.g. arrived during execution)
+    await db.insert(agentWakeupRequests).values({
+      id: deferredWakeupAId,
+      companyId,
+      agentId: agentAId,
+      source: "on_demand",
+      triggerDetail: "system",
+      reason: "issue_comment_wake",
+      payload: { issueId },
+      status: "deferred_issue_execution",
+      requestedAt: new Date("2026-01-01T00:00:05.000Z"),
+    });
+
+    // Operator reassigns the issue to agent B — clears checkout lock but
+    // executionRunId still points to agent A's running run (mirrors real server
+    // behavior where update() clears checkoutRunId on assignee change but the
+    // execution lock is only released when the run itself completes/is reaped).
+    await db
+      .update(issues)
+      .set({
+        assigneeAgentId: agentBId,
+        checkoutRunId: null,
+        updatedAt: new Date("2026-01-01T00:00:10.000Z"),
+      })
+      .where(eq(issues.id, issueId));
+
+    // Reap agent A's orphaned run
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+
+    // Issue must remain owned by agent B
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue?.assigneeAgentId).toBe(agentBId);
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.executionAgentNameKey).toBeNull();
+
+    // Agent A's deferred wakeup must be failed, not promoted to a new run
+    const deferred = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, deferredWakeupAId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(deferred?.status).toBe("failed");
+    expect(deferred?.error).toContain("assigneeAgentId is authoritative");
+
+    // No new heartbeat run must have been created for agent A on this issue
+    const agentARuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentAId));
+    // Only the original (now failed) run — no promoted run
+    expect(agentARuns).toHaveLength(1);
+    expect(agentARuns[0]?.status).toBe("failed");
+  });
+
+  /**
+   * BLA-206 regression: a deferred wakeup queued by agent A (e.g. EPM
+   * scavenging an issue it thought was unowned) must not be promoted into
+   * execution once the issue's assigneeAgentId is set to agent B — even when
+   * agent A's run for a different reason completes and triggers the promotion
+   * sweep.
+   *
+   * Scenario: agent A has a stale deferred request on the issue; agent A's
+   * orphaned run is reaped; releaseIssueExecutionAndPromote must skip agent A's
+   * deferred request because issue.assigneeAgentId = agentBId ≠ agentAId.
+   */
+  it("BLA-206: stale deferred wakeup from agent A is not promoted when issue is owned by agent B", async () => {
+    const { companyId, issuePrefix, agentAId, agentBId } = await seedTwoAgents();
+
+    const issueId = randomUUID();
+    const runAId = randomUUID();
+    const wakeupAId = randomUUID();
+    const deferredScavengeId = randomUUID();
+    const now = new Date("2026-01-01T00:00:00.000Z");
+
+    // Agent A has a running heartbeat (on some other work), holding the execution
+    // lock on this issue via a stale executionRunId (as would happen if EPM's
+    // scavenge path set the lock before the operator re-routed).
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupAId,
+      companyId,
+      agentId: agentAId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      status: "claimed",
+      runId: runAId,
+      claimedAt: now,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runAId,
+      companyId,
+      agentId: agentAId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId: wakeupAId,
+      contextSnapshot: { issueId },
+      processPid: 999_999_999, // dead — will be reaped
+      processLossRetryCount: 1, // retry exhausted; promotes directly
+      startedAt: now,
+      updatedAt: now,
+    });
+
+    // Issue is already assigned to agent B (the legitimate owner)
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Pre-assigned issue (BLA-206 scenario)",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentBId,
+      executionRunId: runAId, // stale lock from agent A's scavenge
+      executionAgentNameKey: "agent alpha",
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    // Agent A's scavenge queued a deferred wakeup on the issue before the
+    // operator corrected the assignment.
+    await db.insert(agentWakeupRequests).values({
+      id: deferredScavengeId,
+      companyId,
+      agentId: agentAId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "scavenge_sprint_child",
+      payload: { issueId },
+      status: "deferred_issue_execution",
+      requestedAt: new Date("2026-01-01T00:00:02.000Z"),
+    });
+
+    // Reap agent A's orphaned run
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+
+    // Issue must remain owned by agent B
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue?.assigneeAgentId).toBe(agentBId);
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.executionAgentNameKey).toBeNull();
+
+    // Agent A's scavenge deferred must be failed, not promoted
+    const scavenge = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, deferredScavengeId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(scavenge?.status).toBe("failed");
+    expect(scavenge?.error).toContain("assigneeAgentId is authoritative");
+
+    // No new run must have been created for agent A
+    const agentARuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentAId));
+    expect(agentARuns).toHaveLength(1);
+    expect(agentARuns[0]?.id).toBe(runAId);
+    expect(agentARuns[0]?.status).toBe("failed");
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3641,6 +3641,7 @@ export function heartbeatService(db: Db) {
         .select({
           id: issues.id,
           companyId: issues.companyId,
+          assigneeAgentId: issues.assigneeAgentId,
         })
         .from(issues)
         .where(and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)))
@@ -3694,6 +3695,25 @@ export function heartbeatService(db: Db) {
               status: "failed",
               finishedAt: new Date(),
               error: "Deferred wake could not be promoted: agent is not invokable",
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
+
+        // Guard: assigneeAgentId is authoritative for ownership. If the issue has been
+        // reassigned to a different agent since this deferred request was queued, skip
+        // promotion — the new assignee will drive execution via their own heartbeat.
+        // Fixes BLA-207 (stale executionAgentNameKey reclaim after reassignment) and
+        // BLA-206 (deferred promotions resurrecting stale ownership after re-routing).
+        if (issue.assigneeAgentId && issue.assigneeAgentId !== deferredAgent.id) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "failed",
+              finishedAt: new Date(),
+              error:
+                "Deferred wake skipped: issue was reassigned to a different agent; assigneeAgentId is authoritative",
               updatedAt: new Date(),
             })
             .where(eq(agentWakeupRequests.id, deferred.id));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     projects: [
+      "packages/adapter-utils",
       "packages/db",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",


### PR DESCRIPTION
## Summary

Fixes two related ownership-transition bugs in `releaseIssueExecutionAndPromote`:

- After an issue is `PATCH`'d to a new assignee, the old agent's orphaned run completing would promote its stale deferred wakeup and re-lock the issue, silently reversing the re-routing decision.
- A scavenging agent that had queued a deferred wakeup before an operator re-routed the issue could resurface as owner when any run for that issue completed.

Root cause: `releaseIssueExecutionAndPromote` did not check `issue.assigneeAgentId` before promoting a deferred wakeup. Fix: read `assigneeAgentId` in the transaction and fail any deferred request whose `agentId` does not match — `assigneeAgentId` is the single authoritative ownership signal.

## Test plan

- [ ] Two embedded-Postgres regression tests in `heartbeat-ownership-transition.test.ts` (one per bug)
- [ ] Scenario 1: reap agent A run after issue reassigned to B → deferred wakeup for A fails, `assigneeAgentId` stays B
- [ ] Scenario 2: scavenge deferred wakeup for A on issue already owned by B → wakeup fails, `assigneeAgentId` stays B

Obsolete PR.
