### PR TITLE
feat(a11y): add main landmark and skip-to-content link

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -42,7 +42,8 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <a href="#root" class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-2 focus:bg-background focus:text-foreground">Skip to content</a>
+    <main id="root"></main>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -43,7 +43,7 @@
   </head>
   <body>
     <a href="#root" class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-2 focus:bg-background focus:text-foreground">Skip to content</a>
-    <main id="root"></main>
+    <main id="root" tabindex="-1"></main>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Humans oversee those agents through a web UI
> - Keyboard-only and screen-reader users rely on page landmarks and skip-to-content links to navigate without tabbing through every element of the chrome
> - The app shell mounts the React root into a bare `<div id="root">` — no landmark, no skip link
> - Missing landmarks are a WCAG 2.4.1 (Bypass Blocks) failure for that audience
> - This pull request wraps the root in a `<main>` landmark, adds a visually-hidden skip link that appears on keyboard focus, and sets `tabindex="-1"` so Chromium actually moves focus when the skip link is activated

## What Changed

- `ui/index.html`:
  - Add a `<a href="#root" class="sr-only focus:not-sr-only …">Skip to content</a>` immediately inside `<body>`.
  - Change `<div id="root">` to `<main id="root" tabindex="-1">`.

The Tailwind utilities (`sr-only`, `focus:not-sr-only`, etc.) are already used elsewhere in the UI.

## Verification

- Manual on Chrome and Firefox: Tab — the skip link becomes visible. Enter — focus lands on `<main>`. Next Tab — focus goes into the app content instead of looping back through the shell.
- NVDA / VoiceOver: the `<main>` landmark shows up in the landmark list.

## Risks

Low. Pure HTML addition; no API surface change. `tabindex="-1"` keeps the element out of the natural tab order.

## Model Used

Claude Opus 4.6 (1M context), extended thinking mode.

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model used specified
- [x] Tests run locally and pass
- [x] CI green
- [x] Greptile review addressed