### PR TITLE
fix(plugins): thread pluginDbId through registerPluginTools call chain

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1812,7 +1812,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -156,6 +156,7 @@ export interface PluginToolDispatcher {
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +430,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Summary

- `plugin-loader.ts` called `toolDispatcher.registerPluginTools(pluginKey, manifest)` without passing `pluginId` (the DB UUID)
- This caused `AgentToolDescriptor.pluginId` to be set to the npm-style plugin key (e.g. `"acme.linear"`) instead of the database row UUID
- Agents calling `executeTool` could not resolve the tool back to its DB record, resulting in 502 errors

The fix threads the `pluginId` (DB UUID) through the `registerPluginTools` interface and implementation as an optional third argument.

## Changes

- `plugin-tool-dispatcher.ts`: add optional `pluginDbId?: string` param to the `PluginToolDispatcher` interface and factory implementation; pass it through to `registry.registerPlugin`
- `plugin-loader.ts`: pass `pluginId` (DB UUID) as the third argument to `toolDispatcher.registerPluginTools`

## Test plan

- [ ] Start server with a plugin that declares tools
- [ ] Verify `AgentToolDescriptor.pluginId` is the DB UUID, not the plugin key
- [ ] Verify agent tool calls no longer 502

Closes #3394

🤖 Generated with [Claude Code](https://claude.com/claude-code)