### PR TITLE
Make routine dispatch failures visible

### DIFF
--- a/docs/api/routines.md
+++ b/docs/api/routines.md
@@ -177,6 +177,13 @@ GET /api/routines/{routineId}/runs?limit=50
 
 Returns recent run history for the routine. Defaults to 50 most recent runs.
 
+Automated schedule and webhook runs are fail-safe. If Paperclip cannot dispatch
+the run into a normal execution issue, the run is marked `failed` and linked to
+a visible blocked issue assigned to the routine assignee. The blocker includes
+the routine, run, trigger, failure reason, owner, and next action. Visual review
+routines must keep browser screenshot or vision failures blocked instead of
+substituting a text-only review.
+
 ## Agent Access Rules
 
 Agents can read all routines in their company but can only create and manage routines assigned to themselves:

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -1,5 +1,5 @@
 import { createHmac, randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
@@ -906,6 +906,144 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(blocker?.originKind).toBe("manual");
     expect(blocker?.description).toContain("queue unavailable");
     expect(blocker?.description).toContain("If this is a visual review routine and browser or vision access is unavailable");
+  });
+
+  it("cleans up automated blocker issues if dispatch failure finalization rolls back", async () => {
+    const { companyId, routine, svc } = await seedFixture({
+      wakeup: async () => {
+        throw new Error("queue unavailable");
+      },
+    });
+
+    const { trigger } = await svc.createTrigger(routine.id, {
+      kind: "schedule",
+      label: "daily",
+      cronExpression: "0 10 * * *",
+      timezone: "UTC",
+    }, {});
+
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: new Date("2026-04-13T10:00:00.000Z") })
+      .where(eq(routineTriggers.id, trigger.id));
+
+    await db.execute(sql.raw(`
+      CREATE OR REPLACE FUNCTION routine_run_failed_update_explodes()
+      RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'routine run finalization exploded';
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER routine_run_failed_update_explodes_trigger
+      BEFORE UPDATE ON routine_runs
+      FOR EACH ROW
+      WHEN (NEW.status = 'failed')
+      EXECUTE FUNCTION routine_run_failed_update_explodes();
+    `));
+
+    try {
+      await expect(
+        svc.tickScheduledTriggers(new Date("2026-04-13T10:00:00.000Z")),
+      ).rejects.toThrow(/routine run finalization exploded/i);
+
+      const companyIssues = await db
+        .select({ id: issues.id, title: issues.title })
+        .from(issues)
+        .where(eq(issues.companyId, companyId));
+      expect(companyIssues).toEqual([]);
+
+      const runs = await db
+        .select({ id: routineRuns.id })
+        .from(routineRuns)
+        .where(eq(routineRuns.routineId, routine.id));
+      expect(runs).toEqual([]);
+    } finally {
+      await db.execute(sql.raw(`
+        DROP TRIGGER IF EXISTS routine_run_failed_update_explodes_trigger ON routine_runs;
+        DROP FUNCTION IF EXISTS routine_run_failed_update_explodes();
+      `));
+    }
+  });
+
+  it("links webhook variable validation failures to a visible blocked issue", async () => {
+    const { agentId, companyId, projectId, svc } = await seedFixture();
+    const variableRoutine = await svc.create(
+      companyId,
+      {
+        projectId,
+        goalId: null,
+        parentIssueId: null,
+        title: "review {{repo}}",
+        description: "Review {{repo}}",
+        assigneeAgentId: agentId,
+        priority: "medium",
+        status: "active",
+        concurrencyPolicy: "coalesce_if_active",
+        catchUpPolicy: "skip_missed",
+        variables: [
+          { name: "repo", label: null, type: "text", defaultValue: null, required: true, options: [] },
+        ],
+      },
+      {},
+    );
+    const { trigger } = await svc.createTrigger(variableRoutine.id, {
+      kind: "webhook",
+      signingMode: "none",
+    }, {});
+
+    const run = await svc.firePublicTrigger(trigger.publicId!, {
+      payload: { event: "opened" },
+    });
+
+    expect(run.source).toBe("webhook");
+    expect(run.status).toBe("failed");
+    expect(run.failureReason).toContain("Missing routine variables: repo");
+    expect(run.linkedIssueId).toBeTruthy();
+
+    const blocker = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, run.linkedIssueId!))
+      .then((rows) => rows[0] ?? null);
+    expect(blocker?.title).toBe(`Blocked routine: ${variableRoutine.title}`);
+    expect(blocker?.status).toBe("blocked");
+    expect(blocker?.assigneeAgentId).toBe(agentId);
+    expect(blocker?.description).toContain("Missing routine variables: repo");
+  });
+
+  it("links webhook default-agent validation failures to a visible blocked issue", async () => {
+    const { companyId, routine, svc } = await seedFixture();
+    await db
+      .update(routines)
+      .set({ assigneeAgentId: null })
+      .where(eq(routines.id, routine.id));
+    const routineWithoutAssignee = await svc.get(routine.id);
+    expect(routineWithoutAssignee?.status).toBe("active");
+    expect(routineWithoutAssignee?.assigneeAgentId).toBeNull();
+
+    const { trigger } = await svc.createTrigger(routine.id, {
+      kind: "webhook",
+      signingMode: "none",
+    }, {});
+
+    const run = await svc.firePublicTrigger(trigger.publicId!, {
+      payload: { event: "opened" },
+    });
+
+    expect(run.source).toBe("webhook");
+    expect(run.status).toBe("failed");
+    expect(run.failureReason).toContain("Default agent required");
+    expect(run.linkedIssueId).toBeTruthy();
+
+    const blocker = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, run.linkedIssueId!))
+      .then((rows) => rows[0] ?? null);
+    expect(blocker?.status).toBe("blocked");
+    expect(blocker?.assigneeAgentId).toBeNull();
+    expect(blocker?.description).toContain("No default routine assignee is configured");
   });
 
   it("accepts standard second-precision webhook timestamps for HMAC triggers", async () => {

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -171,7 +171,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       {},
     );
 
-    return { companyId, agentId, issueSvc, projectId, routine, svc, wakeups };
+    return { companyId, agentId, issuePrefix, issueSvc, projectId, routine, svc, wakeups };
   }
 
   it("creates a fresh execution issue when the previous routine issue is open but idle", async () => {
@@ -813,6 +813,99 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       .where(eq(issues.originId, routine.id));
 
     expect(routineIssues).toHaveLength(0);
+  });
+
+  it("advances a stale company issue counter before scheduled routine issue creation", async () => {
+    const { companyId, issuePrefix, routine, svc } = await seedFixture();
+    await db.insert(issues).values({
+      companyId,
+      projectId: routine.projectId,
+      title: "Existing issue",
+      description: "Created before the counter drifted",
+      status: "todo",
+      priority: "medium",
+      issueNumber: 42,
+      identifier: `${issuePrefix}-42`,
+      originKind: "manual",
+    });
+    await db.update(companies).set({ issueCounter: 1 }).where(eq(companies.id, companyId));
+
+    const { trigger } = await svc.createTrigger(routine.id, {
+      kind: "schedule",
+      label: "daily",
+      cronExpression: "0 10 * * *",
+      timezone: "UTC",
+    }, {});
+
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: new Date("2026-04-13T10:00:00.000Z") })
+      .where(eq(routineTriggers.id, trigger.id));
+
+    const result = await svc.tickScheduledTriggers(new Date("2026-04-13T10:00:00.000Z"));
+    expect(result.triggered).toBe(1);
+
+    const run = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.routineId, routine.id))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("issue_created");
+    expect(run?.linkedIssueId).toBeTruthy();
+
+    const createdIssue = await db
+      .select({ identifier: issues.identifier, issueNumber: issues.issueNumber })
+      .from(issues)
+      .where(eq(issues.id, run!.linkedIssueId!))
+      .then((rows) => rows[0] ?? null);
+    expect(createdIssue).toEqual({
+      identifier: `${issuePrefix}-43`,
+      issueNumber: 43,
+    });
+  });
+
+  it("links automated routine dispatch failures to a visible blocked issue", async () => {
+    const { agentId, routine, svc } = await seedFixture({
+      wakeup: async () => {
+        throw new Error("queue unavailable");
+      },
+    });
+
+    const { trigger } = await svc.createTrigger(routine.id, {
+      kind: "schedule",
+      label: "daily",
+      cronExpression: "0 10 * * *",
+      timezone: "UTC",
+    }, {});
+
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: new Date("2026-04-13T10:00:00.000Z") })
+      .where(eq(routineTriggers.id, trigger.id));
+
+    const result = await svc.tickScheduledTriggers(new Date("2026-04-13T10:00:00.000Z"));
+    expect(result.triggered).toBe(1);
+
+    const run = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.routineId, routine.id))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("failed");
+    expect(run?.failureReason).toContain("queue unavailable");
+    expect(run?.linkedIssueId).toBeTruthy();
+
+    const blocker = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, run!.linkedIssueId!))
+      .then((rows) => rows[0] ?? null);
+    expect(blocker?.title).toBe(`Blocked routine: ${routine.title}`);
+    expect(blocker?.status).toBe("blocked");
+    expect(blocker?.assigneeAgentId).toBe(agentId);
+    expect(blocker?.originKind).toBe("manual");
+    expect(blocker?.description).toContain("queue unavailable");
+    expect(blocker?.description).toContain("If this is a visual review routine and browser or vision access is unavailable");
   });
 
   it("accepts standard second-precision webhook timestamps for HMAC triggers", async () => {

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -80,6 +80,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
         contextSnapshot?: Record<string, unknown>;
       },
     ) => Promise<unknown>;
+    cancelRun?: (runId: string) => Promise<unknown>;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -153,6 +154,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
             .where(eq(issues.id, issueId));
           return { id: queuedRunId };
         },
+        cancelRun: opts?.cancelRun,
       },
     });
     const issueSvc = issueService(db);
@@ -900,6 +902,154 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
         .from(agentWakeupRequests)
         .where(eq(agentWakeupRequests.companyId, companyId));
       expect(wakeupRequests).toEqual([]);
+    } finally {
+      await db.execute(sql.raw(`
+        DROP TRIGGER IF EXISTS routine_run_issue_created_update_explodes_trigger ON routine_runs;
+        DROP FUNCTION IF EXISTS routine_run_issue_created_update_explodes();
+      `));
+    }
+  });
+
+  it("cancels claimed running wakeup artifacts when post-wakeup run finalization fails", async () => {
+    const cancelledRunIds: string[] = [];
+    const { companyId, routine, svc } = await seedFixture({
+      wakeup: async (wakeupAgentId, wakeupOpts) => {
+        const issueId =
+          (typeof wakeupOpts.payload?.issueId === "string" && wakeupOpts.payload.issueId) ||
+          (typeof wakeupOpts.contextSnapshot?.issueId === "string" && wakeupOpts.contextSnapshot.issueId) ||
+          null;
+        if (!issueId) return null;
+
+        const wakeupRequest = await db.insert(agentWakeupRequests).values({
+          companyId,
+          agentId: wakeupAgentId,
+          source: wakeupOpts.source ?? "assignment",
+          triggerDetail: wakeupOpts.triggerDetail ?? null,
+          reason: wakeupOpts.reason ?? null,
+          payload: wakeupOpts.payload ?? null,
+          status: "queued",
+          requestedByActorType: wakeupOpts.requestedByActorType ?? null,
+          requestedByActorId: wakeupOpts.requestedByActorId ?? null,
+        }).returning().then((rows) => rows[0]);
+
+        const runningRun = await db.insert(heartbeatRuns).values({
+          companyId,
+          agentId: wakeupAgentId,
+          invocationSource: wakeupOpts.source ?? "assignment",
+          triggerDetail: wakeupOpts.triggerDetail ?? null,
+          status: "running",
+          wakeupRequestId: wakeupRequest.id,
+          startedAt: new Date(),
+          contextSnapshot: { ...(wakeupOpts.contextSnapshot ?? {}), issueId },
+        }).returning().then((rows) => rows[0]);
+
+        await db
+          .update(agentWakeupRequests)
+          .set({
+            runId: runningRun.id,
+            status: "claimed",
+            claimedAt: new Date(),
+          })
+          .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+        await db
+          .update(issues)
+          .set({
+            executionRunId: runningRun.id,
+            executionLockedAt: new Date(),
+          })
+          .where(eq(issues.id, issueId));
+        await db.insert(agentWakeupRequests).values({
+          companyId,
+          agentId: wakeupAgentId,
+          source: "assignment",
+          triggerDetail: "system",
+          reason: "issue_execution_deferred",
+          payload: { issueId },
+          status: "deferred_issue_execution",
+        });
+        return { id: runningRun.id };
+      },
+      cancelRun: async (runId) => {
+        cancelledRunIds.push(runId);
+        const run = await db
+          .select({ wakeupRequestId: heartbeatRuns.wakeupRequestId })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, runId))
+          .then((rows) => rows[0] ?? null);
+        const finishedAt = new Date();
+        await db
+          .update(heartbeatRuns)
+          .set({
+            status: "cancelled",
+            finishedAt,
+            error: "Cancelled because routine dispatch finalization failed",
+            errorCode: "cancelled",
+          })
+          .where(eq(heartbeatRuns.id, runId));
+        if (run?.wakeupRequestId) {
+          await db
+            .update(agentWakeupRequests)
+            .set({
+              status: "cancelled",
+              finishedAt,
+              error: "Cancelled because routine dispatch finalization failed",
+            })
+            .where(eq(agentWakeupRequests.id, run.wakeupRequestId));
+        }
+        await db
+          .update(issues)
+          .set({
+            executionRunId: null,
+            executionLockedAt: null,
+          })
+          .where(eq(issues.executionRunId, runId));
+      },
+    });
+
+    await db.execute(sql.raw(`
+      CREATE OR REPLACE FUNCTION routine_run_issue_created_update_explodes()
+      RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'routine run issue_created finalization exploded';
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER routine_run_issue_created_update_explodes_trigger
+      BEFORE UPDATE ON routine_runs
+      FOR EACH ROW
+      WHEN (NEW.status = 'issue_created')
+      EXECUTE FUNCTION routine_run_issue_created_update_explodes();
+    `));
+
+    try {
+      await expect(
+        svc.runRoutine(routine.id, { source: "manual" }),
+      ).rejects.toThrow(/issue_created finalization exploded/i);
+
+      const routineIssues = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(eq(issues.originId, routine.id));
+      expect(routineIssues).toEqual([]);
+
+      const runs = await db
+        .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.companyId, companyId));
+      expect(runs).toEqual([{ id: cancelledRunIds[0], status: "cancelled" }]);
+
+      const wakeupRequests = await db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.companyId, companyId));
+      expect(wakeupRequests).toEqual([{ status: "cancelled" }]);
+
+      const activeRuns = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(sql`${heartbeatRuns.companyId} = ${companyId} and ${heartbeatRuns.status} in ('queued', 'running')`);
+      expect(activeRuns).toEqual([]);
+      expect(cancelledRunIds).toHaveLength(1);
     } finally {
       await db.execute(sql.raw(`
         DROP TRIGGER IF EXISTS routine_run_issue_created_update_explodes_trigger ON routine_runs;

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -3,6 +3,7 @@ import { eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
+  agentWakeupRequests,
   agents,
   companies,
   companySecrets,
@@ -52,6 +53,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     await db.delete(companySecretVersions);
     await db.delete(companySecrets);
     await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
     await db.delete(issues);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
@@ -815,6 +817,97 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues).toHaveLength(0);
   });
 
+  it("cleans up queued wakeup artifacts when post-wakeup run finalization fails", async () => {
+    const { companyId, routine, svc } = await seedFixture({
+      wakeup: async (wakeupAgentId, wakeupOpts) => {
+        const issueId =
+          (typeof wakeupOpts.payload?.issueId === "string" && wakeupOpts.payload.issueId) ||
+          (typeof wakeupOpts.contextSnapshot?.issueId === "string" && wakeupOpts.contextSnapshot.issueId) ||
+          null;
+        if (!issueId) return null;
+
+        const wakeupRequest = await db.insert(agentWakeupRequests).values({
+          companyId,
+          agentId: wakeupAgentId,
+          source: wakeupOpts.source ?? "assignment",
+          triggerDetail: wakeupOpts.triggerDetail ?? null,
+          reason: wakeupOpts.reason ?? null,
+          payload: wakeupOpts.payload ?? null,
+          status: "queued",
+          requestedByActorType: wakeupOpts.requestedByActorType ?? null,
+          requestedByActorId: wakeupOpts.requestedByActorId ?? null,
+        }).returning().then((rows) => rows[0]);
+
+        const queuedRun = await db.insert(heartbeatRuns).values({
+          companyId,
+          agentId: wakeupAgentId,
+          invocationSource: wakeupOpts.source ?? "assignment",
+          triggerDetail: wakeupOpts.triggerDetail ?? null,
+          status: "queued",
+          wakeupRequestId: wakeupRequest.id,
+          contextSnapshot: { ...(wakeupOpts.contextSnapshot ?? {}), issueId },
+        }).returning().then((rows) => rows[0]);
+
+        await db
+          .update(agentWakeupRequests)
+          .set({ runId: queuedRun.id })
+          .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+        await db
+          .update(issues)
+          .set({
+            executionRunId: queuedRun.id,
+            executionLockedAt: new Date(),
+          })
+          .where(eq(issues.id, issueId));
+        return { id: queuedRun.id };
+      },
+    });
+
+    await db.execute(sql.raw(`
+      CREATE OR REPLACE FUNCTION routine_run_issue_created_update_explodes()
+      RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'routine run issue_created finalization exploded';
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER routine_run_issue_created_update_explodes_trigger
+      BEFORE UPDATE ON routine_runs
+      FOR EACH ROW
+      WHEN (NEW.status = 'issue_created')
+      EXECUTE FUNCTION routine_run_issue_created_update_explodes();
+    `));
+
+    try {
+      await expect(
+        svc.runRoutine(routine.id, { source: "manual" }),
+      ).rejects.toThrow(/issue_created finalization exploded/i);
+
+      const routineIssues = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(eq(issues.originId, routine.id));
+      expect(routineIssues).toEqual([]);
+
+      const queuedRuns = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.companyId, companyId));
+      expect(queuedRuns).toEqual([]);
+
+      const wakeupRequests = await db
+        .select({ id: agentWakeupRequests.id })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.companyId, companyId));
+      expect(wakeupRequests).toEqual([]);
+    } finally {
+      await db.execute(sql.raw(`
+        DROP TRIGGER IF EXISTS routine_run_issue_created_update_explodes_trigger ON routine_runs;
+        DROP FUNCTION IF EXISTS routine_run_issue_created_update_explodes();
+      `));
+    }
+  });
+
   it("advances a stale company issue counter before scheduled routine issue creation", async () => {
     const { companyId, issuePrefix, routine, svc } = await seedFixture();
     await db.insert(issues).values({
@@ -962,6 +1055,60 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       await db.execute(sql.raw(`
         DROP TRIGGER IF EXISTS routine_run_failed_update_explodes_trigger ON routine_runs;
         DROP FUNCTION IF EXISTS routine_run_failed_update_explodes();
+      `));
+    }
+  });
+
+  it("restores the scheduled trigger time if dispatch aborts after claiming a fire", async () => {
+    const { routine, svc } = await seedFixture();
+    const dueAt = new Date("2026-04-13T10:00:00.000Z");
+    const { trigger } = await svc.createTrigger(routine.id, {
+      kind: "schedule",
+      label: "daily",
+      cronExpression: "0 10 * * *",
+      timezone: "UTC",
+    }, {});
+
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: dueAt })
+      .where(eq(routineTriggers.id, trigger.id));
+
+    await db.execute(sql.raw(`
+      CREATE OR REPLACE FUNCTION routine_run_insert_explodes()
+      RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'routine run insert exploded';
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER routine_run_insert_explodes_trigger
+      BEFORE INSERT ON routine_runs
+      FOR EACH ROW
+      EXECUTE FUNCTION routine_run_insert_explodes();
+    `));
+
+    try {
+      await expect(
+        svc.tickScheduledTriggers(dueAt),
+      ).rejects.toThrow(/routine run insert exploded/i);
+
+      const restoredTrigger = await db
+        .select({ nextRunAt: routineTriggers.nextRunAt })
+        .from(routineTriggers)
+        .where(eq(routineTriggers.id, trigger.id))
+        .then((rows) => rows[0] ?? null);
+      expect(restoredTrigger?.nextRunAt?.getTime()).toBe(dueAt.getTime());
+
+      const runs = await db
+        .select({ id: routineRuns.id })
+        .from(routineRuns)
+        .where(eq(routineRuns.routineId, routine.id));
+      expect(runs).toEqual([]);
+    } finally {
+      await db.execute(sql.raw(`
+        DROP TRIGGER IF EXISTS routine_run_insert_explodes_trigger ON routine_runs;
+        DROP FUNCTION IF EXISTS routine_run_insert_explodes();
       `));
     }
   });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -1291,9 +1291,34 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
   });
 
   it("links automated routine dispatch failures to a visible blocked issue", async () => {
-    const { agentId, routine, svc } = await seedFixture({
-      wakeup: async () => {
-        throw new Error("queue unavailable");
+    const { agentId, routine, svc, wakeups } = await seedFixture({
+      wakeup: async (wakeupAgentId, wakeupOpts) => {
+        const issueId =
+          (typeof wakeupOpts.payload?.issueId === "string" && wakeupOpts.payload.issueId) ||
+          (typeof wakeupOpts.contextSnapshot?.issueId === "string" && wakeupOpts.contextSnapshot.issueId) ||
+          null;
+        if (wakeupOpts.contextSnapshot?.source === "routine.dispatch") {
+          throw new Error("queue unavailable");
+        }
+        if (!issueId) return null;
+        const queuedRunId = randomUUID();
+        await db.insert(heartbeatRuns).values({
+          id: queuedRunId,
+          companyId: routine.companyId,
+          agentId: wakeupAgentId,
+          invocationSource: wakeupOpts.source ?? "assignment",
+          triggerDetail: wakeupOpts.triggerDetail ?? null,
+          status: "queued",
+          contextSnapshot: { ...(wakeupOpts.contextSnapshot ?? {}), issueId },
+        });
+        await db
+          .update(issues)
+          .set({
+            executionRunId: queuedRunId,
+            executionLockedAt: new Date(),
+          })
+          .where(eq(issues.id, issueId));
+        return { id: queuedRunId };
       },
     });
 
@@ -1332,6 +1357,28 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(blocker?.originKind).toBe("manual");
     expect(blocker?.description).toContain("queue unavailable");
     expect(blocker?.description).toContain("If this is a visual review routine and browser or vision access is unavailable");
+    expect(wakeups).toEqual([
+      expect.objectContaining({
+        agentId,
+        opts: expect.objectContaining({
+          reason: "issue_assigned",
+          payload: expect.objectContaining({ mutation: "create" }),
+          contextSnapshot: expect.objectContaining({ source: "routine.dispatch" }),
+        }),
+      }),
+      {
+        agentId,
+        opts: {
+          source: "assignment",
+          triggerDetail: "system",
+          reason: "issue_assigned",
+          payload: { issueId: blocker?.id, mutation: "create" },
+          requestedByActorType: "system",
+          requestedByActorId: null,
+          contextSnapshot: { issueId: blocker?.id, source: "routine.failure_blocker" },
+        },
+      },
+    ]);
   });
 
   it.each([

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -1334,6 +1334,57 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(blocker?.description).toContain("If this is a visual review routine and browser or vision access is unavailable");
   });
 
+  it.each([
+    ["terminated", "Cannot assign work to terminated agents", "the routine's saved assignee is terminated"],
+    ["pending_approval", "Cannot assign work to pending approval agents", "the routine's saved assignee is pending approval"],
+  ] as const)(
+    "creates an unassigned automated blocker when the schedule assignee becomes %s before dispatch",
+    async (agentStatus, failureMessage, ownerMessage) => {
+      const { agentId, routine, svc } = await seedFixture();
+
+      const { trigger } = await svc.createTrigger(routine.id, {
+        kind: "schedule",
+        label: "daily",
+        cronExpression: "0 10 * * *",
+        timezone: "UTC",
+      }, {});
+
+      await db
+        .update(agents)
+        .set({ status: agentStatus })
+        .where(eq(agents.id, agentId));
+      await db
+        .update(routineTriggers)
+        .set({ nextRunAt: new Date("2026-04-13T10:00:00.000Z") })
+        .where(eq(routineTriggers.id, trigger.id));
+
+      const result = await svc.tickScheduledTriggers(new Date("2026-04-13T10:00:00.000Z"));
+      expect(result.triggered).toBe(1);
+
+      const run = await db
+        .select()
+        .from(routineRuns)
+        .where(eq(routineRuns.routineId, routine.id))
+        .then((rows) => rows[0] ?? null);
+      expect(run?.status).toBe("failed");
+      expect(run?.failureReason).toContain(failureMessage);
+      expect(run?.linkedIssueId).toBeTruthy();
+
+      const blocker = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, run!.linkedIssueId!))
+        .then((rows) => rows[0] ?? null);
+      expect(blocker?.title).toBe(`Blocked routine: ${routine.title}`);
+      expect(blocker?.status).toBe("blocked");
+      expect(blocker?.assigneeAgentId).toBeNull();
+      expect(blocker?.originKind).toBe("manual");
+      expect(blocker?.description).toContain(failureMessage);
+      expect(blocker?.description).toContain(ownerMessage);
+      expect(blocker?.description).toContain("Route this blocker to the routine owner or responsible maintainer");
+    },
+  );
+
   it("cleans up automated blocker issues if dispatch failure finalization rolls back", async () => {
     const { companyId, routine, svc } = await seedFixture({
       wakeup: async () => {

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -910,6 +910,189 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     }
   });
 
+  it("cancels wakeup artifacts that become claimed while queued cleanup runs", async () => {
+    const cancelledRunIds: string[] = [];
+    const { companyId, routine, svc } = await seedFixture({
+      wakeup: async (wakeupAgentId, wakeupOpts) => {
+        const issueId =
+          (typeof wakeupOpts.payload?.issueId === "string" && wakeupOpts.payload.issueId) ||
+          (typeof wakeupOpts.contextSnapshot?.issueId === "string" && wakeupOpts.contextSnapshot.issueId) ||
+          null;
+        if (!issueId) return null;
+
+        const wakeupRequest = await db.insert(agentWakeupRequests).values({
+          companyId,
+          agentId: wakeupAgentId,
+          source: wakeupOpts.source ?? "assignment",
+          triggerDetail: wakeupOpts.triggerDetail ?? null,
+          reason: wakeupOpts.reason ?? null,
+          payload: wakeupOpts.payload ?? null,
+          status: "queued",
+          requestedByActorType: wakeupOpts.requestedByActorType ?? null,
+          requestedByActorId: wakeupOpts.requestedByActorId ?? null,
+        }).returning().then((rows) => rows[0]);
+
+        const queuedRun = await db.insert(heartbeatRuns).values({
+          companyId,
+          agentId: wakeupAgentId,
+          invocationSource: wakeupOpts.source ?? "assignment",
+          triggerDetail: wakeupOpts.triggerDetail ?? null,
+          status: "queued",
+          wakeupRequestId: wakeupRequest.id,
+          contextSnapshot: { ...(wakeupOpts.contextSnapshot ?? {}), issueId },
+        }).returning().then((rows) => rows[0]);
+
+        await db
+          .update(agentWakeupRequests)
+          .set({ runId: queuedRun.id })
+          .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+        await db
+          .update(issues)
+          .set({
+            executionRunId: queuedRun.id,
+            executionLockedAt: new Date(),
+          })
+          .where(eq(issues.id, issueId));
+        return { id: queuedRun.id };
+      },
+      cancelRun: async (runId) => {
+        cancelledRunIds.push(runId);
+        const run = await db
+          .select({ wakeupRequestId: heartbeatRuns.wakeupRequestId })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, runId))
+          .then((rows) => rows[0] ?? null);
+        const finishedAt = new Date();
+        await db
+          .update(heartbeatRuns)
+          .set({
+            status: "cancelled",
+            finishedAt,
+            error: "Cancelled because routine dispatch finalization failed",
+            errorCode: "cancelled",
+          })
+          .where(eq(heartbeatRuns.id, runId));
+        if (run?.wakeupRequestId) {
+          await db
+            .update(agentWakeupRequests)
+            .set({
+              status: "cancelled",
+              finishedAt,
+              error: "Cancelled because routine dispatch finalization failed",
+            })
+            .where(eq(agentWakeupRequests.id, run.wakeupRequestId));
+        }
+        await db
+          .update(issues)
+          .set({
+            executionRunId: null,
+            executionLockedAt: null,
+          })
+          .where(eq(issues.executionRunId, runId));
+      },
+    });
+
+    await db.execute(sql.raw(`
+      CREATE OR REPLACE FUNCTION heartbeat_run_delete_claims_routine_wakeup()
+      RETURNS trigger AS $$
+      BEGIN
+        IF OLD.wakeup_request_id IS NOT NULL AND OLD.context_snapshot ->> 'issueId' IS NOT NULL THEN
+          UPDATE agent_wakeup_requests
+          SET status = 'claimed',
+              claimed_at = now(),
+              run_id = OLD.id,
+              updated_at = now()
+          WHERE id = OLD.wakeup_request_id;
+
+          INSERT INTO heartbeat_runs (
+            id,
+            company_id,
+            agent_id,
+            invocation_source,
+            trigger_detail,
+            status,
+            started_at,
+            wakeup_request_id,
+            context_snapshot,
+            created_at,
+            updated_at
+          ) VALUES (
+            OLD.id,
+            OLD.company_id,
+            OLD.agent_id,
+            OLD.invocation_source,
+            OLD.trigger_detail,
+            'running',
+            now(),
+            OLD.wakeup_request_id,
+            OLD.context_snapshot,
+            OLD.created_at,
+            now()
+          );
+        END IF;
+        RETURN OLD;
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER heartbeat_run_delete_claims_routine_wakeup_trigger
+      AFTER DELETE ON heartbeat_runs
+      FOR EACH ROW
+      WHEN (OLD.status = 'queued')
+      EXECUTE FUNCTION heartbeat_run_delete_claims_routine_wakeup();
+
+      CREATE OR REPLACE FUNCTION routine_run_issue_created_update_explodes()
+      RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'routine run issue_created finalization exploded';
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER routine_run_issue_created_update_explodes_trigger
+      BEFORE UPDATE ON routine_runs
+      FOR EACH ROW
+      WHEN (NEW.status = 'issue_created')
+      EXECUTE FUNCTION routine_run_issue_created_update_explodes();
+    `));
+
+    try {
+      await expect(
+        svc.runRoutine(routine.id, { source: "manual" }),
+      ).rejects.toThrow(/issue_created finalization exploded/i);
+
+      const routineIssues = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(eq(issues.originId, routine.id));
+      expect(routineIssues).toEqual([]);
+
+      const runs = await db
+        .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.companyId, companyId));
+      expect(runs).toEqual([{ id: cancelledRunIds[0], status: "cancelled" }]);
+
+      const wakeupRequests = await db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.companyId, companyId));
+      expect(wakeupRequests).toEqual([{ status: "cancelled" }]);
+
+      const activeRuns = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(sql`${heartbeatRuns.companyId} = ${companyId} and ${heartbeatRuns.status} in ('queued', 'running')`);
+      expect(activeRuns).toEqual([]);
+      expect(cancelledRunIds).toHaveLength(1);
+    } finally {
+      await db.execute(sql.raw(`
+        DROP TRIGGER IF EXISTS routine_run_issue_created_update_explodes_trigger ON routine_runs;
+        DROP FUNCTION IF EXISTS routine_run_issue_created_update_explodes();
+        DROP TRIGGER IF EXISTS heartbeat_run_delete_claims_routine_wakeup_trigger ON heartbeat_runs;
+        DROP FUNCTION IF EXISTS heartbeat_run_delete_claims_routine_wakeup();
+      `));
+    }
+  });
+
   it("cancels claimed running wakeup artifacts when post-wakeup run finalization fails", async () => {
     const cancelledRunIds: string[] = [];
     const { companyId, routine, svc } = await seedFixture({

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -371,11 +371,15 @@ function formatRoutineFailureDescription(input: {
   source: "schedule" | "manual" | "api" | "webhook";
   runId: string;
   failureReason: string;
+  blockerAssigneeAgentId?: string | null;
+  fallbackReason?: string | null;
 }) {
   const triggerLabel = input.trigger?.label?.trim() || input.trigger?.kind || "none";
   const triggerId = input.trigger?.id ?? "none";
-  const owner = input.routine.assigneeAgentId
+  const owner = input.blockerAssigneeAgentId
     ? "The routine assignee owns this blocker until they route it to the right maintainer or confirm the next run can create a normal execution issue."
+    : input.fallbackReason
+      ? `No assignable routine assignee is available: ${input.fallbackReason}. Route this blocker to the routine owner or responsible maintainer before rerunning the routine.`
     : "No default routine assignee is configured. Assign this blocker to the routine owner or responsible maintainer before rerunning the routine.";
   return [
     "## Blocker",
@@ -449,6 +453,45 @@ export function routineService(
     if (agent.companyId !== companyId) throw unprocessable("Assignee must belong to same company");
     if (agent.status === "pending_approval") throw conflict("Cannot assign routines to pending approval agents");
     if (agent.status === "terminated") throw conflict("Cannot assign routines to terminated agents");
+  }
+
+  async function resolveAutomatedFailureAssignee(routine: typeof routines.$inferSelect) {
+    if (!routine.assigneeAgentId) {
+      return { assigneeAgentId: null, fallbackReason: null };
+    }
+
+    const agent = await db
+      .select({ id: agents.id, companyId: agents.companyId, status: agents.status })
+      .from(agents)
+      .where(eq(agents.id, routine.assigneeAgentId))
+      .then((rows) => rows[0] ?? null);
+
+    if (!agent) {
+      return {
+        assigneeAgentId: null,
+        fallbackReason: "the routine's saved assignee no longer exists",
+      };
+    }
+    if (agent.companyId !== routine.companyId) {
+      return {
+        assigneeAgentId: null,
+        fallbackReason: "the routine's saved assignee belongs to a different company",
+      };
+    }
+    if (agent.status === "pending_approval") {
+      return {
+        assigneeAgentId: null,
+        fallbackReason: "the routine's saved assignee is pending approval",
+      };
+    }
+    if (agent.status === "terminated") {
+      return {
+        assigneeAgentId: null,
+        fallbackReason: "the routine's saved assignee is terminated",
+      };
+    }
+
+    return { assigneeAgentId: routine.assigneeAgentId, fallbackReason: null };
   }
 
   async function assertProject(companyId: string, projectId: string | null | undefined) {
@@ -780,15 +823,20 @@ export function routineService(
     failureReason: string;
   }) {
     if (input.source !== "schedule" && input.source !== "webhook") return null;
+    const failureAssignee = await resolveAutomatedFailureAssignee(input.routine);
     return issueSvc.create(input.routine.companyId, {
       projectId: input.routine.projectId,
       goalId: input.routine.goalId,
       parentId: input.routine.parentIssueId,
       title: `Blocked routine: ${input.routine.title}`,
-      description: formatRoutineFailureDescription(input),
+      description: formatRoutineFailureDescription({
+        ...input,
+        blockerAssigneeAgentId: failureAssignee.assigneeAgentId,
+        fallbackReason: failureAssignee.fallbackReason,
+      }),
       status: "blocked",
       priority: input.routine.priority,
-      assigneeAgentId: input.routine.assigneeAgentId,
+      assigneeAgentId: failureAssignee.assigneeAgentId,
       originKind: "manual",
     });
   }

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -48,6 +48,10 @@ import { queueIssueAssignmentWakeup, type IssueAssignmentWakeupDeps } from "./is
 import { logActivity } from "./activity-log.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
 
+type RoutineHeartbeatDeps = IssueAssignmentWakeupDeps & {
+  cancelRun?: (runId: string) => Promise<unknown>;
+};
+
 const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
 const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"];
 const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
@@ -399,13 +403,13 @@ function formatRoutineFailureDescription(input: {
 export function routineService(
   db: Db,
   deps: {
-    heartbeat?: IssueAssignmentWakeupDeps;
+    heartbeat?: RoutineHeartbeatDeps;
     pluginWorkerManager?: PluginWorkerManager;
   } = {},
 ) {
   const issueSvc = issueService(db);
   const secretsSvc = secretService(db);
-  const heartbeat = deps.heartbeat ?? heartbeatService(db, {
+  const heartbeat: RoutineHeartbeatDeps = deps.heartbeat ?? heartbeatService(db, {
     pluginWorkerManager: deps.pluginWorkerManager,
   });
 
@@ -790,26 +794,87 @@ export function routineService(
   async function cleanupIssueWakeupArtifacts(input: {
     companyId: string;
     issueId: string;
-  }) {
+  }): Promise<boolean> {
     try {
-      const queuedRuns = await db
+      const liveRuns = await db
         .select({
           id: heartbeatRuns.id,
           wakeupRequestId: heartbeatRuns.wakeupRequestId,
+          status: heartbeatRuns.status,
         })
         .from(heartbeatRuns)
         .where(
           and(
             eq(heartbeatRuns.companyId, input.companyId),
-            eq(heartbeatRuns.status, "queued"),
+            inArray(heartbeatRuns.status, LIVE_HEARTBEAT_RUN_STATUSES),
             sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${input.issueId}`,
           ),
         );
 
+      const queuedRuns = liveRuns.filter((run) => run.status === "queued");
+      const runningRuns = liveRuns.filter((run) => run.status === "running");
       const runIds = queuedRuns.map((run) => run.id);
       const wakeupRequestIds = queuedRuns
         .map((run) => run.wakeupRequestId)
         .filter((id): id is string => Boolean(id));
+
+      await db
+        .delete(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, input.companyId),
+            inArray(agentWakeupRequests.status, ["coalesced", "deferred_issue_execution"]),
+            sql`${agentWakeupRequests.payload} ->> 'issueId' = ${input.issueId}`,
+          ),
+        );
+
+      for (const run of runningRuns) {
+        if (heartbeat.cancelRun) {
+          await heartbeat.cancelRun(run.id);
+          continue;
+        }
+
+        const finishedAt = new Date();
+        await db
+          .update(heartbeatRuns)
+          .set({
+            status: "cancelled",
+            finishedAt,
+            error: "Cancelled because routine dispatch finalization failed",
+            errorCode: "cancelled",
+            updatedAt: finishedAt,
+          })
+          .where(
+            and(
+              eq(heartbeatRuns.companyId, input.companyId),
+              eq(heartbeatRuns.id, run.id),
+              eq(heartbeatRuns.status, "running"),
+            ),
+          );
+        if (run.wakeupRequestId) {
+          await db
+            .update(agentWakeupRequests)
+            .set({
+              status: "cancelled",
+              finishedAt,
+              error: "Cancelled because routine dispatch finalization failed",
+              updatedAt: finishedAt,
+            })
+            .where(eq(agentWakeupRequests.id, run.wakeupRequestId));
+        }
+      }
+
+      if (runningRuns.length > 0) {
+        await db
+          .update(issues)
+          .set({
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(issues.companyId, input.companyId), eq(issues.id, input.issueId)));
+      }
 
       if (runIds.length > 0) {
         await db
@@ -832,11 +897,13 @@ export function routineService(
             or(...wakeupRequestFilters),
           ),
         );
+      return true;
     } catch (err) {
       logger.error(
         { err, companyId: input.companyId, issueId: input.issueId },
-        "failed to clean up queued routine issue wakeup artifacts",
+        "failed to clean up routine issue wakeup artifacts",
       );
+      return false;
     }
   }
 
@@ -847,11 +914,12 @@ export function routineService(
     if (issueIds.length === 0) return;
     try {
       for (const issueId of issueIds) {
-        await cleanupIssueWakeupArtifacts({ companyId: input.companyId, issueId });
+        const cleaned = await cleanupIssueWakeupArtifacts({ companyId: input.companyId, issueId });
+        if (!cleaned) continue;
+        await db
+          .delete(issues)
+          .where(and(eq(issues.companyId, input.companyId), eq(issues.id, issueId)));
       }
-      await db
-        .delete(issues)
-        .where(and(eq(issues.companyId, input.companyId), inArray(issues.id, issueIds)));
     } catch (err) {
       logger.error(
         { err, routineId: input.routineId, issueIds },
@@ -1121,11 +1189,13 @@ export function routineService(
           return updated ?? createdRun;
         } catch (error) {
           if (createdIssue) {
-            await cleanupIssueWakeupArtifacts({
+            const cleaned = await cleanupIssueWakeupArtifacts({
               companyId: input.routine.companyId,
               issueId: createdIssue.id,
             });
-            await txDb.delete(issues).where(eq(issues.id, createdIssue.id));
+            if (cleaned) {
+              await txDb.delete(issues).where(eq(issues.id, createdIssue.id));
+            }
           }
           let failureReason = error instanceof Error ? error.message : String(error);
           let failureIssue: Awaited<ReturnType<typeof createAutomatedFailureIssue>> | null = null;

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -54,6 +54,8 @@ type RoutineHeartbeatDeps = IssueAssignmentWakeupDeps & {
 
 const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
 const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"];
+const ACTIVE_WAKEUP_REQUEST_STATUSES = ["queued", "coalesced", "deferred_issue_execution", "claimed"];
+const ORPHAN_WAKEUP_REQUEST_STATUSES = ["queued", "coalesced", "deferred_issue_execution"];
 const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
 const MAX_CATCH_UP_RUNS = 25;
 const WEEKDAY_INDEX: Record<string, number> = {
@@ -796,7 +798,7 @@ export function routineService(
     issueId: string;
   }): Promise<boolean> {
     try {
-      const liveRuns = await db
+      const findLiveIssueRuns = () => db
         .select({
           id: heartbeatRuns.id,
           wakeupRequestId: heartbeatRuns.wakeupRequestId,
@@ -811,27 +813,52 @@ export function routineService(
           ),
         );
 
-      const queuedRuns = liveRuns.filter((run) => run.status === "queued");
-      const runningRuns = liveRuns.filter((run) => run.status === "running");
-      const runIds = queuedRuns.map((run) => run.id);
-      const wakeupRequestIds = queuedRuns
-        .map((run) => run.wakeupRequestId)
-        .filter((id): id is string => Boolean(id));
-
-      await db
-        .delete(agentWakeupRequests)
+      const findActiveIssueWakeupRequests = () => db
+        .select({
+          id: agentWakeupRequests.id,
+          status: agentWakeupRequests.status,
+          runId: agentWakeupRequests.runId,
+        })
+        .from(agentWakeupRequests)
         .where(
           and(
             eq(agentWakeupRequests.companyId, input.companyId),
-            inArray(agentWakeupRequests.status, ["coalesced", "deferred_issue_execution"]),
-            sql`${agentWakeupRequests.payload} ->> 'issueId' = ${input.issueId}`,
+            inArray(agentWakeupRequests.status, ACTIVE_WAKEUP_REQUEST_STATUSES),
+            or(
+              sql`${agentWakeupRequests.payload} ->> 'issueId' = ${input.issueId}`,
+              sql`exists (
+                select 1 from ${heartbeatRuns}
+                where ${heartbeatRuns.wakeupRequestId} = ${agentWakeupRequests.id}
+                  and ${heartbeatRuns.companyId} = ${input.companyId}
+                  and ${heartbeatRuns.status} in ('queued', 'running')
+                  and ${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${input.issueId}
+              )`,
+            ),
           ),
         );
 
-      for (const run of runningRuns) {
+      const deleteOrphanIssueWakeupRequests = async () => {
+        await db
+          .delete(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, input.companyId),
+              inArray(agentWakeupRequests.status, ORPHAN_WAKEUP_REQUEST_STATUSES),
+              sql`${agentWakeupRequests.payload} ->> 'issueId' = ${input.issueId}`,
+              sql`not exists (
+                select 1 from ${heartbeatRuns}
+                where ${heartbeatRuns.wakeupRequestId} = ${agentWakeupRequests.id}
+                  and ${heartbeatRuns.companyId} = ${input.companyId}
+                  and ${heartbeatRuns.status} in ('queued', 'running')
+              )`,
+            ),
+          );
+      };
+
+      const cancelRunningIssueRun = async (run: { id: string; wakeupRequestId: string | null }) => {
         if (heartbeat.cancelRun) {
           await heartbeat.cancelRun(run.id);
-          continue;
+          return;
         }
 
         const finishedAt = new Date();
@@ -862,9 +889,9 @@ export function routineService(
             })
             .where(eq(agentWakeupRequests.id, run.wakeupRequestId));
         }
-      }
+      };
 
-      if (runningRuns.length > 0) {
+      const clearIssueExecutionLock = async () => {
         await db
           .update(issues)
           .set({
@@ -874,30 +901,74 @@ export function routineService(
             updatedAt: new Date(),
           })
           .where(and(eq(issues.companyId, input.companyId), eq(issues.id, input.issueId)));
+      };
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        await deleteOrphanIssueWakeupRequests();
+
+        const liveRuns = await findLiveIssueRuns();
+        const runningRuns = liveRuns.filter((run) => run.status === "running");
+        const queuedRunIds = liveRuns
+          .filter((run) => run.status === "queued")
+          .map((run) => run.id);
+
+        for (const run of runningRuns) {
+          await cancelRunningIssueRun(run);
+        }
+
+        if (queuedRunIds.length > 0) {
+          const deletedQueuedRuns = await db
+            .delete(heartbeatRuns)
+            .where(
+              and(
+                eq(heartbeatRuns.companyId, input.companyId),
+                eq(heartbeatRuns.status, "queued"),
+                inArray(heartbeatRuns.id, queuedRunIds),
+              ),
+            )
+            .returning({
+              id: heartbeatRuns.id,
+              wakeupRequestId: heartbeatRuns.wakeupRequestId,
+            });
+          const deletedRunIds = deletedQueuedRuns.map((run) => run.id);
+          const deletedWakeupRequestIds = deletedQueuedRuns
+            .map((run) => run.wakeupRequestId)
+            .filter((id): id is string => Boolean(id));
+          const wakeupRequestFilters = [];
+          if (deletedRunIds.length > 0) wakeupRequestFilters.push(inArray(agentWakeupRequests.runId, deletedRunIds));
+          if (deletedWakeupRequestIds.length > 0) {
+            wakeupRequestFilters.push(inArray(agentWakeupRequests.id, deletedWakeupRequestIds));
+          }
+          if (wakeupRequestFilters.length > 0) {
+            await db
+              .delete(agentWakeupRequests)
+              .where(
+                and(
+                  eq(agentWakeupRequests.companyId, input.companyId),
+                  inArray(agentWakeupRequests.status, ["queued", "coalesced"]),
+                  or(...wakeupRequestFilters),
+                ),
+              );
+          }
+        }
+
+        await deleteOrphanIssueWakeupRequests();
+
+        const remainingRuns = await findLiveIssueRuns();
+        const remainingWakeupRequests = await findActiveIssueWakeupRequests();
+        if (remainingRuns.length === 0 && remainingWakeupRequests.length === 0) {
+          await clearIssueExecutionLock();
+          return true;
+        }
       }
 
-      if (runIds.length > 0) {
-        await db
-          .delete(heartbeatRuns)
-          .where(and(eq(heartbeatRuns.companyId, input.companyId), inArray(heartbeatRuns.id, runIds)));
-      }
-
-      const wakeupRequestFilters = [
-        sql`${agentWakeupRequests.payload} ->> 'issueId' = ${input.issueId}`,
-      ];
-      if (runIds.length > 0) wakeupRequestFilters.push(inArray(agentWakeupRequests.runId, runIds));
-      if (wakeupRequestIds.length > 0) wakeupRequestFilters.push(inArray(agentWakeupRequests.id, wakeupRequestIds));
-
-      await db
-        .delete(agentWakeupRequests)
-        .where(
-          and(
-            eq(agentWakeupRequests.companyId, input.companyId),
-            inArray(agentWakeupRequests.status, ["queued", "coalesced"]),
-            or(...wakeupRequestFilters),
-          ),
-        );
-      return true;
+      const remainingRuns = await findLiveIssueRuns();
+      const remainingWakeupRequests = await findActiveIssueWakeupRequests();
+      logger.error(
+        { companyId: input.companyId, issueId: input.issueId, remainingRuns, remainingWakeupRequests },
+        "routine issue wakeup artifacts remained active after cleanup",
+      );
+      return false;
     } catch (err) {
       logger.error(
         { err, companyId: input.companyId, issueId: input.issueId },

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -367,6 +367,9 @@ function formatRoutineFailureDescription(input: {
 }) {
   const triggerLabel = input.trigger?.label?.trim() || input.trigger?.kind || "none";
   const triggerId = input.trigger?.id ?? "none";
+  const owner = input.routine.assigneeAgentId
+    ? "The routine assignee owns this blocker until they route it to the right maintainer or confirm the next run can create a normal execution issue."
+    : "No default routine assignee is configured. Assign this blocker to the routine owner or responsible maintainer before rerunning the routine.";
   return [
     "## Blocker",
     "",
@@ -384,7 +387,7 @@ function formatRoutineFailureDescription(input: {
     "",
     "## Owner",
     "",
-    "The routine assignee owns this blocker until they route it to the right maintainer or confirm the next run can create a normal execution issue.",
+    owner,
     "",
     "## Next Action",
     "",
@@ -783,6 +786,23 @@ export function routineService(
     });
   }
 
+  async function cleanupExternalDispatchIssues(issueIds: string[], input: {
+    routineId: string;
+    companyId: string;
+  }) {
+    if (issueIds.length === 0) return;
+    try {
+      await db
+        .delete(issues)
+        .where(and(eq(issues.companyId, input.companyId), inArray(issues.id, issueIds)));
+    } catch (err) {
+      logger.error(
+        { err, routineId: input.routineId, issueIds },
+        "failed to clean up externally created routine dispatch issues after transaction rollback",
+      );
+    }
+  }
+
   async function createWebhookSecret(
     companyId: string,
     routineId: string,
@@ -827,236 +847,276 @@ export function routineService(
     executionWorkspacePreference?: string | null;
     executionWorkspaceSettings?: Record<string, unknown> | null;
   }) {
+    const isAutomated = input.source === "schedule" || input.source === "webhook";
     const projectId = input.projectId ?? input.routine.projectId ?? null;
     const assigneeAgentId = input.assigneeAgentId ?? input.routine.assigneeAgentId ?? null;
-    if (!assigneeAgentId) {
-      throw unprocessable("Default agent required");
-    }
-    const automaticVariables: Record<string, string | number | boolean> = {};
-    if (input.executionWorkspaceId && routineUsesWorkspaceBranch(input.routine)) {
-      const workspace = await db
-        .select({
-          branchName: executionWorkspaces.branchName,
-          mode: executionWorkspaces.mode,
-        })
-        .from(executionWorkspaces)
-        .where(
-          and(
-            eq(executionWorkspaces.id, input.executionWorkspaceId),
-            eq(executionWorkspaces.companyId, input.routine.companyId),
-          ),
-        )
-        .then((rows) => rows[0] ?? null);
-      const branchName = workspace?.branchName?.trim();
-      if (workspace && workspace.mode !== "shared_workspace" && branchName) {
-        automaticVariables[WORKSPACE_BRANCH_ROUTINE_VARIABLE] = branchName;
-      }
-    }
-    const resolvedVariables = resolveRoutineVariableValues(input.routine.variables ?? [], {
-      ...input,
-      automaticVariables,
-    });
-    const allVariables = { ...getBuiltinRoutineVariableValues(), ...automaticVariables, ...resolvedVariables };
-    const title = interpolateRoutineTemplate(input.routine.title, allVariables) ?? input.routine.title;
-    const description = interpolateRoutineTemplate(input.routine.description, allVariables);
-    const triggerPayload = mergeRoutineRunPayload(input.payload, { ...automaticVariables, ...resolvedVariables });
-    const dispatchFingerprint = createRoutineDispatchFingerprint({
-      payload: triggerPayload,
-      projectId,
-      assigneeAgentId,
-      executionWorkspaceId: input.executionWorkspaceId ?? null,
-      executionWorkspacePreference: input.executionWorkspacePreference ?? null,
-      executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
-      title,
-      description,
-    });
-    const run = await db.transaction(async (tx) => {
-      const txDb = tx as unknown as Db;
-      await tx.execute(
-        sql`select id from ${routines} where ${routines.id} = ${input.routine.id} and ${routines.companyId} = ${input.routine.companyId} for update`,
-      );
+    let manualDispatchValues: {
+      title: string;
+      description: string | null;
+      triggerPayload: Record<string, unknown> | null;
+      dispatchFingerprint: string;
+    } | null = null;
 
-      if (input.idempotencyKey) {
-        const existing = await txDb
-          .select()
-          .from(routineRuns)
+    const resolveDispatchValues = async () => {
+      if (!assigneeAgentId) {
+        throw unprocessable("Default agent required");
+      }
+      const automaticVariables: Record<string, string | number | boolean> = {};
+      if (input.executionWorkspaceId && routineUsesWorkspaceBranch(input.routine)) {
+        const workspace = await db
+          .select({
+            branchName: executionWorkspaces.branchName,
+            mode: executionWorkspaces.mode,
+          })
+          .from(executionWorkspaces)
           .where(
             and(
-              eq(routineRuns.companyId, input.routine.companyId),
-              eq(routineRuns.routineId, input.routine.id),
-              eq(routineRuns.source, input.source),
-              eq(routineRuns.idempotencyKey, input.idempotencyKey),
-              input.trigger ? eq(routineRuns.triggerId, input.trigger.id) : isNull(routineRuns.triggerId),
+              eq(executionWorkspaces.id, input.executionWorkspaceId),
+              eq(executionWorkspaces.companyId, input.routine.companyId),
             ),
           )
-          .orderBy(desc(routineRuns.createdAt))
-          .limit(1)
           .then((rows) => rows[0] ?? null);
-        if (existing) return existing;
+        const branchName = workspace?.branchName?.trim();
+        if (workspace && workspace.mode !== "shared_workspace" && branchName) {
+          automaticVariables[WORKSPACE_BRANCH_ROUTINE_VARIABLE] = branchName;
+        }
       }
+      const resolvedVariables = resolveRoutineVariableValues(input.routine.variables ?? [], {
+        ...input,
+        automaticVariables,
+      });
+      const allVariables = { ...getBuiltinRoutineVariableValues(), ...automaticVariables, ...resolvedVariables };
+      const title = interpolateRoutineTemplate(input.routine.title, allVariables) ?? input.routine.title;
+      const description = interpolateRoutineTemplate(input.routine.description, allVariables);
+      const triggerPayload = mergeRoutineRunPayload(input.payload, { ...automaticVariables, ...resolvedVariables });
+      const dispatchFingerprint = createRoutineDispatchFingerprint({
+        payload: triggerPayload,
+        projectId,
+        assigneeAgentId,
+        executionWorkspaceId: input.executionWorkspaceId ?? null,
+        executionWorkspacePreference: input.executionWorkspacePreference ?? null,
+        executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
+        title,
+        description,
+      });
+      return {
+        title,
+        description,
+        triggerPayload,
+        dispatchFingerprint,
+      };
+    };
 
-      const triggeredAt = new Date();
-      const [createdRun] = await txDb
-        .insert(routineRuns)
-        .values({
-          companyId: input.routine.companyId,
-          routineId: input.routine.id,
-          triggerId: input.trigger?.id ?? null,
-          source: input.source,
-          status: "received",
-          triggeredAt,
-          idempotencyKey: input.idempotencyKey ?? null,
-          triggerPayload,
-          dispatchFingerprint,
-        })
-        .returning();
+    if (!isAutomated) {
+      manualDispatchValues = await resolveDispatchValues();
+    }
 
-      const nextRunAt = input.trigger?.kind === "schedule" && input.trigger.cronExpression && input.trigger.timezone
-        ? nextCronTickInTimeZone(input.trigger.cronExpression, input.trigger.timezone, triggeredAt)
-        : undefined;
+    const externalIssueIds = new Set<string>();
+    let run: typeof routineRuns.$inferSelect;
+    try {
+      run = await db.transaction(async (tx) => {
+        const txDb = tx as unknown as Db;
+        await tx.execute(
+          sql`select id from ${routines} where ${routines.id} = ${input.routine.id} and ${routines.companyId} = ${input.routine.companyId} for update`,
+        );
 
-      let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
-      try {
-        const activeIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint);
-        if (activeIssue && input.routine.concurrencyPolicy !== "always_enqueue") {
-          const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
-          const updated = await finalizeRun(createdRun.id, {
-            status,
-            linkedIssueId: activeIssue.id,
-            coalescedIntoRunId: activeIssue.originRunId,
-            completedAt: triggeredAt,
-          }, txDb);
-          await updateRoutineTouchedState({
-            routineId: input.routine.id,
-            triggerId: input.trigger?.id ?? null,
-            triggeredAt,
-            status,
-            issueId: activeIssue.id,
-            nextRunAt,
-          }, txDb);
-          return updated ?? createdRun;
+        if (input.idempotencyKey) {
+          const existing = await txDb
+            .select()
+            .from(routineRuns)
+            .where(
+              and(
+                eq(routineRuns.companyId, input.routine.companyId),
+                eq(routineRuns.routineId, input.routine.id),
+                eq(routineRuns.source, input.source),
+                eq(routineRuns.idempotencyKey, input.idempotencyKey),
+                input.trigger ? eq(routineRuns.triggerId, input.trigger.id) : isNull(routineRuns.triggerId),
+              ),
+            )
+            .orderBy(desc(routineRuns.createdAt))
+            .limit(1)
+            .then((rows) => rows[0] ?? null);
+          if (existing) return existing;
         }
 
+        const triggeredAt = new Date();
+        const [createdRun] = await txDb
+          .insert(routineRuns)
+          .values({
+            companyId: input.routine.companyId,
+            routineId: input.routine.id,
+            triggerId: input.trigger?.id ?? null,
+            source: input.source,
+            status: "received",
+            triggeredAt,
+            idempotencyKey: input.idempotencyKey ?? null,
+            triggerPayload: manualDispatchValues?.triggerPayload ?? input.payload ?? null,
+            dispatchFingerprint: manualDispatchValues?.dispatchFingerprint ?? null,
+          })
+          .returning();
+
+        const nextRunAt = input.trigger?.kind === "schedule" && input.trigger.cronExpression && input.trigger.timezone
+          ? nextCronTickInTimeZone(input.trigger.cronExpression, input.trigger.timezone, triggeredAt)
+          : undefined;
+
+        let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
         try {
-          createdIssue = await issueSvc.create(input.routine.companyId, {
-            projectId,
-            goalId: input.routine.goalId,
-            parentId: input.routine.parentIssueId,
-            title,
-            description,
-            status: "todo",
-            priority: input.routine.priority,
-            assigneeAgentId,
-            originKind: "routine_execution",
-            originId: input.routine.id,
-            originRunId: createdRun.id,
-            originFingerprint: dispatchFingerprint,
-            executionWorkspaceId: input.executionWorkspaceId ?? null,
-            executionWorkspacePreference: input.executionWorkspacePreference ?? null,
-            executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
-          });
-        } catch (error) {
-          const isOpenExecutionConflict =
-            !!error &&
-            typeof error === "object" &&
-            "code" in error &&
-            (error as { code?: string }).code === "23505" &&
-            "constraint" in error &&
-            (error as { constraint?: string }).constraint === "issues_open_routine_execution_uq";
-          if (!isOpenExecutionConflict || input.routine.concurrencyPolicy === "always_enqueue") {
-            throw error;
+          const dispatchValues = manualDispatchValues ?? await resolveDispatchValues();
+          const activeIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchValues.dispatchFingerprint);
+          if (activeIssue && input.routine.concurrencyPolicy !== "always_enqueue") {
+            const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
+            const updated = await finalizeRun(createdRun.id, {
+              status,
+              linkedIssueId: activeIssue.id,
+              coalescedIntoRunId: activeIssue.originRunId,
+              triggerPayload: dispatchValues.triggerPayload,
+              dispatchFingerprint: dispatchValues.dispatchFingerprint,
+              completedAt: triggeredAt,
+            }, txDb);
+            await updateRoutineTouchedState({
+              routineId: input.routine.id,
+              triggerId: input.trigger?.id ?? null,
+              triggeredAt,
+              status,
+              issueId: activeIssue.id,
+              nextRunAt,
+            }, txDb);
+            return updated ?? createdRun;
           }
 
-          const existingIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint);
-          if (!existingIssue) throw error;
-          const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
+          try {
+            createdIssue = await issueSvc.create(input.routine.companyId, {
+              projectId,
+              goalId: input.routine.goalId,
+              parentId: input.routine.parentIssueId,
+              title: dispatchValues.title,
+              description: dispatchValues.description,
+              status: "todo",
+              priority: input.routine.priority,
+              assigneeAgentId,
+              originKind: "routine_execution",
+              originId: input.routine.id,
+              originRunId: createdRun.id,
+              originFingerprint: dispatchValues.dispatchFingerprint,
+              executionWorkspaceId: input.executionWorkspaceId ?? null,
+              executionWorkspacePreference: input.executionWorkspacePreference ?? null,
+              executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
+            });
+            externalIssueIds.add(createdIssue.id);
+          } catch (error) {
+            const isOpenExecutionConflict =
+              !!error &&
+              typeof error === "object" &&
+              "code" in error &&
+              (error as { code?: string }).code === "23505" &&
+              "constraint" in error &&
+              (error as { constraint?: string }).constraint === "issues_open_routine_execution_uq";
+            if (!isOpenExecutionConflict || input.routine.concurrencyPolicy === "always_enqueue") {
+              throw error;
+            }
+
+            const existingIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchValues.dispatchFingerprint);
+            if (!existingIssue) throw error;
+            const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
+            const updated = await finalizeRun(createdRun.id, {
+              status,
+              linkedIssueId: existingIssue.id,
+              coalescedIntoRunId: existingIssue.originRunId,
+              triggerPayload: dispatchValues.triggerPayload,
+              dispatchFingerprint: dispatchValues.dispatchFingerprint,
+              completedAt: triggeredAt,
+            }, txDb);
+            await updateRoutineTouchedState({
+              routineId: input.routine.id,
+              triggerId: input.trigger?.id ?? null,
+              triggeredAt,
+              status,
+              issueId: existingIssue.id,
+              nextRunAt,
+            }, txDb);
+            return updated ?? createdRun;
+          }
+
+          // Keep the dispatch lock until the issue is linked to a queued heartbeat run.
+          await queueIssueAssignmentWakeup({
+            heartbeat,
+            issue: createdIssue,
+            reason: "issue_assigned",
+            mutation: "create",
+            contextSource: "routine.dispatch",
+            requestedByActorType: input.source === "schedule" ? "system" : undefined,
+            rethrowOnError: true,
+          });
           const updated = await finalizeRun(createdRun.id, {
-            status,
-            linkedIssueId: existingIssue.id,
-            coalescedIntoRunId: existingIssue.originRunId,
-            completedAt: triggeredAt,
+            status: "issue_created",
+            linkedIssueId: createdIssue.id,
+            triggerPayload: dispatchValues.triggerPayload,
+            dispatchFingerprint: dispatchValues.dispatchFingerprint,
           }, txDb);
           await updateRoutineTouchedState({
             routineId: input.routine.id,
             triggerId: input.trigger?.id ?? null,
             triggeredAt,
-            status,
-            issueId: existingIssue.id,
+            status: "issue_created",
+            issueId: createdIssue.id,
             nextRunAt,
           }, txDb);
           return updated ?? createdRun;
-        }
-
-        // Keep the dispatch lock until the issue is linked to a queued heartbeat run.
-        await queueIssueAssignmentWakeup({
-          heartbeat,
-          issue: createdIssue,
-          reason: "issue_assigned",
-          mutation: "create",
-          contextSource: "routine.dispatch",
-          requestedByActorType: input.source === "schedule" ? "system" : undefined,
-          rethrowOnError: true,
-        });
-        const updated = await finalizeRun(createdRun.id, {
-          status: "issue_created",
-          linkedIssueId: createdIssue.id,
-        }, txDb);
-        await updateRoutineTouchedState({
-          routineId: input.routine.id,
-          triggerId: input.trigger?.id ?? null,
-          triggeredAt,
-          status: "issue_created",
-          issueId: createdIssue.id,
-          nextRunAt,
-        }, txDb);
-        return updated ?? createdRun;
-      } catch (error) {
-        if (createdIssue) {
-          await txDb.delete(issues).where(eq(issues.id, createdIssue.id));
-        }
-        let failureReason = error instanceof Error ? error.message : String(error);
-        let failureIssue: Awaited<ReturnType<typeof createAutomatedFailureIssue>> | null = null;
-        try {
-          failureIssue = await createAutomatedFailureIssue({
-            routine: input.routine,
-            trigger: input.trigger,
-            source: input.source,
-            runId: createdRun.id,
-            failureReason,
-          });
-        } catch (failureIssueError) {
-          const failureIssueReason = failureIssueError instanceof Error
-            ? failureIssueError.message
-            : String(failureIssueError);
-          logger.error(
-            {
-              err: failureIssueError,
-              routineId: input.routine.id,
+        } catch (error) {
+          if (createdIssue) {
+            await txDb.delete(issues).where(eq(issues.id, createdIssue.id));
+          }
+          let failureReason = error instanceof Error ? error.message : String(error);
+          let failureIssue: Awaited<ReturnType<typeof createAutomatedFailureIssue>> | null = null;
+          try {
+            failureIssue = await createAutomatedFailureIssue({
+              routine: input.routine,
+              trigger: input.trigger,
+              source: input.source,
               runId: createdRun.id,
-            },
-            "failed to create automated routine blocker issue",
-          );
-          failureReason = `${failureReason}; additionally failed to create blocker issue: ${failureIssueReason}`;
+              failureReason,
+            });
+            if (failureIssue) externalIssueIds.add(failureIssue.id);
+          } catch (failureIssueError) {
+            const failureIssueReason = failureIssueError instanceof Error
+              ? failureIssueError.message
+              : String(failureIssueError);
+            logger.error(
+              {
+                err: failureIssueError,
+                routineId: input.routine.id,
+                runId: createdRun.id,
+              },
+              "failed to create automated routine blocker issue",
+            );
+            failureReason = `${failureReason}; additionally failed to create blocker issue: ${failureIssueReason}`;
+          }
+          const failed = await finalizeRun(createdRun.id, {
+            status: "failed",
+            failureReason,
+            linkedIssueId: failureIssue?.id ?? undefined,
+            completedAt: new Date(),
+          }, txDb);
+          await updateRoutineTouchedState({
+            routineId: input.routine.id,
+            triggerId: input.trigger?.id ?? null,
+            triggeredAt,
+            status: "failed",
+            issueId: failureIssue?.id ?? null,
+            nextRunAt,
+          }, txDb);
+          return failed ?? createdRun;
         }
-        const failed = await finalizeRun(createdRun.id, {
-          status: "failed",
-          failureReason,
-          linkedIssueId: failureIssue?.id ?? undefined,
-          completedAt: new Date(),
-        }, txDb);
-        await updateRoutineTouchedState({
-          routineId: input.routine.id,
-          triggerId: input.trigger?.id ?? null,
-          triggeredAt,
-          status: "failed",
-          issueId: failureIssue?.id ?? null,
-          nextRunAt,
-        }, txDb);
-        return failed ?? createdRun;
-      }
-    });
+      });
+    } catch (error) {
+      await cleanupExternalDispatchIssues([...externalIssueIds], {
+        routineId: input.routine.id,
+        companyId: input.routine.companyId,
+      });
+      throw error;
+    }
 
-    if (input.source === "schedule" || input.source === "webhook") {
+    if (isAutomated) {
       const actorId = input.source === "schedule" ? "routine-scheduler" : "routine-webhook";
       try {
         await logActivity(db, {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -824,7 +824,7 @@ export function routineService(
   }) {
     if (input.source !== "schedule" && input.source !== "webhook") return null;
     const failureAssignee = await resolveAutomatedFailureAssignee(input.routine);
-    return issueSvc.create(input.routine.companyId, {
+    const failureIssue = await issueSvc.create(input.routine.companyId, {
       projectId: input.routine.projectId,
       goalId: input.routine.goalId,
       parentId: input.routine.parentIssueId,
@@ -839,6 +839,15 @@ export function routineService(
       assigneeAgentId: failureAssignee.assigneeAgentId,
       originKind: "manual",
     });
+    await queueIssueAssignmentWakeup({
+      heartbeat,
+      issue: failureIssue,
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "routine.failure_blocker",
+      requestedByActorType: "system",
+    });
+    return failureIssue;
   }
 
   async function cleanupIssueWakeupArtifacts(input: {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -141,6 +141,7 @@ function nextResultText(status: string, issueId?: string | null) {
   if (status === "coalesced") return "Coalesced into an existing live execution issue";
   if (status === "skipped") return "Skipped because a live execution issue already exists";
   if (status === "completed") return "Execution issue completed";
+  if (status === "failed" && issueId) return `Execution failed; created blocker issue ${issueId}`;
   if (status === "failed") return "Execution failed";
   return status;
 }
@@ -355,6 +356,40 @@ function createRoutineDispatchFingerprint(input: {
 function routineUsesWorkspaceBranch(routine: typeof routines.$inferSelect) {
   return (routine.variables ?? []).some((variable) => variable.name === WORKSPACE_BRANCH_ROUTINE_VARIABLE)
     || extractRoutineVariableNames([routine.title, routine.description]).includes(WORKSPACE_BRANCH_ROUTINE_VARIABLE);
+}
+
+function formatRoutineFailureDescription(input: {
+  routine: typeof routines.$inferSelect;
+  trigger: typeof routineTriggers.$inferSelect | null;
+  source: "schedule" | "manual" | "api" | "webhook";
+  runId: string;
+  failureReason: string;
+}) {
+  const triggerLabel = input.trigger?.label?.trim() || input.trigger?.kind || "none";
+  const triggerId = input.trigger?.id ?? "none";
+  return [
+    "## Blocker",
+    "",
+    "Paperclip could not dispatch this automated routine run into a normal execution issue.",
+    "",
+    "## Context",
+    "",
+    `- Routine: ${input.routine.title}`,
+    `- Routine ID: ${input.routine.id}`,
+    `- Routine run ID: ${input.runId}`,
+    `- Source: ${input.source}`,
+    `- Trigger: ${triggerLabel}`,
+    `- Trigger ID: ${triggerId}`,
+    `- Failure: ${input.failureReason}`,
+    "",
+    "## Owner",
+    "",
+    "The routine assignee owns this blocker until they route it to the right maintainer or confirm the next run can create a normal execution issue.",
+    "",
+    "## Next Action",
+    "",
+    "Inspect the routine dispatch failure, fix the underlying issue or reroute to the responsible maintainer, then rerun the routine. If this is a visual review routine and browser or vision access is unavailable, keep this issue blocked and state the missing capability instead of substituting a text-only review.",
+  ].join("\n");
 }
 
 export function routineService(
@@ -727,6 +762,27 @@ export function routineService(
       .then((rows) => rows[0] ?? null);
   }
 
+  async function createAutomatedFailureIssue(input: {
+    routine: typeof routines.$inferSelect;
+    trigger: typeof routineTriggers.$inferSelect | null;
+    source: "schedule" | "manual" | "api" | "webhook";
+    runId: string;
+    failureReason: string;
+  }) {
+    if (input.source !== "schedule" && input.source !== "webhook") return null;
+    return issueSvc.create(input.routine.companyId, {
+      projectId: input.routine.projectId,
+      goalId: input.routine.goalId,
+      parentId: input.routine.parentIssueId,
+      title: `Blocked routine: ${input.routine.title}`,
+      description: formatRoutineFailureDescription(input),
+      status: "blocked",
+      priority: input.routine.priority,
+      assigneeAgentId: input.routine.assigneeAgentId,
+      originKind: "manual",
+    });
+  }
+
   async function createWebhookSecret(
     companyId: string,
     routineId: string,
@@ -958,10 +1014,34 @@ export function routineService(
         if (createdIssue) {
           await txDb.delete(issues).where(eq(issues.id, createdIssue.id));
         }
-        const failureReason = error instanceof Error ? error.message : String(error);
+        let failureReason = error instanceof Error ? error.message : String(error);
+        let failureIssue: Awaited<ReturnType<typeof createAutomatedFailureIssue>> | null = null;
+        try {
+          failureIssue = await createAutomatedFailureIssue({
+            routine: input.routine,
+            trigger: input.trigger,
+            source: input.source,
+            runId: createdRun.id,
+            failureReason,
+          });
+        } catch (failureIssueError) {
+          const failureIssueReason = failureIssueError instanceof Error
+            ? failureIssueError.message
+            : String(failureIssueError);
+          logger.error(
+            {
+              err: failureIssueError,
+              routineId: input.routine.id,
+              runId: createdRun.id,
+            },
+            "failed to create automated routine blocker issue",
+          );
+          failureReason = `${failureReason}; additionally failed to create blocker issue: ${failureIssueReason}`;
+        }
         const failed = await finalizeRun(createdRun.id, {
           status: "failed",
           failureReason,
+          linkedIssueId: failureIssue?.id ?? undefined,
           completedAt: new Date(),
         }, txDb);
         await updateRoutineTouchedState({
@@ -969,6 +1049,7 @@ export function routineService(
           triggerId: input.trigger?.id ?? null,
           triggeredAt,
           status: "failed",
+          issueId: failureIssue?.id ?? null,
           nextRunAt,
         }, txDb);
         return failed ?? createdRun;

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import { and, asc, desc, eq, inArray, isNotNull, isNull, lte, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
+  agentWakeupRequests,
   agents,
   companySecrets,
   executionWorkspaces,
@@ -786,12 +787,68 @@ export function routineService(
     });
   }
 
+  async function cleanupIssueWakeupArtifacts(input: {
+    companyId: string;
+    issueId: string;
+  }) {
+    try {
+      const queuedRuns = await db
+        .select({
+          id: heartbeatRuns.id,
+          wakeupRequestId: heartbeatRuns.wakeupRequestId,
+        })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, input.companyId),
+            eq(heartbeatRuns.status, "queued"),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${input.issueId}`,
+          ),
+        );
+
+      const runIds = queuedRuns.map((run) => run.id);
+      const wakeupRequestIds = queuedRuns
+        .map((run) => run.wakeupRequestId)
+        .filter((id): id is string => Boolean(id));
+
+      if (runIds.length > 0) {
+        await db
+          .delete(heartbeatRuns)
+          .where(and(eq(heartbeatRuns.companyId, input.companyId), inArray(heartbeatRuns.id, runIds)));
+      }
+
+      const wakeupRequestFilters = [
+        sql`${agentWakeupRequests.payload} ->> 'issueId' = ${input.issueId}`,
+      ];
+      if (runIds.length > 0) wakeupRequestFilters.push(inArray(agentWakeupRequests.runId, runIds));
+      if (wakeupRequestIds.length > 0) wakeupRequestFilters.push(inArray(agentWakeupRequests.id, wakeupRequestIds));
+
+      await db
+        .delete(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, input.companyId),
+            inArray(agentWakeupRequests.status, ["queued", "coalesced"]),
+            or(...wakeupRequestFilters),
+          ),
+        );
+    } catch (err) {
+      logger.error(
+        { err, companyId: input.companyId, issueId: input.issueId },
+        "failed to clean up queued routine issue wakeup artifacts",
+      );
+    }
+  }
+
   async function cleanupExternalDispatchIssues(issueIds: string[], input: {
     routineId: string;
     companyId: string;
   }) {
     if (issueIds.length === 0) return;
     try {
+      for (const issueId of issueIds) {
+        await cleanupIssueWakeupArtifacts({ companyId: input.companyId, issueId });
+      }
       await db
         .delete(issues)
         .where(and(eq(issues.companyId, input.companyId), inArray(issues.id, issueIds)));
@@ -1064,6 +1121,10 @@ export function routineService(
           return updated ?? createdRun;
         } catch (error) {
           if (createdIssue) {
+            await cleanupIssueWakeupArtifacts({
+              companyId: input.routine.companyId,
+              issueId: createdIssue.id,
+            });
             await txDb.delete(issues).where(eq(issues.id, createdIssue.id));
           }
           let failureReason = error instanceof Error ? error.message : String(error);
@@ -1734,13 +1795,16 @@ export function routineService(
         if (!row.trigger.nextRunAt || !row.trigger.cronExpression || !row.trigger.timezone) continue;
 
         let runCount = 1;
+        const scheduledRunAts = [row.trigger.nextRunAt];
         let claimedNextRunAt = nextCronTickInTimeZone(row.trigger.cronExpression, row.trigger.timezone, now);
 
         if (row.routine.catchUpPolicy === "enqueue_missed_with_cap") {
           let cursor: Date | null = row.trigger.nextRunAt;
           runCount = 0;
+          scheduledRunAts.length = 0;
           while (cursor && cursor <= now && runCount < MAX_CATCH_UP_RUNS) {
             runCount += 1;
+            scheduledRunAts.push(cursor);
             claimedNextRunAt = nextCronTickInTimeZone(row.trigger.cronExpression, row.trigger.timezone, cursor);
             cursor = claimedNextRunAt;
           }
@@ -1764,12 +1828,31 @@ export function routineService(
         if (!claimed) continue;
 
         for (let i = 0; i < runCount; i += 1) {
-          await dispatchRoutineRun({
-            routine: row.routine,
-            trigger: row.trigger,
-            source: "schedule",
-          });
-          triggered += 1;
+          try {
+            await dispatchRoutineRun({
+              routine: row.routine,
+              trigger: row.trigger,
+              source: "schedule",
+            });
+            triggered += 1;
+          } catch (error) {
+            const retryAt = scheduledRunAts[i] ?? row.trigger.nextRunAt;
+            try {
+              await db
+                .update(routineTriggers)
+                .set({
+                  nextRunAt: retryAt,
+                  updatedAt: new Date(),
+                })
+                .where(eq(routineTriggers.id, row.trigger.id));
+            } catch (restoreError) {
+              logger.error(
+                { err: restoreError, routineId: row.routine.id, triggerId: row.trigger.id, retryAt },
+                "failed to restore scheduled routine trigger after dispatch abort",
+              );
+            }
+            throw error;
+          }
         }
       }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Routines turn scheduled, manual, API, and webhook triggers into execution issues for agents.
> - Visual/product routines are only useful if a scheduled run creates screenshot-backed review work or a visible blocker.
> - The Apr 13 visual and growth routine runs failed before creating linked issues because stale issue numbering collided with `issues_identifier_idx`.
> - The first PR version made automated dispatch failures visible, but Staff found two remaining gaps: blocker issues could be orphaned if the dispatch transaction rolled back, and webhook dispatch validation could fail before a run existed.
> - This pull request closes those gaps by keeping automated validation inside the run lifecycle and cleaning up externally created routine issues if the transaction aborts.
> - The benefit is that automated visual routines either produce actionable execution work or leave a precise, linked blocked issue instead of silently disappearing.

## What Changed

- Moved schedule/webhook assignee and routine-variable validation into the routine-run transaction after the run row is created, so authenticated automated dispatch validation failures become `failed` runs linked to blocked issues.
- Added compensating cleanup for routine execution/blocker issues created through `issueService.create()` if the enclosing dispatch transaction later rolls back.
- Preserved manual/API preflight behavior while continuing to mark post-run dispatch failures as failed runs.
- Added blocker owner copy for legacy/drifted routines that have no default assignee.
- Added regression coverage for stale issue counters, rollback cleanup, automated failure blocker linkage, webhook missing-variable failures, and webhook missing-assignee failures.
- Documented automated schedule/webhook fail-safe behavior in the routines API docs.

## Verification

- `pnpm exec vitest run server/src/__tests__/routines-service.test.ts` passed: 22 tests.
- `pnpm exec tsc --noEmit --pretty false --project server/tsconfig.json` passed.
- `pnpm run typecheck` passed.
- `pnpm build` passed.
- `env -u DATABASE_URL PATH="/Users/fabiannitka/.nvm/versions/node/v24.12.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin" pnpm test:run` passed: 229 files, 1259 passed, 1 skipped.

## Risks

- Low migration risk: no schema changes.
- Behavioral shift: authenticated schedule/webhook dispatch validation failures now create failed routine runs and blocked issues instead of throwing before run creation.
- Cleanup is compensating rather than fully atomic because `issueService.create()` owns its own transaction; regression coverage forces rollback after blocker creation and asserts no orphan issues remain.

## Model Used

- OpenAI GPT-5.4 via Codex CLI, high reasoning mode, with local shell/tool execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge