### PR TITLE
fix(heartbeat): sweep stale execution locks on startup + log silent failures

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4300,7 +4300,54 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (reaped.length > 0) {
       logger.warn({ reapedCount: reaped.length, runIds: reaped }, "reaped orphaned heartbeat runs");
     }
-    return { reaped: reaped.length, runIds: reaped };
+
+    // Second pass: sweep issues whose execution lock points to a terminal run.
+    // Covers cases where releaseIssueExecutionAndPromote failed silently or
+    // wasn't reached during a prior crash.
+    const staleLockedRows = await db
+      .select({
+        issueId: issues.id,
+        runId: issues.executionRunId,
+        runStatus: heartbeatRuns.status,
+      })
+      .from(issues)
+      .leftJoin(heartbeatRuns, eq(issues.executionRunId, heartbeatRuns.id))
+      .where(sql`${issues.executionRunId} IS NOT NULL`);
+
+    const sweptIssueIds: string[] = [];
+    for (const row of staleLockedRows) {
+      if (row.runStatus === "running" || row.runStatus === "queued") continue;
+
+      if (row.runId) {
+        const run = await getRun(row.runId);
+        if (run) {
+          await releaseIssueExecutionAndPromote(run);
+          sweptIssueIds.push(row.issueId);
+          continue;
+        }
+      }
+
+      // Run missing (FK cascaded) — clear lock directly
+      await db
+        .update(issues)
+        .set({
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, row.issueId));
+      sweptIssueIds.push(row.issueId);
+    }
+
+    if (sweptIssueIds.length > 0) {
+      logger.warn(
+        { sweptCount: sweptIssueIds.length, issueIds: sweptIssueIds },
+        "swept stale execution locks on startup",
+      );
+    }
+
+    return { reaped: reaped.length, runIds: reaped, swept: sweptIssueIds.length, sweptIssueIds };
   }
 
   async function resumeQueuedRuns() {
@@ -5692,7 +5739,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               await refreshContinuationSummaryForRun(livenessRun, failedAgent).catch(() => undefined);
               await finalizeIssueCommentPolicy(livenessRun, failedAgent).catch(() => undefined);
             }
-            await releaseIssueExecutionAndPromote(livenessRun).catch(() => undefined);
+            await releaseIssueExecutionAndPromote(livenessRun).catch((err) => {
+              logger.error({ err, runId: livenessRun.id }, "releaseIssueExecutionAndPromote failed in outer catch");
+            });
           }
           // Ensure the agent is not left stuck in "running" if the inner catch handler's
           // DB calls threw (e.g. a transient DB error in finalizeAgentStatus).


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The heartbeat service manages agent run lifecycle, including execution locks on issues
> - When a run crashes or `releaseIssueExecutionAndPromote` fails silently, execution locks can become stale
> - Stale locks permanently block all agent interaction with the affected issue (no checkout, no work)
> - The existing `reapOrphanedRuns()` startup function handles orphaned runs but doesn't check for stale execution locks
> - This pull request adds a second pass to `reapOrphanedRuns()` that sweeps issues locked to terminal/missing runs
> - It also replaces a silent `.catch(() => undefined)` on `releaseIssueExecutionAndPromote` with proper error logging
> - The benefit is automatic recovery from stale execution locks on server restart, plus visibility into release failures

## What Changed

- Added a second pass in `reapOrphanedRuns()` that queries all issues with a non-null `executionRunId` and releases those pointing to runs in terminal state (`succeeded`/`failed`/`cancelled`) or missing runs (FK cascaded)
- For runs that still exist: calls `releaseIssueExecutionAndPromote(run)` to properly release and promote queued runs
- For missing runs (FK cascade deleted): directly clears `executionRunId`, `executionAgentNameKey`, and `executionLockedAt`
- Replaced silent `.catch(() => undefined)` on the outer-catch `releaseIssueExecutionAndPromote` call with `logger.error()` for visibility

## Verification

1. Start a Paperclip server with issues that have stale `execution_run_id` pointing to completed/failed runs
2. On startup, `reapOrphanedRuns()` logs: `"swept stale execution locks on startup"` with issue IDs
3. Verify affected issues have cleared execution lock fields and can be checked out by agents
4. For the error logging: force a `releaseIssueExecutionAndPromote` failure in the outer catch — verify the error is logged instead of silently swallowed

## Risks

- Low risk. The sweep runs only at startup (not on every heartbeat), so no runtime performance impact.
- The query fetches all issues with execution locks, which could be a large set on busy instances. In practice this is bounded by concurrent agent capacity.
- Uses the existing `releaseIssueExecutionAndPromote` for cleanup, which handles queue promotion correctly.

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`) via Claude Code CLI with tool use. Used for conflict resolution and PR description drafting.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Relates to: #2912, #1033, #2533