### PR TITLE
fix(gemini-local): filter startup noise from stderr error fallback

### DIFF
--- a/packages/adapters/gemini-local/package.json
+++ b/packages/adapters/gemini-local/package.json
@@ -48,7 +48,9 @@
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "workspace:*",
@@ -56,6 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.6.0",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -34,7 +34,7 @@ import {
   isGeminiUnknownSessionError,
   parseGeminiJsonl,
 } from "./parse.js";
-import { firstNonEmptyLine } from "./utils.js";
+import { firstMeaningfulStderrLine } from "./utils.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -422,7 +422,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       } as Record<string, unknown>)
       : null;
     const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
-    const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
     const structuredFailure = attempt.parsed.resultEvent
       ? describeGeminiFailure(attempt.parsed.resultEvent)
       : null;

--- a/packages/adapters/gemini-local/src/server/test.ts
+++ b/packages/adapters/gemini-local/src/server/test.ts
@@ -17,7 +17,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "../index.js";
 import { detectGeminiAuthRequired, detectGeminiQuotaExhausted, parseGeminiJsonl } from "./parse.js";
-import { firstNonEmptyLine } from "./utils.js";
+import { firstMeaningfulStderrLine, firstNonEmptyLine } from "./utils.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -35,7 +35,7 @@ function commandLooksLike(command: string, expected: string): boolean {
 }
 
 function summarizeProbeDetail(stdout: string, stderr: string, parsedError: string | null): string | null {
-  const raw = parsedError?.trim() || firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  const raw = parsedError?.trim() || firstMeaningfulStderrLine(stderr) || firstNonEmptyLine(stdout);
   if (!raw) return null;
   const clean = raw.replace(/\s+/g, " ").trim();
   const max = 240;

--- a/packages/adapters/gemini-local/src/server/utils.test.ts
+++ b/packages/adapters/gemini-local/src/server/utils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { firstMeaningfulStderrLine, firstNonEmptyLine } from "./utils.js";
+
+describe("firstNonEmptyLine", () => {
+  it("returns the first non-empty line", () => {
+    expect(firstNonEmptyLine("hello\nworld")).toBe("hello");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(firstNonEmptyLine("")).toBe("");
+  });
+
+  it("skips blank lines", () => {
+    expect(firstNonEmptyLine("\n\nhello")).toBe("hello");
+  });
+});
+
+describe("firstMeaningfulStderrLine — issue #3462 regression", () => {
+  const YOLO_NOISE = "YOLO mode is enabled. All tool calls will be automatically approved.";
+  const PGREP_NOISE = "missing pgrep output";
+  const MCP_NOISE = "Loaded MCP server: paperclip";
+
+  it("skips YOLO startup noise and returns the actual error", () => {
+    const stderr = [
+      YOLO_NOISE,
+      "Error: _recoverFromLoop triggered — repetitive tool calls detected",
+    ].join("\n");
+
+    expect(firstMeaningfulStderrLine(stderr)).toBe(
+      "Error: _recoverFromLoop triggered — repetitive tool calls detected",
+    );
+  });
+
+  it("skips missing pgrep output noise", () => {
+    const stderr = [PGREP_NOISE, "Error: process exited unexpectedly"].join("\n");
+    expect(firstMeaningfulStderrLine(stderr)).toBe("Error: process exited unexpectedly");
+  });
+
+  it("skips MCP loader status lines", () => {
+    const stderr = [MCP_NOISE, "Error: quota exceeded"].join("\n");
+    expect(firstMeaningfulStderrLine(stderr)).toBe("Error: quota exceeded");
+  });
+
+  it("skips multiple leading noise lines before reaching real error", () => {
+    const stderr = [YOLO_NOISE, MCP_NOISE, PGREP_NOISE, "Fatal: out of memory"].join("\n");
+    expect(firstMeaningfulStderrLine(stderr)).toBe("Fatal: out of memory");
+  });
+
+  it("returns empty string when stderr contains only noise", () => {
+    const stderr = [YOLO_NOISE, PGREP_NOISE].join("\n");
+    expect(firstMeaningfulStderrLine(stderr)).toBe("");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(firstMeaningfulStderrLine("")).toBe("");
+  });
+
+  it("returns meaningful line when no noise is present", () => {
+    const stderr = "Error: API quota exceeded";
+    expect(firstMeaningfulStderrLine(stderr)).toBe("Error: API quota exceeded");
+  });
+
+  it("is case-insensitive for noise pattern matching", () => {
+    const stderr = ["yolo mode is enabled. something something", "Real error"].join("\n");
+    expect(firstMeaningfulStderrLine(stderr)).toBe("Real error");
+  });
+});

--- a/packages/adapters/gemini-local/src/server/utils.ts
+++ b/packages/adapters/gemini-local/src/server/utils.ts
@@ -6,3 +6,28 @@ export function firstNonEmptyLine(text: string): string {
             .find(Boolean) ?? ""
     );
 }
+
+/**
+ * Known Gemini CLI startup/diagnostic lines that appear in stderr regardless
+ * of whether the run succeeds or fails. These should never be surfaced as the
+ * representative error message shown to operators.
+ */
+const GEMINI_STDERR_NOISE_RE = [
+    /^YOLO mode is enabled\b/i,
+    /^missing pgrep output/i,
+    /^Loaded MCP (server|tool|plugin)\b/i,
+];
+
+/**
+ * Like firstNonEmptyLine, but skips known Gemini CLI startup/diagnostic noise
+ * so that operators see the actual failure reason instead of e.g.
+ * "YOLO mode is enabled. All tool calls will be automatically approved."
+ */
+export function firstMeaningfulStderrLine(text: string): string {
+    return (
+        text
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .find((line) => Boolean(line) && !GEMINI_STDERR_NOISE_RE.some((re) => re.test(line))) ?? ""
+    );
+}

--- a/packages/adapters/gemini-local/vitest.config.ts
+++ b/packages/adapters/gemini-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/adapters/openclaw-gateway:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     projects: [
       "packages/db",
       "packages/adapters/codex-local",
+      "packages/adapters/gemini-local",
       "packages/adapters/opencode-local",
       "server",
       "ui",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The `gemini-local` adapter runs Gemini CLI as a subprocess to execute agent work
> - When a run fails and neither `parsedError` nor `structuredFailure` yield a message, the adapter falls back to `firstNonEmptyLine(stderr)` to populate `run.error`
> - Gemini CLI always emits "YOLO mode is enabled. All tool calls will be automatically approved." as its very first stderr line when launched with `--approval-mode yolo` — regardless of success or failure
> - This means operators see the YOLO startup message as the error instead of the actual failure reason, losing all diagnostic visibility
> - This pull request adds `firstMeaningfulStderrLine()` which skips known Gemini CLI startup/diagnostic noise before selecting the representative stderr line
> - The benefit is that operators now see actionable error messages (e.g. loop recovery, process crash) instead of irrelevant startup output

## What Changed

- `utils.ts`: Added `firstMeaningfulStderrLine()` — filters known noise patterns (`YOLO mode is enabled`, `missing pgrep output`, `Loaded MCP server/tool/plugin`) before selecting the first meaningful stderr line
- `execute.ts`: Replaced `firstNonEmptyLine(attempt.proc.stderr)` with `firstMeaningfulStderrLine()` — fixes `run.error` shown in run history
- `test.ts`: Same replacement in `summarizeProbeDetail()` — fixes the `detail` field shown in the hello probe failure UI during agent configuration
- `src/server/utils.test.ts` *(new)*: 11 regression tests covering all noise patterns, stacked noise lines, noise-only stderr, empty input, and case-insensitivity
- `vitest.config.ts` *(new)*: Vitest config for the `gemini-local` package
- `package.json`: Added `vitest` devDependency and `test`/`test:watch` scripts
- Root `vitest.config.ts`: Added `packages/adapters/gemini-local` to the projects list

## Verification

- Run `pnpm --filter @paperclipai/adapter-gemini-local exec vitest run` — all 11 tests pass
- Simulate a failed run where `parsedError` and `structuredFailure` are empty: `run.error` now shows the actual failure reason instead of `"YOLO mode is enabled. All tool calls will be automatically approved."`
- Hello probe failure detail in the agent config UI is similarly cleaned up

## Risks

Low risk. The change is additive — `firstMeaningfulStderrLine` is a strict superset of `firstNonEmptyLine` that only skips lines matching a fixed allowlist of known noise patterns. If stderr contains only noise and no real error, the function returns `""`, which causes the fallback chain to continue to the `"Gemini exited with code N"` sentinel — same safe default as before.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.5
- Context window: 200k
- Capabilities used: tool use, multi-file code editing, test generation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
