### PR TITLE
fix: issue identifier regex rejects prefixes with digits

### DIFF
--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -24,7 +24,7 @@ export function activityRoutes(db: Db) {
   const issueSvc = issueService(db);
 
   async function resolveIssueByRef(rawId: string) {
-    if (/^[A-Z]+-\d+$/i.test(rawId)) {
+    if (/^[A-Z][A-Z0-9]*-\d+$/i.test(rawId)) {
       return issueSvc.getByIdentifier(rawId);
     }
     return issueSvc.getById(rawId);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2402,7 +2402,7 @@ export function agentRoutes(db: Db) {
   router.get("/issues/:issueId/live-runs", async (req, res) => {
     const rawId = req.params.issueId as string;
     const issueSvc = issueService(db);
-    const isIdentifier = /^[A-Z]+-\d+$/i.test(rawId);
+    const isIdentifier = /^[A-Z][A-Z0-9]*-\d+$/i.test(rawId);
     const issue = isIdentifier ? await issueSvc.getByIdentifier(rawId) : await issueSvc.getById(rawId);
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
@@ -2440,7 +2440,7 @@ export function agentRoutes(db: Db) {
   router.get("/issues/:issueId/active-run", async (req, res) => {
     const rawId = req.params.issueId as string;
     const issueSvc = issueService(db);
-    const isIdentifier = /^[A-Z]+-\d+$/i.test(rawId);
+    const isIdentifier = /^[A-Z][A-Z0-9]*-\d+$/i.test(rawId);
     const issue = isIdentifier ? await issueSvc.getByIdentifier(rawId) : await issueSvc.getById(rawId);
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -525,7 +525,7 @@ export function issueRoutes(
   }
 
   async function normalizeIssueIdentifier(rawId: string): Promise<string> {
-    if (/^[A-Z]+-\d+$/i.test(rawId)) {
+    if (/^[A-Z][A-Z0-9]*-\d+$/i.test(rawId)) {
       const issue = await svc.getByIdentifier(rawId);
       if (issue) {
         return issue.id;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1253,7 +1253,7 @@ export function issueService(db: Db) {
 
     getById: async (raw: string) => {
       const id = raw.trim();
-      if (/^[A-Z]+-\d+$/i.test(id)) {
+      if (/^[A-Z][A-Z0-9]*-\d+$/i.test(id)) {
         return getIssueByIdentifier(id);
       }
       if (!isUuidLike(id)) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issues are the primary unit of work agents, humans, and the board coordinate on
> - Issues are addressed by human-readable identifiers like `CORE-42` — prefix-plus-number — alongside their UUIDs
> - Several routes accept either form and use a regex to decide which path to take
> - That regex (`^[A-Z]+-\d+$`) rejects any project prefix containing a digit (e.g. `CORE2-1`, `ABC2-42`)
> - Users with such prefixes get 404 on any identifier-based lookup
> - This pull request changes the regex to `^[A-Z][A-Z0-9]*-\d+$` at every call site so those identifiers resolve correctly

## What Changed

- `server/src/services/issues.ts` — `issueService.getById`
- `server/src/routes/issues.ts` — `normalizeIssueIdentifier`
- `server/src/routes/activity.ts` — `resolveIssueByRef`
- `server/src/routes/agents.ts` — live-runs + active-run lookups (2 sites)

The pattern still anchors at both ends and requires a leading letter, so UUIDs and pure-numeric tokens continue to fall through to the UUID path.

## Verification

- Existing tests pass.
- Manual: hit `GET /companies/:id/issues/TESCR9-1` against a company whose prefix is `TESCR9`; returns the issue instead of 404.

## Risks

Low. The new pattern is a strict superset of the old one — every input the old regex matched, the new one matches identically. The only newly-accepted inputs are identifiers with digit-bearing prefixes, which is precisely the fix.

## Model Used

Claude Opus 4.6 (1M context), extended thinking mode.

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model used specified
- [x] Tests run locally and pass
- [x] CI green
- [x] Greptile review addressed