### PR TITLE
fix(comments): serialize Date objects to ISO strings for Postgres queries

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2049,12 +2049,12 @@ export function issueService(db: Db) {
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchor.createdAt.toISOString()}
+                OR (${issueComments.createdAt} = ${anchor.createdAt.toISOString()} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchor.createdAt.toISOString()}
+                OR (${issueComments.createdAt} = ${anchor.createdAt.toISOString()} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issues have threaded comments loaded via cursor-based pagination against the `issue_comments` table
> - The pagination cursor carries an `anchor.createdAt` timestamp and an `anchor.id` for stable ordering
> - Drizzle ORM returns `createdAt` as a JavaScript `Date` object, not an ISO string
> - When the anchor's `Date` is interpolated directly into a raw SQL template literal, `Date.prototype.toString()` produces a format like `"Sun Apr 12 2026 23:39:00 GMT+0900"` — which Postgres cannot parse as a timestamp
> - This caused Postgres to throw `"invalid input syntax for type uuid"` when paginating comments
> - This pull request calls `.toISOString()` on all 4 occurrences of `anchor.createdAt` in the cursor-based comment pagination query
> - The benefit is that comment pagination works correctly regardless of the ORM's JavaScript Date representation

## What Changed

- Added `.toISOString()` to all 4 uses of `anchor.createdAt` in the comment cursor-pagination conditions in `server/src/services/issues.ts` (both `asc` and `desc` order branches)

## Verification

- `pnpm typecheck` — passes
- `pnpm test:run` — all existing tests pass
- Manual: load a thread with enough comments to trigger pagination (more than one page), click "Load more" — no Postgres error, next page loads correctly

## Risks

- Low risk. The change is purely a serialization fix — `Date.toISOString()` produces a valid Postgres timestamp literal. No behavioral change for callers that already passed strings.

## Model Used

- Provider: Z.AI Coding Plan
- Model: glm-5-turbo (zai-coding-plan/glm-5-turbo)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable — N/A (existing comment-pagination tests cover the path; no new logic to unit-test)
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only fix)
- [ ] I have updated relevant documentation to reflect my changes — N/A (internal bug fix)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge