### PR TITLE
fix(docker): update GitHub CLI keyring SHA256 after upstream rotation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates gosu curl git wget ripgrep python3 \
   && mkdir -p -m 755 /etc/apt/keyrings \
   && wget -nv -O/etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-  && echo "20e0125d6f6e077a9ad46f03371bc26d90b04939fb95170f5a1905099cc6bcc0  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
+  && echo "6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
   && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
   && mkdir -p -m 755 /etc/apt/sources.list.d \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \


### PR DESCRIPTION
## Summary

The GitHub CLI APT keyring SHA256 checksum in the Dockerfile is stale — rotated upstream, causing fresh Docker builds to fail at the sha256sum verification step.

- Old: `20e0125d6f6e077a9ad46f03371bc26d90b04939fb95170f5a1905099cc6bcc0`
- New: `6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b`

## Test plan

- [ ] Run `docker build .` on a clean environment — should complete without sha256sum error
- [ ] Verify `gh --version` works inside the built container

🤖 Generated with [Claude Code](https://claude.com/claude-code)