### PR TITLE
fix(issues): suppress comment wakes when target issue is blocked

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1746,7 +1746,13 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+        // Suppress comment wake when the issue's *post-update* status is non-actionable.
+        // `isClosed` already covers `done`/`cancelled` (via `existing.status`); we add a
+        // check on `issue.status` (the post-update value) for `blocked`, so that an
+        // unblock+comment in the same PATCH still wakes the assignee, but a comment on
+        // a still-blocked issue does not. Without this guard, the obvious operator flow
+        // ("mark blocked + leave a context note") wakes the assignee anyway.
+        const skipAssigneeCommentWake = selfComment || isClosed || issue.status === "blocked";
 
         if (assigneeId && !assigneeChanged && !skipAssigneeCommentWake) {
           addWakeup(assigneeId, {
@@ -2264,7 +2270,11 @@ export function issueRoutes(
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;
-      const skipWake = selfComment || isClosed;
+      // Suppress comment wake when the issue is non-actionable. `isClosed` already
+      // covers `done`/`cancelled`; the `blocked` check is symmetric. The `reopened`
+      // path (which handles `done`/`cancelled` → `todo` via this same endpoint) is
+      // gated separately below, so this skip does not interfere with it.
+      const skipWake = selfComment || isClosed || currentIssue.status === "blocked";
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
           wakeups.set(assigneeId, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents wake on issue events: assignment, status change, comment, mention
> - The intuitive operator workflow for pausing an in-flight task is "mark blocked + leave a context note so the agent knows why" — block first, then comment to explain
> - But the comment itself dispatches an `issue_commented` wake to the assignee, who then runs against a blocked task it can't act on, exits, and burned a run
> - The handler already accepts the principle of suppressing wakes for non-actionable states: there's a `skipWake = selfComment || isClosed` guard covering `done`/`cancelled` via `isClosed`
> - This pull request extends that guard to also cover `blocked`, in both comment-dispatching code paths
> - The benefit is that operators can pause work cleanly with a comment for context, without burning a stray Sonnet/Opus run on the assignee

## What Changed

- `server/src/routes/issues.ts` (handler 1, `PATCH /issues/:id` with comment body, around L1751): `skipAssigneeCommentWake` now also suppresses when `issue.status === "blocked"` (post-update — so an unblock+comment in the same PATCH still wakes the assignee correctly)
- `server/src/routes/issues.ts` (handler 2, `POST /issues/:id/comments`, around L2273): `skipWake` now also suppresses when `currentIssue.status === "blocked"`. The `reopened` branch is gated separately above and is unaffected.
- Two `+1` diffs total. No type changes, no API changes, no behavior change for non-blocked issues.

## Verification

**Repro before fix** (on `@paperclipai/server@2026.403.0`):
1. Pick an issue currently `in_progress` with an active assignee.
2. PATCH to `status: blocked`.
3. POST a comment ("paused by operator — do not auto-resume").
4. Activity log shows `wakeReason: issue_commented` fired on the assignee. Agent runs, exits, burns a run.

**After fix**: same sequence. No `issue_commented` wake fires for that comment. Manual repro: patched the running server's compiled `dist/routes/issues.js` with the equivalent guard, restarted, ran the sequence above, confirmed no wake event.

**Unblock+comment regression check**: PATCH `{ status: "todo", body: "back to work" }` on a previously-blocked issue. The post-update `issue.status` is `"todo"`, so `skipAssigneeCommentWake` evaluates to `false` and the wake fires correctly. (This works because handler 1 uses `issue.status` — the post-`svc.update()` value — for the new check, while still using `existing.status` for the existing `isClosed` check that gates reopen logic. The two semantics coexist cleanly.)

**Typecheck**: `pnpm --filter @paperclipai/server typecheck` passes clean.

**No new tests added**: same caveat as the sister PR — there are no existing unit tests under `server/src/routes/` or `server/src/services/`. Happy to add Vitest seed coverage if maintainers want.

## Risks

**Low risk.** The change is additive (an extra disjunct in an existing `skipWake` expression). Behavioral implications:

- **Intended**: comments on blocked issues no longer wake the assignee. Exactly the loss the linked issue is asking for.
- **Edge case considered — agent that wants to "negotiate" a block via comments**: if a workflow exists where a blocked issue gets comments back-and-forth and the assignee is supposed to wake on each one, this PR would break it. I don't see such a pattern in the existing codebase, and if the assignee is supposed to act on a comment, the human or other agent can either (a) unblock first then comment, or (b) explicitly @-mention the assignee (the mention path is a separate dispatcher, untouched by this change).
- **Edge case considered — `done`/`cancelled` issues**: already covered by `isClosed`, so this PR doesn't change anything for them. Just bringing `blocked` into the same bucket.
- **Reopen path**: untouched. The `reopened` branch in handler 2 only fires for `done`/`cancelled` → `todo` (`isClosed && reopenRequested`). Blocked issues never traverse the reopen branch, so the new check has no interaction with it. Verified by reading `reopenRequested && isClosed` at L2176.
- **`@-mention` wake on blocked issues**: out of scope for this PR. Mentions go through `addWakeup(mentionedId, ...)` further down, with no status filter. If a stakeholder explicitly @-mentions someone on a blocked issue they probably want the wake. If maintainers feel otherwise I can extend the same guard there in a follow-up.

Linked: paperclipai/paperclip#3433

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`), provider Anthropic, ~200K context window, extended thinking enabled, accessed via the Claude Code CLI. The model read both `routes/issues.ts` comment-dispatch handlers, the `isClosed` definitions in each, the reopen flow, and the `statusChangedFromBacklog` analog (which exists for backlog→active transitions but not for blocked→active — noted in passing as a potential follow-up but not addressed here). Author reviewed the diff and the typecheck output before pushing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass (typecheck — no server-side unit test suite exists for these routes)
- [ ] I have added or updated tests where applicable (no existing test infrastructure in `server/src/routes/`; happy to add Vitest seed coverage if maintainers want)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-side only)
- [x] I have updated relevant documentation to reflect my changes (no docs reference this dispatcher)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge