### PR TITLE
fix: capture rawBody for form-encoded requests and deduplicate plugin event delivery

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -122,6 +122,17 @@ export async function createApp(
       (req as unknown as { rawBody: Buffer }).rawBody = buf;
     },
   }));
+  // Capture rawBody for form-encoded requests (e.g. Slack slash commands).
+  // express.json() only captures rawBody for application/json payloads; without
+  // this middleware, HMAC signature verification fails for any webhook that
+  // sends application/x-www-form-urlencoded (the Slack slash command format).
+  app.use(express.urlencoded({
+    extended: true,
+    verify: (req, _res, buf) => {
+      const r = req as unknown as { rawBody?: Buffer };
+      if (!r.rawBody) r.rawBody = buf;
+    },
+  }));
   app.use(httpLogger);
   const privateHostnameGateEnabled =
     opts.deploymentMode === "authenticated" && opts.deploymentExposure === "private";

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -460,6 +460,19 @@ export function buildHostServices(
   const assets = assetService(db);
   const scopedBus = eventBus.forPlugin(pluginKey);
 
+  // Deduplicate onEvent deliveries to the worker. A plugin may register
+  // multiple ctx.events.on() handlers for the same event pattern (e.g. one
+  // for notifications and one for watch-storage). Each subscription creates a
+  // server-side handler that calls notifyWorker("onEvent"). Without
+  // deduplication the worker receives N copies of the same event (one per
+  // matching subscription) and dispatches all its registered callbacks each
+  // time, resulting in N×M invocations instead of M.
+  //
+  // Fix: track recently-sent eventIds and skip duplicate notifyWorker calls
+  // within a 10-second window. The worker still dispatches to all its locally
+  // registered handlers on the single delivery it receives.
+  const recentEventIds = new Map<string, number>(); // eventId -> sentAt (ms)
+
   // Track active session event subscriptions for cleanup
   const activeSubscriptions = new Set<{ unsubscribe: () => void; timer: ReturnType<typeof setTimeout> }>();
   let disposed = false;
@@ -563,6 +576,17 @@ export function buildHostServices(
       async subscribe(params: { eventPattern: string; filter?: Record<string, unknown> | null }) {
         const handler = async (event: import("@paperclipai/plugin-sdk").PluginEvent) => {
           if (notifyWorker) {
+            const now = Date.now();
+            if (event.eventId && recentEventIds.has(event.eventId)) {
+              return; // Already delivered this event to the worker via another subscription.
+            }
+            if (event.eventId) {
+              recentEventIds.set(event.eventId, now);
+              // Prune stale entries to prevent unbounded growth.
+              for (const [id, ts] of recentEventIds) {
+                if (now - ts > 10_000) recentEventIds.delete(id);
+              }
+            }
             notifyWorker("onEvent", { event });
           }
         };


### PR DESCRIPTION
## Summary

Two bugs affecting Slack plugin (and potentially other webhook-based plugins) discovered during local testing.

### Bug 1: Slack slash commands always fail HMAC signature verification

**File:** `server/src/app.ts`

`express.json()` is the only body-parsing middleware, and its `verify` callback captures `req.rawBody`. Slack slash commands arrive as `application/x-www-form-urlencoded`, so `express.json()` skips them entirely — `req.rawBody` is never populated. The Slack plugin's HMAC signature verification then computes the HMAC over an empty body, which never matches Slack's real signature.

**Fix:** Add `express.urlencoded()` with the same `verify` callback immediately after `express.json()`, guarded by `if (!r.rawBody)` so JSON requests continue to use the JSON middleware's captured bytes.

### Bug 2: Plugin event bus delivers the same event multiple times to the same worker

**File:** `server/src/services/plugin-host-services.ts`

Each `ctx.events.on(pattern, handler)` call in a plugin worker registers a separate server-side subscription in `buildHostServices`. When an event fires, the bus calls **all** matching subscriptions for that plugin — each independently sending `notifyWorker("onEvent", { event })` via IPC. The worker receives N copies of the same event (one per registered subscription) and dispatches all its registered handlers each time, producing N×M invocations instead of M.

**Observed symptom:** A Slack plugin with two `issue.created` subscriptions produced 2 Slack notifications per issue creation instead of 1.

**Fix:** In the `subscribe` host service, deduplicate `notifyWorker` calls using the event's `eventId` with a short sliding-window cache (10 seconds). This collapses N notifications down to 1 for the same event ID within the dedup window.

## Test plan

- [ ] Slack slash command (`/clip`) correctly verifies HMAC signature and returns a response
- [ ] A plugin with multiple `ctx.events.on("issue.created", ...)` subscriptions receives each `issue.created` event exactly once (not once per subscription)
- [ ] JSON webhook payloads (non-form-encoded) still have `rawBody` populated correctly
- [ ] Events without an `eventId` are still delivered normally (no regression for unkeyed events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)