### PR TITLE
feat: add NanoClaw Gateway adapter for WhatsApp agent orchestration

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -39,6 +39,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
+    "@paperclipai/adapter-nanoclaw-gateway": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -5,6 +5,7 @@ import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
+import { printNanoClawGatewayStreamEvent } from "@paperclipai/adapter-nanoclaw-gateway/cli";
 import { processCLIAdapter } from "./process/index.js";
 import { httpCLIAdapter } from "./http/index.js";
 
@@ -38,6 +39,11 @@ const openclawGatewayCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printOpenClawGatewayStreamEvent,
 };
 
+const nanoclawGatewayCLIAdapter: CLIAdapterModule = {
+  type: "nanoclaw_gateway",
+  formatStdoutEvent: printNanoClawGatewayStreamEvent,
+};
+
 const adaptersByType = new Map<string, CLIAdapterModule>(
   [
     claudeLocalCLIAdapter,
@@ -46,6 +52,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     piLocalCLIAdapter,
     cursorLocalCLIAdapter,
     openclawGatewayCLIAdapter,
+    nanoclawGatewayCLIAdapter,
     processCLIAdapter,
     httpCLIAdapter,
   ].map((a) => [a.type, a]),

--- a/doc/NANOCLAW_ONBOARDING.md
+++ b/doc/NANOCLAW_ONBOARDING.md
@@ -2,34 +2,37 @@
 
 ## Prerequisites
 
-1. **NanoClaw running** — The NanoClaw WhatsApp-to-Claude bridge must be active with its gateway accessible.
-2. **OpenClaw Gateway** — NanoClaw runs on top of OpenClaw. The gateway must be listening (default: `ws://127.0.0.1:18789`).
-3. **Gateway token** — Obtain your OpenClaw gateway auth token for authenticated access.
-4. **Agent containers** — At least one NanoClaw agent (Dozer, Scout, Myco, or Sally) must be running in Docker.
+1. **NanoClaw running** — The NanoClaw WhatsApp-to-Claude bridge must be active with its MCP server listening (default: `http://127.0.0.1:18790`).
+2. **Agent containers** — At least one NanoClaw agent (Dozer, Scout, Myco, or Sally) must be registered and available in Docker.
+3. **Paperclip agent IDs mapped** — Each NanoClaw group that should receive Paperclip tasks needs a `paperclipAgentId` set in its registration.
 
 ## Quick Start
 
 1. In Paperclip, create a new agent and select **NanoClaw Gateway** as the adapter type.
-2. Set the **Gateway URL** (default: `ws://127.0.0.1:18789`).
+2. Set the **NanoClaw URL** (default: `http://127.0.0.1:18790`).
 3. Choose the **Agent Name** from the dropdown (Dozer, Scout, Myco, Sally) or enter a custom name.
-4. Save and run a test heartbeat to verify connectivity.
+4. Save and run a test to verify connectivity.
 
 ## Configuration Reference
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `url` | string | `ws://127.0.0.1:18789` | OpenClaw gateway WebSocket URL |
-| `agentName` | string | *(required)* | NanoClaw agent to route to (dozer, scout, myco, sally, or custom) |
-| `authToken` | string | — | Gateway auth token (can also be set via `headers.x-openclaw-token`) |
-| `timeoutSec` | number | `300` | Adapter timeout in seconds (longer default for Docker agents) |
-| `waitTimeoutMs` | number | `300000` | Agent wait timeout in milliseconds |
-| `sessionKeyStrategy` | string | `issue` | Session routing: `issue`, `fixed`, or `run` |
-| `sessionKey` | string | `paperclip` | Fixed session key (only used when strategy is `fixed`) |
-| `role` | string | `operator` | Gateway role |
-| `scopes` | string[] | `["operator.admin"]` | Gateway scopes |
-| `payloadTemplate` | object | — | Additional fields merged into gateway agent params |
+| `url` | string | `http://127.0.0.1:18790` | NanoClaw MCP server HTTP base URL |
+| `agentName` | string | `dozer` | NanoClaw agent to route to (dozer, scout, myco, sally, or custom) |
+| `agentId` | string | — | Override Paperclip agent ID (defaults to agentName) |
+| `timeoutMs` | number | `30000` | HTTP request timeout in milliseconds |
 
-All OpenClaw gateway fields (`headers`, `password`, `clientId`, `clientMode`, etc.) are also supported as pass-through.
+## How It Works
+
+NanoClaw's integration is **fire-and-forget**:
+
+1. Paperclip POSTs to `{url}/paperclip/wakeup` with `{ agentId, runId, context }`
+2. NanoClaw maps `agentId` to a registered group via the `paperclipAgentId` field
+3. A Docker container is spawned running Claude Agent SDK
+4. The agent processes the request and delivers output via **WhatsApp** (not back to Paperclip)
+5. NanoClaw reports cost data back to Paperclip via `reportCostToPaperclip()`
+
+This means Paperclip issues are dispatched to agents, but responses arrive in WhatsApp — not in the Paperclip UI transcript.
 
 ## Agent Mapping
 
@@ -42,46 +45,43 @@ Map your Paperclip agents to NanoClaw agents based on their specialization:
 | **Myco** | E-commerce | Shopify content, product management |
 | **Sally** | UI/UX | Atomic Design, CRO optimization, web components |
 
-In `adapterConfig`, set `agentName` to the lowercase agent name:
+Example adapter config:
 
 ```json
 {
-  "url": "ws://127.0.0.1:18789",
+  "url": "http://127.0.0.1:18790",
   "agentName": "scout",
-  "timeoutSec": 300
+  "timeoutMs": 30000
 }
 ```
 
 ## Smoke Test
 
-Run these three tests after setup to verify the adapter works:
-
 ### 1. Connectivity Test
 
 From the Paperclip agent settings, click **Test Environment**. Expected result:
-- Gateway URL valid (info)
-- Gateway probe succeeded (info)
+- NanoClaw MCP Server: pass — Reachable at http://127.0.0.1:18790
 
-### 2. Agent Wake Test
+### 2. Agent Wakeup Test
 
-Assign a simple issue to the NanoClaw-backed agent (e.g., "Respond with OK"). Verify:
-- The heartbeat run starts and completes
-- The agent response appears in the run transcript
-- Exit code is 0
+Assign a simple issue to the NanoClaw-backed agent. Verify:
+- The run completes with exit code 0
+- The agent response appears in WhatsApp
+- Log shows: `[nanoclaw-gateway] wakeup accepted`
 
 ### 3. Agent Routing Test
 
 Create two Paperclip agents backed by different NanoClaw agents (e.g., Dozer and Scout). Assign each an issue. Verify:
-- Each issue is handled by the correct NanoClaw agent
+- Each issue reaches the correct agent in WhatsApp
 - Responses reflect the agent's specialization
 
 ## Troubleshooting
 
 | Symptom | Likely Cause | Fix |
 |---------|-------------|-----|
-| "Gateway probe failed" | Gateway not running | Start NanoClaw: check `launchctl` service or run `openclaw gateway start` |
-| "Connect probe rejected" | Bad auth token | Verify `authToken` or `headers.x-openclaw-token` matches gateway config |
-| "Pairing required" | Device not approved | Run `openclaw devices list --json` and approve pending device |
-| Timeout on agent run | Agent container not running | Check `docker ps` for the NanoClaw agent container |
-| Wrong agent responds | `agentName` misconfigured | Verify `agentName` in `adapterConfig` matches the NanoClaw agent name exactly |
-| Port 18789 in use but gateway down | Stale process | Kill stale process: `kill $(lsof -ti :18789)` then restart gateway |
+| "Cannot reach http://127.0.0.1:18790" | NanoClaw not running | Check launchd service: `launchctl list com.nanoclaw` |
+| HTTP 400 on wakeup | Unknown agentId | Verify the NanoClaw group has `paperclipAgentId` set matching the adapter's `agentName` |
+| HTTP 404 | Wrong URL or port | Confirm NanoClaw MCP server is on port 18790, not 18789 (that's OpenClaw) |
+| Timeout | NanoClaw server slow to respond | Increase `timeoutMs` in adapter config |
+| No response in WhatsApp | Container not starting | Check `docker ps` for nanoclaw-agent containers; check `logs/nanoclaw.log` |
+| Port 18790 in use but server down | Stale process | `kill $(lsof -ti :18790)` then restart NanoClaw service |

--- a/doc/NANOCLAW_ONBOARDING.md
+++ b/doc/NANOCLAW_ONBOARDING.md
@@ -1,0 +1,87 @@
+# NanoClaw Gateway Adapter — Onboarding
+
+## Prerequisites
+
+1. **NanoClaw running** — The NanoClaw WhatsApp-to-Claude bridge must be active with its gateway accessible.
+2. **OpenClaw Gateway** — NanoClaw runs on top of OpenClaw. The gateway must be listening (default: `ws://127.0.0.1:18789`).
+3. **Gateway token** — Obtain your OpenClaw gateway auth token for authenticated access.
+4. **Agent containers** — At least one NanoClaw agent (Dozer, Scout, Myco, or Sally) must be running in Docker.
+
+## Quick Start
+
+1. In Paperclip, create a new agent and select **NanoClaw Gateway** as the adapter type.
+2. Set the **Gateway URL** (default: `ws://127.0.0.1:18789`).
+3. Choose the **Agent Name** from the dropdown (Dozer, Scout, Myco, Sally) or enter a custom name.
+4. Save and run a test heartbeat to verify connectivity.
+
+## Configuration Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | `ws://127.0.0.1:18789` | OpenClaw gateway WebSocket URL |
+| `agentName` | string | *(required)* | NanoClaw agent to route to (dozer, scout, myco, sally, or custom) |
+| `authToken` | string | — | Gateway auth token (can also be set via `headers.x-openclaw-token`) |
+| `timeoutSec` | number | `300` | Adapter timeout in seconds (longer default for Docker agents) |
+| `waitTimeoutMs` | number | `300000` | Agent wait timeout in milliseconds |
+| `sessionKeyStrategy` | string | `issue` | Session routing: `issue`, `fixed`, or `run` |
+| `sessionKey` | string | `paperclip` | Fixed session key (only used when strategy is `fixed`) |
+| `role` | string | `operator` | Gateway role |
+| `scopes` | string[] | `["operator.admin"]` | Gateway scopes |
+| `payloadTemplate` | object | — | Additional fields merged into gateway agent params |
+
+All OpenClaw gateway fields (`headers`, `password`, `clientId`, `clientMode`, etc.) are also supported as pass-through.
+
+## Agent Mapping
+
+Map your Paperclip agents to NanoClaw agents based on their specialization:
+
+| NanoClaw Agent | Role | Specialization |
+|----------------|------|----------------|
+| **Dozer** | Main agent | General-purpose, primary NanoClaw agent |
+| **Scout** | SEO/Marketing | Content strategy, GSC reporting, SEO audits |
+| **Myco** | E-commerce | Shopify content, product management |
+| **Sally** | UI/UX | Atomic Design, CRO optimization, web components |
+
+In `adapterConfig`, set `agentName` to the lowercase agent name:
+
+```json
+{
+  "url": "ws://127.0.0.1:18789",
+  "agentName": "scout",
+  "timeoutSec": 300
+}
+```
+
+## Smoke Test
+
+Run these three tests after setup to verify the adapter works:
+
+### 1. Connectivity Test
+
+From the Paperclip agent settings, click **Test Environment**. Expected result:
+- Gateway URL valid (info)
+- Gateway probe succeeded (info)
+
+### 2. Agent Wake Test
+
+Assign a simple issue to the NanoClaw-backed agent (e.g., "Respond with OK"). Verify:
+- The heartbeat run starts and completes
+- The agent response appears in the run transcript
+- Exit code is 0
+
+### 3. Agent Routing Test
+
+Create two Paperclip agents backed by different NanoClaw agents (e.g., Dozer and Scout). Assign each an issue. Verify:
+- Each issue is handled by the correct NanoClaw agent
+- Responses reflect the agent's specialization
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| "Gateway probe failed" | Gateway not running | Start NanoClaw: check `launchctl` service or run `openclaw gateway start` |
+| "Connect probe rejected" | Bad auth token | Verify `authToken` or `headers.x-openclaw-token` matches gateway config |
+| "Pairing required" | Device not approved | Run `openclaw devices list --json` and approve pending device |
+| Timeout on agent run | Agent container not running | Check `docker ps` for the NanoClaw agent container |
+| Wrong agent responds | `agentName` misconfigured | Verify `agentName` in `adapterConfig` matches the NanoClaw agent name exactly |
+| Port 18789 in use but gateway down | Stale process | Kill stale process: `kill $(lsof -ti :18789)` then restart gateway |

--- a/packages/adapters/nanoclaw-gateway/package.json
+++ b/packages/adapters/nanoclaw-gateway/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@paperclipai/adapter-nanoclaw-gateway",
+  "version": "0.2.7",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-openclaw-gateway": "workspace:*",
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1",
+    "ws": "^8.19.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "@types/ws": "^8.18.1",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/nanoclaw-gateway/package.json
+++ b/packages/adapters/nanoclaw-gateway/package.json
@@ -40,14 +40,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
-    "picocolors": "^1.1.1",
-    "ws": "^8.19.0"
+    "picocolors": "^1.1.1"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",
-    "@types/ws": "^8.18.1",
     "typescript": "^5.7.3"
   }
 }

--- a/packages/adapters/nanoclaw-gateway/src/cli/format-event.ts
+++ b/packages/adapters/nanoclaw-gateway/src/cli/format-event.ts
@@ -9,12 +9,7 @@ export function printNanoClawGatewayStreamEvent(raw: string, debug: boolean): vo
     return;
   }
 
-  if (line.startsWith("[openclaw-gateway:event]") || line.startsWith("[nanoclaw-gateway:event]")) {
-    console.log(pc.cyan(line));
-    return;
-  }
-
-  if (line.startsWith("[openclaw-gateway]") || line.startsWith("[nanoclaw-gateway]")) {
+  if (line.startsWith("[nanoclaw-gateway]")) {
     console.log(pc.blue(line));
     return;
   }

--- a/packages/adapters/nanoclaw-gateway/src/cli/format-event.ts
+++ b/packages/adapters/nanoclaw-gateway/src/cli/format-event.ts
@@ -1,0 +1,23 @@
+import pc from "picocolors";
+
+export function printNanoClawGatewayStreamEvent(raw: string, debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  if (!debug) {
+    console.log(line);
+    return;
+  }
+
+  if (line.startsWith("[openclaw-gateway:event]") || line.startsWith("[nanoclaw-gateway:event]")) {
+    console.log(pc.cyan(line));
+    return;
+  }
+
+  if (line.startsWith("[openclaw-gateway]") || line.startsWith("[nanoclaw-gateway]")) {
+    console.log(pc.blue(line));
+    return;
+  }
+
+  console.log(pc.gray(line));
+}

--- a/packages/adapters/nanoclaw-gateway/src/cli/index.ts
+++ b/packages/adapters/nanoclaw-gateway/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printNanoClawGatewayStreamEvent } from "./format-event.js";

--- a/packages/adapters/nanoclaw-gateway/src/index.ts
+++ b/packages/adapters/nanoclaw-gateway/src/index.ts
@@ -1,0 +1,36 @@
+export const type = "nanoclaw_gateway";
+export const label = "NanoClaw Gateway";
+
+export const models: { id: string; label: string }[] = [];
+
+export const NANOCLAW_AGENTS = ["dozer", "scout", "myco", "sally"] as const;
+export type NanoClawAgent = (typeof NANOCLAW_AGENTS)[number];
+
+export const agentConfigurationDoc = `# nanoclaw_gateway agent configuration
+
+Adapter: nanoclaw_gateway
+
+Use when:
+- You want Paperclip to invoke NanoClaw agents (Dozer, Scout, Myco, Sally) via the OpenClaw Gateway.
+- NanoClaw runs Docker-containerized Claude agents on top of the OpenClaw gateway.
+
+Don't use when:
+- You want to talk to the OpenClaw gateway directly (use openclaw_gateway instead).
+- Your NanoClaw instance is not running or the gateway is unreachable.
+
+Core fields:
+- url (string, optional): Gateway WebSocket URL (default ws://127.0.0.1:18789)
+- agentName (string, required): NanoClaw agent to route to (dozer, scout, myco, sally, or custom)
+- authToken (string, optional): shared gateway token override
+
+Request behavior fields:
+- timeoutSec (number, optional): adapter timeout in seconds (default 300 — NanoClaw agents run longer in Docker)
+- waitTimeoutMs (number, optional): agent.wait timeout override (default timeoutSec * 1000)
+
+Session routing fields:
+- sessionKeyStrategy (string, optional): issue (default), fixed, or run
+- sessionKey (string, optional): fixed session key when strategy=fixed (default paperclip)
+
+All other OpenClaw gateway fields (headers, role, scopes, payloadTemplate, etc.) are also supported
+and passed through to the underlying openclaw_gateway adapter.
+`;

--- a/packages/adapters/nanoclaw-gateway/src/index.ts
+++ b/packages/adapters/nanoclaw-gateway/src/index.ts
@@ -11,26 +11,24 @@ export const agentConfigurationDoc = `# nanoclaw_gateway agent configuration
 Adapter: nanoclaw_gateway
 
 Use when:
-- You want Paperclip to invoke NanoClaw agents (Dozer, Scout, Myco, Sally) via the OpenClaw Gateway.
-- NanoClaw runs Docker-containerized Claude agents on top of the OpenClaw gateway.
+- You want Paperclip to invoke NanoClaw agents (Dozer, Scout, Myco, Sally) via NanoClaw's HTTP API.
+- NanoClaw runs Docker-containerized Claude agents with their own MCP server on port 18790.
 
 Don't use when:
 - You want to talk to the OpenClaw gateway directly (use openclaw_gateway instead).
-- Your NanoClaw instance is not running or the gateway is unreachable.
+- Your NanoClaw instance is not running.
 
 Core fields:
-- url (string, optional): Gateway WebSocket URL (default ws://127.0.0.1:18789)
+- url (string, optional): NanoClaw HTTP base URL (default http://127.0.0.1:18790)
 - agentName (string, required): NanoClaw agent to route to (dozer, scout, myco, sally, or custom)
-- authToken (string, optional): shared gateway token override
+- agentId (string, optional): Paperclip agent ID override (defaults to agentName)
 
 Request behavior fields:
-- timeoutSec (number, optional): adapter timeout in seconds (default 300 — NanoClaw agents run longer in Docker)
-- waitTimeoutMs (number, optional): agent.wait timeout override (default timeoutSec * 1000)
+- timeoutMs (number, optional): HTTP request timeout in milliseconds (default 30000)
 
-Session routing fields:
-- sessionKeyStrategy (string, optional): issue (default), fixed, or run
-- sessionKey (string, optional): fixed session key when strategy=fixed (default paperclip)
-
-All other OpenClaw gateway fields (headers, role, scopes, payloadTemplate, etc.) are also supported
-and passed through to the underlying openclaw_gateway adapter.
+How it works:
+- Paperclip POSTs to NanoClaw's /paperclip/wakeup endpoint with { agentId, runId, context }
+- NanoClaw maps agentId to a registered group via the paperclipAgentId field
+- The agent runs in a Docker container and delivers output via WhatsApp
+- This is fire-and-forget — results are delivered asynchronously via WhatsApp, not returned to Paperclip
 `;

--- a/packages/adapters/nanoclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/nanoclaw-gateway/src/server/execute.ts
@@ -1,0 +1,48 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { execute as openclawExecute } from "@paperclipai/adapter-openclaw-gateway/server";
+
+const NANOCLAW_DEFAULTS = {
+  url: "ws://127.0.0.1:18789",
+  timeoutSec: 300,
+  waitTimeoutMs: 300_000,
+  sessionKeyStrategy: "issue",
+  role: "operator",
+  scopes: ["operator.admin"],
+} as const;
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const agentName = typeof ctx.config.agentName === "string" ? ctx.config.agentName.trim() : "";
+
+  // Merge NanoClaw defaults under user-provided config
+  const mergedConfig: Record<string, unknown> = {
+    ...NANOCLAW_DEFAULTS,
+    ...ctx.config,
+  };
+
+  // If url was not explicitly set, apply the NanoClaw default
+  if (!ctx.config.url || (typeof ctx.config.url === "string" && !ctx.config.url.trim())) {
+    mergedConfig.url = NANOCLAW_DEFAULTS.url;
+  }
+
+  // Inject agentName into payloadTemplate for NanoClaw routing
+  if (agentName) {
+    const existing =
+      typeof mergedConfig.payloadTemplate === "object" &&
+      mergedConfig.payloadTemplate !== null &&
+      !Array.isArray(mergedConfig.payloadTemplate)
+        ? (mergedConfig.payloadTemplate as Record<string, unknown>)
+        : {};
+
+    mergedConfig.payloadTemplate = {
+      ...existing,
+      nanoclaw: {
+        agentName,
+      },
+    };
+  }
+
+  return openclawExecute({
+    ...ctx,
+    config: mergedConfig,
+  });
+}

--- a/packages/adapters/nanoclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/nanoclaw-gateway/src/server/execute.ts
@@ -1,48 +1,113 @@
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
-import { execute as openclawExecute } from "@paperclipai/adapter-openclaw-gateway/server";
 
-const NANOCLAW_DEFAULTS = {
-  url: "ws://127.0.0.1:18789",
-  timeoutSec: 300,
-  waitTimeoutMs: 300_000,
-  sessionKeyStrategy: "issue",
-  role: "operator",
-  scopes: ["operator.admin"],
-} as const;
+const NANOCLAW_DEFAULT_URL = "http://127.0.0.1:18790";
+const NANOCLAW_DEFAULT_TIMEOUT_MS = 30_000;
+
+interface WakeupPayload {
+  agentId: string;
+  runId: string;
+  context?: Record<string, unknown>;
+}
+
+interface WakeupResponse {
+  ok: boolean;
+  group?: string;
+  error?: string;
+}
+
+function resolveBaseUrl(config: Record<string, unknown>): string {
+  const url = typeof config.url === "string" ? config.url.trim() : "";
+  return url || NANOCLAW_DEFAULT_URL;
+}
+
+function resolveAgentId(config: Record<string, unknown>): string {
+  const agentName = typeof config.agentName === "string" ? config.agentName.trim() : "";
+  const agentId = typeof config.agentId === "string" ? config.agentId.trim() : "";
+  return agentId || agentName || "dozer";
+}
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const agentName = typeof ctx.config.agentName === "string" ? ctx.config.agentName.trim() : "";
+  const baseUrl = resolveBaseUrl(ctx.config);
+  const agentId = resolveAgentId(ctx.config);
+  const timeoutMs =
+    typeof ctx.config.timeoutMs === "number" ? ctx.config.timeoutMs : NANOCLAW_DEFAULT_TIMEOUT_MS;
 
-  // Merge NanoClaw defaults under user-provided config
-  const mergedConfig: Record<string, unknown> = {
-    ...NANOCLAW_DEFAULTS,
-    ...ctx.config,
+  const payload: WakeupPayload = {
+    agentId,
+    runId: ctx.runId,
+    context: {
+      ...ctx.context,
+    },
   };
 
-  // If url was not explicitly set, apply the NanoClaw default
-  if (!ctx.config.url || (typeof ctx.config.url === "string" && !ctx.config.url.trim())) {
-    mergedConfig.url = NANOCLAW_DEFAULTS.url;
-  }
+  const wakeupUrl = `${baseUrl.replace(/\/+$/, "")}/paperclip/wakeup`;
 
-  // Inject agentName into payloadTemplate for NanoClaw routing
-  if (agentName) {
-    const existing =
-      typeof mergedConfig.payloadTemplate === "object" &&
-      mergedConfig.payloadTemplate !== null &&
-      !Array.isArray(mergedConfig.payloadTemplate)
-        ? (mergedConfig.payloadTemplate as Record<string, unknown>)
-        : {};
+  await ctx.onLog("stdout", `[nanoclaw-gateway] POST ${wakeupUrl} agentId=${agentId} runId=${ctx.runId}\n`);
 
-    mergedConfig.payloadTemplate = {
-      ...existing,
-      nanoclaw: {
-        agentName,
-      },
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(wakeupUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timer);
+
+    const body = (await response.json().catch(() => ({}))) as WakeupResponse;
+
+    if (!response.ok) {
+      const errorMsg = body.error || `HTTP ${response.status} ${response.statusText}`;
+      await ctx.onLog("stderr", `[nanoclaw-gateway] wakeup failed: ${errorMsg}\n`);
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: errorMsg,
+        errorCode: "NANOCLAW_WAKEUP_FAILED",
+        summary: `NanoClaw wakeup failed for agent "${agentId}": ${errorMsg}`,
+      };
+    }
+
+    const group = body.group || agentId;
+    await ctx.onLog(
+      "stdout",
+      `[nanoclaw-gateway] wakeup accepted — agent="${agentId}" group="${group}". Response will be delivered via WhatsApp.\n`,
+    );
+
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: `NanoClaw agent "${agentId}" invoked successfully. Output delivered via WhatsApp.`,
+      provider: "nanoclaw",
+    };
+  } catch (err: unknown) {
+    clearTimeout(timer);
+
+    if (err instanceof DOMException && err.name === "AbortError") {
+      await ctx.onLog("stderr", `[nanoclaw-gateway] wakeup timed out after ${timeoutMs}ms\n`);
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: true,
+        errorMessage: `Wakeup request timed out after ${timeoutMs}ms`,
+        errorCode: "NANOCLAW_TIMEOUT",
+      };
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    await ctx.onLog("stderr", `[nanoclaw-gateway] wakeup error: ${message}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: message,
+      errorCode: "NANOCLAW_CONNECTION_ERROR",
+      summary: `Failed to connect to NanoClaw at ${wakeupUrl}: ${message}`,
     };
   }
-
-  return openclawExecute({
-    ...ctx,
-    config: mergedConfig,
-  });
 }

--- a/packages/adapters/nanoclaw-gateway/src/server/index.ts
+++ b/packages/adapters/nanoclaw-gateway/src/server/index.ts
@@ -1,0 +1,2 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";

--- a/packages/adapters/nanoclaw-gateway/src/server/test.ts
+++ b/packages/adapters/nanoclaw-gateway/src/server/test.ts
@@ -1,32 +1,63 @@
 import type {
   AdapterEnvironmentTestContext,
   AdapterEnvironmentTestResult,
+  AdapterEnvironmentCheck,
 } from "@paperclipai/adapter-utils";
-import { testEnvironment as openclawTestEnvironment } from "@paperclipai/adapter-openclaw-gateway/server";
 
-const NANOCLAW_DEFAULT_URL = "ws://127.0.0.1:18789";
+const NANOCLAW_DEFAULT_URL = "http://127.0.0.1:18790";
 
 export async function testEnvironment(
   ctx: AdapterEnvironmentTestContext,
 ): Promise<AdapterEnvironmentTestResult> {
-  // Apply NanoClaw default URL if none provided
   const config =
     typeof ctx.config === "object" && ctx.config !== null && !Array.isArray(ctx.config)
       ? (ctx.config as Record<string, unknown>)
       : {};
 
-  const url = typeof config.url === "string" && config.url.trim() ? config.url : NANOCLAW_DEFAULT_URL;
+  const baseUrl =
+    typeof config.url === "string" && config.url.trim() ? config.url.trim() : NANOCLAW_DEFAULT_URL;
 
-  const patchedCtx: AdapterEnvironmentTestContext = {
-    ...ctx,
-    config: { ...config, url },
-  };
+  const healthUrl = `${baseUrl.replace(/\/+$/, "")}/health`;
+  const checks: AdapterEnvironmentCheck[] = [];
+  const testedAt = new Date().toISOString();
 
-  const result = await openclawTestEnvironment(patchedCtx);
+  try {
+    const response = await fetch(healthUrl, {
+      method: "GET",
+      signal: AbortSignal.timeout(5_000),
+    });
 
-  // Re-label checks for NanoClaw context
+    if (response.ok) {
+      checks.push({
+        code: "nanoclaw_reachable",
+        level: "info",
+        message: `NanoClaw MCP server reachable at ${baseUrl}`,
+      });
+    } else {
+      checks.push({
+        code: "nanoclaw_unhealthy",
+        level: "error",
+        message: `NanoClaw health check returned HTTP ${response.status}`,
+        hint: "Verify NanoClaw is running and the URL is correct",
+      });
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    checks.push({
+      code: "nanoclaw_unreachable",
+      level: "error",
+      message: `Cannot reach NanoClaw at ${baseUrl}: ${message}`,
+      hint: "Check that NanoClaw service is running (launchctl list com.nanoclaw) and port 18790 is not blocked",
+    });
+  }
+
+  const hasError = checks.some((c) => c.level === "error");
+  const hasWarn = checks.some((c) => c.level === "warn");
+
   return {
-    ...result,
     adapterType: "nanoclaw_gateway",
+    status: hasError ? "fail" : hasWarn ? "warn" : "pass",
+    checks,
+    testedAt,
   };
 }

--- a/packages/adapters/nanoclaw-gateway/src/server/test.ts
+++ b/packages/adapters/nanoclaw-gateway/src/server/test.ts
@@ -1,0 +1,32 @@
+import type {
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { testEnvironment as openclawTestEnvironment } from "@paperclipai/adapter-openclaw-gateway/server";
+
+const NANOCLAW_DEFAULT_URL = "ws://127.0.0.1:18789";
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  // Apply NanoClaw default URL if none provided
+  const config =
+    typeof ctx.config === "object" && ctx.config !== null && !Array.isArray(ctx.config)
+      ? (ctx.config as Record<string, unknown>)
+      : {};
+
+  const url = typeof config.url === "string" && config.url.trim() ? config.url : NANOCLAW_DEFAULT_URL;
+
+  const patchedCtx: AdapterEnvironmentTestContext = {
+    ...ctx,
+    config: { ...config, url },
+  };
+
+  const result = await openclawTestEnvironment(patchedCtx);
+
+  // Re-label checks for NanoClaw context
+  return {
+    ...result,
+    adapterType: "nanoclaw_gateway",
+  };
+}

--- a/packages/adapters/nanoclaw-gateway/src/shared/stream.ts
+++ b/packages/adapters/nanoclaw-gateway/src/shared/stream.ts
@@ -1,0 +1,16 @@
+export function normalizeNanoClawGatewayStreamLine(rawLine: string): {
+  stream: "stdout" | "stderr" | null;
+  line: string;
+} {
+  const trimmed = rawLine.trim();
+  if (!trimmed) return { stream: null, line: "" };
+
+  const prefixed = trimmed.match(/^(stdout|stderr)\s*[:=]?\s*(.*)$/i);
+  if (!prefixed) {
+    return { stream: null, line: trimmed };
+  }
+
+  const stream = prefixed[1]?.toLowerCase() === "stderr" ? "stderr" : "stdout";
+  const line = (prefixed[2] ?? "").trim();
+  return { stream, line };
+}

--- a/packages/adapters/nanoclaw-gateway/src/ui/build-config.ts
+++ b/packages/adapters/nanoclaw-gateway/src/ui/build-config.ts
@@ -1,0 +1,13 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+export function buildNanoClawGatewayConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.url) ac.url = v.url;
+  else ac.url = "ws://127.0.0.1:18789";
+  ac.timeoutSec = 300;
+  ac.waitTimeoutMs = 300_000;
+  ac.sessionKeyStrategy = "issue";
+  ac.role = "operator";
+  ac.scopes = ["operator.admin"];
+  return ac;
+}

--- a/packages/adapters/nanoclaw-gateway/src/ui/build-config.ts
+++ b/packages/adapters/nanoclaw-gateway/src/ui/build-config.ts
@@ -3,11 +3,7 @@ import type { CreateConfigValues } from "@paperclipai/adapter-utils";
 export function buildNanoClawGatewayConfig(v: CreateConfigValues): Record<string, unknown> {
   const ac: Record<string, unknown> = {};
   if (v.url) ac.url = v.url;
-  else ac.url = "ws://127.0.0.1:18789";
-  ac.timeoutSec = 300;
-  ac.waitTimeoutMs = 300_000;
-  ac.sessionKeyStrategy = "issue";
-  ac.role = "operator";
-  ac.scopes = ["operator.admin"];
+  else ac.url = "http://127.0.0.1:18790";
+  ac.timeoutMs = 30_000;
   return ac;
 }

--- a/packages/adapters/nanoclaw-gateway/src/ui/index.ts
+++ b/packages/adapters/nanoclaw-gateway/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseNanoClawGatewayStdoutLine } from "./parse-stdout.js";
+export { buildNanoClawGatewayConfig } from "./build-config.js";

--- a/packages/adapters/nanoclaw-gateway/src/ui/parse-stdout.ts
+++ b/packages/adapters/nanoclaw-gateway/src/ui/parse-stdout.ts
@@ -1,59 +1,6 @@
 import type { TranscriptEntry } from "@paperclipai/adapter-utils";
 import { normalizeNanoClawGatewayStreamLine } from "../shared/stream.js";
 
-function safeJsonParse(text: string): unknown {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
-  }
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
-
-function asString(value: unknown): string {
-  return typeof value === "string" ? value : "";
-}
-
-function parseAgentEventLine(line: string, ts: string): TranscriptEntry[] {
-  const match = line.match(/^\[(?:openclaw|nanoclaw)-gateway:event\]\s+run=([^\s]+)\s+stream=([^\s]+)\s+data=(.*)$/s);
-  if (!match) return [{ kind: "stdout", ts, text: line }];
-
-  const stream = asString(match[2]).toLowerCase();
-  const data = asRecord(safeJsonParse(asString(match[3]).trim()));
-
-  if (stream === "assistant") {
-    const delta = asString(data?.delta);
-    if (delta.length > 0) {
-      return [{ kind: "assistant", ts, text: delta, delta: true }];
-    }
-
-    const text = asString(data?.text);
-    if (text.length > 0) {
-      return [{ kind: "assistant", ts, text }];
-    }
-    return [];
-  }
-
-  if (stream === "error") {
-    const message = asString(data?.error) || asString(data?.message);
-    return message ? [{ kind: "stderr", ts, text: message }] : [];
-  }
-
-  if (stream === "lifecycle") {
-    const phase = asString(data?.phase).toLowerCase();
-    const message = asString(data?.error) || asString(data?.message);
-    if ((phase === "error" || phase === "failed" || phase === "cancelled") && message) {
-      return [{ kind: "stderr", ts, text: message }];
-    }
-  }
-
-  return [];
-}
-
 export function parseNanoClawGatewayStdoutLine(line: string, ts: string): TranscriptEntry[] {
   const normalized = normalizeNanoClawGatewayStreamLine(line);
   if (normalized.stream === "stderr") {
@@ -63,12 +10,8 @@ export function parseNanoClawGatewayStdoutLine(line: string, ts: string): Transc
   const trimmed = normalized.line.trim();
   if (!trimmed) return [];
 
-  if (trimmed.startsWith("[openclaw-gateway:event]") || trimmed.startsWith("[nanoclaw-gateway:event]")) {
-    return parseAgentEventLine(trimmed, ts);
-  }
-
-  if (trimmed.startsWith("[openclaw-gateway]") || trimmed.startsWith("[nanoclaw-gateway]")) {
-    return [{ kind: "system", ts, text: trimmed.replace(/^\[(?:openclaw|nanoclaw)-gateway\]\s*/, "") }];
+  if (trimmed.startsWith("[nanoclaw-gateway]")) {
+    return [{ kind: "system", ts, text: trimmed.replace(/^\[nanoclaw-gateway\]\s*/, "") }];
   }
 
   return [{ kind: "stdout", ts, text: normalized.line }];

--- a/packages/adapters/nanoclaw-gateway/src/ui/parse-stdout.ts
+++ b/packages/adapters/nanoclaw-gateway/src/ui/parse-stdout.ts
@@ -1,0 +1,75 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+import { normalizeNanoClawGatewayStreamLine } from "../shared/stream.js";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function parseAgentEventLine(line: string, ts: string): TranscriptEntry[] {
+  const match = line.match(/^\[(?:openclaw|nanoclaw)-gateway:event\]\s+run=([^\s]+)\s+stream=([^\s]+)\s+data=(.*)$/s);
+  if (!match) return [{ kind: "stdout", ts, text: line }];
+
+  const stream = asString(match[2]).toLowerCase();
+  const data = asRecord(safeJsonParse(asString(match[3]).trim()));
+
+  if (stream === "assistant") {
+    const delta = asString(data?.delta);
+    if (delta.length > 0) {
+      return [{ kind: "assistant", ts, text: delta, delta: true }];
+    }
+
+    const text = asString(data?.text);
+    if (text.length > 0) {
+      return [{ kind: "assistant", ts, text }];
+    }
+    return [];
+  }
+
+  if (stream === "error") {
+    const message = asString(data?.error) || asString(data?.message);
+    return message ? [{ kind: "stderr", ts, text: message }] : [];
+  }
+
+  if (stream === "lifecycle") {
+    const phase = asString(data?.phase).toLowerCase();
+    const message = asString(data?.error) || asString(data?.message);
+    if ((phase === "error" || phase === "failed" || phase === "cancelled") && message) {
+      return [{ kind: "stderr", ts, text: message }];
+    }
+  }
+
+  return [];
+}
+
+export function parseNanoClawGatewayStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const normalized = normalizeNanoClawGatewayStreamLine(line);
+  if (normalized.stream === "stderr") {
+    return [{ kind: "stderr", ts, text: normalized.line }];
+  }
+
+  const trimmed = normalized.line.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith("[openclaw-gateway:event]") || trimmed.startsWith("[nanoclaw-gateway:event]")) {
+    return parseAgentEventLine(trimmed, ts);
+  }
+
+  if (trimmed.startsWith("[openclaw-gateway]") || trimmed.startsWith("[nanoclaw-gateway]")) {
+    return [{ kind: "system", ts, text: trimmed.replace(/^\[(?:openclaw|nanoclaw)-gateway\]\s*/, "") }];
+  }
+
+  return [{ kind: "stdout", ts, text: normalized.line }];
+}

--- a/packages/adapters/nanoclaw-gateway/tsconfig.json
+++ b/packages/adapters/nanoclaw-gateway/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -30,6 +30,7 @@ export const AGENT_ADAPTER_TYPES = [
   "pi_local",
   "cursor",
   "openclaw_gateway",
+  "nanoclaw_gateway",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 
@@ -124,7 +125,12 @@ export type IssuePriority = (typeof ISSUE_PRIORITIES)[number];
 export const GOAL_LEVELS = ["company", "team", "agent", "task"] as const;
 export type GoalLevel = (typeof GOAL_LEVELS)[number];
 
-export const GOAL_STATUSES = ["planned", "active", "achieved", "cancelled"] as const;
+export const GOAL_STATUSES = [
+  "planned",
+  "active",
+  "achieved",
+  "cancelled",
+] as const;
 export type GoalStatus = (typeof GOAL_STATUSES)[number];
 
 export const PROJECT_STATUSES = [
@@ -178,9 +184,15 @@ export const HEARTBEAT_INVOCATION_SOURCES = [
   "on_demand",
   "automation",
 ] as const;
-export type HeartbeatInvocationSource = (typeof HEARTBEAT_INVOCATION_SOURCES)[number];
+export type HeartbeatInvocationSource =
+  (typeof HEARTBEAT_INVOCATION_SOURCES)[number];
 
-export const WAKEUP_TRIGGER_DETAILS = ["manual", "ping", "callback", "system"] as const;
+export const WAKEUP_TRIGGER_DETAILS = [
+  "manual",
+  "ping",
+  "callback",
+  "system",
+] as const;
 export type WakeupTriggerDetail = (typeof WAKEUP_TRIGGER_DETAILS)[number];
 
 export const WAKEUP_REQUEST_STATUSES = [
@@ -233,7 +245,11 @@ export type InviteJoinType = (typeof INVITE_JOIN_TYPES)[number];
 export const JOIN_REQUEST_TYPES = ["human", "agent"] as const;
 export type JoinRequestType = (typeof JOIN_REQUEST_TYPES)[number];
 
-export const JOIN_REQUEST_STATUSES = ["pending_approval", "approved", "rejected"] as const;
+export const JOIN_REQUEST_STATUSES = [
+  "pending_approval",
+  "approved",
+  "rejected",
+] as const;
 export type JoinRequestStatus = (typeof JOIN_REQUEST_STATUSES)[number];
 
 export const PERMISSION_KEYS = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,9 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
+      '@paperclipai/adapter-nanoclaw-gateway':
         specifier: workspace:*
-        version: link:../packages/adapters/openclaw
+        version: link:../packages/adapters/nanoclaw-gateway
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -139,18 +139,27 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
-  packages/adapters/openclaw:
+  packages/adapters/nanoclaw-gateway:
     dependencies:
+      '@paperclipai/adapter-openclaw-gateway':
+        specifier: workspace:*
+        version: link:../openclaw-gateway
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0
     devDependencies:
       '@types/node':
         specifier: ^24.6.0
         version: 24.12.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -261,9 +270,9 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
+      '@paperclipai/adapter-nanoclaw-gateway':
         specifier: workspace:*
-        version: link:../packages/adapters/openclaw
+        version: link:../packages/adapters/nanoclaw-gateway
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -379,9 +388,9 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
+      '@paperclipai/adapter-nanoclaw-gateway':
         specifier: workspace:*
-        version: link:../packages/adapters/openclaw
+        version: link:../packages/adapters/nanoclaw-gateway
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,25 +141,16 @@ importers:
 
   packages/adapters/nanoclaw-gateway:
     dependencies:
-      '@paperclipai/adapter-openclaw-gateway':
-        specifier: workspace:*
-        version: link:../openclaw-gateway
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
-      ws:
-        specifier: ^8.19.0
-        version: 8.19.0
     devDependencies:
       '@types/node':
         specifier: ^24.6.0
         version: 24.12.0
-      '@types/ws':
-        specifier: ^8.18.1
-        version: 8.18.1
       typescript:
         specifier: ^5.7.3
         version: 5.9.3

--- a/server/package.json
+++ b/server/package.json
@@ -36,6 +36,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
+    "@paperclipai/adapter-nanoclaw-gateway": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -4,28 +4,35 @@ import {
   testEnvironment as claudeTestEnvironment,
   sessionCodec as claudeSessionCodec,
 } from "@paperclipai/adapter-claude-local/server";
-import { agentConfigurationDoc as claudeAgentConfigurationDoc, models as claudeModels } from "@paperclipai/adapter-claude-local";
+import {
+  agentConfigurationDoc as claudeAgentConfigurationDoc,
+  models as claudeModels,
+} from "@paperclipai/adapter-claude-local";
 import {
   execute as codexExecute,
   testEnvironment as codexTestEnvironment,
   sessionCodec as codexSessionCodec,
 } from "@paperclipai/adapter-codex-local/server";
-import { agentConfigurationDoc as codexAgentConfigurationDoc, models as codexModels } from "@paperclipai/adapter-codex-local";
+import {
+  agentConfigurationDoc as codexAgentConfigurationDoc,
+  models as codexModels,
+} from "@paperclipai/adapter-codex-local";
 import {
   execute as cursorExecute,
   testEnvironment as cursorTestEnvironment,
   sessionCodec as cursorSessionCodec,
 } from "@paperclipai/adapter-cursor-local/server";
-import { agentConfigurationDoc as cursorAgentConfigurationDoc, models as cursorModels } from "@paperclipai/adapter-cursor-local";
+import {
+  agentConfigurationDoc as cursorAgentConfigurationDoc,
+  models as cursorModels,
+} from "@paperclipai/adapter-cursor-local";
 import {
   execute as openCodeExecute,
   testEnvironment as openCodeTestEnvironment,
   sessionCodec as openCodeSessionCodec,
   listOpenCodeModels,
 } from "@paperclipai/adapter-opencode-local/server";
-import {
-  agentConfigurationDoc as openCodeAgentConfigurationDoc,
-} from "@paperclipai/adapter-opencode-local";
+import { agentConfigurationDoc as openCodeAgentConfigurationDoc } from "@paperclipai/adapter-opencode-local";
 import {
   execute as openclawGatewayExecute,
   testEnvironment as openclawGatewayTestEnvironment,
@@ -34,6 +41,14 @@ import {
   agentConfigurationDoc as openclawGatewayAgentConfigurationDoc,
   models as openclawGatewayModels,
 } from "@paperclipai/adapter-openclaw-gateway";
+import {
+  execute as nanoclawGatewayExecute,
+  testEnvironment as nanoclawGatewayTestEnvironment,
+} from "@paperclipai/adapter-nanoclaw-gateway/server";
+import {
+  agentConfigurationDoc as nanoclawGatewayAgentConfigurationDoc,
+  models as nanoclawGatewayModels,
+} from "@paperclipai/adapter-nanoclaw-gateway";
 import { listCodexModels } from "./codex-models.js";
 import { listCursorModels } from "./cursor-models.js";
 import {
@@ -42,9 +57,7 @@ import {
   sessionCodec as piSessionCodec,
   listPiModels,
 } from "@paperclipai/adapter-pi-local/server";
-import {
-  agentConfigurationDoc as piAgentConfigurationDoc,
-} from "@paperclipai/adapter-pi-local";
+import { agentConfigurationDoc as piAgentConfigurationDoc } from "@paperclipai/adapter-pi-local";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
 
@@ -89,6 +102,15 @@ const openclawGatewayAdapter: ServerAdapterModule = {
   agentConfigurationDoc: openclawGatewayAgentConfigurationDoc,
 };
 
+const nanoclawGatewayAdapter: ServerAdapterModule = {
+  type: "nanoclaw_gateway",
+  execute: nanoclawGatewayExecute,
+  testEnvironment: nanoclawGatewayTestEnvironment,
+  models: nanoclawGatewayModels,
+  supportsLocalAgentJwt: false,
+  agentConfigurationDoc: nanoclawGatewayAgentConfigurationDoc,
+};
+
 const openCodeLocalAdapter: ServerAdapterModule = {
   type: "opencode_local",
   execute: openCodeExecute,
@@ -119,6 +141,7 @@ const adaptersByType = new Map<string, ServerAdapterModule>(
     piLocalAdapter,
     cursorLocalAdapter,
     openclawGatewayAdapter,
+    nanoclawGatewayAdapter,
     processAdapter,
     httpAdapter,
   ].map((a) => [a.type, a]),
@@ -133,7 +156,9 @@ export function getServerAdapter(type: string): ServerAdapterModule {
   return adapter;
 }
 
-export async function listAdapterModels(type: string): Promise<{ id: string; label: string }[]> {
+export async function listAdapterModels(
+  type: string,
+): Promise<{ id: string; label: string }[]> {
   const adapter = adaptersByType.get(type);
   if (!adapter) return [];
   if (adapter.listModels) {

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,6 +19,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
+    "@paperclipai/adapter-nanoclaw-gateway": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/shared": "workspace:*",

--- a/ui/src/adapters/nanoclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/nanoclaw-gateway/config-fields.tsx
@@ -1,0 +1,216 @@
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  DraftInput,
+  help,
+} from "../../components/agent-config-primitives";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+const NANOCLAW_AGENTS = ["dozer", "scout", "myco", "sally"] as const;
+
+function SecretField({
+  label,
+  value,
+  onCommit,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onCommit: (v: string) => void;
+  placeholder?: string;
+}) {
+  const [visible, setVisible] = useState(false);
+  return (
+    <Field label={label}>
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setVisible((v) => !v)}
+          className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+        >
+          {visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+        </button>
+        <DraftInput
+          value={value}
+          onCommit={onCommit}
+          immediate
+          type={visible ? "text" : "password"}
+          className={inputClass + " pl-8"}
+          placeholder={placeholder}
+        />
+      </div>
+    </Field>
+  );
+}
+
+export function NanoClawGatewayConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  const configuredHeaders =
+    config.headers && typeof config.headers === "object" && !Array.isArray(config.headers)
+      ? (config.headers as Record<string, unknown>)
+      : {};
+  const effectiveHeaders =
+    (eff("adapterConfig", "headers", configuredHeaders) as Record<string, unknown>) ?? {};
+
+  const effectiveGatewayToken = typeof effectiveHeaders["x-openclaw-token"] === "string"
+    ? String(effectiveHeaders["x-openclaw-token"])
+    : typeof effectiveHeaders["x-openclaw-auth"] === "string"
+      ? String(effectiveHeaders["x-openclaw-auth"])
+      : "";
+
+  const commitGatewayToken = (rawValue: string) => {
+    const nextValue = rawValue.trim();
+    const nextHeaders: Record<string, unknown> = { ...effectiveHeaders };
+    if (nextValue) {
+      nextHeaders["x-openclaw-token"] = nextValue;
+      delete nextHeaders["x-openclaw-auth"];
+    } else {
+      delete nextHeaders["x-openclaw-token"];
+      delete nextHeaders["x-openclaw-auth"];
+    }
+    mark("adapterConfig", "headers", Object.keys(nextHeaders).length > 0 ? nextHeaders : undefined);
+  };
+
+  const sessionStrategy = eff(
+    "adapterConfig",
+    "sessionKeyStrategy",
+    String(config.sessionKeyStrategy ?? "issue"),
+  );
+
+  const effectiveAgentName = eff(
+    "adapterConfig",
+    "agentName",
+    String(config.agentName ?? "dozer"),
+  );
+
+  return (
+    <>
+      <Field label="Gateway URL" hint={help.webhookUrl}>
+        <DraftInput
+          value={
+            isCreate
+              ? values!.url
+              : eff("adapterConfig", "url", String(config.url ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ url: v })
+              : mark("adapterConfig", "url", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="ws://127.0.0.1:18789"
+        />
+      </Field>
+
+      <Field label="Agent Name">
+        {isCreate ? (
+          <select
+            value={values?.model ?? "dozer"}
+            onChange={(e) => set!({ model: e.target.value })}
+            className={inputClass}
+          >
+            {NANOCLAW_AGENTS.map((name) => (
+              <option key={name} value={name}>
+                {name.charAt(0).toUpperCase() + name.slice(1)}
+              </option>
+            ))}
+            <option value="">Custom...</option>
+          </select>
+        ) : (
+          <>
+            <select
+              value={NANOCLAW_AGENTS.includes(effectiveAgentName as typeof NANOCLAW_AGENTS[number]) ? effectiveAgentName : "__custom__"}
+              onChange={(e) => {
+                if (e.target.value === "__custom__") {
+                  mark("adapterConfig", "agentName", "");
+                } else {
+                  mark("adapterConfig", "agentName", e.target.value);
+                }
+              }}
+              className={inputClass}
+            >
+              {NANOCLAW_AGENTS.map((name) => (
+                <option key={name} value={name}>
+                  {name.charAt(0).toUpperCase() + name.slice(1)}
+                </option>
+              ))}
+              <option value="__custom__">Custom...</option>
+            </select>
+            {!NANOCLAW_AGENTS.includes(effectiveAgentName as typeof NANOCLAW_AGENTS[number]) && (
+              <DraftInput
+                value={effectiveAgentName}
+                onCommit={(v) => mark("adapterConfig", "agentName", v || undefined)}
+                immediate
+                className={inputClass + " mt-1.5"}
+                placeholder="custom-agent-name"
+              />
+            )}
+          </>
+        )}
+      </Field>
+
+      {!isCreate && (
+        <>
+          <SecretField
+            label="Gateway auth token (x-openclaw-token)"
+            value={effectiveGatewayToken}
+            onCommit={commitGatewayToken}
+            placeholder="OpenClaw gateway token"
+          />
+
+          <Field label="Timeout (seconds)">
+            <DraftInput
+              value={eff("adapterConfig", "timeoutSec", String(config.timeoutSec ?? "300"))}
+              onCommit={(v) => {
+                const parsed = Number.parseInt(v.trim(), 10);
+                mark(
+                  "adapterConfig",
+                  "timeoutSec",
+                  Number.isFinite(parsed) && parsed > 0 ? parsed : undefined,
+                );
+              }}
+              immediate
+              className={inputClass}
+              placeholder="300"
+            />
+          </Field>
+
+          <Field label="Session strategy">
+            <select
+              value={sessionStrategy}
+              onChange={(e) => mark("adapterConfig", "sessionKeyStrategy", e.target.value)}
+              className={inputClass}
+            >
+              <option value="issue">Per issue</option>
+              <option value="fixed">Fixed</option>
+              <option value="run">Per run</option>
+            </select>
+          </Field>
+
+          {sessionStrategy === "fixed" && (
+            <Field label="Session key">
+              <DraftInput
+                value={eff("adapterConfig", "sessionKey", String(config.sessionKey ?? "paperclip"))}
+                onCommit={(v) => mark("adapterConfig", "sessionKey", v || undefined)}
+                immediate
+                className={inputClass}
+                placeholder="paperclip"
+              />
+            </Field>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/ui/src/adapters/nanoclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/nanoclaw-gateway/config-fields.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { Eye, EyeOff } from "lucide-react";
 import type { AdapterConfigFieldsProps } from "../types";
 import {
   Field,
@@ -12,41 +11,6 @@ const inputClass =
 
 const NANOCLAW_AGENTS = ["dozer", "scout", "myco", "sally"] as const;
 
-function SecretField({
-  label,
-  value,
-  onCommit,
-  placeholder,
-}: {
-  label: string;
-  value: string;
-  onCommit: (v: string) => void;
-  placeholder?: string;
-}) {
-  const [visible, setVisible] = useState(false);
-  return (
-    <Field label={label}>
-      <div className="relative">
-        <button
-          type="button"
-          onClick={() => setVisible((v) => !v)}
-          className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
-        >
-          {visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
-        </button>
-        <DraftInput
-          value={value}
-          onCommit={onCommit}
-          immediate
-          type={visible ? "text" : "password"}
-          className={inputClass + " pl-8"}
-          placeholder={placeholder}
-        />
-      </div>
-    </Field>
-  );
-}
-
 export function NanoClawGatewayConfigFields({
   isCreate,
   values,
@@ -55,47 +19,13 @@ export function NanoClawGatewayConfigFields({
   eff,
   mark,
 }: AdapterConfigFieldsProps) {
-  const configuredHeaders =
-    config.headers && typeof config.headers === "object" && !Array.isArray(config.headers)
-      ? (config.headers as Record<string, unknown>)
-      : {};
-  const effectiveHeaders =
-    (eff("adapterConfig", "headers", configuredHeaders) as Record<string, unknown>) ?? {};
-
-  const effectiveGatewayToken = typeof effectiveHeaders["x-openclaw-token"] === "string"
-    ? String(effectiveHeaders["x-openclaw-token"])
-    : typeof effectiveHeaders["x-openclaw-auth"] === "string"
-      ? String(effectiveHeaders["x-openclaw-auth"])
-      : "";
-
-  const commitGatewayToken = (rawValue: string) => {
-    const nextValue = rawValue.trim();
-    const nextHeaders: Record<string, unknown> = { ...effectiveHeaders };
-    if (nextValue) {
-      nextHeaders["x-openclaw-token"] = nextValue;
-      delete nextHeaders["x-openclaw-auth"];
-    } else {
-      delete nextHeaders["x-openclaw-token"];
-      delete nextHeaders["x-openclaw-auth"];
-    }
-    mark("adapterConfig", "headers", Object.keys(nextHeaders).length > 0 ? nextHeaders : undefined);
-  };
-
-  const sessionStrategy = eff(
-    "adapterConfig",
-    "sessionKeyStrategy",
-    String(config.sessionKeyStrategy ?? "issue"),
-  );
-
-  const effectiveAgentName = eff(
-    "adapterConfig",
-    "agentName",
-    String(config.agentName ?? "dozer"),
-  );
+  const effectiveAgentName = isCreate
+    ? (values?.model ?? "dozer")
+    : eff("adapterConfig", "agentName", String(config.agentName ?? "dozer"));
 
   return (
     <>
-      <Field label="Gateway URL" hint={help.webhookUrl}>
+      <Field label="NanoClaw URL" hint="HTTP base URL for NanoClaw's MCP server">
         <DraftInput
           value={
             isCreate
@@ -109,7 +39,7 @@ export function NanoClawGatewayConfigFields({
           }
           immediate
           className={inputClass}
-          placeholder="ws://127.0.0.1:18789"
+          placeholder="http://127.0.0.1:18790"
         />
       </Field>
 
@@ -161,55 +91,22 @@ export function NanoClawGatewayConfigFields({
       </Field>
 
       {!isCreate && (
-        <>
-          <SecretField
-            label="Gateway auth token (x-openclaw-token)"
-            value={effectiveGatewayToken}
-            onCommit={commitGatewayToken}
-            placeholder="OpenClaw gateway token"
+        <Field label="Timeout (ms)">
+          <DraftInput
+            value={eff("adapterConfig", "timeoutMs", String(config.timeoutMs ?? "30000"))}
+            onCommit={(v) => {
+              const parsed = Number.parseInt(v.trim(), 10);
+              mark(
+                "adapterConfig",
+                "timeoutMs",
+                Number.isFinite(parsed) && parsed > 0 ? parsed : undefined,
+              );
+            }}
+            immediate
+            className={inputClass}
+            placeholder="30000"
           />
-
-          <Field label="Timeout (seconds)">
-            <DraftInput
-              value={eff("adapterConfig", "timeoutSec", String(config.timeoutSec ?? "300"))}
-              onCommit={(v) => {
-                const parsed = Number.parseInt(v.trim(), 10);
-                mark(
-                  "adapterConfig",
-                  "timeoutSec",
-                  Number.isFinite(parsed) && parsed > 0 ? parsed : undefined,
-                );
-              }}
-              immediate
-              className={inputClass}
-              placeholder="300"
-            />
-          </Field>
-
-          <Field label="Session strategy">
-            <select
-              value={sessionStrategy}
-              onChange={(e) => mark("adapterConfig", "sessionKeyStrategy", e.target.value)}
-              className={inputClass}
-            >
-              <option value="issue">Per issue</option>
-              <option value="fixed">Fixed</option>
-              <option value="run">Per run</option>
-            </select>
-          </Field>
-
-          {sessionStrategy === "fixed" && (
-            <Field label="Session key">
-              <DraftInput
-                value={eff("adapterConfig", "sessionKey", String(config.sessionKey ?? "paperclip"))}
-                onCommit={(v) => mark("adapterConfig", "sessionKey", v || undefined)}
-                immediate
-                className={inputClass}
-                placeholder="paperclip"
-              />
-            </Field>
-          )}
-        </>
+        </Field>
       )}
     </>
   );

--- a/ui/src/adapters/nanoclaw-gateway/index.ts
+++ b/ui/src/adapters/nanoclaw-gateway/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseNanoClawGatewayStdoutLine } from "@paperclipai/adapter-nanoclaw-gateway/ui";
+import { buildNanoClawGatewayConfig } from "@paperclipai/adapter-nanoclaw-gateway/ui";
+import { NanoClawGatewayConfigFields } from "./config-fields";
+
+export const nanoClawGatewayUIAdapter: UIAdapterModule = {
+  type: "nanoclaw_gateway",
+  label: "NanoClaw Gateway",
+  parseStdoutLine: parseNanoClawGatewayStdoutLine,
+  ConfigFields: NanoClawGatewayConfigFields,
+  buildAdapterConfig: buildNanoClawGatewayConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -5,6 +5,7 @@ import { cursorLocalUIAdapter } from "./cursor";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
+import { nanoClawGatewayUIAdapter } from "./nanoclaw-gateway";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
 
@@ -16,6 +17,7 @@ const adaptersByType = new Map<string, UIAdapterModule>(
     piLocalUIAdapter,
     cursorLocalUIAdapter,
     openClawGatewayUIAdapter,
+    nanoClawGatewayUIAdapter,
     processUIAdapter,
     httpUIAdapter,
   ].map((a) => [a.type, a]),


### PR DESCRIPTION
## Summary
- Adds a new `@paperclipai/adapter-nanoclaw-gateway` package enabling Paperclip to dispatch tasks to NanoClaw's Docker-containerized Claude agents (Dozer, Scout, Myco, Sally) over HTTP.
- Wires the adapter into the server/ui/cli registries and adds onboarding docs.
- Includes a follow-up fix rewriting the adapter to use NanoClaw's correct HTTP API surface (superseding an initial protocol assumption).

## Test plan
- [ ] `pnpm -r typecheck` (note: preexisting `disableSignUp` cli errors on master are unrelated)
- [ ] `pnpm test:run` — all 178 tests pass locally
- [ ] `pnpm build`
- [ ] Manual: hire a NanoClaw agent from the board UI and verify heartbeat + task dispatch reach the NanoClaw gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)