### PR TITLE
fix(issues): suppress comment wakes on blocked issues

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1746,7 +1746,7 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+        const skipAssigneeCommentWake = selfComment || isClosed || issue.status === "blocked";
 
         if (assigneeId && !assigneeChanged && !skipAssigneeCommentWake) {
           addWakeup(assigneeId, {
@@ -2264,7 +2264,7 @@ export function issueRoutes(
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;
-      const skipWake = selfComment || isClosed;
+      const skipWake = selfComment || isClosed || currentIssue.status === "blocked";
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
           wakeups.set(assigneeId, {


### PR DESCRIPTION
## Summary

Adding a comment to a `blocked` issue dispatched an `issue_commented` wake to the assignee, defeating the intuitive operator workflow:
1. Mark issue `blocked`
2. Leave a context note for the record
3. Expect the agent to stay paused

Instead, step 2 triggered a new agent run. The agent would wake, find a blocked issue with nothing actionable, and exit — burning ~$0.02–0.05 per spurious wake.

## Root cause

`isClosed` (checked against `done | cancelled`) already suppresses comment wakes for terminal statuses. `blocked` was missing from the skip condition in both comment-handling code paths.

## Changes

`server/src/routes/issues.ts`:
- PATCH `/issues/:id` comment path: `skipAssigneeCommentWake` now also skips when `issue.status === "blocked"`
- POST `/issues/:id/comments` path: `skipWake` now also skips when `currentIssue.status === "blocked"`

The reopened-via-comment path is unaffected — blocked issues don't go through the reopen branch.

## Test plan

- [ ] Mark an issue `blocked` with an active assignee
- [ ] Add a comment — no wake should fire
- [ ] Mark an issue `todo`/`in_progress` and comment — wake fires as before
- [ ] Comment with `reopen: true` on a done issue — reopen wake still fires

Closes #3433

🤖 Generated with [Claude Code](https://claude.com/claude-code)