### PR TITLE
feat: add 'parked' issue status and deduplicate status constants

### DIFF
--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -88,7 +88,7 @@ export const issues = pgTable(
           and ${table.originId} is not null
           and ${table.hiddenAt} is null
           and ${table.executionRunId} is not null
-          and ${table.status} in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked')`,
+          and ${table.status} in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked', 'parked')`,
       ),
   }),
 );

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -129,6 +129,7 @@ export const INBOX_MINE_ISSUE_STATUSES = [
   "in_progress",
   "in_review",
   "blocked",
+  "parked",
   "done",
 ] as const;
 export const INBOX_MINE_ISSUE_STATUS_FILTER = INBOX_MINE_ISSUE_STATUSES.join(",");

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -118,6 +118,7 @@ export const ISSUE_STATUSES = [
   "in_review",
   "done",
   "blocked",
+  "parked",
   "cancelled",
 ] as const;
 export type IssueStatus = (typeof ISSUE_STATUSES)[number];

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -23,7 +23,7 @@ import {
   projects,
 } from "@paperclipai/db";
 import type { IssueRelationIssueSummary } from "@paperclipai/shared";
-import { extractAgentMentionIds, extractProjectMentionIds, isUuidLike } from "@paperclipai/shared";
+import { extractAgentMentionIds, extractProjectMentionIds, isUuidLike, ISSUE_STATUSES } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import {
   defaultIssueExecutionWorkspaceSettingsForProject,
@@ -36,7 +36,7 @@ import { redactCurrentUserText } from "../log-redaction.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
 import { getDefaultCompanyGoal } from "./goals.js";
 
-const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
+const ALL_ISSUE_STATUSES: readonly string[] = ISSUE_STATUSES;
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 
 function assertTransition(from: string, to: string) {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -43,7 +43,7 @@ import { heartbeatService } from "./heartbeat.js";
 import { queueIssueAssignmentWakeup, type IssueAssignmentWakeupDeps } from "./issue-assignment-wakeup.js";
 import { logActivity } from "./activity-log.js";
 
-const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
+const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "parked"];
 const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running"];
 const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
 const MAX_CATCH_UP_RUNS = 25;

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -21,16 +21,9 @@ import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
 import type { Issue } from "@paperclipai/shared";
+import { ISSUE_STATUSES } from "@paperclipai/shared";
 
-const boardStatuses = [
-  "backlog",
-  "todo",
-  "in_progress",
-  "in_review",
-  "blocked",
-  "done",
-  "cancelled",
-];
+const boardStatuses: readonly string[] = ISSUE_STATUSES;
 
 function statusLabel(status: string): string {
   return status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -55,6 +55,7 @@ import {
 import { cn } from "../lib/utils";
 import { extractProviderIdWithFallback } from "../lib/model-utils";
 import { issueStatusText, issueStatusTextDefault, priorityColor, priorityColorDefault } from "../lib/status-colors";
+import { ISSUE_STATUSES } from "@paperclipai/shared";
 import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "./MarkdownEditor";
 import { AgentIcon } from "./AgentIconPicker";
 import { InlineEntitySelector, type InlineEntityOption } from "./InlineEntitySelector";
@@ -225,16 +226,15 @@ function formatFileSize(file: File) {
   return `${(file.size / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-const statuses = [
-  { value: "backlog", label: "Backlog", color: issueStatusText.backlog ?? issueStatusTextDefault },
-  { value: "todo", label: "Todo", color: issueStatusText.todo ?? issueStatusTextDefault },
-  { value: "in_progress", label: "In Progress", color: issueStatusText.in_progress ?? issueStatusTextDefault },
-  { value: "in_review", label: "In Review", color: issueStatusText.in_review ?? issueStatusTextDefault },
-  { value: "done", label: "Done", color: issueStatusText.done ?? issueStatusTextDefault },
-  { value: "blocked", label: "Blocked", color: issueStatusText.blocked ?? issueStatusTextDefault },
-  { value: "parked", label: "Parked", color: issueStatusText.parked ?? issueStatusTextDefault },
-  { value: "cancelled", label: "Cancelled", color: issueStatusText.cancelled ?? issueStatusTextDefault },
-];
+function statusLabel(s: string) {
+  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+const statuses = ISSUE_STATUSES.map((s) => ({
+  value: s,
+  label: statusLabel(s),
+  color: issueStatusText[s] ?? issueStatusTextDefault,
+}));
 
 const priorities = [
   { value: "critical", label: "Critical", icon: AlertTriangle, color: priorityColor.critical ?? priorityColorDefault },

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -231,6 +231,9 @@ const statuses = [
   { value: "in_progress", label: "In Progress", color: issueStatusText.in_progress ?? issueStatusTextDefault },
   { value: "in_review", label: "In Review", color: issueStatusText.in_review ?? issueStatusTextDefault },
   { value: "done", label: "Done", color: issueStatusText.done ?? issueStatusTextDefault },
+  { value: "blocked", label: "Blocked", color: issueStatusText.blocked ?? issueStatusTextDefault },
+  { value: "parked", label: "Parked", color: issueStatusText.parked ?? issueStatusTextDefault },
+  { value: "cancelled", label: "Cancelled", color: issueStatusText.cancelled ?? issueStatusTextDefault },
 ];
 
 const priorities = [

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { cn } from "../lib/utils";
 import { issueStatusIcon, issueStatusIconDefault } from "../lib/status-colors";
+import { ISSUE_STATUSES } from "@paperclipai/shared";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 
-const allStatuses = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled", "blocked"];
+const allStatuses: readonly string[] = ISSUE_STATUSES;
 
 function statusLabel(status: string): string {
   return status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());

--- a/ui/src/hooks/useInboxBadge.ts
+++ b/ui/src/hooks/useInboxBadge.ts
@@ -19,7 +19,7 @@ import {
   READ_ITEMS_KEY,
 } from "../lib/inbox";
 
-const INBOX_ISSUE_STATUSES = "backlog,todo,in_progress,in_review,blocked,done";
+const INBOX_ISSUE_STATUSES = "backlog,todo,in_progress,in_review,blocked,parked,done";
 
 export function useDismissedInboxAlerts() {
   const [dismissed, setDismissed] = useState<Set<string>>(loadDismissedInboxAlerts);

--- a/ui/src/lib/status-colors.ts
+++ b/ui/src/lib/status-colors.ts
@@ -18,6 +18,7 @@ export const issueStatusIcon: Record<string, string> = {
   done: "text-green-600 border-green-600 dark:text-green-400 dark:border-green-400",
   cancelled: "text-neutral-500 border-neutral-500",
   blocked: "text-red-600 border-red-600 dark:text-red-400 dark:border-red-400",
+  parked: "text-amber-600 border-amber-600 dark:text-amber-400 dark:border-amber-400",
 };
 
 export const issueStatusIconDefault = "text-muted-foreground border-muted-foreground";
@@ -31,6 +32,7 @@ export const issueStatusText: Record<string, string> = {
   done: "text-green-600 dark:text-green-400",
   cancelled: "text-neutral-500",
   blocked: "text-red-600 dark:text-red-400",
+  parked: "text-amber-600 dark:text-amber-400",
 };
 
 export const issueStatusTextDefault = "text-muted-foreground";
@@ -72,6 +74,7 @@ export const statusBadge: Record<string, string> = {
   in_progress: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/50 dark:text-yellow-300",
   in_review: "bg-violet-100 text-violet-700 dark:bg-violet-900/50 dark:text-violet-300",
   blocked: "bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300",
+  parked: "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300",
   done: "bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300",
   cancelled: "bg-muted text-muted-foreground",
 };


### PR DESCRIPTION
## Summary
- Adds a new `parked` issue status for tasks intentionally set aside (distinct from `blocked` which implies external dependency)
- Deduplicates hardcoded status arrays across 3 components — `KanbanBoard`, `StatusIcon`, and `issues.ts` service now import from `ISSUE_STATUSES` in `@paperclipai/shared` instead of maintaining local copies
- `NewIssueDialog` was missing `blocked` and `cancelled` from its status picker — added along with `parked`
- Amber color theme for parked status across icon, text, and badge styles

## Files changed (8)
| File | Change |
|---|---|
| `packages/shared/constants.ts` | Add `"parked"` to `ISSUE_STATUSES` |
| `server/services/issues.ts` | Replace local `ALL_ISSUE_STATUSES` copy with import from shared |
| `server/services/routines.ts` | Add `"parked"` to `OPEN_ISSUE_STATUSES` (not terminal) |
| `ui/components/KanbanBoard.tsx` | Import `ISSUE_STATUSES` from shared instead of local array |
| `ui/components/StatusIcon.tsx` | Import `ISSUE_STATUSES` from shared instead of local array |
| `ui/components/NewIssueDialog.tsx` | Add `blocked`, `parked`, `cancelled` to create picker |
| `ui/hooks/useInboxBadge.ts` | Add `parked` to inbox status filter |
| `ui/lib/status-colors.ts` | Add `parked` colors (amber) to icon, text, and badge maps |

## Test plan
- [ ] Create an issue, verify "Parked" appears in status picker
- [ ] Change an existing issue to "Parked" via StatusIcon popover
- [ ] Verify Kanban board shows a "Parked" column
- [ ] Verify inbox shows parked issues
- [ ] Verify API accepts `parked` as a valid status on create and update

🤖 Generated with [Claude Code](https://claude.com/claude-code)