### PR TITLE
feat: show project chips on issue board cards

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -30,6 +30,7 @@ import {
   resolveIssueWorkspaceName,
   type InboxIssueColumn,
 } from "../lib/inbox";
+import { shouldShowBoardProjectChip } from "../lib/issue-board";
 import { cn } from "../lib/utils";
 import {
   InboxIssueMetaLeading,
@@ -465,6 +466,10 @@ export function IssuesList({
   });
 
   const activeFilterCount = countActiveIssueFilters(viewState, enableRoutineVisibilityFilter);
+  const showBoardProjectNames = useMemo(
+    () => shouldShowBoardProjectChip(filtered, projectId),
+    [filtered, projectId],
+  );
 
   const groupedContent = useMemo(() => {
     if (viewState.groupBy === "none") {
@@ -746,6 +751,8 @@ export function IssuesList({
         <KanbanBoard
           issues={filtered}
           agents={agents}
+          projects={projects?.map((project) => ({ id: project.id, name: project.name, color: project.color }))}
+          showProjectNames={showBoardProjectNames}
           liveIssueIds={liveIssueIds}
           onUpdateIssue={onUpdateIssue}
         />

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -17,6 +17,7 @@ import {
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
+import { pickTextColorForPillBg } from "@/lib/color-contrast";
 import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
@@ -41,9 +42,17 @@ interface Agent {
   name: string;
 }
 
+interface ProjectOption {
+  id: string;
+  name: string;
+  color?: string | null;
+}
+
 interface KanbanBoardProps {
   issues: Issue[];
   agents?: Agent[];
+  projects?: ProjectOption[];
+  showProjectNames?: boolean;
   liveIssueIds?: Set<string>;
   onUpdateIssue: (id: string, data: Record<string, unknown>) => void;
 }
@@ -54,11 +63,15 @@ function KanbanColumn({
   status,
   issues,
   agents,
+  projects,
+  showProjectNames,
   liveIssueIds,
 }: {
   status: string;
   issues: Issue[];
   agents?: Agent[];
+  projects?: ProjectOption[];
+  showProjectNames?: boolean;
   liveIssueIds?: Set<string>;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: status });
@@ -95,6 +108,8 @@ function KanbanColumn({
               key={issue.id}
               issue={issue}
               agents={agents}
+              projects={projects}
+              showProjectName={showProjectNames}
               isLive={liveIssueIds?.has(issue.id)}
             />
           ))}
@@ -109,11 +124,15 @@ function KanbanColumn({
 function KanbanCard({
   issue,
   agents,
+  projects,
+  showProjectName,
   isLive,
   isOverlay,
 }: {
   issue: Issue;
   agents?: Agent[];
+  projects?: ProjectOption[];
+  showProjectName?: boolean;
   isLive?: boolean;
   isOverlay?: boolean;
 }) {
@@ -135,6 +154,9 @@ function KanbanCard({
     if (!id || !agents) return null;
     return agents.find((a) => a.id === id)?.name ?? null;
   };
+
+  const project = issue.project ?? (issue.projectId ? projects?.find((entry) => entry.id === issue.projectId) : null);
+  const projectColor = project?.color ?? "#64748b";
 
   return (
     <div
@@ -165,6 +187,20 @@ function KanbanCard({
               <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
             </span>
           )}
+          {showProjectName && project?.name && (
+            <span
+              className="ml-auto inline-flex min-w-0 max-w-[55%] items-center gap-1 rounded-full border px-1.5 py-0 text-[10px] font-medium"
+              style={{
+                borderColor: projectColor,
+                color: pickTextColorForPillBg(projectColor, 0.12),
+                backgroundColor: `${projectColor}1f`,
+              }}
+              title={project.name}
+            >
+              <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: projectColor }} />
+              <span className="truncate">{project.name}</span>
+            </span>
+          )}
         </div>
         <p className="text-sm leading-snug line-clamp-2 mb-2">{issue.title}</p>
         <div className="flex items-center gap-2">
@@ -190,6 +226,8 @@ function KanbanCard({
 export function KanbanBoard({
   issues,
   agents,
+  projects,
+  showProjectNames,
   liveIssueIds,
   onUpdateIssue,
 }: KanbanBoardProps) {
@@ -267,13 +305,21 @@ export function KanbanBoard({
             status={status}
             issues={columnIssues[status] ?? []}
             agents={agents}
+            projects={projects}
+            showProjectNames={showProjectNames}
             liveIssueIds={liveIssueIds}
           />
         ))}
       </div>
       <DragOverlay>
         {activeIssue ? (
-          <KanbanCard issue={activeIssue} agents={agents} isOverlay />
+          <KanbanCard
+            issue={activeIssue}
+            agents={agents}
+            projects={projects}
+            showProjectName={showProjectNames}
+            isOverlay
+          />
         ) : null}
       </DragOverlay>
     </DndContext>

--- a/ui/src/lib/issue-board.test.ts
+++ b/ui/src/lib/issue-board.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { Issue } from "@paperclipai/shared";
+import { shouldShowBoardProjectChip } from "./issue-board";
+
+function makeIssue(overrides: Partial<Issue>): Issue {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    companyId: "company-1",
+    projectId: overrides.projectId ?? null,
+    projectWorkspaceId: null,
+    goalId: null,
+    parentId: null,
+    title: overrides.title ?? "Issue",
+    description: null,
+    status: overrides.status ?? "todo",
+    priority: overrides.priority ?? "medium",
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionAgentNameKey: null,
+    executionLockedAt: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    issueNumber: null,
+    identifier: overrides.identifier ?? null,
+    requestDepth: 0,
+    billingCode: null,
+    assigneeAdapterOverrides: null,
+    executionWorkspaceId: null,
+    executionWorkspacePreference: null,
+    executionWorkspaceSettings: null,
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    hiddenAt: null,
+    createdAt: overrides.createdAt ?? new Date("2026-04-01T00:00:00Z"),
+    updatedAt: overrides.updatedAt ?? new Date("2026-04-01T00:00:00Z"),
+  };
+}
+
+describe("shouldShowBoardProjectChip", () => {
+  it("returns false for project-scoped boards", () => {
+    const issues = [makeIssue({ projectId: "project-1" })];
+    expect(shouldShowBoardProjectChip(issues, "project-1")).toBe(false);
+  });
+
+  it("returns true when visible issues span multiple projects", () => {
+    const issues = [
+      makeIssue({ projectId: "project-1" }),
+      makeIssue({ projectId: "project-2" }),
+    ];
+
+    expect(shouldShowBoardProjectChip(issues)).toBe(true);
+  });
+
+  it("returns false when visible issues only reference one project", () => {
+    const issues = [
+      makeIssue({ projectId: "project-1" }),
+      makeIssue({ projectId: "project-1" }),
+      makeIssue({ projectId: null }),
+    ];
+
+    expect(shouldShowBoardProjectChip(issues)).toBe(false);
+  });
+});

--- a/ui/src/lib/issue-board.ts
+++ b/ui/src/lib/issue-board.ts
@@ -1,0 +1,13 @@
+import type { Issue } from "@paperclipai/shared";
+
+export function shouldShowBoardProjectChip(issues: Issue[], projectId?: string): boolean {
+  if (projectId) return false;
+
+  const visibleProjectIds = new Set(
+    issues
+      .map((issue) => issue.projectId)
+      .filter((value): value is string => Boolean(value)),
+  );
+
+  return visibleProjectIds.size > 1;
+}


### PR DESCRIPTION
## Summary
- show a project chip on kanban cards when the visible board spans multiple projects
- hide the chip on project-scoped boards and single-project mixed views
- add a focused helper test covering the board chip visibility rules

## Testing
- pnpm exec vitest run --config ui/vitest.config.ts ui/src/lib/issue-board.test.ts
- pnpm --filter @paperclipai/ui typecheck *(fails in this worktree due existing missing module/type resolution issues like @assistant-ui/react and hermes-paperclip-adapter/ui; no remaining errors from the SUP-984 files after fixing the local null-color type mismatch)*