### PR TITLE
feat: UX improvements — auto in_progress, Approve button, kanban auto-assign

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2531,6 +2531,16 @@ export function heartbeatService(db: Db) {
           .where(and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)))
           .then((rows) => rows[0] ?? null)
       : null;
+    // Auto-transition linked issue to in_progress when a run starts executing.
+    // Allowlist: only transition from statuses where a new run means active work is starting.
+    // Excludes blocked (needs user guidance), done/cancelled (terminal), in_progress (already there).
+    if (
+      issueContext &&
+      (issueContext.status === "backlog" || issueContext.status === "todo" || issueContext.status === "in_review")
+    ) {
+      await issuesSvc.update(issueContext.id, { status: "in_progress" });
+      issueContext.status = "in_progress";
+    }
     const issueAssigneeOverrides =
       issueContext && issueContext.assigneeAgentId === agent.id
         ? parseIssueAssigneeAdapterOverrides(

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -71,6 +71,7 @@ interface CommentThreadProps {
     options?: { allowSharing?: boolean; reason?: string },
   ) => Promise<void>;
   onAdd: (body: string, reopen?: boolean, reassignment?: CommentReassignment) => Promise<void>;
+  onApprove?: () => Promise<void>;
   issueStatus?: string;
   agentMap?: Map<string, Agent>;
   currentUserId?: string | null;
@@ -611,6 +612,8 @@ export function CommentThread({
   onInterruptQueued,
   interruptingQueuedRunId = null,
   composerDisabledReason = null,
+  issueStatus,
+  onApprove,
 }: CommentThreadProps) {
   const [body, setBody] = useState("");
   const [reopen, setReopen] = useState(true);
@@ -935,6 +938,24 @@ export function CommentThread({
             <Button size="sm" disabled={!canSubmit} onClick={handleSubmit}>
               {submitting ? "Posting..." : "Comment"}
             </Button>
+            {issueStatus === "in_review" && onApprove && (
+              <Button
+                size="sm"
+                disabled={submitting}
+                onClick={async () => {
+                  setSubmitting(true);
+                  try {
+                    await onApprove();
+                  } finally {
+                    setSubmitting(false);
+                  }
+                }}
+                className="bg-emerald-600 hover:bg-emerald-700 text-white"
+              >
+                <Check className="h-3.5 w-3.5 mr-1" />
+                Approve
+              </Button>
+            )}
           </div>
         </div>
       )}

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -244,7 +244,11 @@ export function KanbanBoard({
     }
 
     if (targetStatus && targetStatus !== issue.status) {
-      onUpdateIssue(issueId, { status: targetStatus });
+      const patch: Record<string, unknown> = { status: targetStatus };
+      if (targetStatus === "todo" && !issue.assigneeAgentId && agents?.length) {
+        patch.assigneeAgentId = agents[0].id;
+      }
+      onUpdateIssue(issueId, patch);
     }
   }
 

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1786,6 +1786,14 @@ export function IssueDetail() {
               await uploadAttachment.mutateAsync(file);
             }}
             liveRunSlot={<LiveRunWidget issueId={issueId!} companyId={issue.companyId} />}
+            onApprove={
+              issue.status === "in_review"
+                ? async () => {
+                    await addComment.mutateAsync({ body: "Approved" });
+                    navigate(sourceBreadcrumb.href, { replace: true });
+                  }
+                : undefined
+            }
           />
         </TabsContent>
 


### PR DESCRIPTION
## Summary

- **Auto in_progress on dispatch**: `heartbeat.ts executeRun()` now auto-transitions linked issues to `in_progress` when a run starts executing (allowlist: `backlog`, `todo`, `in_review`). Eliminates the visual delay between agent dispatch and status change in the UI.
- **Approve button**: Adds a green "Approve" button (with Check icon) to the comment composer, visible when the issue is `in_review`. One click posts "Approved" and navigates back to the issues list.
- **Kanban auto-assign**: When dragging a card to `todo` on the Kanban board, auto-assigns the first available agent if no assignee is set.

## Motivation

Mobile workflow friction: cards stayed visually stuck at their previous status after agent dispatch, approving a plan required typing "Approved" manually, and navigating back required a gesture/scroll.

## Test plan

- [ ] Assign an issue to an agent — verify the card shows `in_progress` immediately (not after agent startup delay)
- [ ] View an `in_review` issue — verify the green "Approve" button appears next to "Comment"
- [ ] Click "Approve" — verify "Approved" comment is posted and navigation returns to the source page
- [ ] Drag an unassigned card to "todo" on Kanban — verify the first agent is auto-assigned
- [ ] Verify `blocked`, `done`, `cancelled` cards are NOT auto-transitioned
- [ ] TypeScript compilation passes for both `ui` and `server`