### PR TITLE
openclaw-gateway: respect ctx.config.claimedApiKeyPath in wake prompt

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -362,8 +362,8 @@ function buildWakeText(
   payload: WakePayload,
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,
+  claimedApiKeyPath: string,
 ): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -1109,6 +1109,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     structuredWakeJson
       ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
       : structuredWakePrompt,
+    resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath),
   );
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, brokering work to them via cloud adapters
> - The `openclaw-gateway` adapter wakes an OpenClaw agent over a WebSocket and emits a wake prompt that tells the agent how to call Paperclip back over HTTP
> - That HTTP call needs a Bearer `PAPERCLIP_API_KEY`, which the agent loads from a JSON file on its own filesystem (the "claimed" API key file)
> - The adapter already supports an optional per-agent override via `adapterConfig.claimedApiKeyPath`, plumbed through a helper called `resolveClaimedApiKeyPath()` — but `buildWakeText` ignored the resolved value and re-hardcoded the default path inline
> - Effect: every cloud-adapter agent loaded the same default key file when woken, so all comments, checkouts, and status patches were attributed to whichever Paperclip identity owned that shared token (typically the wrapper for the default openclaw agent), regardless of which agent actually did the work
> - This pull request threads the resolved `claimedApiKeyPath` into `buildWakeText` so the existing override mechanism actually takes effect
> - The benefit is per-agent identity in Paperclip: comments and status changes show up under the agent that authored them instead of being silently re-attributed to the default-agent wrapper

## What Changed

- `buildWakeText` now takes `claimedApiKeyPath: string` as a 4th parameter and uses it in place of the local hardcoded constant.
- The single call site in `execute()` passes `resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath)`. The resolver already falls back to `DEFAULT_CLAIMED_API_KEY_PATH` when the override is unset, so behavior is unchanged for any existing agent that doesn't set `adapterConfig.claimedApiKeyPath`.

No schema changes, no migrations, no new config keys (the field already existed in the resolver).

## Verification

**Static reasoning:** When `ctx.config.claimedApiKeyPath` is undefined, `resolveClaimedApiKeyPath(value)` returns `nonEmpty(value) ?? DEFAULT_CLAIMED_API_KEY_PATH`, which is bit-identical to the string previously hardcoded in `buildWakeText`. Existing deployments are unaffected.

**End-to-end on a private deployment:**

1. Minted Paperclip API keys for two non-default cloud-adapter agents (one with its own dedicated openclaw runtime, one sharing the default openclaw runtime with the default Paperclip identity).
2. Saved each token under a per-agent JSON file at a path the openclaw process can read.
3. Set `adapterConfig.claimedApiKeyPath` on each `agents` row to the corresponding path.
4. Created two throwaway issues, one assigned to each agent.
5. Observed in `issue_comments`: `author_agent_id` matches the woken agent's UUID and `created_by_run_id` matches that agent's runId — instead of both being attributed to the default-agent wrapper as before.

Unit tests for `buildWakeText` were not added in this PR; happy to add them if requested.

## Risks

Low risk.

- Two-line change, no schema migration, no new config keys.
- Existing deployments without `claimedApiKeyPath` set are bit-identical to before, since the resolver returns the same default string the old hardcoded constant produced.
- Agents that opt in to a per-agent path must ensure the file actually exists on the openclaw side and is readable by the agent's process — the same operational requirement that already applied to the default file.
- No behavioral change to the structured wake payload, the session-key strategy, or any other adapter surface.

## Model Used

- **Provider:** Anthropic
- **Model:** Claude Opus 4.6
- **Exact ID:** `claude-opus-4-6`
- **Context window:** 1M context variant
- **Reasoning mode:** standard (no extended thinking)
- **Tools used:** filesystem read/edit/write, shell exec (in running paperclip-server and openclaw containers), HTTP via curl for end-to-end verification, gh for PR creation

The bug was originally diagnosed and patched in a running deployment while debugging a downstream OpenClaw/Paperclip integration. Once the in-deployment fix was verified end-to-end, the same diff was applied against `upstream/master` and pushed here as a clean PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass (verified the change end-to-end on a private deployment, but did not run the upstream test suite)
- [ ] I have added or updated tests where applicable (no `buildWakeText` unit tests added; happy to add if requested)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — adapter-only change)
- [x] I have updated relevant documentation to reflect my changes (N/A — this brings `buildWakeText` into line with the already-documented `adapterConfig.claimedApiKeyPath` field)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
