### PR TITLE
Fix stale execution lock cleanup

### DIFF
--- a/packages/db/scripts/stale-lock-blackbox.ts
+++ b/packages/db/scripts/stale-lock-blackbox.ts
@@ -1,0 +1,284 @@
+import { randomUUID } from "node:crypto";
+import postgres from "postgres";
+
+const baseUrl = (process.env.PAPERCLIP_BASE_URL ?? "http://127.0.0.1:3101").replace(/\/+$/, "");
+const databaseUrl = process.env.DATABASE_URL ?? process.env.PAPERCLIP_DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error("Set DATABASE_URL or PAPERCLIP_DATABASE_URL to the disposable Paperclip database URL.");
+}
+
+type Json = Record<string, unknown>;
+
+const sql = postgres(databaseUrl, { max: 1 });
+const createdCompanyIds: string[] = [];
+
+function log(message: string, data?: Json) {
+  if (data) {
+    console.log(`${message}: ${JSON.stringify(data)}`);
+    return;
+  }
+  console.log(message);
+}
+
+async function api<T = Json>(path: string, init: RequestInit = {}): Promise<T> {
+  const headers = new Headers(init.headers);
+  if (!headers.has("content-type") && init.body) headers.set("content-type", "application/json");
+  const response = await fetch(`${baseUrl}${path}`, { ...init, headers });
+  const text = await response.text();
+  const body = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    throw new Error(`${init.method ?? "GET"} ${path} failed (${response.status}): ${text}`);
+  }
+  return body as T;
+}
+
+async function waitFor<T>(
+  label: string,
+  fn: () => Promise<T | null | undefined | false>,
+  timeoutMs = 20_000,
+  intervalMs = 250,
+): Promise<T> {
+  const started = Date.now();
+  let lastValue: T | null | undefined | false = null;
+  while (Date.now() - started < timeoutMs) {
+    lastValue = await fn();
+    if (lastValue) return lastValue;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for ${label}; last value: ${JSON.stringify(lastValue)}`);
+}
+
+function processAgentConfig(sleepMs: number) {
+  return {
+    command: process.execPath,
+    args: ["-e", `setTimeout(() => {}, ${sleepMs})`],
+  };
+}
+
+async function createFixture() {
+  const suffix = randomUUID().slice(0, 8);
+  const company = await api<{ id: string }>("/api/companies", {
+    method: "POST",
+    body: JSON.stringify({ name: `Stale Lock QA ${suffix}` }),
+  });
+  createdCompanyIds.push(company.id);
+
+  const owner = await api<{ id: string }>(`/api/companies/${company.id}/agents`, {
+    method: "POST",
+    body: JSON.stringify({
+      name: `Fixture Owner ${suffix}`,
+      role: "engineer",
+      adapterType: "process",
+      adapterConfig: processAgentConfig(2_000),
+      runtimeConfig: { heartbeat: { enabled: false } },
+    }),
+  });
+
+  const contender = await api<{ id: string }>(`/api/companies/${company.id}/agents`, {
+    method: "POST",
+    body: JSON.stringify({
+      name: `Fixture Contender ${suffix}`,
+      role: "engineer",
+      adapterType: "process",
+      adapterConfig: processAgentConfig(500),
+      runtimeConfig: { heartbeat: { enabled: false } },
+    }),
+  });
+
+  const staleIssue = await api<{ id: string; identifier: string }>(`/api/companies/${company.id}/issues`, {
+    method: "POST",
+    body: JSON.stringify({
+      title: `Terminal stale lock ${suffix}`,
+      status: "todo",
+      priority: "high",
+    }),
+  });
+
+  const deferredIssue = await api<{ id: string; identifier: string }>(`/api/companies/${company.id}/issues`, {
+    method: "POST",
+    body: JSON.stringify({
+      title: `Deferred promotion ${suffix}`,
+      status: "todo",
+      priority: "high",
+    }),
+  });
+
+  const contenderKey = await api<{ token: string }>(`/api/agents/${contender.id}/keys`, {
+    method: "POST",
+    body: JSON.stringify({ name: "stale-lock-blackbox" }),
+  });
+
+  return { company, owner, contender, contenderKey, staleIssue, deferredIssue };
+}
+
+async function verifyTerminalStaleCheckout(fixture: Awaited<ReturnType<typeof createFixture>>) {
+  const runId = randomUUID();
+  const now = new Date();
+
+  await sql.begin(async (tx) => {
+    await tx`
+      insert into heartbeat_runs (
+        id, company_id, agent_id, invocation_source, trigger_detail, status,
+        started_at, finished_at, exit_code, context_snapshot, created_at, updated_at
+      )
+      values (
+        ${runId}, ${fixture.company.id}, ${fixture.owner.id}, 'on_demand', 'manual', 'succeeded',
+        ${now}, ${now}, 0, ${tx.json({ issueId: fixture.staleIssue.id })}, ${now}, ${now}
+      )
+    `;
+
+    const rows = await tx`
+      update issues i
+      set assignee_agent_id = ${fixture.contender.id},
+          execution_run_id = ${runId},
+          execution_agent_name_key = 'fixture-owner',
+          execution_locked_at = ${now},
+          updated_at = ${now}
+      where i.id = ${fixture.staleIssue.id}
+        and i.company_id = ${fixture.company.id}
+        and not exists (
+          select 1
+          from heartbeat_runs live
+          where live.id = ${runId}
+            and live.status in ('queued', 'running')
+        )
+      returning i.id
+    `;
+    if (rows.count !== 1) {
+      throw new Error("Guarded stale-lock fixture update did not affect exactly one row.");
+    }
+  });
+
+  const inbox = await api<Array<{ id: string; activeRun: unknown }>>("/api/agents/me/inbox-lite", {
+    headers: { authorization: `Bearer ${fixture.contenderKey.token}` },
+  });
+  const inboxIssue = inbox.find((issue) => issue.id === fixture.staleIssue.id);
+  if (!inboxIssue) throw new Error("Stale fixture issue was not present in contender inbox-lite.");
+  if (inboxIssue.activeRun !== null) {
+    throw new Error(`Expected inbox-lite activeRun=null for terminal stale lock; got ${JSON.stringify(inboxIssue.activeRun)}`);
+  }
+
+  const checkedOut = await api<{ id: string; status: string; executionRunId: string | null }>(
+    `/api/issues/${fixture.staleIssue.id}/checkout`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        agentId: fixture.contender.id,
+        expectedStatuses: ["todo", "in_progress", "blocked"],
+      }),
+    },
+  );
+
+  if (checkedOut.executionRunId !== null || checkedOut.status !== "in_progress") {
+    throw new Error(`Checkout did not repair terminal stale lock as expected: ${JSON.stringify(checkedOut)}`);
+  }
+
+  log("terminal-stale-checkout: pass", {
+    issue: fixture.staleIssue.identifier,
+    terminalRunId: runId,
+    inboxActiveRun: inboxIssue.activeRun,
+    checkoutStatus: checkedOut.status,
+  });
+}
+
+async function verifyDeferredPromotion(fixture: Awaited<ReturnType<typeof createFixture>>) {
+  const ownerRun = await api<{ id: string; status: string }>(`/api/agents/${fixture.owner.id}/wakeup`, {
+    method: "POST",
+    body: JSON.stringify({
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "stale-lock-blackbox-owner",
+      payload: { issueId: fixture.deferredIssue.id },
+    }),
+  });
+
+  await waitFor("owner run to own issue execution", async () => {
+    const active = await api<{ id: string; status: string } | null>(`/api/issues/${fixture.deferredIssue.id}/active-run`);
+    return active?.id === ownerRun.id && active.status === "running" ? active : null;
+  });
+
+  await api(`/api/agents/${fixture.contender.id}/wakeup`, {
+    method: "POST",
+    body: JSON.stringify({
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "stale-lock-blackbox-contender",
+      payload: { issueId: fixture.deferredIssue.id },
+    }),
+  });
+
+  await waitFor("deferred wake request", async () => {
+    const rows = await sql`
+      select id
+      from agent_wakeup_requests
+      where company_id = ${fixture.company.id}
+        and agent_id = ${fixture.contender.id}
+        and status = 'deferred_issue_execution'
+        and payload ->> 'issueId' = ${fixture.deferredIssue.id}
+      limit 1
+    `;
+    return rows[0] ?? null;
+  });
+
+  const promoted = await waitFor("promoted contender run", async () => {
+    const rows = await sql`
+      select id, status
+      from heartbeat_runs
+      where company_id = ${fixture.company.id}
+        and agent_id = ${fixture.contender.id}
+        and context_snapshot ->> 'issueId' = ${fixture.deferredIssue.id}
+        and status in ('queued', 'running', 'succeeded')
+      order by created_at desc
+      limit 1
+    `;
+    return rows[0] ?? null;
+  }, 30_000);
+
+  const ownerFinal = await api<{ id: string; status: string }>(`/api/heartbeat-runs/${ownerRun.id}`);
+  if (ownerFinal.status !== "succeeded") {
+    throw new Error(`Owner run did not finish successfully: ${JSON.stringify(ownerFinal)}`);
+  }
+
+  log("deferred-promotion: pass", {
+    issue: fixture.deferredIssue.identifier,
+    ownerRunId: ownerRun.id,
+    promotedRunId: promoted.id,
+    promotedStatus: promoted.status,
+  });
+}
+
+async function main() {
+  log("stale-lock black-box harness starting", { baseUrl });
+  await api("/api/health");
+  const fixture = await createFixture();
+  log("fixture-created", {
+    companyId: fixture.company.id,
+    ownerAgentId: fixture.owner.id,
+    contenderAgentId: fixture.contender.id,
+    staleIssue: fixture.staleIssue.identifier,
+    deferredIssue: fixture.deferredIssue.identifier,
+  });
+
+  try {
+    await verifyTerminalStaleCheckout(fixture);
+    await verifyDeferredPromotion(fixture);
+    log("stale-lock black-box harness complete");
+  } finally {
+    for (const companyId of createdCompanyIds.reverse()) {
+      try {
+        await api(`/api/companies/${companyId}`, { method: "DELETE" });
+        log("cleanup: deleted disposable company", { companyId });
+      } catch (error) {
+        console.error(`cleanup warning: failed to delete company ${companyId}:`, error);
+      }
+    }
+    await sql.end({ timeout: 5 });
+  }
+}
+
+main().catch(async (error) => {
+  console.error(error);
+  await sql.end({ timeout: 5 }).catch(() => undefined);
+  process.exitCode = 1;
+});

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -429,6 +429,146 @@ describe("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
+  it("clears execution locks from every issue touched by a successful run", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueAId = randomUUID();
+    const issueBId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values([
+        {
+          id: issueAId,
+          companyId,
+          title: "Primary run issue",
+          status: "todo",
+          priority: "medium",
+          assigneeAgentId: agentId,
+          issueNumber: 1,
+          identifier: `${issuePrefix}-1`,
+        },
+        {
+          id: issueBId,
+          companyId,
+          title: "Second issue touched by same run",
+          status: "todo",
+          priority: "medium",
+          assigneeAgentId: agentId,
+          issueNumber: 2,
+          identifier: `${issuePrefix}-2`,
+        },
+      ]);
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId: issueAId },
+        contextSnapshot: {
+          issueId: issueAId,
+          taskId: issueAId,
+          wakeReason: "issue_assigned",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      await db
+        .update(issues)
+        .set({
+          executionRunId: firstRun!.id,
+          executionAgentNameKey: "gateway-agent",
+          executionLockedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueBId));
+
+      await db.insert(issueComments).values({
+        companyId,
+        issueId: issueAId,
+        authorAgentId: agentId,
+        createdByRunId: firstRun?.id ?? null,
+        body: "Heartbeat handled primary issue",
+      });
+
+      gateway.releaseFirstWait();
+
+      await waitFor(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "succeeded";
+      }, 90_000);
+
+      const lockedIssues = await db
+        .select({
+          id: issues.id,
+          executionRunId: issues.executionRunId,
+          executionAgentNameKey: issues.executionAgentNameKey,
+          executionLockedAt: issues.executionLockedAt,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), eq(issues.executionRunId, firstRun!.id)));
+
+      expect(lockedIssues).toHaveLength(0);
+
+      const issueB = await db
+        .select({
+          executionRunId: issues.executionRunId,
+          executionAgentNameKey: issues.executionAgentNameKey,
+          executionLockedAt: issues.executionLockedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueBId))
+        .then((rows) => rows[0] ?? null);
+
+      expect(issueB).toMatchObject({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      });
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
   it("promotes deferred comment wakes after the active run closes the issue", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -8,6 +8,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -1179,6 +1180,154 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
       id: parentId,
       assigneeAgentId,
       childIssueIds: [childA, childB],
+    });
+  });
+});
+
+describeEmbeddedPostgres("issueService checkout ownership recovery", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-ownership-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function insertOwnershipFixture(input: { lockRunStatus: "running" | "succeeded" }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const lockRunId = randomUUID();
+    const actorRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const now = new Date();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Monitor",
+      role: "sre",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: lockRunId,
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: input.lockRunStatus,
+        startedAt: now,
+        finishedAt: input.lockRunStatus === "succeeded" ? now : null,
+        exitCode: input.lockRunStatus === "succeeded" ? 0 : null,
+        contextSnapshot: { issueId },
+      },
+      {
+        id: actorRunId,
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "running",
+        startedAt: now,
+        contextSnapshot: { issueId },
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Parent monitor thread",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: lockRunId,
+      executionAgentNameKey: "monitor",
+      executionLockedAt: now,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    return { agentId, actorRunId, issueId, lockRunId };
+  }
+
+  it("adopts terminal execution locks when checkout ownership is missing", async () => {
+    const { agentId, actorRunId, issueId, lockRunId } = await insertOwnershipFixture({
+      lockRunStatus: "succeeded",
+    });
+
+    const ownership = await svc.assertCheckoutOwner(issueId, agentId, actorRunId);
+
+    expect(ownership).toMatchObject({
+      id: issueId,
+      checkoutRunId: actorRunId,
+      executionRunId: actorRunId,
+      adoptedFromRunId: lockRunId,
+      adoptedReason: "stale_execution_run",
+    });
+
+    const issue = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toMatchObject({
+      checkoutRunId: actorRunId,
+      executionRunId: actorRunId,
+      executionAgentNameKey: "monitor",
+    });
+  });
+
+  it("does not adopt live execution locks when checkout ownership is missing", async () => {
+    const { agentId, actorRunId, issueId, lockRunId } = await insertOwnershipFixture({
+      lockRunStatus: "running",
+    });
+
+    await expect(svc.assertCheckoutOwner(issueId, agentId, actorRunId)).rejects.toMatchObject({
+      status: 409,
+      details: expect.objectContaining({
+        executionRunId: lockRunId,
+      }),
     });
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -427,9 +427,9 @@ export function issueRoutes(
         entityType: "issue",
         entityId: issue.id,
         details: {
-          previousCheckoutRunId: ownership.adoptedFromRunId,
+          previousRunId: ownership.adoptedFromRunId,
           checkoutRunId: runId,
-          reason: "stale_checkout_run",
+          reason: ownership.adoptedReason ?? "stale_checkout_run",
         },
       });
     }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4015,18 +4015,18 @@ export function heartbeatService(db: Db) {
   async function releaseIssueExecutionAndPromote(run: typeof heartbeatRuns.$inferSelect) {
     const runContext = parseObject(run.contextSnapshot);
     const contextIssueId = readNonEmptyString(runContext.issueId);
-    const promotionResult = await db.transaction(async (tx) => {
+    const promotionResults = await db.transaction(async (tx) => {
       if (contextIssueId) {
         await tx.execute(
-          sql`select id from issues where company_id = ${run.companyId} and id = ${contextIssueId} for update`,
+          sql`select id from issues where company_id = ${run.companyId} and (id = ${contextIssueId} or execution_run_id = ${run.id}) order by id for update`,
         );
       } else {
         await tx.execute(
-          sql`select id from issues where company_id = ${run.companyId} and execution_run_id = ${run.id} for update`,
+          sql`select id from issues where company_id = ${run.companyId} and execution_run_id = ${run.id} order by id for update`,
         );
       }
 
-      let issue = await tx
+      const affectedIssues = await tx
         .select({
           id: issues.id,
           companyId: issues.companyId,
@@ -4038,204 +4038,215 @@ export function heartbeatService(db: Db) {
         .where(
           and(
             eq(issues.companyId, run.companyId),
-            contextIssueId ? eq(issues.id, contextIssueId) : eq(issues.executionRunId, run.id),
+            contextIssueId
+              ? or(eq(issues.id, contextIssueId), eq(issues.executionRunId, run.id))
+              : eq(issues.executionRunId, run.id),
           ),
         )
-        .then((rows) => rows[0] ?? null);
+        .orderBy(asc(issues.id));
 
-      if (!issue) return null;
-      if (issue.executionRunId && issue.executionRunId !== run.id) return null;
+      const results: Array<{
+        run: typeof heartbeatRuns.$inferSelect;
+        reopenedActivity: LogActivityInput | null;
+      }> = [];
 
-      if (issue.executionRunId === run.id) {
-        await tx
-          .update(issues)
-          .set({
-            executionRunId: null,
-            executionAgentNameKey: null,
-            executionLockedAt: null,
-            updatedAt: new Date(),
-          })
-          .where(eq(issues.id, issue.id));
-      }
+      for (let issue of affectedIssues) {
+        if (issue.executionRunId && issue.executionRunId !== run.id) continue;
 
-      while (true) {
-        const deferred = await tx
-          .select()
-          .from(agentWakeupRequests)
-          .where(
-            and(
-              eq(agentWakeupRequests.companyId, issue.companyId),
-              eq(agentWakeupRequests.status, "deferred_issue_execution"),
-              sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}`,
-            ),
-          )
-          .orderBy(asc(agentWakeupRequests.requestedAt))
-          .limit(1)
-          .then((rows) => rows[0] ?? null);
+        if (issue.executionRunId === run.id) {
+          await tx
+            .update(issues)
+            .set({
+              executionRunId: null,
+              executionAgentNameKey: null,
+              executionLockedAt: null,
+              updatedAt: new Date(),
+            })
+            .where(and(eq(issues.id, issue.id), eq(issues.executionRunId, run.id)));
+        }
 
-        if (!deferred) return null;
+        while (true) {
+          const deferred = await tx
+            .select()
+            .from(agentWakeupRequests)
+            .where(
+              and(
+                eq(agentWakeupRequests.companyId, issue.companyId),
+                eq(agentWakeupRequests.status, "deferred_issue_execution"),
+                sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}`,
+              ),
+            )
+            .orderBy(asc(agentWakeupRequests.requestedAt))
+            .limit(1)
+            .then((rows) => rows[0] ?? null);
 
-        const deferredAgent = await tx
-          .select()
-          .from(agents)
-          .where(eq(agents.id, deferred.agentId))
-          .then((rows) => rows[0] ?? null);
+          if (!deferred) break;
 
-        if (
-          !deferredAgent ||
-          deferredAgent.companyId !== issue.companyId ||
-          deferredAgent.status === "paused" ||
-          deferredAgent.status === "terminated" ||
-          deferredAgent.status === "pending_approval"
-        ) {
+          const deferredAgent = await tx
+            .select()
+            .from(agents)
+            .where(eq(agents.id, deferred.agentId))
+            .then((rows) => rows[0] ?? null);
+
+          if (
+            !deferredAgent ||
+            deferredAgent.companyId !== issue.companyId ||
+            deferredAgent.status === "paused" ||
+            deferredAgent.status === "terminated" ||
+            deferredAgent.status === "pending_approval"
+          ) {
+            await tx
+              .update(agentWakeupRequests)
+              .set({
+                status: "failed",
+                finishedAt: new Date(),
+                error: "Deferred wake could not be promoted: agent is not invokable",
+                updatedAt: new Date(),
+              })
+              .where(eq(agentWakeupRequests.id, deferred.id));
+            continue;
+          }
+
+          const deferredPayload = parseObject(deferred.payload);
+          const deferredContextSeed = parseObject(deferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
+          const promotedContextSeed: Record<string, unknown> = { ...deferredContextSeed };
+          const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
+          const shouldReopenDeferredCommentWake =
+            deferredCommentIds.length > 0 && (issue.status === "done" || issue.status === "cancelled");
+          let reopenedActivity: LogActivityInput | null = null;
+
+          if (shouldReopenDeferredCommentWake) {
+            const reopenedFromStatus = issue.status;
+            const reopenedIssue = await issuesSvc.update(
+              issue.id,
+              {
+                status: "todo",
+                executionState: null,
+              },
+              tx,
+            );
+            if (reopenedIssue) {
+              issue = {
+                ...issue,
+                identifier: reopenedIssue.identifier,
+                status: reopenedIssue.status,
+                executionRunId: reopenedIssue.executionRunId,
+              };
+              if (!readNonEmptyString(promotedContextSeed.reopenedFrom)) {
+                promotedContextSeed.reopenedFrom = reopenedFromStatus;
+              }
+              reopenedActivity = {
+                companyId: issue.companyId,
+                actorType: "system",
+                actorId: "heartbeat",
+                agentId: deferred.agentId,
+                runId: run.id,
+                action: "issue.updated",
+                entityType: "issue",
+                entityId: issue.id,
+                details: {
+                  status: "todo",
+                  reopened: true,
+                  reopenedFrom: reopenedFromStatus,
+                  source: "deferred_comment_wake",
+                  identifier: issue.identifier,
+                },
+              };
+            }
+          }
+
+          const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
+          const promotedSource =
+            (readNonEmptyString(deferred.source) as WakeupOptions["source"]) ?? "automation";
+          const promotedTriggerDetail =
+            (readNonEmptyString(deferred.triggerDetail) as WakeupOptions["triggerDetail"]) ?? null;
+          const promotedPayload = deferredPayload;
+          delete promotedPayload[DEFERRED_WAKE_CONTEXT_KEY];
+
+          const {
+            contextSnapshot: promotedContextSnapshot,
+            taskKey: promotedTaskKey,
+          } = enrichWakeContextSnapshot({
+            contextSnapshot: promotedContextSeed,
+            reason: promotedReason,
+            source: promotedSource,
+            triggerDetail: promotedTriggerDetail,
+            payload: promotedPayload,
+          });
+
+          const sessionBefore =
+            readNonEmptyString(promotedContextSnapshot.resumeSessionDisplayId) ??
+            await resolveSessionBeforeForWakeup(deferredAgent, promotedTaskKey);
+          const now = new Date();
+          const newRun = await tx
+            .insert(heartbeatRuns)
+            .values({
+              companyId: deferredAgent.companyId,
+              agentId: deferredAgent.id,
+              invocationSource: promotedSource,
+              triggerDetail: promotedTriggerDetail,
+              status: "queued",
+              wakeupRequestId: deferred.id,
+              contextSnapshot: promotedContextSnapshot,
+              sessionIdBefore: sessionBefore,
+            })
+            .returning()
+            .then((rows) => rows[0]);
+
           await tx
             .update(agentWakeupRequests)
             .set({
-              status: "failed",
-              finishedAt: new Date(),
-              error: "Deferred wake could not be promoted: agent is not invokable",
-              updatedAt: new Date(),
+              status: "queued",
+              reason: "issue_execution_promoted",
+              runId: newRun.id,
+              claimedAt: null,
+              finishedAt: null,
+              error: null,
+              updatedAt: now,
             })
             .where(eq(agentWakeupRequests.id, deferred.id));
-          continue;
+
+          await tx
+            .update(issues)
+            .set({
+              executionRunId: newRun.id,
+              executionAgentNameKey: normalizeAgentNameKey(deferredAgent.name),
+              executionLockedAt: now,
+              updatedAt: now,
+            })
+            .where(eq(issues.id, issue.id));
+
+          results.push({
+            run: newRun,
+            reopenedActivity,
+          });
+          break;
         }
-
-        const deferredPayload = parseObject(deferred.payload);
-        const deferredContextSeed = parseObject(deferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
-        const promotedContextSeed: Record<string, unknown> = { ...deferredContextSeed };
-        const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
-        const shouldReopenDeferredCommentWake =
-          deferredCommentIds.length > 0 && (issue.status === "done" || issue.status === "cancelled");
-        let reopenedActivity: LogActivityInput | null = null;
-
-        if (shouldReopenDeferredCommentWake) {
-          const reopenedFromStatus = issue.status;
-          const reopenedIssue = await issuesSvc.update(
-            issue.id,
-            {
-              status: "todo",
-              executionState: null,
-            },
-            tx,
-          );
-          if (reopenedIssue) {
-            issue = {
-              ...issue,
-              identifier: reopenedIssue.identifier,
-              status: reopenedIssue.status,
-              executionRunId: reopenedIssue.executionRunId,
-            };
-            if (!readNonEmptyString(promotedContextSeed.reopenedFrom)) {
-              promotedContextSeed.reopenedFrom = reopenedFromStatus;
-            }
-            reopenedActivity = {
-              companyId: issue.companyId,
-              actorType: "system",
-              actorId: "heartbeat",
-              agentId: deferred.agentId,
-              runId: run.id,
-              action: "issue.updated",
-              entityType: "issue",
-              entityId: issue.id,
-              details: {
-                status: "todo",
-                reopened: true,
-                reopenedFrom: reopenedFromStatus,
-                source: "deferred_comment_wake",
-                identifier: issue.identifier,
-              },
-            };
-          }
-        }
-
-        const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
-        const promotedSource =
-          (readNonEmptyString(deferred.source) as WakeupOptions["source"]) ?? "automation";
-        const promotedTriggerDetail =
-          (readNonEmptyString(deferred.triggerDetail) as WakeupOptions["triggerDetail"]) ?? null;
-        const promotedPayload = deferredPayload;
-        delete promotedPayload[DEFERRED_WAKE_CONTEXT_KEY];
-
-        const {
-          contextSnapshot: promotedContextSnapshot,
-          taskKey: promotedTaskKey,
-        } = enrichWakeContextSnapshot({
-          contextSnapshot: promotedContextSeed,
-          reason: promotedReason,
-          source: promotedSource,
-          triggerDetail: promotedTriggerDetail,
-          payload: promotedPayload,
-        });
-
-        const sessionBefore =
-          readNonEmptyString(promotedContextSnapshot.resumeSessionDisplayId) ??
-          await resolveSessionBeforeForWakeup(deferredAgent, promotedTaskKey);
-        const now = new Date();
-        const newRun = await tx
-          .insert(heartbeatRuns)
-          .values({
-            companyId: deferredAgent.companyId,
-            agentId: deferredAgent.id,
-            invocationSource: promotedSource,
-            triggerDetail: promotedTriggerDetail,
-            status: "queued",
-            wakeupRequestId: deferred.id,
-            contextSnapshot: promotedContextSnapshot,
-            sessionIdBefore: sessionBefore,
-          })
-          .returning()
-          .then((rows) => rows[0]);
-
-        await tx
-          .update(agentWakeupRequests)
-          .set({
-            status: "queued",
-            reason: "issue_execution_promoted",
-            runId: newRun.id,
-            claimedAt: null,
-            finishedAt: null,
-            error: null,
-            updatedAt: now,
-          })
-          .where(eq(agentWakeupRequests.id, deferred.id));
-
-        await tx
-          .update(issues)
-          .set({
-            executionRunId: newRun.id,
-            executionAgentNameKey: normalizeAgentNameKey(deferredAgent.name),
-            executionLockedAt: now,
-            updatedAt: now,
-          })
-          .where(eq(issues.id, issue.id));
-
-        return {
-          run: newRun,
-          reopenedActivity,
-        };
       }
+
+      return results;
     });
 
-    const promotedRun = promotionResult?.run ?? null;
-    if (!promotedRun) return;
+    for (const promotionResult of promotionResults) {
+      if (promotionResult.reopenedActivity) {
+        await logActivity(db, promotionResult.reopenedActivity);
+      }
 
-    if (promotionResult?.reopenedActivity) {
-      await logActivity(db, promotionResult.reopenedActivity);
+      const promotedRun = promotionResult.run;
+      publishLiveEvent({
+        companyId: promotedRun.companyId,
+        type: "heartbeat.run.queued",
+        payload: {
+          runId: promotedRun.id,
+          agentId: promotedRun.agentId,
+          invocationSource: promotedRun.invocationSource,
+          triggerDetail: promotedRun.triggerDetail,
+          wakeupRequestId: promotedRun.wakeupRequestId,
+        },
+      });
+
+      await startNextQueuedRunForAgent(promotedRun.agentId);
     }
-
-    publishLiveEvent({
-      companyId: promotedRun.companyId,
-      type: "heartbeat.run.queued",
-      payload: {
-        runId: promotedRun.id,
-        agentId: promotedRun.agentId,
-        invocationSource: promotedRun.invocationSource,
-        triggerDetail: promotedRun.triggerDetail,
-        wakeupRequestId: promotedRun.wakeupRequestId,
-      },
-    });
-
-    await startNextQueuedRunForAgent(promotedRun.agentId);
   }
 
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -909,6 +909,47 @@ export function issueService(db: Db) {
     return adopted;
   }
 
+  async function adoptRecoverableExecutionRun(input: {
+    issueId: string;
+    actorAgentId: string;
+    actorRunId: string;
+    expectedExecutionRunId: string;
+  }) {
+    if (input.expectedExecutionRunId !== input.actorRunId) {
+      const stale = await isTerminalOrMissingHeartbeatRun(input.expectedExecutionRunId);
+      if (!stale) return null;
+    }
+
+    const now = new Date();
+    const adopted = await db
+      .update(issues)
+      .set({
+        checkoutRunId: input.actorRunId,
+        executionRunId: input.actorRunId,
+        executionLockedAt: now,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(issues.id, input.issueId),
+          eq(issues.status, "in_progress"),
+          eq(issues.assigneeAgentId, input.actorAgentId),
+          isNull(issues.checkoutRunId),
+          eq(issues.executionRunId, input.expectedExecutionRunId),
+        ),
+      )
+      .returning({
+        id: issues.id,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .then((rows) => rows[0] ?? null);
+
+    return adopted;
+  }
+
   return {
     list: async (companyId: string, filters?: IssueFilters) => {
       const conditions = [eq(issues.companyId, companyId)];
@@ -1901,6 +1942,7 @@ export function issueService(db: Db) {
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
           checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
         })
         .from(issues)
         .where(eq(issues.id, id))
@@ -1913,7 +1955,7 @@ export function issueService(db: Db) {
         current.assigneeAgentId === actorAgentId &&
         sameRunLock(current.checkoutRunId, actorRunId)
       ) {
-        return { ...current, adoptedFromRunId: null as string | null };
+        return { ...current, adoptedFromRunId: null as string | null, adoptedReason: null as string | null };
       }
 
       if (
@@ -1934,6 +1976,30 @@ export function issueService(db: Db) {
           return {
             ...adopted,
             adoptedFromRunId: current.checkoutRunId,
+            adoptedReason: "stale_checkout_run",
+          };
+        }
+      }
+
+      if (
+        actorRunId &&
+        current.status === "in_progress" &&
+        current.assigneeAgentId === actorAgentId &&
+        current.checkoutRunId == null &&
+        current.executionRunId
+      ) {
+        const adopted = await adoptRecoverableExecutionRun({
+          issueId: id,
+          actorAgentId,
+          actorRunId,
+          expectedExecutionRunId: current.executionRunId,
+        });
+
+        if (adopted) {
+          return {
+            ...adopted,
+            adoptedFromRunId: current.executionRunId,
+            adoptedReason: "stale_execution_run",
           };
         }
       }
@@ -1943,6 +2009,7 @@ export function issueService(db: Db) {
         status: current.status,
         assigneeAgentId: current.assigneeAgentId,
         checkoutRunId: current.checkoutRunId,
+        executionRunId: current.executionRunId,
         actorAgentId,
         actorRunId,
       });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent companies through issue assignment, heartbeat runs, and auditable control-plane state.
> - The heartbeat finalizer and issue ownership checks jointly decide whether an agent run may continue work on an issue.
> - A single heartbeat can touch more than one issue, but the prior finalizer only reconciled one issue row for the completed `executionRunId`.
> - That left terminal heartbeat runs recorded as active execution locks on earlier issues, which made checkout and parent-thread writes reject future owner runs while `inbox-lite` showed no active run.
> - Additional monitor evidence showed the same stale-lock class blocked posting canonical parent-thread scan comments.
> - This pull request makes completed heartbeat finalization reconcile every affected issue, preserves deferred wake promotion per issue, and lets issue ownership checks adopt only terminal/missing execution locks.
> - The benefit is that checkout, comment writes, inbox state, and deferred wakeups stay consistent after one run touches multiple issues.

## What Changed

- Updated `server/src/services/heartbeat.ts` so `releaseIssueExecutionAndPromote(run)` locks and reconciles every issue in the company with `executionRunId = run.id`, plus the context issue when present.
- Preserved deferred wake promotion per affected issue: each released issue scans its own deferred queue, promotes the earliest invokable wake deterministically, publishes the queued run event, and starts the agent queue.
- Updated `server/src/services/issues.ts` so `assertCheckoutOwner()` can adopt a missing-checkout ownership state when the issue's `executionRunId` points to the same run, a terminal run, or a missing run, while still refusing live queued/running execution locks.
- Updated issue-route adoption telemetry to distinguish stale checkout-run adoption from stale execution-run adoption.
- Added regression coverage in `server/src/__tests__/heartbeat-comment-wake-batching.test.ts` for a successful run touching two issues and clearing both execution locks.
- Added regression coverage in `server/src/__tests__/issues-service.test.ts` for parent-thread-style ownership recovery: terminal execution locks are adopted, live execution locks are rejected.
- Added `packages/db/scripts/stale-lock-blackbox.ts`, an operator/QA smoke harness that creates disposable fixtures for terminal stale-lock checkout repair and deferred promotion through API-observable behavior.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-service.test.ts src/__tests__/heartbeat-comment-wake-batching.test.ts src/__tests__/heartbeat-process-recovery.test.ts src/__tests__/issues-checkout-wakeup.test.ts` passed on this branch: 4 files, 40 tests.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-service.test.ts` passed after final cleanup: 1 file, 19 tests.
- `pnpm --filter @paperclipai/server typecheck` passed on this branch.
- `pnpm --filter @paperclipai/db typecheck` passed on this branch.
- Earlier Developer verification also passed `pnpm -r typecheck` and `pnpm build`.
- Earlier `pnpm test:run` reached this new heartbeat regression successfully but had pre-existing/environmental failures outside this change: Tailnet tests using a real `100.102.138.49` address, worktree provisioning DB restore failures around missing `gin_trgm_ops`, a missing temp `local_encrypted` secrets key in worktree seeding, and worktree port repair expectation mismatches.
- CTO review passed in [CON-39](/CON/issues/CON-39): architecture, deferred wake semantics, and regression coverage were approved for QA before the parent-thread evidence arrived.
- QA black-box validation passed in [CON-39 comment c9532c74](/CON/issues/CON-39#comment-c9532c74-0958-40f7-a4ab-f7b419f05163): `terminal-stale-checkout: pass`, `deferred-promotion: pass`, `stale-lock black-box harness complete`, and disposable company cleanup.
- Follow-up evidence in [CON-39 comment 3acd4e10](/CON/issues/CON-39#comment-3acd4e10-b445-4243-aadd-0fb9b40c8020) showed parent-thread write conflicts from the same stale-lock class; the new `issues-service` regression covers that ownership gate directly.

## Risks

- This validates current source behavior, not the live installed `@paperclipai/server@2026.403.0` runtime. Live backport/deploy remains a separate release step.
- The finalizer can now promote multiple deferred wakeups after one completed run if multiple issues were locked to that run. That is intended, but it broadens the finalizer from single-issue to per-issue behavior.
- The ownership recovery path intentionally adopts only terminal/missing execution locks or the same actor run; live queued/running execution locks still block writes.
- The QA harness uses guarded SQL to create states the public API should not intentionally create. It is scoped to disposable companies and refuses to seed stale locks when the referenced run is queued or running.

## Model Used

- OpenAI GPT-5.4 via Codex local agent, with terminal/tool use and code execution in the Paperclip source workspace.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
