### PR TITLE
feat: add server-side utility functions to support windows ps1 extension

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -581,6 +581,11 @@ function resolveWindowsCmdShell(env: NodeJS.ProcessEnv): string {
   return path.join(fallbackRoot, "System32", "cmd.exe");
 }
 
+function resolveWindowsPowerShell(env: NodeJS.ProcessEnv): string {
+  const fallbackRoot = env.SystemRoot || process.env.SystemRoot || "C:\\Windows";
+  return path.join(fallbackRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
+
 async function resolveSpawnTarget(
   command: string,
   args: string[],
@@ -606,8 +611,9 @@ async function resolveSpawnTarget(
   }
 
   if (/\.ps1$/i.test(executable)) {
-    // Run PowerShell scripts via powershell.exe with bypass policy
-    const shell = "powershell.exe";
+    // Run PowerShell scripts via powershell.exe with bypass policy.
+    // Use an absolute path to the shell because PATH may be restricted.
+    const shell = resolveWindowsPowerShell(env);
     return {
       command: shell,
       args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", executable, ...args],

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -526,7 +526,7 @@ export function defaultPathForPlatform() {
 }
 
 function windowsPathExts(env: NodeJS.ProcessEnv): string[] {
-  return (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean);
+  return (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM;.PS1").split(";").filter(Boolean);
 }
 
 async function pathExists(candidate: string) {
@@ -602,6 +602,15 @@ async function resolveSpawnTarget(
     return {
       command: shell,
       args: ["/d", "/s", "/c", commandLine],
+    };
+  }
+
+  if (/\.ps1$/i.test(executable)) {
+    // Run PowerShell scripts via powershell.exe with bypass policy
+    const shell = "powershell.exe";
+    return {
+      command: shell,
+      args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", executable, ...args],
     };
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The agent adapter system communicates with external tools like OpenCode via local process execution.
> - On Windows, some tools (like OpenCode installed via Miniconda or npm) are provided as PowerShell shims (.ps1).
> - The existing command execution logic in adapter-utils fails to execute .ps1 files when shell: false is set, as Windows requires an explicit handler for non-binary executables unless using a shell.
> - This pull request adds explicit handling for .ps1 files in resolveSpawnTarget and ensures .PS1 is considered a valid executable extension on Windows.
> - This enables Paperclip to correctly discover and run models for adapters that rely on PowerShell-based CLI tools on Windows.

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

- Added .PS1 to the default extensions list in windowsPathExts.
- Updated resolveSpawnTarget to wrap .ps1 scripts with powershell.exe -NoProfile -ExecutionPolicy Bypass -File <path> when running on Windows.

## Verification

- Manually verified that the OpenCode adapter can now successfully discover models on a Windows host.
Verified that the model list correctly populates in the "New Agent" UI.

## Risks

- Low risk: This change only affects Windows environments and specifically targets .ps1 files that were previously failing to launch. Existing .exe or .cmd logic remains unchanged.

## Model Used

Provider: Google
Model: Gemini 3.1 Pro (High)
Capabilities: Tool use, code analysis, and multi-turn reasoning.


## Checklist

- [ v ] I have included a thinking path that traces from project context to this change
- [ v ] I have specified the model used (with version and capability details)
- [ v ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ v ] I have updated relevant documentation to reflect my changes
- [ v ] I have considered and documented any risks above
- [ v ] I will address all Greptile and reviewer comments before requesting merge
