### PR TITLE
fix(issue-assignment-wakeup): suppress wake on terminal-status issues

### DIFF
--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -29,6 +29,10 @@ export function queueIssueAssignmentWakeup(input: {
   rethrowOnError?: boolean;
 }) {
   if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return;
+  // Suppress wake when the issue is created (or transitioned) into a terminal
+  // state in the same request. There is nothing for the assignee to do, and
+  // any procedure that re-creates such an issue on each wake would loop.
+  if (input.issue.status === "done" || input.issue.status === "cancelled") return;
 
   return input.heartbeat
     .wakeup(input.issue.assigneeAgentId, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents wake on events: timer heartbeats, assignments, comments, mentions, approvals
> - One of those events is `issue_assigned` — fired when an issue is created or transitioned to a state where the assignee should act
> - But there is no real "act" needed when the issue is created in a terminal state (`done` / `cancelled`) in a single POST — for example, an agent logging "I composed today's brief" as a record-of-completion task assigned to itself
> - Today the wake fires anyway, the agent runs, finds nothing to do, exits — wasted run; with a procedure that recreates such a record per heartbeat, this becomes a stable loop until the budget cap intervenes
> - This pull request adds a one-line guard to `queueIssueAssignmentWakeup` so the wake is suppressed for terminal statuses, symmetric to the existing `backlog` filter
> - The benefit is that the obvious "log a completed action as an issue" pattern stops burning runs (and stops being a footgun for procedures that loop)

## What Changed

- `server/src/services/issue-assignment-wakeup.ts`: added a guard that returns early when `input.issue.status` is `"done"` or `"cancelled"`, sitting next to the existing `backlog` guard. Four lines added (guard + comment), zero lines removed, no API/type changes.

## Verification

**Repro before fix** (on `@paperclipai/server@2026.403.0`):
1. Have an agent `POST /api/companies/:id/issues` with `assigneeAgentId` set to its own id and `status: "done"` in the same body.
2. Activity log shows `wakeReason: issue_assigned` fired on the same agent with `PAPERCLIP_TASK_ID` pointing at the brief.
3. Agent wakes, inbox is empty, exits clean. ~$0.02 wasted per wake on Sonnet.

**After fix**: same POST does not produce a wake. Verified locally by patching the running server's `dist/services/issue-assignment-wakeup.js` with the equivalent guard, restarting the server, repeating the POST, and confirming no `issue_assigned` event for that agent in the activity log.

**Typecheck**: `pnpm --filter @paperclipai/server typecheck` passes clean (no new diagnostics).

**No new tests added**: there is no existing unit test file for `issue-assignment-wakeup.ts` (or for any sibling service in `server/src/services/`) — this package has no server-side unit test infrastructure to extend. Happy to add one if the maintainers want to seed Vitest coverage here as part of this PR.

## Risks

**Low risk.** The change only adds a guard; it does not modify any existing wake-firing branch. Behavioral implications:

- **Intended**: an issue created or transitioned to `done`/`cancelled` no longer wakes its assignee. This is the intended behavior — the assignee has nothing to act on.
- **Edge case considered**: an agent that *legitimately* needed to be notified about a record-of-completion issue assigned to it would not be woken. This pattern doesn't appear to exist in the codebase — the `done` status is used as a terminal state, and agents normally listen for inbox-driven work, not completion notifications. If this is wrong I'm happy to narrow the guard further (e.g., only suppress when `input.mutation === "create"`).
- **Reopen path**: not affected. The reopen flow in `routes/issues.ts` mutates the status from `done` → `todo` *before* the wake is queued, so the guard sees `todo` and lets the wake through.

The companion observation in the linked issue — that self-assignment specifically (`assigneeAgentId === createdByAgentId`) is also a smell — was deliberately not included in this PR. Implementing it would require widening the `issue` parameter type to include `createdByAgentId` and updating both call sites. That's a bigger surface for the same loop-prevention benefit, so I left it out. Happy to follow up with a separate PR if maintainers want that defense in depth.

Linked: paperclipai/paperclip#3431

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`), provider Anthropic, ~200K context window, extended thinking enabled, accessed via the Claude Code CLI. The model read the source for `services/issue-assignment-wakeup.ts`, both call sites in `routes/issues.ts` and `services/routines.ts`, and the surrounding wake-dispatch logic before proposing the guard. Author reviewed the diff and the typecheck output before pushing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass (typecheck — no server-side unit test suite exists for this file)
- [ ] I have added or updated tests where applicable (no existing test infrastructure in `server/src/services/`; happy to add Vitest seed coverage if maintainers want)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-side only)
- [x] I have updated relevant documentation to reflect my changes (no docs reference this internal helper)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge