### PR TITLE
fix(server): tighten server.log permissions to 0600

### DIFF
--- a/server/src/__tests__/log-perms.test.ts
+++ b/server/src/__tests__/log-perms.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensureLogPathPermissions } from "../middleware/logger.js";
+
+describe("ensureLogPathPermissions", () => {
+  let tempRoot: string;
+
+  beforeEach(() => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-log-perms-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("creates the log directory at mode 0700", () => {
+    const dir = path.join(tempRoot, "logs");
+    const file = path.join(dir, "server.log");
+
+    ensureLogPathPermissions(dir, file);
+
+    const dirStat = fs.statSync(dir);
+    expect(dirStat.isDirectory()).toBe(true);
+    expect(dirStat.mode & 0o777).toBe(0o700);
+  });
+
+  it("pre-creates a new log file at mode 0600", () => {
+    const dir = path.join(tempRoot, "logs");
+    const file = path.join(dir, "server.log");
+
+    ensureLogPathPermissions(dir, file);
+
+    const fileStat = fs.statSync(file);
+    expect(fileStat.isFile()).toBe(true);
+    expect(fileStat.mode & 0o777).toBe(0o600);
+  });
+
+  it("tightens an existing 0644 log file to 0600", () => {
+    const dir = path.join(tempRoot, "logs");
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, "server.log");
+    fs.writeFileSync(file, "pre-existing content\n", { mode: 0o644 });
+    fs.chmodSync(file, 0o644);
+    expect(fs.statSync(file).mode & 0o777).toBe(0o644);
+
+    ensureLogPathPermissions(dir, file);
+
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    expect(fs.readFileSync(file, "utf8")).toBe("pre-existing content\n");
+  });
+
+  it("tightens the directory from 0755 to 0700 on second call", () => {
+    const dir = path.join(tempRoot, "logs");
+    fs.mkdirSync(dir, { recursive: true, mode: 0o755 });
+    fs.chmodSync(dir, 0o755);
+    const file = path.join(dir, "server.log");
+
+    ensureLogPathPermissions(dir, file);
+
+    expect(fs.statSync(dir).mode & 0o777).toBe(0o700);
+  });
+
+});

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -16,9 +16,21 @@ function resolveServerLogDir(): string {
 }
 
 const logDir = resolveServerLogDir();
-fs.mkdirSync(logDir, { recursive: true });
+fs.mkdirSync(logDir, { recursive: true, mode: 0o700 });
 
 const logFile = path.join(logDir, "server.log");
+
+// Ensure the log file is owner-only (0600) even if Pino/sonic-boom creates it
+// with a umask-dependent default (typically 0644). Request bodies on 4xx/5xx
+// responses can contain sensitive form fields, so group/other must never read.
+try {
+  if (!fs.existsSync(logFile)) {
+    fs.closeSync(fs.openSync(logFile, "a", 0o600));
+  }
+  fs.chmodSync(logFile, 0o600);
+} catch {
+  // Non-fatal: continue even if the chmod fails (e.g., read-only mount).
+}
 
 const sharedOpts = {
   translateTime: "SYS:HH:MM:ss",

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -15,22 +15,29 @@ function resolveServerLogDir(): string {
   return resolveDefaultLogsDir();
 }
 
-const logDir = resolveServerLogDir();
-fs.mkdirSync(logDir, { recursive: true, mode: 0o700 });
-
-const logFile = path.join(logDir, "server.log");
-
-// Ensure the log file is owner-only (0600) even if Pino/sonic-boom creates it
-// with a umask-dependent default (typically 0644). Request bodies on 4xx/5xx
-// responses can contain sensitive form fields, so group/other must never read.
-try {
-  if (!fs.existsSync(logFile)) {
-    fs.closeSync(fs.openSync(logFile, "a", 0o600));
+/**
+ * Create the log directory at 0700 and ensure the server log file ends up at 0600,
+ * even if Pino/sonic-boom creates it later with a umask-dependent default (typically
+ * 0644). Request bodies on 4xx/5xx responses can contain sensitive form fields, so
+ * group/other must never read. Safe to call at module init; exported so tests can
+ * exercise the same code path without importing the whole logger transport.
+ */
+export function ensureLogPathPermissions(dir: string, file: string): void {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    fs.chmodSync(dir, 0o700);
+    if (!fs.existsSync(file)) {
+      fs.closeSync(fs.openSync(file, "a", 0o600));
+    }
+    fs.chmodSync(file, 0o600);
+  } catch {
+    // Non-fatal: continue even if the chmod fails (e.g., read-only mount).
   }
-  fs.chmodSync(logFile, 0o600);
-} catch {
-  // Non-fatal: continue even if the chmod fails (e.g., read-only mount).
 }
+
+const logDir = resolveServerLogDir();
+const logFile = path.join(logDir, "server.log");
+ensureLogPathPermissions(logDir, logFile);
 
 const sharedOpts = {
   translateTime: "SYS:HH:MM:ss",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Every heartbeat run writes pino logs to `~/.paperclip/instances/<id>/logs/server.log`
> - The HTTP logger records request bodies on 4xx/5xx responses, so failed-auth bodies end up in that file
> - Pino's file transport creates `server.log` with a umask-dependent default (typically `0644`), leaving group and other with read access
> - The containing `~/.paperclip/instances/<id>/logs/` directory is `0700` on fresh installs, but the file itself leaks to any local user who can read it, and an existing 0755 dir from a prior run never gets tightened because `mkdirSync({recursive: true})` does not re-chmod existing directories
> - This PR enforces `0700` on the logs directory (every startup, not just fresh installs) and `0600` on `server.log` at logger init, pre-creating the file so sonic-boom cannot race us to it
> - The benefit is that even if a future code path logs a sensitive field that isn't in the redaction list, the blast radius is contained to the paperclip process owner

## What Changed

- `server/src/middleware/logger.ts`: extracted the permission-enforcement block into a named export `ensureLogPathPermissions(dir, file)` so it's directly unit-testable without importing the full transport
- `server/src/middleware/logger.ts`: `mkdirSync` passes `{ mode: 0o700 }` for the fresh-dir case, and now also calls `fs.chmodSync(dir, 0o700)` inside the try block so an existing 0755 logs directory from a prior run is tightened on every startup (gap caught while writing tests — `mkdirSync({recursive: true})` does NOT re-apply mode to existing dirs per Node docs)
- `server/src/middleware/logger.ts`: pre-creates `server.log` with `openSync(..., 'a', 0o600)` then applies `chmodSync(..., 0o600)` to cover the existing-file case, wrapped in `try/catch` to survive read-only mounts and foreign-owned files
- `server/src/__tests__/log-perms.test.ts`: 4 new vitest cases covering fresh-dir 0700, fresh-file 0600, existing-0644-file tightened to 0600 with content preserved, existing-0755-dir tightened to 0700

## Why a separate PR from #3138

#3138 fixes the content side (redacts credential fields in logged bodies). This PR fixes the access side (who can read the file). They are complementary — if a future code path logs a sensitive field outside the redaction list, `0600` mode still contains the blast radius to the paperclip process owner.

## Impact on existing installs

New log writes after restart get `0600`. Existing `server.log` files at `0644` are chmod'd to `0600` at startup by the new `chmodSync` call. Existing logs *directories* at `0755` are now tightened to `0700` too (this case was silently broken before — only fresh installs got `0700`, upgrades kept whatever umask produced). Operators should verify with:

```
stat -c '%a' ~/.paperclip/instances/default/logs/server.log
→ 600
stat -c '%a' ~/.paperclip/instances/default/logs/
→ 700
```

## Verification

```
$ cd server && pnpm exec vitest run src/__tests__/log-perms.test.ts

 RUN  v3.2.4 /home/yunsu/dev/paperclip/server

 ✓ src/__tests__/log-perms.test.ts (4 tests) 4ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Manual confirmation on a fresh install: `stat` shows 600/700 as expected. Existing-file case: started with a `0644` `server.log` already present — `chmodSync` tightened it to `0600` at init without crashing the server.

## Risks

Low risk. The chmod and mkdirSync calls are at logger init only, wrapped in try/catch for the foreign-owned and read-only-mount cases. No schema changes, no behavioral change to request handling. Refactor to expose `ensureLogPathPermissions` preserves all prior call-site behavior (module init still calls it with the same arguments at the same time).

## Model Used

- Anthropic Claude, claude-opus-4-7, 1M context window, tool use + extended thinking

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (`pnpm exec vitest run src/__tests__/log-perms.test.ts` — 4/4, output in Verification section above)
- [x] I have added or updated tests where applicable (`server/src/__tests__/log-perms.test.ts` — 4 cases covering fresh-dir, fresh-file, existing-file tighten, existing-dir tighten)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — no UI surface touched; change is limited to server-side logger init)
- [x] I have updated relevant documentation to reflect my changes (N/A — `grep -rn "server\.log\|PAPERCLIP_LOG_DIR" docs/ README.md` finds zero canonical operator docs describing log file location or permissions; the only reference is in a solutions post-mortem. No user-facing doc surface exists to update for this fix)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
