### PR TITLE
[codex] Discover runtime adapters from configured directories

### DIFF
--- a/packages/shared/src/config-schema.ts
+++ b/packages/shared/src/config-schema.ts
@@ -50,6 +50,7 @@ export const serverConfigSchema = z.object({
   exposure: z.enum(DEPLOYMENT_EXPOSURES).default("private"),
   bind: z.enum(BIND_MODES).optional(),
   customBindHost: z.string().optional(),
+  adapterPluginsDir: z.string().optional(),
   host: z.string().default("127.0.0.1"),
   port: z.number().int().min(1).max(65535).default(3100),
   allowedHostnames: z.array(z.string().min(1)).default([]),

--- a/server/src/__tests__/adapter-plugin-loader.test.ts
+++ b/server/src/__tests__/adapter-plugin-loader.test.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  loadConfigMock,
+  listAdapterPluginsMock,
+  getAdapterPluginsDirMock,
+  getAdapterPluginByTypeMock,
+  loggerMock,
+} = vi.hoisted(() => ({
+  loadConfigMock: vi.fn(),
+  listAdapterPluginsMock: vi.fn(),
+  getAdapterPluginsDirMock: vi.fn(),
+  getAdapterPluginByTypeMock: vi.fn(),
+  loggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../config.js", () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock("../services/adapter-plugin-store.js", () => ({
+  listAdapterPlugins: listAdapterPluginsMock,
+  getAdapterPluginsDir: getAdapterPluginsDirMock,
+  getAdapterPluginByType: getAdapterPluginByTypeMock,
+}));
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: loggerMock,
+}));
+
+async function writeAdapterPackage(
+  packageDir: string,
+  packageName: string,
+  moduleSource: string,
+): Promise<void> {
+  await fs.mkdir(packageDir, { recursive: true });
+  await fs.writeFile(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({
+      name: packageName,
+      version: "1.2.3",
+      type: "module",
+      exports: {
+        ".": "./index.js",
+      },
+    }, null, 2),
+    "utf8",
+  );
+  await fs.writeFile(path.join(packageDir, "index.js"), moduleSource, "utf8");
+}
+
+describe("adapter plugin loader", () => {
+  let rootDir: string;
+  let discoveryDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-adapter-loader-"));
+    discoveryDir = path.join(rootDir, "discovered");
+    await fs.mkdir(discoveryDir, { recursive: true });
+
+    loadConfigMock.mockReturnValue({ adapterPluginsDir: discoveryDir });
+    listAdapterPluginsMock.mockReturnValue([]);
+    getAdapterPluginsDirMock.mockReturnValue(path.join(rootDir, "managed"));
+    getAdapterPluginByTypeMock.mockReturnValue(undefined);
+    loggerMock.info.mockReset();
+    loggerMock.warn.mockReset();
+    loggerMock.error.mockReset();
+  });
+
+  afterEach(async () => {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  it("loads valid adapters from the configured discovery directory and skips invalid packages", async () => {
+    await writeAdapterPackage(
+      path.join(discoveryDir, "valid-adapter"),
+      "valid-adapter",
+      `export function createServerAdapter() {
+        return {
+          type: "directory_test",
+          execute: async () => ({ exitCode: 0, signal: null, timedOut: false }),
+          testEnvironment: async () => ({
+            adapterType: "directory_test",
+            status: "pass",
+            checks: [],
+            testedAt: new Date(0).toISOString(),
+          }),
+          models: [],
+          supportsLocalAgentJwt: false,
+        };
+      }`,
+    );
+
+    await writeAdapterPackage(
+      path.join(discoveryDir, "broken-adapter"),
+      "broken-adapter",
+      `export const notAnAdapter = true;`,
+    );
+
+    const {
+      buildExternalAdapters,
+      listRuntimeDiscoveredAdapterRecords,
+    } = await import("../adapters/plugin-loader.js");
+
+    const adapters = await buildExternalAdapters();
+
+    expect(adapters.map((adapter) => adapter.type)).toEqual(["directory_test"]);
+    expect(listRuntimeDiscoveredAdapterRecords()).toEqual([
+      expect.objectContaining({
+        packageName: "valid-adapter",
+        localPath: path.join(discoveryDir, "valid-adapter"),
+        type: "directory_test",
+        version: "1.2.3",
+      }),
+    ]);
+    expect(loggerMock.warn).toHaveBeenCalled();
+  });
+});

--- a/server/src/adapters/plugin-loader.ts
+++ b/server/src/adapters/plugin-loader.ts
@@ -11,8 +11,10 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { ServerAdapterModule } from "./types.js";
 import { logger } from "../middleware/logger.js";
+import { loadConfig } from "../config.js";
 
 import {
   listAdapterPlugins,
@@ -26,6 +28,7 @@ import type { AdapterPluginRecord } from "../services/adapter-plugin-store.js";
 // ---------------------------------------------------------------------------
 
 const uiParserCache = new Map<string, string>();
+const runtimeDiscoveredAdapterRecords = new Map<string, AdapterPluginRecord>();
 
 export function getUiParserSource(adapterType: string): string | undefined {
   return uiParserCache.get(adapterType);
@@ -54,6 +57,10 @@ export function getOrExtractUiParserSource(adapterType: string): string | undefi
   return source;
 }
 
+export function listRuntimeDiscoveredAdapterRecords(): AdapterPluginRecord[] {
+  return Array.from(runtimeDiscoveredAdapterRecords.values());
+}
+
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
@@ -73,6 +80,79 @@ function resolvePackageEntryPoint(packageDir: string): string {
     return typeof exp === "string" ? exp : (exp.import ?? exp.default ?? "index.js");
   }
   return pkg.main ?? "index.js";
+}
+
+interface DirectoryAdapterCandidate {
+  packageName: string;
+  localPath: string;
+  version?: string;
+}
+
+function resolveConfiguredAdapterPluginsDir(): string | undefined {
+  return loadConfig().adapterPluginsDir;
+}
+
+function isPackageDirectory(candidateDir: string): boolean {
+  return fs.existsSync(path.join(candidateDir, "package.json"));
+}
+
+function readPackageMetadata(packageDir: string): { packageName: string; version?: string } | null {
+  try {
+    const pkgRaw = fs.readFileSync(path.join(packageDir, "package.json"), "utf-8");
+    const pkg = JSON.parse(pkgRaw) as { name?: string; version?: string };
+    return {
+      packageName: typeof pkg.name === "string" && pkg.name.trim().length > 0
+        ? pkg.name.trim()
+        : path.basename(packageDir),
+      version: typeof pkg.version === "string" && pkg.version.trim().length > 0
+        ? pkg.version.trim()
+        : undefined,
+    };
+  } catch (err) {
+    logger.warn({ err, packageDir }, "Failed to read adapter package metadata");
+    return null;
+  }
+}
+
+function listConfiguredDirectoryAdapterCandidates(): DirectoryAdapterCandidate[] {
+  const configuredDir = resolveConfiguredAdapterPluginsDir();
+  if (!configuredDir) return [];
+  if (!fs.existsSync(configuredDir)) {
+    logger.warn({ configuredDir }, "Configured adapter plugins directory does not exist");
+    return [];
+  }
+
+  const candidates: DirectoryAdapterCandidate[] = [];
+
+  const addCandidate = (packageDir: string) => {
+    const metadata = readPackageMetadata(packageDir);
+    if (!metadata) return;
+    candidates.push({
+      packageName: metadata.packageName,
+      localPath: packageDir,
+      version: metadata.version,
+    });
+  };
+
+  if (isPackageDirectory(configuredDir)) {
+    addCandidate(configuredDir);
+    return candidates;
+  }
+
+  for (const entry of fs.readdirSync(configuredDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+      continue;
+    }
+
+    const packageDir = path.join(configuredDir, entry.name);
+    if (!isPackageDirectory(packageDir)) {
+      continue;
+    }
+
+    addCandidate(packageDir);
+  }
+
+  return candidates;
 }
 
 // ---------------------------------------------------------------------------
@@ -177,7 +257,7 @@ export async function loadExternalAdapterPackage(
 
   logger.info({ packageName, packageDir, entryPoint, modulePath, hasUiParser: !!uiParserSource }, "Loading external adapter package");
 
-  const mod = await import(modulePath);
+  const mod = await import(pathToFileURL(modulePath).href);
   const adapterModule = validateAdapterModule(mod, packageName);
 
   if (uiParserSource) {
@@ -257,12 +337,40 @@ export async function reloadExternalAdapter(
  */
 export async function buildExternalAdapters(): Promise<ServerAdapterModule[]> {
   const results: ServerAdapterModule[] = [];
+  runtimeDiscoveredAdapterRecords.clear();
+  const seenPackageDirs = new Set<string>();
 
   const storeRecords = listAdapterPlugins();
   for (const record of storeRecords) {
+    seenPackageDirs.add(resolvePackageDir(record));
     const adapter = await loadFromRecord(record);
     if (adapter) {
       results.push(adapter);
+    }
+  }
+
+  for (const candidate of listConfiguredDirectoryAdapterCandidates()) {
+    const resolvedPackageDir = path.resolve(candidate.localPath);
+    if (seenPackageDirs.has(resolvedPackageDir)) {
+      continue;
+    }
+
+    try {
+      const adapter = await loadExternalAdapterPackage(candidate.packageName, candidate.localPath);
+      results.push(adapter);
+      runtimeDiscoveredAdapterRecords.set(adapter.type, {
+        packageName: candidate.packageName,
+        localPath: candidate.localPath,
+        version: candidate.version,
+        type: adapter.type,
+        installedAt: new Date(0).toISOString(),
+      });
+      seenPackageDirs.add(resolvedPackageDir);
+    } catch (err) {
+      logger.warn(
+        { err, packageName: candidate.packageName, localPath: candidate.localPath },
+        "Failed to dynamically load adapter from configured discovery directory; skipping",
+      );
     }
   }
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -54,6 +54,7 @@ export interface Config {
   deploymentExposure: DeploymentExposure;
   bind: BindMode;
   customBindHost: string | undefined;
+  adapterPluginsDir: string | undefined;
   host: string;
   port: number;
   allowedHostnames: string[];
@@ -189,6 +190,10 @@ export function loadConfig(): Config {
     fileConfig?.server.bind ??
     inferBindModeFromHost(configuredHost, { tailnetBindHost });
   const customBindHost = process.env.PAPERCLIP_BIND_HOST ?? fileConfig?.server.customBindHost;
+  const adapterPluginsDirRaw =
+    process.env.PAPERCLIP_ADAPTERS_DIR?.trim() ||
+    fileConfig?.server.adapterPluginsDir?.trim() ||
+    undefined;
   const authBaseUrlModeFromEnvRaw = process.env.PAPERCLIP_AUTH_BASE_URL_MODE;
   const authBaseUrlModeFromEnv =
     authBaseUrlModeFromEnvRaw &&
@@ -289,6 +294,7 @@ export function loadConfig(): Config {
     deploymentExposure,
     bind: resolvedBind.bind,
     customBindHost: resolvedBind.customBindHost,
+    adapterPluginsDir: adapterPluginsDirRaw ? resolveHomeAwarePath(adapterPluginsDirRaw) : undefined,
     host: resolvedBind.host,
     port: Number(process.env.PORT) || fileConfig?.server.port || 3100,
     allowedHostnames,

--- a/server/src/dev-watch-ignore.ts
+++ b/server/src/dev-watch-ignore.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { loadConfig } from "./config.js";
 
 function toGlobstarPath(candidate: string): string {
   return `${candidate.replaceAll(path.sep, "/")}/**`;
@@ -18,6 +19,7 @@ function addIgnorePath(target: Set<string>, candidate: string): void {
 }
 
 export function resolveServerDevWatchIgnorePaths(serverRoot: string): string[] {
+  const config = loadConfig();
   const ignorePaths = new Set<string>([
     "**/{node_modules,bower_components,vendor}/**",
     "**/.vite-temp/**",
@@ -33,6 +35,10 @@ export function resolveServerDevWatchIgnorePaths(serverRoot: string): string[] {
     process.env.HOME + "/.paperclip/adapter-plugins",
   ]) {
     addIgnorePath(ignorePaths, path.resolve(serverRoot, relativePath));
+  }
+
+  if (config.adapterPluginsDir) {
+    addIgnorePath(ignorePaths, config.adapterPluginsDir);
   }
 
   return [...ignorePaths];

--- a/server/src/routes/adapters.ts
+++ b/server/src/routes/adapters.ts
@@ -39,7 +39,13 @@ import {
 } from "../services/adapter-plugin-store.js";
 import type { AdapterPluginRecord } from "../services/adapter-plugin-store.js";
 import type { ServerAdapterModule, AdapterConfigSchema } from "../adapters/types.js";
-import { loadExternalAdapterPackage, getUiParserSource, getOrExtractUiParserSource, reloadExternalAdapter } from "../adapters/plugin-loader.js";
+import {
+  loadExternalAdapterPackage,
+  getUiParserSource,
+  getOrExtractUiParserSource,
+  listRuntimeDiscoveredAdapterRecords,
+  reloadExternalAdapter,
+} from "../adapters/plugin-loader.js";
 import { logger } from "../middleware/logger.js";
 import { assertBoard } from "./authz.js";
 import { BUILTIN_ADAPTER_TYPES } from "../adapters/builtin-adapter-types.js";
@@ -178,7 +184,7 @@ export function adapterRoutes() {
 
     const registeredAdapters = listServerAdapters();
     const externalRecords = new Map(
-      listAdapterPlugins().map((r) => [r.type, r]),
+      [...listAdapterPlugins(), ...listRuntimeDiscoveredAdapterRecords()].map((r) => [r.type, r]),
     );
     const disabledSet = new Set(getDisabledAdapterTypes());
 


### PR DESCRIPTION
## Summary
- add config support for runtime adapter plugin directories via `PAPERCLIP_ADAPTERS_DIR` and `server.adapterPluginsDir`
- scan configured directories for adapter packages at runtime without crashing on a single bad package
- surface discovered adapters through the adapters API and keep the dev watcher from thrashing on plugin directories

## Why
Fixes #3375.

Paperclip could load built-in adapters, but there was no clean runtime discovery path for user-provided adapter packages. This change adds an explicit, configurable discovery path that keeps failures isolated and observable.

## Impact
Teams can drop custom adapters into a configured directory and have them show up through normal adapter loading and API discovery, which makes local extension workflows much easier.

## Validation
- `corepack pnpm vitest run server/src/__tests__/adapter-plugin-loader.test.ts`
- `corepack pnpm --filter @paperclipai/shared exec tsc --noEmit`