### PR TITLE
fix(routines): coalesce into stranded execution issue instead of failing dispatch

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -349,6 +349,75 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues[0]?.id).toBe(previousIssue.id);
   });
 
+  it("coalesces when the existing execution issue has a stale (finished) heartbeat run but is still open", async () => {
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const finishedHeartbeatRunId = randomUUID();
+
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "todo",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "schedule",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+      completedAt: new Date("2026-03-20T12:00:00.000Z"),
+    });
+
+    // Simulate: heartbeat run was queued and has since finished, but the issue was never closed.
+    await db.insert(heartbeatRuns).values({
+      id: finishedHeartbeatRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "completed",
+      contextSnapshot: { issueId: previousIssue.id },
+      startedAt: new Date("2026-03-20T12:01:00.000Z"),
+    });
+
+    await db
+      .update(issues)
+      .set({
+        executionRunId: finishedHeartbeatRunId,
+        executionLockedAt: new Date("2026-03-20T12:01:00.000Z"),
+      })
+      .where(eq(issues.id, previousIssue.id));
+
+    // findLiveExecutionIssue returns null (heartbeat run is not live), so activeIssue is null.
+    const detailBefore = await svc.getDetail(routine.id);
+    expect(detailBefore?.activeIssue).toBeNull();
+
+    // The routine dispatch should coalesce into the stranded issue instead of
+    // throwing "duplicate key value violates unique constraint issues_open_routine_execution_uq".
+    const run = await svc.runRoutine(routine.id, { source: "schedule" });
+    expect(run.status).toBe("coalesced");
+    expect(run.linkedIssueId).toBe(previousIssue.id);
+    expect(run.coalescedIntoRunId).toBe(previousRunId);
+
+    const routineIssues = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+
+    expect(routineIssues).toHaveLength(1);
+    expect(routineIssues[0]?.id).toBe(previousIssue.id);
+  });
+
   it("interpolates routine variables into the execution issue and stores resolved values", async () => {
     const { companyId, agentId, projectId, svc } = await seedFixture();
     const variableRoutine = await svc.create(

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -640,6 +640,31 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  /**
+   * Finds any open execution issue for the routine that has an executionRunId stamped on it,
+   * regardless of whether the heartbeat run is still live. Used as a fallback when the
+   * unique constraint fires but findLiveExecutionIssue returns null — which happens when
+   * the heartbeat run has finished but the agent never closed the issue.
+   */
+  async function findStrandedOpenExecutionIssue(routine: typeof routines.$inferSelect, executor: Db = db) {
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, "routine_execution"),
+          eq(issues.originId, routine.id),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+          isNotNull(issues.executionRunId),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -752,7 +777,11 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
-        const activeIssue = await findLiveExecutionIssue(input.routine, txDb);
+        const activeIssue =
+          (await findLiveExecutionIssue(input.routine, txDb)) ??
+          (input.routine.concurrencyPolicy !== "always_enqueue"
+            ? await findStrandedOpenExecutionIssue(input.routine, txDb)
+            : null);
         if (activeIssue && input.routine.concurrencyPolicy !== "always_enqueue") {
           const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
           const updated = await finalizeRun(createdRun.id, {
@@ -801,7 +830,9 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
             throw error;
           }
 
-          const existingIssue = await findLiveExecutionIssue(input.routine, txDb);
+          const existingIssue =
+            (await findLiveExecutionIssue(input.routine, txDb)) ??
+            (await findStrandedOpenExecutionIssue(input.routine, txDb));
           if (!existingIssue) throw error;
           const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
           const updated = await finalizeRun(createdRun.id, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Routines are recurring tasks that fire on a schedule; each run creates an execution issue assigned to an agent
> - The `issues_open_routine_execution_uq` partial unique index ensures only one open execution issue exists per routine at a time — but only when `executionRunId IS NOT NULL`
> - `executionRunId` is stamped on the issue when a heartbeat run is queued for it (via `queueIssueAssignmentWakeup`)
> - If the heartbeat run finishes but the agent never closes the issue, the issue stays open with a stale `executionRunId`
> - The pre-check (`findLiveExecutionIssue`) only finds issues with a *live* heartbeat run — so it returns null for stranded issues
> - This causes the dispatch to attempt creating a new issue; the heartbeat wakeup then tries to stamp `executionRunId` on it, hitting the unique constraint — causing the routine run to be marked `failed`
> - This PR adds `findStrandedOpenExecutionIssue` and uses it as a fallback in the pre-check so the dispatch coalesces into the stranded issue instead

## What Changed

- **`server/src/services/routines.ts`**: Added `findStrandedOpenExecutionIssue` — finds any open routine execution issue where `executionRunId IS NOT NULL`, regardless of heartbeat run status. Used as a fallback in the pre-check and the constraint catch handler.
- **`server/src/__tests__/routines-service.test.ts`**: Added regression test: seeds an execution issue with a *finished* heartbeat run (simulating an agent that ran but never closed the issue), verifies `activeIssue` is null (live check returns null), then confirms the next dispatch returns `status: "coalesced"` rather than `status: "failed"`.

## Verification

```bash
pnpm vitest run server/src/__tests__/routines-service.test.ts
# 18 tests pass (including the new regression test)

pnpm vitest run server/src/__tests__/routines-e2e.test.ts
# 4 tests pass
```

**Production confirmation:** This bug was observed in a live deployment. A routine execution issue was left in `todo` with a finished heartbeat run. Every subsequent scheduled and manual run failed with `duplicate key value violates unique constraint "issues_open_routine_execution_uq"`. This fix prevents the failure path by coalescing into the stranded issue.

## Risks

- **Low risk.** The fallback only applies to issues where `executionRunId IS NOT NULL` (heartbeat was queued but is no longer live). Issues with `executionRunId IS NULL` (truly idle) still trigger fresh issue creation as before.
- Gated on `concurrencyPolicy !== "always_enqueue"`, consistent with existing live-issue coalescing logic.
- Constraint catch handler retained as defense-in-depth for concurrent race conditions.

## Model Used

- **Provider:** Anthropic
- **Model:** Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- **Mode:** Tool use / agentic (running as a Paperclip Ops Agent inside a heartbeat run)