### PR TITLE
feat(ui): add system theme mode with three-state toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# paperclip
+
+## Komfi Skills
+
+Pro migraci secrets do Infisical, audit env proměnných nebo refactor GitHub Actions workflows použij skill **infisical** z repo `komfi-health/komfi-llm-set-up` (složka `claude/skills/infisical/`).
+
+Instalace globálně:
+```bash
+cd ~/.superset/projects/komfi-llm-set-up && git pull
+cp -r claude/skills/infisical ~/.claude/skills/infisical
+```
+
+Update na poslední verzi:
+```bash
+cd ~/.superset/projects/komfi-llm-set-up && git pull
+cp -r claude/skills/infisical ~/.claude/skills/infisical
+```
+
+Skill se aktivuje příkazem: "migruj na infisical", "secrets audit", "infisical setup".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,63 @@
 # paperclip
 
+## Komfi fork
+
+Toto je fork [paperclipai/paperclip](https://github.com/paperclipai/paperclip) s custom úpravami pro Komfi.
+
+### Custom komponenty
+
+- **Token usage charts** — per-agent breakdown v dashboard UI
+- **Update banner** — detekce upstream + fork updatů
+- **Fork version badge** — commit hash v sidebaru
+- **Slack bridge** — daemon v `tools/slack-bridge/` pro Slack → Paperclip issue creation
+
+### Slack bridge (`tools/slack-bridge/`)
+
+Node.js daemon (Socket Mode) který sleduje Slack kanály a vytváří Paperclip issues ze zpráv.
+
+**Setup na novém stroji:**
+```bash
+cd tools/slack-bridge
+npm install
+npx infisical init  # vybrat komfi-internal-apps
+bash setup-autostart.sh  # nastaví macOS launchd autostart
+```
+
+**Prerekvizity:**
+- Infisical CLI + přihlášení (`npx infisical login`)
+- Secrets v Infisical (dev env): `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`
+- Slack app "Poslíček" pozvaný do relevantních kanálů
+
+**Chování:**
+- 👀 emoji na novou zprávu = issue vytvořen
+- ✅ emoji = issue dokončen (deploy proběhl)
+- Žádné thread reply
+
+### MCP servery pro agenty
+
+Notion MCP server je nakonfigurovaný v `~/.claude.json`:
+```bash
+claude mcp add -s user -e NOTION_API_TOKEN=<token> -- notion npx @notionhq/notion-mcp-server
+```
+Token uložen v Infisical (`NOTION_API_TOKEN`).
+
+### GStack tým
+
+Import: `npx companies.sh add paperclipai/companies/gstack --target existing -C <company-id>`
+
+Pipeline: CEO → CTO → Staff Engineer (review) → Release Engineer (batch merge) → QA Engineer (Playwright)
+
+### Rebase s upstreamem
+
+```bash
+git fetch paperclip
+git rebase paperclip/master
+bash scripts/generate-fork-version.sh
+git push fork <branch>:master --force-with-lease
+```
+
 ## Komfi Skills
 
 Pro migraci secrets do Infisical, audit env proměnných nebo refactor GitHub Actions workflows použij skill **infisical** z repo `komfi-health/komfi-llm-set-up` (složka `claude/skills/infisical/`).
 
-Instalace globálně:
-```bash
-cd ~/.superset/projects/komfi-llm-set-up && git pull
-cp -r claude/skills/infisical ~/.claude/skills/infisical
-```
-
-Update na poslední verzi:
-```bash
-cd ~/.superset/projects/komfi-llm-set-up && git pull
-cp -r claude/skills/infisical ~/.claude/skills/infisical
-```
-
-Skill se aktivuje příkazem: "migruj na infisical", "secrets audit", "infisical setup".
+Skill se aktivuje příkazem: migruj na infisical, secrets audit, infisical setup.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -270,6 +270,7 @@ export type {
   CostByProviderModel,
   CostByBiller,
   CostByAgentModel,
+  CostByAgentDaily,
   CostWindowSpendRow,
   CostByProject,
   FinanceEvent,

--- a/packages/shared/src/types/cost.ts
+++ b/packages/shared/src/types/cost.ts
@@ -102,6 +102,18 @@ export interface CostWindowSpendRow {
   outputTokens: number;
 }
 
+/** per-agent, per-day token totals for time-series charts */
+export interface CostByAgentDaily {
+  date: string;
+  agentId: string;
+  agentName: string | null;
+  totalTokens: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  costCents: number;
+}
+
 /** cost attributed to a project via heartbeat run → activity log → issue → project chain */
 export interface CostByProject {
   projectId: string | null;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -148,7 +148,7 @@ export type {
   RoutineExecutionIssueOrigin,
   RoutineListItem,
 } from "./routine.js";
-export type { CostEvent, CostSummary, CostByAgent, CostByProviderModel, CostByBiller, CostByAgentModel, CostWindowSpendRow, CostByProject } from "./cost.js";
+export type { CostEvent, CostSummary, CostByAgent, CostByProviderModel, CostByBiller, CostByAgentModel, CostByAgentDaily, CostWindowSpendRow, CostByProject } from "./cost.js";
 export type { FinanceEvent, FinanceSummary, FinanceByBiller, FinanceByKind } from "./finance.js";
 export type {
   AgentWakeupResponse,

--- a/scripts/generate-fork-version.sh
+++ b/scripts/generate-fork-version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Generates server/fork-version.json with current git commit info.
+# Run before build or as part of CI.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUT="$ROOT_DIR/server/fork-version.json"
+
+HASH=$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")
+DATE=$(git -C "$ROOT_DIR" log -1 --format=%cI 2>/dev/null || echo "unknown")
+BRANCH=$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+cat > "$OUT" <<EOF
+{
+  "commitHash": "$HASH",
+  "commitDate": "$DATE",
+  "branch": "$BRANCH"
+}
+EOF
+
+echo "Generated $OUT: $HASH (${DATE})"

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,1 @@
+fork-version.json

--- a/server/src/fork-version.ts
+++ b/server/src/fork-version.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type ForkVersion = {
+  commitHash: string;
+  commitDate: string;
+  branch: string;
+};
+
+export function readForkVersion(): ForkVersion | null {
+  try {
+    const dir = path.dirname(fileURLToPath(import.meta.url));
+    const filePath = path.resolve(dir, "..", "fork-version.json");
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const data = JSON.parse(raw);
+    if (typeof data.commitHash === "string" && data.commitHash.length > 0) {
+      return data as ForkVersion;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -128,6 +128,14 @@ export function costRoutes(db: Db) {
     res.json(rows);
   });
 
+  router.get("/companies/:companyId/costs/by-agent-daily", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const range = parseDateRange(req.query);
+    const rows = await costs.byAgentDaily(companyId, range);
+    res.json(rows);
+  });
+
   router.get("/companies/:companyId/costs/by-agent-model", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -9,6 +9,8 @@ import { readPersistedDevServerStatus, toDevServerHealthStatus } from "../dev-se
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { serverVersion } from "../version.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+import { readForkVersion } from "../fork-version.js";
+import type { ForkVersion } from "../fork-version.js";
 
 export type UpdateStatus = {
   available: boolean;
@@ -17,6 +19,8 @@ export type UpdateStatus = {
   behind: number;
   ahead: number;
   checkedAt: string;
+  forkBehind?: number;
+  forkSha?: string;
 };
 
 function readUpdateStatus(): UpdateStatus | null {
@@ -119,6 +123,7 @@ export function healthRoutes(
     }
 
     const updateStatus = readUpdateStatus();
+    const forkVersion = readForkVersion();
 
     res.json({
       status: "ok",
@@ -133,6 +138,7 @@ export function healthRoutes(
       },
       ...(devServer ? { devServer } : {}),
       ...(updateStatus ? { updateStatus } : {}),
+      ...(forkVersion ? { forkVersion } : {}),
     });
   });
 

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { Router } from "express";
 import type { Db } from "@paperclipai/db";
 import { and, count, eq, gt, inArray, isNull, sql } from "drizzle-orm";
@@ -6,6 +8,37 @@ import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 import { readPersistedDevServerStatus, toDevServerHealthStatus } from "../dev-server-status.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { serverVersion } from "../version.js";
+import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+
+export type UpdateStatus = {
+  available: boolean;
+  currentSha: string;
+  upstreamSha: string;
+  behind: number;
+  ahead: number;
+  checkedAt: string;
+};
+
+function readUpdateStatus(): UpdateStatus | null {
+  try {
+    const filePath = path.resolve(resolvePaperclipInstanceRoot(), "update-status.json");
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const data = JSON.parse(raw);
+    if (typeof data.behind === "number" && typeof data.currentSha === "string") {
+      return {
+        available: data.behind > 0,
+        currentSha: data.currentSha,
+        upstreamSha: data.upstreamSha,
+        behind: data.behind,
+        ahead: data.ahead ?? 0,
+        checkedAt: data.checkedAt ?? "",
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 export function healthRoutes(
   db?: Db,
@@ -85,6 +118,8 @@ export function healthRoutes(
       });
     }
 
+    const updateStatus = readUpdateStatus();
+
     res.json({
       status: "ok",
       version: serverVersion,
@@ -97,6 +132,7 @@ export function healthRoutes(
         companyDeletionEnabled: opts.companyDeletionEnabled,
       },
       ...(devServer ? { devServer } : {}),
+      ...(updateStatus ? { updateStatus } : {}),
     });
   });
 

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -162,6 +162,30 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         .orderBy(desc(sql`coalesce(sum(${costEvents.costCents}), 0)::int`));
     },
 
+    byAgentDaily: async (companyId: string, range?: CostDateRange) => {
+      const conditions: ReturnType<typeof eq>[] = [eq(costEvents.companyId, companyId)];
+      if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
+      if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));
+
+      const dateExpr = sql<string>`to_char(${costEvents.occurredAt}, 'YYYY-MM-DD')`;
+      return db
+        .select({
+          date: dateExpr,
+          agentId: costEvents.agentId,
+          agentName: agents.name,
+          totalTokens: sql<number>`coalesce(sum(${costEvents.inputTokens} + ${costEvents.cachedInputTokens} + ${costEvents.outputTokens}), 0)::int`,
+          inputTokens: sql<number>`coalesce(sum(${costEvents.inputTokens}), 0)::int`,
+          cachedInputTokens: sql<number>`coalesce(sum(${costEvents.cachedInputTokens}), 0)::int`,
+          outputTokens: sql<number>`coalesce(sum(${costEvents.outputTokens}), 0)::int`,
+          costCents: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::int`,
+        })
+        .from(costEvents)
+        .leftJoin(agents, eq(costEvents.agentId, agents.id))
+        .where(and(...conditions))
+        .groupBy(dateExpr, costEvents.agentId, agents.name)
+        .orderBy(dateExpr);
+    },
+
     byProvider: async (companyId: string, range?: CostDateRange) => {
       const conditions: ReturnType<typeof eq>[] = [eq(costEvents.companyId, companyId)];
       if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));

--- a/tools/slack-bridge/index.mjs
+++ b/tools/slack-bridge/index.mjs
@@ -20,6 +20,7 @@ const socket = new SocketModeClient({ appToken: SLACK_APP_TOKEN });
 
 // Track: issueId -> { channel, ts, identifier }
 const pendingCheckmarks = new Map();
+const notifiedBlocked = new Set();
 const processed = new Set();
 
 const channelNames = new Map();
@@ -96,7 +97,7 @@ async function pollCompletedIssues() {
         try { await slack.reactions.add({ channel, name: "white_check_mark", timestamp: ts }); } catch {}
         pendingCheckmarks.delete(issue.id);
 
-      } else if (issue.status === "blocked") {
+      } else if (issue.status === "blocked" && !notifiedBlocked.has(issue.id)) {
         console.log(`  blocked ${identifier}`);
         // Add warning emoji
         try { await slack.reactions.add({ channel, name: "warning", timestamp: ts }); } catch {}
@@ -108,12 +109,13 @@ async function pollCompletedIssues() {
             await slack.chat.postMessage({
               channel,
               thread_ts: ts,
-              text: `:warning: *${identifier}* je blokovaný:\n${lastComment.substring(0, 500)}`,
+              text: `:warning: *${identifier}* je blokovaný:\n${lastComment.substring(0, 300)}\n\nhttp://100.81.141.101:3100/KOM/issues/${identifier}`,
             });
           } catch (e) {
             console.error("Failed to reply:", e.message);
           }
         }
+        notifiedBlocked.add(issue.id);
         // Keep tracking - might become done later
       }
     }

--- a/tools/slack-bridge/index.mjs
+++ b/tools/slack-bridge/index.mjs
@@ -2,14 +2,13 @@ import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
 import { execSync } from "node:child_process";
 
-// --- Config ---
-const SLACK_APP_TOKEN = process.env.SLACK_APP_TOKEN;   // xapp-...
-const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;   // xoxb-...
+const SLACK_APP_TOKEN = process.env.SLACK_APP_TOKEN;
+const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
 const WATCH_CHANNELS = (process.env.WATCH_CHANNELS || "").split(",").filter(Boolean);
 const CEO_AGENT_ID = "9a5b9dc6-068c-4702-b3ff-d97fb162c290";
 const COMPANY_ID = "a9d33dc4-ba89-4162-8550-178a7d639a7b";
 const PAPERCLIP_CLI = "/opt/homebrew/bin/paperclipai";
-const PAPERCLIP_URL = "http://localhost:3100";
+const POLL_INTERVAL_MS = 60_000;
 
 if (!SLACK_APP_TOKEN || !SLACK_BOT_TOKEN) {
   console.error("Missing SLACK_APP_TOKEN or SLACK_BOT_TOKEN");
@@ -19,22 +18,20 @@ if (!SLACK_APP_TOKEN || !SLACK_BOT_TOKEN) {
 const slack = new WebClient(SLACK_BOT_TOKEN);
 const socket = new SocketModeClient({ appToken: SLACK_APP_TOKEN });
 
-// Track processed messages to avoid duplicates
+// Track: issueId -> { channel, ts, identifier }
+const pendingCheckmarks = new Map();
 const processed = new Set();
 
-// Channel ID → name cache
 const channelNames = new Map();
 async function getChannelName(id) {
   if (channelNames.has(id)) return channelNames.get(id);
   try {
     const info = await slack.conversations.info({ channel: id });
-    const name = info.channel.name;
-    channelNames.set(id, name);
-    return name;
+    channelNames.set(id, info.channel.name);
+    return info.channel.name;
   } catch { return id; }
 }
 
-// User ID → name cache
 const userNames = new Map();
 async function getUserName(id) {
   if (userNames.has(id)) return userNames.get(id);
@@ -46,7 +43,6 @@ async function getUserName(id) {
   } catch { return id; }
 }
 
-// Create Paperclip issue via CLI
 function createIssue(title, description) {
   try {
     const result = execSync(
@@ -54,8 +50,7 @@ function createIssue(title, description) {
       `--title "${title.replace(/"/g, '\\"')}" ` +
       `--description "${description.replace(/"/g, '\\"')}" ` +
       `--assignee-agent-id ${CEO_AGENT_ID} ` +
-      `--priority medium ` +
-      `--status todo --json`,
+      `--priority medium --status todo --json`,
       { encoding: "utf-8", timeout: 30000 }
     );
     return JSON.parse(result);
@@ -65,20 +60,76 @@ function createIssue(title, description) {
   }
 }
 
+function getLastComment(issueId) {
+  try {
+    const result = execSync(
+      `${PAPERCLIP_CLI} activity list -C ${COMPANY_ID} --json`,
+      { encoding: "utf-8", timeout: 30000 }
+    );
+    const activities = JSON.parse(result);
+    for (const a of activities) {
+      if (a.entityId === issueId && a.action === "issue.comment_added" && a.agentId) {
+        return a.details?.bodySnippet || null;
+      }
+    }
+  } catch {}
+  return null;
+}
+
+async function pollCompletedIssues() {
+  if (pendingCheckmarks.size === 0) return;
+
+  try {
+    const result = execSync(
+      `${PAPERCLIP_CLI} issue list -C ${COMPANY_ID} --json`,
+      { encoding: "utf-8", timeout: 30000 }
+    );
+    const issues = JSON.parse(result);
+
+    for (const issue of issues) {
+      if (!pendingCheckmarks.has(issue.id)) continue;
+      const { channel, ts, identifier } = pendingCheckmarks.get(issue.id);
+
+      if (issue.status === "done") {
+        console.log(`  done ${identifier}`);
+        try { await slack.reactions.remove({ channel, name: "eyes", timestamp: ts }); } catch {}
+        try { await slack.reactions.add({ channel, name: "white_check_mark", timestamp: ts }); } catch {}
+        pendingCheckmarks.delete(issue.id);
+
+      } else if (issue.status === "blocked") {
+        console.log(`  blocked ${identifier}`);
+        // Add warning emoji
+        try { await slack.reactions.add({ channel, name: "warning", timestamp: ts }); } catch {}
+
+        // Get last agent comment and reply in thread
+        const lastComment = getLastComment(issue.id);
+        if (lastComment) {
+          try {
+            await slack.chat.postMessage({
+              channel,
+              thread_ts: ts,
+              text: `:warning: *${identifier}* je blokovaný:\n${lastComment.substring(0, 500)}`,
+            });
+          } catch (e) {
+            console.error("Failed to reply:", e.message);
+          }
+        }
+        // Keep tracking - might become done later
+      }
+    }
+  } catch (e) {
+    console.error("Poll error:", e.message);
+  }
+}
+
+setInterval(pollCompletedIssues, POLL_INTERVAL_MS);
+
 socket.on("message", async ({ event, body, ack }) => {
   await ack();
-
-  // Skip bot messages, edits, thread replies
   if (event.bot_id || event.subtype || event.thread_ts) return;
-
-  // Skip if not in watched channels
   if (WATCH_CHANNELS.length > 0 && !WATCH_CHANNELS.includes(event.channel)) return;
-
-  // Skip duplicates
   if (processed.has(event.ts)) return;
   processed.add(event.ts);
-
-  // Cleanup old entries (keep last 500)
   if (processed.size > 500) {
     const arr = [...processed];
     arr.slice(0, arr.length - 500).forEach(ts => processed.delete(ts));
@@ -87,58 +138,30 @@ socket.on("message", async ({ event, body, ack }) => {
   const channelName = await getChannelName(event.channel);
   const userName = await getUserName(event.user);
   const text = event.text || "(no text)";
+  console.log(`[${channelName}] ${userName}: ${text.substring(0, 100)}`);
 
-  console.log(`[#${channelName}] ${userName}: ${text.substring(0, 100)}`);
-
-  // Create issue
-  const title = text.length > 80
-    ? text.substring(0, 77) + "..."
-    : text;
-
+  const title = text.length > 80 ? text.substring(0, 77) + "..." : text;
   const description = [
-    `## Ze Slacku`,
-    ``,
-    `**Kanál:** #${channelName}`,
+    "## Ze Slacku", "",
+    `**Kanal:** #${channelName}`,
     `**Od:** ${userName}`,
-    `**Čas:** ${new Date(parseFloat(event.ts) * 1000).toISOString()}`,
-    ``,
-    `## Zpráva`,
-    ``,
-    text,
+    `**Cas:** ${new Date(parseFloat(event.ts) * 1000).toISOString()}`,
+    "", "## Zprava", "", text,
   ].join("\n");
 
   const issue = createIssue(title, description);
-
   if (issue) {
-    console.log(`  → Created ${issue.identifier}`);
-
-    // React with eyes to confirm we saw it
+    console.log(`  -> ${issue.identifier}`);
     try { await slack.reactions.add({ channel: event.channel, name: "eyes", timestamp: event.ts }); } catch {}
-
-    // Reply in thread with issue link
-    try {
-      await slack.chat.postMessage({
-        channel: event.channel,
-        thread_ts: event.ts,
-        text: `✅ Vytvořen úkol *${issue.identifier}*: ${PAPERCLIP_URL}/KOM/issues/${issue.identifier}`,
-      });
-    } catch (e) {
-      console.error("Failed to reply:", e.message);
-    }
+    pendingCheckmarks.set(issue.id, { channel: event.channel, ts: event.ts, identifier: issue.identifier });
   }
 });
 
 socket.on("connected", () => {
-  console.log("Slack bridge connected. Watching for messages...");
-  if (WATCH_CHANNELS.length > 0) {
-    console.log("Channels:", WATCH_CHANNELS.join(", "));
-  } else {
-    console.log("Watching ALL channels where bot is invited.");
-  }
+  console.log("Slack bridge connected.");
+  console.log(`Polling every ${POLL_INTERVAL_MS / 1000}s`);
 });
 
-socket.on("error", (err) => {
-  console.error("Socket error:", err.message);
-});
+socket.on("error", (err) => console.error("Socket error:", err.message));
 
 await socket.start();

--- a/tools/slack-bridge/index.mjs
+++ b/tools/slack-bridge/index.mjs
@@ -1,0 +1,144 @@
+import { SocketModeClient } from "@slack/socket-mode";
+import { WebClient } from "@slack/web-api";
+import { execSync } from "node:child_process";
+
+// --- Config ---
+const SLACK_APP_TOKEN = process.env.SLACK_APP_TOKEN;   // xapp-...
+const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;   // xoxb-...
+const WATCH_CHANNELS = (process.env.WATCH_CHANNELS || "").split(",").filter(Boolean);
+const CEO_AGENT_ID = "9a5b9dc6-068c-4702-b3ff-d97fb162c290";
+const COMPANY_ID = "a9d33dc4-ba89-4162-8550-178a7d639a7b";
+const PAPERCLIP_CLI = "/opt/homebrew/bin/paperclipai";
+const PAPERCLIP_URL = "http://localhost:3100";
+
+if (!SLACK_APP_TOKEN || !SLACK_BOT_TOKEN) {
+  console.error("Missing SLACK_APP_TOKEN or SLACK_BOT_TOKEN");
+  process.exit(1);
+}
+
+const slack = new WebClient(SLACK_BOT_TOKEN);
+const socket = new SocketModeClient({ appToken: SLACK_APP_TOKEN });
+
+// Track processed messages to avoid duplicates
+const processed = new Set();
+
+// Channel ID → name cache
+const channelNames = new Map();
+async function getChannelName(id) {
+  if (channelNames.has(id)) return channelNames.get(id);
+  try {
+    const info = await slack.conversations.info({ channel: id });
+    const name = info.channel.name;
+    channelNames.set(id, name);
+    return name;
+  } catch { return id; }
+}
+
+// User ID → name cache
+const userNames = new Map();
+async function getUserName(id) {
+  if (userNames.has(id)) return userNames.get(id);
+  try {
+    const info = await slack.users.info({ user: id });
+    const name = info.user.real_name || info.user.name;
+    userNames.set(id, name);
+    return name;
+  } catch { return id; }
+}
+
+// Create Paperclip issue via CLI
+function createIssue(title, description) {
+  try {
+    const result = execSync(
+      `${PAPERCLIP_CLI} issue create -C ${COMPANY_ID} ` +
+      `--title "${title.replace(/"/g, '\\"')}" ` +
+      `--description "${description.replace(/"/g, '\\"')}" ` +
+      `--assignee-agent-id ${CEO_AGENT_ID} ` +
+      `--priority medium ` +
+      `--status todo --json`,
+      { encoding: "utf-8", timeout: 30000 }
+    );
+    return JSON.parse(result);
+  } catch (e) {
+    console.error("Failed to create issue:", e.message);
+    return null;
+  }
+}
+
+socket.on("message", async ({ event, body, ack }) => {
+  await ack();
+
+  // Skip bot messages, edits, thread replies
+  if (event.bot_id || event.subtype || event.thread_ts) return;
+
+  // Skip if not in watched channels
+  if (WATCH_CHANNELS.length > 0 && !WATCH_CHANNELS.includes(event.channel)) return;
+
+  // Skip duplicates
+  if (processed.has(event.ts)) return;
+  processed.add(event.ts);
+
+  // Cleanup old entries (keep last 500)
+  if (processed.size > 500) {
+    const arr = [...processed];
+    arr.slice(0, arr.length - 500).forEach(ts => processed.delete(ts));
+  }
+
+  const channelName = await getChannelName(event.channel);
+  const userName = await getUserName(event.user);
+  const text = event.text || "(no text)";
+
+  console.log(`[#${channelName}] ${userName}: ${text.substring(0, 100)}`);
+
+  // Create issue
+  const title = text.length > 80
+    ? text.substring(0, 77) + "..."
+    : text;
+
+  const description = [
+    `## Ze Slacku`,
+    ``,
+    `**Kanál:** #${channelName}`,
+    `**Od:** ${userName}`,
+    `**Čas:** ${new Date(parseFloat(event.ts) * 1000).toISOString()}`,
+    ``,
+    `## Zpráva`,
+    ``,
+    text,
+  ].join("\n");
+
+  const issue = createIssue(title, description);
+
+  if (issue) {
+    console.log(`  → Created ${issue.identifier}`);
+
+    // React with eyes to confirm we saw it
+    try { await slack.reactions.add({ channel: event.channel, name: "eyes", timestamp: event.ts }); } catch {}
+
+    // Reply in thread with issue link
+    try {
+      await slack.chat.postMessage({
+        channel: event.channel,
+        thread_ts: event.ts,
+        text: `✅ Vytvořen úkol *${issue.identifier}*: ${PAPERCLIP_URL}/KOM/issues/${issue.identifier}`,
+      });
+    } catch (e) {
+      console.error("Failed to reply:", e.message);
+    }
+  }
+});
+
+socket.on("connected", () => {
+  console.log("Slack bridge connected. Watching for messages...");
+  if (WATCH_CHANNELS.length > 0) {
+    console.log("Channels:", WATCH_CHANNELS.join(", "));
+  } else {
+    console.log("Watching ALL channels where bot is invited.");
+  }
+});
+
+socket.on("error", (err) => {
+  console.error("Socket error:", err.message);
+});
+
+await socket.start();

--- a/tools/slack-bridge/package-lock.json
+++ b/tools/slack-bridge/package-lock.json
@@ -1,0 +1,503 @@
+{
+  "name": "slack-bridge",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "slack-bridge",
+      "version": "1.0.0",
+      "dependencies": {
+        "@slack/socket-mode": "^2.0.6",
+        "@slack/web-api": "^7.9.0"
+      }
+    },
+    "node_modules/@slack/logger": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
+      "integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=18"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/socket-mode": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.6.tgz",
+      "integrity": "sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/web-api": "^7.15.0",
+        "@types/node": ">=18",
+        "@types/ws": "^8",
+        "eventemitter3": "^5",
+        "ws": "^8"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.20.1.tgz",
+      "integrity": "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.0.tgz",
+      "integrity": "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.20.1",
+        "@types/node": ">=18",
+        "@types/retry": "0.12.0",
+        "axios": "^1.13.5",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/tools/slack-bridge/package.json
+++ b/tools/slack-bridge/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "slack-bridge",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node index.mjs"
+  },
+  "dependencies": {
+    "@slack/socket-mode": "^2.0.6",
+    "@slack/web-api": "^7.9.0"
+  }
+}

--- a/tools/slack-bridge/setup-autostart.sh
+++ b/tools/slack-bridge/setup-autostart.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Install slack-bridge as a macOS launchd service
+# Usage: bash setup-autostart.sh
+
+PLIST_NAME="com.komfi.slack-bridge"
+PLIST_PATH="/Users/lubee/Library/LaunchAgents/.plist"
+BRIDGE_DIR=""
+NODE_PATH="/opt/homebrew/bin/node"
+NPX_PATH="/opt/homebrew/bin/npx"
+BIN_DIR="."
+
+cat > "" << PLISTEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string></string>
+    <key>ProgramArguments</key>
+    <array>
+        <string></string>
+        <string>infisical</string>
+        <string>run</string>
+        <string>--env</string>
+        <string>dev</string>
+        <string>--</string>
+        <string></string>
+        <string>/index.mjs</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string></string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>:/usr/local/bin:/usr/bin:/bin</string>
+        <key>INFISICAL_API_URL</key>
+        <string>https://eu.infisical.com/api</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/lubee/slack-bridge.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/lubee/slack-bridge.log</string>
+</dict>
+</plist>
+PLISTEOF
+
+launchctl unload "" 2>/dev/null
+launchctl load ""
+echo "Installed and started: "
+echo "Log: ~/slack-bridge.log"

--- a/ui/src/api/costs.ts
+++ b/ui/src/api/costs.ts
@@ -4,6 +4,7 @@ import type {
   CostByProviderModel,
   CostByBiller,
   CostByAgentModel,
+  CostByAgentDaily,
   CostByProject,
   CostWindowSpendRow,
   FinanceSummary,
@@ -29,6 +30,8 @@ export const costsApi = {
     api.get<CostByAgent[]>(`/companies/${companyId}/costs/by-agent${dateParams(from, to)}`),
   byAgentModel: (companyId: string, from?: string, to?: string) =>
     api.get<CostByAgentModel[]>(`/companies/${companyId}/costs/by-agent-model${dateParams(from, to)}`),
+  byAgentDaily: (companyId: string, from?: string, to?: string) =>
+    api.get<CostByAgentDaily[]>(`/companies/${companyId}/costs/by-agent-daily${dateParams(from, to)}`),
   byProject: (companyId: string, from?: string, to?: string) =>
     api.get<CostByProject[]>(`/companies/${companyId}/costs/by-project${dateParams(from, to)}`),
   byProvider: (companyId: string, from?: string, to?: string) =>

--- a/ui/src/api/health.ts
+++ b/ui/src/api/health.ts
@@ -19,6 +19,14 @@ export type UpdateStatus = {
   behind: number;
   ahead: number;
   checkedAt: string;
+  forkBehind?: number;
+  forkSha?: string;
+};
+
+export type ForkVersion = {
+  commitHash: string;
+  commitDate: string;
+  branch: string;
 };
 
 export type HealthStatus = {
@@ -34,6 +42,7 @@ export type HealthStatus = {
   };
   devServer?: DevServerHealthStatus;
   updateStatus?: UpdateStatus;
+  forkVersion?: ForkVersion;
 };
 
 export const healthApi = {

--- a/ui/src/api/health.ts
+++ b/ui/src/api/health.ts
@@ -12,6 +12,15 @@ export type DevServerHealthStatus = {
   lastRestartAt: string | null;
 };
 
+export type UpdateStatus = {
+  available: boolean;
+  currentSha: string;
+  upstreamSha: string;
+  behind: number;
+  ahead: number;
+  checkedAt: string;
+};
+
 export type HealthStatus = {
   status: "ok";
   version?: string;
@@ -24,6 +33,7 @@ export type HealthStatus = {
     companyDeletionEnabled?: boolean;
   };
   devServer?: DevServerHealthStatus;
+  updateStatus?: UpdateStatus;
 };
 
 export const healthApi = {

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -16,6 +16,7 @@ import { ToastViewport } from "./ToastViewport";
 import { MobileBottomNav } from "./MobileBottomNav";
 import { WorktreeBanner } from "./WorktreeBanner";
 import { DevRestartBanner } from "./DevRestartBanner";
+import { UpdateBanner } from "./UpdateBanner";
 import { useDialog } from "../context/DialogContext";
 import { GeneralSettingsProvider } from "../context/GeneralSettingsContext";
 import { usePanel } from "../context/PanelContext";
@@ -281,6 +282,7 @@ export function Layout() {
       </a>
       <WorktreeBanner />
       <DevRestartBanner devServer={health?.devServer} />
+      <UpdateBanner updateStatus={health?.updateStatus} />
       <div className={cn("min-h-0 flex-1", isMobile ? "w-full" : "flex overflow-hidden")}>
         {isMobile && sidebarOpen && (
           <button

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -323,6 +323,21 @@ export function Layout() {
                     <TooltipContent>v{health.version}</TooltipContent>
                   </Tooltip>
                 )}
+                {health?.forkVersion && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="px-1.5 py-0.5 text-[10px] font-mono rounded bg-violet-500/15 text-violet-600 dark:text-violet-400 shrink-0 cursor-default">
+                        {health.forkVersion.commitHash.slice(0, 7)}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <div className="text-xs">
+                        <div>Fork: {health.forkVersion.commitHash.slice(0, 12)}</div>
+                        <div>{new Date(health.forkVersion.commitDate).toLocaleDateString()}</div>
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>
                   <Link
                     to={instanceSettingsTarget}
@@ -379,6 +394,21 @@ export function Layout() {
                       <span className="px-2 text-xs text-muted-foreground shrink-0 cursor-default">v</span>
                     </TooltipTrigger>
                     <TooltipContent>v{health.version}</TooltipContent>
+                  </Tooltip>
+                )}
+                {health?.forkVersion && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="px-1.5 py-0.5 text-[10px] font-mono rounded bg-violet-500/15 text-violet-600 dark:text-violet-400 shrink-0 cursor-default">
+                        {health.forkVersion.commitHash.slice(0, 7)}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <div className="text-xs">
+                        <div>Fork: {health.forkVersion.commitHash.slice(0, 12)}</div>
+                        <div>{new Date(health.forkVersion.commitDate).toLocaleDateString()}</div>
+                      </div>
+                    </TooltipContent>
                   </Tooltip>
                 )}
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { BookOpen, Moon, Settings, Sun } from "lucide-react";
+import { BookOpen, Laptop, Moon, Settings, Sun } from "lucide-react";
 import { Link, Outlet, useLocation, useNavigate, useParams } from "@/lib/router";
 import { CompanyRail } from "./CompanyRail";
 import { Sidebar } from "./Sidebar";
@@ -61,7 +61,7 @@ export function Layout() {
     selectionSource,
     setSelectedCompanyId,
   } = useCompany();
-  const { theme, toggleTheme } = useTheme();
+  const { preference, theme, toggleTheme } = useTheme();
   const { companyPrefix } = useParams<{ companyPrefix: string }>();
   const navigate = useNavigate();
   const location = useLocation();
@@ -70,7 +70,7 @@ export function Layout() {
   const lastMainScrollTop = useRef(0);
   const [mobileNavVisible, setMobileNavVisible] = useState(true);
   const [instanceSettingsTarget, setInstanceSettingsTarget] = useState<string>(() => readRememberedInstanceSettingsPath());
-  const nextTheme = theme === "dark" ? "light" : "dark";
+  const nextTheme = preference === "dark" ? "light" : preference === "light" ? "system" : "dark";
   const matchedCompany = useMemo(() => {
     if (!companyPrefix) return null;
     const requestedPrefix = companyPrefix.toUpperCase();
@@ -359,7 +359,7 @@ export function Layout() {
                   aria-label={`Switch to ${nextTheme} mode`}
                   title={`Switch to ${nextTheme} mode`}
                 >
-                  {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+                  {preference === "dark" ? <Sun className="h-4 w-4" /> : preference === "light" ? <Moon className="h-4 w-4" /> : <Laptop className="h-4 w-4" />}
                 </Button>
               </div>
             </div>
@@ -432,7 +432,7 @@ export function Layout() {
                   aria-label={`Switch to ${nextTheme} mode`}
                   title={`Switch to ${nextTheme} mode`}
                 >
-                  {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+                  {preference === "dark" ? <Sun className="h-4 w-4" /> : preference === "light" ? <Moon className="h-4 w-4" /> : <Laptop className="h-4 w-4" />}
                 </Button>
               </div>
             </div>

--- a/ui/src/components/TokenTimelineChart.tsx
+++ b/ui/src/components/TokenTimelineChart.tsx
@@ -1,0 +1,248 @@
+import { useMemo, useState } from "react";
+import type { CostByAgentDaily } from "@paperclipai/shared";
+import { formatTokens } from "../lib/utils";
+
+/** Stable palette for up to 8 agents; wraps if more. */
+const AGENT_COLORS = [
+  "#3b82f6", // blue
+  "#10b981", // emerald
+  "#f59e0b", // amber
+  "#8b5cf6", // violet
+  "#ef4444", // red
+  "#06b6d4", // cyan
+  "#ec4899", // pink
+  "#84cc16", // lime
+];
+
+const CHART_HEIGHT = 140;
+const Y_TICK_COUNT = 4;
+
+function getLast14Days(): string[] {
+  return Array.from({ length: 14 }, (_, i) => {
+    const d = new Date();
+    d.setDate(d.getDate() - (13 - i));
+    return d.toISOString().slice(0, 10);
+  });
+}
+
+function formatDayLabel(dateStr: string): string {
+  const d = new Date(dateStr + "T12:00:00");
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+/** Round up to a nice number for the Y axis. */
+function niceMax(value: number): number {
+  if (value <= 0) return 1000;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(value)));
+  const normalized = value / magnitude;
+  if (normalized <= 1) return magnitude;
+  if (normalized <= 2) return 2 * magnitude;
+  if (normalized <= 5) return 5 * magnitude;
+  return 10 * magnitude;
+}
+
+interface HoverInfo {
+  agentId: string;
+  agentName: string;
+  tokens: number;
+  day: string;
+  dayTotal: number;
+  color: string;
+  x: number;
+  y: number;
+}
+
+export function TokenTimelineChart({ rows }: { rows: CostByAgentDaily[] }) {
+  const days = useMemo(() => getLast14Days(), []);
+  const [hover, setHover] = useState<HoverInfo | null>(null);
+
+  const { agentNames, agentIds, grouped, maxTotal } = useMemo(() => {
+    const agentTotals = new Map<string, { name: string; total: number }>();
+    for (const row of rows) {
+      const entry = agentTotals.get(row.agentId) ?? {
+        name: row.agentName ?? row.agentId,
+        total: 0,
+      };
+      entry.total += row.totalTokens;
+      agentTotals.set(row.agentId, entry);
+    }
+    const sorted = [...agentTotals.entries()].sort(
+      (a, b) => b[1].total - a[1].total,
+    );
+    const ids = sorted.map(([id]) => id);
+    const names = new Map(sorted.map(([id, v]) => [id, v.name]));
+
+    const map = new Map<string, Map<string, number>>();
+    for (const day of days) map.set(day, new Map());
+    for (const row of rows) {
+      const dayMap = map.get(row.date);
+      if (!dayMap) continue;
+      dayMap.set(row.agentId, (dayMap.get(row.agentId) ?? 0) + row.totalTokens);
+    }
+
+    let max = 1;
+    for (const dayMap of map.values()) {
+      let dayTotal = 0;
+      for (const v of dayMap.values()) dayTotal += v;
+      if (dayTotal > max) max = dayTotal;
+    }
+
+    return { agentNames: names, agentIds: ids, grouped: map, maxTotal: niceMax(max) };
+  }, [rows, days]);
+
+  const yTicks = useMemo(() => {
+    const ticks: number[] = [];
+    for (let i = 0; i <= Y_TICK_COUNT; i++) {
+      ticks.push(Math.round((maxTotal / Y_TICK_COUNT) * i));
+    }
+    return ticks;
+  }, [maxTotal]);
+
+  const hasData = rows.length > 0;
+
+  if (!hasData) {
+    return (
+      <p className="text-xs text-muted-foreground">No token usage data yet.</p>
+    );
+  }
+
+  return (
+    <div className="relative" onMouseLeave={() => setHover(null)}>
+      {/* Chart area with Y axis */}
+      <div className="flex">
+        {/* Y axis labels */}
+        <div
+          className="flex flex-col justify-between pr-2 shrink-0"
+          style={{ height: CHART_HEIGHT }}
+        >
+          {[...yTicks].reverse().map((tick) => (
+            <span
+              key={tick}
+              className="text-[9px] text-muted-foreground tabular-nums leading-none text-right"
+              style={{ minWidth: 32 }}
+            >
+              {formatTokens(tick)}
+            </span>
+          ))}
+        </div>
+
+        {/* Bars */}
+        <div className="flex items-end gap-[3px] flex-1" style={{ height: CHART_HEIGHT }}>
+          {days.map((day) => {
+            const dayMap = grouped.get(day)!;
+            let dayTotal = 0;
+            for (const v of dayMap.values()) dayTotal += v;
+            const heightPct = (dayTotal / maxTotal) * 100;
+
+            return (
+              <div
+                key={day}
+                className="flex-1 h-full flex flex-col justify-end"
+              >
+                {dayTotal > 0 ? (
+                  <div
+                    className="flex flex-col-reverse overflow-hidden rounded-t-sm"
+                    style={{ height: `${heightPct}%`, minHeight: 2 }}
+                  >
+                    {agentIds.map((agentId, i) => {
+                      const tokens = dayMap.get(agentId) ?? 0;
+                      if (tokens <= 0) return null;
+                      const color = AGENT_COLORS[i % AGENT_COLORS.length];
+                      return (
+                        <div
+                          key={agentId}
+                          className="transition-opacity duration-75"
+                          style={{
+                            flex: tokens,
+                            backgroundColor: color,
+                            opacity:
+                              hover && (hover.agentId !== agentId || hover.day !== day)
+                                ? 0.35
+                                : 1,
+                          }}
+                          onMouseEnter={(e) => {
+                            const rect = (e.target as HTMLElement).getBoundingClientRect();
+                            const containerRect = (e.target as HTMLElement).closest(".relative")!.getBoundingClientRect();
+                            setHover({
+                              agentId,
+                              agentName: agentNames.get(agentId) ?? agentId,
+                              tokens,
+                              day,
+                              dayTotal,
+                              color,
+                              x: rect.left - containerRect.left + rect.width / 2,
+                              y: rect.top - containerRect.top,
+                            });
+                          }}
+                        />
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="bg-muted/30 rounded-sm" style={{ height: 2 }} />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* X-axis labels */}
+      <div className="flex gap-[3px] mt-1.5" style={{ paddingLeft: 40 }}>
+        {days.map((day, i) => (
+          <div key={day} className="flex-1 text-center">
+            {i === 0 || i === 6 || i === 13 ? (
+              <span className="text-[9px] text-muted-foreground tabular-nums">
+                {formatDayLabel(day)}
+              </span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-x-2.5 gap-y-0.5 mt-2">
+        {agentIds.map((id, i) => (
+          <span
+            key={id}
+            className="flex items-center gap-1 text-[9px] text-muted-foreground"
+          >
+            <span
+              className="h-1.5 w-1.5 rounded-full shrink-0"
+              style={{
+                backgroundColor: AGENT_COLORS[i % AGENT_COLORS.length],
+              }}
+            />
+            {agentNames.get(id)}
+          </span>
+        ))}
+      </div>
+
+      {/* Tooltip */}
+      {hover && (
+        <div
+          className="absolute z-50 pointer-events-none rounded-md border border-border bg-popover px-3 py-2 text-xs shadow-md"
+          style={{
+            left: hover.x,
+            top: hover.y - 8,
+            transform: "translate(-50%, -100%)",
+          }}
+        >
+          <div className="flex items-center gap-1.5 font-medium">
+            <span
+              className="h-2 w-2 rounded-full shrink-0"
+              style={{ backgroundColor: hover.color }}
+            />
+            {hover.agentName}
+          </div>
+          <div className="mt-1 tabular-nums text-muted-foreground">
+            {formatTokens(hover.tokens)} tokens
+          </div>
+          <div className="tabular-nums text-muted-foreground">
+            {formatDayLabel(hover.day)} &middot; day total {formatTokens(hover.dayTotal)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/TokenUsageByAgentChart.tsx
+++ b/ui/src/components/TokenUsageByAgentChart.tsx
@@ -1,0 +1,97 @@
+import type { CostByAgent } from "@paperclipai/shared";
+import { formatTokens } from "../lib/utils";
+
+const TOKEN_COLORS = {
+  input: "#3b82f6",
+  cached: "#8b5cf6",
+  output: "#10b981",
+} as const;
+
+export function TokenUsageByAgentChart({ agents }: { agents: CostByAgent[] }) {
+  if (agents.length === 0) {
+    return <p className="text-xs text-muted-foreground">No token usage yet.</p>;
+  }
+
+  const sorted = agents
+    .map((a) => ({
+      ...a,
+      total: a.inputTokens + a.cachedInputTokens + a.outputTokens,
+    }))
+    .sort((a, b) => b.total - a.total);
+
+  const maxTotal = Math.max(...sorted.map((a) => a.total), 1);
+
+  return (
+    <div className="space-y-2">
+      {sorted.map((agent) => {
+        const widthPct = (agent.total / maxTotal) * 100;
+        return (
+          <div key={agent.agentId} className="space-y-1">
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="truncate font-medium">
+                {agent.agentName ?? agent.agentId}
+              </span>
+              <span className="shrink-0 tabular-nums text-muted-foreground">
+                {formatTokens(agent.total)}
+              </span>
+            </div>
+            <div
+              className="flex h-5 overflow-hidden rounded-sm"
+              style={{ width: `${Math.max(widthPct, 2)}%` }}
+              title={`Input: ${formatTokens(agent.inputTokens)} · Cached: ${formatTokens(agent.cachedInputTokens)} · Output: ${formatTokens(agent.outputTokens)}`}
+            >
+              {agent.inputTokens > 0 && (
+                <div
+                  style={{
+                    flex: agent.inputTokens,
+                    backgroundColor: TOKEN_COLORS.input,
+                  }}
+                />
+              )}
+              {agent.cachedInputTokens > 0 && (
+                <div
+                  style={{
+                    flex: agent.cachedInputTokens,
+                    backgroundColor: TOKEN_COLORS.cached,
+                  }}
+                />
+              )}
+              {agent.outputTokens > 0 && (
+                <div
+                  style={{
+                    flex: agent.outputTokens,
+                    backgroundColor: TOKEN_COLORS.output,
+                  }}
+                />
+              )}
+            </div>
+          </div>
+        );
+      })}
+
+      <div className="flex flex-wrap gap-x-2.5 gap-y-0.5 mt-2">
+        <span className="flex items-center gap-1 text-[9px] text-muted-foreground">
+          <span
+            className="h-1.5 w-1.5 rounded-full shrink-0"
+            style={{ backgroundColor: TOKEN_COLORS.input }}
+          />
+          Input
+        </span>
+        <span className="flex items-center gap-1 text-[9px] text-muted-foreground">
+          <span
+            className="h-1.5 w-1.5 rounded-full shrink-0"
+            style={{ backgroundColor: TOKEN_COLORS.cached }}
+          />
+          Cached input
+        </span>
+        <span className="flex items-center gap-1 text-[9px] text-muted-foreground">
+          <span
+            className="h-1.5 w-1.5 rounded-full shrink-0"
+            style={{ backgroundColor: TOKEN_COLORS.output }}
+          />
+          Output
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/UpdateBanner.tsx
+++ b/ui/src/components/UpdateBanner.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ArrowUpCircle, X } from "lucide-react";
+import { ArrowUpCircle, GitBranch, X } from "lucide-react";
 import type { UpdateStatus } from "../api/health";
 
 function formatCheckedAt(value: string): string | null {
@@ -20,28 +20,42 @@ function formatCheckedAt(value: string): string | null {
 export function UpdateBanner({ updateStatus }: { updateStatus?: UpdateStatus }) {
   const [dismissed, setDismissed] = useState(false);
 
-  if (!updateStatus?.available || dismissed) return null;
+  if (!updateStatus || dismissed) return null;
+
+  const hasUpstream = updateStatus.available && updateStatus.behind > 0;
+  const hasFork = (updateStatus.forkBehind ?? 0) > 0;
+
+  if (!hasUpstream && !hasFork) return null;
 
   const checkedAt = formatCheckedAt(updateStatus.checkedAt);
 
   return (
     <div className="border-b border-blue-300/60 bg-blue-50 text-blue-950 dark:border-blue-500/25 dark:bg-blue-500/10 dark:text-blue-100">
       <div className="flex items-center justify-between gap-3 px-3 py-2.5">
-        <div className="flex min-w-0 items-center gap-2">
-          <ArrowUpCircle className="h-4 w-4 shrink-0" />
-          <span className="text-sm font-medium">
-            Upstream update available — {updateStatus.behind} commit{updateStatus.behind === 1 ? "" : "s"} behind
-          </span>
+        <div className="flex min-w-0 flex-col gap-1">
+          {hasFork && (
+            <div className="flex items-center gap-2">
+              <GitBranch className="h-3.5 w-3.5 shrink-0 text-violet-500" />
+              <span className="text-sm font-medium">
+                Fork update available — {updateStatus.forkBehind} commit{updateStatus.forkBehind === 1 ? "" : "s"} behind origin
+              </span>
+            </div>
+          )}
+          {hasUpstream && (
+            <div className="flex items-center gap-2">
+              <ArrowUpCircle className="h-3.5 w-3.5 shrink-0" />
+              <span className="text-sm font-medium">
+                Upstream update — {updateStatus.behind} commit{updateStatus.behind === 1 ? "" : "s"} behind
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
           {checkedAt ? (
             <span className="text-xs text-blue-900/60 dark:text-blue-100/50">
               checked {checkedAt}
             </span>
           ) : null}
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <span className="text-xs text-blue-900/60 dark:text-blue-100/50">
-            {updateStatus.currentSha.slice(0, 7)} → {updateStatus.upstreamSha.slice(0, 7)}
-          </span>
           <button
             type="button"
             onClick={() => setDismissed(true)}

--- a/ui/src/components/UpdateBanner.tsx
+++ b/ui/src/components/UpdateBanner.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { ArrowUpCircle, X } from "lucide-react";
+import type { UpdateStatus } from "../api/health";
+
+function formatCheckedAt(value: string): string | null {
+  if (!value) return null;
+  const timestamp = new Date(value).getTime();
+  if (Number.isNaN(timestamp)) return null;
+
+  const deltaMs = Date.now() - timestamp;
+  if (deltaMs < 60_000) return "just now";
+  const deltaMinutes = Math.round(deltaMs / 60_000);
+  if (deltaMinutes < 60) return `${deltaMinutes}m ago`;
+  const deltaHours = Math.round(deltaMinutes / 60);
+  if (deltaHours < 24) return `${deltaHours}h ago`;
+  const deltaDays = Math.round(deltaHours / 24);
+  return `${deltaDays}d ago`;
+}
+
+export function UpdateBanner({ updateStatus }: { updateStatus?: UpdateStatus }) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!updateStatus?.available || dismissed) return null;
+
+  const checkedAt = formatCheckedAt(updateStatus.checkedAt);
+
+  return (
+    <div className="border-b border-blue-300/60 bg-blue-50 text-blue-950 dark:border-blue-500/25 dark:bg-blue-500/10 dark:text-blue-100">
+      <div className="flex items-center justify-between gap-3 px-3 py-2.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <ArrowUpCircle className="h-4 w-4 shrink-0" />
+          <span className="text-sm font-medium">
+            Upstream update available — {updateStatus.behind} commit{updateStatus.behind === 1 ? "" : "s"} behind
+          </span>
+          {checkedAt ? (
+            <span className="text-xs text-blue-900/60 dark:text-blue-100/50">
+              checked {checkedAt}
+            </span>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="text-xs text-blue-900/60 dark:text-blue-100/50">
+            {updateStatus.currentSha.slice(0, 7)} → {updateStatus.upstreamSha.slice(0, 7)}
+          </span>
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            className="rounded p-1 hover:bg-blue-900/10 dark:hover:bg-blue-100/10"
+            aria-label="Dismiss update notification"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/context/ThemeContext.tsx
+++ b/ui/src/context/ThemeContext.tsx
@@ -8,11 +8,15 @@ import {
   type ReactNode,
 } from "react";
 
-type Theme = "light" | "dark";
+type ThemePreference = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
 
 interface ThemeContextValue {
-  theme: Theme;
-  setTheme: (theme: Theme) => void;
+  /** The user's preference: light, dark, or system. */
+  preference: ThemePreference;
+  /** The resolved theme actually applied to the document. */
+  theme: ResolvedTheme;
+  setTheme: (theme: ThemePreference) => void;
   toggleTheme: () => void;
 }
 
@@ -21,12 +25,23 @@ const DARK_THEME_COLOR = "#18181b";
 const LIGHT_THEME_COLOR = "#ffffff";
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
-function resolveThemeFromDocument(): Theme {
-  if (typeof document === "undefined") return "dark";
-  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === "undefined") return "dark";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
-function applyTheme(theme: Theme) {
+function resolveTheme(preference: ThemePreference): ResolvedTheme {
+  return preference === "system" ? getSystemTheme() : preference;
+}
+
+function getSavedPreference(): ThemePreference {
+  if (typeof localStorage === "undefined") return "system";
+  const saved = localStorage.getItem(THEME_STORAGE_KEY);
+  if (saved === "light" || saved === "dark" || saved === "system") return saved;
+  return "system";
+}
+
+function applyTheme(theme: ResolvedTheme) {
   if (typeof document === "undefined") return;
   const isDark = theme === "dark";
   const root = document.documentElement;
@@ -39,32 +54,48 @@ function applyTheme(theme: Theme) {
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>(() => resolveThemeFromDocument());
+  const [preference, setPreferenceState] = useState<ThemePreference>(() => getSavedPreference());
+  const [resolved, setResolved] = useState<ResolvedTheme>(() => resolveTheme(getSavedPreference()));
 
-  const setTheme = useCallback((nextTheme: Theme) => {
-    setThemeState(nextTheme);
+  const setTheme = useCallback((nextPref: ThemePreference) => {
+    setPreferenceState(nextPref);
+    setResolved(resolveTheme(nextPref));
   }, []);
 
   const toggleTheme = useCallback(() => {
-    setThemeState((current) => (current === "dark" ? "light" : "dark"));
+    setPreferenceState((current) => {
+      const next = current === "dark" ? "light" : current === "light" ? "system" : "dark";
+      setResolved(resolveTheme(next));
+      return next;
+    });
   }, []);
 
+  // Listen for system theme changes when preference is "system"
   useEffect(() => {
-    applyTheme(theme);
+    if (preference !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => setResolved(getSystemTheme());
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [preference]);
+
+  useEffect(() => {
+    applyTheme(resolved);
     try {
-      localStorage.setItem(THEME_STORAGE_KEY, theme);
+      localStorage.setItem(THEME_STORAGE_KEY, preference);
     } catch {
       // Ignore local storage write failures in restricted environments.
     }
-  }, [theme]);
+  }, [resolved, preference]);
 
   const value = useMemo(
     () => ({
-      theme,
+      preference,
+      theme: resolved,
       setTheme,
       toggleTheme,
     }),
-    [theme, setTheme, toggleTheme],
+    [preference, resolved, setTheme, toggleTheme],
   );
 
   return (

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -20,6 +20,8 @@ import { FinanceBillerCard } from "../components/FinanceBillerCard";
 import { FinanceKindCard } from "../components/FinanceKindCard";
 import { FinanceTimelineCard } from "../components/FinanceTimelineCard";
 import { Identity } from "../components/Identity";
+import { TokenUsageByAgentChart } from "../components/TokenUsageByAgentChart";
+import { TokenTimelineChart } from "../components/TokenTimelineChart";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { PageTabBar } from "../components/PageTabBar";
 import { ProviderQuotaCard } from "../components/ProviderQuotaCard";
@@ -240,6 +242,12 @@ export function Costs() {
       ]);
       return { summary, byAgent, byProject, byAgentModel };
     },
+    enabled: !!selectedCompanyId && customReady,
+  });
+
+  const { data: agentDailyData } = useQuery({
+    queryKey: ["costs", "by-agent-daily", companyId, from, to],
+    queryFn: () => costsApi.byAgentDaily(companyId, from || undefined, to || undefined),
     enabled: !!selectedCompanyId && customReady,
   });
 
@@ -713,17 +721,30 @@ export function Costs() {
                 />
               </div>
 
+              <Card>
+                <CardHeader className="px-5 pt-5 pb-2">
+                  <CardTitle className="text-base">Token usage over time</CardTitle>
+                  <CardDescription>Daily token consumption stacked by agent (last 14 days).</CardDescription>
+                </CardHeader>
+                <CardContent className="px-5 pb-5 pt-2">
+                  <TokenTimelineChart rows={agentDailyData ?? []} />
+                </CardContent>
+              </Card>
+
               <div className="grid gap-4 xl:grid-cols-[1.25fr,0.95fr]">
                 <Card>
                   <CardHeader className="px-5 pt-5 pb-2">
                     <CardTitle className="text-base">By agent</CardTitle>
                     <CardDescription>What each agent consumed in the selected period.</CardDescription>
                   </CardHeader>
-                  <CardContent className="space-y-2 px-5 pb-5 pt-2">
+                  <CardContent className="space-y-4 px-5 pb-5 pt-2">
                     {(spendData?.byAgent.length ?? 0) === 0 ? (
                       <p className="text-sm text-muted-foreground">No cost events yet.</p>
                     ) : (
-                      spendData?.byAgent.map((row) => {
+                      <>
+                      <TokenUsageByAgentChart agents={spendData?.byAgent ?? []} />
+                      <div className="space-y-2">
+                      {spendData?.byAgent.map((row) => {
                         const modelRows = agentModelRows.get(row.agentId) ?? [];
                         const isExpanded = expandedAgents.has(row.agentId);
                         const hasBreakdown = modelRows.length > 0;
@@ -796,7 +817,9 @@ export function Costs() {
                             ) : null}
                           </div>
                         );
-                      })
+                      })}
+                      </div>
+                      </>
                     )}
                   </CardContent>
                 </Card>


### PR DESCRIPTION
## Summary
- Adds a "system" option to the theme toggle that follows the OS color scheme via `prefers-color-scheme`
- The toggle cycles through dark → light → system with Lucide `Moon`, `Sun`, and `Laptop` icons
- When set to system, the theme updates automatically when the OS preference changes
- Backward compatible: existing `localStorage` values (`light`/`dark`) still work, `system` is the new default when no preference is saved

## Changes
- `ui/src/context/ThemeContext.tsx`: Added `ThemePreference` type (`light | dark | system`), system theme resolution, and `prefers-color-scheme` media query listener
- `ui/src/components/Layout.tsx`: Updated toggle to cycle through three states with appropriate Lucide icons

## Test plan
- [ ] Click theme toggle: dark → light → system → dark cycle
- [ ] In system mode, change OS dark/light preference → UI updates immediately
- [ ] Refresh page → preference persists from localStorage
- [ ] Clear localStorage → defaults to system mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)