### PR TITLE
fix(process-adapter): pass runtimeEnv instead of env to runChildProcess

### DIFF
--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -23,7 +23,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;
   }
-  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env }) as Record<string, string>;
   const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
   const loggedEnv = buildInvocationEnvForLogs(env, {
     runtimeEnv,
@@ -46,7 +46,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const proc = await runChildProcess(runId, command, args, {
     cwd,
-    env,
+    env: runtimeEnv,
     timeoutSec,
     graceSec,
     onLog,


### PR DESCRIPTION
## Summary

The process adapter builds `runtimeEnv = ensurePathInEnv({...process.env, ...env})` correctly, but then passes the unmerged `env` (only `PAPERCLIP_*` vars) to `runChildProcess`. Spawned processes never inherit parent-process environment variables like `ANTHROPIC_API_KEY`, `HOME`, or `PATH`.

**Impact:** When running as a LaunchDaemon or any environment where API keys are set in the parent process (the correct production pattern on macOS), spawned Claude Code processes fail with "Not logged in · Please run /login".

## Changes

- `server/src/adapters/process/execute.ts`: pass `runtimeEnv` (with type cast to `Record<string, string>`) instead of `env` to `runChildProcess`

## Test plan

- [ ] Configure process adapter with no `env` block in agent config
- [ ] Set `ANTHROPIC_API_KEY` only in parent process environment
- [ ] Verify spawned process inherits the key and auth succeeds

Closes #3430

🤖 Generated with [Claude Code](https://claude.com/claude-code)