### PR TITLE
fix(ui): prevent routine schedule from resetting to 10 AM

### DIFF
--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -157,14 +157,18 @@ function TriggerEditor({
     replayWindowSec: String(trigger.replayWindowSec ?? 300),
   });
 
+  // Only reset the draft when the trigger identity changes (not on every background refetch)
+  const prevTriggerIdRef = useRef(trigger.id);
   useEffect(() => {
+    if (prevTriggerIdRef.current === trigger.id) return;
+    prevTriggerIdRef.current = trigger.id;
     setDraft({
       label: trigger.label ?? "",
       cronExpression: trigger.cronExpression ?? "",
       signingMode: trigger.signingMode ?? "bearer",
       replayWindowSec: String(trigger.replayWindowSec ?? 300),
     });
-  }, [trigger]);
+  }, [trigger.id, trigger.label, trigger.cronExpression, trigger.signingMode, trigger.replayWindowSec]);
 
   return (
     <div className="rounded-lg border border-border p-4 space-y-4">


### PR DESCRIPTION
Fixes #3580

## Summary
- Fix routine trigger schedule editor resetting to 10 AM on background React Query refetches
- The `TriggerEditor` `useEffect` depended on the entire `trigger` object reference, which changes identity on every refetch, discarding unsaved draft edits
- Track trigger identity with a `useRef` and only reset the draft when the trigger ID changes

## Thinking Path
- **Project**: Paperclip — routines allow scheduled agent execution via cron triggers
- **Problem**: Schedule time reverts to 10 AM (the default `0 10 * * *`) after editing without saving
- **Investigation**: Data layer (DB → API → types) correctly stores and returns `cronExpression`. The bug is in the UI: `TriggerEditor`'s `useEffect` dependency on `[trigger]` fires on every React Query refetch because object identity changes
- **Fix**: Use `useRef` to track `trigger.id` and skip draft reset when identity is unchanged

## Model Used
- **Provider**: Anthropic
- **Model ID**: claude-opus-4-6
- **Context window**: 1M tokens

## Test plan
- [ ] Open a routine with a schedule trigger
- [ ] Change the time (e.g., from 10 AM to 2 PM) without saving
- [ ] Switch to another browser tab and come back — schedule should retain the edited value
- [ ] Save the trigger — verify the new time persists after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)