### PR TITLE
fix(gemini-local): inject gemini-system.md and add /tmp to --include-directories

### DIFF
--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -44,6 +44,14 @@ const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
  */
 const GEMINI_SYSTEM_FILENAME = "gemini-system.md";
 
+function appendTmpDirectory(includeDirectories: string): string {
+  const trimmed = includeDirectories.trim();
+  if (trimmed.length === 0) return "/tmp";
+  const entries = trimmed.split(":").map((entry) => entry.trim()).filter(Boolean);
+  if (entries.includes("/tmp")) return trimmed;
+  return `${trimmed}:/tmp`;
+}
+
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];
   return typeof raw === "string" && raw.trim().length > 0;
@@ -336,6 +344,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const buildArgs = (resumeSessionId: string | null) => {
     const args = ["--output-format", "stream-json"];
+    const mergedExtraArgs = [...extraArgs];
+    const includeDirectoriesFlagIndex = mergedExtraArgs.findIndex((value) => value === "--include-directories");
+    const includeDirectoriesInlineIndex = mergedExtraArgs.findIndex((value) => value.startsWith("--include-directories="));
+    if (includeDirectoriesFlagIndex >= 0) {
+      const nextValue = mergedExtraArgs[includeDirectoriesFlagIndex + 1] ?? "";
+      const canPatchNextValue = nextValue.length === 0 || !nextValue.startsWith("-");
+      if (canPatchNextValue) {
+        mergedExtraArgs[includeDirectoriesFlagIndex + 1] = appendTmpDirectory(nextValue);
+      }
+    } else if (includeDirectoriesInlineIndex >= 0) {
+      const [, inlineValue = ""] = mergedExtraArgs[includeDirectoriesInlineIndex].split("=", 2);
+      mergedExtraArgs[includeDirectoriesInlineIndex] = `--include-directories=${appendTmpDirectory(inlineValue)}`;
+    } else {
+      args.push("--include-directories", `${cwd}:/tmp`);
+    }
     if (resumeSessionId) args.push("--resume", resumeSessionId);
     if (model && model !== DEFAULT_GEMINI_LOCAL_MODEL) args.push("--model", model);
     args.push("--approval-mode", "yolo");
@@ -344,9 +367,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     } else {
       args.push("--sandbox=none");
     }
-    // Allow agents to write intermediate results to /tmp (e.g., test output capping)
-    args.push("--include-directories", `${cwd}:/tmp`);
-    if (extraArgs.length > 0) args.push(...extraArgs);
+    if (mergedExtraArgs.length > 0) args.push(...mergedExtraArgs);
     args.push("--prompt", prompt);
     return args;
   };
@@ -360,7 +381,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     renderedBootstrapPrompt,
     paperclipEnvNote,
     apiAccessNote,
-    renderedPrompt,
   ]);
   if (systemPrompt.trim().length > 0) {
     const systemFilePath = path.join(cwd, GEMINI_SYSTEM_FILENAME);

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -38,6 +38,12 @@ import { firstNonEmptyLine } from "./utils.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Filename for the auto-injected system prompt that Gemini CLI reads for context.
+ * Written to the agent's cwd so Gemini discovers it naturally without env overrides.
+ */
+const GEMINI_SYSTEM_FILENAME = "gemini-system.md";
+
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];
   return typeof raw === "string" && raw.trim().length > 0;
@@ -338,10 +344,39 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     } else {
       args.push("--sandbox=none");
     }
+    // Allow agents to write intermediate results to /tmp (e.g., test output capping)
+    args.push("--include-directories", `${cwd}:/tmp`);
     if (extraArgs.length > 0) args.push(...extraArgs);
     args.push("--prompt", prompt);
     return args;
   };
+
+  /**
+   * Inject the system prompt as gemini-system.md in the agent's cwd.
+   * Gemini CLI auto-reads this file for system context when present.
+   */
+  const systemPrompt = joinPromptSections([
+    instructionsPrefix,
+    renderedBootstrapPrompt,
+    paperclipEnvNote,
+    apiAccessNote,
+    renderedPrompt,
+  ]);
+  if (systemPrompt.trim().length > 0) {
+    const systemFilePath = path.join(cwd, GEMINI_SYSTEM_FILENAME);
+    try {
+      await fs.writeFile(systemFilePath, systemPrompt, "utf8");
+      await onLog(
+        "stderr",
+        `[paperclip] Injected system prompt as ${systemFilePath}\n`,
+      );
+    } catch (err) {
+      await onLog(
+        "stderr",
+        `[paperclip] Warning: could not write ${systemFilePath}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
 
   const runAttempt = async (resumeSessionId: string | null) => {
     const args = buildArgs(resumeSessionId);


### PR DESCRIPTION
## Summary

Fixes two friction points in gemini-local adapter production deployments:

### Changes

1. **Auto-inject system prompt as `gemini-system.md`**
   - The Paperclip-managed system prompt (instructions, bootstrap, env notes, API access notes, rendered prompt) is now written to `gemini-system.md` in the agent's working directory.
   - Gemini CLI automatically reads this file for system context when present.
   - Gracefully handles file write failures with warning logs.

2. **Add `/tmp` to `--include-directories`**
   - Agents can now write intermediate results to `/tmp` (e.g., test output capping via `cmd 2>&1 | tail -N > /tmp/out.txt`).
   - This prevents permissions errors during heartbeat operations.



Closes #3520