### PR TITLE
fix: add missing fields to shared types for gemini-local adapter (#3519)

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -28,6 +28,7 @@ export interface UsageSummary {
   inputTokens: number;
   outputTokens: number;
   cachedInputTokens?: number;
+  thinkingTokens?: number;
 }
 
 export type AdapterBillingType =
@@ -38,6 +39,7 @@ export type AdapterBillingType =
   | "subscription_overage"
   | "credits"
   | "fixed"
+  | "estimated_cost"
   | "unknown";
 
 export interface AdapterRuntimeServiceReport {
@@ -80,6 +82,7 @@ export interface AdapterExecutionResult {
   model?: string | null;
   billingType?: AdapterBillingType | null;
   costUsd?: number | null;
+  retryDelaySec?: number | null;
   resultJson?: Record<string, unknown> | null;
   runtimeServices?: AdapterRuntimeServiceReport[];
   summary?: string | null;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -249,6 +249,7 @@ export const BILLING_TYPES = [
   "subscription_overage",
   "credits",
   "fixed",
+  "estimated_cost",
   "unknown",
 ] as const;
 export type BillingType = (typeof BILLING_TYPES)[number];

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -423,6 +423,8 @@ function normalizeLedgerBillingType(value: unknown): BillingType {
       return "credits";
     case "fixed":
       return "fixed";
+    case "estimated_cost":
+      return "estimated_cost";
     default:
       return "unknown";
   }

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -78,6 +78,7 @@ export function billingTypeDisplayName(billingType: BillingType): string {
     subscription_overage: "Subscription overage",
     credits: "Credits",
     fixed: "Fixed",
+    estimated_cost: "Estimated cost",
     unknown: "Unknown",
   };
   return map[billingType];


### PR DESCRIPTION
## Thinking Path
The gemini-local adapter requires three fields that were absent from shared types, causing gaps in token tracking, retry handling, and billing display.

## What Changed
- Added `thinkingTokens?: number` to UsageSummary in packages/adapter-utils
- Added `retryDelaySec?: number | null` to AdapterExecutionResult
- Added `"estimated_cost"` to AdapterBillingType and BILLING_TYPES
- Added display name for estimated_cost in UI billing utils

## Verification
- TypeScript compiles without errors: `pnpm -r typecheck`

## Risks
- Low: These are additive optional fields with no breaking changes

## Model Used
None — human-authored

## Checklist
- [x] Types added to adapter-utils
- [x] Constants added to shared
- [x] UI display name added
- [x] Typecheck passes