### PR TITLE
Keep assigned agents moving through recoverable heartbeat failures

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -8,6 +8,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -66,6 +67,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -696,6 +698,106 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(result.find((issue) => issue.id === olderIssueId)?.lastActivityAt?.toISOString()).toBe(
       "2026-03-26T10:00:00.000Z",
     );
+  });
+
+  it("clears execution locks on release so another agent can check out the issue", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const nextAgentId = randomUUID();
+    const staleRunId = randomUUID();
+    const releaseRunId = randomUUID();
+    const nextRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "CodexMax",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: nextAgentId,
+        companyId,
+        name: "Nano",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        status: "running",
+        startedAt: new Date("2026-04-06T00:00:00.000Z"),
+      },
+      {
+        id: releaseRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        status: "running",
+        startedAt: new Date("2026-04-11T12:00:00.000Z"),
+      },
+      {
+        id: nextRunId,
+        companyId,
+        agentId: nextAgentId,
+        status: "running",
+        startedAt: new Date("2026-04-11T12:05:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale lock issue",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId,
+      checkoutRunId: staleRunId,
+      executionRunId: staleRunId,
+      executionAgentNameKey: "codexmax",
+      executionLockedAt: new Date("2026-04-06T00:00:00.000Z"),
+      createdByAgentId: assigneeAgentId,
+    });
+
+    const released = await svc.release(issueId, assigneeAgentId, releaseRunId);
+    expect(released).toMatchObject({
+      id: issueId,
+      status: "todo",
+      assigneeAgentId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+
+    const checkedOut = await svc.checkout(issueId, nextAgentId, ["todo"], nextRunId);
+    expect(checkedOut).toMatchObject({
+      id: issueId,
+      status: "in_progress",
+      assigneeAgentId: nextAgentId,
+      checkoutRunId: nextRunId,
+      executionRunId: nextRunId,
+    });
   });
 });
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1980,6 +1980,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through heartbeat-triggered execution runs, issue ownership, and adapter-mediated runtime environments.
> - This change sits in the heartbeat recovery path plus the OpenClaw gateway adapter, where failed or reaped runs need to hand work back to the same assigned agent cleanly.
> - Recoverable provider failures were leaving assigned issues stranded between runs, and gateway-backed local agents were not consistently receiving the short-lived Paperclip JWT needed for direct API mutations.
> - That created a control-plane gap: work that should have auto-continued instead stalled, and OpenClaw gateway runs could miss the auth context local agents depend on.
> - This pull request teaches heartbeat recovery to enqueue a continuation only for recoverable failures, preserves execution-lock ownership on that continuation, and aligns routine/direct assignment guards with paused/open-issue constraints.
> - It also updates the OpenClaw gateway adapter to opt into local-agent JWT injection and merge runtime env into outbound execution payloads without clobbering explicit overrides.
> - The benefit is that assigned work keeps moving after transient failures without creating detached retries, and gateway-backed agents can mutate Paperclip state using the same short-lived auth model as other local agents.

## What Changed

- Added heartbeat recovery logic that queues continuation runs for recoverable failures/reaped runs while preserving issue execution-lock ownership on the queued retry.
- Hardened issue and routine assignment paths so paused agents and agents with open issues are filtered consistently across direct assignment and routine dispatch.
- Enabled the OpenClaw gateway adapter to declare local-agent JWT support and merge runtime env into outbound execute payloads while preserving payload-template overrides.
- Added focused regressions across heartbeat recovery, routines, issue assignment, adapter registry behavior, and OpenClaw gateway execution env injection.
- Documented the gateway auth/env behavior in the adapter README.

## Verification

- `pnpm vitest run server/src/__tests__/issues-service.test.ts server/src/__tests__/routines-service.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts server/src/__tests__/openclaw-gateway-adapter.test.ts server/src/__tests__/adapter-registry.test.ts`
- `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck`
- `git diff --check origin/master...HEAD`

## Risks

- Moderate risk: heartbeat recovery and issue execution-lock handling are concurrency-sensitive, so regressions could cause duplicate continuation runs or incorrectly preserved locks if adjacent lifecycle code changes later.
- The full workspace `pnpm -r typecheck` still stalls in `packages/shared` on this machine, so repo-wide verification remains incomplete even though the touched surfaces and focused test suite are green.

## Model Used

- OpenAI Codex CLI on GPT-5.4 with tool use/code execution in a local macOS workspace. Reasoning effort: high via Codex execution lane.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
