### PR TITLE
fix(a11y): remove maximum-scale and user-scalable=no from viewport

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#18181b" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Humans watch and oversee those agents through a web UI
> - Accessibility matters for anyone who cannot read small text comfortably — they rely on browser zoom
> - The app shell's viewport meta tag includes `maximum-scale=1.0, user-scalable=no`
> - Those tokens disable pinch-zoom and are a WCAG 2.1 SC 1.4.4 (Resize Text) failure
> - The original motivation — suppressing iOS Safari's auto-zoom on focused inputs — is actually a font-size issue, not a viewport issue, and modern Safari only auto-zooms when input font-size is below 16px
> - This pull request drops the two tokens, restoring pinch-zoom while leaving the real fix (inputs at ≥16px) to CSS

## What Changed

- `ui/index.html` — remove `maximum-scale=1.0, user-scalable=no` from the viewport meta tag. Keep `width=device-width, initial-scale=1.0, viewport-fit=cover`.

## Verification

- Manual on iOS and Chrome mobile: pinch-to-zoom now works across the app.
- Manual on desktop: Ctrl+/- zoom already worked via `initial-scale=1.0`; unchanged.

## Risks

Low. Users who were relying on auto-zoom-suppression for text inputs will notice nothing (modern Safari only auto-zooms below 16px). No API surface change.

## Model Used

Claude Opus 4.6 (1M context), extended thinking mode.

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model used specified
- [x] Tests run locally and pass
- [x] CI green
- [x] Greptile review addressed