### PR TITLE
fix(issues): cancel active run when issue becomes done or cancelled

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1832,6 +1832,32 @@ export function issueRoutes(
 
       const becameTerminal =
         !["done", "cancelled"].includes(existing.status) && ["done", "cancelled"].includes(issue.status);
+
+      if (becameTerminal && actor.actorType !== "agent") {
+        const runToCancel = await resolveActiveIssueRun(existing);
+        if (runToCancel) {
+          const cancelled = await heartbeat.cancelRun(runToCancel.id);
+          if (cancelled) {
+            await logActivity(db, {
+              companyId: cancelled.companyId,
+              actorType: actor.actorType,
+              actorId: actor.actorId,
+              agentId: actor.agentId,
+              runId: actor.runId,
+              action: "heartbeat.cancelled",
+              entityType: "heartbeat_run",
+              entityId: cancelled.id,
+              details: {
+                agentId: cancelled.agentId,
+                source: "issue_status_terminal",
+                issueId: existing.id,
+                newStatus: issue.status,
+              },
+            });
+          }
+        }
+      }
+
       if (becameTerminal && issue.parentId) {
         const parent = await svc.getWakeableParentAfterChildCompletion(issue.parentId);
         if (parent) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1834,27 +1834,31 @@ export function issueRoutes(
         !["done", "cancelled"].includes(existing.status) && ["done", "cancelled"].includes(issue.status);
 
       if (becameTerminal && actor.actorType !== "agent") {
-        const runToCancel = await resolveActiveIssueRun(existing);
-        if (runToCancel) {
-          const cancelled = await heartbeat.cancelRun(runToCancel.id);
-          if (cancelled) {
-            await logActivity(db, {
-              companyId: cancelled.companyId,
-              actorType: actor.actorType,
-              actorId: actor.actorId,
-              agentId: actor.agentId,
-              runId: actor.runId,
-              action: "heartbeat.cancelled",
-              entityType: "heartbeat_run",
-              entityId: cancelled.id,
-              details: {
-                agentId: cancelled.agentId,
-                source: "issue_status_terminal",
-                issueId: existing.id,
-                newStatus: issue.status,
-              },
-            });
+        try {
+          const runToCancel = await resolveActiveIssueRun(existing);
+          if (runToCancel) {
+            const cancelled = await heartbeat.cancelRun(runToCancel.id);
+            if (cancelled) {
+              await logActivity(db, {
+                companyId: cancelled.companyId,
+                actorType: actor.actorType,
+                actorId: actor.actorId,
+                agentId: actor.agentId,
+                runId: actor.runId,
+                action: "heartbeat.cancelled",
+                entityType: "heartbeat_run",
+                entityId: cancelled.id,
+                details: {
+                  agentId: cancelled.agentId,
+                  source: "issue_status_terminal",
+                  issueId: existing.id,
+                  newStatus: issue.status,
+                },
+              });
+            }
           }
+        } catch (err) {
+          logger.warn({ err, issueId: existing.id }, "failed to cancel run on terminal status transition");
         }
       }
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1833,7 +1833,7 @@ export function issueRoutes(
       const becameTerminal =
         !["done", "cancelled"].includes(existing.status) && ["done", "cancelled"].includes(issue.status);
 
-      if (becameTerminal && actor.actorType !== "agent") {
+      if (becameTerminal && !(actor.actorType === "agent" && actor.actorId === existing.assigneeAgentId)) {
         try {
           const runToCancel = await resolveActiveIssueRun(existing);
           if (runToCancel) {


### PR DESCRIPTION
## Summary

- When an external actor (board user) transitions an issue to `done` or `cancelled`, the agent's heartbeat run is left orphaned — the Claude process keeps running indefinitely, consuming memory and CPU
- This adds automatic run cancellation on terminal status transitions, mirroring the existing pattern in `agents.ts` ([783e9727](https://github.com/paperclipai/paperclip/commit/783e9727)) which cancels active runs before agent deletion
- Skips cancellation when the actor is the agent itself, since the agent's run will terminate naturally

## Repro

1. Assign an issue to an agent — agent starts running
2. Externally mark the issue as `done` (via board UI or API)
3. The agent's Claude process keeps running indefinitely (observed: 10+ hours, 556MB memory)

## Test plan

- [ ] Mark an in-progress issue as `done` via board → verify the agent's heartbeat run is cancelled and process terminates
- [ ] Mark an in-progress issue as `cancelled` via board → same verification
- [ ] Agent self-completing an issue (setting status to `done` itself) → verify the run is NOT prematurely cancelled and completes gracefully
- [ ] Verify `heartbeat.cancelled` activity log is recorded with `source: "issue_status_terminal"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)