### PR TITLE
add run-log credential redaction guardrail

### DIFF
--- a/server/src/__tests__/heartbeat-redaction.test.ts
+++ b/server/src/__tests__/heartbeat-redaction.test.ts
@@ -1,0 +1,314 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  companySkills,
+  costEvents,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  registerServerAdapter,
+  unregisterServerAdapter,
+  type ServerAdapterModule,
+} from "../adapters/index.ts";
+import { RUN_LOG_CREDENTIAL_REDACTION_TOKEN } from "../log-redaction.js";
+
+const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
+const mockTrackAgentFirstHeartbeat = vi.hoisted(() => vi.fn());
+const mockWorkspaceRuntime = vi.hoisted(() => ({
+  setupFailureMessage: null as string | null,
+}));
+
+vi.mock("../telemetry.ts", () => ({
+  getTelemetryClient: () => mockTelemetryClient,
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: mockTrackAgentFirstHeartbeat,
+  };
+});
+
+vi.mock("../services/workspace-runtime.js", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("../services/workspace-runtime.js");
+  return {
+    ...actual,
+    realizeExecutionWorkspace: async (...args: unknown[]) => {
+      if (mockWorkspaceRuntime.setupFailureMessage) {
+        throw new Error(mockWorkspaceRuntime.setupFailureMessage);
+      }
+      return (actual.realizeExecutionWorkspace as (...innerArgs: unknown[]) => Promise<unknown>)(...args);
+    },
+  };
+});
+
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+const TEST_ADAPTER_TYPE = "redaction_test_adapter";
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat redaction tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 10_000, intervalMs = 50) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+describeEmbeddedPostgres("heartbeat redaction", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-redaction-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    mockWorkspaceRuntime.setupFailureMessage = null;
+    unregisterServerAdapter(TEST_ADAPTER_TYPE);
+    await db.delete(costEvents);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companySkills);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    unregisterServerAdapter(TEST_ADAPTER_TYPE);
+    await tempDb?.cleanup();
+  });
+
+  it("redacts adapter failure credentials in agent runtime state while preserving usage accounting", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const fakeApiKey = "fake-runtime-key-value";
+    const fakeBearer = "fake-runtime-bearer-value";
+    const fakeJwt = "fakehead1.fakepayload2.fakesignature-";
+    const fakeErrorMessage =
+      `adapter failed PAPERCLIP_API_KEY=${fakeApiKey} Authorization: Bearer ${fakeBearer} ${fakeJwt}`;
+
+    const adapter: ServerAdapterModule = {
+      type: TEST_ADAPTER_TYPE,
+      execute: async () => ({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: fakeErrorMessage,
+        errorCode: "redaction_test_failure",
+        provider: "redaction-test-provider",
+        biller: "redaction-test-biller",
+        model: "redaction-test-model",
+        billingType: "metered_api",
+        costUsd: 1.23,
+        usage: {
+          inputTokens: 11,
+          cachedInputTokens: 5,
+          outputTokens: 7,
+        },
+      }),
+      testEnvironment: async () => ({
+        adapterType: TEST_ADAPTER_TYPE,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    };
+    registerServerAdapter(adapter);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Redaction Test Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: TEST_ADAPTER_TYPE,
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const heartbeat = heartbeatService(db);
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "redaction_test",
+      requestedByActorType: "system",
+      requestedByActorId: null,
+    });
+    expect(run).not.toBeNull();
+
+    await waitFor(async () => {
+      const state = await db
+        .select()
+        .from(agentRuntimeState)
+        .where(eq(agentRuntimeState.agentId, agentId))
+        .then((rows) => rows[0] ?? null);
+      return state?.lastRunStatus === "failed";
+    });
+
+    const state = await db
+      .select()
+      .from(agentRuntimeState)
+      .where(eq(agentRuntimeState.agentId, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(state?.lastError).toContain(`PAPERCLIP_API_KEY=${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`);
+    expect(state?.lastError).toContain(`Authorization: Bearer ${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`);
+    expect(state?.lastError).not.toContain(fakeApiKey);
+    expect(state?.lastError).not.toContain(fakeBearer);
+    expect(state?.lastError).not.toContain(fakeJwt);
+    expect(state?.totalInputTokens).toBe(11);
+    expect(state?.totalCachedInputTokens).toBe(5);
+    expect(state?.totalOutputTokens).toBe(7);
+    expect(state?.totalCostCents).toBe(123);
+
+    const runRow = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, run!.id))
+      .then((rows) => rows[0] ?? null);
+    expect(runRow?.error).toEqual(state?.lastError);
+
+    const costEvent = await db
+      .select()
+      .from(costEvents)
+      .where(eq(costEvents.heartbeatRunId, run!.id))
+      .then((rows) => rows[0] ?? null);
+    expect(costEvent).toMatchObject({
+      provider: "redaction-test-provider",
+      biller: "redaction-test-biller",
+      billingType: "metered_api",
+      model: "redaction-test-model",
+      inputTokens: 11,
+      cachedInputTokens: 5,
+      outputTokens: 7,
+      costCents: 123,
+    });
+  });
+
+  it("redacts setup failure credentials in run status, wakeup status, and timeline events", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const fakeApiKey = "fake-setup-key-value";
+    const fakeBearer = "fake-setup-bearer-value";
+    const fakeJwt = "fakehead1.fakepayload2.fakesetupsig-";
+    const fakeErrorMessage =
+      `setup failed PAPERCLIP_API_KEY=${fakeApiKey} Authorization: Bearer ${fakeBearer} ${fakeJwt}`;
+    mockWorkspaceRuntime.setupFailureMessage = fakeErrorMessage;
+
+    const execute = vi.fn(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+    }));
+    const adapter: ServerAdapterModule = {
+      type: TEST_ADAPTER_TYPE,
+      execute,
+      testEnvironment: async () => ({
+        adapterType: TEST_ADAPTER_TYPE,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    };
+    registerServerAdapter(adapter);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Setup Failure Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: TEST_ADAPTER_TYPE,
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const heartbeat = heartbeatService(db);
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "setup_redaction_test",
+      requestedByActorType: "system",
+      requestedByActorId: null,
+    });
+    expect(run).not.toBeNull();
+
+    await waitFor(async () => {
+      const runRow = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run!.id))
+        .then((rows) => rows[0] ?? null);
+      return runRow?.status === "failed";
+    });
+
+    const runRow = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, run!.id))
+      .then((rows) => rows[0] ?? null);
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.runId, run!.id))
+      .then((rows) => rows[0] ?? null);
+    const event = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, run!.id))
+      .then((rows) => rows.find((row) => row.eventType === "error") ?? null);
+
+    for (const persistedMessage of [runRow?.error, wakeup?.error, event?.message]) {
+      expect(persistedMessage).toContain(`PAPERCLIP_API_KEY=${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`);
+      expect(persistedMessage).toContain(`Authorization: Bearer ${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`);
+      expect(persistedMessage).not.toContain(fakeApiKey);
+      expect(persistedMessage).not.toContain(fakeBearer);
+      expect(persistedMessage).not.toContain(fakeJwt);
+    }
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/log-redaction.test.ts
+++ b/server/src/__tests__/log-redaction.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  RUN_LOG_CREDENTIAL_REDACTION_TOKEN,
   maskUserNameForLogs,
   redactCurrentUserText,
   redactCurrentUserValue,
+  redactRunLogCredentialsText,
+  redactRunLogCredentialsValue,
 } from "../log-redaction.js";
 
 describe("log redaction", () => {
@@ -70,5 +73,64 @@ describe("log redaction", () => {
   it("skips redaction when disabled", () => {
     const input = "cwd=/Users/paperclipuser/paperclip";
     expect(redactCurrentUserText(input, { enabled: false })).toBe(input);
+  });
+
+  it("redacts credential-shaped values from run log text", () => {
+    const apiKey = "fake-paperclip-key-value";
+    const bearer = "fake-bearer-token-value";
+    const token = "fake-session-token-value";
+    const secret = "fake-private-secret-value";
+    const jwt = "eyJmYWtlIjoiand0In0.eyJmYWtlIjoicGF5bG9hZCJ9.ZmFrZS1zaWduYXR1cmU";
+    const input = [
+      `PAPERCLIP_API_KEY=${apiKey}`,
+      `Authorization: Bearer ${bearer}`,
+      `SESSION_TOKEN=${token}`,
+      `PRIVATE_SECRET="${secret}"`,
+      `declare -x API_TOKEN='${token}'`,
+      `stdout still keeps useful context ${jwt}`,
+    ].join("\n");
+
+    const result = redactRunLogCredentialsText(input);
+
+    expect(result).toContain(`PAPERCLIP_API_KEY=${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`);
+    expect(result).toContain(`Authorization: Bearer ${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`);
+    expect(result).toContain(`SESSION_TOKEN=${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`);
+    expect(result).toContain(`PRIVATE_SECRET="${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}"`);
+    expect(result).toContain(`API_TOKEN='${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}'`);
+    expect(result).toContain(`stdout still keeps useful context ${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`);
+    for (const sensitiveValue of [apiKey, bearer, token, secret, jwt]) {
+      expect(result).not.toContain(sensitiveValue);
+    }
+  });
+
+  it("does not redact non-sensitive key names that merely contain sensitive words", () => {
+    const result = redactRunLogCredentialsText("TOKENIZER_MODEL=fake-debug-model");
+
+    expect(result).toBe("TOKENIZER_MODEL=fake-debug-model");
+  });
+
+  it("redacts token-shaped values whose final segment ends in a hyphen", () => {
+    const tokenShapedValue = "fakehead1.fakepayload2.fakesignature-";
+    const result = redactRunLogCredentialsText(`stdout ${tokenShapedValue} next`);
+
+    expect(result).toBe(`stdout ${RUN_LOG_CREDENTIAL_REDACTION_TOKEN} next`);
+    expect(result).not.toContain(tokenShapedValue);
+  });
+
+  it("redacts credential-shaped strings recursively in run log values", () => {
+    const fakeValue = "fake-nested-token-value";
+    const result = redactRunLogCredentialsValue({
+      message: `API_TOKEN=${fakeValue}`,
+      nested: {
+        lines: [`Authorization: Bearer ${fakeValue}`],
+      },
+    });
+
+    expect(result).toEqual({
+      message: `API_TOKEN=${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`,
+      nested: {
+        lines: [`Authorization: Bearer ${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`],
+      },
+    });
   });
 });

--- a/server/src/__tests__/run-log-store.test.ts
+++ b/server/src/__tests__/run-log-store.test.ts
@@ -1,0 +1,47 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { RUN_LOG_CREDENTIAL_REDACTION_TOKEN } from "../log-redaction.js";
+import { createLocalFileRunLogStore } from "../services/run-log-store.js";
+
+describe("run log store", () => {
+  it("redacts credential-shaped values before persisting local log chunks", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "paperclip-run-log-"));
+    const apiKey = "fake-paperclip-key-value";
+    const bearer = "fake-bearer-token-value";
+
+    try {
+      const store = createLocalFileRunLogStore(dir);
+      const handle = await store.begin({
+        companyId: "company-1",
+        agentId: "agent-1",
+        runId: "run-1",
+      });
+
+      await store.append(handle, {
+        stream: "stdout",
+        ts: "2026-04-13T00:00:00.000Z",
+        chunk: [
+          "starting run",
+          `PAPERCLIP_API_KEY=${apiKey}`,
+          `Authorization: Bearer ${bearer}`,
+          "finished run",
+        ].join("\n"),
+      });
+
+      const result = await store.read(handle);
+      const [line] = result.content.trim().split(/\r?\n/);
+      const entry = JSON.parse(line!) as { chunk: string };
+
+      expect(entry.chunk).toContain("starting run");
+      expect(entry.chunk).toContain(`PAPERCLIP_API_KEY=${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`);
+      expect(entry.chunk).toContain(`Authorization: Bearer ${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`);
+      expect(entry.chunk).toContain("finished run");
+      expect(result.content).not.toContain(apiKey);
+      expect(result.content).not.toContain(bearer);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/log-redaction.ts
+++ b/server/src/log-redaction.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 
 export const CURRENT_USER_REDACTION_TOKEN = "*";
+export const RUN_LOG_CREDENTIAL_REDACTION_TOKEN = "[REDACTED]";
 
 export interface CurrentUserRedactionOptions {
   enabled?: boolean;
@@ -14,6 +15,22 @@ type CurrentUserCandidates = {
   homeDirs: string[];
   replacement: string;
 };
+
+const RUN_LOG_KEY_PATTERN = String.raw`[A-Za-z_][A-Za-z0-9_-]*`;
+const SENSITIVE_RUN_LOG_ASSIGNMENT_RE = new RegExp(
+  String.raw`\b((?:(?:export|declare\s+-x)\s+)?(${RUN_LOG_KEY_PATTERN})\s*=\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s#;]+)`,
+  "gi",
+);
+const SENSITIVE_RUN_LOG_PROPERTY_RE = new RegExp(
+  String.raw`(["'])(${RUN_LOG_KEY_PATTERN})\1\s*:\s*(["'])([^"'\\\r\n]*)\3`,
+  "gi",
+);
+const AUTHORIZATION_BEARER_RE = /\b(Authorization\s*[:=]\s*["']?Bearer\s+)([^\s"'`,;\\]+)/gi;
+const JWT_LIKE_SEGMENT_PATTERN = String.raw`[A-Za-z0-9_-]{8,}`;
+const JWT_LIKE_VALUE_RE = new RegExp(
+  String.raw`(?<![A-Za-z0-9_-])${JWT_LIKE_SEGMENT_PATTERN}\.${JWT_LIKE_SEGMENT_PATTERN}\.${JWT_LIKE_SEGMENT_PATTERN}(?:\.${JWT_LIKE_SEGMENT_PATTERN})?(?![A-Za-z0-9_-]|\.[A-Za-z0-9_-])`,
+  "g",
+);
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
@@ -143,6 +160,55 @@ export function redactCurrentUserValue<T>(value: T, opts?: CurrentUserRedactionO
   const redacted: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
     redacted[key] = redactCurrentUserValue(entry, opts);
+  }
+  return redacted as T;
+}
+
+function redactedValueForMatchedText(rawValue: string) {
+  const quote = rawValue[0] === "\"" || rawValue[0] === "'" ? rawValue[0] : "";
+  return quote ? `${quote}${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}${quote}` : RUN_LOG_CREDENTIAL_REDACTION_TOKEN;
+}
+
+function isSensitiveRunLogKey(key: string) {
+  const normalized = key.replace(/-/g, "_").toUpperCase();
+  return /(^|_)(API_KEY|APIKEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTHORIZATION|COOKIE)($|_)/.test(
+    normalized,
+  );
+}
+
+export function redactRunLogCredentialsText(input: string) {
+  if (!input) return input;
+  return input
+    .replace(AUTHORIZATION_BEARER_RE, (_match, prefix: string) => `${prefix}${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}`)
+    .replace(SENSITIVE_RUN_LOG_ASSIGNMENT_RE, (match: string, prefix: string, key: string) => {
+      if (!isSensitiveRunLogKey(key)) return match;
+      const rawValue = match.slice(prefix.length);
+      return `${prefix}${redactedValueForMatchedText(rawValue)}`;
+    })
+    .replace(
+      SENSITIVE_RUN_LOG_PROPERTY_RE,
+      (_match, keyQuote: string, key: string, valueQuote: string) =>
+        isSensitiveRunLogKey(key)
+          ? `${keyQuote}${key}${keyQuote}: ${valueQuote}${RUN_LOG_CREDENTIAL_REDACTION_TOKEN}${valueQuote}`
+          : _match,
+    )
+    .replace(JWT_LIKE_VALUE_RE, RUN_LOG_CREDENTIAL_REDACTION_TOKEN);
+}
+
+export function redactRunLogCredentialsValue<T>(value: T): T {
+  if (typeof value === "string") {
+    return redactRunLogCredentialsText(value) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactRunLogCredentialsValue(entry)) as T;
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    redacted[key] = redactRunLogCredentialsValue(entry);
   }
   return redacted as T;
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1048,6 +1048,23 @@ function normalizeBilledCostCents(costUsd: number | null | undefined, billingTyp
   return Math.max(0, Math.round(costUsd * 100));
 }
 
+function sanitizeErrorForHeartbeatLog(
+  error: unknown,
+  sanitizedMessage: string,
+  currentUserRedactionOptions?: Parameters<typeof redactCurrentUserText>[1],
+) {
+  if (!(error instanceof Error)) {
+    return { message: sanitizedMessage };
+  }
+  return {
+    type: error.name,
+    message: sanitizedMessage,
+    ...(error.stack
+      ? { stack: redactRunLogCredentialsText(redactCurrentUserText(error.stack, currentUserRedactionOptions)) }
+      : {}),
+  };
+}
+
 async function resolveLedgerScopeForRun(
   db: Db,
   companyId: string,
@@ -4527,6 +4544,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     result: AdapterExecutionResult,
     session: { legacySessionId: string | null },
     normalizedUsage?: UsageTotals | null,
+    opts?: { lastError?: string | null },
   ) {
     await ensureRuntimeState(agent);
     const usage = normalizedUsage ?? normalizeUsageTotals(result.usage);
@@ -4539,6 +4557,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const provider = result.provider ?? "unknown";
     const biller = resolveLedgerBiller(result);
     const ledgerScope = await resolveLedgerScopeForRun(db, agent.companyId, run);
+    const lastError = opts && "lastError" in opts
+      ? (opts.lastError ?? null)
+      : result.errorMessage
+        ? redactRunLogCredentialsText(
+            redactCurrentUserText(
+              result.errorMessage,
+              await getCurrentUserRedactionOptions().catch(() => undefined),
+            ),
+          )
+        : null;
 
     await db
       .update(agentRuntimeState)
@@ -4547,7 +4575,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         sessionId: session.legacySessionId,
         lastRunId: run.id,
         lastRunStatus: run.status,
-        lastError: result.errorMessage ?? null,
+        lastError,
         totalInputTokens: sql`${agentRuntimeState.totalInputTokens} + ${inputTokens}`,
         totalOutputTokens: sql`${agentRuntimeState.totalOutputTokens} + ${outputTokens}`,
         totalCachedInputTokens: sql`${agentRuntimeState.totalCachedInputTokens} + ${cachedInputTokens}`,
@@ -5738,6 +5766,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             legacySessionId: nextSessionState.legacySessionId,
           },
           normalizedUsage,
+          { lastError: runErrorMessage },
         );
         if (taskKey) {
           if (adapterResult.clearSession || (!nextSessionState.params && !nextSessionState.displayId)) {
@@ -5754,20 +5783,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               sessionParamsJson: nextSessionState.params,
               sessionDisplayId: nextSessionState.displayId,
               lastRunId: finalizedRun.id,
-              lastError: outcome === "succeeded" ? null : (persistedError ?? "run_failed"),
+              lastError: outcome === "succeeded" ? null : (runErrorMessage ?? "run_failed"),
             });
           }
         }
       }
       await finalizeAgentStatus(agent.id, outcome);
     } catch (err) {
+      const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
       const message = redactRunLogCredentialsText(
         redactCurrentUserText(
           err instanceof Error ? err.message : "Unknown adapter failure",
-          await getCurrentUserRedactionOptions(),
+          currentUserRedactionOptions,
         ),
       );
-      logger.error({ err, runId }, "heartbeat execution failed");
+      logger.error(
+        { err: sanitizeErrorForHeartbeatLog(err, message, currentUserRedactionOptions), runId },
+        "heartbeat execution failed",
+      );
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {
@@ -5823,7 +5856,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           errorMessage: message,
         }, {
           legacySessionId: runtimeForAdapter.sessionId,
-        });
+        }, undefined, { lastError: message });
 
         if (taskKey && (previousSessionParams || previousSessionDisplayId || taskSession)) {
           await upsertTaskSession({
@@ -5844,8 +5877,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     } catch (outerErr) {
           // Setup code before adapter.execute threw (e.g. ensureRuntimeState, resolveWorkspaceForRun).
           // The inner catch did not fire, so we must record the failure here.
-          const message = outerErr instanceof Error ? outerErr.message : "Unknown setup failure";
-          logger.error({ err: outerErr, runId }, "heartbeat execution setup failed");
+          const currentUserRedactionOptions = await getCurrentUserRedactionOptions().catch(() => undefined);
+          const message = redactRunLogCredentialsText(
+            redactCurrentUserText(
+              outerErr instanceof Error ? outerErr.message : "Unknown setup failure",
+              currentUserRedactionOptions,
+            ),
+          );
+          logger.error(
+            { err: sanitizeErrorForHeartbeatLog(outerErr, message, currentUserRedactionOptions), runId },
+            "heartbeat execution setup failed",
+          );
           const setupFailureAgent = await getAgent(run.agentId).catch(() => null);
           await setRunStatus(runId, "failed", {
             error: message,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -111,7 +111,12 @@ import {
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
 import { recoveryService } from "./recovery/service.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
-import { redactCurrentUserText, redactCurrentUserValue } from "../log-redaction.js";
+import {
+  redactCurrentUserText,
+  redactCurrentUserValue,
+  redactRunLogCredentialsText,
+  redactRunLogCredentialsValue,
+} from "../log-redaction.js";
 import {
   hasSessionCompactionThresholds,
   resolveSessionCompactionPolicy,
@@ -2885,13 +2890,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   ) {
     const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
     const sanitizedMessage = event.message
-      ? redactCurrentUserText(event.message, currentUserRedactionOptions)
+      ? redactRunLogCredentialsText(redactCurrentUserText(event.message, currentUserRedactionOptions))
       : event.message;
     const boundedPayload = event.payload
       ? boundHeartbeatRunEventPayloadForStorage(event.payload)
       : event.payload;
     const sanitizedPayload = boundedPayload
-      ? redactCurrentUserValue(boundedPayload, currentUserRedactionOptions)
+      ? redactRunLogCredentialsValue(redactCurrentUserValue(boundedPayload, currentUserRedactionOptions))
       : boundedPayload;
 
     await db.insert(heartbeatRunEvents).values({
@@ -5348,8 +5353,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
-        const sanitizedChunk = compactRunLogChunk(
-          redactCurrentUserText(chunk, currentUserRedactionOptions),
+        // Primary run-log boundary: sanitize before excerpts, persistent logs, and live events share the chunk.
+        const sanitizedChunk = redactRunLogCredentialsText(
+          compactRunLogChunk(
+            redactCurrentUserText(chunk, currentUserRedactionOptions),
+          ),
         );
         if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
         if (stream === "stderr") stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
@@ -5581,12 +5589,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
       const runErrorMessage =
         outcome === "cancelled"
-          ? (latestRun?.error ?? adapterResult.errorMessage ?? "Cancelled")
+          ? redactRunLogCredentialsText(latestRun?.error ?? adapterResult.errorMessage ?? "Cancelled")
           : outcome === "succeeded"
             ? null
-            : redactCurrentUserText(
-                adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
-                currentUserRedactionOptions,
+            : redactRunLogCredentialsText(
+                redactCurrentUserText(
+                  adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
+                  currentUserRedactionOptions,
+                ),
               );
       const runErrorCode =
         outcome === "timed_out"
@@ -5642,17 +5652,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             } as Record<string, unknown>)
           : null;
 
-      const persistedResultJson = mergeHeartbeatRunResultJson(
-        mergeRunStopMetadataForAgent(agent, outcome, {
-          resultJson: mergeAdapterRecoveryMetadata({
-            resultJson: adapterResult.resultJson ?? null,
-            errorFamily: adapterResult.errorFamily ?? null,
-            retryNotBefore: adapterResult.retryNotBefore ?? null,
+      const persistedResultJson = redactRunLogCredentialsValue(
+        mergeHeartbeatRunResultJson(
+          mergeRunStopMetadataForAgent(agent, outcome, {
+            resultJson: mergeAdapterRecoveryMetadata({
+              resultJson: adapterResult.resultJson ?? null,
+              errorFamily: adapterResult.errorFamily ?? null,
+              retryNotBefore: adapterResult.retryNotBefore ?? null,
+            }),
+            errorCode: runErrorCode,
+            errorMessage: runErrorMessage,
           }),
-          errorCode: runErrorCode,
-          errorMessage: runErrorMessage,
-        }),
-        adapterResult.summary ?? null,
+          adapterResult.summary ?? null,
+        ),
       );
 
       let persistedRun = await setRunStatus(run.id, status, {
@@ -5718,9 +5730,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       if (finalizedRun) {
-        await updateRuntimeState(agent, finalizedRun, adapterResult, {
-          legacySessionId: nextSessionState.legacySessionId,
-        }, normalizedUsage);
+        await updateRuntimeState(
+          agent,
+          finalizedRun,
+          adapterResult,
+          {
+            legacySessionId: nextSessionState.legacySessionId,
+          },
+          normalizedUsage,
+        );
         if (taskKey) {
           if (adapterResult.clearSession || (!nextSessionState.params && !nextSessionState.displayId)) {
             await clearTaskSessions(agent.companyId, agent.id, {
@@ -5736,16 +5754,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               sessionParamsJson: nextSessionState.params,
               sessionDisplayId: nextSessionState.displayId,
               lastRunId: finalizedRun.id,
-              lastError: outcome === "succeeded" ? null : (adapterResult.errorMessage ?? "run_failed"),
+              lastError: outcome === "succeeded" ? null : (persistedError ?? "run_failed"),
             });
           }
         }
       }
       await finalizeAgentStatus(agent.id, outcome);
     } catch (err) {
-      const message = redactCurrentUserText(
-        err instanceof Error ? err.message : "Unknown adapter failure",
-        await getCurrentUserRedactionOptions(),
+      const message = redactRunLogCredentialsText(
+        redactCurrentUserText(
+          err instanceof Error ? err.message : "Unknown adapter failure",
+          await getCurrentUserRedactionOptions(),
+        ),
       );
       logger.error({ err, runId }, "heartbeat execution failed");
 

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import { notFound } from "../errors.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+import { redactRunLogCredentialsText } from "../log-redaction.js";
 
 export type RunLogStoreType = "local_file";
 
@@ -50,7 +51,7 @@ function resolveWithin(basePath: string, relativePath: string) {
   return resolved;
 }
 
-function createLocalFileRunLogStore(basePath: string): RunLogStore {
+export function createLocalFileRunLogStore(basePath: string): RunLogStore {
   async function ensureDir(relativeDir: string) {
     const dir = resolveWithin(basePath, relativeDir);
     await fs.mkdir(dir, { recursive: true });
@@ -112,7 +113,8 @@ function createLocalFileRunLogStore(basePath: string): RunLogStore {
       const line = JSON.stringify({
         ts: event.ts,
         stream: event.stream,
-        chunk: event.chunk,
+        // Defense in depth for callers that append without going through heartbeat's primary log boundary.
+        chunk: redactRunLogCredentialsText(event.chunk),
       });
       const persisted = `${line}\n`;
       await fs.appendFile(absPath, persisted, "utf8");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for AI-agent companies, and agent execution must remain auditable without exposing operator credentials.
> - The involved subsystem is heartbeat execution logging: adapter stdout/stderr chunks, heartbeat run events, excerpts, errors, result payloads, local run-log files, and heartbeat failure state.
> - this issue exposed that command output can include injected runtime credentials or credential-shaped values.
> - this issue exists to add a backend guardrail before run-log and failure-state content is persisted, while keeping enough log text to debug agent runs.
> - The existing server/src/log-redaction.ts module already owns related current-user path redaction, so this PR extends that central place instead of creating a separate sanitizer.
> - This pull request applies credential redaction in the heartbeat service and the local run-log store, then covers the required fake-value shapes with regression tests.
> - The benefit is safer persisted run logs and heartbeat metadata without blanking whole logs.

## What Changed

- Added a central [REDACTED] run-log credential redactor for sensitive env-style assignments, JSON/header-style sensitive fields, Authorization: Bearer values, and JWT-like values.
- Applied that redactor before persisting heartbeat run events, stdout/stderr excerpts, errors, result JSON, live log chunks, read-log responses, local NDJSON run-log chunks, and runtime failure state.
- Used explicit token-character lookaround for JWT-like boundaries so fake token-shaped values whose final segment ends in a hyphen are fully redacted.
- Sanitized agent_runtime_state.lastError by passing the already-redacted heartbeat failure message into runtime-state persistence while preserving usage, billing, provider, and model accounting from the raw adapter result.
- Sanitized the outer setup-failure catch before writing run status, wakeup status, and timeline events, and sanitized the catch logger payload so the same fake failure text is not echoed raw to server logs.
- Documented the heartbeat/run-log-store boundary split: heartbeat is the primary log boundary, and the store redaction is defense-in-depth for callers that bypass heartbeat.
- Added regression coverage for fake PAPERCLIP_API_KEY assignments, Authorization: Bearer values, *_TOKEN values, *_SECRET values, JWT-like strings, a trailing-hyphen JWT-like token, multiline env dumps, non-secret substring false positives, agent runtime-state lastError, usage/cost accounting preservation, and setup-failure status/timeline persistence.
- Added a run-log store test proving fake credential-shaped chunk values are redacted before the local log file content is read back.

## Verification

- pnpm test:run server/src/__tests__/log-redaction.test.ts server/src/__tests__/run-log-store.test.ts server/src/__tests__/heartbeat-redaction.test.ts passed.
- pnpm -r typecheck passed.
- pnpm build passed. Vite emitted the existing large-chunk warning only.
- pnpm check:tokens passed.
- Verified PR #3584 now contains only the six this issue redaction files: server/src/log-redaction.ts, server/src/services/heartbeat.ts, server/src/services/run-log-store.ts, server/src/__tests__/log-redaction.test.ts, server/src/__tests__/run-log-store.test.ts, and server/src/__tests__/heartbeat-redaction.test.ts.

## Risks

- Low migration risk: no schema changes.
- Redaction is intentionally pattern-based. It covers the required env, bearer, and JWT-like shapes, but arbitrary custom credential formats that do not include sensitive key names, bearer headers, or JWT-like structure may still need future patterns.
- Very adversarial stream chunk splitting can still create edge cases; this PR adds defense at both the heartbeat and run-log-store boundaries but does not introduce a stateful streaming parser.

## Model Used

- OpenAI Codex, GPT-5-based coding agent. Exact hosted model variant and context window were not exposed in this session. Tool-enabled code execution and repository inspection were used.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] UI screenshots are not applicable because this is backend-only
- [x] Documentation updates are not applicable because behavior is an internal backend guardrail
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge