### PR TITLE
feat: add kimi_local adapter for Kimi CLI support

### DIFF
--- a/packages/adapters/kimi-local/package.json
+++ b/packages/adapters/kimi-local/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@paperclipai/adapter-kimi-local",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/kimi-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist",
+    "skills"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/kimi-local/src/cli/index.ts
+++ b/packages/adapters/kimi-local/src/cli/index.ts
@@ -1,0 +1,2 @@
+// CLI utilities for kimi-local adapter
+export {};

--- a/packages/adapters/kimi-local/src/index.ts
+++ b/packages/adapters/kimi-local/src/index.ts
@@ -1,0 +1,42 @@
+export const type = "kimi_local";
+export const label = "Kimi (local)";
+
+export const models = [
+  { id: "kimi-for-coding", label: "Kimi for Coding" },
+];
+
+export const agentConfigurationDoc = `# kimi_local agent configuration
+
+Adapter: kimi_local
+
+Use when:
+- You want Paperclip to run Kimi CLI (the AI coding agent by Moonshot AI) locally as the agent runtime
+- You want to leverage Kimi's code understanding and generation capabilities
+- You want session resume across heartbeats via --session
+- You need Kimi's tool set (read, bash, edit, write, grep, find, ls)
+
+Don't use when:
+- You need webhook-style external invocation (use openclaw_gateway or http)
+- You only need one-shot shell commands (use process)
+- Kimi CLI is not installed on the machine
+
+Core fields:
+- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file injected at runtime
+- model (string, optional): Kimi model id (defaults to "kimi-for-coding")
+- thinking (boolean, optional): enable thinking mode (defaults to true)
+- command (string, optional): defaults to "kimi"
+- extraArgs (string[], optional): additional CLI args
+- env (object, optional): KEY=VALUE environment variables
+- maxStepsPerTurn (number, optional): max steps per turn (default: from config)
+- workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
+- workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+
+Notes:
+- When Paperclip realizes a workspace/runtime for a run, it injects PAPERCLIP_WORKSPACE_* and PAPERCLIP_RUNTIME_* env vars for agent-side tooling.
+- Kimi CLI uses OAuth for authentication. Run \`kimi login\` to authenticate.
+`;

--- a/packages/adapters/kimi-local/src/server/execute.ts
+++ b/packages/adapters/kimi-local/src/server/execute.ts
@@ -1,0 +1,580 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
+import {
+  asString,
+  asNumber,
+  asBoolean,
+  asStringArray,
+  parseObject,
+  buildPaperclipEnv,
+  readPaperclipRuntimeSkillEntries,
+  joinPromptSections,
+  buildInvocationEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  resolveCommandForLogs,
+  renderTemplate,
+  renderPaperclipWakePrompt,
+  stringifyPaperclipWakePayload,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  parseKimiStreamJson,
+  detectKimiLoginRequired,
+  describeKimiFailure,
+  isKimiMaxTurnsResult,
+  isKimiUnknownSessionError,
+  extractKimiSessionId,
+} from "./parse.js";
+import { resolveKimiDesiredSkillNames } from "./skills.js";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+interface KimiExecutionInput {
+  runId: string;
+  agent: AdapterExecutionContext["agent"];
+  config: Record<string, unknown>;
+  context: Record<string, unknown>;
+  authToken?: string;
+}
+
+interface KimiRuntimeConfig {
+  command: string;
+  resolvedCommand: string;
+  cwd: string;
+  workspaceId: string | null;
+  workspaceRepoUrl: string | null;
+  workspaceRepoRef: string | null;
+  env: Record<string, string>;
+  loggedEnv: Record<string, string>;
+  timeoutSec: number;
+  graceSec: number;
+  extraArgs: string[];
+}
+
+function buildLoginResult(input: {
+  proc: RunProcessResult;
+  loginUrl: string | null;
+}) {
+  return {
+    exitCode: input.proc.exitCode,
+    signal: input.proc.signal,
+    timedOut: input.proc.timedOut,
+    stdout: input.proc.stdout,
+    stderr: input.proc.stderr,
+    loginUrl: input.loginUrl,
+  };
+}
+
+async function buildKimiRuntimeConfig(input: KimiExecutionInput): Promise<KimiRuntimeConfig> {
+  const { runId, agent, config, context, authToken } = input;
+
+  const command = asString(config.command, "kimi");
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceStrategy = asString(workspaceContext.strategy, "");
+  const workspaceId = asString(workspaceContext.workspaceId, "") || null;
+  const workspaceRepoUrl = asString(workspaceContext.repoUrl, "") || null;
+  const workspaceRepoRef = asString(workspaceContext.repoRef, "") || null;
+  const workspaceBranch = asString(workspaceContext.branchName, "") || null;
+  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "") || null;
+  const agentHome = asString(workspaceContext.agentHome, "") || null;
+  const workspaceHints = Array.isArray(context.paperclipWorkspaces)
+    ? context.paperclipWorkspaces.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimeServiceIntents = Array.isArray(context.paperclipRuntimeServiceIntents)
+    ? context.paperclipRuntimeServiceIntents.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimeServices = Array.isArray(context.paperclipRuntimeServices)
+    ? context.paperclipRuntimeServices.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  const envConfig = parseObject(config.env);
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
+
+  if (wakeTaskId) {
+    env.PAPERCLIP_TASK_ID = wakeTaskId;
+  }
+  if (wakeReason) {
+    env.PAPERCLIP_WAKE_REASON = wakeReason;
+  }
+  if (wakeCommentId) {
+    env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  }
+  if (approvalId) {
+    env.PAPERCLIP_APPROVAL_ID = approvalId;
+  }
+  if (approvalStatus) {
+    env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  }
+  if (linkedIssueIds.length > 0) {
+    env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  }
+  if (wakePayloadJson) {
+    env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
+  }
+  if (effectiveWorkspaceCwd) {
+    env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  }
+  if (workspaceSource) {
+    env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  }
+  if (workspaceStrategy) {
+    env.PAPERCLIP_WORKSPACE_STRATEGY = workspaceStrategy;
+  }
+  if (workspaceId) {
+    env.PAPERCLIP_WORKSPACE_ID = workspaceId;
+  }
+  if (workspaceRepoUrl) {
+    env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
+  }
+  if (workspaceRepoRef) {
+    env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  }
+  if (workspaceBranch) {
+    env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
+  }
+  if (workspaceWorktreePath) {
+    env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
+  }
+  if (agentHome) {
+    env.AGENT_HOME = agentHome;
+  }
+  if (workspaceHints.length > 0) {
+    env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+  }
+  if (runtimeServiceIntents.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(runtimeServiceIntents);
+  }
+  if (runtimeServices.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICES_JSON = JSON.stringify(runtimeServices);
+  }
+  if (runtimePrimaryUrl) {
+    env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
+  }
+
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  await ensureCommandResolvable(command, cwd, runtimeEnv);
+  const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
+  const loggedEnv = buildInvocationEnvForLogs(env, {
+    runtimeEnv,
+    includeRuntimeKeys: ["HOME"],
+    resolvedCommand,
+  });
+
+  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const graceSec = asNumber(config.graceSec, 20);
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+
+  return {
+    command,
+    resolvedCommand,
+    cwd,
+    workspaceId,
+    workspaceRepoUrl,
+    workspaceRepoRef,
+    env,
+    loggedEnv,
+    timeoutSec,
+    graceSec,
+    extraArgs,
+  };
+}
+
+export async function runKimiLogin(input: {
+  runId: string;
+  agent: AdapterExecutionContext["agent"];
+  config: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  authToken?: string;
+  onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+}) {
+  const onLog = input.onLog ?? (async () => {});
+  const runtime = await buildKimiRuntimeConfig({
+    runId: input.runId,
+    agent: input.agent,
+    config: input.config,
+    context: input.context ?? {},
+    authToken: input.authToken,
+  });
+
+  const proc = await runChildProcess(input.runId, runtime.command, ["login"], {
+    cwd: runtime.cwd,
+    env: runtime.env,
+    timeoutSec: runtime.timeoutSec,
+    graceSec: runtime.graceSec,
+    onLog,
+  });
+
+  const loginMeta = detectKimiLoginRequired({
+    parsed: null,
+    stdout: proc.stdout,
+    stderr: proc.stderr,
+  });
+
+  return buildLoginResult({
+    proc,
+    loginUrl: loginMeta.loginUrl,
+  });
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
+  );
+  const model = asString(config.model, "");
+  const thinking = asBoolean(config.thinking, true);
+  const maxStepsPerTurn = asNumber(config.maxStepsPerTurn, 0);
+
+  const runtimeConfig = await buildKimiRuntimeConfig({
+    runId,
+    agent,
+    config,
+    context,
+    authToken,
+  });
+  const {
+    command,
+    resolvedCommand,
+    cwd,
+    workspaceId,
+    workspaceRepoUrl,
+    workspaceRepoRef,
+    env,
+    loggedEnv,
+    timeoutSec,
+    graceSec,
+    extraArgs,
+  } = runtimeConfig;
+
+  const kimiSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredSkillNames = new Set(resolveKimiDesiredSkillNames(config, kimiSkillEntries));
+
+  // Handle instructions file
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  let combinedInstructionsContents: string | null = null;
+  if (instructionsFilePath) {
+    try {
+      const fs = await import("node:fs/promises");
+      const instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
+      const pathDirective =
+        `\nThe above agent instructions were loaded from ${instructionsFilePath}. ` +
+        `Resolve any relative file references from ${instructionsFileDir}. ` +
+        `This base directory is authoritative for sibling instruction files such as ` +
+        `./HEARTBEAT.md, ./SOUL.md, and ./TOOLS.md; do not resolve those from the parent agent directory.`;
+      combinedInstructionsContents = instructionsContent + pathDirective;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stderr",
+        `[paperclip] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`,
+      );
+    }
+  }
+
+  // Handle session
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const canResumeSession =
+    runtimeSessionId.length > 0 &&
+    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
+
+  const sessionId = canResumeSession ? runtimeSessionId : null;
+  if (
+    runtimeSessionId &&
+    runtimeSessionCwd.length > 0 &&
+    path.resolve(runtimeSessionCwd) !== path.resolve(cwd)
+  ) {
+    await onLog(
+      "stdout",
+      `[paperclip] Kimi session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+
+  const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const renderedBootstrapPrompt =
+    !sessionId && bootstrapPromptTemplate.trim().length > 0
+      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      : "";
+  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: Boolean(sessionId) });
+  const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
+  const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+
+  // Build system prompt with instructions
+  let systemPrompt = renderedBootstrapPrompt;
+  if (combinedInstructionsContents) {
+    systemPrompt = combinedInstructionsContents + (systemPrompt ? "\n\n" + systemPrompt : "");
+  }
+
+  const prompt = joinPromptSections([wakePrompt, sessionHandoffNote, renderedPrompt]);
+  const promptMetrics = {
+    promptChars: prompt.length,
+    bootstrapPromptChars: renderedBootstrapPrompt.length,
+    wakePromptChars: wakePrompt.length,
+    sessionHandoffChars: sessionHandoffNote.length,
+    heartbeatPromptChars: renderedPrompt.length,
+  };
+
+  const buildKimiArgs = (resumeSessionId: string | null): string[] => {
+    const args = ["--print", "--yolo"];
+
+    if (model) args.push("--model", model);
+    if (thinking) args.push("--thinking");
+    else args.push("--no-thinking");
+    if (maxStepsPerTurn > 0) args.push("--max-steps-per-turn", String(maxStepsPerTurn));
+
+    args.push("--output-format", "stream-json");
+
+    if (resumeSessionId) {
+      args.push("--resume", resumeSessionId);
+    }
+
+    // Add skills directories
+    for (const entry of kimiSkillEntries) {
+      if (desiredSkillNames.has(entry.key)) {
+        args.push("--skills-dir", entry.source);
+      }
+    }
+
+    if (extraArgs.length > 0) args.push(...extraArgs);
+
+    return args;
+  };
+
+  const parseFallbackErrorMessage = (proc: RunProcessResult) => {
+    const stderrLine =
+      proc.stderr
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find(Boolean) ?? "";
+
+    if ((proc.exitCode ?? 0) === 0) {
+      return "Failed to parse Kimi JSON output";
+    }
+
+    return stderrLine
+      ? `Kimi exited with code ${proc.exitCode ?? -1}: ${stderrLine}`
+      : `Kimi exited with code ${proc.exitCode ?? -1}`;
+  };
+
+  const runAttempt = async (resumeSessionId: string | null) => {
+    const args = buildKimiArgs(resumeSessionId);
+    const commandNotes: string[] = [];
+    if (instructionsFilePath && combinedInstructionsContents) {
+      commandNotes.push(
+        `Loaded agent instructions from ${instructionsFilePath}`,
+        `Instructions will be prepended to the prompt.`,
+      );
+    }
+    if (onMeta) {
+      await onMeta({
+        adapterType: "kimi_local",
+        command: resolvedCommand,
+        cwd,
+        commandArgs: args,
+        commandNotes,
+        env: loggedEnv,
+        prompt,
+        promptMetrics,
+        context,
+      });
+    }
+
+    const proc = await runChildProcess(runId, command, args, {
+      cwd,
+      env,
+      stdin: prompt,
+      timeoutSec,
+      graceSec,
+      onSpawn,
+      onLog,
+    });
+
+    const parsedStream = parseKimiStreamJson(proc.stdout);
+    const extractedSessionId = extractKimiSessionId(proc.stdout) ?? parsedStream.sessionId;
+
+    return { proc, parsedStream, extractedSessionId };
+  };
+
+  const toAdapterResult = (
+    attempt: {
+      proc: RunProcessResult;
+      parsedStream: ReturnType<typeof parseKimiStreamJson>;
+      extractedSessionId: string | null;
+    },
+    opts: { fallbackSessionId: string | null; clearSessionOnMissingSession?: boolean },
+  ): AdapterExecutionResult => {
+    const { proc, parsedStream, extractedSessionId } = attempt;
+    const loginMeta = detectKimiLoginRequired({
+      parsed: parsedStream.resultJson,
+      stdout: proc.stdout,
+      stderr: proc.stderr,
+    });
+    const errorMeta =
+      loginMeta.loginUrl != null
+        ? {
+            loginUrl: loginMeta.loginUrl,
+          }
+        : undefined;
+
+    if (proc.timedOut) {
+      return {
+        exitCode: proc.exitCode,
+        signal: proc.signal,
+        timedOut: true,
+        errorMessage: `Timed out after ${timeoutSec}s`,
+        errorCode: "timeout",
+        errorMeta,
+        clearSession: Boolean(opts.clearSessionOnMissingSession),
+      };
+    }
+
+    if (!parsedStream.resultJson && (proc.exitCode ?? 0) !== 0) {
+      return {
+        exitCode: proc.exitCode,
+        signal: proc.signal,
+        timedOut: false,
+        errorMessage: parseFallbackErrorMessage(proc),
+        errorCode: loginMeta.requiresLogin ? "kimi_auth_required" : null,
+        errorMeta,
+        resultJson: {
+          stdout: proc.stdout,
+          stderr: proc.stderr,
+        },
+        clearSession: Boolean(opts.clearSessionOnMissingSession),
+      };
+    }
+
+    const resolvedSessionId = extractedSessionId ?? opts.fallbackSessionId;
+    const resolvedSessionParams = resolvedSessionId
+      ? ({
+          sessionId: resolvedSessionId,
+          cwd,
+          ...(workspaceId ? { workspaceId } : {}),
+          ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+          ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+        } as Record<string, unknown>)
+      : null;
+
+    const clearSessionForMaxTurns = isKimiMaxTurnsResult(parsedStream.resultJson);
+
+    return {
+      exitCode: proc.exitCode,
+      signal: proc.signal,
+      timedOut: false,
+      errorMessage:
+        (proc.exitCode ?? 0) === 0
+          ? null
+          : describeKimiFailure(parsedStream.resultJson ?? {}) ?? `Kimi exited with code ${proc.exitCode ?? -1}`,
+      errorCode: loginMeta.requiresLogin ? "kimi_auth_required" : null,
+      errorMeta,
+      usage: parsedStream.usage ?? {
+        inputTokens: 0,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+      sessionId: resolvedSessionId,
+      sessionParams: resolvedSessionParams,
+      sessionDisplayId: resolvedSessionId,
+      provider: "moonshot",
+      biller: "moonshot",
+      model: parsedStream.model || model,
+      billingType: "unknown",
+      costUsd: parsedStream.costUsd,
+      resultJson: parsedStream.resultJson ?? {
+        stdout: proc.stdout,
+        stderr: proc.stderr,
+      },
+      summary: parsedStream.summary,
+      clearSession: clearSessionForMaxTurns || Boolean(opts.clearSessionOnMissingSession),
+    };
+  };
+
+  const initial = await runAttempt(sessionId ?? null);
+  if (
+    sessionId &&
+    !initial.proc.timedOut &&
+    (initial.proc.exitCode ?? 0) !== 0 &&
+    isKimiUnknownSessionError(initial.proc.stdout, initial.proc.stderr)
+  ) {
+    await onLog(
+      "stdout",
+      `[paperclip] Kimi resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+    );
+    const retry = await runAttempt(null);
+    return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+  }
+
+  return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+}

--- a/packages/adapters/kimi-local/src/server/index.ts
+++ b/packages/adapters/kimi-local/src/server/index.ts
@@ -1,0 +1,71 @@
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId = readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(record.cwd) ??
+      readNonEmptyString(record.workdir) ??
+      readNonEmptyString(record.folder);
+    const promptBundleKey =
+      readNonEmptyString(record.promptBundleKey) ??
+      readNonEmptyString(record.prompt_bundle_key);
+    const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+    const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(promptBundleKey ? { promptBundleKey } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(params.cwd) ??
+      readNonEmptyString(params.workdir) ??
+      readNonEmptyString(params.folder);
+    const promptBundleKey =
+      readNonEmptyString(params.promptBundleKey) ??
+      readNonEmptyString(params.prompt_bundle_key);
+    const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
+    const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
+    const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(promptBundleKey ? { promptBundleKey } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+  },
+};
+
+export { execute, runKimiLogin } from "./execute.js";
+export { listKimiSkills, syncKimiSkills } from "./skills.js";
+export { testEnvironment } from "./test.js";
+export {
+  parseKimiStreamJson,
+  describeKimiFailure,
+  isKimiMaxTurnsResult,
+  isKimiUnknownSessionError,
+  extractKimiSessionId,
+  detectKimiLoginRequired,
+} from "./parse.js";

--- a/packages/adapters/kimi-local/src/server/parse.ts
+++ b/packages/adapters/kimi-local/src/server/parse.ts
@@ -1,0 +1,166 @@
+import type { UsageSummary } from "@paperclipai/adapter-utils";
+import { asString, asNumber, parseObject, parseJson } from "@paperclipai/adapter-utils/server-utils";
+
+const KIMI_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?kimi\s+login`?|login\s+required|requires\+login|unauthorized|authentication\s+required)/i;
+
+interface KimiContentBlock {
+  type: string;
+  text?: string;
+  think?: string;
+  encrypted?: unknown;
+}
+
+interface KimiMessage {
+  role: string;
+  content: KimiContentBlock[];
+}
+
+/**
+ * Parse Kimi's stream-json output format.
+ * Kimi outputs JSON lines with different message types.
+ */
+export function parseKimiStreamJson(stdout: string): {
+  sessionId: string | null;
+  model: string;
+  costUsd: number | null;
+  usage: UsageSummary | null;
+  summary: string;
+  resultJson: Record<string, unknown> | null;
+  messages: KimiMessage[];
+} {
+  const messages: KimiMessage[] = [];
+  let sessionId: string | null = null;
+  let model = "";
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const event = parseJson(line);
+    if (!event) continue;
+
+    // Parse assistant messages
+    const role = asString(event.role, "");
+    if (role === "assistant") {
+      const content = Array.isArray(event.content) ? event.content : [];
+      messages.push({ role: "assistant", content });
+      continue;
+    }
+
+    // Parse system messages for session info
+    const type = asString(event.type, "");
+    if (type === "system" || type === "init") {
+      const sid = asString(event.session_id, "");
+      if (sid) sessionId = sid;
+      const m = asString(event.model, "");
+      if (m) model = m;
+    }
+  }
+
+  // Extract text content from messages for summary
+  const texts: string[] = [];
+  for (const msg of messages) {
+    for (const block of msg.content) {
+      if (block.type === "text" && block.text) {
+        texts.push(block.text);
+      }
+    }
+  }
+
+  // Kimi doesn't currently provide usage in stream output
+  const usage: UsageSummary = {
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+  };
+
+  return {
+    sessionId,
+    model,
+    costUsd: null,
+    usage,
+    summary: texts.join("\n\n").trim(),
+    resultJson: messages.length > 0 ? { messages } : null,
+    messages,
+  };
+}
+
+function extractKimiErrorMessages(parsed: Record<string, unknown>): string[] {
+  const messages: string[] = [];
+
+  // Check for error field
+  const error = asString(parsed.error, "");
+  if (error) messages.push(error);
+
+  // Check for errors array
+  const errors = Array.isArray(parsed.errors) ? parsed.errors : [];
+  for (const entry of errors) {
+    if (typeof entry === "string") {
+      const msg = entry.trim();
+      if (msg) messages.push(msg);
+    } else if (typeof entry === "object" && entry !== null) {
+      const obj = entry as Record<string, unknown>;
+      const msg = asString(obj.message, "") || asString(obj.error, "") || asString(obj.code, "");
+      if (msg) messages.push(msg);
+    }
+  }
+
+  return messages;
+}
+
+export function extractKimiSessionId(stdout: string): string | null {
+  // Look for "To resume this session: kimi -r <session-id>"
+  const match = stdout.match(/kimi\s+(?:-r|--resume)\s+([a-f0-9-]+)/i);
+  if (match) return match[1];
+
+  // Also try to find UUID pattern in output
+  const uuidMatch = stdout.match(/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i);
+  return uuidMatch ? uuidMatch[1] : null;
+}
+
+export function detectKimiLoginRequired(input: {
+  parsed: Record<string, unknown> | null;
+  stdout: string;
+  stderr: string;
+}): { requiresLogin: boolean; loginUrl: string | null } {
+  const resultText = asString(input.parsed?.result, "").trim();
+  const messages = [resultText, ...extractKimiErrorMessages(input.parsed ?? {}), input.stdout, input.stderr]
+    .join("\n")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const requiresLogin = messages.some((line) => KIMI_AUTH_REQUIRED_RE.test(line));
+
+  // Kimi OAuth doesn't provide a direct URL in output
+  return {
+    requiresLogin,
+    loginUrl: requiresLogin ? "https://kimi.com/login" : null,
+  };
+}
+
+export function describeKimiFailure(parsed: Record<string, unknown>): string | null {
+  const error = asString(parsed.error, "").trim();
+  const errors = extractKimiErrorMessages(parsed);
+
+  let detail = error;
+  if (!detail && errors.length > 0) {
+    detail = errors[0] ?? "";
+  }
+
+  const parts = ["Kimi run failed"];
+  if (detail) parts.push(detail);
+  return parts.length > 1 ? parts.join(": ") : null;
+}
+
+export function isKimiMaxTurnsResult(parsed: Record<string, unknown> | null | undefined): boolean {
+  if (!parsed) return false;
+
+  const resultText = asString(parsed.result, "").trim().toLowerCase();
+  return /max(?:imum)?\s+steps?/i.test(resultText);
+}
+
+export function isKimiUnknownSessionError(stdout: string, stderr: string): boolean {
+  const allText = `${stdout}\n${stderr}`.toLowerCase();
+  return /no\s+(?:session|conversation)\s+found|session\s+not\s+found|invalid\s+session/i.test(allText);
+}

--- a/packages/adapters/kimi-local/src/server/skills.ts
+++ b/packages/adapters/kimi-local/src/server/skills.ts
@@ -1,0 +1,96 @@
+import type {
+  AdapterSkillContext,
+  AdapterSkillEntry,
+  AdapterSkillSnapshot,
+} from "@paperclipai/adapter-utils";
+import type { PaperclipSkillEntry } from "@paperclipai/adapter-utils/server-utils";
+
+const KIMI_BUILTIN_TOOLS = new Set([
+  "read",
+  "bash",
+  "edit",
+  "write",
+  "grep",
+  "find",
+  "ls",
+]);
+
+/**
+ * Resolve which skills should be enabled for Kimi.
+ * Kimi has built-in tools, so we filter to only include skills that aren't built-in.
+ */
+export function resolveKimiDesiredSkillNames(
+  config: Record<string, unknown>,
+  entries: PaperclipSkillEntry[],
+): string[] {
+  // If config has explicit skills, use those
+  const configSkills = config.skills;
+  if (Array.isArray(configSkills)) {
+    return configSkills.filter((s): s is string => typeof s === "string");
+  }
+
+  // Otherwise, include all non-built-in skills
+  return entries
+    .filter((entry) => !KIMI_BUILTIN_TOOLS.has(entry.key))
+    .map((entry) => entry.key);
+}
+
+function buildKimiSkillSnapshot(config: Record<string, unknown>): AdapterSkillSnapshot {
+  // Kimi skills are passed via --skills-dir flags, not synced to a directory
+  // So we return a minimal snapshot with available skills
+  const desiredSkills = resolveKimiDesiredSkillNames(config, []);
+
+  const entries: AdapterSkillEntry[] = Array.from(KIMI_BUILTIN_TOOLS).map((key) => ({
+    key,
+    runtimeName: null,
+    desired: false, // Built-in tools are always available, not "desired"
+    managed: false, // Built-in tools are not managed by Paperclip
+    state: "available",
+    origin: "external_unknown",
+    originLabel: "Kimi built-in tool",
+    readOnly: true,
+    sourcePath: null,
+    targetPath: null,
+  }));
+
+  return {
+    adapterType: "kimi_local",
+    supported: false, // Kimi doesn't support Paperclip skill sync in the traditional sense
+    mode: "unsupported",
+    desiredSkills,
+    entries,
+    warnings: [],
+  };
+}
+
+/**
+ * List available skills for Kimi.
+ */
+export async function listKimiSkills(ctx: AdapterSkillContext): Promise<AdapterSkillSnapshot> {
+  return buildKimiSkillSnapshot(ctx.config);
+}
+
+/**
+ * Sync skills to Kimi's skill directories.
+ * Kimi uses --skills-dir flags, so this is a no-op that returns the snapshot.
+ */
+export async function syncKimiSkills(
+  ctx: AdapterSkillContext,
+  _desiredSkills: string[],
+): Promise<AdapterSkillSnapshot> {
+  // Kimi skills are loaded via CLI args, no filesystem sync needed
+  return buildKimiSkillSnapshot(ctx.config);
+}
+
+function getBuiltinToolDescription(name: string): string {
+  const descriptions: Record<string, string> = {
+    read: "Read file contents",
+    bash: "Execute shell commands",
+    edit: "Edit existing files",
+    write: "Write new files",
+    grep: "Search file contents",
+    find: "Find files by pattern",
+    ls: "List directory contents",
+  };
+  return descriptions[name] || "Kimi built-in tool";
+}

--- a/packages/adapters/kimi-local/src/server/test.ts
+++ b/packages/adapters/kimi-local/src/server/test.ts
@@ -1,0 +1,189 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asBoolean,
+  asNumber,
+  parseObject,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import path from "node:path";
+import { detectKimiLoginRequired } from "./parse.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function isNonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function commandLooksLike(command: string, expected: string): boolean {
+  const base = path.basename(command).toLowerCase();
+  return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
+}
+
+function summarizeProbeDetail(stdout: string, stderr: string): string | null {
+  const raw = firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  if (!raw) return null;
+  const clean = raw.replace(/\s+/g, " ").trim();
+  const max = 240;
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "kimi");
+  const cwd = asString(config.cwd, process.cwd());
+
+  try {
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+    checks.push({
+      code: "kimi_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "kimi_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  try {
+    await ensureCommandResolvable(command, cwd, runtimeEnv);
+    checks.push({
+      code: "kimi_command_resolvable",
+      level: "info",
+      message: `Command is executable: ${command}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "kimi_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+    });
+  }
+
+  const canRunProbe =
+    checks.every((check) => check.code !== "kimi_cwd_invalid" && check.code !== "kimi_command_unresolvable");
+  if (canRunProbe) {
+    if (!commandLooksLike(command, "kimi")) {
+      checks.push({
+        code: "kimi_hello_probe_skipped_custom_command",
+        level: "info",
+        message: "Skipped hello probe because command is not `kimi`.",
+        detail: command,
+        hint: "Use the `kimi` CLI command to run the automatic login and installation probe.",
+      });
+    } else {
+      const model = asString(config.model, "").trim();
+      const thinking = asBoolean(config.thinking, true);
+      const maxSteps = asNumber(config.maxStepsPerTurn, 0);
+
+      const args = ["--print", "--yolo"];
+      if (model) args.push("--model", model);
+      if (thinking) args.push("--thinking");
+      else args.push("--no-thinking");
+      if (maxSteps > 0) args.push("--max-steps-per-turn", String(maxSteps));
+      args.push("--output-format", "stream-json");
+
+      const probe = await runChildProcess(
+        `kimi-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        command,
+        args,
+        {
+          cwd,
+          env,
+          timeoutSec: 45,
+          graceSec: 5,
+          stdin: "Respond with hello",
+          onLog: async () => {},
+        },
+      );
+
+      const detail = summarizeProbeDetail(probe.stdout, probe.stderr);
+      const loginMeta = detectKimiLoginRequired({
+        parsed: null,
+        stdout: probe.stdout,
+        stderr: probe.stderr,
+      });
+
+      if (probe.timedOut) {
+        checks.push({
+          code: "kimi_hello_probe_timed_out",
+          level: "warn",
+          message: "Kimi hello probe timed out.",
+          hint: "Retry the probe. If this persists, verify Kimi can run `Respond with hello` from this directory manually.",
+        });
+      } else if (loginMeta.requiresLogin) {
+        checks.push({
+          code: "kimi_hello_probe_auth_required",
+          level: "warn",
+          message: "Kimi CLI is installed, but login is required.",
+          ...(detail ? { detail } : {}),
+          hint: "Run `kimi login` in this environment, then retry the probe.",
+        });
+      } else if ((probe.exitCode ?? 1) === 0) {
+        const hasHello = /\bhello\b/i.test(probe.stdout);
+        checks.push({
+          code: hasHello ? "kimi_hello_probe_passed" : "kimi_hello_probe_unexpected_output",
+          level: hasHello ? "info" : "warn",
+          message: hasHello
+            ? "Kimi hello probe succeeded."
+            : "Kimi probe ran but did not return `hello` as expected.",
+          ...(detail ? { detail: detail.slice(0, 240) } : {}),
+          ...(hasHello
+            ? {}
+            : {
+                hint: "Try the probe manually (`kimi --print --yolo --output-format stream-json`) and prompt `Respond with hello`.",
+              }),
+        });
+      } else {
+        checks.push({
+          code: "kimi_hello_probe_failed",
+          level: "error",
+          message: "Kimi hello probe failed.",
+          ...(detail ? { detail } : {}),
+          hint: "Run `kimi --print --yolo --output-format stream-json` manually in this directory and prompt `Respond with hello` to debug.",
+        });
+      }
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/kimi-local/src/ui/build-config.ts
+++ b/packages/adapters/kimi-local/src/ui/build-config.ts
@@ -1,0 +1,56 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+/**
+ * Build the adapter configuration for a Kimi local agent from UI form values.
+ */
+export function buildKimiLocalConfig(values: CreateConfigValues): Record<string, unknown> {
+  const config: Record<string, unknown> = {};
+
+  if (values.instructionsFilePath?.trim()) {
+    config.instructionsFilePath = values.instructionsFilePath.trim();
+  }
+
+  if (values.cwd?.trim()) {
+    config.cwd = values.cwd.trim();
+  }
+
+  if (values.model?.trim()) {
+    config.model = values.model.trim();
+  }
+
+  // Kimi-specific config - use thinkingEffort as thinking (boolean)
+  // Convert thinkingEffort to boolean: if set and not "off", enable thinking
+  if (values.thinkingEffort) {
+    config.thinking = values.thinkingEffort !== "off";
+  } else {
+    config.thinking = true; // Default to true
+  }
+
+  if (values.maxTurnsPerRun && values.maxTurnsPerRun > 0) {
+    config.maxStepsPerTurn = values.maxTurnsPerRun;
+  }
+
+  if (values.extraArgs?.trim()) {
+    config.extraArgs = values.extraArgs.split(",").map((s) => s.trim()).filter(Boolean);
+  }
+
+  if (values.envVars?.trim()) {
+    // Parse env vars string into key-value pairs
+    const env: Record<string, string> = {};
+    for (const line of values.envVars.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq > 0) {
+        const key = trimmed.slice(0, eq).trim();
+        const value = trimmed.slice(eq + 1).trim();
+        if (key) env[key] = value;
+      }
+    }
+    if (Object.keys(env).length > 0) {
+      config.env = env;
+    }
+  }
+
+  return config;
+}

--- a/packages/adapters/kimi-local/src/ui/index.ts
+++ b/packages/adapters/kimi-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseKimiStdoutLine } from "./parse-stdout.js";
+export { buildKimiLocalConfig } from "./build-config.js";

--- a/packages/adapters/kimi-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/kimi-local/src/ui/parse-stdout.ts
@@ -1,0 +1,95 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, defaultValue = ""): string {
+  return typeof value === "string" ? value : defaultValue;
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a single line of Kimi's stream-json output.
+ */
+export function parseKimiStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+
+  const event = asRecord(safeJsonParse(trimmed));
+  if (!event) {
+    // Not valid JSON, treat as plain text output
+    return [
+      {
+        kind: "assistant",
+        ts,
+        text: trimmed,
+      },
+    ];
+  }
+
+  const entries: TranscriptEntry[] = [];
+  const role = asString(event.role, "");
+
+  // Handle assistant messages
+  if (role === "assistant") {
+    const content = Array.isArray(event.content) ? event.content : [];
+    for (const blockRaw of content) {
+      const block = asRecord(blockRaw);
+      if (!block) continue;
+      
+      const blockType = asString(block.type, "");
+      if (blockType === "think") {
+        const text = asString(block.think, "");
+        if (text) {
+          entries.push({
+            kind: "thinking",
+            ts,
+            text,
+          });
+        }
+      } else if (blockType === "text") {
+        const text = asString(block.text, "");
+        if (text) {
+          entries.push({
+            kind: "assistant",
+            ts,
+            text,
+          });
+        }
+      }
+    }
+    return entries.length > 0 ? entries : [{ kind: "stdout", ts, text: line }];
+  }
+
+  // Handle tool calls (if Kimi supports them in this format)
+  const toolCalls = event.tool_calls;
+  if (Array.isArray(toolCalls)) {
+    for (const toolCall of toolCalls) {
+      const tc = asRecord(toolCall);
+      if (!tc) continue;
+      
+      const toolName = asString(tc.name, "");
+      const toolInput = tc.arguments || tc.input || {};
+      if (toolName) {
+        entries.push({
+          kind: "tool_call",
+          ts,
+          name: toolName,
+          input: typeof toolInput === "object" ? toolInput : {},
+        });
+      }
+    }
+  }
+
+  // If no specific handling, return empty
+  return entries.length > 0 ? entries : [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/kimi-local/tsconfig.json
+++ b/packages/adapters/kimi-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -30,6 +30,7 @@ export const AGENT_ADAPTER_TYPES = [
   "claude_local",
   "codex_local",
   "gemini_local",
+  "kimi_local",
   "opencode_local",
   "pi_local",
   "cursor",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,22 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/kimi-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/adapters/openclaw-gateway:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -477,6 +493,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-kimi-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/kimi-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -634,6 +653,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-kimi-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/kimi-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway

--- a/server/package.json
+++ b/server/package.json
@@ -48,6 +48,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-kimi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -6,6 +6,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "codex_local",
   "cursor",
   "gemini_local",
+  "kimi_local",
   "openclaw_gateway",
   "opencode_local",
   "pi_local",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -69,6 +69,17 @@ import {
   agentConfigurationDoc as piAgentConfigurationDoc,
 } from "@paperclipai/adapter-pi-local";
 import {
+  execute as kimiExecute,
+  listKimiSkills,
+  syncKimiSkills,
+  testEnvironment as kimiTestEnvironment,
+  sessionCodec as kimiSessionCodec,
+} from "@paperclipai/adapter-kimi-local/server";
+import {
+  agentConfigurationDoc as kimiAgentConfigurationDoc,
+  models as kimiModels,
+} from "@paperclipai/adapter-kimi-local";
+import {
   execute as hermesExecute,
   testEnvironment as hermesTestEnvironment,
   sessionCodec as hermesSessionCodec,
@@ -180,6 +191,19 @@ const piLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: piAgentConfigurationDoc,
 };
 
+const kimiLocalAdapter: ServerAdapterModule = {
+  type: "kimi_local",
+  execute: kimiExecute,
+  testEnvironment: kimiTestEnvironment,
+  listSkills: listKimiSkills,
+  syncSkills: syncKimiSkills,
+  sessionCodec: kimiSessionCodec,
+  sessionManagement: getAdapterSessionManagement("kimi_local") ?? undefined,
+  models: kimiModels,
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: kimiAgentConfigurationDoc,
+};
+
 const hermesLocalAdapter: ServerAdapterModule = {
   type: "hermes_local",
   execute: hermesExecute,
@@ -210,6 +234,7 @@ function registerBuiltInAdapters() {
     codexLocalAdapter,
     openCodeLocalAdapter,
     piLocalAdapter,
+    kimiLocalAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,
     openclawGatewayAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -36,6 +36,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-kimi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/ui/src/adapters/kimi-local/config-fields.tsx
+++ b/ui/src/adapters/kimi-local/config-fields.tsx
@@ -1,0 +1,119 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  ToggleField,
+  DraftInput,
+  DraftNumberInput,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+import { LocalWorkspaceRuntimeFields } from "../local-workspace-runtime-fields";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Injected into the system prompt at runtime.";
+
+export function KimiLocalConfigFields({
+  mode,
+  isCreate,
+  adapterType,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  models,
+  hideInstructionsFile,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      {!hideInstructionsFile && (
+        <Field label="Agent instructions file" hint={instructionsFileHint}>
+          <div className="flex items-center gap-2">
+            <DraftInput
+              value={
+                isCreate
+                  ? values!.instructionsFilePath ?? ""
+                  : eff(
+                      "adapterConfig",
+                      "instructionsFilePath",
+                      String(config.instructionsFilePath ?? ""),
+                    )
+              }
+              onCommit={(v) =>
+                isCreate
+                  ? set!({ instructionsFilePath: v })
+                  : mark("adapterConfig", "instructionsFilePath", v || undefined)
+              }
+              immediate
+              className={inputClass}
+              placeholder="/absolute/path/to/AGENTS.md"
+            />
+            <ChoosePathButton />
+          </div>
+        </Field>
+      )}
+
+      {/* Thinking mode toggle */}
+      <ToggleField
+        label="Enable thinking mode"
+        hint="Enable Kimi's thinking mode for deeper reasoning"
+        checked={
+          isCreate
+            ? (values!.adapterSchemaValues?.thinking as boolean | undefined) ?? true
+            : eff("adapterConfig", "thinking", config.thinking !== false)
+        }
+        onChange={(v) =>
+          isCreate
+            ? set!({ adapterSchemaValues: { ...(values!.adapterSchemaValues ?? {}), thinking: v } })
+            : mark("adapterConfig", "thinking", v)
+        }
+      />
+
+      {/* Max steps per turn */}
+      <Field label="Max steps per turn" hint="Maximum number of steps per turn (0 = use default)">
+        {isCreate ? (
+          <input
+            type="number"
+            min={0}
+            className={inputClass}
+            value={(values!.adapterSchemaValues?.maxStepsPerTurn as number | undefined) ?? ""}
+            onChange={(e) => {
+              const val = e.target.value;
+              set!({ 
+                adapterSchemaValues: { 
+                  ...(values!.adapterSchemaValues ?? {}), 
+                  maxStepsPerTurn: val ? Number(val) : undefined 
+                } 
+              });
+            }}
+          />
+        ) : (
+          <DraftNumberInput
+            value={eff(
+              "adapterConfig",
+              "maxStepsPerTurn",
+              Number(config.maxStepsPerTurn ?? 0),
+            )}
+            onCommit={(v) => mark("adapterConfig", "maxStepsPerTurn", v || 0)}
+            immediate
+            className={inputClass}
+          />
+        )}
+      </Field>
+
+      <LocalWorkspaceRuntimeFields
+        isCreate={isCreate}
+        values={values}
+        set={set}
+        config={config}
+        mark={mark}
+        eff={eff}
+        mode={mode}
+        adapterType={adapterType}
+        models={models}
+      />
+    </>
+  );
+}

--- a/ui/src/adapters/kimi-local/index.ts
+++ b/ui/src/adapters/kimi-local/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseKimiStdoutLine } from "@paperclipai/adapter-kimi-local/ui";
+import { KimiLocalConfigFields } from "./config-fields";
+import { buildKimiLocalConfig } from "@paperclipai/adapter-kimi-local/ui";
+
+export const kimiLocalUIAdapter: UIAdapterModule = {
+  type: "kimi_local",
+  label: "Kimi (local)",
+  parseStdoutLine: parseKimiStdoutLine,
+  ConfigFields: KimiLocalConfigFields,
+  buildAdapterConfig: buildKimiLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -3,6 +3,7 @@ import { claudeLocalUIAdapter } from "./claude-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
+import { kimiLocalUIAdapter } from "./kimi-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
@@ -51,6 +52,7 @@ function registerBuiltInUIAdapters() {
     codexLocalUIAdapter,
     geminiLocalUIAdapter,
     hermesLocalUIAdapter,
+    kimiLocalUIAdapter,
     openCodeLocalUIAdapter,
     piLocalUIAdapter,
     cursorLocalUIAdapter,


### PR DESCRIPTION
Adds a new built-in adapter for Kimi (Moonshot AI's coding agent):

- New package @paperclipai/adapter-kimi-local with server and UI components
- Supports Kimi's stream-json output format with transcript parsing
- Session management for resume across heartbeats
- Environment testing with login detection
- Thinking mode toggle and max steps per turn configuration
- Registered in both server and UI adapter registries

Users can now select 'Kimi (local)' as an adapter option when creating or configuring agents.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
