### PR TITLE
fix(heartbeat): add hermes_local to SESSIONED_LOCAL_ADAPTERS

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -88,6 +88,7 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "codex_local",
   "cursor",
   "gemini_local",
+  "hermes_local",
   "opencode_local",
   "pi_local",
 ]);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The heartbeat service monitors agent health via PID liveness checks for local adapters
> - `SESSIONED_LOCAL_ADAPTERS` in `heartbeat.ts` controls which adapters get PID tracking and retry-on-lost behavior
> - `hermes_local` (the Hermes Agent adapter) was missing from this set
> - Without it, the orphan reaper immediately marks all Hermes runs as `process_lost` instead of retrying
> - This PR adds the one-line registration so `hermes_local` gets the same treatment as `claude_local`, `codex_local`, `cursor`, and `gemini_local`
> - The benefit is Hermes agent runs complete normally instead of being killed after ~5 minutes

## What Changed

- Added `"hermes_local"` to the `SESSIONED_LOCAL_ADAPTERS` set in `server/src/services/heartbeat.ts`

## Verification

- Trigger a Hermes agent run via the wakeup API
- Confirm `heartbeat_runs.status` transitions to `succeeded` (not `process_lost`)
- Tested end-to-end on a production Paperclip instance with Hermes agent running heartbeat cycles for 48+ hours

## Risks

Low risk. Additive one-line change — adds a string to an existing set. No behavioral change for other adapters. Consistent with `BUILTIN_ADAPTER_TYPES` which already includes `hermes_local`.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.6 (claude-opus-4-6)
- Context window: 1M tokens
- Capabilities: Tool use, code execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge