### PR TITLE
fix(ui): include bundle rootPath in instructionsFile query key; surface load errors

### DIFF
--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -19,8 +19,8 @@ export const queryKeys = {
     taskSessions: (id: string) => ["agents", "task-sessions", id] as const,
     skills: (id: string) => ["agents", "skills", id] as const,
     instructionsBundle: (id: string) => ["agents", "instructions-bundle", id] as const,
-    instructionsFile: (id: string, relativePath: string) =>
-      ["agents", "instructions-bundle", id, "file", relativePath] as const,
+    instructionsFile: (id: string, relativePath: string, rootPath?: string) =>
+      ["agents", "instructions-bundle", id, "file", rootPath ?? "", relativePath] as const,
     keys: (agentId: string) => ["agents", "keys", agentId] as const,
     configRevisions: (agentId: string) => ["agents", "config-revisions", agentId] as const,
     adapterModels: (companyId: string, adapterType: string) =>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1764,8 +1764,9 @@ function PromptsTab({
   const selectedFileExists = bundleMatchesDraft && fileOptions.includes(selectedOrEntryFile);
   const selectedFileSummary = bundle?.files.find((file) => file.path === selectedOrEntryFile) ?? null;
 
-  const { data: selectedFileDetail, isLoading: fileLoading } = useQuery({
-    queryKey: queryKeys.agents.instructionsFile(agent.id, selectedOrEntryFile),
+  const bundleRootPath = bundle?.rootPath ?? "";
+  const { data: selectedFileDetail, isLoading: fileLoading, error: fileError } = useQuery({
+    queryKey: queryKeys.agents.instructionsFile(agent.id, selectedOrEntryFile, bundleRootPath),
     queryFn: () => agentsApi.instructionsFile(agent.id, selectedOrEntryFile, companyId),
     enabled: Boolean(companyId && isLocal && selectedFileExists),
   });
@@ -1793,7 +1794,7 @@ function PromptsTab({
     onSuccess: (_, variables) => {
       setPendingFiles((prev) => prev.filter((f) => f !== variables.path));
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.instructionsBundle(agent.id) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.agents.instructionsFile(agent.id, variables.path) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.instructionsFile(agent.id, variables.path, bundleRootPath) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.id) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.urlKey) });
     },
@@ -1805,7 +1806,7 @@ function PromptsTab({
     onMutate: () => setAwaitingRefresh(true),
     onSuccess: (_, relativePath) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.instructionsBundle(agent.id) });
-      queryClient.removeQueries({ queryKey: queryKeys.agents.instructionsFile(agent.id, relativePath) });
+      queryClient.removeQueries({ queryKey: queryKeys.agents.instructionsFile(agent.id, relativePath, bundleRootPath) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.id) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.urlKey) });
     },
@@ -2334,6 +2335,12 @@ function PromptsTab({
 
           {selectedFileExists && fileLoading && !selectedFileDetail ? (
             <PromptEditorSkeleton />
+          ) : selectedFileExists && fileError && !selectedFileDetail ? (
+            <div className="flex min-h-[420px] items-center justify-center rounded-md border border-border">
+              <p className="text-sm text-destructive">
+                Failed to load file: {fileError instanceof Error ? fileError.message : "Unknown error"}
+              </p>
+            </div>
           ) : isMarkdown(selectedOrEntryFile) ? (
             <MarkdownEditor
               key={selectedOrEntryFile}


### PR DESCRIPTION
## Summary

Two improvements to the Instructions tab file preview:

- **Include `bundle.rootPath` in the `instructionsFile` query key** - prevents stale cached content from persisting when the instruction root path changes (e.g. after fixing a whitespace-tainted External bundle path, or after switching root paths). Previously the cache key only included agent ID and relative file path, so a path change would leave old data in the cache.

- **Surface fetch errors instead of falling back to placeholder** - when the file content fetch fails (e.g. 404 from a missing or misconfigured root), the pane now shows a descriptive error message instead of silently displaying the `# Agent instructions` placeholder.

## Test plan

- [ ] Set an agent to External bundle mode, add leading whitespace to the root path, save — confirm all files show the error message in the preview pane
- [ ] Fix the whitespace and save — confirm files now show correct content (cache was invalidated by rootPath change)
- [ ] Set managed bundle mode with valid files — confirm switching between files in the sidebar shows correct content
- [ ] Delete a file and re-add it with different content — confirm the cache is properly invalidated

Closes #3427

🤖 Generated with [Claude Code](https://claude.com/claude-code)