### PR TITLE
fix(claude-local): detect and clear ghost resume sessions for local/Ollama models

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -29,6 +29,7 @@ import {
   detectClaudeLoginRequired,
   isClaudeMaxTurnsResult,
   isClaudeUnknownSessionError,
+  isClaudeGhostResumeResult,
 } from "./parse.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
@@ -623,6 +624,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     );
     const retry = await runAttempt(null);
     return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+  }
+
+  // Detect "ghost resume": session resumed successfully but model produced zero
+  // output tokens and no result text. This happens with local/Ollama-backed models
+  // (e.g. Gemma via a proxy) when the resumed session has no pending context and
+  // the model silently no-ops. Clear the session so the next heartbeat starts
+  // fresh with a new session and re-reads the agent instructions.
+  if (sessionId && isClaudeGhostResumeResult(initial.parsed, true)) {
+    await onLog(
+      "stdout",
+      `[paperclip] Claude resumed session "${sessionId}" produced no output (ghost resume). ` +
+        `Clearing session so next heartbeat starts fresh.\n`,
+    );
+    return toAdapterResult(initial, { fallbackSessionId: null, clearSessionOnMissingSession: true });
   }
 
   return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -177,3 +177,29 @@ export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): bo
     /no conversation found with session id|unknown session|session .* not found/i.test(msg),
   );
 }
+
+/**
+ * Detects a "ghost resume" — a resumed session that completed successfully
+ * (exit code 0, valid JSON result) but produced zero output tokens. This
+ * happens with local/Ollama-backed models (e.g. Gemma via Manifest router)
+ * when the session was resumed but the model had nothing pending in its
+ * context and silently completed with no response.
+ *
+ * In this case the session should be cleared and the next heartbeat should
+ * start fresh so the model can re-read its instructions and act on its inbox.
+ */
+export function isClaudeGhostResumeResult(
+  parsed: Record<string, unknown> | null,
+  resumedSession: boolean,
+): boolean {
+  if (!parsed || !resumedSession) return false;
+  // Only applies to successful runs (subtype=success, exit code 0)
+  const subtype = asString(parsed.subtype, "").trim().toLowerCase();
+  if (subtype !== "success") return false;
+  // Check for zero output tokens — the telltale sign of a ghost resume
+  const usageObj = parseObject(parsed.usage);
+  const outputTokens = asNumber(usageObj.output_tokens, -1);
+  const result = asString(parsed.result, "").trim();
+  // Zero output tokens AND empty result text = ghost resume
+  return outputTokens === 0 && result.length === 0;
+}


### PR DESCRIPTION
When local model backends (Gemma, Llama via Ollama etc.) resume a Claude session with no pending context, they silently no-op with exit code 0, subtype=success, but zero output tokens. The agent appears to run every heartbeat but never picks up issues. This adds isClaudeGhostResumeResult() to detect the condition and clear the session so the next heartbeat starts fresh. Confirmed with Gemma 4 26B via Ollama + Manifest proxy (ANTHROPIC_BASE_URL pointing to localhost). Full writeup in PR description.