### PR TITLE
[PAP-1390] Slack done-thread notification

### DIFF
--- a/packages/plugins/slack-sync/package.json
+++ b/packages/plugins/slack-sync/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@paperclipai/plugin-slack-sync",
+  "version": "0.1.0",
+  "description": "Sync Paperclip projects and issues to Slack channels and threads",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js"
+  },
+  "scripts": {
+    "prebuild": "node ../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/plugins/slack-sync/src/index.ts
+++ b/packages/plugins/slack-sync/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/slack-sync/src/manifest.ts
+++ b/packages/plugins/slack-sync/src/manifest.ts
@@ -1,0 +1,77 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+export const PLUGIN_ID = "paperclip.slack-sync";
+export const PLUGIN_VERSION = "0.1.0";
+export const WEBHOOK_KEY = "slack-events";
+export const JOB_KEY = "init-sync";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Slack Sync",
+  description:
+    "Syncs Paperclip projects to Slack channels and issues to threads. " +
+    "Supports bi-directional sync: Slack @mentions write back to Paperclip issue comments.",
+  author: "Paperclip",
+  categories: ["connector"],
+  capabilities: [
+    "events.subscribe",
+    "projects.read",
+    "issues.read",
+    "issue.comments.read",
+    "issue.comments.create",
+    "plugin.state.read",
+    "plugin.state.write",
+    "http.outbound",
+    "secrets.read-ref",
+    "webhooks.receive",
+    "jobs.schedule",
+    "activity.log.write",
+  ],
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      slackBotToken: {
+        type: "string",
+        title: "Slack Bot Token (secret ref)",
+        description: "Secret reference for the Slack Bot OAuth token (xoxb-...)",
+      },
+      channelPrefix: {
+        type: "string",
+        title: "Channel Name Prefix",
+        description: "Prefix for auto-created Slack channels",
+        default: "proj-",
+      },
+      inviteUserIds: {
+        type: "array",
+        title: "Auto-invite User IDs",
+        description: "Slack user IDs to auto-invite when creating channels",
+        items: { type: "string" },
+        default: [],
+      },
+    },
+    required: ["slackBotToken"],
+  },
+  webhooks: [
+    {
+      endpointKey: WEBHOOK_KEY,
+      displayName: "Slack Events",
+      description:
+        "Receives Slack Events API callbacks (url_verification, app_mention).",
+    },
+  ],
+  jobs: [
+    {
+      jobKey: JOB_KEY,
+      displayName: "Initial Sync",
+      description:
+        "Scans all existing projects and creates Slack channels for any that are missing. Run manually after first install.",
+    },
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+  },
+};
+
+export default manifest;

--- a/packages/plugins/slack-sync/src/slack-client.ts
+++ b/packages/plugins/slack-sync/src/slack-client.ts
@@ -1,0 +1,135 @@
+/**
+ * Thin wrapper around the Slack Web API.
+ * Uses plain fetch — no SDK dependency needed.
+ */
+
+const SLACK_API = "https://slack.com/api";
+
+export interface SlackChannel {
+  id: string;
+  name: string;
+}
+
+export interface SlackMessage {
+  ts: string;
+  channel: string;
+}
+
+export interface SlackReply {
+  user: string;
+  text: string;
+  ts: string;
+}
+
+export class SlackClient {
+  constructor(private token: string) {}
+
+  private async call<T>(method: string, body: Record<string, unknown>): Promise<T> {
+    const res = await fetch(`${SLACK_API}/${method}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(body),
+    });
+    const data = (await res.json()) as { ok: boolean; error?: string } & T;
+    if (!data.ok) {
+      throw new Error(`Slack ${method} failed: ${data.error ?? "unknown"}`);
+    }
+    return data;
+  }
+
+  /** Create a public channel. Returns channel ID. */
+  async createChannel(name: string): Promise<SlackChannel> {
+    const data = await this.call<{ channel: SlackChannel }>(
+      "conversations.create",
+      { name, is_private: false },
+    );
+    return data.channel;
+  }
+
+  /** Set channel topic (shows the Paperclip project link). */
+  async setTopic(channelId: string, topic: string): Promise<void> {
+    await this.call("conversations.setTopic", { channel: channelId, topic });
+  }
+
+  /** Post a message. Returns message ts. */
+  async postMessage(
+    channelId: string,
+    text: string,
+    opts?: { threadTs?: string; blocks?: unknown[] },
+  ): Promise<SlackMessage> {
+    const body: Record<string, unknown> = { channel: channelId, text };
+    if (opts?.threadTs) body.thread_ts = opts.threadTs;
+    if (opts?.blocks) body.blocks = opts.blocks;
+    const data = await this.call<{ ts: string }>("chat.postMessage", body);
+    return { ts: data.ts, channel: channelId };
+  }
+
+  /** Update an existing message. */
+  async updateMessage(
+    channelId: string,
+    ts: string,
+    text: string,
+    blocks?: unknown[],
+  ): Promise<void> {
+    // Slack requires ts as string; JSONB state round-trips can return number
+    const body: Record<string, unknown> = { channel: channelId, ts: String(ts), text };
+    if (blocks) body.blocks = blocks;
+    await this.call("chat.update", body);
+  }
+
+  /** Read all replies in a thread. */
+  async getReplies(channelId: string, threadTs: string): Promise<SlackReply[]> {
+    const data = await this.call<{ messages: SlackReply[] }>(
+      "conversations.replies",
+      { channel: channelId, ts: threadTs },
+    );
+    return data.messages;
+  }
+
+  /** Invite users to a channel. */
+  async inviteUsers(channelId: string, userIds: string[]): Promise<void> {
+    try {
+      await this.call("conversations.invite", {
+        channel: channelId,
+        users: userIds.join(","),
+      });
+    } catch (e) {
+      // Ignore "already_in_channel" errors
+      if (!(e instanceof Error && e.message.includes("already_in_channel"))) {
+        throw e;
+      }
+    }
+  }
+
+  /** Pin a message. Returns true on success, false if scope is missing. */
+  async pinMessage(channelId: string, ts: string): Promise<boolean> {
+    try {
+      await this.call("pins.add", { channel: channelId, timestamp: ts });
+      return true;
+    } catch (e) {
+      if (e instanceof Error) {
+        // already pinned → treat as success
+        if (e.message.includes("already_pinned")) return true;
+        // missing scope → swallow; caller logs
+        if (e.message.includes("missing_scope")) return false;
+      }
+      throw e;
+    }
+  }
+
+  /** Look up channel by name. Returns null if not found. */
+  async findChannel(name: string): Promise<SlackChannel | null> {
+    try {
+      const data = await this.call<{ channels: SlackChannel[] }>(
+        "conversations.list",
+        { types: "public_channel", limit: 200 },
+      );
+      return data.channels.find((c) => c.name === name) ?? null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/plugins/slack-sync/src/worker.ts
+++ b/packages/plugins/slack-sync/src/worker.ts
@@ -433,6 +433,31 @@ const plugin = definePlugin({
         channelId,
         titleChanged,
       });
+
+      // Notify the originating Slack thread when issue is marked done
+      const statusChangedToDone =
+        issue.status === "done" && payload._previous &&
+        (payload._previous as Record<string, unknown>).status !== "done";
+      if (statusChangedToDone) {
+        const meta = (issue as unknown as Record<string, unknown>).metadata as
+          | Record<string, unknown>
+          | null
+          | undefined;
+        const sourceChannel = meta?.sourceChannel as string | undefined;
+        const sourceThreadTs = meta?.sourceThreadTs as string | undefined;
+        if (sourceChannel && sourceThreadTs) {
+          await client.postMessage(
+            sourceChannel,
+            `✅ ${(issue as unknown as { identifier: string }).identifier} ${issue.title} 已完成`,
+            { threadTs: sourceThreadTs },
+          );
+          ctx!.logger.info("issue.updated → done notification sent to source thread", {
+            issueId,
+            sourceChannel,
+            sourceThreadTs,
+          });
+        }
+      }
     });
 
     // ----- issue.comment.created -----

--- a/packages/plugins/slack-sync/src/worker.ts
+++ b/packages/plugins/slack-sync/src/worker.ts
@@ -1,0 +1,539 @@
+import {
+  definePlugin,
+  runWorker,
+  type PluginContext,
+  type PluginEvent,
+  type PluginJobContext,
+  type PluginWebhookInput,
+} from "@paperclipai/plugin-sdk";
+import { SlackClient } from "./slack-client.js";
+import { WEBHOOK_KEY, JOB_KEY } from "./manifest.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SlackSyncConfig {
+  slackBotToken?: string;
+  channelPrefix?: string;
+  inviteUserIds?: string[];
+}
+
+// State keys (scoped to project or issue)
+const STATE = {
+  channelId: "slack-channel-id",
+  messageTs: "slack-message-ts",
+  contextMessageTs: "slack-context-message-ts",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let ctx: PluginContext | null = null;
+
+async function getSlack(): Promise<{ client: SlackClient; prefix: string }> {
+  if (!ctx) throw new Error("Plugin not initialized");
+  const config = (await ctx.config.get()) as SlackSyncConfig;
+  if (!config.slackBotToken) throw new Error("slackBotToken not configured");
+  // Support both direct token and secret ref
+  const token = config.slackBotToken.startsWith("xoxb-")
+    ? config.slackBotToken
+    : await ctx.secrets.resolve(config.slackBotToken);
+  return {
+    client: new SlackClient(token),
+    prefix: config.channelPrefix ?? "proj-",
+  };
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60); // Slack channel name limit is 80 chars
+}
+
+function issueStatusEmoji(status: string): string {
+  switch (status) {
+    case "todo":
+      return "\u{1f4cb}"; // clipboard
+    case "in_progress":
+      return "\u{1f6a7}"; // construction
+    case "in_review":
+      return "\u{1f50d}"; // magnifying glass
+    case "done":
+      return "\u2705"; // check mark
+    case "cancelled":
+      return "\u274c"; // cross mark
+    default:
+      return "\u{1f4a0}"; // diamond
+  }
+}
+
+function formatSlackQuote(text: string): string {
+  return text
+    .split(/\r?\n/)
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
+function formatIssueAnchorMessage(issue: {
+  title: string;
+}): string {
+  return issue.title.replace(/\s+/g, " ").trim();
+}
+
+function formatIssueThreadMessage(issue: {
+  identifier: string;
+  title: string;
+  status: string;
+  priority: string;
+  description?: string | null;
+}, opts?: { heading?: string }): string {
+  const emoji = issueStatusEmoji(issue.status);
+  const lines = opts?.heading ? [opts.heading] : [];
+  lines.push(
+    `${emoji} *${issue.identifier}* — ${issue.title}`,
+    `Status: \`${issue.status}\` | Priority: \`${issue.priority}\``,
+  );
+  if (issue.description) {
+    lines.push("*Description*", formatSlackQuote(issue.description));
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Ensure a Slack channel exists for a project (idempotent)
+// ---------------------------------------------------------------------------
+
+async function ensureProjectChannel(
+  projectId: string,
+  projectName: string,
+  projectUrlKey: string,
+  companyId: string,
+): Promise<string> {
+  if (!ctx) throw new Error("Plugin not initialized");
+  const { client, prefix } = await getSlack();
+
+  // Check if we already have a channel ID stored
+  const existing = await ctx.state.get({
+    scopeKind: "project",
+    scopeId: projectId,
+    stateKey: STATE.channelId,
+  });
+  if (typeof existing === "string") return existing;
+
+  // Try to find or create the channel
+  const channelName = `${prefix}${slugify(projectUrlKey || projectName)}`;
+
+  let channel = await client.findChannel(channelName);
+  if (!channel) {
+    channel = await client.createChannel(channelName);
+    ctx.logger.info("Created Slack channel", {
+      channelId: channel.id,
+      channelName,
+      projectId,
+    });
+  }
+
+  // Set topic
+  await client.setTopic(
+    channel.id,
+    `Paperclip project: ${projectName}`,
+  );
+
+  // Auto-invite configured users
+  const config = (await ctx.config.get()) as SlackSyncConfig;
+  if (config.inviteUserIds && config.inviteUserIds.length > 0) {
+    await client.inviteUsers(channel.id, config.inviteUserIds);
+  }
+
+  // Persist mapping
+  await ctx.state.set(
+    { scopeKind: "project", scopeId: projectId, stateKey: STATE.channelId },
+    channel.id,
+  );
+
+  return channel.id;
+}
+
+// ---------------------------------------------------------------------------
+// Render project context as Slack message body
+// ---------------------------------------------------------------------------
+
+function renderContextMessage(project: {
+  name: string;
+  description?: string | null;
+  context?: string | null;
+}): string {
+  const lines = [
+    `:pushpin: *Project Context — ${project.name}*`,
+    "_由 Paperclip 自動同步；編輯請在 Slack @maltbot 請它改，或直接改 Paperclip UI_",
+    "",
+  ];
+  if (project.description) {
+    lines.push(project.description);
+    lines.push("");
+  }
+  if (project.context) {
+    lines.push(project.context);
+  } else {
+    lines.push("_(尚未設定 context)_");
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Sync project context to the Slack channel's pinned message
+// Idempotent: creates on first call, updates on subsequent calls.
+// ---------------------------------------------------------------------------
+
+async function syncContextPin(
+  projectId: string,
+  companyId: string,
+): Promise<void> {
+  if (!ctx) throw new Error("Plugin not initialized");
+
+  const project = await ctx.projects.get(projectId, companyId);
+  if (!project) return;
+
+  const channelId = (await ctx.state.get({
+    scopeKind: "project",
+    scopeId: projectId,
+    stateKey: STATE.channelId,
+  })) as string | null;
+  if (!channelId) return; // no channel bound yet
+
+  const body = renderContextMessage(
+    project as unknown as Parameters<typeof renderContextMessage>[0],
+  );
+  const { client } = await getSlack();
+
+  const existingTs = (await ctx.state.get({
+    scopeKind: "project",
+    scopeId: projectId,
+    stateKey: STATE.contextMessageTs,
+  })) as string | null;
+
+  if (existingTs) {
+    try {
+      ctx.logger.info("Context pin updating", {
+        projectId,
+        channelId,
+        existingTs,
+        bodyBytes: Buffer.byteLength(body, "utf8"),
+      });
+      await client.updateMessage(channelId, existingTs, body);
+      ctx.logger.info("Context pin updated", { projectId, channelId });
+      return;
+    } catch (e) {
+      // message may have been deleted — fall through to repost
+      ctx.logger.warn("Context pin update failed; will repost", {
+        projectId,
+        channelId,
+        existingTs,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  const msg = await client.postMessage(channelId, body);
+  const pinned = await client.pinMessage(channelId, msg.ts);
+  if (!pinned) {
+    ctx.logger.warn(
+      "pins.add failed (likely missing pins:write scope); context message posted but not pinned",
+      { projectId, channelId, ts: msg.ts },
+    );
+  }
+  await ctx.state.set(
+    {
+      scopeKind: "project",
+      scopeId: projectId,
+      stateKey: STATE.contextMessageTs,
+    },
+    msg.ts,
+  );
+  ctx.logger.info("Context pin created", { projectId, channelId, ts: msg.ts });
+}
+
+// ---------------------------------------------------------------------------
+// Plugin definition
+// ---------------------------------------------------------------------------
+
+const plugin = definePlugin({
+  async setup(context) {
+    ctx = context;
+    ctx.logger.info("slack-sync plugin setup");
+
+    // ----- project.created -----
+    ctx.events.on("project.created", async (event: PluginEvent) => {
+      const projectId = event.entityId;
+      const companyId = event.companyId;
+      if (!projectId || !companyId) return;
+
+      const project = await ctx!.projects.get(projectId, companyId);
+      if (!project) return;
+
+      const channelId = await ensureProjectChannel(
+        projectId,
+        project.name,
+        (project as unknown as Record<string, unknown>).urlKey as string ?? project.name,
+        companyId,
+      );
+
+      ctx!.logger.info("project.created → Slack channel ready", {
+        projectId,
+        channelId,
+      });
+
+      // Post + pin the context message so the channel has a canonical
+      // "what is this project about" anchor that stays in sync with Paperclip.
+      try {
+        await syncContextPin(projectId, companyId);
+      } catch (e) {
+        ctx!.logger.warn("project.created: syncContextPin failed", {
+          projectId,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    });
+
+    // ----- project.updated -----
+    ctx.events.on("project.updated", async (event: PluginEvent) => {
+      const projectId = event.entityId;
+      const companyId = event.companyId;
+      if (!projectId || !companyId) return;
+
+      // Only re-render if fields that appear in the pinned message changed.
+      const payload = (event.payload ?? {}) as Record<string, unknown>;
+      const touched =
+        "context" in payload || "description" in payload || "name" in payload;
+      if (!touched) return;
+
+      try {
+        await syncContextPin(projectId, companyId);
+      } catch (e) {
+        ctx!.logger.warn("project.updated: syncContextPin failed", {
+          projectId,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    });
+
+    // ----- issue.created -----
+    ctx.events.on("issue.created", async (event: PluginEvent) => {
+      const issueId = event.entityId;
+      const companyId = event.companyId;
+      if (!issueId || !companyId) return;
+
+      const issue = await ctx!.issues.get(issueId, companyId);
+      if (!issue || !issue.projectId) return;
+
+      // Idempotency: if we've already posted a thread anchor for this issue, skip.
+      const existingTs = (await ctx!.state.get({
+        scopeKind: "issue",
+        scopeId: issueId,
+        stateKey: STATE.messageTs,
+      })) as string | null;
+      if (existingTs) {
+        ctx!.logger.info("issue.created → skip, anchor already posted", {
+          issueId,
+          existingTs,
+        });
+        return;
+      }
+
+      // Get project channel
+      const channelId = (await ctx!.state.get({
+        scopeKind: "project",
+        scopeId: issue.projectId,
+        stateKey: STATE.channelId,
+      })) as string | null;
+      if (!channelId) return; // Project has no Slack channel
+
+      const { client } = await getSlack();
+      const msg = await client.postMessage(
+        channelId,
+        formatIssueAnchorMessage(issue as unknown as Parameters<typeof formatIssueAnchorMessage>[0]),
+      );
+
+      const pinned = await client.pinMessage(channelId, msg.ts);
+      if (!pinned) {
+        ctx!.logger.warn(
+          "pins.add failed (likely missing pins:write scope); issue message posted but not pinned",
+          { issueId, channelId, ts: msg.ts },
+        );
+      }
+
+      // Store message ts for future updates
+      await ctx!.state.set(
+        { scopeKind: "issue", scopeId: issueId, stateKey: STATE.messageTs },
+        `${channelId}:${msg.ts}`,
+      );
+
+      await client.postMessage(
+        channelId,
+        formatIssueThreadMessage(
+          issue as unknown as Parameters<typeof formatIssueThreadMessage>[0],
+        ),
+        { threadTs: msg.ts },
+      );
+
+      ctx!.logger.info("issue.created → posted pinned title anchor", {
+        issueId,
+        channelId,
+        ts: msg.ts,
+      });
+    });
+
+    // ----- issue.updated -----
+    ctx.events.on("issue.updated", async (event: PluginEvent) => {
+      const issueId = event.entityId;
+      const companyId = event.companyId;
+      if (!issueId || !companyId) return;
+
+      const stored = (await ctx!.state.get({
+        scopeKind: "issue",
+        scopeId: issueId,
+        stateKey: STATE.messageTs,
+      })) as string | null;
+      if (!stored) return;
+
+      const [channelId, messageTs] = stored.split(":");
+      if (!channelId || !messageTs) return;
+
+      const issue = await ctx!.issues.get(issueId, companyId);
+      if (!issue) return;
+
+      const payload = (event.payload ?? {}) as Record<string, unknown>;
+      const titleChanged = "title" in payload;
+
+      const { client } = await getSlack();
+      if (titleChanged) {
+        await client.updateMessage(
+          channelId,
+          messageTs,
+          formatIssueAnchorMessage(issue as unknown as Parameters<typeof formatIssueAnchorMessage>[0]),
+        );
+      }
+
+      await client.postMessage(
+        channelId,
+        formatIssueThreadMessage(
+          issue as unknown as Parameters<typeof formatIssueThreadMessage>[0],
+          { heading: ":memo: Issue updated" },
+        ),
+        { threadTs: messageTs },
+      );
+
+      ctx!.logger.info("issue.updated → synced to Slack thread", {
+        issueId,
+        channelId,
+        titleChanged,
+      });
+    });
+
+    // ----- issue.comment.created -----
+    ctx.events.on("issue.comment.created", async (event: PluginEvent) => {
+      const issueId = event.entityId;
+      const companyId = event.companyId;
+      if (!issueId || !companyId) return;
+
+      const stored = (await ctx!.state.get({
+        scopeKind: "issue",
+        scopeId: issueId,
+        stateKey: STATE.messageTs,
+      })) as string | null;
+      if (!stored) return;
+
+      const [channelId, messageTs] = stored.split(":");
+      if (!channelId || !messageTs) return;
+
+      // Get the latest comment
+      const comments = await ctx!.issues.listComments(issueId, companyId);
+      const latest = comments[comments.length - 1];
+      if (!latest) return;
+
+      const { client } = await getSlack();
+      await client.postMessage(channelId, latest.body, {
+        threadTs: messageTs,
+      });
+
+      ctx!.logger.info("issue.comment.created → thread reply", {
+        issueId,
+        channelId,
+      });
+    });
+
+    // ----- Init sync job -----
+    ctx.jobs.register(JOB_KEY, async (_job: PluginJobContext) => {
+      ctx!.logger.info("Running initial sync — scanning all projects");
+
+      // Use companyId from the most recent event or config.
+      // For init sync, list projects without company filter (SDK supports it).
+      const config = (await ctx!.config.get()) as SlackSyncConfig & { companyId?: string };
+      const companyId = config.companyId ?? "15653bc9-07c7-44c3-bd19-5e67ba0e9ff5";
+
+      const projects = await ctx!.projects.list({ companyId });
+
+      let created = 0;
+      let skipped = 0;
+
+      for (const project of projects) {
+        const existing = await ctx!.state.get({
+          scopeKind: "project",
+          scopeId: project.id,
+          stateKey: STATE.channelId,
+        });
+        if (existing) {
+          skipped++;
+          continue;
+        }
+
+        await ensureProjectChannel(
+          project.id,
+          project.name,
+          (project as unknown as Record<string, unknown>).urlKey as string ?? project.name,
+          companyId,
+        );
+        created++;
+      }
+
+      ctx!.logger.info("Initial sync complete", { created, skipped });
+    });
+  },
+
+  // ----- Slack Events webhook -----
+  async onWebhook(input: PluginWebhookInput) {
+    if (input.endpointKey !== WEBHOOK_KEY) {
+      throw new Error(`Unknown webhook endpoint: ${input.endpointKey}`);
+    }
+
+    const body = input.parsedBody as Record<string, unknown> | undefined;
+    if (!body) return;
+
+    // Slack URL verification challenge
+    if (body.type === "url_verification") {
+      // The plugin webhook system should return the challenge.
+      // For now, log it — Paperclip's webhook handler may need adjustment.
+      ctx?.logger.info("Slack URL verification", {
+        challenge: body.challenge,
+      });
+      return;
+    }
+
+    // Event callback — app_mention handling is delegated to OpenClaw Slack
+    // adapter (channel-pm). This plugin now only handles url_verification.
+    if (body.type !== "event_callback") return;
+    return;
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "slack-sync plugin ready" };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/slack-sync/tests/worker.spec.ts
+++ b/packages/plugins/slack-sync/tests/worker.spec.ts
@@ -260,4 +260,93 @@ describe("slack-sync plugin", () => {
     expect(String(postCalls[0].body.text)).toContain("Fresh details");
     expect(postCalls[1].body).toMatchObject({ channel: CHANNEL_ID, thread_ts: "ts-1", text: "A follow-up comment" });
   });
+
+  it("sends a done notification to the source Slack thread when status changes to done and metadata has source info", async () => {
+    const { harness, calls } = await setupIssueHarness();
+
+    const SOURCE_CHANNEL = "C-SOURCE";
+    const SOURCE_THREAD_TS = "source-ts-1";
+
+    await harness.ctx.state.set({
+      scopeKind: "issue",
+      scopeId: ISSUE_ID,
+      stateKey: "slack-message-ts",
+    }, `${CHANNEL_ID}:ts-1`);
+    await harness.ctx.issues.update(
+      ISSUE_ID,
+      { status: "done", metadata: { sourceChannel: SOURCE_CHANNEL, sourceThreadTs: SOURCE_THREAD_TS } } as Record<string, unknown>,
+      COMPANY_ID,
+    );
+
+    await harness.emit(
+      "issue.updated",
+      { status: "done", _previous: { status: "in_progress" } },
+      { entityId: ISSUE_ID, entityType: "issue", companyId: COMPANY_ID },
+    );
+
+    const postCalls = calls.filter((call) => call.url.endsWith("/chat.postMessage"));
+    const doneNotification = postCalls.find(
+      (call) => call.body.channel === SOURCE_CHANNEL && call.body.thread_ts === SOURCE_THREAD_TS,
+    );
+    expect(doneNotification).toBeDefined();
+    expect(String(doneNotification?.body.text)).toContain("✅");
+    expect(String(doneNotification?.body.text)).toContain("PAP-1379");
+    expect(String(doneNotification?.body.text)).toContain("已完成");
+  });
+
+  it("does NOT send a done notification when status changes to done but metadata lacks source info", async () => {
+    const { harness, calls } = await setupIssueHarness();
+
+    await harness.ctx.state.set({
+      scopeKind: "issue",
+      scopeId: ISSUE_ID,
+      stateKey: "slack-message-ts",
+    }, `${CHANNEL_ID}:ts-1`);
+    await harness.ctx.issues.update(
+      ISSUE_ID,
+      { status: "done" },
+      COMPANY_ID,
+    );
+
+    await harness.emit(
+      "issue.updated",
+      { status: "done", _previous: { status: "in_progress" } },
+      { entityId: ISSUE_ID, entityType: "issue", companyId: COMPANY_ID },
+    );
+
+    const postCalls = calls.filter((call) => call.url.endsWith("/chat.postMessage"));
+    // Should only have the regular thread update, no source-thread notification
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0].body.channel).toBe(CHANNEL_ID);
+  });
+
+  it("does NOT send a done notification when issue is already done and gets updated again", async () => {
+    const { harness, calls } = await setupIssueHarness();
+
+    const SOURCE_CHANNEL = "C-SOURCE";
+    const SOURCE_THREAD_TS = "source-ts-1";
+
+    await harness.ctx.state.set({
+      scopeKind: "issue",
+      scopeId: ISSUE_ID,
+      stateKey: "slack-message-ts",
+    }, `${CHANNEL_ID}:ts-1`);
+    await harness.ctx.issues.update(
+      ISSUE_ID,
+      { status: "done", metadata: { sourceChannel: SOURCE_CHANNEL, sourceThreadTs: SOURCE_THREAD_TS } } as Record<string, unknown>,
+      COMPANY_ID,
+    );
+
+    await harness.emit(
+      "issue.updated",
+      { title: "Renamed", _previous: { title: "Old", status: "done" } },
+      { entityId: ISSUE_ID, entityType: "issue", companyId: COMPANY_ID },
+    );
+
+    const postCalls = calls.filter((call) => call.url.endsWith("/chat.postMessage"));
+    const doneNotifications = postCalls.filter(
+      (call) => call.body.channel === SOURCE_CHANNEL,
+    );
+    expect(doneNotifications).toHaveLength(0);
+  });
 });

--- a/packages/plugins/slack-sync/tests/worker.spec.ts
+++ b/packages/plugins/slack-sync/tests/worker.spec.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import manifest from "../src/manifest.js";
+import plugin from "../src/worker.js";
+
+const COMPANY_ID = "comp-1";
+const PROJECT_ID = "proj-1";
+const ISSUE_ID = "iss-1";
+const CHANNEL_ID = "C123";
+
+type SlackCall = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+function makeProject(overrides: Record<string, unknown> = {}) {
+  return {
+    id: PROJECT_ID,
+    companyId: COMPANY_ID,
+    goalId: null,
+    name: "Paperclip",
+    description: null,
+    context: null,
+    status: "planned" as const,
+    leadAgentId: null,
+    targetDate: null,
+    color: null,
+    pauseReason: null,
+    pausedAt: null,
+    executionWorkspacePolicy: null,
+    archivedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ISSUE_ID,
+    companyId: COMPANY_ID,
+    projectId: PROJECT_ID,
+    projectWorkspaceId: null,
+    goalId: null,
+    parentId: null,
+    title: "Slack sync should only send title",
+    description: "Detailed body lives in thread",
+    status: "todo" as const,
+    priority: "medium" as const,
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionAgentNameKey: null,
+    executionLockedAt: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    issueNumber: 1379,
+    identifier: "PAP-1379",
+    originKind: "manual",
+    originId: null,
+    originRunId: null,
+    requestDepth: 0,
+    billingCode: null,
+    assigneeAdapterOverrides: null,
+    executionWorkspaceId: null,
+    executionWorkspacePreference: null,
+    executionWorkspaceSettings: null,
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    hiddenAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function jsonResponse(payload: Record<string, unknown>) {
+  return new Response(JSON.stringify(payload), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function installSlackMock(calls: SlackCall[]) {
+  let postCounter = 0;
+  vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    calls.push({ url, body });
+
+    if (url.endsWith("/chat.postMessage")) {
+      postCounter += 1;
+      return jsonResponse({ ok: true, ts: `ts-${postCounter}` });
+    }
+
+    if (url.endsWith("/chat.update")) {
+      return jsonResponse({ ok: true, ts: String(body.ts ?? "ts-1") });
+    }
+
+    if (url.endsWith("/pins.add")) {
+      return jsonResponse({ ok: true });
+    }
+
+    throw new Error(`Unexpected Slack API call: ${url}`);
+  }));
+}
+
+async function setupIssueHarness() {
+  const calls: SlackCall[] = [];
+  installSlackMock(calls);
+
+  const harness = createTestHarness({
+    manifest,
+    capabilities: [...manifest.capabilities, "issues.update"],
+    config: { slackBotToken: "xoxb-test-token" },
+  });
+  await plugin.definition.setup(harness.ctx);
+
+  harness.seed({
+    projects: [makeProject()],
+    issues: [makeIssue()],
+  });
+
+  await harness.ctx.state.set({
+    scopeKind: "project",
+    scopeId: PROJECT_ID,
+    stateKey: "slack-channel-id",
+  }, CHANNEL_ID);
+
+  return { harness, calls };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("slack-sync plugin", () => {
+  it("posts a title-only anchor when issue.created fires", async () => {
+    const { harness, calls } = await setupIssueHarness();
+
+    await harness.emit(
+      "issue.created",
+      { issueId: ISSUE_ID },
+      { entityId: ISSUE_ID, entityType: "issue", companyId: COMPANY_ID },
+    );
+
+    const postCalls = calls.filter((call) => call.url.endsWith("/chat.postMessage"));
+    expect(postCalls).toHaveLength(2);
+    expect(postCalls[0].body.text).toBe("Slack sync should only send title");
+    expect(postCalls[0].body.thread_ts).toBeUndefined();
+  });
+
+  it("pins the new issue anchor on issue.created", async () => {
+    const { harness, calls } = await setupIssueHarness();
+
+    await harness.emit(
+      "issue.created",
+      { issueId: ISSUE_ID },
+      { entityId: ISSUE_ID, entityType: "issue", companyId: COMPANY_ID },
+    );
+
+    const pinCall = calls.find((call) => call.url.endsWith("/pins.add"));
+    expect(pinCall).toBeDefined();
+    expect(pinCall?.body).toMatchObject({ channel: CHANNEL_ID, timestamp: "ts-1" });
+  });
+
+  it("posts the issue description as the first thread reply on issue.created", async () => {
+    const { harness, calls } = await setupIssueHarness();
+
+    await harness.emit(
+      "issue.created",
+      { issueId: ISSUE_ID },
+      { entityId: ISSUE_ID, entityType: "issue", companyId: COMPANY_ID },
+    );
+
+    const postCalls = calls.filter((call) => call.url.endsWith("/chat.postMessage"));
+    expect(postCalls[1].body.thread_ts).toBe("ts-1");
+    expect(String(postCalls[1].body.text)).toContain("Detailed body lives in thread");
+    expect(String(postCalls[1].body.text)).toContain("PAP-1379");
+  });
+
+  it("writes issue.updated details into the thread without updating the main message when title is unchanged", async () => {
+    const { harness, calls } = await setupIssueHarness();
+
+    await harness.ctx.state.set({
+      scopeKind: "issue",
+      scopeId: ISSUE_ID,
+      stateKey: "slack-message-ts",
+    }, `${CHANNEL_ID}:ts-1`);
+    await harness.ctx.issues.update(
+      ISSUE_ID,
+      { status: "in_progress", description: "Updated details stay in thread" },
+      COMPANY_ID,
+    );
+
+    await harness.emit(
+      "issue.updated",
+      { status: "in_progress", description: "Updated details stay in thread", _previous: { status: "todo" } },
+      { entityId: ISSUE_ID, entityType: "issue", companyId: COMPANY_ID },
+    );
+
+    expect(calls.some((call) => call.url.endsWith("/chat.update"))).toBe(false);
+    const threadReply = calls.find((call) => call.url.endsWith("/chat.postMessage"));
+    expect(threadReply?.body.thread_ts).toBe("ts-1");
+    expect(String(threadReply?.body.text)).toContain(":memo: Issue updated");
+    expect(String(threadReply?.body.text)).toContain("Updated details stay in thread");
+  });
+
+  it("updates the main message only when the title changes, and sends comments to the thread", async () => {
+    const { harness, calls } = await setupIssueHarness();
+
+    await harness.ctx.state.set({
+      scopeKind: "issue",
+      scopeId: ISSUE_ID,
+      stateKey: "slack-message-ts",
+    }, `${CHANNEL_ID}:ts-1`);
+    await harness.ctx.issues.update(
+      ISSUE_ID,
+      { title: "New issue title", description: "Fresh details" },
+      COMPANY_ID,
+    );
+
+    await harness.emit(
+      "issue.updated",
+      { title: "New issue title", _previous: { title: "Slack sync should only send title" } },
+      { entityId: ISSUE_ID, entityType: "issue", companyId: COMPANY_ID },
+    );
+
+    harness.seed({
+      issueComments: [{
+        id: "comment-1",
+        companyId: COMPANY_ID,
+        issueId: ISSUE_ID,
+        authorAgentId: null,
+        authorUserId: null,
+        body: "A follow-up comment",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }],
+    });
+
+    await harness.emit(
+      "issue.comment.created",
+      { commentId: "comment-1" },
+      { entityId: ISSUE_ID, entityType: "issue", companyId: COMPANY_ID },
+    );
+
+    const updateCall = calls.find((call) => call.url.endsWith("/chat.update"));
+    expect(updateCall?.body).toMatchObject({ channel: CHANNEL_ID, ts: "ts-1", text: "New issue title" });
+
+    const postCalls = calls.filter((call) => call.url.endsWith("/chat.postMessage"));
+    expect(postCalls).toHaveLength(2);
+    expect(postCalls[0].body.thread_ts).toBe("ts-1");
+    expect(String(postCalls[0].body.text)).toContain("Fresh details");
+    expect(postCalls[1].body).toMatchObject({ channel: CHANNEL_ID, thread_ts: "ts-1", text: "A follow-up comment" });
+  });
+});

--- a/packages/plugins/slack-sync/tsconfig.json
+++ b/packages/plugins/slack-sync/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023"]
+  },
+  "include": ["src"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,13 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    projects: ["packages/db", "packages/adapters/opencode-local", "server", "ui", "cli"],
+    projects: [
+      "packages/db",
+      "packages/adapters/opencode-local",
+      "packages/plugins/slack-sync",
+      "server",
+      "ui",
+      "cli",
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- When an issue transitions to **done**, check `issue.metadata` for `sourceChannel` + `sourceThreadTs`
- If present, post a `✅ {identifier} {title} 已完成` reply in the originating Slack thread
- Metadata accessed via type assertion — no changes to the shared Issue model (PAP-1389 scope)

## Test plan
- [x] New test: sends done notification to source thread when status → done with metadata
- [x] New test: no notification when metadata lacks source info
- [x] New test: no notification when issue was already done (no status transition)
- [x] All 8 existing + new tests pass (`vitest run packages/plugins/slack-sync/tests/worker.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)