### PR TITLE
fix(heartbeat): add cross-path dedup in enqueueWakeup non-issue path

### DIFF
--- a/server/src/__tests__/heartbeat-dedup-window.test.ts
+++ b/server/src/__tests__/heartbeat-dedup-window.test.ts
@@ -219,15 +219,17 @@ describeEmbeddedPostgres("enqueueWakeup cross-path dedup", () => {
     expect(timerRun!.id).not.toBe(assignmentRun!.id);
   }, 15_000);
 
-  it("cross-path dedup catches a queued run outside the 5s window", async () => {
+  it("cross-path dedup catches a queued run invisible to sameScopeQueuedRun", async () => {
     const { companyId, agentId, issueId } = await seedAgentWithBlockedQueue();
     const heartbeat = heartbeatService(db);
 
-    // Directly insert a queued run with createdAt older than 5 seconds
-    // to simulate a run that the 5s dedup window would miss
+    // Simulate the TOCTOU race: the issue-execution path committed a run
+    // that the activeRuns query missed. We give it an explicit taskKey that
+    // differs from issueId so sameScopeQueuedRun (which compares taskKey)
+    // won't match it, but the cross-path dedup (which checks
+    // contextSnapshot->>'issueId') will.
     const oldRunId = randomUUID();
     const oldWakeupId = randomUUID();
-    const sixSecondsAgo = new Date(Date.now() - 6_000);
     await db.insert(agentWakeupRequests).values({
       id: oldWakeupId,
       companyId,
@@ -247,12 +249,12 @@ describeEmbeddedPostgres("enqueueWakeup cross-path dedup", () => {
       triggerDetail: "system",
       status: "queued",
       wakeupRequestId: oldWakeupId,
-      contextSnapshot: { issueId },
-      createdAt: sixSecondsAgo,
+      contextSnapshot: { issueId, taskKey: `issue-exec-${issueId}` },
     });
 
-    // Mention-wake should coalesce via the cross-path dedup check
-    // (not the 5s window, since the run is older than 5s)
+    // Mention-wake has taskKey = issueId (no explicit taskKey in context).
+    // sameScopeQueuedRun won't match (taskKey mismatch), so the cross-path
+    // dedup is the only guard that prevents a duplicate run.
     const mentionRun = await heartbeat.wakeup(agentId, {
       source: "on_demand",
       triggerDetail: "mention",

--- a/server/src/__tests__/heartbeat-dedup-window.test.ts
+++ b/server/src/__tests__/heartbeat-dedup-window.test.ts
@@ -1,0 +1,266 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  agentRuntimeState,
+  agentTaskSessions,
+  agentWakeupRequests,
+  companies,
+  companySkills,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issues,
+  createDb,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
+const mockTrackAgentFirstHeartbeat = vi.hoisted(() => vi.fn());
+const mockPublishLiveEvent = vi.hoisted(() => vi.fn());
+
+vi.mock("../telemetry.ts", () => ({
+  getTelemetryClient: () => mockTelemetryClient,
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: mockTrackAgentFirstHeartbeat,
+  };
+});
+
+vi.mock("../services/live-events.ts", async () => {
+  const actual = await vi.importActual<typeof import("../services/live-events.ts")>(
+    "../services/live-events.ts",
+  );
+  return {
+    ...actual,
+    publishLiveEvent: mockPublishLiveEvent,
+  };
+});
+
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres dedup-window tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("enqueueWakeup cross-path dedup", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-dedup-window-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await new Promise((r) => setTimeout(r, 200));
+    await db.delete(issues);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentTaskSessions);
+    await db.delete(agentRuntimeState);
+    await db.delete(companySkills);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedAgentWithBlockedQueue() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "TestCo",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { enabled: true, maxConcurrentRuns: 1, wakeOnDemand: true } },
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Test issue",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    // Insert a running run to block the queue (maxConcurrentRuns=1)
+    const blockingRunId = randomUUID();
+    const blockingWakeupId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: blockingWakeupId,
+      companyId,
+      agentId,
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "blocking_run",
+      payload: {},
+      status: "queued",
+      runId: blockingRunId,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: blockingRunId,
+      companyId,
+      agentId,
+      invocationSource: "on_demand",
+      triggerDetail: "manual",
+      status: "running",
+      wakeupRequestId: blockingWakeupId,
+      contextSnapshot: {},
+    });
+
+    return { companyId, agentId, issueId, blockingRunId };
+  }
+
+  it("two issue-execution wakes for same agent+issue produce 1 run (regression guard)", async () => {
+    const { agentId, issueId } = await seedAgentWithBlockedQueue();
+    const heartbeat = heartbeatService(db);
+
+    // First assignment wake — goes through issue execution lock path
+    const run1 = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      contextSnapshot: { issueId },
+      payload: { issueId },
+    });
+    expect(run1).toBeTruthy();
+    expect(run1!.status).toBe("queued");
+
+    // Second assignment wake — same agent+issue, goes through same lock path
+    // Should coalesce into the existing queued run
+    const run2 = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "automation",
+      reason: "issue_assigned",
+      contextSnapshot: { issueId },
+      payload: { issueId },
+    });
+    expect(run2).toBeTruthy();
+    expect(run2!.id).toBe(run1!.id);
+
+    // Verify only one queued run exists
+    const queuedRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.status, "queued"),
+        ),
+      );
+    expect(queuedRuns).toHaveLength(1);
+  }, 15_000);
+
+  it("timer wake + issue-execution wake produce separate runs (expected)", async () => {
+    const { agentId, issueId, blockingRunId } = await seedAgentWithBlockedQueue();
+    const heartbeat = heartbeatService(db);
+
+    // Timer wake — no issueId, goes through non-issue path.
+    // Coalesces into the blocking run (same null taskKey scope), returns running.
+    const timerRun = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "heartbeat_timer",
+      reason: "heartbeat_timer",
+      contextSnapshot: {},
+      payload: {},
+    });
+    expect(timerRun).toBeTruthy();
+    expect(timerRun!.id).toBe(blockingRunId);
+
+    // Assignment wake — has issueId, goes through issue execution lock path
+    const assignmentRun = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      contextSnapshot: { issueId },
+      payload: { issueId },
+    });
+    expect(assignmentRun).toBeTruthy();
+
+    // Timer and assignment runs are separate — timer has no issueId,
+    // so cross-path dedup correctly does not merge them
+    expect(timerRun!.id).not.toBe(assignmentRun!.id);
+  }, 15_000);
+
+  it("cross-path dedup catches a queued run outside the 5s window", async () => {
+    const { companyId, agentId, issueId } = await seedAgentWithBlockedQueue();
+    const heartbeat = heartbeatService(db);
+
+    // Directly insert a queued run with createdAt older than 5 seconds
+    // to simulate a run that the 5s dedup window would miss
+    const oldRunId = randomUUID();
+    const oldWakeupId = randomUUID();
+    const sixSecondsAgo = new Date(Date.now() - 6_000);
+    await db.insert(agentWakeupRequests).values({
+      id: oldWakeupId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      status: "queued",
+      runId: oldRunId,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: oldRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      wakeupRequestId: oldWakeupId,
+      contextSnapshot: { issueId },
+      createdAt: sixSecondsAgo,
+    });
+
+    // Mention-wake should coalesce via the cross-path dedup check
+    // (not the 5s window, since the run is older than 5s)
+    const mentionRun = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "mention",
+      reason: "issue_comment_mentioned",
+      contextSnapshot: { issueId, wakeCommentId: randomUUID() },
+      payload: { issueId },
+    });
+
+    expect(mentionRun!.id).toBe(oldRunId);
+  }, 15_000);
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4166,10 +4166,9 @@ export function heartbeatService(db: Db) {
 
     // Cross-path dedup: when a comment-mention bypass wake has an issueId,
     // check for any queued/running run that was created via the issue execution
-    // path. The sameScopeQueuedRun check above uses a cached activeRuns list
-    // and may miss runs committed by a concurrent FOR UPDATE transaction.
-    // The 5s dedup window has a time constraint that may not cover all cases.
-    // This final check queries fresh with no time restriction.
+    // path. Due to a TOCTOU race, the activeRuns query above may execute before
+    // a concurrent FOR UPDATE transaction commits its new run. This fresh query
+    // runs later and can catch runs that were invisible to the earlier read.
     if (issueId) {
       const crossPathRun = await db
         .select()

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4164,6 +4164,69 @@ export function heartbeatService(db: Db) {
       return mergedRun;
     }
 
+    // Cross-path dedup: when a comment-mention bypass wake has an issueId,
+    // check for any queued/running run that was created via the issue execution
+    // path. The sameScopeQueuedRun check above uses a cached activeRuns list
+    // and may miss runs committed by a concurrent FOR UPDATE transaction.
+    // The 5s dedup window has a time constraint that may not cover all cases.
+    // This final check queries fresh with no time restriction.
+    if (issueId) {
+      const crossPathRun = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.agentId, agentId),
+            inArray(heartbeatRuns.status, ["queued", "running"]),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+          ),
+        )
+        .orderBy(
+          sql`case when ${heartbeatRuns.status} = 'queued' then 0 else 1 end`,
+          asc(heartbeatRuns.createdAt),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+
+      if (crossPathRun) {
+        const skipForCommentFollowup =
+          crossPathRun.status === "running" && Boolean(wakeCommentId);
+
+        if (!skipForCommentFollowup) {
+          const mergedContextSnapshot = mergeCoalescedContextSnapshot(
+            crossPathRun.contextSnapshot,
+            contextSnapshot,
+          );
+          const mergedRun = await db
+            .update(heartbeatRuns)
+            .set({
+              contextSnapshot: mergedContextSnapshot,
+              updatedAt: new Date(),
+            })
+            .where(eq(heartbeatRuns.id, crossPathRun.id))
+            .returning()
+            .then((rows) => rows[0] ?? crossPathRun);
+
+          await db.insert(agentWakeupRequests).values({
+            companyId: agent.companyId,
+            agentId,
+            source,
+            triggerDetail,
+            reason,
+            payload,
+            status: "coalesced",
+            coalescedCount: 1,
+            requestedByActorType: opts.requestedByActorType ?? null,
+            requestedByActorId: opts.requestedByActorId ?? null,
+            idempotencyKey: opts.idempotencyKey ?? null,
+            runId: mergedRun.id,
+            finishedAt: new Date(),
+          });
+          return mergedRun;
+        }
+      }
+    }
+
     const wakeupRequest = await db
       .insert(agentWakeupRequests)
       .values({


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The heartbeat service manages agent wake-ups and run creation
> - When multiple wake paths (issue execution lock vs. non-issue/mention bypass) fire concurrently for the same agent+issue, they can each create a separate run
> - The existing `sameScopeQueuedRun` check uses a cached `activeRuns` list that can miss runs committed by a concurrent `FOR UPDATE` transaction, and the 5s dedup window has a time constraint
> - This pull request adds a final cross-path dedup check that queries fresh by issueId with no time restriction
> - The benefit is eliminating duplicate runs that waste agent budget and cause conflicting concurrent sessions on the same issue

## Related

- **Issue:** #2489 — "No idempotency key enforcement in enqueueWakeup" describes that `idempotencyKey` is accepted but never used for dedup.
- **PR:** #2550 — "fix: enforce idempotency key in enqueueWakeup to prevent duplicate runs" addresses #2489 via caller-provided idempotency keys.

**This PR is complementary to #2550, not overlapping.** The two address different failure modes:

| | This PR (cross-path dedup) | #2550 (idempotency key) |
|---|---|---|
| **Mechanism** | Server-side query on agent+issue at each wake | Caller-provided key, server deduplicates on key |
| **Failure mode** | Two wake paths (issue execution lock vs. non-issue bypass) fire concurrently for same agent+issue | Same caller sends the same request twice |
| **Requires caller cooperation** | No — safety net | Yes — caller must provide key |
| **Scope** | Non-issue execution path with `issueId` only | All `enqueueWakeup` calls with key |

#2550 prevents duplicate runs when callers provide a key. This PR catches the case where two different code paths concurrently create a run for the same agent+issue — without requiring callers to do anything.

## What Changed

- Added a cross-path dedup check in `enqueueWakeup()` (non-issue execution path) that queries `heartbeat_runs` by `contextSnapshot->>'issueId'` for any queued/running run matching the same agent+issue
- When a matching run is found, the new wake is coalesced into it (context merged, wakeup request recorded as `coalesced`)
- Comment-wake follow-up behavior is preserved: if the existing run is `running` and the new wake has a `wakeCommentId`, a new queued run is still created so the comment is not missed
- Added 3 integration tests using embedded Postgres:
  - Two issue-execution wakes for same agent+issue → 1 run (regression guard)
  - Timer + issue-execution wake → separate runs (expected, no false dedup)
  - Cross-path dedup catches a queued run outside the 5s window

## Verification

```bash
cd server
npx vitest run src/__tests__/heartbeat-dedup-window.test.ts
# All 3 tests pass

# Regression check — existing heartbeat tests:
npx vitest run src/__tests__/heartbeat-comment-wake-batching.test.ts \
  src/__tests__/heartbeat-process-recovery.test.ts \
  src/__tests__/heartbeat-workspace-session.test.ts \
  src/__tests__/heartbeat-list.test.ts \
  src/__tests__/heartbeat-run-summary.test.ts \
  src/__tests__/heartbeat-project-env.test.ts
# All 55 tests pass
```

## Risks

- The cross-path dedup query adds one extra DB read per `enqueueWakeup` call when `issueId` is present. The query is lightweight (indexed on `agentId`, filtered to `queued`/`running` status, `LIMIT 1`) and only fires in the non-issue-execution path, so the performance impact is negligible.
- No migration changes — purely additive application logic.

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`) via Claude Code CLI with tool use. Extended context, no explicit reasoning mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Co-Authored-By: Paperclip <noreply@paperclip.ing>