### PR TITLE
chore: add v2026.410.0 release notes for security release

### DIFF
--- a/releases/v2026.410.0.md
+++ b/releases/v2026.410.0.md
@@ -1,0 +1,50 @@
+# v2026.410.0
+
+> Released: 2026-04-13
+
+## Security
+
+- **Authorization hardening (GHSA-68qg-g8mg-6pr7)** — Scoped import, approval, activity, and heartbeat API routes to enforce proper authorization checks. Previously, certain administrative endpoints were accessible without adequate permission verification. All users are strongly encouraged to upgrade. ([#3315](https://github.com/cryppadotta/paperclip/pull/3315))
+- **Removed hardcoded JWT secret fallback** — The `createBetterAuthInstance` function no longer falls back to a hardcoded JWT secret, closing a credential-hygiene gap.
+- **Redact Bearer tokens in logs** — Server log output now redacts Bearer tokens to prevent accidental credential exposure. ([#2659](https://github.com/cryppadotta/paperclip/pull/2659))
+- **Dependency bumps** — Updated `multer` to 2.1.1 (HIGH CVEs) and `rollup` to 4.59.0 (path-traversal CVE). ([#2819](https://github.com/cryppadotta/paperclip/pull/2819))
+
+## Highlights
+
+- **Issue-to-issue navigation** — Faster navigation between issues with scroll reset, prefetch, and detail-view optimizations. ([#3542](https://github.com/cryppadotta/paperclip/pull/3542))
+- **Auto-checkout for scoped wakes** — Agent harness now automatically checks out the scoped issue on comment-driven wakes, reducing latency for agent heartbeats. ([#3538](https://github.com/cryppadotta/paperclip/pull/3538))
+- **Inbox parent-child nesting** — Issues in the Mine inbox can now be grouped by parent, with a toggle and keyboard-traversable nested rows.
+- **Keyboard shortcut cheatsheet** — Press `?` to see all available keyboard shortcuts in a dialog.
+- **Issue search in inbox** — Broadened comment matching for inbox issue search with fallback.
+- **Codex fast mode** — Added fast mode support for `codex_local` adapters with env probe safeguards.
+- **Backups with retention** — Gzip-compressed database backups with tiered daily/weekly/monthly retention and UI controls in Instance Settings.
+- **AWS Bedrock auth** — Added AWS Bedrock authentication support on `claude-local` adapters. ([#2793](https://github.com/cryppadotta/paperclip/pull/2793))
+
+## Improvements
+
+- **Issue detail stability** — Faster comment loading, reduced rerenders on interrupted runs, stable transcript rendering for non-succeeded runs.
+- **Execution workspaces** — Fixed linked worktree reuse, dev runner isolation, workspace import regressions, and workspace preflight through server toolchain.
+- **Agent runtime** — Hardened heartbeat and adapter runtime workflows, scoped-wake fast path skips full heartbeat on comment wakes, signoff stage access fixes.
+- **Execution policy** — Fixed non-participant stage mutation rejection, decision persistence, and signoff PR follow-up flows.
+- **Chat UX polish** — Shimmer animation improvements, image gallery in chat messages, inline comment composer, Working/Worked status tokens.
+- **Inbox refinements** — Avoid refetching on filter-only changes, archive shortcut fix, badge fixture alignment, nesting column alignment.
+- **Typing performance** — Fixed typing lag in long comment threads. ([#3163](https://github.com/cryppadotta/paperclip/pull/3163))
+- **Issue list grouping** — Added workspace and parent issue grouping to the issues list view.
+- **Worktree tooling** — Improved worktree helpers, bind presets for deployment setup, tailnet bind hardening.
+- **Plugin SDK** — Plugin SDK now prepares before CLI dev boot. ([#3343](https://github.com/cryppadotta/paperclip/pull/3343))
+
+## Fixes
+
+- **Agent env bindings** — Cleared agent env bindings now persist correctly on save.
+- **Comment editor sync** — Hardened issue comment editor synchronization.
+- **Document revisions** — Latest issue document revision stays current in the UI. ([#3342](https://github.com/cryppadotta/paperclip/pull/3342))
+- **Claude instructions** — Fixed instruction sibling path hints, gate file I/O to fresh sessions only, skip `--append-system-prompt-file` on resumed sessions.
+- **Codex transcript** — Fixed Codex tool-use transcript completion parsing.
+- **Backup cleanup** — Orphaned `.sql` files cleaned up on compression failure; stale startup log fixed.
+- **Chat layout** — Fixed avatar positioning, activity line alignment, comment alignment, and feedback panel closing.
+
+## Upgrade Guide
+
+Multiple database migrations will run automatically on startup. All migrations are additive — no existing data is modified.
+
+**Security:** This release addresses [GHSA-68qg-g8mg-6pr7](https://github.com/cryppadotta/paperclip/security/advisories/GHSA-68qg-g8mg-6pr7). All deployments should upgrade as soon as possible.


### PR DESCRIPTION
## Summary

- Adds release notes for v2026.410.0 security release covering GHSA-68qg-g8mg-6pr7
- Required before triggering the stable release workflow to publish 2026.410.0 to npm

## Context

The security advisory GHSA-68qg-g8mg-6pr7 was published on 2026-04-10 listing 2026.410.0 as the patched version, but only canary builds exist on npm. The authz fix (PR #3315) is already merged to master. This PR adds release notes so the stable release workflow can be triggered.

## Test plan

- Verify release notes content is accurate
- Merge, then trigger release.yml workflow_dispatch with source_ref=master, stable_date=2026-04-10, dry_run=false
- Confirm npm view paperclipai version returns 2026.410.0