### PR TITLE
feat(gemini-local): export detectGeminiQuotaExhausted for plugin adapter reuse

### DIFF
--- a/packages/adapters/gemini-local/src/server/index.ts
+++ b/packages/adapters/gemini-local/src/server/index.ts
@@ -6,6 +6,7 @@ export {
   isGeminiUnknownSessionError,
   describeGeminiFailure,
   detectGeminiAuthRequired,
+  detectGeminiQuotaExhausted,
   isGeminiTurnLimitResult,
 } from "./parse.js";
 import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents via pluggable server-side adapters, one per provider / CLI backend
> - Each adapter package exposes a server entry point (`@paperclipai/adapter-<name>/server`) that downstream consumers — including plugin adapters that wrap or extend the stock behavior — re-use for helper functions
> - `gemini-local`'s server entry re-exports a curated set of parse helpers from `./parse.js` (`parseGeminiJsonl`, `isGeminiUnknownSessionError`, `describeGeminiFailure`, `detectGeminiAuthRequired`, `isGeminiTurnLimitResult`) so consumers can classify provider output without reaching into the package's internals
> - `detectGeminiQuotaExhausted` lives in the same `parse.ts` file next to `detectGeminiAuthRequired`, is defined with `export function`, and is the package's single source of truth for "is this output a Gemini quota hit?" — but it is missing from the entry-point re-export block
> - As a result, any consumer that wants to classify quota exhaustion either has to deep-import from `./server/parse.js` (brittle against future `exports`-field changes) or reimplement the regex locally (drift risk against the authoritative heuristic)
> - This pull request adds `detectGeminiQuotaExhausted` to the existing re-export block, placed next to its thematic sibling `detectGeminiAuthRequired`, with no other changes
> - The benefit is one extra supported public symbol on `@paperclipai/adapter-gemini-local/server` — a purely additive ergonomic improvement with no behavior change and no existing consumer impact

## What Changed

- `packages/adapters/gemini-local/src/server/index.ts`: added `detectGeminiQuotaExhausted` to the `export { ... } from "./parse.js"` block, inserted between `detectGeminiAuthRequired` and `isGeminiTurnLimitResult` (thematic grouping — both `detect*` helpers)

## Verification

Local verification against the branch commit (base: `upstream/master` at `b649bd45`):

```
$ pnpm --filter @paperclipai/adapter-gemini-local typecheck
> @paperclipai/adapter-gemini-local@0.3.1 typecheck
> tsc --noEmit
(exit 0)

$ pnpm --filter @paperclipai/adapter-gemini-local build
> @paperclipai/adapter-gemini-local@0.3.1 build
> tsc
(exit 0)

$ cd server && pnpm exec vitest run src/__tests__/gemini-local-execute.test.ts
 RUN  v3.2.4

 ✓ src/__tests__/gemini-local-execute.test.ts (3 tests) 1487ms
   ✓ gemini execute > passes prompt via --prompt and injects paperclip env vars
   ✓ gemini execute > always passes --approval-mode yolo
   ✓ gemini execute > uses a compact wake delta instead of the full heartbeat prompt when resuming a session

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Existing-consumer check — all references to `detectGeminiQuotaExhausted` anywhere in the tree:

```
packages/adapters/gemini-local/src/server/index.ts:9    (this PR's new re-export)
packages/adapters/gemini-local/src/server/parse.ts:253  (the definition)
packages/adapters/gemini-local/src/server/test.ts:19    (intra-package import from "./parse.js")
packages/adapters/gemini-local/src/server/test.ts:174   (intra-package usage)
```

No cross-package consumer references the symbol today, so the new re-export cannot break any existing import. It is strictly additive to the public surface of `@paperclipai/adapter-gemini-local/server`.

## Risks

None. Purely additive re-export of a symbol that is already a named export on `./parse.ts`. The clean-success path, failure paths, and all other adapter behavior are untouched. No existing consumer is affected.

## Model Used

- **Provider**: Anthropic
- **Model**: Claude Opus 4.6 (1M context)
- **Interface**: Claude Code CLI
- **Role**: Upstream state verification (grep + diff against current master), PR drafting against the `CONTRIBUTING.md` template, local typecheck / build / test execution
- **Reasoning Mode**: Extended thinking enabled
- **Human oversight**: Noah Kellner reviewed the one-line re-export addition and approved submission

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
