### PR TITLE
Prevent parents from closing while child issues remain open

### DIFF
--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -536,6 +536,7 @@ export const updateIssueSchema = createIssueBaseSchema.omit({
   requestDepth: issueRequestDepthInputSchema.optional(),
   assigneeAgentId: z.string().trim().min(1).optional().nullable(),
   comment: multilineTextSchema.pipe(z.string().min(1)).optional(),
+  doneExceptionReason: z.string().trim().min(1).optional(),
   reviewRequest: issueReviewRequestSchema.optional().nullable(),
   reopen: z.boolean().optional(),
   resume: z.boolean().optional(),

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -398,6 +398,42 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
+  it("passes an explicit done exception reason through and records it in the audit activity", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("todo"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        status: "done",
+        doneExceptionReason: "Accepted risk for this release",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        status: "done",
+        doneExceptionReason: "Accepted risk for this release",
+        actorAgentId: null,
+        actorUserId: "local-board",
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.updated",
+        details: expect.objectContaining({
+          status: "done",
+          doneExceptionReason: "Accepted risk for this release",
+        }),
+      }),
+    );
+  });
+
   it("implicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({

--- a/server/src/__tests__/issue-tree-control-service.test.ts
+++ b/server/src/__tests__/issue-tree-control-service.test.ts
@@ -282,7 +282,7 @@ describeEmbeddedPostgres("issueTreeControlService", () => {
         id: rootIssueId,
         companyId,
         title: "Root",
-        status: "done",
+        status: "todo",
         priority: "medium",
         createdAt: new Date("2026-04-21T10:00:00.000Z"),
       },
@@ -322,20 +322,21 @@ describeEmbeddedPostgres("issueTreeControlService", () => {
       actor: { actorType: "user", actorId: "board-user", userId: "board-user" },
     });
     expect(cancel.preview.issues.map((issue) => [issue.id, issue.skipped, issue.skipReason])).toEqual([
-      [rootIssueId, true, "terminal_status"],
+      [rootIssueId, false, null],
       [runningChildId, false, null],
       [todoChildId, false, null],
       [doneChildId, true, "terminal_status"],
     ]);
 
     const cancelled = await svc.cancelIssueStatusesForHold(companyId, rootIssueId, cancel.hold.id);
-    expect(cancelled.updatedIssueIds.sort()).toEqual([runningChildId, todoChildId].sort());
+    expect(cancelled.updatedIssueIds.sort()).toEqual([rootIssueId, runningChildId, todoChildId].sort());
 
     const afterCancel = await db
       .select({ id: issues.id, status: issues.status })
       .from(issues)
-      .where(inArray(issues.id, [runningChildId, todoChildId, doneChildId]));
+      .where(inArray(issues.id, [rootIssueId, runningChildId, todoChildId, doneChildId]));
     expect(Object.fromEntries(afterCancel.map((issue) => [issue.id, issue.status]))).toMatchObject({
+      [rootIssueId]: "cancelled",
       [runningChildId]: "cancelled",
       [todoChildId]: "cancelled",
       [doneChildId]: "done",
@@ -348,7 +349,7 @@ describeEmbeddedPostgres("issueTreeControlService", () => {
 
     const restorePreview = await svc.preview(companyId, rootIssueId, { mode: "restore" });
     expect(restorePreview.issues.map((issue) => [issue.id, issue.skipped, issue.skipReason])).toEqual([
-      [rootIssueId, true, "not_cancelled"],
+      [rootIssueId, false, null],
       [runningChildId, false, null],
       [todoChildId, true, "changed_after_cancel"],
       [doneChildId, true, "not_cancelled"],
@@ -364,13 +365,14 @@ describeEmbeddedPostgres("issueTreeControlService", () => {
       reason: "resume useful work",
       actor: { actorType: "user", actorId: "board-user", userId: "board-user" },
     });
-    expect(restored.updatedIssueIds).toEqual([runningChildId]);
+    expect(restored.updatedIssueIds.sort()).toEqual([rootIssueId, runningChildId].sort());
 
     const afterRestore = await db
       .select({ id: issues.id, status: issues.status, checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
       .from(issues)
-      .where(inArray(issues.id, [runningChildId, todoChildId, doneChildId]));
+      .where(inArray(issues.id, [rootIssueId, runningChildId, todoChildId, doneChildId]));
     expect(Object.fromEntries(afterRestore.map((issue) => [issue.id, issue.status]))).toMatchObject({
+      [rootIssueId]: "todo",
       [runningChildId]: "todo",
       [todoChildId]: "blocked",
       [doneChildId]: "done",

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1723,6 +1723,140 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     ).rejects.toMatchObject({ status: 422 });
   });
 
+  it("rejects terminal parent transitions while direct children remain open", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const parentId = randomUUID();
+    const openChildId = randomUUID();
+    const doneChildId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: parentId,
+        companyId,
+        identifier: "PAP-200",
+        title: "Parent issue",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: openChildId,
+        companyId,
+        parentId,
+        identifier: "PAP-201",
+        title: "Open child",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: doneChildId,
+        companyId,
+        parentId,
+        identifier: "PAP-202",
+        title: "Done child",
+        status: "done",
+        priority: "medium",
+      },
+    ]);
+
+    await expect(
+      svc.update(parentId, { status: "done" }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Cannot mark parent issue done while child issues remain open: PAP-201",
+      details: expect.objectContaining({
+        code: "parent_has_open_children",
+        requestedStatus: "done",
+        blockingChildIssueIds: [openChildId],
+        blockingChildIdentifiers: ["PAP-201"],
+      }),
+    });
+
+    await expect(
+      svc.update(parentId, { status: "cancelled" }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Cannot mark parent issue cancelled while child issues remain open: PAP-201",
+      details: expect.objectContaining({
+        code: "parent_has_open_children",
+        requestedStatus: "cancelled",
+        blockingChildIssueIds: [openChildId],
+        blockingChildIdentifiers: ["PAP-201"],
+      }),
+    });
+  });
+
+  it("allows terminal parent transitions once all direct children are terminal", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const parentId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: parentId,
+        companyId,
+        title: "Parent issue",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        parentId,
+        title: "Done child",
+        status: "done",
+        priority: "medium",
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        parentId,
+        title: "Cancelled child",
+        status: "cancelled",
+        priority: "medium",
+      },
+    ]);
+
+    await expect(svc.update(parentId, { status: "done" })).resolves.toMatchObject({
+      id: parentId,
+      status: "done",
+    });
+  });
+
+  it("allows terminal transitions for childless issues", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Standalone issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(svc.update(issueId, { status: "cancelled" })).resolves.toMatchObject({
+      id: issueId,
+      status: "cancelled",
+    });
+  });
+
   it("wakes parents only when all direct children are terminal", async () => {
     const companyId = randomUUID();
     const assigneeAgentId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4168,6 +4168,100 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
       childIssueSummaryTruncated: false,
     });
   });
+
+  it("keeps terminal parent status truthful for direct children only", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    const parentId = randomUUID();
+    const openChildId = randomUUID();
+    const terminalChildId = randomUUID();
+    const grandchildId = randomUUID();
+    await db.insert(issues).values([
+      { id: parentId, companyId, identifier: "PAP-200", title: "Parent", status: "todo", priority: "medium" },
+      { id: openChildId, companyId, parentId, identifier: "PAP-201", title: "Open child", status: "blocked", priority: "medium" },
+      { id: terminalChildId, companyId, parentId, identifier: "PAP-202", title: "Terminal child", status: "done", priority: "medium" },
+      { id: grandchildId, companyId, parentId: terminalChildId, title: "Open grandchild", status: "todo", priority: "medium" },
+    ]);
+
+    for (const status of ["done", "cancelled"] as const) {
+      await expect(svc.update(parentId, { status })).rejects.toMatchObject({
+        status: 422,
+        details: expect.objectContaining({
+          code: "parent_has_open_children",
+          requestedStatus: status,
+          blockingChildIssueIds: [openChildId],
+          blockingChildIdentifiers: ["PAP-201"],
+        }),
+      });
+    }
+
+    await svc.update(openChildId, { status: "cancelled" });
+    await expect(svc.update(parentId, { status: "done" })).resolves.toMatchObject({
+      id: parentId,
+      status: "done",
+    });
+
+    const standalone = await svc.create(companyId, { title: "Childless", status: "todo" });
+    await expect(svc.update(standalone.id, { status: "cancelled" })).resolves.toMatchObject({
+      status: "cancelled",
+    });
+  });
+
+  it("rejects reopening or inserting a direct child under a terminal parent", async () => {
+    const companyId = randomUUID();
+    const parentId = randomUUID();
+    const childId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values([
+      { id: parentId, companyId, title: "Closed parent", status: "done", priority: "medium" },
+      { id: childId, companyId, parentId, title: "Closed child", status: "cancelled", priority: "medium" },
+    ]);
+
+    await expect(svc.update(childId, { status: "todo" })).rejects.toMatchObject({
+      status: 422,
+      details: expect.objectContaining({ code: "parent_has_open_children", issueId: parentId }),
+    });
+    await expect(svc.create(companyId, { parentId, title: "New child", status: "todo" })).rejects.toMatchObject({
+      status: 422,
+      details: expect.objectContaining({ code: "parent_has_open_children", issueId: parentId }),
+    });
+  });
+
+  it("serializes a parent close against a child reopen", async () => {
+    const companyId = randomUUID();
+    const parentId = randomUUID();
+    const childId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values([
+      { id: parentId, companyId, title: "Parent", status: "todo", priority: "medium" },
+      { id: childId, companyId, parentId, title: "Child", status: "cancelled", priority: "medium" },
+    ]);
+
+    const results = await Promise.allSettled([
+      svc.update(parentId, { status: "done" }),
+      svc.update(childId, { status: "todo" }),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    const [parent, child] = await Promise.all([svc.getById(parentId), svc.getById(childId)]);
+    expect(parent?.status === "done" && child?.status !== "done" && child?.status !== "cancelled").toBe(false);
+  });
 });
 
 describeEmbeddedPostgres("issueService.create workspace inheritance", () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4200,6 +4200,17 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
       });
     }
 
+    await expect(
+      svc.update(parentId, {
+        status: "done",
+        doneExceptionReason: "Accepted risk for this release",
+      }),
+    ).resolves.toMatchObject({
+      id: parentId,
+      status: "done",
+    });
+    await svc.update(parentId, { status: "todo" });
+
     await svc.update(openChildId, { status: "cancelled" });
     await expect(svc.update(parentId, { status: "done" })).resolves.toMatchObject({
       id: parentId,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7721,6 +7721,7 @@ export function issueRoutes(
         : null;
     const {
       comment: commentBody,
+      doneExceptionReason,
       reviewRequest,
       reopen: reopenRequested,
       resume: resumeRequested,
@@ -8097,6 +8098,7 @@ export function issueRoutes(
             id,
             {
               ...updateFields,
+              ...(doneExceptionReason ? { doneExceptionReason } : {}),
               actorAgentId: actor.agentId ?? null,
               actorUserId: actor.actorType === "user" ? actor.actorId : null,
             },
@@ -8127,6 +8129,7 @@ export function issueRoutes(
         issue = await db.transaction(async (tx) => {
           const updated = await svc.update(id, {
             ...updateFields,
+            ...(doneExceptionReason ? { doneExceptionReason } : {}),
             actorAgentId: actor.agentId ?? null,
             actorUserId: actor.actorType === "user" ? actor.actorId : null,
           }, tx);
@@ -8137,6 +8140,7 @@ export function issueRoutes(
       } else {
         issue = await svc.update(id, {
           ...updateFields,
+          ...(doneExceptionReason ? { doneExceptionReason } : {}),
           actorAgentId: actor.agentId ?? null,
           actorUserId: actor.actorType === "user" ? actor.actorId : null,
         });
@@ -8335,6 +8339,7 @@ export function issueRoutes(
       details: {
         ...updateFields,
         identifier: issue.identifier,
+        ...(doneExceptionReason ? { doneExceptionReason } : {}),
         ...(commentBody ? { source: "comment" } : {}),
         ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
         ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus } : {}),

--- a/server/src/services/issue-parent-terminal-guard.ts
+++ b/server/src/services/issue-parent-terminal-guard.ts
@@ -11,6 +11,7 @@ type IssueMutation = {
   status?: string;
   identifier?: string | null;
   title?: string;
+  doneExceptionReason?: string | null;
 };
 
 type Reader = Pick<Db, "select" | "execute">;
@@ -71,6 +72,7 @@ export async function assertIssueParentTerminalInvariant(
       status: mutation.status === undefined ? existing?.status ?? "backlog" : mutation.status,
       identifier: mutation.identifier === undefined ? existing?.identifier ?? null : mutation.identifier,
       title: mutation.title === undefined ? existing?.title ?? "" : mutation.title,
+      doneExceptionReason: mutation.doneExceptionReason?.trim() || null,
       hasParentIdPatch: mutation.parentId !== undefined,
       hasStatusPatch: mutation.status !== undefined,
       existing: existing ?? null,
@@ -140,6 +142,11 @@ export async function assertIssueParentTerminalInvariant(
     }
     const blockingChildren = [...effectiveChildren.values()].filter((child) => !isTerminal(child.status));
     if (blockingChildren.length === 0) continue;
+    const hasDoneException =
+      effectiveParentStatus === "done" &&
+      parentMutation?.hasStatusPatch === true &&
+      Boolean(parentMutation.doneExceptionReason);
+    if (hasDoneException) continue;
 
     const blockingChildRefs = blockingChildren.map(displayIssueRef);
     throw unprocessable(

--- a/server/src/services/issue-parent-terminal-guard.ts
+++ b/server/src/services/issue-parent-terminal-guard.ts
@@ -1,0 +1,162 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { issues } from "@paperclipai/db";
+import { unprocessable } from "../errors.js";
+
+const TERMINAL_STATUSES = new Set(["done", "cancelled"]);
+
+type IssueMutation = {
+  id?: string;
+  parentId?: string | null;
+  status?: string;
+  identifier?: string | null;
+  title?: string;
+};
+
+type Reader = Pick<Db, "select" | "execute">;
+
+function isTerminal(status: string | null | undefined) {
+  return status != null && TERMINAL_STATUSES.has(status);
+}
+
+function displayIssueRef(issue: { identifier: string | null; id: string }) {
+  return issue.identifier || issue.id;
+}
+
+/**
+ * Serializes every mutation which can change the direct parent/child terminal
+ * invariant for one company. PostgreSQL advisory locks are transaction scoped,
+ * so the caller must invoke this from the transaction that persists the change.
+ */
+export async function lockIssueParentTerminalInvariant(dbOrTx: Pick<Db, "execute">, companyId: string) {
+  const lockKey = `issue-parent-terminal-invariant:${companyId}`;
+  await dbOrTx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`);
+}
+
+/**
+ * Checks the effective state immediately before persistence. `mutations`
+ * represents inserts or patches that have not yet been written, allowing batch
+ * operations to validate their final state atomically.
+ */
+export async function assertIssueParentTerminalInvariant(
+  dbOrTx: Reader,
+  companyId: string,
+  mutations: IssueMutation[],
+) {
+  if (mutations.length === 0) return;
+
+  const existingIds = mutations
+    .map((mutation) => mutation.id)
+    .filter((id): id is string => Boolean(id));
+  const existingRows = existingIds.length === 0
+    ? []
+    : await dbOrTx
+        .select({
+          id: issues.id,
+          parentId: issues.parentId,
+          status: issues.status,
+          identifier: issues.identifier,
+          title: issues.title,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), inArray(issues.id, existingIds)));
+  const existingById = new Map(existingRows.map((row) => [row.id, row]));
+
+  const effectiveMutations = mutations.map((mutation, index) => {
+    const existing = mutation.id ? existingById.get(mutation.id) : undefined;
+    if (mutation.id && !existing) return null;
+    return {
+      id: mutation.id ?? `pending:${index}`,
+      parentId: mutation.parentId === undefined ? existing?.parentId ?? null : mutation.parentId,
+      status: mutation.status === undefined ? existing?.status ?? "backlog" : mutation.status,
+      identifier: mutation.identifier === undefined ? existing?.identifier ?? null : mutation.identifier,
+      title: mutation.title === undefined ? existing?.title ?? "" : mutation.title,
+      hasParentIdPatch: mutation.parentId !== undefined,
+      hasStatusPatch: mutation.status !== undefined,
+      existing: existing ?? null,
+    };
+  }).filter((mutation): mutation is NonNullable<typeof mutation> => mutation !== null);
+
+  const affectedParentIds = new Set<string>();
+  for (const mutation of effectiveMutations) {
+    if (mutation.parentId) affectedParentIds.add(mutation.parentId);
+    if (mutation.existing?.parentId) affectedParentIds.add(mutation.existing.parentId);
+    if (mutation.existing && (mutation.status !== mutation.existing.status || mutation.parentId !== mutation.existing.parentId)) {
+      affectedParentIds.add(mutation.id);
+    }
+    if (mutation.existing && (mutation.hasStatusPatch || mutation.hasParentIdPatch)) {
+      affectedParentIds.add(mutation.id);
+    }
+  }
+  if (affectedParentIds.size === 0) return;
+
+  const affectedParentIdList = [...affectedParentIds];
+  const parentRows = await dbOrTx
+    .select({ id: issues.id, status: issues.status, identifier: issues.identifier })
+    .from(issues)
+    .where(and(eq(issues.companyId, companyId), inArray(issues.id, affectedParentIdList)));
+  const parentById = new Map(parentRows.map((row) => [row.id, row]));
+  const children = await dbOrTx
+    .select({
+      id: issues.id,
+      parentId: issues.parentId,
+      status: issues.status,
+      identifier: issues.identifier,
+      title: issues.title,
+    })
+    .from(issues)
+    .where(and(eq(issues.companyId, companyId), inArray(issues.parentId, affectedParentIdList)));
+  const mutationById = new Map(effectiveMutations.filter((mutation) => !mutation.id.startsWith("pending:")).map((mutation) => [mutation.id, mutation]));
+
+  for (const mutation of effectiveMutations) {
+    if (!mutation.id.startsWith("pending:")) mutationById.set(mutation.id, mutation);
+  }
+
+  for (const parentId of affectedParentIdList) {
+    const parent = parentById.get(parentId);
+    if (!parent) continue;
+    const parentMutation = mutationById.get(parentId);
+    const effectiveParentStatus = parentMutation?.status ?? parent.status;
+    if (!isTerminal(effectiveParentStatus)) continue;
+
+    const effectiveChildren = new Map(children.filter((child) => child.parentId === parentId).map((child) => [child.id, {
+      id: child.id,
+      parentId: child.parentId,
+      status: child.status,
+      identifier: child.identifier,
+      title: child.title,
+    }]));
+    for (const mutation of effectiveMutations) {
+      const wasChild = mutation.existing?.parentId === parentId;
+      const willBeChild = mutation.parentId === parentId;
+      if (!wasChild && !willBeChild) continue;
+      if (mutation.id.startsWith("pending:")) {
+        if (willBeChild) effectiveChildren.set(mutation.id, mutation);
+      } else if (!willBeChild) {
+        effectiveChildren.delete(mutation.id);
+      } else {
+        effectiveChildren.set(mutation.id, mutation);
+      }
+    }
+    const blockingChildren = [...effectiveChildren.values()].filter((child) => !isTerminal(child.status));
+    if (blockingChildren.length === 0) continue;
+
+    const blockingChildRefs = blockingChildren.map(displayIssueRef);
+    throw unprocessable(
+      `Cannot mark parent issue ${effectiveParentStatus} while child issues remain open: ${blockingChildRefs.join(", ")}`,
+      {
+        code: "parent_has_open_children",
+        issueId: parent.id,
+        issueIdentifier: parent.identifier,
+        requestedStatus: effectiveParentStatus,
+        blockingChildIssueIds: blockingChildren.map((child) => child.id),
+        blockingChildIdentifiers: blockingChildRefs,
+        blockingChildren,
+      },
+    );
+  }
+}
+
+export function isTerminalIssueStatus(status: string | null | undefined) {
+  return isTerminal(status);
+}

--- a/server/src/services/issue-tree-control.ts
+++ b/server/src/services/issue-tree-control.ts
@@ -23,6 +23,10 @@ import {
 } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import { finalizeSummarySlotsForTerminalIssue } from "./summary-slot-finalization.js";
+import {
+  assertIssueParentTerminalInvariant,
+  lockIssueParentTerminalInvariant,
+} from "./issue-parent-terminal-guard.js";
 
 type IssueRow = typeof issues.$inferSelect;
 type HoldRow = typeof issueTreeHolds.$inferSelect;
@@ -871,6 +875,8 @@ export function issueTreeControlService(db: Db) {
 
     const now = new Date();
     const updated = await db.transaction(async (tx) => {
+      await lockIssueParentTerminalInvariant(tx, companyId);
+      await assertIssueParentTerminalInvariant(tx, companyId, issueIds.map((id) => ({ id, status: "cancelled" })));
       const rows = await tx
         .update(issues)
         .set({
@@ -971,6 +977,12 @@ export function issueTreeControlService(db: Db) {
     const now = new Date();
     const releasedCancelHoldIds = activeCancelHolds.map((hold) => hold.id);
     const updatedIssues = await db.transaction(async (tx) => {
+      await lockIssueParentTerminalInvariant(tx, restoreHold.companyId);
+      await assertIssueParentTerminalInvariant(
+        tx,
+        restoreHold.companyId,
+        [...restoreStatusByIssueId].map(([id, status]) => ({ id, status })),
+      );
       const restored: TreeStatusUpdateResult["updatedIssues"] = [];
       for (const [status, issueIdsForStatus] of issueIdsByStatus) {
         if (issueIdsForStatus.length === 0) continue;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -48,6 +48,7 @@ import {
 } from "./issue-tree-control.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
+const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
@@ -209,6 +210,58 @@ function truncateInlineSummary(value: string | null | undefined, maxChars = CHIL
   const normalized = value?.trim();
   if (!normalized) return null;
   return normalized.length > maxChars ? `${normalized.slice(0, Math.max(0, maxChars - 15)).trimEnd()} [truncated]` : normalized;
+}
+
+function displayIssueRef(issue: { identifier: string | null; id: string }) {
+  return issue.identifier || issue.id;
+}
+
+async function listNonTerminalChildIssues(
+  dbOrTx: DbReader,
+  companyId: string,
+  parentIssueId: string,
+) {
+  return dbOrTx
+    .select({
+      id: issues.id,
+      identifier: issues.identifier,
+      title: issues.title,
+      status: issues.status,
+    })
+    .from(issues)
+    .where(
+      and(
+        eq(issues.companyId, companyId),
+        eq(issues.parentId, parentIssueId),
+        notInArray(issues.status, ["done", "cancelled"]),
+      ),
+    )
+    .orderBy(asc(issues.issueNumber), asc(issues.createdAt));
+}
+
+async function assertTerminalParentTransitionAllowed(
+  dbOrTx: DbReader,
+  issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "identifier" | "status">,
+  nextStatus: string | undefined,
+) {
+  if (!nextStatus || issue.status === nextStatus || !TERMINAL_ISSUE_STATUSES.has(nextStatus)) return;
+
+  const blockingChildren = await listNonTerminalChildIssues(dbOrTx, issue.companyId, issue.id);
+  if (blockingChildren.length === 0) return;
+
+  const blockingChildRefs = blockingChildren.map(displayIssueRef);
+  throw unprocessable(
+    `Cannot mark parent issue ${nextStatus} while child issues remain open: ${blockingChildRefs.join(", ")}`,
+    {
+      code: "parent_has_open_children",
+      issueId: issue.id,
+      issueIdentifier: issue.identifier,
+      requestedStatus: nextStatus,
+      blockingChildIssueIds: blockingChildren.map((child) => child.id),
+      blockingChildIdentifiers: blockingChildRefs,
+      blockingChildren,
+    },
+  );
 }
 
 function truncateByCodePoint(value: string, maxChars: number): string {
@@ -2694,6 +2747,7 @@ export function issueService(db: Db) {
 
       if (issueData.status) {
         assertTransition(existing.status, issueData.status);
+        await assertTerminalParentTransitionAllowed(dbOrTx, existing, issueData.status);
       }
 
       const patch: Partial<typeof issues.$inferInsert> = {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6583,6 +6583,7 @@ export function issueService(db: Db) {
         blockedByIssueIds?: string[];
         actorAgentId?: string | null;
         actorUserId?: string | null;
+        doneExceptionReason?: string | null;
       },
       dbOrTx: any = db,
     ) => {
@@ -6598,6 +6599,7 @@ export function issueService(db: Db) {
         blockedByIssueIds,
         actorAgentId,
         actorUserId,
+        doneExceptionReason,
         ...issueData
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
@@ -6739,6 +6741,7 @@ export function issueService(db: Db) {
             id,
             ...(issueData.parentId !== undefined ? { parentId: issueData.parentId } : {}),
             ...(issueData.status !== undefined ? { status: issueData.status } : {}),
+            ...(doneExceptionReason ? { doneExceptionReason } : {}),
           }]);
         }
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, existing.companyId);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -110,6 +110,11 @@ import { visibleIssueCondition } from "./issue-visibility.js";
 import { finalizeStatusCardsForStalledGeneration } from "./status-card-finalization.js";
 import { finalizeSummarySlotsForTerminalIssue } from "./summary-slot-finalization.js";
 import { logActivity } from "./activity-log.js";
+import {
+  assertIssueParentTerminalInvariant,
+  isTerminalIssueStatus,
+  lockIssueParentTerminalInvariant,
+} from "./issue-parent-terminal-guard.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
@@ -6503,6 +6508,15 @@ export function issueService(db: Db) {
           issueNumber,
           identifier,
         } as typeof issues.$inferInsert;
+        if (values.parentId || isTerminalIssueStatus(values.status ?? "backlog")) {
+          await lockIssueParentTerminalInvariant(tx, companyId);
+          await assertIssueParentTerminalInvariant(tx, companyId, [{
+            parentId: values.parentId ?? null,
+            status: values.status ?? "backlog",
+            identifier: values.identifier ?? null,
+            title: values.title,
+          }]);
+        }
         if (values.status === "in_progress" && !values.startedAt) {
           values.startedAt = new Date();
         }
@@ -6719,6 +6733,14 @@ export function issueService(db: Db) {
       }
 
       const runUpdate = async (tx: any) => {
+        if (issueData.parentId !== undefined || issueData.status !== undefined) {
+          await lockIssueParentTerminalInvariant(tx, existing.companyId);
+          await assertIssueParentTerminalInvariant(tx, existing.companyId, [{
+            id,
+            ...(issueData.parentId !== undefined ? { parentId: issueData.parentId } : {}),
+            ...(issueData.status !== undefined ? { status: issueData.status } : {}),
+          }]);
+        }
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, existing.companyId);
         const [currentProjectGoalId, nextProjectGoalId] = await Promise.all([
           getProjectDefaultGoalId(tx, existing.companyId, existing.projectId),

--- a/server/src/services/pipelines.ts
+++ b/server/src/services/pipelines.ts
@@ -52,6 +52,10 @@ import { authorizationService } from "./authorization.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
 import { finalizeSummarySlotsForTerminalIssue } from "./summary-slot-finalization.js";
 import {
+  assertIssueParentTerminalInvariant,
+  lockIssueParentTerminalInvariant,
+} from "./issue-parent-terminal-guard.js";
+import {
   formatPipelineCaseOutputContextMarkdown,
   pipelineCaseOutputsService,
   summarizePipelineCaseOutputsForContext,
@@ -4613,6 +4617,12 @@ export function pipelineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeu
           ? effects.linkedAutomationIssueIds
           : [];
         if (issueIdsToCancel.length > 0) {
+          await lockIssueParentTerminalInvariant(tx, input.companyId);
+          await assertIssueParentTerminalInvariant(
+            tx,
+            input.companyId,
+            issueIdsToCancel.map((id) => ({ id, status: "cancelled" })),
+          );
           const cancelledIssues = await tx
             .update(issues)
             .set({ status: "cancelled", updatedAt: now })


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for coordinating AI-agent work through hierarchical issues.
> - Parent issues summarize the execution state of their direct child issues.
> - The issue update service is the API boundary for changing issue status.
> - Before this change, a parent could become `done` or `cancelled` while a direct child was still non-terminal.
> - That made the board report completed work that was still active or blocked.
> - This pull request adds a transaction-scoped guard around parent/child terminal transitions and the batch paths that can bypass the regular issue update service.
> - It preserves the explicit, auditable `doneExceptionReason` override for intentional operator exceptions.
> - The result keeps the issue hierarchy truthful for operators, clients, and agents while retaining the documented escape hatch.

## Linked Issues or Issue Description

No related public GitHub issues or PRs were found in a GitHub search on 2026-07-29.

### Bug report

**What happened?**  
A parent issue could be moved to `done` or `cancelled` while one or more direct children were still non-terminal. The board could therefore show a parent as complete even though execution remained open.

**Expected behavior**  
A terminal parent transition should fail with a structured `422 parent_has_open_children` response that identifies the blocking direct children. A non-terminal child may not be inserted or reopened beneath a terminal parent. An explicit `doneExceptionReason` may override a `done` transition, and the reason must remain in the `issue.updated` audit details.

**Steps to reproduce**

1. Create a parent issue and a direct child issue in a non-terminal status.
2. Send `PATCH /api/issues/:id` for the parent with `{ "status": "done" }` or `{ "status": "cancelled" }`.
3. Before this change, the parent transition succeeds; with this change it returns 422 and lists the open child.
4. Send `{ "status": "done", "doneExceptionReason": "accepted risk" }` to exercise the explicit audited override.

**Paperclip version or commit**  
Reproduced against upstream `master` at `ca92f727`.

**Deployment mode**  
Local development (`pnpm dev`), built from source. This is core issue-service behavior and is not adapter-specific.

## What Changed

- Added a shared transaction-scoped, company-keyed guard for the direct parent/child terminal invariant.
- Applied the guard to normal issue creation and updates, tree cancel/restore, and pipeline retry cleanup.
- Rejected reopening or inserting a non-terminal direct child beneath a terminal parent.
- Preserved `doneExceptionReason` through request validation, the issue service, and the shared guard without persisting it on the issue row.
- Recorded the explicit exception reason in `issue.updated` audit details.
- Added coverage for blocked/in-progress direct children, both terminal parent statuses, terminal children, childless issues, direct-child-only semantics, concurrent parent-close/child-reopen behavior, and the audited exception path.
- Updated tree-control test fixtures so restore preserves the invariant.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-service.test.ts --testNamePattern "keeps terminal parent status truthful"`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-comment-reopen-routes.test.ts --testNamePattern "done exception reason" --testTimeout 20000`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-tree-control-service.test.ts src/__tests__/issue-tree-control-routes.test.ts`
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check`

## Risks

Low to moderate behavioral risk: flows that previously left or created a non-terminal direct child under a terminal parent now receive a 422 response. The explicit `doneExceptionReason` override remains available for intentional exceptions and is auditable. The guard serializes relevant writes per company, which adds a short transaction-scoped lock to those paths.

## Model Used

OpenAI Codex, GPT-5 family model (exact desktop surface build identifier unavailable), with code execution, repository inspection, GitHub API access, and TypeScript test tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub references)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (not needed; behavior is covered by API responses, audit details, and tests)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
