### PR TITLE
[codex] Increase the gemini_local hello probe timeout

### DIFF
--- a/packages/adapters/gemini-local/src/server/test.ts
+++ b/packages/adapters/gemini-local/src/server/test.ts
@@ -135,7 +135,7 @@ export async function testEnvironment(
       const model = asString(config.model, DEFAULT_GEMINI_LOCAL_MODEL).trim();
       const approvalMode = asString(config.approvalMode, asBoolean(config.yolo, false) ? "yolo" : "default");
       const sandbox = asBoolean(config.sandbox, false);
-      const helloProbeTimeoutSec = Math.max(1, asNumber(config.helloProbeTimeoutSec, 10));
+      const helloProbeTimeoutSec = Math.max(1, asNumber(config.helloProbeTimeoutSec, 30));
       const extraArgs = (() => {
         const fromExtraArgs = asStringArray(config.extraArgs);
         if (fromExtraArgs.length > 0) return fromExtraArgs;

--- a/server/src/__tests__/gemini-local-hello-probe-timeout.test.ts
+++ b/server/src/__tests__/gemini-local-hello-probe-timeout.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let capturedTimeoutSec: number | null = null;
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+
+  return {
+    ...actual,
+    ensureAbsoluteDirectory: vi.fn(async () => {}),
+    ensureCommandResolvable: vi.fn(async () => {}),
+    ensurePathInEnv: vi.fn((env: Record<string, string>) => env),
+    runChildProcess: vi.fn(async (_id, _command, _args, options: { timeoutSec: number }) => {
+      capturedTimeoutSec = options.timeoutSec;
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: `${JSON.stringify({ type: "result", subtype: "success", result: "hello" })}\n`,
+        stderr: "",
+      };
+    }),
+  };
+});
+
+describe("gemini_local hello probe timeout", () => {
+  beforeEach(() => {
+    capturedTimeoutSec = null;
+  });
+
+  it("uses 30 seconds as the default hello probe timeout", async () => {
+    const { testEnvironment } = await import("@paperclipai/adapter-gemini-local/server");
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "gemini_local",
+      config: {
+        command: "gemini",
+        cwd: process.cwd(),
+        env: {
+          GEMINI_API_KEY: "test-key",
+        },
+      },
+    });
+
+    expect(result.status).toBe("pass");
+    expect(capturedTimeoutSec).toBe(30);
+  });
+});


### PR DESCRIPTION
## Summary
- raise the default `gemini_local` hello probe timeout from 10 seconds to 30 seconds
- add a focused regression test that asserts the longer timeout is passed into the child process probe

## Why
Fixes #3372.

The initial hello probe timeout was short enough to fail on slower local Gemini startups even when the adapter would become healthy moments later. Extending the probe window reduces false negatives without changing the rest of the adapter handshake behavior.

## Impact
`gemini_local` adapters get a more realistic startup window, which makes local adapter health checks less brittle on slower machines.

## Validation
- `corepack pnpm vitest run server/src/__tests__/gemini-local-hello-probe-timeout.test.ts`