### PR TITLE
fix(openclaw-gateway): stop sending top-level paperclip payload

### DIFF
--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -30,7 +30,7 @@ Gateway connect identity fields:
 - disableDeviceAuth (boolean, optional): disable signed device payload in connect params (default false)
 
 Request behavior fields:
-- payloadTemplate (object, optional): additional fields merged into gateway agent params
+- payloadTemplate (object, optional): additional fields merged into gateway agent params; \`text\` is folded into \`message\`, and \`paperclip\` is rendered into the wake message instead of being sent as a top-level request property
 - workspaceRuntime (object, optional): reserved workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
 - timeoutSec (number, optional): adapter timeout in seconds (default 120)
 - waitTimeoutMs (number, optional): agent.wait timeout override (default timeoutSec * 1000)
@@ -43,10 +43,10 @@ Session routing fields:
 - sessionKey (string, optional): fixed session key when strategy=fixed (default paperclip)
 
 Standard outbound payload additions:
-- paperclip (object): standardized Paperclip context added to every gateway agent request
-- paperclip.workspace (object, optional): resolved execution workspace for this run
-- paperclip.workspaces (array, optional): additional workspace hints Paperclip exposed to the run
-- paperclip.workspaceRuntime (object, optional): reserved workspace runtime metadata when explicitly supplied outside normal heartbeat execution
+- No top-level \`paperclip\` object is sent to the gateway; the adapter delivers Paperclip wake metadata through \`message\`
+- Resolved execution workspace hints are appended to the wake message as structured JSON context
+- Additional exposed workspaces are appended to the wake message as structured JSON context
+- Workspace runtime metadata is appended to the wake message as structured JSON context when explicitly supplied outside normal heartbeat execution
 
 Standard result metadata supported:
 - meta.runtimeServices (array, optional): normalized adapter-managed runtime service reports

--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,5 +1,67 @@
-import { describe, expect, it } from "vitest";
-import { resolveSessionKey } from "./execute.js";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import { execute, resolveSessionKey } from "./execute.js";
+
+let gatewayServer: WebSocketServer | null = null;
+
+afterEach(async () => {
+  if (!gatewayServer) return;
+  for (const client of gatewayServer.clients) {
+    client.terminate();
+  }
+  gatewayServer.close();
+  gatewayServer = null;
+});
+
+async function startGatewayServer(
+  onAgentParams: (params: Record<string, unknown>) => void,
+): Promise<{ url: string }> {
+  gatewayServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await once(gatewayServer, "listening");
+
+  gatewayServer.on("connection", (socket) => {
+    socket.send(JSON.stringify({ type: "event", event: "connect.challenge", payload: { nonce: "nonce-123" } }));
+
+    socket.on("message", (raw) => {
+      const frame = JSON.parse(raw.toString()) as {
+        type?: string;
+        id?: string;
+        method?: string;
+        params?: Record<string, unknown>;
+      };
+
+      if (frame.type !== "req" || !frame.id) return;
+
+      if (frame.method === "connect") {
+        socket.send(JSON.stringify({ type: "res", id: frame.id, ok: true, payload: { protocol: 3 } }));
+        return;
+      }
+
+      if (frame.method === "agent") {
+        onAgentParams(frame.params ?? {});
+        socket.send(
+          JSON.stringify({
+            type: "res",
+            id: frame.id,
+            ok: true,
+            payload: {
+              status: "ok",
+              runId: "gateway-run-1",
+              result: { text: "done" },
+              meta: {},
+            },
+          }),
+        );
+      }
+    });
+  });
+
+  const { port } = gatewayServer.address() as AddressInfo;
+  return { url: `ws://127.0.0.1:${port}` };
+}
 
 describe("resolveSessionKey", () => {
   it("prefixes run-scoped session keys with the configured agent", () => {
@@ -48,5 +110,64 @@ describe("resolveSessionKey", () => {
         issueId: null,
       }),
     ).toBe("agent:meridian:paperclip");
+  });
+
+  it("does not send a top-level paperclip payload to the gateway agent request", async () => {
+    let capturedParams: Record<string, unknown> | null = null;
+    const gateway = await startGatewayServer((params) => {
+      capturedParams = params;
+    });
+
+    const ctx: AdapterExecutionContext = {
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Meridian",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        url: gateway.url,
+        agentId: "meridian",
+        disableDeviceAuth: true,
+        payloadTemplate: {
+          text: "Follow the existing checklist.",
+          paperclip: {
+            apiUrl: "https://paperclip.example.test",
+            wakeReason: "comment_added",
+          },
+        },
+      },
+      context: {
+        issueId: "issue-456",
+        wakeReason: "comment_added",
+      },
+      onLog: async () => {},
+    };
+
+    const result = await execute(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(capturedParams).not.toBeNull();
+    if (capturedParams === null) {
+      throw new Error("gateway agent params were not captured");
+    }
+    const params = capturedParams;
+    expect(params).not.toHaveProperty("paperclip");
+    expect(params).not.toHaveProperty("text");
+    expect(params).toMatchObject({
+      agentId: "meridian",
+      sessionKey: "agent:meridian:paperclip:issue:issue-456",
+      idempotencyKey: "run-123",
+    });
+    expect(String(params["message"])).toContain("Follow the existing checklist.");
+    expect(String(params["message"])).toContain("PAPERCLIP_RUN_ID=run-123");
   });
 });

--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -9,10 +9,17 @@ let gatewayServer: WebSocketServer | null = null;
 
 afterEach(async () => {
   if (!gatewayServer) return;
-  for (const client of gatewayServer.clients) {
+  for (const client of [...gatewayServer.clients]) {
     client.terminate();
+    await Promise.race([
+      once(client, "close").then(() => undefined),
+      new Promise<void>((resolve) => setTimeout(resolve, 250)),
+    ]);
   }
-  gatewayServer.close();
+  await Promise.race([
+    new Promise<void>((resolve) => gatewayServer!.close(() => resolve())),
+    new Promise<void>((resolve) => setTimeout(resolve, 250)),
+  ]);
   gatewayServer = null;
 });
 
@@ -111,7 +118,9 @@ describe("resolveSessionKey", () => {
       }),
     ).toBe("agent:meridian:paperclip");
   });
+});
 
+describe("execute", () => {
   it("does not send a top-level paperclip payload to the gateway agent request", async () => {
     let capturedParams: Record<string, unknown> | null = null;
     const gateway = await startGatewayServer((params) => {
@@ -137,17 +146,39 @@ describe("resolveSessionKey", () => {
         url: gateway.url,
         agentId: "meridian",
         disableDeviceAuth: true,
+        workspaceRuntime: {
+          mode: "manual",
+        },
         payloadTemplate: {
           text: "Follow the existing checklist.",
+          model: "openclaw-pro",
+          temperature: 0.2,
           paperclip: {
-            apiUrl: "https://paperclip.example.test",
-            wakeReason: "comment_added",
+            hints: {
+              source: "payload-template",
+            },
           },
         },
       },
       context: {
         issueId: "issue-456",
         wakeReason: "comment_added",
+        paperclipWorkspace: {
+          id: "workspace-1",
+          cwd: "/tmp/project",
+        },
+        paperclipWorkspaces: [
+          {
+            id: "workspace-2",
+            cwd: "/tmp/secondary",
+          },
+        ],
+        paperclipRuntimeServiceIntents: [
+          {
+            id: "svc-1",
+            kind: "preview",
+          },
+        ],
       },
       onLog: async () => {},
     };
@@ -166,8 +197,18 @@ describe("resolveSessionKey", () => {
       agentId: "meridian",
       sessionKey: "agent:meridian:paperclip:issue:issue-456",
       idempotencyKey: "run-123",
+      model: "openclaw-pro",
+      temperature: 0.2,
     });
     expect(String(params["message"])).toContain("Follow the existing checklist.");
     expect(String(params["message"])).toContain("PAPERCLIP_RUN_ID=run-123");
+    expect(String(params["message"])).toContain("Additional Paperclip context JSON:");
+    expect(String(params["message"])).toContain('"workspace": {');
+    expect(String(params["message"])).toContain('"cwd": "/tmp/project"');
+    expect(String(params["message"])).toContain('"workspaces": [');
+    expect(String(params["message"])).toContain('"workspaceRuntime": {');
+    expect(String(params["message"])).toContain('"mode": "manual"');
+    expect(String(params["message"])).toContain('"services": [');
+    expect(String(params["message"])).toContain('"source": "payload-template"');
   });
 });

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -459,6 +459,50 @@ function joinWakePayloadSections(structuredWakePrompt: string, structuredWakeJso
   return sections.join("\n");
 }
 
+function buildSupplementalPaperclipContext(
+  ctx: AdapterExecutionContext,
+  payloadTemplate: Record<string, unknown>,
+): Record<string, unknown> {
+  const supplemental = parseObject(payloadTemplate.paperclip);
+  const workspace = asRecord(ctx.context.paperclipWorkspace);
+  const workspaces = Array.isArray(ctx.context.paperclipWorkspaces)
+    ? ctx.context.paperclipWorkspaces.filter((entry): entry is Record<string, unknown> => Boolean(asRecord(entry)))
+    : [];
+  const configuredWorkspaceRuntime = parseObject(ctx.config.workspaceRuntime);
+  const runtimeServiceIntents = Array.isArray(ctx.context.paperclipRuntimeServiceIntents)
+    ? ctx.context.paperclipRuntimeServiceIntents.filter(
+        (entry): entry is Record<string, unknown> => Boolean(asRecord(entry)),
+      )
+    : [];
+
+  if (workspace) {
+    supplemental.workspace = workspace;
+  }
+  if (workspaces.length > 0) {
+    supplemental.workspaces = workspaces;
+  }
+  if (runtimeServiceIntents.length > 0 || Object.keys(configuredWorkspaceRuntime).length > 0) {
+    supplemental.workspaceRuntime = {
+      ...configuredWorkspaceRuntime,
+      ...(runtimeServiceIntents.length > 0 ? { services: runtimeServiceIntents } : {}),
+    };
+  }
+
+  return supplemental;
+}
+
+function appendSupplementalPaperclipContext(baseText: string, context: Record<string, unknown>): string {
+  if (Object.keys(context).length === 0) return baseText;
+
+  return [
+    baseText.trim(),
+    "Additional Paperclip context JSON:",
+    "```json",
+    JSON.stringify(context, null, 2),
+    "```",
+  ].join("\n");
+}
+
 function normalizeUrl(input: string): URL | null {
   try {
     return new URL(input);
@@ -1066,7 +1110,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
-  const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
+  const supplementalPaperclipContext = buildSupplementalPaperclipContext(ctx, payloadTemplate);
+  const enrichedWakeText = appendSupplementalPaperclipContext(wakeText, supplementalPaperclipContext);
+  const message = templateMessage ? appendWakeText(templateMessage, enrichedWakeText) : enrichedWakeText;
   const { text: _ignoredText, paperclip: _ignoredPaperclip, ...payloadTemplateWithoutPaperclip } = payloadTemplate;
 
   const agentParams: Record<string, unknown> = {

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -459,62 +459,6 @@ function joinWakePayloadSections(structuredWakePrompt: string, structuredWakeJso
   return sections.join("\n");
 }
 
-function buildStandardPaperclipPayload(
-  ctx: AdapterExecutionContext,
-  wakePayload: WakePayload,
-  paperclipEnv: Record<string, string>,
-  payloadTemplate: Record<string, unknown>,
-): Record<string, unknown> {
-  const templatePaperclip = parseObject(payloadTemplate.paperclip);
-  const workspace = asRecord(ctx.context.paperclipWorkspace);
-  const workspaces = Array.isArray(ctx.context.paperclipWorkspaces)
-    ? ctx.context.paperclipWorkspaces.filter((entry): entry is Record<string, unknown> => Boolean(asRecord(entry)))
-    : [];
-  const configuredWorkspaceRuntime = parseObject(ctx.config.workspaceRuntime);
-  const runtimeServiceIntents = Array.isArray(ctx.context.paperclipRuntimeServiceIntents)
-    ? ctx.context.paperclipRuntimeServiceIntents.filter(
-        (entry): entry is Record<string, unknown> => Boolean(asRecord(entry)),
-      )
-    : [];
-
-  const standardPaperclip: Record<string, unknown> = {
-    runId: ctx.runId,
-    companyId: ctx.agent.companyId,
-    agentId: ctx.agent.id,
-    agentName: ctx.agent.name,
-    taskId: wakePayload.taskId,
-    issueId: wakePayload.issueId,
-    issueIds: wakePayload.issueIds,
-    wakeReason: wakePayload.wakeReason,
-    wakeCommentId: wakePayload.wakeCommentId,
-    approvalId: wakePayload.approvalId,
-    approvalStatus: wakePayload.approvalStatus,
-    apiUrl: paperclipEnv.PAPERCLIP_API_URL ?? null,
-  };
-  const structuredWake = parseObject(ctx.context.paperclipWake);
-  if (Object.keys(structuredWake).length > 0) {
-    standardPaperclip.wake = structuredWake;
-  }
-
-  if (workspace) {
-    standardPaperclip.workspace = workspace;
-  }
-  if (workspaces.length > 0) {
-    standardPaperclip.workspaces = workspaces;
-  }
-  if (runtimeServiceIntents.length > 0 || Object.keys(configuredWorkspaceRuntime).length > 0) {
-    standardPaperclip.workspaceRuntime = {
-      ...configuredWorkspaceRuntime,
-      ...(runtimeServiceIntents.length > 0 ? { services: runtimeServiceIntents } : {}),
-    };
-  }
-
-  return {
-    ...templatePaperclip,
-    ...standardPaperclip,
-  };
-}
-
 function normalizeUrl(input: string): URL | null {
   try {
     return new URL(input);
@@ -1123,16 +1067,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
   const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
+  const { text: _ignoredText, paperclip: _ignoredPaperclip, ...payloadTemplateWithoutPaperclip } = payloadTemplate;
 
   const agentParams: Record<string, unknown> = {
-    ...payloadTemplate,
+    ...payloadTemplateWithoutPaperclip,
     message,
     sessionKey,
     idempotencyKey: ctx.runId,
   };
-  delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -216,6 +216,17 @@ async function createControlledGatewayServer() {
   };
 }
 
+function extractStructuredWakePayload(message: unknown): Record<string, unknown> {
+  if (typeof message !== "string") {
+    throw new Error("Expected gateway message to be a string");
+  }
+  const match = message.match(/Structured wake payload JSON:\n```json\n([\s\S]*?)\n```/);
+  if (!match?.[1]) {
+    throw new Error("Structured wake payload JSON block not found in gateway message");
+  }
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
 describe("heartbeat comment wake batching", () => {
   let db!: ReturnType<typeof createDb>;
   let instance: EmbeddedPostgresInstance | null = null;
@@ -414,11 +425,9 @@ describe("heartbeat comment wake batching", () => {
       }, 90_000);
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          commentIds: [comment2.id, comment3.id],
-          latestCommentId: comment3.id,
-        },
+      expect(extractStructuredWakePayload(secondPayload.message)).toMatchObject({
+        commentIds: [comment2.id, comment3.id],
+        latestCommentId: comment3.id,
       });
       expect(String(secondPayload.message ?? "")).toContain("Second comment");
       expect(String(secondPayload.message ?? "")).toContain("Third comment");
@@ -594,18 +603,16 @@ describe("heartbeat comment wake batching", () => {
       });
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_commented",
-          commentIds: [comment2.id],
-          latestCommentId: comment2.id,
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Reopen after deferred comment",
-            status: "in_progress",
-            priority: "medium",
-          },
+      expect(extractStructuredWakePayload(secondPayload.message)).toMatchObject({
+        reason: "issue_commented",
+        commentIds: [comment2.id],
+        latestCommentId: comment2.id,
+        issue: {
+          id: issueId,
+          identifier: `${issuePrefix}-1`,
+          title: "Reopen after deferred comment",
+          status: "in_progress",
+          priority: "medium",
         },
       });
       expect(String(secondPayload.message ?? "")).toContain("Please handle this follow-up after you finish");
@@ -680,19 +687,17 @@ describe("heartbeat comment wake batching", () => {
       expect(firstRun).not.toBeNull();
       await waitFor(() => gateway.getAgentPayloads().length === 1);
       const firstPayload = gateway.getAgentPayloads()[0] ?? {};
-      expect(firstPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_assigned",
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Require a comment",
-            status: "in_progress",
-            priority: "medium",
-          },
-          checkedOutByHarness: true,
-          commentIds: [],
+      expect(extractStructuredWakePayload(firstPayload.message)).toMatchObject({
+        reason: "issue_assigned",
+        issue: {
+          id: issueId,
+          identifier: `${issuePrefix}-1`,
+          title: "Require a comment",
+          status: "in_progress",
+          priority: "medium",
         },
+        checkedOutByHarness: true,
+        commentIds: [],
       });
       expect(String(firstPayload.message ?? "")).toContain("## Paperclip Wake Payload");
       expect(String(firstPayload.message ?? "")).toContain("Do not switch to another issue until you have handled this wake.");

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -172,6 +172,17 @@ async function createMockGatewayServer(options?: {
   };
 }
 
+function extractStructuredWakePayload(message: unknown): Record<string, unknown> {
+  if (typeof message !== "string") {
+    throw new Error("Expected gateway message to be a string");
+  }
+  const match = message.match(/Structured wake payload JSON:\n```json\n([\s\S]*?)\n```/);
+  if (!match?.[1]) {
+    throw new Error("Structured wake payload JSON block not found in gateway message");
+  }
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
 async function createMockGatewayServerWithPairing() {
   const server = createServer();
   const wss = new WebSocketServer({ server });
@@ -502,11 +513,9 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
-      expect(payload?.paperclip).toMatchObject({
-        wake: {
-          latestCommentId: "comment-2",
-          commentIds: ["comment-1", "comment-2"],
-        },
+      expect(extractStructuredWakePayload(payload?.message)).toMatchObject({
+        latestCommentId: "comment-2",
+        commentIds: ["comment-1", "comment-2"],
       });
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);


### PR DESCRIPTION
## Thinking Path

> - Paperclip routes wake events through adapter-specific execution backends.
> - The OpenClaw gateway adapter must emit a request shape that the gateway schema accepts.
> - The top-level `paperclip` field was causing gateway-side request rejection.
> - Simply removing that field fixes the schema error, but it can also drop workspace/runtime hints that were previously bundled inside that object.
> - This pull request keeps the request schema valid while preserving those hints through the existing `message` path instead of reviving the rejected top-level field.
> - The result is a gateway request that stays contract-safe without regressing the Paperclip execution context available to the agent.

## What Changed

- Kept stripping the unsupported top-level `paperclip` field from outbound OpenClaw gateway agent requests.
- Preserved supplemental Paperclip context by appending payload-template hints, workspace hints, additional workspaces, and workspace runtime metadata to the wake message as structured JSON.
- Continued to strip top-level `text` while preserving other legal `payloadTemplate` fields such as model/temperature passthrough.
- Moved the integration regression into its own `describe("execute")` block and hardened WebSocket teardown so the test cleans up reliably.
- Updated the adapter configuration docs so they match the actual request contract.

## Verification

- `bash -lc 'cat >/tmp/vitest.openclaw-gateway.config.ts <<"EOV"
import { defineConfig } from "vitest/config";

export default defineConfig({
  test: {
    environment: "node",
    include: ["src/server/execute.test.ts"],
  },
});
EOV
cd packages/adapters/openclaw-gateway && ../../../node_modules/.bin/vitest run --config /tmp/vitest.openclaw-gateway.config.ts'`
- `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck`

## Risks

- Low risk. The gateway request remains narrower than before because the unsupported top-level field is still removed.
- The only behavioral addition is that previously bundled Paperclip context now travels through the existing `message` channel as structured JSON.

## Model Used

- OpenAI Codex GPT-5 coding agent with terminal tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
