### PR TITLE
feat(issues): add done-status guardrail — only creator agent can close

### DIFF
--- a/server/src/__tests__/issue-done-status-guardrail.test.ts
+++ b/server/src/__tests__/issue-done-status-guardrail.test.ts
@@ -1,0 +1,208 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { issueRoutes } from "../routes/issues.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  findMentionedAgents: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+  }),
+  goalService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    })),
+    listCompanyIds: vi.fn(async () => ["company-1"]),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+}));
+
+const ISSUE_ID = "11111111-1111-4111-8111-111111111111";
+const AGENT_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const AGENT_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function createApp(actor: Record<string, unknown>) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function boardActor() {
+  return {
+    type: "board",
+    userId: "local-board",
+    companyIds: ["company-1"],
+    source: "local_implicit",
+    isInstanceAdmin: false,
+  };
+}
+
+function agentActor(agentId: string) {
+  return {
+    type: "agent",
+    agentId,
+    companyId: "company-1",
+    source: "agent_key",
+    runId: null,
+  };
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ISSUE_ID,
+    companyId: "company-1",
+    status: "todo",
+    assigneeAgentId: AGENT_A,
+    assigneeUserId: null,
+    createdByAgentId: AGENT_A,
+    createdByUserId: null,
+    identifier: "PAP-1",
+    title: "Test issue",
+    ...overrides,
+  };
+}
+
+describe("done-status guardrail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+  });
+
+  it("allows creator agent to set status to done", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue());
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue(),
+      ...patch,
+    }));
+
+    const res = await request(createApp(agentActor(AGENT_A)))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("blocks non-creator agent from setting status to done (422)", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ createdByAgentId: AGENT_A }));
+
+    const res = await request(createApp(agentActor(AGENT_B)))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("DONE_NOT_CREATOR");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("blocks agent from setting done on board-created task (422)", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ createdByAgentId: null, createdByUserId: "local-board" }),
+    );
+
+    const res = await request(createApp(agentActor(AGENT_A)))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("DONE_NOT_CREATOR");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows board user to set done on board-created task", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ createdByAgentId: null, createdByUserId: "local-board" }),
+    );
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ createdByAgentId: null, createdByUserId: "local-board" }),
+      ...patch,
+    }));
+
+    const res = await request(createApp(boardActor()))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("allows board user to set done on agent-created task", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ createdByAgentId: AGENT_A }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ createdByAgentId: AGENT_A }),
+      ...patch,
+    }));
+
+    const res = await request(createApp(boardActor()))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("allows non-creator agent to set status to in_review (not blocked)", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ createdByAgentId: AGENT_A }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ createdByAgentId: AGENT_A }),
+      ...patch,
+    }));
+
+    const res = await request(createApp(agentActor(AGENT_B)))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "in_review" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issue-done-status-guardrail.test.ts
+++ b/server/src/__tests__/issue-done-status-guardrail.test.ts
@@ -6,6 +6,8 @@ import { errorHandler } from "../middleware/index.js";
 
 const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
   update: vi.fn(),
   addComment: vi.fn(),
   findMentionedAgents: vi.fn(),
@@ -116,6 +118,8 @@ describe("done-status guardrail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
   });
 
   it("allows creator agent to set status to done", async () => {

--- a/server/src/__tests__/issue-telemetry-routes.test.ts
+++ b/server/src/__tests__/issue-telemetry-routes.test.ts
@@ -59,7 +59,8 @@ function makeIssue(status: "todo" | "done") {
     status,
     assigneeAgentId: "22222222-2222-4222-8222-222222222222",
     assigneeUserId: null,
-    createdByUserId: "local-board",
+    createdByAgentId: "agent-1",
+    createdByUserId: null,
     identifier: "PAP-1018",
     title: "Telemetry test",
   };

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1370,9 +1370,12 @@ export function issueRoutes(
     if (commentBody && reopenRequested === true && isClosed && updateFields.status === undefined) {
       updateFields.status = "todo";
     }
-    // Platform guardrail: only creator/delegator can set status to "done" (board users exempt)
-    if (updateFields.status === "done" && req.actor.type === "agent") {
-      if (req.actor.agentId !== existing.createdByAgentId) {
+    // Platform guardrail: only creator/delegator can set status to "done" (board users exempt).
+    // Skip when an execution policy is active — the policy intercepts "done" and routes
+    // through its own stages, so the agent never truly sets the final status.
+    const hasExecutionPolicy = normalizeIssueExecutionPolicy(existing.executionPolicy ?? null) !== null;
+    if (updateFields.status === "done" && req.actor.type === "agent" && !hasExecutionPolicy) {
+      if ((req.actor.agentId ?? null) !== existing.createdByAgentId) {
         res.status(422).json({
           error: "Only the creator/delegator can close this task. Use in_review instead.",
           code: "DONE_NOT_CREATOR",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1370,6 +1370,17 @@ export function issueRoutes(
     if (commentBody && reopenRequested === true && isClosed && updateFields.status === undefined) {
       updateFields.status = "todo";
     }
+    // Platform guardrail: only creator/delegator can set status to "done" (board users exempt)
+    if (updateFields.status === "done" && req.actor.type === "agent") {
+      if (req.actor.agentId !== existing.createdByAgentId) {
+        res.status(422).json({
+          error: "Only the creator/delegator can close this task. Use in_review instead.",
+          code: "DONE_NOT_CREATOR",
+        });
+        return;
+      }
+    }
+
     if (req.body.executionPolicy !== undefined) {
       updateFields.executionPolicy = normalizeIssueExecutionPolicy(req.body.executionPolicy);
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents work on issues and update their status through the PATCH /api/issues/:id endpoint
> - When an issue reaches "done" status, it should only be closed by the original creator/delegator — this enforces accountability and prevents agents from prematurely closing work they didn't delegate
> - Currently there is no server-side enforcement of this convention — any agent can set any task to "done"
> - This pull request adds a platform guardrail that returns 422 (DONE_NOT_CREATOR) when a non-creator agent tries to set status to "done"
> - Board (human) users are exempt, as they have full authority
> - The benefit is a clean enforcement of the delegation pattern at the API level, preventing accidental or incorrect task closure

## What Changed

- Added a status guard in the PATCH `/api/issues/:id` handler that checks `req.actor.agentId` against `existing.createdByAgentId` when `status === "done"`
- Non-creator agents receive a `422` response with error code `DONE_NOT_CREATOR` and a message suggesting `in_review` instead
- Board users (`req.actor.type !== "agent"`) bypass the guard entirely
- Added comprehensive test suite (`issue-done-status-guardrail.test.ts`) with 6 test cases covering: agent-creator allowed, non-creator blocked, board user exemption, in_review unaffected, and edge cases

## Verification

```bash
cd server
npx vitest run src/__tests__/issue-done-status-guardrail.test.ts
# Expected: 6 passed
```

Manual verification:
1. As a non-creator agent, PATCH an issue with `{ "status": "done" }` → expect 422 with `DONE_NOT_CREATOR`
2. As the creator agent, same request → expect 200
3. As a board user, same request → expect 200

## Risks

- Low risk. The guard is a simple conditional check early in the PATCH handler, before any state mutation. It only affects the `done` status transition for agent actors. No database migration, no schema change.

## Model Used

- Claude Opus 4.6 (`claude-opus-4-6`) via Claude Code CLI, with tool use capabilities

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge