### PR TITLE
fix: increase orphan reaper stale threshold and make configurable

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -84,6 +84,7 @@ export interface Config {
   feedbackExportBackendToken: string | undefined;
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
+  orphanReapStaleThresholdMs: number;
   companyDeletionEnabled: boolean;
   telemetryEnabled: boolean;
 }
@@ -329,6 +330,7 @@ export function loadConfig(): Config {
     feedbackExportBackendToken,
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
+    orphanReapStaleThresholdMs: Math.max(60000, Number(process.env.ORPHAN_REAP_STALE_THRESHOLD_MS) || 15 * 60 * 1000),
     companyDeletionEnabled,
     telemetryEnabled: fileConfig?.telemetry?.enabled ?? true,
   };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -612,7 +612,7 @@ export async function startServer(): Promise<StartedServer> {
       // Periodically reap orphaned runs (5-min staleness threshold) and make sure
       // persisted queued work is still being driven forward.
       void heartbeat
-        .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+        .reapOrphanedRuns({ staleThresholdMs: config.orphanReapStaleThresholdMs })
         .then(() => heartbeat.resumeQueuedRuns())
         .catch((err) => {
           logger.error({ err }, "periodic heartbeat recovery failed");
@@ -714,6 +714,7 @@ export async function startServer(): Promise<StartedServer> {
         migrationSummary,
         heartbeatSchedulerEnabled: config.heartbeatSchedulerEnabled,
         heartbeatSchedulerIntervalMs: config.heartbeatSchedulerIntervalMs,
+        orphanReapStaleThresholdMs: config.orphanReapStaleThresholdMs,
         databaseBackupEnabled: config.databaseBackupEnabled,
         databaseBackupIntervalMinutes: config.databaseBackupIntervalMinutes,
         databaseBackupRetentionDays: config.databaseBackupRetentionDays,


### PR DESCRIPTION
## Problem

The periodic orphan reaper falsely kills active runs that are still making progress.

### Observed behavior

Runs `985525bc`, `9f689eb5`, `6b11fa8a` were reaped as orphaned at 15:15 UTC. However, those same run IDs continued making successful API calls (issue checkout, PATCH updates, comment creation) until 15:31 UTC. The runs eventually completed with `subtype: "success"`, but by then the DB already had them as `failed` and their agents were permanently stuck in `error` state.

### Root cause

The periodic reaper uses a **5-minute stale threshold** based on `heartbeat_runs.updatedAt`. However, `updatedAt` is only refreshed on:
- Status transitions (`setRunStatus`)
- Process metadata persistence (`persistRunProcessMetadata`)
- A few other explicit touchpoints

It is **not** refreshed when the agent makes regular API calls during execution (issue comments, file writes, etc.). So a run that spends >5 minutes actively working between status changes gets incorrectly flagged as stale and reaped.

The PID-based liveness check (`isProcessAlive`) should catch this, but there are edge cases where PID detection fails (e.g., after server restart where in-memory process handles are lost, or when the adapter spawns intermediate wrapper processes).

### Fix

1. **Increase default stale threshold** from 5 minutes to 15 minutes — most agent runs complete within this window
2. **Make it configurable** via `ORPHAN_REAP_STALE_THRESHOLD_MS` environment variable (minimum 60s, default 900000ms)
3. Expose the configured value in the `/info` endpoint for observability

### Future improvement

A more robust fix would be to touch `updatedAt` (debounced) whenever a run makes any API call identified by the `x-paperclip-run-id` header. This would make the staleness check reflect actual activity rather than just status transitions.