### PR TITLE
[codex] Add agent model failover chains

### DIFF
--- a/packages/adapter-utils/src/failover-models.ts
+++ b/packages/adapter-utils/src/failover-models.ts
@@ -1,0 +1,29 @@
+export function parseFailoverModelList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return Array.from(
+      new Set(
+        value
+          .filter((entry): entry is string => typeof entry === "string")
+          .map((entry) => entry.trim())
+          .filter(Boolean),
+      ),
+    );
+  }
+
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      value
+        .split(/[\r\n,]+/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+export function serializeFailoverModelList(value: unknown): string {
+  return parseFailoverModelList(value).join("\n");
+}

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -54,3 +54,7 @@ export {
   redactTranscriptEntryPaths,
 } from "./log-redaction.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
+export {
+  parseFailoverModelList,
+  serializeFailoverModelList,
+} from "./failover-models.js";

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -368,6 +368,7 @@ export interface CreateConfigValues {
   instructionsFilePath?: string;
   promptTemplate: string;
   model: string;
+  failoverModelsText: string;
   thinkingEffort: string;
   chrome: boolean;
   dangerouslySkipPermissions: boolean;

--- a/packages/adapters/claude-local/src/ui/build-config.ts
+++ b/packages/adapters/claude-local/src/ui/build-config.ts
@@ -1,4 +1,4 @@
-import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { parseFailoverModelList, type CreateConfigValues } from "@paperclipai/adapter-utils";
 
 function parseCommaArgs(value: string): string[] {
   return value
@@ -69,6 +69,8 @@ export function buildClaudeLocalConfig(v: CreateConfigValues): Record<string, un
   if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
   if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
   if (v.model) ac.model = v.model;
+  const failoverModels = parseFailoverModelList(v.failoverModelsText);
+  if (failoverModels.length > 0) ac.failoverModels = failoverModels;
   if (v.thinkingEffort) ac.effort = v.thinkingEffort;
   if (v.chrome) ac.chrome = true;
   ac.timeoutSec = 0;

--- a/packages/adapters/codex-local/src/ui/build-config.test.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.test.ts
@@ -9,6 +9,7 @@ function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigVa
     instructionsFilePath: "",
     promptTemplate: "",
     model: "gpt-5.4",
+    failoverModelsText: "",
     thinkingEffort: "",
     chrome: false,
     dangerouslySkipPermissions: true,
@@ -50,5 +51,18 @@ describe("buildCodexLocalConfig", () => {
       fastMode: true,
       dangerouslyBypassApprovalsAndSandbox: true,
     });
+  });
+
+  it("parses backup models into failoverModels", () => {
+    const config = buildCodexLocalConfig(
+      makeValues({
+        failoverModelsText: "gpt-5.4-mini\nclaude-sonnet-4-6",
+      }),
+    );
+
+    expect(config.failoverModels).toEqual([
+      "gpt-5.4-mini",
+      "claude-sonnet-4-6",
+    ]);
   });
 });

--- a/packages/adapters/codex-local/src/ui/build-config.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.ts
@@ -1,4 +1,4 @@
-import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { parseFailoverModelList, type CreateConfigValues } from "@paperclipai/adapter-utils";
 import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
   DEFAULT_CODEX_LOCAL_MODEL,
@@ -73,6 +73,8 @@ export function buildCodexLocalConfig(v: CreateConfigValues): Record<string, unk
   if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
   if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
   ac.model = v.model || DEFAULT_CODEX_LOCAL_MODEL;
+  const failoverModels = parseFailoverModelList(v.failoverModelsText);
+  if (failoverModels.length > 0) ac.failoverModels = failoverModels;
   if (v.thinkingEffort) ac.modelReasoningEffort = v.thinkingEffort;
   ac.timeoutSec = 0;
   ac.graceSec = 15;

--- a/packages/adapters/cursor-local/src/ui/build-config.ts
+++ b/packages/adapters/cursor-local/src/ui/build-config.ts
@@ -1,4 +1,4 @@
-import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { parseFailoverModelList, type CreateConfigValues } from "@paperclipai/adapter-utils";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "../index.js";
 
 function parseCommaArgs(value: string): string[] {
@@ -64,6 +64,8 @@ export function buildCursorLocalConfig(v: CreateConfigValues): Record<string, un
   if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
   if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
   ac.model = v.model || DEFAULT_CURSOR_LOCAL_MODEL;
+  const failoverModels = parseFailoverModelList(v.failoverModelsText);
+  if (failoverModels.length > 0) ac.failoverModels = failoverModels;
   const mode = normalizeMode(v.thinkingEffort);
   if (mode) ac.mode = mode;
   ac.timeoutSec = 0;

--- a/packages/adapters/gemini-local/src/ui/build-config.ts
+++ b/packages/adapters/gemini-local/src/ui/build-config.ts
@@ -1,4 +1,4 @@
-import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { parseFailoverModelList, type CreateConfigValues } from "@paperclipai/adapter-utils";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "../index.js";
 
 function parseCommaArgs(value: string): string[] {
@@ -58,6 +58,8 @@ export function buildGeminiLocalConfig(v: CreateConfigValues): Record<string, un
   if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
   if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
   ac.model = v.model || DEFAULT_GEMINI_LOCAL_MODEL;
+  const failoverModels = parseFailoverModelList(v.failoverModelsText);
+  if (failoverModels.length > 0) ac.failoverModels = failoverModels;
   ac.timeoutSec = 0;
   ac.graceSec = 15;
   const env = parseEnvBindings(v.envBindings);

--- a/packages/adapters/opencode-local/src/ui/build-config.ts
+++ b/packages/adapters/opencode-local/src/ui/build-config.ts
@@ -1,4 +1,4 @@
-import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { parseFailoverModelList, type CreateConfigValues } from "@paperclipai/adapter-utils";
 
 function parseCommaArgs(value: string): string[] {
   return value
@@ -57,6 +57,8 @@ export function buildOpenCodeLocalConfig(v: CreateConfigValues): Record<string, 
   if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
   if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
   if (v.model) ac.model = v.model;
+  const failoverModels = parseFailoverModelList(v.failoverModelsText);
+  if (failoverModels.length > 0) ac.failoverModels = failoverModels;
   if (v.thinkingEffort) ac.variant = v.thinkingEffort;
   ac.dangerouslySkipPermissions = v.dangerouslySkipPermissions;
   // OpenCode sessions can run until the CLI exits naturally; keep timeout disabled (0)

--- a/packages/adapters/pi-local/src/ui/build-config.ts
+++ b/packages/adapters/pi-local/src/ui/build-config.ts
@@ -1,4 +1,4 @@
-import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { parseFailoverModelList, type CreateConfigValues } from "@paperclipai/adapter-utils";
 
 function parseEnvVars(text: string): Record<string, string> {
   const env: Record<string, string> = {};
@@ -50,6 +50,8 @@ export function buildPiLocalConfig(v: CreateConfigValues): Record<string, unknow
   if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
   if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
   if (v.model) ac.model = v.model;
+  const failoverModels = parseFailoverModelList(v.failoverModelsText);
+  if (failoverModels.length > 0) ac.failoverModels = failoverModels;
   if (v.thinkingEffort) ac.thinking = v.thinkingEffort;
   
   // Pi sessions can run until the CLI exits naturally; keep timeout disabled (0)

--- a/server/src/__tests__/adapter-failover.test.ts
+++ b/server/src/__tests__/adapter-failover.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildAdapterFailoverPlan,
+  executeWithAdapterFailover,
+  isRetryableAdapterFailure,
+} from "../services/adapter-failover.js";
+
+describe("adapter failover", () => {
+  it("treats quota and rate-limit failures as retryable", () => {
+    expect(isRetryableAdapterFailure({
+      timedOut: false,
+      errorCode: "quota_exhausted",
+      errorMessage: "429 RESOURCE_EXHAUSTED",
+    })).toBe(true);
+
+    expect(isRetryableAdapterFailure({
+      timedOut: false,
+      errorCode: "model_access_denied",
+      errorMessage: "model access denied",
+    })).toBe(false);
+  });
+
+  it("builds a primary plus backup plan across adapter model catalogs", async () => {
+    const resolution = await buildAdapterFailoverPlan({
+      primaryAdapterType: "claude_local",
+      runtimeConfig: {
+        model: "claude-opus-4-6",
+        failoverModels: [
+          "claude-sonnet-4-6",
+          "gpt-5.4",
+          "missing-model",
+        ],
+      },
+      resolveModels: async (adapterType) => {
+        if (adapterType === "claude_local") {
+          return [
+            { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
+            { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+          ];
+        }
+        if (adapterType === "codex_local") {
+          return [{ id: "gpt-5.4", label: "GPT-5.4" }];
+        }
+        return [];
+      },
+      listAdapterTypes: () => ["claude_local", "codex_local"],
+    });
+
+    expect(resolution.attempts).toEqual([
+      expect.objectContaining({
+        adapterType: "claude_local",
+        model: "claude-opus-4-6",
+        usesFailover: false,
+      }),
+      expect.objectContaining({
+        adapterType: "claude_local",
+        model: "claude-sonnet-4-6",
+        usesFailover: true,
+      }),
+      expect.objectContaining({
+        adapterType: "codex_local",
+        model: "gpt-5.4",
+        usesFailover: true,
+      }),
+    ]);
+    expect(resolution.warnings).toEqual([
+      'No adapter model catalog matched failover model "missing-model".',
+    ]);
+  });
+
+  it("falls through retryable failures until a backup succeeds", async () => {
+    const onFailover = vi.fn();
+    const execution = await executeWithAdapterFailover({
+      attempts: [
+        {
+          adapterType: "claude_local",
+          model: "claude-opus-4-6",
+          config: { model: "claude-opus-4-6" },
+          usesFailover: false,
+        },
+        {
+          adapterType: "codex_local",
+          model: "gpt-5.4",
+          config: { model: "gpt-5.4" },
+          usesFailover: true,
+        },
+      ],
+      executeAttempt: async (attempt) => {
+        if (attempt.adapterType === "claude_local") {
+          return {
+            exitCode: 1,
+            signal: null,
+            timedOut: false,
+            errorCode: "quota_exhausted",
+            errorMessage: "429 RESOURCE_EXHAUSTED",
+          };
+        }
+
+        return {
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          model: "gpt-5.4",
+        };
+      },
+      onFailover,
+    });
+
+    expect(execution.attempt.adapterType).toBe("codex_local");
+    expect(execution.result.exitCode).toBe(0);
+    expect(onFailover).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/services/adapter-failover.ts
+++ b/server/src/services/adapter-failover.ts
@@ -1,0 +1,198 @@
+import {
+  parseFailoverModelList,
+  type AdapterExecutionResult,
+  type AdapterModel,
+} from "@paperclipai/adapter-utils";
+
+const RETRYABLE_MODEL_FAILURE_PATTERN =
+  /(?:\b429\b|resource_exhausted|quota|rate[-\s]?limit|too many requests|billing details)/i;
+
+const CROSS_ADAPTER_SAFE_CONFIG_KEYS = [
+  "cwd",
+  "instructionsFilePath",
+  "promptTemplate",
+  "bootstrapPromptTemplate",
+  "env",
+  "timeoutSec",
+  "graceSec",
+  "extraArgs",
+  "workspaceStrategy",
+  "workspaceRuntime",
+  "maxTurnsPerRun",
+  "dangerouslySkipPermissions",
+  "paperclipRuntimeSkills",
+  "paperclipRuntimeServices",
+  "sandbox",
+  "approvalMode",
+] as const;
+
+export interface AdapterFailoverAttempt {
+  adapterType: string;
+  model: string | null;
+  config: Record<string, unknown>;
+  usesFailover: boolean;
+}
+
+export interface AdapterFailoverExecution<T> {
+  attempt: AdapterFailoverAttempt;
+  result: T;
+}
+
+export interface AdapterFailoverResolution {
+  attempts: AdapterFailoverAttempt[];
+  warnings: string[];
+}
+
+export function isRetryableAdapterFailure(
+  result: Pick<AdapterExecutionResult, "errorCode" | "errorMessage" | "timedOut">,
+): boolean {
+  if (result.timedOut) {
+    return false;
+  }
+
+  const errorCode = typeof result.errorCode === "string" ? result.errorCode : "";
+  const errorMessage = typeof result.errorMessage === "string" ? result.errorMessage : "";
+  return RETRYABLE_MODEL_FAILURE_PATTERN.test(`${errorCode}\n${errorMessage}`);
+}
+
+export function shouldPersistSessionForAttempt(
+  attempt: AdapterFailoverAttempt,
+  primaryAdapterType: string,
+  primaryModel: string | null,
+): boolean {
+  return !attempt.usesFailover
+    && attempt.adapterType === primaryAdapterType
+    && attempt.model === primaryModel;
+}
+
+export function buildFailoverAdapterConfig(input: {
+  primaryAdapterType: string;
+  targetAdapterType: string;
+  baseConfig: Record<string, unknown>;
+  model: string;
+}): Record<string, unknown> {
+  if (input.targetAdapterType === input.primaryAdapterType) {
+    return {
+      ...input.baseConfig,
+      model: input.model,
+    };
+  }
+
+  const next: Record<string, unknown> = {};
+  for (const key of CROSS_ADAPTER_SAFE_CONFIG_KEYS) {
+    if (input.baseConfig[key] !== undefined) {
+      next[key] = input.baseConfig[key];
+    }
+  }
+  next.model = input.model;
+  return next;
+}
+
+export async function buildAdapterFailoverPlan(input: {
+  primaryAdapterType: string;
+  runtimeConfig: Record<string, unknown>;
+  resolveModels: (adapterType: string) => Promise<AdapterModel[]>;
+  listAdapterTypes: () => string[];
+}): Promise<AdapterFailoverResolution> {
+  const primaryModel =
+    typeof input.runtimeConfig.model === "string" && input.runtimeConfig.model.trim().length > 0
+      ? input.runtimeConfig.model.trim()
+      : null;
+  const failoverModels = parseFailoverModelList(input.runtimeConfig.failoverModels);
+  const attempts: AdapterFailoverAttempt[] = [
+    {
+      adapterType: input.primaryAdapterType,
+      model: primaryModel,
+      config: input.runtimeConfig,
+      usesFailover: false,
+    },
+  ];
+  const warnings: string[] = [];
+
+  if (failoverModels.length === 0) {
+    return { attempts, warnings };
+  }
+
+  const adapterTypes = input.listAdapterTypes();
+  const modelCache = new Map<string, AdapterModel[]>();
+
+  const getModels = async (adapterType: string) => {
+    if (!modelCache.has(adapterType)) {
+      modelCache.set(adapterType, await input.resolveModels(adapterType));
+    }
+    return modelCache.get(adapterType) ?? [];
+  };
+
+  const primaryModels = await getModels(input.primaryAdapterType);
+
+  for (const failoverModel of failoverModels) {
+    if (failoverModel === primaryModel) {
+      continue;
+    }
+
+    let targetAdapterType: string | null =
+      primaryModels.some((entry) => entry.id === failoverModel) ? input.primaryAdapterType : null;
+
+    if (!targetAdapterType) {
+      for (const adapterType of adapterTypes) {
+        if (adapterType === input.primaryAdapterType) continue;
+        const models = await getModels(adapterType);
+        if (models.some((entry) => entry.id === failoverModel)) {
+          targetAdapterType = adapterType;
+          break;
+        }
+      }
+    }
+
+    if (!targetAdapterType) {
+      warnings.push(`No adapter model catalog matched failover model "${failoverModel}".`);
+      continue;
+    }
+
+    attempts.push({
+      adapterType: targetAdapterType,
+      model: failoverModel,
+      config: buildFailoverAdapterConfig({
+        primaryAdapterType: input.primaryAdapterType,
+        targetAdapterType,
+        baseConfig: input.runtimeConfig,
+        model: failoverModel,
+      }),
+      usesFailover: true,
+    });
+  }
+
+  return { attempts, warnings };
+}
+
+export async function executeWithAdapterFailover<T extends AdapterExecutionResult>(input: {
+  attempts: AdapterFailoverAttempt[];
+  executeAttempt: (attempt: AdapterFailoverAttempt) => Promise<T>;
+  onFailover?: (current: AdapterFailoverExecution<T>, nextAttempt: AdapterFailoverAttempt) => Promise<void> | void;
+}): Promise<{
+  attempt: AdapterFailoverAttempt;
+  result: T;
+  trail: Array<AdapterFailoverExecution<T>>;
+}> {
+  const trail: Array<AdapterFailoverExecution<T>> = [];
+
+  for (let index = 0; index < input.attempts.length; index += 1) {
+    const attempt = input.attempts[index]!;
+    const result = await input.executeAttempt(attempt);
+    trail.push({ attempt, result });
+
+    const nextAttempt = input.attempts[index + 1];
+    if (!nextAttempt || !attempt.usesFailover && !isRetryableAdapterFailure(result)) {
+      return { attempt, result, trail };
+    }
+
+    if (nextAttempt && isRetryableAdapterFailure(result)) {
+      await input.onFailover?.({ attempt, result }, nextAttempt);
+      continue;
+    }
+
+    return { attempt, result, trail };
+  }
+
+  throw new Error("Adapter failover plan contained no attempts");
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2798,7 +2798,7 @@ export function heartbeatService(db: Db) {
       secretsSvc,
     });
     const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId);
-    const runtimeConfig = {
+    const runtimeConfig: Record<string, unknown> = {
       ...resolvedConfig,
       paperclipRuntimeSkills: runtimeSkillEntries,
     };

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -21,7 +21,7 @@ import { conflict, notFound } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import { publishLiveEvent } from "./live-events.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
-import { getServerAdapter, runningProcesses } from "../adapters/index.js";
+import { getServerAdapter, listAdapterModels, listServerAdapters, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
@@ -67,6 +67,11 @@ import {
   resolveSessionCompactionPolicy,
   type SessionCompactionPolicy,
 } from "@paperclipai/adapter-utils";
+import {
+  buildAdapterFailoverPlan,
+  executeWithAdapterFailover,
+  shouldPersistSessionForAttempt,
+} from "./adapter-failover.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = 1;
@@ -2797,6 +2802,12 @@ export function heartbeatService(db: Db) {
       ...resolvedConfig,
       paperclipRuntimeSkills: runtimeSkillEntries,
     };
+    const failoverPlan = await buildAdapterFailoverPlan({
+      primaryAdapterType: agent.adapterType,
+      runtimeConfig,
+      resolveModels: listAdapterModels,
+      listAdapterTypes: () => listServerAdapters().map((adapter) => adapter.type),
+    });
     const workspaceOperationRecorder = workspaceOperationsSvc.createRecorder({
       companyId: agent.companyId,
       heartbeatRunId: run.id,
@@ -2981,6 +2992,7 @@ export function heartbeatService(db: Db) {
     const runtimeWorkspaceWarnings = [
       ...resolvedWorkspace.warnings,
       ...executionWorkspace.warnings,
+      ...failoverPlan.warnings,
       ...(runtimeSessionResolution.warning ? [runtimeSessionResolution.warning] : []),
       ...(resetTaskSession && sessionResetReason
         ? [
@@ -3228,45 +3240,89 @@ export function heartbeatService(db: Db) {
         });
       };
 
-      const adapter = getServerAdapter(agent.adapterType);
-      const authToken = adapter.supportsLocalAgentJwt
-        ? createLocalAgentJwt(agent.id, agent.companyId, agent.adapterType, run.id)
-        : null;
-      if (adapter.supportsLocalAgentJwt && !authToken) {
-        logger.warn(
-          {
-            companyId: agent.companyId,
-            agentId: agent.id,
+      const {
+        attempt: completedAttempt,
+        result: adapterResult,
+        trail: failoverTrail,
+      } = await executeWithAdapterFailover({
+        attempts: failoverPlan.attempts,
+        executeAttempt: async (attempt) => {
+          const adapter = getServerAdapter(attempt.adapterType);
+          const authToken = adapter.supportsLocalAgentJwt
+            ? createLocalAgentJwt(agent.id, agent.companyId, attempt.adapterType, run.id)
+            : null;
+
+          if (adapter.supportsLocalAgentJwt && !authToken) {
+            logger.warn(
+              {
+                companyId: agent.companyId,
+                agentId: agent.id,
+                runId: run.id,
+                adapterType: attempt.adapterType,
+              },
+              "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
+            );
+          }
+
+          return adapter.execute({
             runId: run.id,
-            adapterType: agent.adapterType,
-          },
-          "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
-        );
-      }
-      const adapterResult = await adapter.execute({
-        runId: run.id,
-        agent,
-        runtime: runtimeForAdapter,
-        config: runtimeConfig,
-        context,
-        onLog,
-        onMeta: onAdapterMeta,
-        onSpawn: async (meta) => {
-          await persistRunProcessMetadata(run.id, {
-            pid: meta.pid,
-            processGroupId:
-              "processGroupId" in meta && typeof meta.processGroupId === "number"
-                ? meta.processGroupId
-                : null,
-            startedAt: meta.startedAt,
+            agent: {
+              ...agent,
+              adapterType: attempt.adapterType,
+              adapterConfig: attempt.config,
+            },
+            runtime: attempt.usesFailover
+              ? {
+                  ...runtimeForAdapter,
+                  sessionId: null,
+                  sessionParams: null,
+                  sessionDisplayId: null,
+                }
+              : runtimeForAdapter,
+            config: attempt.config,
+            context,
+            onLog,
+            onMeta: onAdapterMeta,
+            onSpawn: async (meta) => {
+              await persistRunProcessMetadata(run.id, {
+                pid: meta.pid,
+                processGroupId:
+                  "processGroupId" in meta && typeof meta.processGroupId === "number"
+                    ? meta.processGroupId
+                    : null,
+                startedAt: meta.startedAt,
+              });
+            },
+            authToken: authToken ?? undefined,
           });
         },
-        authToken: authToken ?? undefined,
+        onFailover: async ({ attempt, result }, nextAttempt) => {
+          const fromLabel = attempt.model ? `${attempt.adapterType}:${attempt.model}` : attempt.adapterType;
+          const toLabel = nextAttempt.model ? `${nextAttempt.adapterType}:${nextAttempt.model}` : nextAttempt.adapterType;
+
+          await onLog(
+            "stderr",
+            `[paperclip] Retryable adapter failure on ${fromLabel}; retrying with ${toLabel}.\n`,
+          );
+          await appendRunEvent(currentRun, seq++, {
+            eventType: "lifecycle",
+            stream: "system",
+            level: "warn",
+            message: "adapter failover",
+            payload: {
+              fromAdapterType: attempt.adapterType,
+              fromModel: attempt.model,
+              toAdapterType: nextAttempt.adapterType,
+              toModel: nextAttempt.model,
+              reason: result.errorCode ?? result.errorMessage ?? "retryable_adapter_failure",
+            },
+          });
+        },
       });
       const adapterManagedRuntimeServices = adapterResult.runtimeServices
         ? await persistAdapterManagedRuntimeServices({
             db,
-            adapterType: agent.adapterType,
+            adapterType: completedAttempt.adapterType,
             runId: run.id,
             agent: {
               id: agent.id,
@@ -3311,13 +3367,24 @@ export function heartbeatService(db: Db) {
           }
         }
       }
-      const nextSessionState = resolveNextSessionState({
-        codec: sessionCodec,
-        adapterResult,
-        previousParams: previousSessionParams,
-        previousDisplayId: runtimeForAdapter.sessionDisplayId,
-        previousLegacySessionId: runtimeForAdapter.sessionId,
-      });
+      const persistSession = shouldPersistSessionForAttempt(
+        completedAttempt,
+        agent.adapterType,
+        readNonEmptyString(runtimeConfig.model),
+      );
+      const nextSessionState = persistSession
+        ? resolveNextSessionState({
+            codec: sessionCodec,
+            adapterResult,
+            previousParams: previousSessionParams,
+            previousDisplayId: runtimeForAdapter.sessionDisplayId,
+            previousLegacySessionId: runtimeForAdapter.sessionId,
+          })
+        : {
+            params: null,
+            displayId: null,
+            legacySessionId: null,
+          };
       const rawUsage = normalizeUsageTotals(adapterResult.usage);
       const sessionUsageResolution = await resolveNormalizedUsageForSession({
         agentId: agent.id,
@@ -3369,6 +3436,18 @@ export function heartbeatService(db: Db) {
               sessionReused: runtimeForAdapter.sessionId != null || runtimeForAdapter.sessionDisplayId != null,
               taskSessionReused: taskSessionForRun != null,
               freshSession: runtimeForAdapter.sessionId == null && runtimeForAdapter.sessionDisplayId == null,
+              failoverUsed: completedAttempt.usesFailover,
+              primaryAdapterType: agent.adapterType,
+              primaryModel: readNonEmptyString(runtimeConfig.model) ?? "unknown",
+              effectiveAdapterType: completedAttempt.adapterType,
+              effectiveModel: completedAttempt.model ?? readNonEmptyString(adapterResult.model) ?? "unknown",
+              failoverTrail: failoverTrail.map(({ attempt, result }) => ({
+                adapterType: attempt.adapterType,
+                model: attempt.model,
+                usesFailover: attempt.usesFailover,
+                errorCode: result.errorCode ?? null,
+                errorMessage: result.errorMessage ?? null,
+              })),
               sessionRotated: sessionCompaction.rotate,
               sessionRotationReason: sessionCompaction.reason,
               provider: readNonEmptyString(adapterResult.provider) ?? "unknown",

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -33,6 +33,7 @@ import {
   ToggleWithNumber,
   CollapsibleSection,
   DraftInput,
+  DraftTextarea,
   DraftNumberInput,
   help,
   adapterLabels,
@@ -56,7 +57,11 @@ import { buildAgentUpdatePatch, type AgentConfigOverlay } from "../lib/agent-con
 // Canonical type lives in @paperclipai/adapter-utils; re-exported here
 // so existing imports from this file keep working.
 export type { CreateConfigValues } from "@paperclipai/adapter-utils";
-import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import {
+  parseFailoverModelList,
+  serializeFailoverModelList,
+  type CreateConfigValues,
+} from "@paperclipai/adapter-utils";
 
 /* ---- Props ---- */
 
@@ -716,6 +721,32 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     : "Failed to load adapter models."}
                 </p>
               )}
+
+              <Field label="Failover models" hint={help.failoverModels}>
+                <DraftTextarea
+                  value={
+                    isCreate
+                      ? val!.failoverModelsText
+                      : serializeFailoverModelList(
+                          eff("adapterConfig", "failoverModels", config.failoverModels),
+                        )
+                  }
+                  onCommit={(value) => {
+                    const failoverModels = parseFailoverModelList(value);
+                    if (isCreate) {
+                      set!({ failoverModelsText: value });
+                    } else {
+                      mark(
+                        "adapterConfig",
+                        "failoverModels",
+                        failoverModels.length > 0 ? failoverModels : undefined,
+                      );
+                    }
+                  }}
+                  placeholder={"claude-sonnet-4-6\ngpt-5.4\ngemini-2.5-pro"}
+                  minRows={3}
+                />
+              </Field>
 
               {showThinkingEffort && (
                 <>

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -6,6 +6,7 @@ export const defaultCreateValues: CreateConfigValues = {
   instructionsFilePath: "",
   promptTemplate: "",
   model: "",
+  failoverModelsText: "",
   thinkingEffort: "",
   chrome: false,
   dangerouslySkipPermissions: true,

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -29,6 +29,7 @@ export const help: Record<string, string> = {
   cwd: "Deprecated legacy working directory fallback for local adapters. Existing agents may still carry this value, but new configurations should use project workspaces instead.",
   promptTemplate: "Sent on every heartbeat. Keep this small and dynamic. Use it for current-task framing, not large static instructions. Supports {{ agent.id }}, {{ agent.name }}, {{ agent.role }} and other template variables.",
   model: "Override the default model used by the adapter.",
+  failoverModels: "Optional backup models to try automatically when the primary model hits quota or rate limits. Enter one model per line.",
   thinkingEffort: "Control model reasoning depth. Supported values vary by adapter/model.",
   chrome: "Enable Claude's Chrome integration by passing --chrome.",
   dangerouslySkipPermissions: "Run unattended by auto-approving adapter permission prompts when supported.",


### PR DESCRIPTION
## Summary
- add shared parsing/serialization helpers for per-agent failover model lists
- expose failover model editing in the agent config UI and persist it through adapter config builders
- teach heartbeat execution to retry retryable quota/rate-limit failures against configured backup models

## Why
Fixes #3374.

When a primary model hits a retryable provider failure such as quota exhaustion or rate limiting, the current run stops even if a safe fallback model is already known. This change adds explicit failover chains so the system can recover automatically while keeping the behavior transparent in usage metadata and run events.

## Impact
Agent runs can continue through transient provider/model availability issues with a configured backup model instead of failing immediately, and operators can manage that behavior per agent from the existing config flow.

## Validation
- `corepack pnpm vitest run server/src/__tests__/adapter-failover.test.ts packages/adapters/codex-local/src/ui/build-config.test.ts`
- `corepack pnpm --filter @paperclipai/ui exec tsc -b`
- `corepack pnpm --filter @paperclipai/adapter-utils exec tsc --noEmit`
- `corepack pnpm --filter @paperclipai/adapter-codex-local exec tsc --noEmit`
- `corepack pnpm --filter @paperclipai/adapter-claude-local --filter @paperclipai/adapter-cursor-local --filter @paperclipai/adapter-gemini-local --filter @paperclipai/adapter-opencode-local --filter @paperclipai/adapter-pi-local exec tsc --noEmit`