### PR TITLE
fix: serialize Date to ISO string in comment cursor query

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2049,12 +2049,12 @@ export function issueService(db: Db) {
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchor.createdAt.toISOString()}
+                OR (${issueComments.createdAt} = ${anchor.createdAt.toISOString()} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchor.createdAt.toISOString()}
+                OR (${issueComments.createdAt} = ${anchor.createdAt.toISOString()} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }


### PR DESCRIPTION
## Problem

`GET /api/issues/:id/comments?after=<uuid>&order=asc` returns 500 Internal Server Error:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string
or an instance of Buffer or ArrayBuffer. Received an instance of Date
    at Buffer.byteLength (node:buffer:787:11)
    at reset.str (postgres/src/bytes.js:22:27)
    at postgres/src/connection.js:964:16
```

## Root Cause

In `listComments()` (`server/src/services/issues.ts`), cursor-based pagination looks up the anchor comment and passes `anchor.createdAt` (a `Date` object) directly into a drizzle `sql` template literal for comparison. The `postgres.js` driver (`porsager/postgres ^3.4.5`) does not auto-serialize `Date` objects in raw sql template bindings, causing the `Buffer.byteLength` TypeError.

## Fix

Explicitly convert `anchor.createdAt` to an ISO string via `.toISOString()` before passing it into the sql template. This ensures the postgres driver receives a string, which it can serialize correctly.

## Testing

Verified that the endpoint was returning 500 before this change on a live Paperclip 2026.403.0 instance with embedded postgres.