### PR TITLE
feat(routines): add failed-run follow-up issue automation

### DIFF
--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+
+describe("queueIssueAssignmentWakeup", () => {
+  it("forwards silent completion and onComplete follow-up settings to heartbeat wakeups", async () => {
+    const wakeup = vi.fn().mockResolvedValue({ id: "run-1" });
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "issue-1",
+        assigneeAgentId: "agent-1",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "routine.dispatch",
+      requestedByActorType: "system",
+      silentCompletion: true,
+      onComplete: {
+        issueStatus: "blocked",
+        onlyOn: ["failed", "timed_out"],
+      },
+    });
+
+    expect(wakeup).toHaveBeenCalledWith("agent-1", {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: "issue-1", mutation: "create" },
+      requestedByActorType: "system",
+      requestedByActorId: null,
+      contextSnapshot: { issueId: "issue-1", source: "routine.dispatch" },
+      silentCompletion: true,
+      onComplete: {
+        issueStatus: "blocked",
+        onlyOn: ["failed", "timed_out"],
+      },
+    });
+  });
+});

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -259,6 +259,31 @@ describe("issue comment reopen routes", () => {
     );
   });
 
+  it("reopens closed issues even when the incoming patch still includes a closed status", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        comment: "hello",
+        reopen: true,
+        status: "done",
+        assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        status: "todo",
+      }),
+    );
+  });
+
   it("interrupts an active run before a combined comment update", async () => {
     const issue = {
       ...makeIssue("todo"),

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -76,6 +76,8 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
         requestedByActorType?: "user" | "agent" | "system";
         requestedByActorId?: string | null;
         contextSnapshot?: Record<string, unknown>;
+        silentCompletion?: boolean;
+        onComplete?: Record<string, unknown> | null;
       },
     ) => Promise<unknown>;
   }) {
@@ -93,6 +95,8 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
         requestedByActorType?: "user" | "agent" | "system";
         requestedByActorId?: string | null;
         contextSnapshot?: Record<string, unknown>;
+        silentCompletion?: boolean;
+        onComplete?: Record<string, unknown> | null;
       };
     }> = [];
 
@@ -264,6 +268,20 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
           requestedByActorType: undefined,
           requestedByActorId: null,
           contextSnapshot: { issueId: run.linkedIssueId, source: "routine.dispatch" },
+          silentCompletion: true,
+          onComplete: {
+            issueStatus: "blocked",
+            commentBody: "루틴 실행이 비정상 종료되었습니다. 결과: {outcome}. 후속 이슈: {createdIssueIdentifier}",
+            createIssue: {
+              title: "Follow-up: ascii frog",
+              description: "Automatically created because the routine execution heartbeat failed or timed out.",
+              status: "todo",
+              priority: "medium",
+              assignToAgentId: agentId,
+              commentBody: "이 이슈는 실행 {runId} 의 실패 후 자동 생성되었습니다. 부모 이슈: {issueId}",
+            },
+            onlyOn: ["failed", "timed_out"],
+          },
         },
       },
     ]);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1367,7 +1367,7 @@ export function issueRoutes(
     if (hiddenAtRaw !== undefined) {
       updateFields.hiddenAt = hiddenAtRaw ? new Date(hiddenAtRaw) : null;
     }
-    if (commentBody && reopenRequested === true && isClosed && updateFields.status === undefined) {
+    if (commentBody && reopenRequested === true && isClosed) {
       updateFields.status = "todo";
     }
     if (req.body.executionPolicy !== undefined) {

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -14,6 +14,8 @@ export interface IssueAssignmentWakeupDeps {
       requestedByActorType?: "user" | "agent" | "system";
       requestedByActorId?: string | null;
       contextSnapshot?: Record<string, unknown>;
+      silentCompletion?: boolean;
+      onComplete?: Record<string, unknown> | null;
     },
   ) => Promise<unknown>;
 }
@@ -26,6 +28,8 @@ export function queueIssueAssignmentWakeup(input: {
   contextSource: string;
   requestedByActorType?: "user" | "agent" | "system";
   requestedByActorId?: string | null;
+  silentCompletion?: boolean;
+  onComplete?: Record<string, unknown> | null;
   rethrowOnError?: boolean;
 }) {
   if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return;
@@ -39,6 +43,8 @@ export function queueIssueAssignmentWakeup(input: {
       requestedByActorType: input.requestedByActorType,
       requestedByActorId: input.requestedByActorId ?? null,
       contextSnapshot: { issueId: input.issue.id, source: input.contextSource },
+      silentCompletion: input.silentCompletion,
+      onComplete: input.onComplete ?? null,
     })
     .catch((err) => {
       logger.warn({ err, issueId: input.issue.id }, "failed to wake assignee on issue assignment");

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -829,8 +829,26 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
           mutation: "create",
           contextSource: "routine.dispatch",
           requestedByActorType: input.source === "schedule" ? "system" : undefined,
+          silentCompletion: true,
+          onComplete: {
+            issueStatus: "blocked",
+            commentBody:
+              "루틴 실행이 비정상 종료되었습니다. 결과: {outcome}. 후속 이슈: {createdIssueIdentifier}",
+            createIssue: {
+              title: `Follow-up: ${createdIssue.title}`,
+              description:
+                "Automatically created because the routine execution heartbeat failed or timed out.",
+              status: "todo",
+              priority: createdIssue.priority as "critical" | "high" | "medium" | "low",
+              assignToAgentId: createdIssue.assigneeAgentId,
+              commentBody:
+                "이 이슈는 실행 {runId} 의 실패 후 자동 생성되었습니다. 부모 이슈: {issueId}",
+            },
+            onlyOn: ["failed", "timed_out"],
+          },
           rethrowOnError: true,
         });
+
         const updated = await finalizeRun(createdRun.id, {
           status: "issue_created",
           linkedIssueId: createdIssue.id,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and their issue-driven work across companies.
> - Routine dispatch is one of the control-plane paths that turns scheduled or manual automation into assignee work on issues.
> - When a routine-created execution issue wakes an agent, failure handling needs to leave a clear follow-up trail instead of silently stalling.
> - The issue comment PATCH path is part of that same operator loop, because reopening a closed issue with feedback should reliably return it to an actionable state.
> - Upstream already had the routine dispatch wakeup path and reopen comment path, but it did not carry the follow-up completion policy through the wakeup helper and it could preserve a closed status from the incoming patch.
> - This pull request threads failed-run follow-up automation through `queueIssueAssignmentWakeup` and makes comment-driven reopen requests force the issue back to `todo`.
> - The benefit is that failed routine runs now have a consistent blocked-plus-follow-up path, and board feedback can reopen closed issues predictably.

## What Changed

- Added `silentCompletion` and `onComplete` passthrough support to `queueIssueAssignmentWakeup`.
- Updated routine dispatch wakeups to attach failed-run follow-up automation when creating a fresh execution issue.
- Updated the issue PATCH comment/reopen flow so closed issues reopen to `todo` even if the incoming patch still includes a closed status.
- Added a focused unit test for `queueIssueAssignmentWakeup` passthrough behavior.
- Added a regression test for closed-issue reopen requests that still carry a closed status.
- Updated the embedded Postgres routine service expectation to cover the follow-up wakeup payload shape.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-assignment-wakeup.test.ts src/__tests__/issue-comment-reopen-routes.test.ts`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/routines-service.test.ts -t "wakes the assignee when a routine creates a fresh execution issue"`
  - Skipped on this host because the embedded Postgres init script exited early in the current worktree environment.
- `pnpm --filter @paperclipai/server exec tsx --eval "import('./src/services/routines.ts').then(() => console.log('ROUTINES_IMPORT_OK')); import('./src/routes/issues.ts').then(() => console.log('ISSUES_ROUTE_IMPORT_OK'));"`

## Risks

- Low to moderate risk: routine-created wakeups now carry extra completion automation fields, so any consumer assuming a narrower wakeup payload could surface integration issues.
- The embedded Postgres routine service regression assertion was updated, but full execution of that integration test was skipped on this host due the local embedded Postgres init problem noted above.

## Model Used

- OpenAI Codex provider using `gpt-5.4` in a Hermes CLI tool-use session with terminal, file-editing, and git execution capabilities.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
