### PR TITLE
feat(ui): add minimal i18n runtime groundwork

### DIFF
--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "common.signOut": "Sign out",
+  "common.signingOut": "Signing out..."
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1,4 +1,8 @@
 {
   "common.signOut": "Sign out",
-  "common.signingOut": "Signing out..."
+  "common.signingOut": "Signing out...",
+  "relativeTime.justNow": "just now",
+  "relativeTime.minutesAgo": "{{count}}m ago",
+  "relativeTime.hoursAgo": "{{count}}h ago",
+  "relativeTime.daysAgo": "{{count}}d ago"
 }

--- a/ui/src/i18n/locales/zh-CN.json
+++ b/ui/src/i18n/locales/zh-CN.json
@@ -1,0 +1,4 @@
+{
+  "common.signOut": "退出登录",
+  "common.signingOut": "正在退出登录..."
+}

--- a/ui/src/i18n/locales/zh-CN.json
+++ b/ui/src/i18n/locales/zh-CN.json
@@ -1,4 +1,8 @@
 {
   "common.signOut": "退出登录",
-  "common.signingOut": "正在退出登录..."
+  "common.signingOut": "正在退出登录...",
+  "relativeTime.justNow": "刚刚",
+  "relativeTime.minutesAgo": "{{count}} 分钟前",
+  "relativeTime.hoursAgo": "{{count}} 小时前",
+  "relativeTime.daysAgo": "{{count}} 天前"
 }

--- a/ui/src/i18n/runtime/adapter.test.ts
+++ b/ui/src/i18n/runtime/adapter.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { normalizeLocale, setCurrentLocale, translate } from "./adapter";
+
+describe("i18n adapter", () => {
+  beforeEach(() => {
+    setCurrentLocale("en");
+  });
+
+  it("normalizes supported locales", () => {
+    expect(normalizeLocale("zh")).toBe("zh-CN");
+    expect(normalizeLocale("zh-CN")).toBe("zh-CN");
+    expect(normalizeLocale("en-US")).toBe("en");
+    expect(normalizeLocale("fr-FR")).toBe("en");
+  });
+
+  it("returns translated messages for the requested locale", () => {
+    expect(translate("common.signOut", { locale: "zh-CN" })).toBe("退出登录");
+    expect(translate("common.signOut", { locale: "en" })).toBe("Sign out");
+  });
+
+  it("falls back to English when the locale is unsupported", () => {
+    expect(translate("common.signOut", { locale: "fr-FR" })).toBe("Sign out");
+  });
+});

--- a/ui/src/i18n/runtime/adapter.ts
+++ b/ui/src/i18n/runtime/adapter.ts
@@ -1,0 +1,117 @@
+import enMessages from "../locales/en.json";
+import zhCnMessages from "../locales/zh-CN.json";
+
+export const supportedLocales = ["en", "zh-CN"] as const;
+export type SupportedLocale = (typeof supportedLocales)[number];
+export type TranslationValues = Record<string, string | number | boolean | null | undefined>;
+export type MessageKey = keyof typeof enMessages;
+
+type MessageCatalog = Record<MessageKey, string>;
+
+const defaultLocale: SupportedLocale = "en";
+const intlLocaleBySupportedLocale: Record<SupportedLocale, string> = {
+  en: "en-US",
+  "zh-CN": "zh-CN",
+};
+const messageCatalogs: Record<SupportedLocale, MessageCatalog> = {
+  en: enMessages,
+  "zh-CN": zhCnMessages,
+};
+
+let currentLocale: SupportedLocale = defaultLocale;
+
+export function normalizeLocale(locale: string | null | undefined): SupportedLocale {
+  if (!locale) return defaultLocale;
+  const normalized = locale.trim().toLowerCase();
+  if (normalized.startsWith("zh")) return "zh-CN";
+  return "en";
+}
+
+export function setCurrentLocale(locale: string | null | undefined): SupportedLocale {
+  currentLocale = normalizeLocale(locale);
+  return currentLocale;
+}
+
+export function getCurrentLocale(): SupportedLocale {
+  return currentLocale;
+}
+
+export function getCurrentIntlLocale(locale: string | null | undefined = currentLocale): string {
+  return intlLocaleBySupportedLocale[normalizeLocale(locale)];
+}
+
+function interpolateMessage(message: string, values?: TranslationValues): string {
+  if (!values) return message;
+  return message.replace(/\{\{\s*([A-Za-z0-9_]+)\s*\}\}/g, (_match, key: string) => {
+    const value = values[key];
+    return value == null ? "" : String(value);
+  });
+}
+
+export function translate(
+  key: MessageKey,
+  options: {
+    locale?: string | null | undefined;
+    fallback?: string;
+    values?: TranslationValues;
+  } = {},
+): string {
+  const locale = normalizeLocale(options.locale);
+  const message = messageCatalogs[locale][key]
+    ?? messageCatalogs[defaultLocale][key]
+    ?? options.fallback
+    ?? key;
+  return interpolateMessage(message, options.values);
+}
+
+export function formatDate(date: Date | string, locale: string | null | undefined = currentLocale): string {
+  return new Date(date).toLocaleDateString(getCurrentIntlLocale(locale), {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function formatDateTime(date: Date | string, locale: string | null | undefined = currentLocale): string {
+  return new Date(date).toLocaleString(getCurrentIntlLocale(locale), {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function formatShortDate(date: Date | string, locale: string | null | undefined = currentLocale): string {
+  return new Date(date).toLocaleString(getCurrentIntlLocale(locale), {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function relativeTime(date: Date | string, locale: string | null | undefined = currentLocale): string {
+  const resolvedLocale = normalizeLocale(locale);
+  const now = Date.now();
+  const then = new Date(date).getTime();
+  const diffSec = Math.round((now - then) / 1000);
+
+  if (resolvedLocale === "zh-CN") {
+    if (diffSec < 60) return "刚刚";
+    const diffMin = Math.round(diffSec / 60);
+    if (diffMin < 60) return `${diffMin} 分钟前`;
+    const diffHr = Math.round(diffMin / 60);
+    if (diffHr < 24) return `${diffHr} 小时前`;
+    const diffDay = Math.round(diffHr / 24);
+    if (diffDay < 30) return `${diffDay} 天前`;
+    return formatDate(date, resolvedLocale);
+  }
+
+  if (diffSec < 60) return "just now";
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.round(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  return formatDate(date, resolvedLocale);
+}

--- a/ui/src/i18n/runtime/adapter.ts
+++ b/ui/src/i18n/runtime/adapter.ts
@@ -95,23 +95,36 @@ export function relativeTime(date: Date | string, locale: string | null | undefi
   const then = new Date(date).getTime();
   const diffSec = Math.round((now - then) / 1000);
 
-  if (resolvedLocale === "zh-CN") {
-    if (diffSec < 60) return "刚刚";
-    const diffMin = Math.round(diffSec / 60);
-    if (diffMin < 60) return `${diffMin} 分钟前`;
-    const diffHr = Math.round(diffMin / 60);
-    if (diffHr < 24) return `${diffHr} 小时前`;
-    const diffDay = Math.round(diffHr / 24);
-    if (diffDay < 30) return `${diffDay} 天前`;
-    return formatDate(date, resolvedLocale);
+  if (diffSec < 60) {
+    return translate("relativeTime.justNow", { locale: resolvedLocale, fallback: "just now" });
   }
 
-  if (diffSec < 60) return "just now";
   const diffMin = Math.round(diffSec / 60);
-  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffMin < 60) {
+    return translate("relativeTime.minutesAgo", {
+      locale: resolvedLocale,
+      fallback: "{{count}}m ago",
+      values: { count: diffMin },
+    });
+  }
+
   const diffHr = Math.round(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffHr < 24) {
+    return translate("relativeTime.hoursAgo", {
+      locale: resolvedLocale,
+      fallback: "{{count}}h ago",
+      values: { count: diffHr },
+    });
+  }
+
   const diffDay = Math.round(diffHr / 24);
-  if (diffDay < 30) return `${diffDay}d ago`;
+  if (diffDay < 30) {
+    return translate("relativeTime.daysAgo", {
+      locale: resolvedLocale,
+      fallback: "{{count}}d ago",
+      values: { count: diffDay },
+    });
+  }
+
   return formatDate(date, resolvedLocale);
 }

--- a/ui/src/i18n/runtime/index.ts
+++ b/ui/src/i18n/runtime/index.ts
@@ -1,0 +1,16 @@
+export { I18nProvider, I18N_LOCALE_STORAGE_KEY, useI18n } from "./provider";
+export {
+  formatDate,
+  formatDateTime,
+  formatShortDate,
+  getCurrentIntlLocale,
+  getCurrentLocale,
+  normalizeLocale,
+  relativeTime,
+  setCurrentLocale,
+  supportedLocales,
+  translate,
+  type MessageKey,
+  type SupportedLocale,
+  type TranslationValues,
+} from "./adapter";

--- a/ui/src/i18n/runtime/provider.tsx
+++ b/ui/src/i18n/runtime/provider.tsx
@@ -1,0 +1,95 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  getCurrentLocale,
+  setCurrentLocale,
+  supportedLocales,
+  normalizeLocale,
+  translate,
+  type MessageKey,
+  type SupportedLocale,
+  type TranslationValues,
+} from "./adapter";
+
+export const I18N_LOCALE_STORAGE_KEY = "paperclip.locale";
+
+interface I18nContextValue {
+  locale: SupportedLocale;
+  setLocale: (locale: SupportedLocale) => void;
+  supportedLocales: readonly SupportedLocale[];
+  t: (key: MessageKey, fallback?: string, values?: TranslationValues) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+function resolveLocaleFromEnvironment(): SupportedLocale {
+  try {
+    const storedLocale = localStorage.getItem(I18N_LOCALE_STORAGE_KEY);
+    if (storedLocale) return normalizeLocale(storedLocale);
+  } catch {
+    // Ignore local storage read failures in restricted environments.
+  }
+
+  if (typeof navigator !== "undefined") {
+    return normalizeLocale(navigator.languages?.[0] ?? navigator.language);
+  }
+
+  return getCurrentLocale();
+}
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<SupportedLocale>(() => {
+    const resolvedLocale = resolveLocaleFromEnvironment();
+    setCurrentLocale(resolvedLocale);
+    return resolvedLocale;
+  });
+
+  const setLocale = useCallback((nextLocale: SupportedLocale) => {
+    const normalizedLocale = setCurrentLocale(nextLocale);
+    setLocaleState(normalizedLocale);
+  }, []);
+
+  useEffect(() => {
+    setCurrentLocale(locale);
+    if (typeof document !== "undefined") {
+      document.documentElement.lang = locale;
+    }
+    try {
+      localStorage.setItem(I18N_LOCALE_STORAGE_KEY, locale);
+    } catch {
+      // Ignore local storage write failures in restricted environments.
+    }
+  }, [locale]);
+
+  const t = useCallback(
+    (key: MessageKey, fallback?: string, values?: TranslationValues) => translate(key, { locale, fallback, values }),
+    [locale],
+  );
+
+  const value = useMemo<I18nContextValue>(
+    () => ({
+      locale,
+      setLocale,
+      supportedLocales,
+      t,
+    }),
+    [locale, setLocale, t],
+  );
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error("useI18n must be used within I18nProvider");
+  }
+  return context;
+}

--- a/ui/src/i18n/runtime/provider.tsx
+++ b/ui/src/i18n/runtime/provider.tsx
@@ -57,7 +57,6 @@ export function I18nProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    setCurrentLocale(locale);
     if (typeof document !== "undefined") {
       document.documentElement.lang = locale;
     }

--- a/ui/src/lib/utils.test.ts
+++ b/ui/src/lib/utils.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { formatDate, relativeTime } from "./utils";
+import { setCurrentLocale } from "@/i18n/runtime/adapter";
+
+describe("utils i18n formatting", () => {
+  beforeEach(() => {
+    setCurrentLocale("en");
+  });
+
+  it("formats dates using the current locale", () => {
+    const date = new Date("2026-04-01T00:00:00.000Z");
+
+    setCurrentLocale("en");
+    const english = formatDate(date);
+
+    setCurrentLocale("zh-CN");
+    const chinese = formatDate(date);
+
+    expect(english).not.toBe(chinese);
+    expect(chinese).toMatch(/2026/);
+  });
+
+  it("formats relative time using the current locale", () => {
+    const now = Date.now();
+    const recentDate = new Date(now - 90_000);
+
+    setCurrentLocale("en");
+    expect(relativeTime(recentDate)).toContain("ago");
+
+    setCurrentLocale("zh-CN");
+    expect(relativeTime(recentDate)).toContain("前");
+  });
+});

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -2,6 +2,12 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { deriveAgentUrlKey, deriveProjectUrlKey, normalizeProjectUrlKey, hasNonAsciiContent } from "@paperclipai/shared";
 import type { BillingType, FinanceDirection, FinanceEventKind } from "@paperclipai/shared";
+import {
+  formatDate as formatDateWithLocale,
+  formatDateTime as formatDateTimeWithLocale,
+  formatShortDate as formatShortDateWithLocale,
+  relativeTime as relativeTimeWithLocale,
+} from "@/i18n/runtime/adapter";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -12,42 +18,19 @@ export function formatCents(cents: number): string {
 }
 
 export function formatDate(date: Date | string): string {
-  return new Date(date).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+  return formatDateWithLocale(date);
 }
 
 export function formatDateTime(date: Date | string): string {
-  return new Date(date).toLocaleString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+  return formatDateTimeWithLocale(date);
 }
 
 export function formatShortDate(date: Date | string): string {
-  return new Date(date).toLocaleString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
+  return formatShortDateWithLocale(date);
 }
 
 export function relativeTime(date: Date | string): string {
-  const now = Date.now();
-  const then = new Date(date).getTime();
-  const diffSec = Math.round((now - then) / 1000);
-  if (diffSec < 60) return "just now";
-  const diffMin = Math.round(diffSec / 60);
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.round(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  const diffDay = Math.round(diffHr / 24);
-  if (diffDay < 30) return `${diffDay}d ago`;
-  return formatDate(date);
+  return relativeTimeWithLocale(date);
 }
 
 export function formatTokens(n: number): string {

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -14,6 +14,7 @@ import { DialogProvider } from "./context/DialogContext";
 import { EditorAutocompleteProvider } from "./context/EditorAutocompleteContext";
 import { ToastProvider } from "./context/ToastContext";
 import { ThemeProvider } from "./context/ThemeContext";
+import { I18nProvider } from "@/i18n/runtime";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { initPluginBridge } from "./plugins/bridge-init";
 import { PluginLauncherProvider } from "./plugins/launchers";
@@ -40,31 +41,33 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <BrowserRouter>
-          <CompanyProvider>
-            <EditorAutocompleteProvider>
-              <ToastProvider>
-                <LiveUpdatesProvider>
-                  <TooltipProvider>
-                    <BreadcrumbProvider>
-                      <SidebarProvider>
-                        <PanelProvider>
-                          <PluginLauncherProvider>
-                            <DialogProvider>
-                              <App />
-                            </DialogProvider>
-                          </PluginLauncherProvider>
-                        </PanelProvider>
-                      </SidebarProvider>
-                    </BreadcrumbProvider>
-                  </TooltipProvider>
-                </LiveUpdatesProvider>
-              </ToastProvider>
-            </EditorAutocompleteProvider>
-          </CompanyProvider>
-        </BrowserRouter>
-      </ThemeProvider>
+      <I18nProvider>
+        <ThemeProvider>
+          <BrowserRouter>
+            <CompanyProvider>
+              <EditorAutocompleteProvider>
+                <ToastProvider>
+                  <LiveUpdatesProvider>
+                    <TooltipProvider>
+                      <BreadcrumbProvider>
+                        <SidebarProvider>
+                          <PanelProvider>
+                            <PluginLauncherProvider>
+                              <DialogProvider>
+                                <App />
+                              </DialogProvider>
+                            </PluginLauncherProvider>
+                          </PanelProvider>
+                        </SidebarProvider>
+                      </BreadcrumbProvider>
+                    </TooltipProvider>
+                  </LiveUpdatesProvider>
+                </ToastProvider>
+              </EditorAutocompleteProvider>
+            </CompanyProvider>
+          </BrowserRouter>
+        </ThemeProvider>
+      </I18nProvider>
     </QueryClientProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The UI already surfaces time, status, and operator-facing controls across many pages
> - There have been repeated requests for localization and multilingual support, but a full rollout would touch a very large UI surface
> - Without a small runtime boundary, later localization work would keep reintroducing ad hoc formatting and locale handling
> - This pull request adds the minimum localization groundwork at the UI runtime layer
> - It establishes locale normalization, persisted locale selection, English fallback, and locale-aware shared formatting
> - The benefit is that future localization work can land incrementally in small follow-up PRs instead of requiring a large architectural rewrite

## What Changed

- added a lightweight UI i18n runtime with locale normalization and persisted locale selection
- added English fallback and minimal locale resources used by the runtime
- routed shared date/time formatting helpers through the new locale-aware runtime
- added focused runtime and formatter tests
- addressed initial review comments by moving relative-time strings into locale resources and simplifying locale synchronization in the provider

## Verification

- `pnpm --dir ui typecheck`
- `pnpm --dir ui exec vitest run src/i18n/runtime/adapter.test.ts src/lib/utils.test.ts`

## Risks

- Low risk: this PR only introduces runtime groundwork and shared formatter integration
- No broad page-by-page text migration is included here
- Future localization follow-ups will still need product and copy review for specific surfaces

## Model Used

- Provider: Anthropic Claude Code
- Model: Claude Opus 4.6 (`claude-opus-4-6`)
- Capabilities used: extended reasoning, repository code search, file editing, bash execution, and test/typecheck verification

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge