### PR TITLE
Improve New Issue Dialog validation UX with inline warnings and button feedback

### DIFF
--- a/ui/src/components/NewIssueDialog.test.tsx
+++ b/ui/src/components/NewIssueDialog.test.tsx
@@ -193,6 +193,7 @@ vi.mock("@/components/ui/dialog", () => ({
     onEscapeKeyDown?: (event: unknown) => void;
     onPointerDownOutside?: (event: unknown) => void;
   }) => <div {...props}>{children}</div>,
+  DialogTitle: ({ children, ...props }: ComponentProps<"h2">) => <h2 {...props}>{children}</h2>,
 }));
 
 vi.mock("@/components/ui/button", () => ({
@@ -211,6 +212,12 @@ vi.mock("@/components/ui/popover", () => ({
   Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
   PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -391,6 +398,119 @@ describe("NewIssueDialog", () => {
     expect(bodyScrollRegion?.className).toContain("overflow-y-auto");
     expect(bodyScrollRegion?.contains(titleInput ?? null)).toBe(true);
     expect(bodyScrollRegion?.contains(descriptionInput ?? null)).toBe(true);
+
+    act(() => root.unmount());
+  });
+
+  it("does not show inline title warning on initial render", async () => {
+    const { root } = renderDialog(container);
+    await flush();
+
+    expect(container.textContent).not.toContain("Issue title is required");
+
+    act(() => root.unmount());
+  });
+
+  it("shows inline title warning and button shake after clicking Create Issue with empty title", async () => {
+    const { root } = renderDialog(container);
+    await flush();
+
+    const submitButton = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("Create Issue"));
+    expect(submitButton).not.toBeUndefined();
+
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    expect(container.textContent).toContain("Issue title is required");
+    expect(container.textContent).toContain("Please enter an issue title before creating");
+
+    act(() => root.unmount());
+  });
+
+  it("hides inline title warning once a title is entered after an attempt", async () => {
+    const { root } = renderDialog(container);
+    await flush();
+
+    const submitButton = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("Create Issue"));
+    expect(submitButton).not.toBeUndefined();
+
+    // Trigger the warning by clicking with empty title
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    expect(container.textContent).toContain("Issue title is required");
+
+    // Enter a title via nativeInputValueSetter to properly trigger React's onChange
+    const titleInput = container.querySelector('textarea[placeholder="Issue title"]') as HTMLTextAreaElement;
+    expect(titleInput).not.toBeNull();
+
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )!.set;
+    await act(async () => {
+      nativeInputValueSetter!.call(titleInput, "My new issue");
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await flush();
+
+    expect(container.textContent).not.toContain("Issue title is required");
+
+    act(() => root.unmount());
+  });
+
+  it("does not trigger shake or warning banner when issue creation is pending", async () => {
+    // Make create hang so isPending stays true
+    let resolveCreate: (value: unknown) => void;
+    mockIssuesApi.create.mockReturnValue(new Promise((resolve) => { resolveCreate = resolve; }));
+
+    const { root } = renderDialog(container);
+    await flush();
+
+    // Enter a title and submit to start creation
+    const titleInput = container.querySelector('textarea[placeholder="Issue title"]') as HTMLTextAreaElement;
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )!.set;
+    await act(async () => {
+      nativeInputValueSetter!.call(titleInput, "Valid title");
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await flush();
+
+    const submitButton = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("Create Issue"));
+
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    // Now creation is pending. The button should show "Creating..."
+    expect(container.textContent).toContain("Creating...");
+
+    // Clicking the button during pending should NOT trigger shake or warning banner
+    // (handleButtonClick returns early when isPending)
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    // The warning banner should NOT appear during pending state
+    expect(container.textContent).not.toContain("Please enter an issue title before creating");
+
+    // Resolve the pending creation to clean up
+    await act(async () => {
+      resolveCreate!({ id: "issue-3", companyId: "company-1", identifier: "PAP-3" });
+    });
+    await flush();
 
     act(() => root.unmount());
   });

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -23,9 +23,11 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Popover,
   PopoverContent,
@@ -319,6 +321,11 @@ export function NewIssueDialog() {
   const [priorityOpen, setPriorityOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
   const [companyOpen, setCompanyOpen] = useState(false);
+  const [buttonShake, setButtonShake] = useState(false);
+  const [showTitleWarning, setShowTitleWarning] = useState(false);
+  const [hasAttempted, setHasAttempted] = useState(false);
+  const shakeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const descriptionEditorRef = useRef<MarkdownEditorRef>(null);
   const stageFileInputRef = useRef<HTMLInputElement | null>(null);
   const assigneeSelectorRef = useRef<HTMLButtonElement | null>(null);
@@ -643,6 +650,8 @@ export function NewIssueDialog() {
   useEffect(() => {
     return () => {
       if (draftTimer.current) clearTimeout(draftTimer.current);
+      if (shakeTimerRef.current) clearTimeout(shakeTimerRef.current);
+      if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
     };
   }, []);
 
@@ -669,6 +678,11 @@ export function NewIssueDialog() {
     setStagedFiles([]);
     setIsFileDragOver(false);
     setCompanyOpen(false);
+    setHasAttempted(false);
+    setButtonShake(false);
+    setShowTitleWarning(false);
+    if (shakeTimerRef.current) clearTimeout(shakeTimerRef.current);
+    if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
     executionWorkspaceDefaultProjectId.current = null;
   }
 
@@ -694,6 +708,21 @@ export function NewIssueDialog() {
     clearDraft();
     reset();
     closeNewIssue();
+  }
+
+  function handleButtonClick() {
+    if (createIssue.isPending) return;
+    if (!title.trim()) {
+      setHasAttempted(true);
+      if (shakeTimerRef.current) clearTimeout(shakeTimerRef.current);
+      if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
+      setButtonShake(true);
+      shakeTimerRef.current = setTimeout(() => setButtonShake(false), 500);
+      setShowTitleWarning(true);
+      warningTimerRef.current = setTimeout(() => setShowTitleWarning(false), 3000);
+      return;
+    }
+    handleSubmit();
   }
 
   function handleSubmit() {
@@ -974,6 +1003,7 @@ export function NewIssueDialog() {
           }
         }}
       >
+        <DialogTitle className="sr-only">New Issue</DialogTitle>
         {/* Header bar */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border shrink-0">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -1095,12 +1125,26 @@ export function NewIssueDialog() {
               }
             }}
             autoFocus
-            />
-          </div>
+          />
+          {hasAttempted && !title.trim() && (
+            <div className="mt-1 text-xs text-destructive">
+              Issue title is required
+            </div>
+          )}
+        </div>
 
-          <div className="px-4 pb-2">
-            <div className="overflow-x-auto overscroll-x-contain">
-              <div className="inline-flex items-center gap-2 text-sm text-muted-foreground flex-wrap sm:flex-nowrap sm:min-w-max">
+        {showTitleWarning && (
+          <div className="mx-4 mb-2 px-4 py-2.5 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-600 dark:text-amber-400 text-sm font-medium flex items-center gap-2 animate-[fadeIn_0.2s_ease-out]">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4 shrink-0">
+              <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.168 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+            </svg>
+            <span>Please enter an issue title before creating</span>
+          </div>
+        )}
+
+        <div className="px-4 pb-2 shrink-0">
+          <div className="overflow-x-auto overscroll-x-contain">
+            <div className="inline-flex items-center gap-2 text-sm text-muted-foreground flex-wrap sm:flex-nowrap sm:min-w-max">
               <span className="w-6 shrink-0 text-center">For</span>
               <InlineEntitySelector
                 ref={assigneeSelectorRef}
@@ -1678,18 +1722,24 @@ export function NewIssueDialog() {
                 <span className="text-xs text-destructive">{createIssueErrorMessage}</span>
               ) : null}
             </div>
-            <Button
-              size="sm"
-              className="min-w-[8.5rem] disabled:opacity-100"
-              disabled={!title.trim() || createIssue.isPending}
-              onClick={handleSubmit}
-              aria-busy={createIssue.isPending}
-            >
-              <span className="inline-flex items-center justify-center gap-1.5">
-                {createIssue.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
-                <span>{createIssue.isPending ? "Creating..." : isSubIssueMode ? "Create Sub-Issue" : "Create Issue"}</span>
-              </span>
-            </Button>
+            <Tooltip delayDuration={300}>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  className={`min-w-[8.5rem] ${!title.trim() && !createIssue.isPending ? 'opacity-50 cursor-not-allowed' : ''} ${createIssue.isPending ? 'opacity-50 cursor-not-allowed' : ''} ${buttonShake ? 'animate-[shake_0.5s_ease-in-out]' : ''}`}
+                  onClick={createIssue.isPending ? undefined : handleButtonClick}
+                  aria-busy={createIssue.isPending}
+                >
+                  <span className="inline-flex items-center justify-center gap-1.5">
+                    {createIssue.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                    <span>{createIssue.isPending ? "Creating..." : isSubIssueMode ? "Create Sub-Issue" : "Create Issue"}</span>
+                  </span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-[240px] text-xs">
+                {!title.trim() ? "Please enter a title to create an issue" : createIssue.isPending ? "Creating issue, please wait..." : "Click to create issue"}
+              </TooltipContent>
+            </Tooltip>
           </div>
         </div>
       </DialogContent>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -855,3 +855,16 @@ a.paperclip-project-mention-chip {
 [class*="_toolbarNodeKindSelectContainer_"] {
   z-index: 81 !important;
 }
+
+/* Shake animation for button feedback */
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  10%, 30%, 50%, 70%, 90% { transform: translateX(-2px); }
+  20%, 40%, 60%, 80% { transform: translateX(2px); }
+}
+
+/* Fade in animation for inline warnings */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary

Improved the user experience of the New Issue Dialog when submitting without a title, replacing the top-page toast notification with more prominent, in-dialog feedback.


## Thinking Path

When creating a new issue, the title is not filled in, clicking the submit button does not respond, and there is no obvious prompt. It is not very user-friendly for first-time use, so I want to optimize the effect


## Changes

- **Inline title warning**: Added a red "Issue title is required" hint below the title input field when it's empty
- **Centered warning banner**: Displayed an amber warning banner inside the dialog ("Please enter an issue title before creating") with a fade-in animation, auto-dismisses after 3 seconds
- **Button shake animation**: Added a shake animation on the "Create Issue" button when clicked without a title, providing immediate visual feedback
- **Tooltip hint**: Added a tooltip on the submit button showing contextual messages ("Please enter a title to create an issue" / "Click to create issue")
- **Visual button state**: Changed disabled button styling to use reduced opacity with cursor-not-allowed instead of fully disabled, so users can still interact and see the tooltip
- **Accessibility**: Added a hidden `DialogTitle` for screen reader support
- **CSS animations**: Added `@keyframes shake` and `@keyframes fadeIn` animations in `index.css`


## Verification

- Click "Create Issue" with empty title → warning banner appears in dialog center, button shakes, inline hint shows
- Warning banner auto-dismisses after 3 seconds
- Enter a title and submit → no warning, normal creation flow
- Tooltip shows contextual messages based on current state
