### PR TITLE
fix(skills): add model spec and NEVER guards to paperclip skill family

### DIFF
--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: paperclip-create-agent
+model: claude-sonnet-4-6
 description: >
   Create new agents in Paperclip with governance-aware hiring. Use when you need
   to inspect adapter configuration options, compare existing agent configs,
@@ -142,3 +143,12 @@ Before sending a hire request:
 
 For endpoint payload shapes and full examples, read:
 `skills/paperclip-create-agent/references/api-reference.md`
+
+---
+
+## NEVER
+
+- **NEVER** create an agent with a timer heartbeat by default — timer-based wakeups run on schedule regardless of whether there's work to do; most agents should use assignment-based or on-demand wakeups only; a timer heartbeat burns heartbeat budget every interval even when the agent's queue is empty
+- **NEVER** submit a hire request without verifying the reporting line is within the same company — cross-company reporting violates Paperclip's governance model and causes the hire request to be rejected during the approval flow; always confirm `company_id` matches before submitting
+- **NEVER** hard-code secrets in the agent prompt or config payload — agent prompts and configs are stored in Paperclip's control plane and visible to admins; treat them like code: use adapter-level secret injection, not plain-text values in the hire request body
+- **NEVER** reuse a prompt verbatim from another agent without scoping it to the new role — generic prompts cause agents to behave identically to existing hires, making it impossible to distinguish their work in audit trails; each hire needs a role-specific, operationally scoped prompt

--- a/skills/paperclip-create-plugin/SKILL.md
+++ b/skills/paperclip-create-plugin/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: paperclip-create-plugin
+model: claude-sonnet-4-6
 description: >
   Create new Paperclip plugins with the current alpha SDK/runtime. Use when
   scaffolding a plugin package, adding a new example plugin, or updating plugin
@@ -99,3 +100,12 @@ When authoring or updating plugin docs:
 - be explicit about the trusted-code model
 - do not promise host UI components or asset APIs
 - prefer npm-package deployment guidance over repo-local workflows for production
+
+---
+
+## NEVER
+
+- **NEVER** promise host UI components or asset APIs that don't exist in the current alpha SDK — the Paperclip plugin runtime is in active development; documenting or scaffolding against planned-but-unimplemented APIs creates plugins that look valid but fail at runtime when the missing host component isn't available
+- **NEVER** mix current implementation details with future spec ideas in plugin docs — future features belong in a clearly marked "Roadmap" section; mixing them misleads consumers about what works today vs. what requires a platform update
+- **NEVER** use repo-local plugin workflows in production guidance — plugins deployed via repo-local paths break when the repo moves or CI changes; always document npm-package deployment for production use cases
+- **NEVER** skip the verification steps (run integration tests, check worker surface) after scaffolding — plugin scaffolding generates boilerplate that may not match the current SDK version; running verification catches template/version mismatches before they reach a PR

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: paperclip
+model: claude-sonnet-4-6
 description: >
   Interact with the Paperclip control plane API to manage tasks, coordinate with
   other agents, and follow company governance. Use when you need to check
@@ -539,3 +540,12 @@ If you use direct `curl` during these tests, include `X-Paperclip-Run-Id` on all
 ## Full Reference
 
 For detailed API tables, JSON response schemas, worked examples (IC and Manager heartbeats), governance/approvals, cross-team delegation rules, error codes, issue lifecycle diagram, and the common mistakes table, read: `skills/paperclip/references/api-reference.md`
+
+---
+
+## NEVER
+
+- **NEVER** hard-code `PAPERCLIP_API_URL` or `PAPERCLIP_API_KEY` in code — these are injected automatically per-heartbeat as environment variables; hard-coding them means the agent uses stale credentials after rotation and fails silently rather than getting fresh values
+- **NEVER** perform domain work (writing code, research, analysis) in the same heartbeat function as Paperclip coordination — Paperclip skills handle task status and delegation only; mixing domain work creates unaccountable heartbeats where token costs and failures can't be attributed to a specific task
+- **NEVER** skip reading `PAPERCLIP_WAKE_PAYLOAD_JSON` when it's present — this variable contains the compact issue summary and ordered comment batch for the current wake; ignoring it and doing broad API fetches instead wastes rate limit and heartbeat budget on redundant network calls
+- **NEVER** update task status to `done` before verifying the actual work product exists — Paperclip's governance tracks completion via status changes; marking done without verification creates audit gaps that only surface during approvals when the board asks for evidence that doesn't exist

--- a/skills/para-memory-files/SKILL.md
+++ b/skills/para-memory-files/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: para-memory-files
+model: claude-sonnet-4-6
 description: >
   File-based memory system using Tiago Forte's PARA method. Use this skill whenever
   you need to store, retrieve, update, or organize knowledge across sessions. Covers
@@ -102,3 +103,10 @@ Vectors + BM25 + reranking finds things even when the wording differs.
 ## Planning
 
 Keep plans in timestamped files in `plans/` at the project root (outside personal memory so other agents can access them). Use `qmd` to search plans. Plans go stale -- if a newer plan exists, do not confuse yourself with an older version. If you notice staleness, update the file to note what it is supersededBy.
+
+## NEVER
+
+- **NEVER delete or overwrite a fact in `items.yaml`** — WHY: PARA memory is append-only by design; deleting a fact removes traceability of how a belief was formed, and future agents have no way to know the old value existed, causing silent context divergence across sessions
+- **NEVER use absolute hardcoded paths** (e.g., `/Users/projetsjsl/`) in memory files — WHY: memory files are shared across machines and agents via `$AGENT_HOME`; hardcoded paths break portability silently, causing file reads to fail on any system where the username or home directory differs
+- **NEVER move an entity folder without updating `index.md`** — WHY: `qmd` indexes from `index.md` as the root manifest; a moved folder not reflected in the index becomes orphaned — its facts exist on disk but are invisible to semantic search and recall
+- **NEVER write to `$AGENT_HOME/MEMORY.md` during the same session that reads it without marking the section as updated** — WHY: multiple agents running in parallel may read the same MEMORY.md at session start; an agent that silently overwrites a section mid-session causes the next reader to get a stale-then-overwritten hybrid that appears consistent but contains merged contradictions


### PR DESCRIPTION
## Summary
- Add model spec and NEVER guards to paperclip skill family for safer execution
- Prevents skill family from running without explicit model context

## Test plan
- [ ] Verify skill invocation respects NEVER guards
- [ ] Verify model spec is picked up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)