### PR TITLE
fix(heartbeat): force session reset for timer heartbeat wakes

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -284,8 +284,8 @@ describe("shouldResetTaskSessionForWake", () => {
     expect(shouldResetTaskSessionForWake({ wakeReason: "execution_changes_requested" })).toBe(true);
   });
 
-  it("preserves session context on timer heartbeats", () => {
-    expect(shouldResetTaskSessionForWake({ wakeSource: "timer" })).toBe(false);
+  it("resets session context on timer heartbeats", () => {
+    expect(shouldResetTaskSessionForWake({ wakeSource: "timer" })).toBe(true);
   });
 
   it("preserves session context on manual on-demand invokes by default", () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -725,6 +725,9 @@ export function shouldResetTaskSessionForWake(
   ) {
     return true;
   }
+
+  const wakeSource = readNonEmptyString(contextSnapshot?.wakeSource);
+  if (wakeSource === "timer") return true;
   return false;
 }
 
@@ -757,6 +760,9 @@ function describeSessionResetReason(
   if (wakeReason === "execution_review_requested") return "wake reason is execution_review_requested";
   if (wakeReason === "execution_approval_requested") return "wake reason is execution_approval_requested";
   if (wakeReason === "execution_changes_requested") return "wake reason is execution_changes_requested";
+
+  const wakeSource = readNonEmptyString(contextSnapshot?.wakeSource);
+  if (wakeSource === "timer") return "wake source is timer (fresh session per timer heartbeat)";
   return null;
 }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -691,8 +691,13 @@ function deriveTaskKey(
 
 /**
  * Extended task key derivation that falls back to a stable synthetic key
- * for timer/heartbeat wakes. This ensures timer wakes can resume their
- * previous session via `agentTaskSessions` instead of starting fresh.
+ * for timer/heartbeat wakes. This provides a consistent storage key so
+ * the session written at the end of a timer run is recorded under a stable
+ * identifier in `agentTaskSessions`.
+ *
+ * Note: timer wakes always start with a fresh session (see
+ * `shouldResetTaskSessionForWake`); this key is used for write-back
+ * consistency, not resumption.
  *
  * The synthetic key is only used when:
  * - No explicit task/issue key exists in the context


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The heartbeat service manages agent wake-ups and session lifecycle
> - `shouldResetTaskSessionForWake()` determines whether an agent gets a fresh session or reuses the existing one
> - Previously, only `issue_assigned` wakes triggered a session reset — timer wakes reused existing sessions
> - This allowed agents to see prior conversation context during periodic heartbeats, enabling "nothing changed since last heartbeat" shortcuts that skip the full inbox scan
> - Timer heartbeats are designed for broad scans (check all assignments, team health, blocked items) — stale session context defeats this purpose
> - This pull request adds `wakeSource === "timer"` as a session reset trigger, matching the behavior of `issue_assigned` wakes

## What Changed

- Extended `shouldResetTaskSessionForWake()` in `server/src/services/heartbeat.ts` to return `true` when `wakeSource === "timer"`
- Extended `describeSessionResetReason()` to return a descriptive reason for timer-based resets
- Updated test expectation in `heartbeat-workspace-session.test.ts`: timer heartbeats now expect session reset (`true`) instead of session preservation (`false`)

## Verification

```bash
cd server
npx vitest run src/__tests__/heartbeat-workspace-session.test.ts
# All tests pass

# Regression check — existing heartbeat tests:
npx vitest run src/__tests__/heartbeat-comment-wake-batching.test.ts \
  src/__tests__/heartbeat-process-recovery.test.ts \
  src/__tests__/heartbeat-workspace-session.test.ts \
  src/__tests__/heartbeat-list.test.ts \
  src/__tests__/heartbeat-run-summary.test.ts \
  src/__tests__/heartbeat-project-env.test.ts
# All pass
```

## Risks

- Minimal. Timer heartbeats get slightly longer startup (fresh session init vs. resume), but this is the correct behavior for periodic full scans.
- No migration changes — purely additive application logic (+6 lines, 2 test lines changed).
- The change only affects timer wakes. Event-triggered wakes (mentions, comments) and manual invokes remain unchanged.

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`) via Claude Code CLI with tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Co-Authored-By: Paperclip <noreply@paperclip.ing>