### PR TITLE
fix: convert Date to ISO string in listComments cursor query (fixes #3661)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1182,3 +1182,366 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     });
   });
 });
+
+describeEmbeddedPostgres("issueService.listComments cursor pagination", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-comments-cursor-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("returns comments after a given comment ID cursor in ascending order", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const comment1Id = randomUUID();
+    const comment2Id = randomUUID();
+    const comment3Id = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Test issue for comments",
+      status: "todo",
+      priority: "medium",
+    });
+
+    // Insert comments with explicit timestamps to test cursor pagination
+    await db.insert(issueComments).values([
+      {
+        id: comment1Id,
+        companyId,
+        issueId,
+        body: "First comment",
+        createdAt: new Date("2026-04-01T10:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T10:00:00.000Z"),
+      },
+      {
+        id: comment2Id,
+        companyId,
+        issueId,
+        body: "Second comment",
+        createdAt: new Date("2026-04-01T11:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T11:00:00.000Z"),
+      },
+      {
+        id: comment3Id,
+        companyId,
+        issueId,
+        body: "Third comment",
+        createdAt: new Date("2026-04-01T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T12:00:00.000Z"),
+      },
+    ]);
+
+    // Fetch comments after the first comment using cursor (afterCommentId)
+    const commentsAfterFirst = await svc.listComments(issueId, {
+      afterCommentId: comment1Id,
+      order: "asc",
+    });
+
+    // Should return only comment2 and comment3 (not comment1)
+    expect(commentsAfterFirst.length).toBe(2);
+    expect(commentsAfterFirst.map((c) => c.id)).toEqual([comment2Id, comment3Id]);
+    expect(commentsAfterFirst[0]!.body).toBe("Second comment");
+    expect(commentsAfterFirst[1]!.body).toBe("Third comment");
+  });
+
+  it("returns comments before a given comment ID cursor in descending order", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const comment1Id = randomUUID();
+    const comment2Id = randomUUID();
+    const comment3Id = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Test issue for comments",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        id: comment1Id,
+        companyId,
+        issueId,
+        body: "First comment",
+        createdAt: new Date("2026-04-01T10:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T10:00:00.000Z"),
+      },
+      {
+        id: comment2Id,
+        companyId,
+        issueId,
+        body: "Second comment",
+        createdAt: new Date("2026-04-01T11:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T11:00:00.000Z"),
+      },
+      {
+        id: comment3Id,
+        companyId,
+        issueId,
+        body: "Third comment",
+        createdAt: new Date("2026-04-01T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T12:00:00.000Z"),
+      },
+    ]);
+
+    // Fetch comments before the third comment using cursor (afterCommentId) in desc order
+    const commentsBeforeThird = await svc.listComments(issueId, {
+      afterCommentId: comment3Id,
+      order: "desc",
+    });
+
+    // Should return comment2 and comment1 in descending order (newest to oldest)
+    expect(commentsBeforeThird.length).toBe(2);
+    expect(commentsBeforeThird.map((c) => c.id)).toEqual([comment2Id, comment1Id]);
+  });
+
+  it("respects limit parameter with cursor pagination", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const comment1Id = randomUUID();
+    const comment2Id = randomUUID();
+    const comment3Id = randomUUID();
+    const comment4Id = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Test issue for comments",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        id: comment1Id,
+        companyId,
+        issueId,
+        body: "First comment",
+        createdAt: new Date("2026-04-01T10:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T10:00:00.000Z"),
+      },
+      {
+        id: comment2Id,
+        companyId,
+        issueId,
+        body: "Second comment",
+        createdAt: new Date("2026-04-01T11:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T11:00:00.000Z"),
+      },
+      {
+        id: comment3Id,
+        companyId,
+        issueId,
+        body: "Third comment",
+        createdAt: new Date("2026-04-01T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T12:00:00.000Z"),
+      },
+      {
+        id: comment4Id,
+        companyId,
+        issueId,
+        body: "Fourth comment",
+        createdAt: new Date("2026-04-01T13:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T13:00:00.000Z"),
+      },
+    ]);
+
+    // Fetch only 1 comment after the first using cursor with limit
+    const limitedComments = await svc.listComments(issueId, {
+      afterCommentId: comment1Id,
+      order: "asc",
+      limit: 1,
+    });
+
+    expect(limitedComments.length).toBe(1);
+    expect(limitedComments[0]!.id).toBe(comment2Id);
+  });
+
+  it("returns empty array when cursor comment ID does not exist", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Test issue for comments",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      body: "Some comment",
+      createdAt: new Date("2026-04-01T10:00:00.000Z"),
+      updatedAt: new Date("2026-04-01T10:00:00.000Z"),
+    });
+
+    // Using a non-existent comment ID as cursor should return empty array
+    const commentsAfterNonExistent = await svc.listComments(issueId, {
+      afterCommentId: randomUUID(),
+      order: "asc",
+    });
+
+    expect(commentsAfterNonExistent).toEqual([]);
+  });
+
+  it("returns all comments when no cursor is provided", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Test issue for comments",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        companyId,
+        issueId,
+        body: "First comment",
+        createdAt: new Date("2026-04-01T10:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T10:00:00.000Z"),
+      },
+      {
+        companyId,
+        issueId,
+        body: "Second comment",
+        createdAt: new Date("2026-04-01T11:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T11:00:00.000Z"),
+      },
+    ]);
+
+    // Without cursor, should return all comments
+    const allComments = await svc.listComments(issueId, {});
+
+    expect(allComments.length).toBe(2);
+  });
+
+  it("handles comments with same createdAt timestamp using ID tiebreaker", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    // Use predictable UUIDs so we can verify ordering (UUIDs are compared lexicographically)
+    const comment1Id = "00000000-0000-0000-0000-000000000001";
+    const comment2Id = "00000000-0000-0000-0000-000000000002";
+    const comment3Id = "00000000-0000-0000-0000-000000000003";
+    const sameTimestamp = new Date("2026-04-01T10:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Test issue for comments",
+      status: "todo",
+      priority: "medium",
+    });
+
+    // Insert comments with the exact same timestamp
+    await db.insert(issueComments).values([
+      {
+        id: comment1Id,
+        companyId,
+        issueId,
+        body: "Comment A",
+        createdAt: sameTimestamp,
+        updatedAt: sameTimestamp,
+      },
+      {
+        id: comment2Id,
+        companyId,
+        issueId,
+        body: "Comment B",
+        createdAt: sameTimestamp,
+        updatedAt: sameTimestamp,
+      },
+      {
+        id: comment3Id,
+        companyId,
+        issueId,
+        body: "Comment C",
+        createdAt: sameTimestamp,
+        updatedAt: sameTimestamp,
+      },
+    ]);
+
+    // Fetch comments after comment1 - should use ID tiebreaker
+    const commentsAfterFirst = await svc.listComments(issueId, {
+      afterCommentId: comment1Id,
+      order: "asc",
+    });
+
+    expect(commentsAfterFirst.length).toBe(2);
+    expect(commentsAfterFirst.map((c) => c.id)).toEqual([comment2Id, comment3Id]);
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2046,15 +2046,17 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        // Convert Date to ISO string to avoid TypeError when interpolating into SQL
+        const anchorCreatedAtIso = anchor.createdAt.toISOString();
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorCreatedAtIso}::timestamptz
+                OR (${issueComments.createdAt} = ${anchorCreatedAtIso}::timestamptz AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorCreatedAtIso}::timestamptz
+                OR (${issueComments.createdAt} = ${anchorCreatedAtIso}::timestamptz AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The issue service provides API endpoints for agents to interact with issues, including listing comments with cursor-based pagination
> - Issue #3661 reported that `GET /api/issues/:id/comments?after=:commentId` returns a 500 error with `TypeError: The "string" argument must be of type string`
> - The root cause is that `anchor.createdAt` (a `Date` object from the database) is being directly interpolated into Drizzle's SQL template literal, which expects a string
> - This pull request fixes the type mismatch by converting the Date to an ISO string before SQL interpolation
> - The benefit is that agents using cursor-based comment fetching can now properly paginate through comments without entering error states

## What Changed

- **server/src/services/issues.ts**: Convert `anchor.createdAt` to ISO string before using in SQL template literal, with explicit `::timestamptz` cast for proper PostgreSQL type handling
- **server/src/__tests__/issues-service.test.ts**: Add comprehensive test suite for `listComments` cursor pagination covering:
  - Ascending order pagination after a given comment ID
  - Descending order pagination before a given comment ID  
  - Limit parameter with cursor pagination
  - Non-existent cursor comment ID handling (returns empty array)
  - No cursor provided (returns all comments)
  - Same-timestamp tiebreaker using comment ID for consistent ordering

## Verification

1. Run the new tests:
   \`\`\`bash
   pnpm test:run -- --testPathPattern="issues-service.test.ts"
   \`\`\`

2. Verify typecheck passes:
   \`\`\`bash
   pnpm -r typecheck
   \`\`\`

3. Manual API test (with a running Paperclip instance):
   \`\`\`bash
   # Create an issue and add comments
   # Then test cursor pagination:
   curl "http://localhost:3100/api/issues/{issueId}/comments?after={commentId}&order=asc"
   \`\`\`

## Risks

- **Low risk**: The change is isolated to the `listComments` service function
- **No migration required**: This is a code-only fix with no schema changes
- **Backwards compatible**: The API contract remains unchanged; the fix only corrects the internal implementation
- **PostgreSQL type safety**: The explicit `::timestamptz` cast ensures the ISO string is properly interpreted as a timestamp

## Model Used

- Provider: Anthropic (via Amazon Bedrock)
- Model ID: us.anthropic.claude-opus-4-5-20251101-v1:0
- Context window: 200K tokens
- Capabilities: Extended reasoning, tool use (file read/edit, bash, grep, glob)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A - backend only)
- [x] I have updated relevant documentation to reflect my changes (N/A - no doc changes needed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge