### PR TITLE
[codex] Fix plugin tool dispatcher pluginDbId routing

### DIFF
--- a/server/src/__tests__/plugin-tool-dispatcher.test.ts
+++ b/server/src/__tests__/plugin-tool-dispatcher.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
+import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+
+describe("plugin tool dispatcher", () => {
+  it("routes tool execution using the plugin database id when provided", async () => {
+    const call = vi.fn(async () => ({
+      content: [{ type: "text", text: "ok" }],
+    }));
+
+    const workerManager = {
+      startWorker: vi.fn(),
+      stopWorker: vi.fn(),
+      getWorker: vi.fn(),
+      isRunning: vi.fn((pluginId: string) => pluginId === "plugin-db-id"),
+      stopAll: vi.fn(),
+      diagnostics: vi.fn(() => []),
+      call,
+    } satisfies PluginWorkerManager;
+
+    const dispatcher = createPluginToolDispatcher({ workerManager });
+    dispatcher.registerPluginTools(
+      "acme.example",
+      {
+        apiVersion: 1,
+        name: "acme.example",
+        version: "1.0.0",
+        tools: [
+          {
+            name: "search",
+            description: "Search",
+            parametersSchema: { type: "object" },
+          },
+        ],
+      },
+      "plugin-db-id",
+    );
+
+    const result = await dispatcher.executeTool(
+      "acme.example:search",
+      { query: "bug" },
+      {
+        agentId: "agent-1",
+        runId: "run-1",
+        companyId: "company-1",
+        projectId: "project-1",
+      },
+    );
+
+    expect(workerManager.isRunning).toHaveBeenCalledWith("plugin-db-id");
+    expect(call).toHaveBeenCalledWith(
+      "plugin-db-id",
+      "executeTool",
+      expect.objectContaining({
+        toolName: "search",
+        parameters: { query: "bug" },
+      }),
+    );
+    expect(result.pluginId).toBe("acme.example");
+    expect(result.toolName).toBe("search");
+  });
+});

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1812,7 +1812,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -156,6 +156,7 @@ export interface PluginToolDispatcher {
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +430,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Summary
- thread the persisted plugin database id through plugin tool registration
- route external plugin tool execution by `pluginDbId` instead of only in-memory plugin metadata
- add a focused regression test for `agent.tools.execute` dispatching through external plugins

## Why
Fixes #3394.

The dispatcher was registering tools without the plugin database id that downstream execution expects. That left external plugin `agent.tools.execute` calls unable to resolve the plugin record cleanly, which surfaced as a `502` failure path.

## Impact
External plugin tool calls now resolve through the same persisted identifier used elsewhere in the server, which makes plugin-backed tool execution reliable and keeps the fix tightly scoped to the registration/dispatch layer.

## Validation
- `corepack pnpm vitest run server/src/__tests__/plugin-tool-dispatcher.test.ts`