### PR TITLE
fix(heartbeat): queue follow-up run on approval_approved when requester is mid-run

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3947,8 +3947,12 @@ export function heartbeatService(db: Db) {
             Boolean(wakeCommentId) &&
             activeExecutionRun.status === "running" &&
             isSameExecutionAgent;
+          const shouldQueueFollowupForApproval =
+            reason === "approval_approved" &&
+            activeExecutionRun.status === "running" &&
+            isSameExecutionAgent;
 
-          if (isSameExecutionAgent && !shouldQueueFollowupForCommentWake) {
+          if (isSameExecutionAgent && !shouldQueueFollowupForCommentWake && !shouldQueueFollowupForApproval) {
             const mergedContextSnapshot = mergeCoalescedContextSnapshot(
               activeExecutionRun.contextSnapshot,
               enrichedContextSnapshot,
@@ -4126,10 +4130,16 @@ export function heartbeatService(db: Db) {
     );
     const shouldQueueFollowupForCommentWake =
       Boolean(wakeCommentId) && Boolean(sameScopeRunningRun) && !sameScopeQueuedRun;
+    // approval_approved must always produce a fresh queued run so the requester
+    // agent sees and acts on the resolution. Coalescing it into a running run
+    // means the agent never re-polls approval state mid-run and the originating
+    // issue stays blocked indefinitely after the run ends.
+    const shouldQueueFollowupForApproval =
+      reason === "approval_approved" && Boolean(sameScopeRunningRun) && !sameScopeQueuedRun;
 
     const coalescedTargetRun =
       sameScopeQueuedRun ??
-      (shouldQueueFollowupForCommentWake ? null : sameScopeRunningRun ?? null);
+      ((shouldQueueFollowupForCommentWake || shouldQueueFollowupForApproval) ? null : sameScopeRunningRun ?? null);
 
     if (coalescedTargetRun) {
       const mergedContextSnapshot = mergeCoalescedContextSnapshot(


### PR DESCRIPTION
## Summary

When an operator approves a pending approval while the requester agent is currently mid-run, `heartbeat.wakeup()` was coalescing the `approval_approved` event into the in-flight run. The agent doesn't re-poll approval state mid-run, so the wake was silently swallowed. After the run ended, no fresh wake fired and the originating issue stayed `blocked` indefinitely.

This fix applies the same "queue a follow-up run" pattern already used for comment wakes: when `reason === "approval_approved"` and there is a same-scope running run but no already-queued run, produce a fresh queued run instead of coalescing. The new queued run fires after the current run completes, delivering the approval resolution cleanly.

The fix is applied to both coalescing paths in `heartbeat.ts`:
- The generic agent-scope coalescing path (lines ~4127-4132)
- The issue-execution coalescing path (lines ~3946-3951)

## Test plan

- [ ] Agent submits an approval, marks issue `blocked`, continues working in the same run
- [ ] Operator approves while agent is mid-run
- [ ] Confirm a new `queued` heartbeat run is created (not coalesced onto the running one)
- [ ] Confirm the new run fires after the current run ends
- [ ] Confirm the agent receives the `approval_approved` wake and can act on it
- [ ] Confirm existing comment-wake follow-up behavior is unaffected

Closes #3432

🤖 Generated with [Claude Code](https://claude.com/claude-code)