### PR TITLE
fix: update GitHub CLI GPG keyring SHA256 checksum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates gosu curl git wget ripgrep python3 \
   && mkdir -p -m 755 /etc/apt/keyrings \
   && wget -nv -O/etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-  && echo "20e0125d6f6e077a9ad46f03371bc26d90b04939fb95170f5a1905099cc6bcc0  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
+  && echo "6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
   && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
   && mkdir -p -m 755 /etc/apt/sources.list.d \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \


### PR DESCRIPTION
## Summary

Fixes #3641 - Docker build fails due to stale SHA256 checksum for GitHub CLI GPG keyring.

## Problem

The hardcoded SHA256 checksum in the Dockerfile was pointing to an old version of the GitHub CLI GPG keyring, causing fresh Docker builds to fail with checksum mismatch errors.

## Solution

Updated the checksum from:
`20e0125d6f6e077a9ad46f03371bc26d90b04939fb95170f5a1905099cc6bcc0`

To current value:
`6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b`

## Testing

- ✅ Downloaded current keyring from `https://cli.github.com/packages/githubcli-archive-keyring.gpg`
- ✅ Verified SHA256 matches: `6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b`  
- ✅ Checksum verification passes locally

## Breaking Changes

None. This is a pure infrastructure fix.

## Status

Ready for review. This resolves Docker build failures on fresh environments.