### PR TITLE
Backend implementation: board-safe issue assets API and document export

### DIFF
--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -104,6 +104,10 @@ describe("normalizeContentType", () => {
     expect(normalizeContentType(" Application/Zip ")).toBe("application/zip");
   });
 
+  it("strips media type parameters", () => {
+    expect(normalizeContentType(" Image/Svg+Xml; Charset=UTF-8 ")).toBe("image/svg+xml");
+  });
+
   it("falls back to octet-stream when the type is missing", () => {
     expect(normalizeContentType(undefined)).toBe("application/octet-stream");
     expect(normalizeContentType("")).toBe("application/octet-stream");

--- a/server/src/__tests__/issue-assets-routes.test.ts
+++ b/server/src/__tests__/issue-assets-routes.test.ts
@@ -223,6 +223,32 @@ describe("issue assets routes", () => {
     expect(res.body.workspace.status).toBe("unavailable");
   });
 
+  it("does not expose parameterized svg attachments as previewable", async () => {
+    mockIssueService.listAttachments.mockResolvedValue([
+      {
+        ...attachment,
+        contentType: "image/svg+xml; charset=utf-8",
+        originalFilename: "diagram.svg",
+      },
+    ]);
+    mockDocumentsService.listIssueDocuments.mockResolvedValue([]);
+    mockWorkProductService.listForIssue.mockResolvedValue([]);
+
+    const res = await request(createApp()).get(`/api/issues/${issueId}/assets`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.assets).toEqual([
+      expect.objectContaining({
+        kind: "attachment",
+        title: "diagram.svg",
+        contentType: "image/svg+xml",
+        previewable: false,
+        previewUrl: null,
+        downloadUrl: "/api/attachments/attachment-1/content?download=1",
+      }),
+    ]);
+  });
+
   it("exports the latest issue document revision as markdown download", async () => {
     const body = "# Plan\n\nShip it.";
     mockDocumentsService.getIssueDocumentByKey.mockResolvedValue({ ...document, body });

--- a/server/src/__tests__/issue-assets-routes.test.ts
+++ b/server/src/__tests__/issue-assets-routes.test.ts
@@ -1,0 +1,267 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { issueRoutes } from "../routes/issues.js";
+import { errorHandler } from "../middleware/index.js";
+
+const issueId = "11111111-1111-4111-8111-111111111111";
+const companyId = "22222222-2222-4222-8222-222222222222";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(),
+  listAttachments: vi.fn(),
+}));
+
+const mockDocumentsService = vi.hoisted(() => ({
+  listIssueDocuments: vi.fn(),
+  getIssueDocumentByKey: vi.fn(),
+}));
+
+const mockWorkProductService = vi.hoisted(() => ({
+  listForIssue: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => mockDocumentsService,
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+  }),
+  goalService: () => ({}),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+    getRun: vi.fn(async () => null),
+    getActiveRunForAgent: vi.fn(async () => null),
+    cancelRun: vi.fn(async () => null),
+  }),
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    })),
+    listCompanyIds: vi.fn(async () => [companyId]),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => mockWorkProductService,
+}));
+
+const allowedBoardActor = {
+  type: "board",
+  userId: "board-user",
+  companyIds: [companyId],
+  source: "auth0",
+  isInstanceAdmin: false,
+};
+
+function createApp(actor: Record<string, unknown> = allowedBoardActor) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+const now = new Date("2026-04-12T12:00:00.000Z");
+const issue = {
+  id: issueId,
+  companyId,
+  identifier: "PAP-1",
+  title: "Assets",
+  status: "in_progress",
+};
+const document = {
+  id: "document-1",
+  companyId,
+  issueId,
+  key: "plan",
+  title: "Plan",
+  format: "markdown",
+  body: "# Plan",
+  latestRevisionId: "revision-1",
+  latestRevisionNumber: 1,
+  createdByAgentId: null,
+  createdByUserId: "board-user",
+  updatedByAgentId: null,
+  updatedByUserId: "board-user",
+  createdAt: now,
+  updatedAt: now,
+};
+const attachment = {
+  id: "attachment-1",
+  companyId,
+  issueId,
+  issueCommentId: null,
+  assetId: "asset-1",
+  provider: "local_disk",
+  objectKey: "issues/issue-1/report.pdf",
+  contentType: "application/pdf",
+  byteSize: 12,
+  sha256: "sha256-sample",
+  originalFilename: "report.pdf",
+  createdByAgentId: null,
+  createdByUserId: "board-user",
+  createdAt: now,
+  updatedAt: now,
+};
+const workProduct = {
+  id: "work-product-1",
+  companyId,
+  projectId: null,
+  issueId,
+  executionWorkspaceId: null,
+  runtimeServiceId: null,
+  type: "pull_request",
+  provider: "github",
+  externalId: "123",
+  title: "PR #123",
+  url: "https://github.com/paperclipai/paperclip/pull/123",
+  status: "ready_for_review",
+  reviewState: "needs_board_review",
+  isPrimary: true,
+  healthStatus: "unknown",
+  summary: null,
+  metadata: null,
+  createdByRunId: null,
+  createdAt: now,
+  updatedAt: now,
+};
+
+describe("issue assets routes", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.listAttachments.mockResolvedValue([attachment]);
+    mockDocumentsService.listIssueDocuments.mockResolvedValue([document]);
+    mockDocumentsService.getIssueDocumentByKey.mockResolvedValue(document);
+    mockWorkProductService.listForIssue.mockResolvedValue([workProduct]);
+  });
+
+  it("returns an issue-scoped assets manifest without storage object paths", async () => {
+    const res = await request(createApp()).get(`/api/issues/${issueId}/assets`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.issue).toEqual({ id: issueId, identifier: "PAP-1" });
+    expect(res.body.workspace).toEqual({
+      status: "unavailable",
+      reason: "workspace_browsing_disabled",
+    });
+    expect(res.body.assets.map((asset: { kind: string }) => asset.kind)).toEqual([
+      "document",
+      "attachment",
+      "work_product",
+    ]);
+    expect(res.body.assets[0]).toEqual(expect.objectContaining({
+      kind: "document",
+      title: "Plan",
+      contentType: "text/markdown; charset=utf-8",
+      byteSize: Buffer.byteLength(document.body, "utf8"),
+      previewable: true,
+      previewUrl: `/api/issues/${issueId}/documents/plan`,
+      downloadUrl: `/api/issues/${issueId}/documents/plan/export`,
+      reviewState: null,
+      isPrimary: null,
+    }));
+    expect(res.body.assets[1]).toEqual(expect.objectContaining({
+      kind: "attachment",
+      title: "report.pdf",
+      contentType: "application/pdf",
+      byteSize: 12,
+      previewable: true,
+      previewUrl: "/api/attachments/attachment-1/content",
+      downloadUrl: "/api/attachments/attachment-1/content?download=1",
+      reviewState: null,
+      isPrimary: null,
+    }));
+    expect(res.body.assets[1]).not.toHaveProperty("objectKey");
+    expect(res.body.assets[2]).toEqual(expect.objectContaining({
+      kind: "work_product",
+      title: "PR #123",
+      contentType: null,
+      byteSize: null,
+      previewable: true,
+      previewUrl: "https://github.com/paperclipai/paperclip/pull/123",
+      downloadUrl: null,
+      reviewState: "needs_board_review",
+      isPrimary: true,
+      type: "pull_request",
+      provider: "github",
+    }));
+  });
+
+  it("returns an empty assets manifest with workspace browsing unavailable", async () => {
+    mockIssueService.listAttachments.mockResolvedValue([]);
+    mockDocumentsService.listIssueDocuments.mockResolvedValue([]);
+    mockWorkProductService.listForIssue.mockResolvedValue([]);
+
+    const res = await request(createApp()).get(`/api/issues/${issueId}/assets`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.assets).toEqual([]);
+    expect(res.body.workspace.status).toBe("unavailable");
+  });
+
+  it("exports the latest issue document revision as markdown download", async () => {
+    const body = "# Plan\n\nShip it.";
+    mockDocumentsService.getIssueDocumentByKey.mockResolvedValue({ ...document, body });
+
+    const res = await request(createApp()).get(`/api/issues/${issueId}/documents/plan/export`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toBe(body);
+    expect(res.headers["content-type"]).toContain("text/markdown");
+    expect(res.headers["content-length"]).toBe(String(Buffer.byteLength(body, "utf8")));
+    expect(res.headers["content-disposition"]).toBe('attachment; filename="PAP-1-plan.md"');
+    expect(res.headers["cache-control"]).toBe("private, max-age=60");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  it("rejects invalid document export keys before loading the document", async () => {
+    const res = await request(createApp()).get(`/api/issues/${issueId}/documents/INVALID%20KEY/export`);
+
+    expect(res.status).toBe(400);
+    expect(mockDocumentsService.getIssueDocumentByKey).not.toHaveBeenCalled();
+  });
+
+  it("returns not found when exporting a missing document", async () => {
+    mockDocumentsService.getIssueDocumentByKey.mockResolvedValue(null);
+
+    const res = await request(createApp()).get(`/api/issues/${issueId}/documents/plan/export`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("uses existing company access checks for document export", async () => {
+    const deniedActor = {
+      ...allowedBoardActor,
+      companyIds: ["other-company"],
+    };
+
+    const res = await request(createApp(deniedActor)).get(`/api/issues/${issueId}/documents/plan/export`);
+
+    expect(res.status).toBe(403);
+    expect(mockDocumentsService.getIssueDocumentByKey).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -183,6 +183,30 @@ describe("issue attachment routes", () => {
     expect(res.headers["x-content-type-options"]).toBe("nosniff");
   });
 
+  it("serves svg attachments as downloads with sandboxing headers", async () => {
+    const storage = createStorageService();
+    mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("image/svg+xml", "diagram.svg"));
+
+    const app = await createApp(storage);
+    const res = await request(app).get("/api/attachments/attachment-1/content");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-disposition"]).toBe('attachment; filename="diagram.svg"');
+    expect(res.headers["content-security-policy"]).toContain("sandbox");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  it("serves binary attachments as downloads", async () => {
+    const storage = createStorageService();
+    mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("application/octet-stream", "bundle.bin"));
+
+    const app = await createApp(storage);
+    const res = await request(app).get("/api/attachments/attachment-1/content");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-disposition"]).toBe('attachment; filename="bundle.bin"');
+  });
+
   it("keeps image attachments inline for previews", async () => {
     const storage = createStorageService();
     mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("image/png", "preview.png"));
@@ -195,5 +219,27 @@ describe("issue attachment routes", () => {
       undefined,
       'inline; filename="preview.png"',
     ]).toContain(res.headers["content-disposition"]);
+  });
+
+  it("forces image attachments to download with download=1", async () => {
+    const storage = createStorageService();
+    mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("image/png", "preview.png"));
+
+    const app = await createApp(storage);
+    const res = await request(app).get("/api/attachments/attachment-1/content?download=1");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-disposition"]).toBe('attachment; filename="preview.png"');
+  });
+
+  it("sanitizes unsafe attachment download filenames", async () => {
+    const storage = createStorageService();
+    mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("text/html", "evil\r\n/..\\report\".html"));
+
+    const app = await createApp(storage);
+    const res = await request(app).get("/api/attachments/attachment-1/content");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-disposition"]).toBe('attachment; filename="evil_.._report_.html"');
   });
 });

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -196,6 +196,22 @@ describe("issue attachment routes", () => {
     expect(res.headers["x-content-type-options"]).toBe("nosniff");
   });
 
+  it("serves parameterized svg attachments as downloads with sandboxing headers", async () => {
+    const storage = createStorageService();
+    mockIssueService.getAttachmentById.mockResolvedValue(
+      makeAttachment("image/svg+xml; charset=utf-8", "diagram.svg"),
+    );
+
+    const app = await createApp(storage);
+    const res = await request(app).get("/api/attachments/attachment-1/content");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("image/svg+xml");
+    expect(res.headers["content-disposition"]).toBe('attachment; filename="diagram.svg"');
+    expect(res.headers["content-security-policy"]).toContain("sandbox");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+
   it("serves binary attachments as downloads", async () => {
     const storage = createStorageService();
     mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("application/octet-stream", "bundle.bin"));

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -60,7 +60,7 @@ export function parseAllowedTypes(raw: string | undefined): string[] {
  * patterns ("image/*", "application/vnd.openxmlformats-officedocument.*").
  */
 export function matchesContentType(contentType: string, allowedPatterns: string[]): boolean {
-  const ct = contentType.toLowerCase();
+  const ct = normalizeContentType(contentType);
   return allowedPatterns.some((pattern) => {
     if (pattern === "*") return true;
     if (pattern.endsWith("/*") || pattern.endsWith(".*")) {
@@ -71,7 +71,8 @@ export function matchesContentType(contentType: string, allowedPatterns: string[
 }
 
 export function normalizeContentType(contentType: string | null | undefined): string {
-  const normalized = (contentType ?? "").trim().toLowerCase();
+  const [baseMediaType] = (contentType ?? "").split(";", 1);
+  const normalized = (baseMediaType ?? "").trim().toLowerCase();
   return normalized || DEFAULT_ATTACHMENT_CONTENT_TYPE;
 }
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -63,6 +63,7 @@ import {
 } from "../services/issue-execution-policy.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
+const MARKDOWN_CONTENT_TYPE = "text/markdown; charset=utf-8";
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
@@ -87,6 +88,48 @@ type ExecutionStageWakeContext = {
   lastDecisionOutcome: ParsedExecutionState["lastDecisionOutcome"];
   allowedActions: string[];
 };
+type IssueAssetManifestItem = {
+  kind: "document" | "attachment" | "work_product";
+  id: string;
+  title: string;
+  contentType: string | null;
+  byteSize: number | null;
+  previewable: boolean;
+  previewUrl: string | null;
+  downloadUrl: string | null;
+  reviewState: string | null;
+  isPrimary: boolean | null;
+  [key: string]: unknown;
+};
+
+function sanitizeDownloadFilename(input: string | null | undefined, fallback = "download") {
+  const raw = input && input.trim().length > 0 ? input : fallback;
+  const sanitized = raw
+    .replace(/[\x00-\x1F\x7F"\\\/;]+/g, "_")
+    .replace(/[^\x20-\x7E]+/g, "_")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^\.+$/, "");
+  const fallbackSanitized = fallback
+    .replace(/[\x00-\x1F\x7F"\\\/;]+/g, "_")
+    .replace(/[^\x20-\x7E]+/g, "_")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^\.+$/, "");
+  return (sanitized || fallbackSanitized || "download").slice(0, 180);
+}
+
+function contentDisposition(disposition: "inline" | "attachment", filename: string | null | undefined) {
+  return `${disposition}; filename="${sanitizeDownloadFilename(filename, "attachment")}"`;
+}
+
+function encodeApiPathSegment(segment: string) {
+  return encodeURIComponent(segment);
+}
+
+function isPreviewableAttachmentContentType(contentType: string) {
+  return contentType !== SVG_CONTENT_TYPE && isInlineAttachmentContentType(contentType);
+}
 
 function executionPrincipalsEqual(
   left: ParsedExecutionState["currentParticipant"] | null,
@@ -305,6 +348,85 @@ export function issueRoutes(
 
   function parseBooleanQuery(value: unknown) {
     return value === true || value === "true" || value === "1";
+  }
+
+  function buildIssueAssetsManifest(input: {
+    issue: { id: string; identifier: string | null };
+    documents: Awaited<ReturnType<ReturnType<typeof documentService>["listIssueDocuments"]>>;
+    attachments: Awaited<ReturnType<ReturnType<typeof issueService>["listAttachments"]>>;
+    workProducts: Awaited<ReturnType<ReturnType<typeof workProductService>["listForIssue"]>>;
+  }) {
+    const issuePathId = encodeApiPathSegment(input.issue.id);
+    const documentAssets: IssueAssetManifestItem[] = input.documents.map((doc) => {
+      const key = encodeApiPathSegment(doc.key);
+      return {
+        kind: "document",
+        id: doc.id,
+        key: doc.key,
+        title: doc.title ?? doc.key,
+        contentType: MARKDOWN_CONTENT_TYPE,
+        byteSize: Buffer.byteLength(doc.body, "utf8"),
+        previewable: true,
+        previewUrl: `/api/issues/${issuePathId}/documents/${key}`,
+        downloadUrl: `/api/issues/${issuePathId}/documents/${key}/export`,
+        reviewState: null,
+        isPrimary: null,
+        latestRevisionId: doc.latestRevisionId,
+        latestRevisionNumber: doc.latestRevisionNumber,
+        updatedAt: doc.updatedAt,
+      };
+    });
+    const attachmentAssets: IssueAssetManifestItem[] = input.attachments.map((attachment) => {
+      const contentType = normalizeContentType(attachment.contentType);
+      const previewable = isPreviewableAttachmentContentType(contentType);
+      const contentPath = `/api/attachments/${encodeApiPathSegment(attachment.id)}/content`;
+      return {
+        kind: "attachment",
+        id: attachment.id,
+        title: attachment.originalFilename ?? "attachment",
+        contentType,
+        byteSize: attachment.byteSize,
+        previewable,
+        previewUrl: previewable ? contentPath : null,
+        downloadUrl: `${contentPath}?download=1`,
+        reviewState: null,
+        isPrimary: null,
+        createdAt: attachment.createdAt,
+        updatedAt: attachment.updatedAt,
+      };
+    });
+    const workProductAssets: IssueAssetManifestItem[] = input.workProducts.map((product) => {
+      const url = product.url && product.url.trim().length > 0 ? product.url : null;
+      return {
+        kind: "work_product",
+        id: product.id,
+        title: product.title,
+        contentType: null,
+        byteSize: null,
+        previewable: Boolean(url),
+        previewUrl: url,
+        downloadUrl: product.type === "artifact" || product.type === "document" ? url : null,
+        reviewState: product.reviewState,
+        isPrimary: product.isPrimary,
+        type: product.type,
+        provider: product.provider,
+        status: product.status,
+        healthStatus: product.healthStatus,
+        updatedAt: product.updatedAt,
+      };
+    });
+
+    return {
+      issue: {
+        id: input.issue.id,
+        identifier: input.issue.identifier,
+      },
+      assets: [...documentAssets, ...attachmentAssets, ...workProductAssets],
+      workspace: {
+        status: "unavailable",
+        reason: "workspace_browsing_disabled",
+      },
+    };
   }
 
   function parseDateQuery(value: unknown, field: string) {
@@ -767,6 +889,23 @@ export function issueRoutes(
     });
   });
 
+  router.get("/issues/:id/assets", async (req, res) => {
+    const id = req.params.id as string;
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+
+    const [documents, attachments, workProducts] = await Promise.all([
+      documentsSvc.listIssueDocuments(issue.id),
+      svc.listAttachments(issue.id),
+      workProductsSvc.listForIssue(issue.id),
+    ]);
+    res.json(buildIssueAssetsManifest({ issue, documents, attachments, workProducts }));
+  });
+
   router.get("/issues/:id/work-products", async (req, res) => {
     const id = req.params.id as string;
     const issue = await svc.getById(id);
@@ -810,6 +949,34 @@ export function issueRoutes(
       return;
     }
     res.json(doc);
+  });
+
+  router.get("/issues/:id/documents/:key/export", async (req, res) => {
+    const id = req.params.id as string;
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    const keyParsed = issueDocumentKeySchema.safeParse(String(req.params.key ?? "").trim().toLowerCase());
+    if (!keyParsed.success) {
+      res.status(400).json({ error: "Invalid document key", details: keyParsed.error.issues });
+      return;
+    }
+    const doc = await documentsSvc.getIssueDocumentByKey(issue.id, keyParsed.data);
+    if (!doc) {
+      res.status(404).json({ error: "Document not found" });
+      return;
+    }
+    const body = doc.body;
+    const filename = `${issue.identifier ?? issue.id}-${doc.key}.md`;
+    res.setHeader("Content-Type", MARKDOWN_CONTENT_TYPE);
+    res.setHeader("Content-Length", String(Buffer.byteLength(body, "utf8")));
+    res.setHeader("Cache-Control", "private, max-age=60");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Content-Disposition", contentDisposition("attachment", filename));
+    res.send(body);
   });
 
   router.put("/issues/:id/documents/:key", validate(upsertIssueDocumentSchema), async (req, res) => {
@@ -2572,8 +2739,11 @@ export function issueRoutes(
       res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'");
     }
     const filename = attachment.originalFilename ?? "attachment";
-    const disposition = isInlineAttachmentContentType(responseContentType) ? "inline" : "attachment";
-    res.setHeader("Content-Disposition", `${disposition}; filename=\"${filename.replaceAll("\"", "")}\"`);
+    const disposition =
+      parseBooleanQuery(req.query.download) || !isPreviewableAttachmentContentType(responseContentType)
+        ? "attachment"
+        : "inline";
+    res.setHeader("Content-Disposition", contentDisposition(disposition, filename));
 
     object.stream.on("error", (err) => {
       next(err);

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -1,7 +1,7 @@
 import { and, asc, desc, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { documentRevisions, documents, issueDocuments, issues } from "@paperclipai/db";
-import { issueDocumentKeySchema } from "@paperclipai/shared";
+import { issueDocumentKeySchema, type IssueDocument, type IssueDocumentSummary } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 
 function normalizeDocumentKey(key: string) {
@@ -25,34 +25,34 @@ export function extractLegacyPlanBody(description: string | null | undefined) {
   return body ? body : null;
 }
 
-function mapIssueDocumentRow(
-  row: {
-    id: string;
-    companyId: string;
-    issueId: string;
-    key: string;
-    title: string | null;
-    format: string;
-    latestBody: string;
-    latestRevisionId: string | null;
-    latestRevisionNumber: number;
-    createdByAgentId: string | null;
-    createdByUserId: string | null;
-    updatedByAgentId: string | null;
-    updatedByUserId: string | null;
-    createdAt: Date;
-    updatedAt: Date;
-  },
-  includeBody: boolean,
-) {
-  return {
+type IssueDocumentRow = {
+  id: string;
+  companyId: string;
+  issueId: string;
+  key: string;
+  title: string | null;
+  format: string;
+  latestBody: string;
+  latestRevisionId: string | null;
+  latestRevisionNumber: number;
+  createdByAgentId: string | null;
+  createdByUserId: string | null;
+  updatedByAgentId: string | null;
+  updatedByUserId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function mapIssueDocumentRow(row: IssueDocumentRow, includeBody: true): IssueDocument;
+function mapIssueDocumentRow(row: IssueDocumentRow, includeBody: false): IssueDocumentSummary;
+function mapIssueDocumentRow(row: IssueDocumentRow, includeBody: boolean): IssueDocument | IssueDocumentSummary {
+  const mapped = {
     id: row.id,
     companyId: row.companyId,
     issueId: row.issueId,
     key: row.key,
     title: row.title,
-    format: row.format,
-    ...(includeBody ? { body: row.latestBody } : {}),
+    format: row.format as IssueDocumentSummary["format"],
     latestRevisionId: row.latestRevisionId ?? null,
     latestRevisionNumber: row.latestRevisionNumber,
     createdByAgentId: row.createdByAgentId,
@@ -62,6 +62,7 @@ function mapIssueDocumentRow(
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
+  return includeBody ? { ...mapped, body: row.latestBody } : mapped;
 }
 
 const issueDocumentSelect = {


### PR DESCRIPTION
## Summary

- Add `GET /api/issues/:id/assets` with document, attachment, and issue work product manifest entries while keeping workspace browsing unavailable.
- Add markdown document export at `GET /api/issues/:id/documents/:key/export` with private/nosniff download headers.
- Extend attachment content responses so `download=1` forces attachment disposition and filenames are sanitized for header/path safety.

## Validation

- `pnpm test:run server/src/__tests__/issue-assets-routes.test.ts server/src/__tests__/issue-attachment-routes.test.ts server/src/__tests__/issue-document-restore-routes.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check`

## Notes

The upstream push was blocked by GitHub 403 for the configured local HTTPS user, so this PR is opened from the authenticated user's fork branch.