### PR TITLE
fix(server): handle postgres.js constraint_name field in conflict detection

### DIFF
--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1479,9 +1479,11 @@ function isInviteTokenHashCollisionError(error: unknown) {
         ? candidate.message
         : "";
     const constraint =
-      "constraint" in candidate && typeof candidate.constraint === "string"
-        ? candidate.constraint
-        : null;
+      "constraint_name" in candidate && typeof candidate.constraint_name === "string"
+        ? candidate.constraint_name
+        : "constraint" in candidate && typeof candidate.constraint === "string"
+          ? candidate.constraint
+          : null;
     if (code !== "23505") continue;
     if (constraint === "invites_token_hash_unique_idx") return true;
     if (message.includes("invites_token_hash_unique_idx")) return true;

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -790,13 +790,12 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
             executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
           });
         } catch (error) {
+          const err = error as { code?: string; constraint?: string; constraint_name?: string } | null;
+          const constraint = err?.constraint ?? err?.constraint_name;
           const isOpenExecutionConflict =
-            !!error &&
-            typeof error === "object" &&
-            "code" in error &&
-            (error as { code?: string }).code === "23505" &&
-            "constraint" in error &&
-            (error as { constraint?: string }).constraint === "issues_open_routine_execution_uq";
+            !!err &&
+            err.code === "23505" &&
+            constraint === "issues_open_routine_execution_uq";
           if (!isOpenExecutionConflict || input.routine.concurrencyPolicy === "always_enqueue") {
             throw error;
           }


### PR DESCRIPTION
## Summary

The `postgres.js` driver (v3.x, used by `@paperclipai/db`) exposes the violated unique-constraint name on errors as `error.constraint_name`, not `error.constraint`. Two conflict handlers in the server were checking only `error.constraint`, which caused them to silently miss all unique-constraint violations.

**Affected sites:**

1. **`services/routines.ts`** — the routine dispatch conflict handler on `issues_open_routine_execution_uq` (the partial unique index that enforces one live routine-execution issue per `(company, origin_kind, origin_id)`). When the handler couldn't detect the violation, the `coalesced`/`skipped` fallback never fired and the `INSERT` re-threw, leaving the run `failed`.

2. **`routes/access.ts`** — `isInviteTokenHashCollisionError` never returned `true`, so the invite-token hash-collision retry path was unreachable.

Existing helpers in `services/companies.ts` and `services/plugin-registry.ts` already use a defensive `??` fallback across both field names. This patch aligns the two remaining call sites with that pattern.

## Real-world impact (reported from production)

On 2026-04-13/14 I observed Executive Sweep and Chief of Staff routines looping `failed` for 12+ hours on a production Paperclip instance (v2026.410.0). Every dispatch hit `PostgresError: duplicate key value violates unique constraint \"issues_open_routine_execution_uq\"` and re-threw, because the conflict handler at `services/routines.ts:798` was checking `error.constraint` (undefined under `postgres.js`) instead of `error.constraint_name`.

The knock-on effect was a fully stuck queue — the sweep routines never coalesced, so the downstream executive audit loop never ran, and real critical-lane incidents (a 5-day CMS firewall outage) went without a single supervision pass for 12+ hours.

Patch applied locally, server restarted, zero new `issues_open_routine_execution_uq` errors in the 30 minutes following the restart. Dispatch is healthy.

## Change

Use the same defensive `err.constraint ?? err.constraint_name` pattern that `services/plugin-registry.ts:41` and `services/companies.ts:124-128` already use. This keeps backward compatibility with any other driver that exposes the old `.constraint` field.

## Test plan

- [ ] Repo typecheck / lint
- [ ] Unit test: trigger `issues_open_routine_execution_uq` and assert the handler coalesces/skips instead of throwing
- [ ] Unit test: trigger `invites_token_hash_unique_idx` and assert `isInviteTokenHashCollisionError` returns \`true\`
- [ ] Manual: run any routine with a live-execution row present, confirm second dispatch is \`coalesced\`/\`skipped\` per \`concurrencyPolicy\`

## Notes

- No schema or behavior changes — purely restoring the intended conflict-detection logic.
- \`services/companies.ts\` and \`services/plugin-registry.ts\` already handle both field names, so this brings the two outliers into line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)