### PR TITLE
Add mobile onboarding handoff and readiness routes

### DIFF
--- a/packages/db/src/migrations/0056_mobile_web_handoffs.sql
+++ b/packages/db/src/migrations/0056_mobile_web_handoffs.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "mobile_web_handoffs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"token_hash" text NOT NULL,
+	"user_id" text NOT NULL,
+	"target_path" text NOT NULL,
+	"company_id" uuid,
+	"expires_at" timestamp with time zone NOT NULL,
+	"used_at" timestamp with time zone,
+	"created_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "mobile_web_handoffs_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "mobile_web_handoffs" ADD CONSTRAINT "mobile_web_handoffs_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "mobile_web_handoffs" ADD CONSTRAINT "mobile_web_handoffs_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE set null ON UPDATE no action;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1775825256196,
       "tag": "0055_kind_weapon_omega",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1776052800000,
+      "tag": "0056_mobile_web_handoffs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,6 +1,7 @@
 export { companies } from "./companies.js";
 export { companyLogos } from "./company_logos.js";
 export { authUsers, authSessions, authAccounts, authVerifications } from "./auth.js";
+export { mobileWebHandoffs } from "./mobile_web_handoffs.js";
 export { instanceSettings } from "./instance_settings.js";
 export { instanceUserRoles } from "./instance_user_roles.js";
 export { agents } from "./agents.js";

--- a/packages/db/src/schema/mobile_web_handoffs.ts
+++ b/packages/db/src/schema/mobile_web_handoffs.ts
@@ -1,0 +1,14 @@
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { authUsers } from "./auth.js";
+import { companies } from "./companies.js";
+
+export const mobileWebHandoffs = pgTable("mobile_web_handoffs", {
+  id: text("id").primaryKey(),
+  tokenHash: text("token_hash").notNull().unique(),
+  userId: text("user_id").notNull().references(() => authUsers.id, { onDelete: "cascade" }),
+  targetPath: text("target_path").notNull(),
+  companyId: uuid("company_id").references(() => companies.id, { onDelete: "set null" }),
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+  usedAt: timestamp("used_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -163,6 +163,11 @@ export {
 
 export type {
   Company,
+  CompanyReadiness,
+  CompanyReadinessReason,
+  CreateMobileWebHandoffRequest,
+  MobileWebHandoffResponse,
+  MobileWebHandoffTarget,
   FeedbackVote,
   FeedbackDataSharingPreference,
   FeedbackTargetType,

--- a/packages/shared/src/types/company-readiness.ts
+++ b/packages/shared/src/types/company-readiness.ts
@@ -1,0 +1,8 @@
+export type CompanyReadinessReason = "missing_secrets" | "no_agents_configured";
+
+export interface CompanyReadiness {
+  companyId: string;
+  status: "ready" | "not_ready";
+  reasons: CompanyReadinessReason[];
+  webSetupUrl: string;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,4 +1,10 @@
 export type { Company } from "./company.js";
+export type { CompanyReadiness, CompanyReadinessReason } from "./company-readiness.js";
+export type {
+  CreateMobileWebHandoffRequest,
+  MobileWebHandoffResponse,
+  MobileWebHandoffTarget,
+} from "./mobile-web-handoff.js";
 export type {
   FeedbackVote,
   FeedbackDataSharingPreference,

--- a/packages/shared/src/types/mobile-web-handoff.ts
+++ b/packages/shared/src/types/mobile-web-handoff.ts
@@ -1,0 +1,12 @@
+export type MobileWebHandoffTarget = "onboarding";
+
+export interface CreateMobileWebHandoffRequest {
+  target: MobileWebHandoffTarget;
+  companyId?: string;
+  returnUrl?: string;
+}
+
+export interface MobileWebHandoffResponse {
+  url: string;
+  expiresAt: string;
+}

--- a/packages/shared/src/types/mobile-web-handoff.ts
+++ b/packages/shared/src/types/mobile-web-handoff.ts
@@ -1,8 +1,9 @@
-export type MobileWebHandoffTarget = "onboarding";
+export type MobileWebHandoffTarget = "onboarding" | "agent_configuration";
 
 export interface CreateMobileWebHandoffRequest {
   target: MobileWebHandoffTarget;
   companyId?: string;
+  agentId?: string;
   returnUrl?: string;
 }
 

--- a/server/src/__tests__/company-branding-route.test.ts
+++ b/server/src/__tests__/company-branding-route.test.ts
@@ -38,6 +38,9 @@ const mockFeedbackService = vi.hoisted(() => ({
   getFeedbackTraceById: vi.fn(),
   saveIssueVote: vi.fn(),
 }));
+const mockSecretService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
 
 vi.mock("../services/index.js", () => ({
   accessService: () => mockAccessService,
@@ -47,6 +50,7 @@ vi.mock("../services/index.js", () => ({
   companyService: () => mockCompanyService,
   feedbackService: () => mockFeedbackService,
   logActivity: mockLogActivity,
+  secretService: () => mockSecretService,
 }));
 
 function createCompany() {

--- a/server/src/__tests__/company-portability-routes.test.ts
+++ b/server/src/__tests__/company-portability-routes.test.ts
@@ -38,6 +38,9 @@ const mockFeedbackService = vi.hoisted(() => ({
   getFeedbackTraceById: vi.fn(),
   saveIssueVote: vi.fn(),
 }));
+const mockSecretService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
 
 function registerServiceMocks() {
   vi.doMock("../services/index.js", () => ({
@@ -48,6 +51,7 @@ function registerServiceMocks() {
     companyService: () => mockCompanyService,
     feedbackService: () => mockFeedbackService,
     logActivity: mockLogActivity,
+    secretService: () => mockSecretService,
   }));
 }
 

--- a/server/src/__tests__/company-readiness-route.test.ts
+++ b/server/src/__tests__/company-readiness-route.test.ts
@@ -1,0 +1,208 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCompanyService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const mockSecretService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({}),
+  agentService: () => mockAgentService,
+  budgetService: () => ({}),
+  companyPortabilityService: () => ({}),
+  companyService: () => mockCompanyService,
+  feedbackService: () => ({}),
+  secretService: () => mockSecretService,
+  logActivity: vi.fn(),
+}));
+
+function createCompany(overrides: Record<string, unknown> = {}) {
+  const now = new Date("2026-03-19T02:00:00.000Z");
+  return {
+    id: "company-1",
+    name: "Paperclip",
+    description: null,
+    status: "active",
+    pauseReason: null,
+    pausedAt: null,
+    issuePrefix: "PAP",
+    issueCounter: 1,
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    requireBoardApprovalForNewAgents: false,
+    feedbackDataSharingEnabled: false,
+    feedbackDataSharingConsentAt: null,
+    feedbackDataSharingConsentByUserId: null,
+    feedbackDataSharingTermsVersion: null,
+    brandColor: null,
+    logoAssetId: null,
+    logoUrl: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ companyRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/companies.js"),
+    import("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api/companies", companyRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("GET /api/companies/:companyId/readiness", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+  });
+
+  it("returns ready when the company has agents and secrets", async () => {
+    mockCompanyService.getById.mockResolvedValue(createCompany());
+    mockAgentService.list.mockResolvedValue([{ id: "agent-1", status: "active" }]);
+    mockSecretService.list.mockResolvedValue([{ id: "secret-1" }]);
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "local_implicit",
+    });
+
+    const res = await request(app)
+      .get("/api/companies/company-1/readiness")
+      .set("host", "paperclip.example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      companyId: "company-1",
+      status: "ready",
+      reasons: [],
+      webSetupUrl: "http://paperclip.example.com/PAP/onboarding",
+    });
+    expect(mockAgentService.list).toHaveBeenCalledWith("company-1");
+    expect(mockSecretService.list).toHaveBeenCalledWith("company-1");
+  });
+
+  it("returns both reasons when agents and secrets are missing", async () => {
+    mockCompanyService.getById.mockResolvedValue(createCompany());
+    mockAgentService.list.mockResolvedValue([]);
+    mockSecretService.list.mockResolvedValue([]);
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "local_implicit",
+    });
+
+    const res = await request(app).get("/api/companies/company-1/readiness");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("not_ready");
+    expect(res.body.reasons).toEqual(["missing_secrets", "no_agents_configured"]);
+  });
+
+  it("returns missing_secrets when only secrets are missing", async () => {
+    mockCompanyService.getById.mockResolvedValue(createCompany());
+    mockAgentService.list.mockResolvedValue([{ id: "agent-1", status: "active" }]);
+    mockSecretService.list.mockResolvedValue([]);
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "local_implicit",
+    });
+
+    const res = await request(app).get("/api/companies/company-1/readiness");
+
+    expect(res.status).toBe(200);
+    expect(res.body.reasons).toEqual(["missing_secrets"]);
+  });
+
+  it("returns no_agents_configured when only agents are missing", async () => {
+    mockCompanyService.getById.mockResolvedValue(createCompany());
+    mockAgentService.list.mockResolvedValue([]);
+    mockSecretService.list.mockResolvedValue([{ id: "secret-1" }]);
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "local_implicit",
+    });
+
+    const res = await request(app).get("/api/companies/company-1/readiness");
+
+    expect(res.status).toBe(200);
+    expect(res.body.reasons).toEqual(["no_agents_configured"]);
+  });
+
+  it("falls back to /onboarding when the company prefix is missing", async () => {
+    mockCompanyService.getById.mockResolvedValue(createCompany({ issuePrefix: "" }));
+    mockAgentService.list.mockResolvedValue([]);
+    mockSecretService.list.mockResolvedValue([]);
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "local_implicit",
+    });
+
+    const res = await request(app)
+      .get("/api/companies/company-1/readiness")
+      .set("x-forwarded-proto", "https")
+      .set("x-forwarded-host", "paperclip.example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body.webSetupUrl).toBe("https://paperclip.example.com/onboarding");
+  });
+
+  it("returns 404 when the company does not exist", async () => {
+    mockCompanyService.getById.mockResolvedValue(null);
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "local_implicit",
+    });
+
+    const res = await request(app).get("/api/companies/company-1/readiness");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Company not found");
+  });
+
+  it("rejects board callers without company access", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "remote_auth",
+      companyIds: [],
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app).get("/api/companies/company-1/readiness");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("does not have access");
+  });
+
+  it("rejects unauthenticated callers", async () => {
+    const app = await createApp({
+      type: "none",
+    });
+
+    const res = await request(app).get("/api/companies/company-1/readiness");
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/src/__tests__/mobile-web-handoff-route.test.ts
+++ b/server/src/__tests__/mobile-web-handoff-route.test.ts
@@ -1,0 +1,219 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCompanyService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockMobileWebHandoffService = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => mockCompanyService,
+  mobileWebHandoffService: () => mockMobileWebHandoffService,
+}));
+
+function createCompany(overrides: Record<string, unknown> = {}) {
+  const now = new Date("2026-03-19T02:00:00.000Z");
+  return {
+    id: "company-1",
+    name: "Paperclip",
+    description: null,
+    status: "active",
+    pauseReason: null,
+    pausedAt: null,
+    issuePrefix: "PAP",
+    issueCounter: 1,
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    requireBoardApprovalForNewAgents: false,
+    feedbackDataSharingEnabled: false,
+    feedbackDataSharingConsentAt: null,
+    feedbackDataSharingConsentByUserId: null,
+    feedbackDataSharingTermsVersion: null,
+    brandColor: null,
+    logoAssetId: null,
+    logoUrl: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ mobileWebHandoffRedirectRoutes, mobileWebHandoffRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/mobile-web-handoff.js"),
+    import("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use(mobileWebHandoffRedirectRoutes());
+  app.use("/api/mobile-web-handoff", mobileWebHandoffRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("mobile web handoff routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+  });
+
+  it("creates a no-company onboarding handoff", async () => {
+    mockMobileWebHandoffService.create.mockResolvedValue({
+      token: "token-123",
+      expiresAt: new Date("2026-04-13T16:00:00.000Z"),
+    });
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "local_implicit",
+    });
+
+    const res = await request(app)
+      .post("/api/mobile-web-handoff")
+      .set("host", "paperclip.example.com")
+      .send({ target: "onboarding" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      url: "http://paperclip.example.com/auth/mobile-handoff?token=token-123",
+      expiresAt: "2026-04-13T16:00:00.000Z",
+    });
+    expect(mockMobileWebHandoffService.create).toHaveBeenCalledWith({
+      userId: "user-1",
+      targetPath: "/onboarding",
+      companyId: null,
+    });
+  });
+
+  it("creates a company-scoped onboarding handoff", async () => {
+    mockCompanyService.getById.mockResolvedValue(createCompany());
+    mockMobileWebHandoffService.create.mockResolvedValue({
+      token: "token-123",
+      expiresAt: new Date("2026-04-13T16:00:00.000Z"),
+    });
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "remote_auth",
+      companyIds: ["company-1"],
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .post("/api/mobile-web-handoff")
+      .send({ target: "onboarding", companyId: "company-1" });
+
+    expect(res.status).toBe(200);
+    expect(mockMobileWebHandoffService.create).toHaveBeenCalledWith({
+      userId: "user-1",
+      targetPath: "/PAP/onboarding",
+      companyId: "company-1",
+    });
+  });
+
+  it("passes through the fixed onboarding return url", async () => {
+    mockCompanyService.getById.mockResolvedValue({
+      id: "company-1",
+      issuePrefix: "PAP",
+    });
+    mockMobileWebHandoffService.create.mockResolvedValue({
+      token: "token-123",
+      expiresAt: new Date("2026-04-13T16:00:00.000Z"),
+    });
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "remote_auth",
+      companyIds: ["company-1"],
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .post("/api/mobile-web-handoff")
+      .send({
+        target: "onboarding",
+        companyId: "company-1",
+        returnUrl: "clipios://onboarding-complete",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockMobileWebHandoffService.create).toHaveBeenCalledWith({
+      userId: "user-1",
+      targetPath: "/PAP/onboarding?returnUrl=clipios%3A%2F%2Fonboarding-complete",
+      companyId: "company-1",
+    });
+  });
+
+  it("rejects unsupported return urls", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "remote_auth",
+      companyIds: [],
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .post("/api/mobile-web-handoff")
+      .send({
+        target: "onboarding",
+        returnUrl: "https://example.com/callback",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Unsupported returnUrl");
+  });
+
+  it("returns 404 when the requested company is missing", async () => {
+    mockCompanyService.getById.mockResolvedValue(null);
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "remote_auth",
+      companyIds: ["company-1"],
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .post("/api/mobile-web-handoff")
+      .send({ target: "onboarding", companyId: "company-1" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Company not found");
+  });
+
+  it("rejects unauthorized company access", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "remote_auth",
+      companyIds: [],
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .post("/api/mobile-web-handoff")
+      .send({ target: "onboarding", companyId: "company-1" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("redirects public handoff requests into the auth consume route", async () => {
+    const app = await createApp({
+      type: "none",
+    });
+
+    const res = await request(app).get("/auth/mobile-handoff?token=token-123");
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe("/api/auth/mobile-web-handoff/consume?token=token-123");
+  });
+});

--- a/server/src/__tests__/mobile-web-handoff-route.test.ts
+++ b/server/src/__tests__/mobile-web-handoff-route.test.ts
@@ -6,12 +6,17 @@ const mockCompanyService = vi.hoisted(() => ({
   getById: vi.fn(),
 }));
 
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
 const mockMobileWebHandoffService = vi.hoisted(() => ({
   create: vi.fn(),
 }));
 
 vi.mock("../services/index.js", () => ({
   companyService: () => mockCompanyService,
+  agentService: () => mockAgentService,
   mobileWebHandoffService: () => mockMobileWebHandoffService,
 }));
 
@@ -38,6 +43,31 @@ function createCompany(overrides: Record<string, unknown> = {}) {
     logoUrl: null,
     createdAt: now,
     updatedAt: now,
+    ...overrides,
+  };
+}
+
+function createAgent(overrides: Record<string, unknown> = {}) {
+  const now = new Date("2026-03-19T02:00:00.000Z");
+  return {
+    id: "agent-1",
+    companyId: "company-1",
+    name: "CTO",
+    role: "cto",
+    status: "active",
+    adapterType: "openai",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    title: null,
+    reportsTo: null,
+    capabilities: null,
+    metadata: null,
+    permissions: [],
+    createdAt: now,
+    updatedAt: now,
+    urlKey: "cto",
     ...overrides,
   };
 }
@@ -152,6 +182,37 @@ describe("mobile web handoff routes", () => {
     });
   });
 
+  it("creates an agent configuration handoff", async () => {
+    mockCompanyService.getById.mockResolvedValue(createCompany());
+    mockAgentService.getById.mockResolvedValue(createAgent());
+    mockMobileWebHandoffService.create.mockResolvedValue({
+      token: "token-123",
+      expiresAt: new Date("2026-04-13T16:00:00.000Z"),
+    });
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "remote_auth",
+      companyIds: ["company-1"],
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .post("/api/mobile-web-handoff")
+      .send({
+        target: "agent_configuration",
+        companyId: "company-1",
+        agentId: "agent-1",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockMobileWebHandoffService.create).toHaveBeenCalledWith({
+      userId: "user-1",
+      targetPath: "/PAP/agents/cto/configuration",
+      companyId: "company-1",
+    });
+  });
+
   it("rejects unsupported return urls", async () => {
     const app = await createApp({
       type: "board",
@@ -188,6 +249,29 @@ describe("mobile web handoff routes", () => {
 
     expect(res.status).toBe(404);
     expect(res.body.error).toBe("Company not found");
+  });
+
+  it("returns 404 when the requested agent is missing", async () => {
+    mockCompanyService.getById.mockResolvedValue(createCompany());
+    mockAgentService.getById.mockResolvedValue(null);
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "remote_auth",
+      companyIds: ["company-1"],
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .post("/api/mobile-web-handoff")
+      .send({
+        target: "agent_configuration",
+        companyId: "company-1",
+        agentId: "agent-1",
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Agent not found");
   });
 
   it("rejects unauthorized company access", async () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -32,6 +32,7 @@ import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
+import { mobileWebHandoffRedirectRoutes, mobileWebHandoffRoutes } from "./routes/mobile-web-handoff.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
 import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
@@ -136,6 +137,7 @@ export async function createApp(
   if (opts.betterAuthHandler) {
     app.all("/api/auth/{*authPath}", opts.betterAuthHandler);
   }
+  app.use(mobileWebHandoffRedirectRoutes());
   app.use(llmRoutes(db));
 
   // Mount API routes
@@ -151,6 +153,7 @@ export async function createApp(
     }),
   );
   api.use("/companies", companyRoutes(db, opts.storageService));
+  api.use("/mobile-web-handoff", mobileWebHandoffRoutes(db));
   api.use(companySkillRoutes(db));
   api.use(agentRoutes(db));
   api.use(assetRoutes(db, opts.storageService));

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -11,6 +11,7 @@ import {
   authVerifications,
 } from "@paperclipai/db";
 import type { Config } from "../config.js";
+import { mobileWebHandoffAuthPlugin } from "./mobile-web-handoff-plugin.js";
 
 export type BetterAuthSessionUser = {
   id: string;
@@ -23,7 +24,7 @@ export type BetterAuthSessionResult = {
   user: BetterAuthSessionUser | null;
 };
 
-type BetterAuthInstance = ReturnType<typeof betterAuth>;
+export type BetterAuthInstance = ReturnType<typeof betterAuth>;
 
 function headersFromNodeHeaders(rawHeaders: IncomingHttpHeaders): Headers {
   const headers = new Headers();
@@ -97,6 +98,7 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?
       requireEmailVerification: false,
       disableSignUp: config.authDisableSignUp,
     },
+    plugins: [mobileWebHandoffAuthPlugin(db)],
     ...(isHttpOnly ? { advanced: { useSecureCookies: false } } : {}),
   };
 

--- a/server/src/auth/mobile-web-handoff-plugin.ts
+++ b/server/src/auth/mobile-web-handoff-plugin.ts
@@ -1,0 +1,56 @@
+import { setSessionCookie } from "better-auth/cookies";
+import { createAuthEndpoint } from "better-auth/api";
+import * as z from "zod";
+import type { Db } from "@paperclipai/db";
+import { mobileWebHandoffService } from "../services/mobile-web-handoffs.js";
+
+const consumeMobileWebHandoffQuerySchema = z.object({
+  token: z.string().min(1),
+});
+
+export function mobileWebHandoffAuthPlugin(db: Db) {
+  const handoffs = mobileWebHandoffService(db);
+
+  return {
+    id: "mobile-web-handoff",
+    endpoints: {
+      consumeMobileWebHandoff: createAuthEndpoint("/mobile-web-handoff/consume", {
+        method: "GET",
+        query: consumeMobileWebHandoffQuerySchema,
+        requireHeaders: true,
+      }, async (ctx) => {
+        const failureUrl = new URL("/onboarding", ctx.context.baseURL);
+        const redirectToFailure = (reason: string): never => {
+          const url = new URL(failureUrl);
+          url.searchParams.set("handoff", reason);
+          throw ctx.redirect(url.toString());
+        };
+
+        const result = await handoffs.consume(ctx.query.token);
+        const handoff = (() => {
+          switch (result.status) {
+          case "ok":
+            return result.handoff;
+          case "invalid":
+            return redirectToFailure("invalid");
+          case "expired":
+            return redirectToFailure("expired");
+          case "used":
+            return redirectToFailure("used");
+          }
+        })();
+
+        const user = (await ctx.context.internalAdapter.findUserById(handoff.userId))
+          ?? redirectToFailure("missing_user");
+
+        const session = await ctx.context.internalAdapter.createSession(user.id);
+        if (!session) {
+          redirectToFailure("session_failed");
+        }
+
+        await setSessionCookie(ctx, { session, user });
+        throw ctx.redirect(new URL(handoff.targetPath, ctx.context.baseURL).toString());
+      }),
+    },
+  };
+}

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1754,6 +1754,7 @@ export function accessRoutes(
     if (req.actor.type !== "board" || !req.actor.userId) {
       throw unauthorized("Board authentication required");
     }
+    res.setHeader("Cache-Control", "no-store");
     const accessSnapshot = await boardAuth.resolveBoardAccess(req.actor.userId);
     res.json({
       user: accessSnapshot.user,

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -2,6 +2,7 @@ import { Router, type Request } from "express";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_FEEDBACK_DATA_SHARING_TERMS_VERSION,
+  type CompanyReadiness,
   companyPortabilityExportSchema,
   companyPortabilityImportSchema,
   companyPortabilityPreviewSchema,
@@ -22,6 +23,7 @@ import {
   companyService,
   feedbackService,
   logActivity,
+  secretService,
 } from "../services/index.js";
 import type { StorageService } from "../storage/types.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
@@ -34,6 +36,7 @@ export function companyRoutes(db: Db, storage?: StorageService) {
   const access = accessService(db);
   const budgets = budgetService(db);
   const feedback = feedbackService(db);
+  const secrets = secretService(db);
 
   function parseBooleanQuery(value: unknown) {
     return value === true || value === "true" || value === "1";
@@ -46,6 +49,23 @@ export function companyRoutes(db: Db, storage?: StorageService) {
       throw badRequest(`Invalid ${field} query value`);
     }
     return parsed;
+  }
+
+  function requestBaseUrl(req: Request) {
+    const forwardedProto = req.header("x-forwarded-proto");
+    const proto = forwardedProto?.split(",")[0]?.trim() || req.protocol || "http";
+    const host =
+      req.header("x-forwarded-host")?.split(",")[0]?.trim() || req.header("host");
+    if (!host) return "";
+    return `${proto}://${host}`;
+  }
+
+  function buildOnboardingUrl(req: Request, issuePrefix: string | null | undefined) {
+    const path = issuePrefix && issuePrefix.trim().length > 0
+      ? `/${issuePrefix}/onboarding`
+      : "/onboarding";
+    const baseUrl = requestBaseUrl(req);
+    return baseUrl ? `${baseUrl}${path}` : path;
   }
 
   function assertImportTargetAccess(
@@ -132,6 +152,39 @@ export function companyRoutes(db: Db, storage?: StorageService) {
       return;
     }
     res.json(company);
+  });
+
+  router.get("/:companyId/readiness", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    assertBoard(req);
+
+    const company = await svc.getById(companyId);
+    if (!company) {
+      res.status(404).json({ error: "Company not found" });
+      return;
+    }
+
+    const [companyAgents, companySecrets] = await Promise.all([
+      agents.list(companyId),
+      secrets.list(companyId),
+    ]);
+
+    const reasons: CompanyReadiness["reasons"] = [];
+    if (companySecrets.length === 0) {
+      reasons.push("missing_secrets");
+    }
+    if (companyAgents.length === 0) {
+      reasons.push("no_agents_configured");
+    }
+
+    const payload: CompanyReadiness = {
+      companyId,
+      status: reasons.length === 0 ? "ready" : "not_ready",
+      reasons,
+      webSetupUrl: buildOnboardingUrl(req, company.issuePrefix),
+    };
+    res.json(payload);
   });
 
   router.get("/:companyId/feedback-traces", async (req, res) => {

--- a/server/src/routes/mobile-web-handoff.ts
+++ b/server/src/routes/mobile-web-handoff.ts
@@ -1,0 +1,116 @@
+import { Router, type Request } from "express";
+import * as z from "zod";
+import type { Db } from "@paperclipai/db";
+import type {
+  CreateMobileWebHandoffRequest,
+  MobileWebHandoffResponse,
+} from "@paperclipai/shared";
+import { companyService, mobileWebHandoffService } from "../services/index.js";
+import { badRequest } from "../errors.js";
+import { assertBoard, assertCompanyAccess } from "./authz.js";
+
+const createMobileWebHandoffBodySchema = z.object({
+  target: z.literal("onboarding"),
+  companyId: z.string().trim().min(1).optional(),
+  returnUrl: z.string().trim().url().optional(),
+});
+
+const ALLOWED_RETURN_URL = "clipios://onboarding-complete";
+
+function requestBaseUrl(req: Request) {
+  const forwardedProto = req.header("x-forwarded-proto");
+  const proto = forwardedProto?.split(",")[0]?.trim() || req.protocol || "http";
+  const host =
+    req.header("x-forwarded-host")?.split(",")[0]?.trim() || req.header("host");
+  if (!host) return "";
+  return `${proto}://${host}`;
+}
+
+function buildAbsoluteUrl(req: Request, path: string) {
+  const baseUrl = requestBaseUrl(req);
+  return baseUrl ? `${baseUrl}${path}` : path;
+}
+
+function buildAuthConsumePath(token: string) {
+  const query = new URLSearchParams({ token });
+  return `/auth/mobile-handoff?${query.toString()}`;
+}
+
+function buildPluginConsumePath(token: string) {
+  const query = new URLSearchParams({ token });
+  return `/api/auth/mobile-web-handoff/consume?${query.toString()}`;
+}
+
+function buildOnboardingTargetPath(issuePrefix: string | null | undefined) {
+  return issuePrefix && issuePrefix.trim().length > 0
+    ? `/${issuePrefix}/onboarding`
+    : "/onboarding";
+}
+
+export function mobileWebHandoffRoutes(db: Db) {
+  const router = Router();
+  const companies = companyService(db);
+  const handoffs = mobileWebHandoffService(db);
+
+  router.post("/", async (req, res) => {
+    assertBoard(req);
+    const body = createMobileWebHandoffBodySchema.parse(req.body) as CreateMobileWebHandoffRequest;
+    const userId = req.actor.userId;
+    if (!userId) {
+      throw badRequest("Missing board user");
+    }
+
+    let companyId: string | null = null;
+    let targetPath = "/onboarding";
+
+    if (body.returnUrl && body.returnUrl !== ALLOWED_RETURN_URL) {
+      throw badRequest("Unsupported returnUrl");
+    }
+
+    if (body.companyId) {
+      companyId = body.companyId;
+      assertCompanyAccess(req, companyId);
+      const company = await companies.getById(companyId);
+      if (!company) {
+        res.status(404).json({ error: "Company not found" });
+        return;
+      }
+      targetPath = buildOnboardingTargetPath(company.issuePrefix);
+    }
+
+    if (body.returnUrl) {
+      const targetUrl = new URL(targetPath, "http://paperclip.local");
+      targetUrl.searchParams.set("returnUrl", body.returnUrl);
+      targetPath = `${targetUrl.pathname}${targetUrl.search}`;
+    }
+
+    const handoff = await handoffs.create({
+      userId,
+      targetPath,
+      companyId,
+    });
+
+    const payload: MobileWebHandoffResponse = {
+      url: buildAbsoluteUrl(req, buildAuthConsumePath(handoff.token)),
+      expiresAt: handoff.expiresAt.toISOString(),
+    };
+    res.json(payload);
+  });
+
+  return router;
+}
+
+export function mobileWebHandoffRedirectRoutes() {
+  const router = Router();
+
+  router.get("/auth/mobile-handoff", (req, res) => {
+    const token = typeof req.query.token === "string" ? req.query.token.trim() : "";
+    if (!token) {
+      res.status(400).send("Missing token");
+      return;
+    }
+    res.redirect(302, buildPluginConsumePath(token));
+  });
+
+  return router;
+}

--- a/server/src/routes/mobile-web-handoff.ts
+++ b/server/src/routes/mobile-web-handoff.ts
@@ -5,15 +5,22 @@ import type {
   CreateMobileWebHandoffRequest,
   MobileWebHandoffResponse,
 } from "@paperclipai/shared";
-import { companyService, mobileWebHandoffService } from "../services/index.js";
+import { agentService, companyService, mobileWebHandoffService } from "../services/index.js";
 import { badRequest } from "../errors.js";
 import { assertBoard, assertCompanyAccess } from "./authz.js";
 
-const createMobileWebHandoffBodySchema = z.object({
-  target: z.literal("onboarding"),
-  companyId: z.string().trim().min(1).optional(),
-  returnUrl: z.string().trim().url().optional(),
-});
+const createMobileWebHandoffBodySchema = z.discriminatedUnion("target", [
+  z.object({
+    target: z.literal("onboarding"),
+    companyId: z.string().trim().min(1).optional(),
+    returnUrl: z.string().trim().url().optional(),
+  }),
+  z.object({
+    target: z.literal("agent_configuration"),
+    companyId: z.string().trim().min(1),
+    agentId: z.string().trim().min(1),
+  }),
+]);
 
 const ALLOWED_RETURN_URL = "clipios://onboarding-complete";
 
@@ -50,6 +57,7 @@ function buildOnboardingTargetPath(issuePrefix: string | null | undefined) {
 export function mobileWebHandoffRoutes(db: Db) {
   const router = Router();
   const companies = companyService(db);
+  const agents = agentService(db);
   const handoffs = mobileWebHandoffService(db);
 
   router.post("/", async (req, res) => {
@@ -60,28 +68,42 @@ export function mobileWebHandoffRoutes(db: Db) {
       throw badRequest("Missing board user");
     }
 
-    let companyId: string | null = null;
+    let companyId: string | null = body.companyId ?? null;
     let targetPath = "/onboarding";
 
-    if (body.returnUrl && body.returnUrl !== ALLOWED_RETURN_URL) {
+    if (body.target === "onboarding" && body.returnUrl && body.returnUrl !== ALLOWED_RETURN_URL) {
       throw badRequest("Unsupported returnUrl");
     }
 
     if (body.companyId) {
-      companyId = body.companyId;
-      assertCompanyAccess(req, companyId);
-      const company = await companies.getById(companyId);
+      const requestedCompanyId = body.companyId;
+      companyId = requestedCompanyId;
+      assertCompanyAccess(req, requestedCompanyId);
+      const company = await companies.getById(requestedCompanyId);
       if (!company) {
         res.status(404).json({ error: "Company not found" });
         return;
       }
-      targetPath = buildOnboardingTargetPath(company.issuePrefix);
-    }
 
-    if (body.returnUrl) {
-      const targetUrl = new URL(targetPath, "http://paperclip.local");
-      targetUrl.searchParams.set("returnUrl", body.returnUrl);
-      targetPath = `${targetUrl.pathname}${targetUrl.search}`;
+      if (body.target === "onboarding") {
+        targetPath = buildOnboardingTargetPath(company.issuePrefix);
+        if (body.returnUrl) {
+          const targetUrl = new URL(targetPath, "http://paperclip.local");
+          targetUrl.searchParams.set("returnUrl", body.returnUrl);
+          targetPath = `${targetUrl.pathname}${targetUrl.search}`;
+        }
+      } else {
+        if (!body.agentId) {
+          throw badRequest("Missing agentId");
+        }
+        const agentId = body.agentId;
+        const agent = await agents.getById(agentId);
+        if (!agent || agent.companyId !== requestedCompanyId) {
+          res.status(404).json({ error: "Agent not found" });
+          return;
+        }
+        targetPath = `/${company.issuePrefix}/agents/${agent.urlKey ?? agent.id}/configuration`;
+      }
     }
 
     const handoff = await handoffs.create({

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, gte, inArray, lt, sql } from "drizzle-orm";
+import { and, count, eq, gte, inArray, lt, ne, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   companies,
@@ -154,7 +154,8 @@ export function companyService(db: Db) {
 
   return {
     list: async () => {
-      const rows = await getCompanyQuery(db);
+      const rows = await getCompanyQuery(db)
+        .where(ne(companies.status, "archived"));
       const hydrated = await hydrateCompanySpend(rows);
       return hydrated.map((row) => enrichCompany(row));
     },

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -22,6 +22,7 @@ export { sidebarBadgeService } from "./sidebar-badges.js";
 export { inboxDismissalService } from "./inbox-dismissals.js";
 export { accessService } from "./access.js";
 export { boardAuthService } from "./board-auth.js";
+export { mobileWebHandoffService } from "./mobile-web-handoffs.js";
 export { instanceSettingsService } from "./instance-settings.js";
 export { companyPortabilityService } from "./company-portability.js";
 export { executionWorkspaceService } from "./execution-workspaces.js";

--- a/server/src/services/mobile-web-handoffs.ts
+++ b/server/src/services/mobile-web-handoffs.ts
@@ -1,0 +1,85 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { and, eq, isNull } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { mobileWebHandoffs } from "@paperclipai/db";
+
+export const MOBILE_WEB_HANDOFF_TTL_MS = 10 * 60 * 1000;
+
+export type MobileWebHandoffConsumeResult =
+  | { status: "invalid" }
+  | { status: "expired" }
+  | { status: "used" }
+  | { status: "ok"; handoff: typeof mobileWebHandoffs.$inferSelect };
+
+function hashToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function createToken() {
+  return `pcp_mwh_${randomBytes(24).toString("hex")}`;
+}
+
+export function mobileWebHandoffService(db: Db) {
+  async function create(input: {
+    userId: string;
+    targetPath: string;
+    companyId?: string | null;
+  }) {
+    const token = createToken();
+    const expiresAt = new Date(Date.now() + MOBILE_WEB_HANDOFF_TTL_MS);
+    await db.insert(mobileWebHandoffs).values({
+      id: randomUUID(),
+      tokenHash: hashToken(token),
+      userId: input.userId,
+      targetPath: input.targetPath,
+      companyId: input.companyId ?? null,
+      expiresAt,
+      createdAt: new Date(),
+    });
+
+    return { token, expiresAt };
+  }
+
+  async function consume(token: string): Promise<MobileWebHandoffConsumeResult> {
+    const tokenHash = hashToken(token);
+    const handoff = await db
+      .select()
+      .from(mobileWebHandoffs)
+      .where(eq(mobileWebHandoffs.tokenHash, tokenHash))
+      .then((rows) => rows[0] ?? null);
+
+    if (!handoff) {
+      return { status: "invalid" };
+    }
+    if (handoff.usedAt) {
+      return { status: "used" };
+    }
+    if (handoff.expiresAt.getTime() <= Date.now()) {
+      return { status: "expired" };
+    }
+
+    const usedAt = new Date();
+    const consumed = await db
+      .update(mobileWebHandoffs)
+      .set({ usedAt })
+      .where(
+        and(
+          eq(mobileWebHandoffs.id, handoff.id),
+          isNull(mobileWebHandoffs.usedAt),
+        ),
+      )
+      .returning()
+      .then((rows) => rows[0] ?? null);
+
+    if (!consumed) {
+      return { status: "used" };
+    }
+
+    return { status: "ok", handoff: consumed };
+  }
+
+  return {
+    create,
+    consume,
+  };
+}

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -118,6 +118,12 @@ export function OnboardingWizard() {
   const [forceUnsetAnthropicApiKey, setForceUnsetAnthropicApiKey] =
     useState(false);
   const [unsetAnthropicLoading, setUnsetAnthropicLoading] = useState(false);
+  const onboardingReturnUrl = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const candidate = params.get("returnUrl")?.trim();
+    if (!candidate) return null;
+    return candidate === "clipios://onboarding-complete" ? candidate : null;
+  }, [location.search]);
   const [showMoreAdapters, setShowMoreAdapters] = useState(false);
 
   // Step 3
@@ -575,6 +581,10 @@ export function OnboardingWizard() {
       }
 
       setSelectedCompanyId(createdCompanyId);
+      if (onboardingReturnUrl) {
+        window.location.assign(onboardingReturnUrl);
+        return;
+      }
       reset();
       closeOnboarding();
       navigate(

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback, useMemo } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
 import { useLocation, useNavigate, useParams } from "@/lib/router";
@@ -7,8 +7,6 @@ import { useCompany } from "../context/CompanyContext";
 import { companiesApi } from "../api/companies";
 import { goalsApi } from "../api/goals";
 import { agentsApi } from "../api/agents";
-import { issuesApi } from "../api/issues";
-import { projectsApi } from "../api/projects";
 import { queryKeys } from "../lib/queryKeys";
 import { Dialog, DialogPortal } from "@/components/ui/dialog";
 import {
@@ -17,7 +15,7 @@ import {
   PopoverTrigger
 } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
-import { cn } from "../lib/utils";
+import { agentUrl, cn } from "../lib/utils";
 import {
   extractModelName,
   extractProviderIdWithFallback
@@ -28,11 +26,6 @@ import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 import { getAdapterDisplay } from "../adapters/adapter-display-registry";
 import { defaultCreateValues } from "./agent-config-defaults";
 import { parseOnboardingGoalInput } from "../lib/onboarding-goal";
-import {
-  buildOnboardingIssuePayload,
-  buildOnboardingProjectPayload,
-  selectDefaultCompanyGoalId
-} from "../lib/onboarding-launch";
 import { buildNewAgentRuntimeConfig } from "../lib/new-agent-runtime-config";
 import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
@@ -45,8 +38,6 @@ import { AsciiArtAnimation } from "./AsciiArtAnimation";
 import {
   Building2,
   Bot,
-  ListTodo,
-  Rocket,
   ArrowLeft,
   ArrowRight,
   Check,
@@ -56,14 +47,8 @@ import {
 } from "lucide-react";
 
 
-type Step = 1 | 2 | 3 | 4;
+type Step = 1 | 2;
 type AdapterType = string;
-
-const DEFAULT_TASK_DESCRIPTION = `You are the CEO. You set the direction for the company.
-
-- hire a founding engineer
-- write a hiring plan
-- break the roadmap into concrete tasks and start delegating work`;
 
 export function OnboardingWizard() {
   const { onboardingOpen, onboardingOptions, closeOnboarding } = useDialog();
@@ -91,7 +76,8 @@ export function OnboardingWizard() {
     ? onboardingOptions
     : routeOnboardingOptions ?? {};
 
-  const initialStep = effectiveOnboardingOptions.initialStep ?? 1;
+  const initialStep: Step =
+    effectiveOnboardingOptions.initialStep === 2 ? 2 : 1;
   const existingCompanyId = effectiveOnboardingOptions.companyId;
 
   const [step, setStep] = useState<Step>(initialStep);
@@ -126,23 +112,6 @@ export function OnboardingWizard() {
   }, [location.search]);
   const [showMoreAdapters, setShowMoreAdapters] = useState(false);
 
-  // Step 3
-  const [taskTitle, setTaskTitle] = useState(
-    "Hire your first engineer and create a hiring plan"
-  );
-  const [taskDescription, setTaskDescription] = useState(
-    DEFAULT_TASK_DESCRIPTION
-  );
-
-  // Auto-grow textarea for task description
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const autoResizeTextarea = useCallback(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = el.scrollHeight + "px";
-  }, []);
-
   // Created entity IDs — pre-populate from existing company when skipping step 1
   const [createdCompanyId, setCreatedCompanyId] = useState<string | null>(
     existingCompanyId ?? null
@@ -150,12 +119,7 @@ export function OnboardingWizard() {
   const [createdCompanyPrefix, setCreatedCompanyPrefix] = useState<
     string | null
   >(null);
-  const [createdCompanyGoalId, setCreatedCompanyGoalId] = useState<string | null>(
-    null
-  );
   const [createdAgentId, setCreatedAgentId] = useState<string | null>(null);
-  const [createdProjectId, setCreatedProjectId] = useState<string | null>(null);
-  const [createdIssueRef, setCreatedIssueRef] = useState<string | null>(null);
 
   useEffect(() => {
     setRouteDismissed(false);
@@ -167,13 +131,10 @@ export function OnboardingWizard() {
   useEffect(() => {
     if (!effectiveOnboardingOpen) return;
     const cId = effectiveOnboardingOptions.companyId ?? null;
-    setStep(effectiveOnboardingOptions.initialStep ?? 1);
+    setStep(effectiveOnboardingOptions.initialStep === 2 ? 2 : 1);
     setCreatedCompanyId(cId);
     setCreatedCompanyPrefix(null);
-    setCreatedCompanyGoalId(null);
-    setCreatedProjectId(null);
     setCreatedAgentId(null);
-    setCreatedIssueRef(null);
   }, [
     effectiveOnboardingOpen,
     effectiveOnboardingOptions.companyId,
@@ -186,11 +147,6 @@ export function OnboardingWizard() {
     const company = companies.find((c) => c.id === createdCompanyId);
     if (company) setCreatedCompanyPrefix(company.issuePrefix);
   }, [effectiveOnboardingOpen, createdCompanyId, createdCompanyPrefix, companies]);
-
-  // Resize textarea when step 3 is shown or description changes
-  useEffect(() => {
-    if (step === 3) autoResizeTextarea();
-  }, [step, taskDescription, autoResizeTextarea]);
 
   const {
     data: adapterModels,
@@ -301,14 +257,9 @@ export function OnboardingWizard() {
     setAdapterEnvLoading(false);
     setForceUnsetAnthropicApiKey(false);
     setUnsetAnthropicLoading(false);
-    setTaskTitle("Hire your first engineer and create a hiring plan");
-    setTaskDescription(DEFAULT_TASK_DESCRIPTION);
     setCreatedCompanyId(null);
     setCreatedCompanyPrefix(null);
-    setCreatedCompanyGoalId(null);
     setCreatedAgentId(null);
-    setCreatedProjectId(null);
-    setCreatedIssueRef(null);
   }
 
   function handleClose() {
@@ -395,7 +346,7 @@ export function OnboardingWizard() {
 
       if (companyGoal.trim()) {
         const parsedGoal = parseOnboardingGoalInput(companyGoal);
-        const goal = await goalsApi.create(company.id, {
+        await goalsApi.create(company.id, {
           title: parsedGoal.title,
           ...(parsedGoal.description
             ? { description: parsedGoal.description }
@@ -403,12 +354,9 @@ export function OnboardingWizard() {
           level: "company",
           status: "active"
         });
-        setCreatedCompanyGoalId(goal.id);
         queryClient.invalidateQueries({
           queryKey: queryKeys.goals.list(company.id)
         });
-      } else {
-        setCreatedCompanyGoalId(null);
       }
 
       setStep(2);
@@ -473,7 +421,18 @@ export function OnboardingWizard() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.agents.list(createdCompanyId)
       });
-      setStep(3);
+      setSelectedCompanyId(createdCompanyId);
+      if (onboardingReturnUrl) {
+        window.location.assign(onboardingReturnUrl);
+        return;
+      }
+      reset();
+      closeOnboarding();
+      navigate(
+        createdCompanyPrefix
+          ? `/${createdCompanyPrefix}${agentUrl(agent)}`
+          : agentUrl(agent)
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create agent");
     } finally {
@@ -530,82 +489,11 @@ export function OnboardingWizard() {
     }
   }
 
-  async function handleStep3Next() {
-    if (!createdCompanyId || !createdAgentId) return;
-    setError(null);
-    setStep(4);
-  }
-
-  async function handleLaunch() {
-    if (!createdCompanyId || !createdAgentId) return;
-    setLoading(true);
-    setError(null);
-    try {
-      let goalId = createdCompanyGoalId;
-      if (!goalId) {
-        const goals = await goalsApi.list(createdCompanyId);
-        goalId = selectDefaultCompanyGoalId(goals);
-        setCreatedCompanyGoalId(goalId);
-      }
-
-      let projectId = createdProjectId;
-      if (!projectId) {
-        const project = await projectsApi.create(
-          createdCompanyId,
-          buildOnboardingProjectPayload(goalId)
-        );
-        projectId = project.id;
-        setCreatedProjectId(projectId);
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.projects.list(createdCompanyId)
-        });
-      }
-
-      let issueRef = createdIssueRef;
-      if (!issueRef) {
-        const issue = await issuesApi.create(
-          createdCompanyId,
-          buildOnboardingIssuePayload({
-            title: taskTitle,
-            description: taskDescription,
-            assigneeAgentId: createdAgentId,
-            projectId,
-            goalId
-          })
-        );
-        issueRef = issue.identifier ?? issue.id;
-        setCreatedIssueRef(issueRef);
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.issues.list(createdCompanyId)
-        });
-      }
-
-      setSelectedCompanyId(createdCompanyId);
-      if (onboardingReturnUrl) {
-        window.location.assign(onboardingReturnUrl);
-        return;
-      }
-      reset();
-      closeOnboarding();
-      navigate(
-        createdCompanyPrefix
-          ? `/${createdCompanyPrefix}/issues/${issueRef}`
-          : `/issues/${issueRef}`
-      );
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create task");
-    } finally {
-      setLoading(false);
-    }
-  }
-
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       if (step === 1 && companyName.trim()) handleStep1Next();
       else if (step === 2 && agentName.trim()) handleStep2Next();
-      else if (step === 3 && taskTitle.trim()) handleStep3Next();
-      else if (step === 4) handleLaunch();
     }
   }
 
@@ -649,9 +537,7 @@ export function OnboardingWizard() {
                 {(
                   [
                     { step: 1 as Step, label: "Company", icon: Building2 },
-                    { step: 2 as Step, label: "Agent", icon: Bot },
-                    { step: 3 as Step, label: "Task", icon: ListTodo },
-                    { step: 4 as Step, label: "Launch", icon: Rocket }
+                    { step: 2 as Step, label: "Agent", icon: Bot }
                   ] as const
                 ).map(({ step: s, label, icon: Icon }) => (
                   <button
@@ -1096,98 +982,6 @@ export function OnboardingWizard() {
                 </div>
               )}
 
-              {step === 3 && (
-                <div className="space-y-5">
-                  <div className="flex items-center gap-3 mb-1">
-                    <div className="bg-muted/50 p-2">
-                      <ListTodo className="h-5 w-5 text-muted-foreground" />
-                    </div>
-                    <div>
-                      <h3 className="font-medium">Give it something to do</h3>
-                      <p className="text-xs text-muted-foreground">
-                        Give your agent a small task to start with — a bug fix,
-                        a research question, writing a script.
-                      </p>
-                    </div>
-                  </div>
-                  <div>
-                    <label className="text-xs text-muted-foreground mb-1 block">
-                      Task title
-                    </label>
-                    <input
-                      className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
-                      placeholder="e.g. Research competitor pricing"
-                      value={taskTitle}
-                      onChange={(e) => setTaskTitle(e.target.value)}
-                      autoFocus
-                    />
-                  </div>
-                  <div>
-                    <label className="text-xs text-muted-foreground mb-1 block">
-                      Description (optional)
-                    </label>
-                    <textarea
-                      ref={textareaRef}
-                      className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50 resize-none min-h-[120px] max-h-[300px] overflow-y-auto"
-                      placeholder="Add more detail about what the agent should do..."
-                      value={taskDescription}
-                      onChange={(e) => setTaskDescription(e.target.value)}
-                    />
-                  </div>
-                </div>
-              )}
-
-              {step === 4 && (
-                <div className="space-y-5">
-                  <div className="flex items-center gap-3 mb-1">
-                    <div className="bg-muted/50 p-2">
-                      <Rocket className="h-5 w-5 text-muted-foreground" />
-                    </div>
-                    <div>
-                      <h3 className="font-medium">Ready to launch</h3>
-                      <p className="text-xs text-muted-foreground">
-                        Everything is set up. Launching now will create the
-                        starter task, wake the agent, and open the issue.
-                      </p>
-                    </div>
-                  </div>
-                  <div className="border border-border divide-y divide-border">
-                    <div className="flex items-center gap-3 px-3 py-2.5">
-                      <Building2 className="h-4 w-4 text-muted-foreground shrink-0" />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium truncate">
-                          {companyName}
-                        </p>
-                        <p className="text-xs text-muted-foreground">Company</p>
-                      </div>
-                      <Check className="h-4 w-4 text-green-500 shrink-0" />
-                    </div>
-                    <div className="flex items-center gap-3 px-3 py-2.5">
-                      <Bot className="h-4 w-4 text-muted-foreground shrink-0" />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium truncate">
-                          {agentName}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {getUIAdapter(adapterType).label}
-                        </p>
-                      </div>
-                      <Check className="h-4 w-4 text-green-500 shrink-0" />
-                    </div>
-                    <div className="flex items-center gap-3 px-3 py-2.5">
-                      <ListTodo className="h-4 w-4 text-muted-foreground shrink-0" />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium truncate">
-                          {taskTitle}
-                        </p>
-                        <p className="text-xs text-muted-foreground">Task</p>
-                      </div>
-                      <Check className="h-4 w-4 text-green-500 shrink-0" />
-                    </div>
-                  </div>
-                </div>
-              )}
-
               {/* Error */}
               {error && (
                 <div className="mt-3">
@@ -1238,31 +1032,7 @@ export function OnboardingWizard() {
                       ) : (
                         <ArrowRight className="h-3.5 w-3.5 mr-1" />
                       )}
-                      {loading ? "Creating..." : "Next"}
-                    </Button>
-                  )}
-                  {step === 3 && (
-                    <Button
-                      size="sm"
-                      disabled={!taskTitle.trim() || loading}
-                      onClick={handleStep3Next}
-                    >
-                      {loading ? (
-                        <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
-                      ) : (
-                        <ArrowRight className="h-3.5 w-3.5 mr-1" />
-                      )}
-                      {loading ? "Creating..." : "Next"}
-                    </Button>
-                  )}
-                  {step === 4 && (
-                    <Button size="sm" disabled={loading} onClick={handleLaunch}>
-                      {loading ? (
-                        <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
-                      ) : (
-                        <ArrowRight className="h-3.5 w-3.5 mr-1" />
-                      )}
-                      {loading ? "Creating..." : "Create & Open Issue"}
+                      {loading ? "Creating..." : "Create Agent"}
                     </Button>
                   )}
                 </div>


### PR DESCRIPTION
## Summary\n- add company readiness route and types\n- add mobile web handoff token flow and consume route\n- redirect onboarding back to ClipIOS when a validated return URL is present\n\n## Verification\n- pnpm exec vitest run server/src/__tests__/mobile-web-handoff-route.test.ts\n- pnpm exec tsc --noEmit -p server/tsconfig.json\n- pnpm --filter @paperclipai/ui build\n