### PR TITLE
feat: persist and resume sessions across heartbeats

### DIFF
--- a/docs/adapters/codex-local.md
+++ b/docs/adapters/codex-local.md
@@ -25,7 +25,11 @@ The `codex_local` adapter runs OpenAI's Codex CLI locally. It supports session p
 
 ## Session Persistence
 
-Codex uses `previous_response_id` for session continuity. The adapter serializes and restores this across heartbeats, allowing the agent to maintain conversation context.
+Codex sessions are persisted and resumed across heartbeats by default.
+
+- `codex_local` now defaults to **agent-scoped** session resume: one persistent Codex thread per agent.
+- You can opt into task-scoped resume by setting `runtimeConfig.heartbeat.sessionScope` to `"task"`.
+- Provide `forceFreshSession: true` in a wake context to explicitly reset and start a new session.
 
 ## Skills Injection
 

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -67,6 +67,9 @@ Notes:
 - Prompts are piped via stdin (Codex receives "-" prompt argument).
 - If instructionsFilePath is configured, Paperclip prepends that file's contents to the stdin prompt on every run.
 - Codex exec automatically applies repo-scoped AGENTS.md instructions from the active workspace. Paperclip cannot suppress that discovery in exec mode, so repo AGENTS.md files may still apply even when you only configured an explicit instructionsFilePath.
+- Session resume defaults to agent scope for codex_local: heartbeats reuse one persistent Codex thread per agent unless an explicit taskKey is provided.
+- To opt into task-scoped sessions (legacy behavior), set runtimeConfig.heartbeat.sessionScope to "task".
+- Set context.forceFreshSession=true on a wake to force a clean session start.
 - Paperclip injects desired local skills into the effective CODEX_HOME/skills/ directory at execution time so Codex can discover "$paperclip" and related skills without polluting the project working directory. In managed-home mode (the default) this is ~/.paperclip/instances/<id>/companies/<companyId>/codex-home/skills/; when CODEX_HOME is explicitly overridden in adapter config, that override is used instead.
 - Unless explicitly overridden in adapter config, Paperclip runs Codex with a per-company managed CODEX_HOME under the active Paperclip instance and seeds auth/config from the shared Codex home (the CODEX_HOME env var, when set, or ~/.codex).
 - Some model/tool combinations reject certain effort levels (for example minimal with web search enabled).

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -13,6 +13,7 @@ import {
   mergeCoalescedContextSnapshot,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
+  resolveTaskKeyForWake,
   resolveRuntimeSessionParamsForWorkspace,
   stripWorkspaceRuntimeFromExecutionRunConfig,
   shouldResetTaskSessionForWake,
@@ -322,6 +323,17 @@ describe("shouldResetTaskSessionForWake", () => {
     ).toBe(true);
   });
 
+  it("preserves session context when adapter session scope is agent-level", () => {
+    expect(
+      shouldResetTaskSessionForWake(
+        {
+          wakeReason: "issue_assigned",
+        },
+        { preserveAcrossWakes: true },
+      ),
+    ).toBe(false);
+  });
+
   it("does not reset session context on mention wake comment", () => {
     expect(
       shouldResetTaskSessionForWake({
@@ -355,6 +367,35 @@ describe("shouldResetTaskSessionForWake", () => {
         wakeTriggerDetail: "callback",
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveTaskKeyForWake", () => {
+  it("defaults codex_local to a stable agent session key", () => {
+    const key = resolveTaskKeyForWake(buildAgent("codex_local"), { wakeSource: "timer" }, null);
+    expect(key).toBe("__agent_session__:agent-1");
+  });
+
+  it("honors explicit task keys even when codex uses agent scope", () => {
+    const key = resolveTaskKeyForWake(
+      buildAgent("codex_local"),
+      { taskKey: "issue-123", wakeSource: "timer" },
+      null,
+    );
+    expect(key).toBe("issue-123");
+  });
+
+  it("allows codex agents to opt back into task-scoped resume", () => {
+    const key = resolveTaskKeyForWake(
+      buildAgent("codex_local", {
+        heartbeat: {
+          sessionScope: "task",
+        },
+      }),
+      { wakeSource: "timer" },
+      null,
+    );
+    expect(key).toBe("__heartbeat__");
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6924,13 +6924,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .orderBy(desc(heartbeatRuns.createdAt));
 
     const sameScopeQueuedRun = activeRuns.find(
-      (candidate) => candidate.status === "queued" && isSameTaskScope(runTaskKey(candidate), taskKey),
+      (candidate) =>
+        candidate.status === "queued" && isSameTaskScope(runTaskKey(candidate), effectiveTaskKey),
     );
     const sameScopeScheduledRetryRun = activeRuns.find(
       (candidate) => candidate.status === "scheduled_retry" && isSameTaskScope(runTaskKey(candidate), taskKey),
     );
     const sameScopeRunningRun = activeRuns.find(
-      (candidate) => candidate.status === "running" && isSameTaskScope(runTaskKey(candidate), taskKey),
+      (candidate) =>
+        candidate.status === "running" && isSameTaskScope(runTaskKey(candidate), effectiveTaskKey),
     );
     const shouldQueueFollowupForRunningWake =
       Boolean(sameScopeRunningRun) &&

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -143,6 +143,7 @@ const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
 const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+const AGENT_SESSION_TASK_KEY_PREFIX = "__agent_session__:";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
@@ -1277,6 +1278,7 @@ function parseIssueAssigneeAdapterOverrides(
  * simpler `agentRuntimeState.sessionId` fallback.
  */
 const HEARTBEAT_TASK_KEY = "__heartbeat__";
+type SessionResumeScope = "task" | "agent";
 
 function deriveTaskKey(
   contextSnapshot: Record<string, unknown> | null | undefined,
@@ -1315,10 +1317,37 @@ export function deriveTaskKeyWithHeartbeatFallback(
   return null;
 }
 
+function deriveAgentSessionTaskKey(agentId: string): string {
+  return `${AGENT_SESSION_TASK_KEY_PREFIX}${agentId}`;
+}
+
+function resolveSessionResumeScope(agent: typeof agents.$inferSelect): SessionResumeScope {
+  const runtimeConfig = parseObject(agent.runtimeConfig);
+  const heartbeat = parseObject(runtimeConfig.heartbeat);
+  const configuredScope = readNonEmptyString(heartbeat.sessionScope);
+  if (configuredScope === "agent" || configuredScope === "task") return configuredScope;
+  return agent.adapterType === "codex_local" ? "agent" : "task";
+}
+
+export function resolveTaskKeyForWake(
+  agent: typeof agents.$inferSelect,
+  contextSnapshot: Record<string, unknown> | null | undefined,
+  payload: Record<string, unknown> | null | undefined,
+) {
+  const explicitTaskKey = deriveTaskKey(contextSnapshot, payload);
+  if (explicitTaskKey) return explicitTaskKey;
+  if (resolveSessionResumeScope(agent) === "agent") {
+    return deriveAgentSessionTaskKey(agent.id);
+  }
+  return deriveTaskKeyWithHeartbeatFallback(contextSnapshot, payload);
+}
+
 export function shouldResetTaskSessionForWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
+  opts: { preserveAcrossWakes?: boolean } = {},
 ) {
   if (contextSnapshot?.forceFreshSession === true) return true;
+  if (opts.preserveAcrossWakes) return false;
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (
@@ -4669,7 +4698,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const runtime = await ensureRuntimeState(agent);
     const context = parseObject(run.contextSnapshot);
-    const taskKey = deriveTaskKeyWithHeartbeatFallback(context, null);
+    const taskKey = resolveTaskKeyForWake(agent, context, null);
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
     const issueId = readNonEmptyString(context.issueId);
     let issueContext = issueId ? await getIssueExecutionContext(agent.companyId, issueId) : null;
@@ -4741,7 +4770,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const taskSession = taskKey
       ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, taskKey)
       : null;
-    const resetTaskSession = shouldResetTaskSessionForWake(context);
+    const sessionResumeScope = resolveSessionResumeScope(agent);
+    const resetTaskSession = shouldResetTaskSessionForWake(context, {
+      preserveAcrossWakes: sessionResumeScope === "agent",
+    });
     const sessionResetReason = describeSessionResetReason(context);
     const taskSessionForRun = resetTaskSession ? null : taskSession;
     const explicitResumeSessionParams = normalizeSessionParams(
@@ -6315,7 +6347,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const {
       contextSnapshot: enrichedContextSnapshot,
       issueIdFromPayload,
-      taskKey,
+      taskKey: derivedTaskKey,
       wakeCommentId,
     } = enrichWakeContextSnapshot({
       contextSnapshot,
@@ -6344,7 +6376,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
       issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueId;
     }
-    const effectiveTaskKey = readNonEmptyString(enrichedContextSnapshot.taskKey) ?? taskKey;
+    const effectiveTaskKey =
+      resolveTaskKeyForWake(agent, enrichedContextSnapshot, payload) ?? derivedTaskKey;
+    if (effectiveTaskKey) {
+      enrichedContextSnapshot.taskKey = effectiveTaskKey;
+    }
     const sessionBefore =
       explicitResumeSession?.sessionDisplayId ??
       await resolveSessionBeforeForWakeup(agent, effectiveTaskKey);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6360,7 +6360,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");
-    const explicitResumeSession = await resolveExplicitResumeSessionOverride(agent, payload, taskKey);
+    const explicitResumeSession = await resolveExplicitResumeSessionOverride(agent, payload, derivedTaskKey);
     if (explicitResumeSession) {
       enrichedContextSnapshot.resumeFromRunId = explicitResumeSession.resumeFromRunId;
       enrichedContextSnapshot.resumeSessionDisplayId = explicitResumeSession.sessionDisplayId;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6928,7 +6928,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         candidate.status === "queued" && isSameTaskScope(runTaskKey(candidate), effectiveTaskKey),
     );
     const sameScopeScheduledRetryRun = activeRuns.find(
-      (candidate) => candidate.status === "scheduled_retry" && isSameTaskScope(runTaskKey(candidate), taskKey),
+      (candidate) =>
+        candidate.status === "scheduled_retry" && isSameTaskScope(runTaskKey(candidate), effectiveTaskKey),
     );
     const sameScopeRunningRun = activeRuns.find(
       (candidate) =>


### PR DESCRIPTION
## Thinking Path
- Paperclip orchestrates long-running agent workflows through heartbeat wakes.
- `codex_local` sessions were effectively reset too often, causing repeated cold starts.
- Cold starts force reloading instruction/context data and increase token/cost usage.
- Session continuity should be the default for Codex when the same agent is woken repeatedly.
- This PR adds agent-scoped session resume by default for `codex_local`, while preserving explicit task scoping when needed.

Closes #3345

## What Changed

- Adds agent-scoped session persistence across heartbeats for codex_local, aligned with the adapter session management model documented in the adapters tree (codec-backed sessionParams, resume vs. reset semantics).
- Introduces adapter-aware wake task key resolution so codex_local defaults to a stable per-agent session key when no explicit scope is provided.
- Updated reset behavior so agent-scoped Codex sessions are preserved across wake reasons unless `forceFreshSession` is explicitly set.
- Added tests for:
  - codex default agent-scoped keying
  - explicit task key precedence
  - opting back into task-scoped behavior
  - preserve-across-wakes reset semantics
- Updated codex adapter docs/config guidance to document new default and overrides.

## Verification
- Confirm session reuse across repeated heartbeats for the same codex agent (same session/thread id persists).
- Confirm explicit `taskKey` still creates/uses task-scoped session behavior.
- Confirm `runtimeConfig.heartbeat.sessionScope = "task"` restores legacy task-scoped behavior.
- Confirm `forceFreshSession: true` forces a fresh session.
- Run tests and CI; ensure all checks are green.

## Risks
- Changing default session scope may alter behavior for workflows that relied on implicit task-level separation.
- If operators expect hard isolation per issue without explicit `taskKey`, behavior now favors continuity.
- Requires careful validation in multi-issue wake patterns.


## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
