### PR TITLE
fix(goals-ui): add delete button, parent goal picker, nullable description

### DIFF
--- a/ui/src/components/GoalProperties.tsx
+++ b/ui/src/components/GoalProperties.tsx
@@ -70,6 +70,54 @@ function PickerButton({
   );
 }
 
+function GoalPickerButton({
+  currentId,
+  goals,
+  parentGoal,
+  onChange,
+}: {
+  currentId: string | null;
+  goals: Goal[];
+  parentGoal: Goal | null;
+  onChange: (id: string | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button className="cursor-pointer hover:opacity-80 transition-opacity text-sm">
+          {parentGoal ? (
+            <span className="hover:underline">{parentGoal.title}</span>
+          ) : (
+            <span className="text-muted-foreground">None</span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 p-1 max-h-64 overflow-y-auto" align="end">
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn("w-full justify-start text-xs", !currentId && "bg-accent")}
+          onClick={() => { onChange(null); setOpen(false); }}
+        >
+          None
+        </Button>
+        {goals.map((g) => (
+          <Button
+            key={g.id}
+            variant="ghost"
+            size="sm"
+            className={cn("w-full justify-start text-xs", g.id === currentId && "bg-accent")}
+            onClick={() => { onChange(g.id); setOpen(false); }}
+          >
+            {g.title}
+          </Button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 export function GoalProperties({ goal, onUpdate }: GoalPropertiesProps) {
   const { selectedCompanyId } = useCompany();
 
@@ -137,16 +185,25 @@ export function GoalProperties({ goal, onUpdate }: GoalPropertiesProps) {
           )}
         </PropertyRow>
 
-        {goal.parentId && (
-          <PropertyRow label="Parent Goal">
+        <PropertyRow label="Parent Goal">
+          {onUpdate ? (
+            <GoalPickerButton
+              currentId={goal.parentId ?? null}
+              goals={(allGoals ?? []).filter((g) => g.id !== goal.id)}
+              parentGoal={parentGoal ?? null}
+              onChange={(id) => onUpdate({ parentId: id })}
+            />
+          ) : goal.parentId ? (
             <Link
               to={`/goals/${goal.parentId}`}
               className="text-sm hover:underline"
             >
               {parentGoal?.title ?? goal.parentId.slice(0, 8)}
             </Link>
-          </PropertyRow>
-        )}
+          ) : (
+            <span className="text-sm text-muted-foreground">None</span>
+          )}
+        </PropertyRow>
       </div>
 
       <Separator />

--- a/ui/src/pages/GoalDetail.tsx
+++ b/ui/src/pages/GoalDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useParams } from "@/lib/router";
+import { useParams, useNavigate } from "@/lib/router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { goalsApi } from "../api/goals";
 import { projectsApi } from "../api/projects";
@@ -18,7 +18,7 @@ import { PageSkeleton } from "../components/PageSkeleton";
 import { cn, projectUrl } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Plus, SlidersHorizontal } from "lucide-react";
+import { Plus, SlidersHorizontal, Trash2 } from "lucide-react";
 import type { Goal, Project } from "@paperclipai/shared";
 
 interface GoalPropertiesToggleButtonProps {
@@ -53,6 +53,7 @@ export function GoalDetail() {
   const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const {
     data: goal,
@@ -94,6 +95,18 @@ export function GoalDetail() {
           queryKey: queryKeys.goals.list(resolvedCompanyId)
         });
       }
+    }
+  });
+
+  const deleteGoal = useMutation({
+    mutationFn: () => goalsApi.remove(goalId!),
+    onSuccess: () => {
+      if (resolvedCompanyId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.goals.list(resolvedCompanyId)
+        });
+      }
+      navigate("/goals");
     }
   });
 
@@ -147,7 +160,21 @@ export function GoalDetail() {
             {goal.level}
           </span>
           <StatusBadge status={goal.status} />
-          <div className="ml-auto">
+          <div className="ml-auto flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="text-muted-foreground hover:text-destructive"
+              title="Delete goal"
+              disabled={deleteGoal.isPending}
+              onClick={() => {
+                if (window.confirm(`Delete "${goal.title}"? This cannot be undone.`)) {
+                  deleteGoal.mutate();
+                }
+              }}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
             <GoalPropertiesToggleButton
               panelVisible={panelVisible}
               onShowProperties={() => setPanelVisible(true)}
@@ -164,11 +191,12 @@ export function GoalDetail() {
 
         <InlineEditor
           value={goal.description ?? ""}
-          onSave={(description) => updateGoal.mutate({ description })}
+          onSave={(description) => updateGoal.mutate({ description: description || null })}
           as="p"
           className="text-sm text-muted-foreground"
           placeholder="Add a description..."
           multiline
+          nullable
           imageUploadHandler={async (file) => {
             const asset = await uploadImage.mutateAsync(file);
             return asset.contentPath;


### PR DESCRIPTION
## Summary

Three fixes for the Goals UI (#3361):

### 1. Delete button
`GoalDetail` lacked any way to delete a goal. Added a trash-icon button in the header that:
- Prompts with `window.confirm` before deleting (consistent with project patterns in `ProjectProperties.tsx`)
- Calls `DELETE /goals/:id` via the existing `goalsApi.remove`
- Invalidates the goals list cache and navigates to `/goals` on success

### 2. Parent goal picker
`GoalProperties` showed the parent goal as a read-only link with no way to change it. Added a `GoalPickerButton` component (a Popover with "None" + all other goals as options) that calls `onUpdate({ parentId: ... })` when a new parent is selected.

### 3. Nullable description
The description `InlineEditor` had no `nullable` prop, so clearing a description (setting it to empty) would silently no-op (`Boolean("" && changed) === false`). Now passes `nullable` and maps empty string → null in `onSave`.

## Test plan

- [ ] Open a goal — trash icon appears in header; clicking prompts for confirmation; confirming deletes and redirects to /goals
- [ ] Open a goal with no parent — Parent Goal field shows "None" picker; selecting a goal updates it
- [ ] Open a goal with a parent — picker shows current parent; can change or clear to "None"
- [ ] Edit and clear a goal's description — change saves (description becomes null)

Closes #3361

🤖 Generated with [Claude Code](https://claude.com/claude-code)