### PR TITLE
fix(wakeup): guard against terminal-status and self-assign wakes

### DIFF
--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -20,7 +20,7 @@ export interface IssueAssignmentWakeupDeps {
 
 export function queueIssueAssignmentWakeup(input: {
   heartbeat: IssueAssignmentWakeupDeps;
-  issue: { id: string; assigneeAgentId: string | null; status: string };
+  issue: { id: string; assigneeAgentId: string | null; createdByAgentId?: string | null; status: string };
   reason: string;
   mutation: string;
   contextSource: string;
@@ -29,6 +29,16 @@ export function queueIssueAssignmentWakeup(input: {
   rethrowOnError?: boolean;
 }) {
   if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return;
+  // Never wake on already-terminal issues — there is no work for the agent.
+  if (input.issue.status === "done" || input.issue.status === "cancelled") return;
+  // On create, skip self-assignment wakes: the agent just created this issue
+  // itself, so dispatching an issue_assigned wake back to the same agent is
+  // noise at best and a loop hazard at worst.
+  if (
+    input.mutation === "create" &&
+    input.issue.createdByAgentId &&
+    input.issue.createdByAgentId === input.issue.assigneeAgentId
+  ) return;
 
   return input.heartbeat
     .wakeup(input.issue.assigneeAgentId, {


### PR DESCRIPTION
## Summary

`queueIssueAssignmentWakeup` was firing in two problematic scenarios:

1. **Terminal-status issues** (done/cancelled) - the assigned agent has nothing to do; waking it causes a spurious run that immediately finds no actionable work
2. **Agent self-assign on create** - when an agent creates an issue and assigns it to itself, the function was dispatching an `issue_assigned` wake back to the same agent, which is noise and can cause agent creation loops

## Changes

- `issue-assignment-wakeup.ts`: add `createdByAgentId?: string | null` to the issue type; add two early-return guards:
  - Skip if `status === "done" || status === "cancelled"`
  - Skip if `mutation === "create"` and `createdByAgentId === assigneeAgentId`

## Test plan

- [ ] Assign an in-progress agent to a done issue — no wake should fire
- [ ] Have an agent create and self-assign an issue — no immediate wake back to that agent
- [ ] Normal assignment (user assigns agent to an open issue) — wake fires as before

Closes #3431

🤖 Generated with [Claude Code](https://claude.com/claude-code)