### PR TITLE
chore(ui): drop console.* and legal comments in production builds

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -3,8 +3,18 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react(), tailwindcss()],
+  build: {
+    minify: "esbuild",
+  },
+  esbuild:
+    mode === "production"
+      ? {
+          drop: ["console", "debugger"],
+          legalComments: "none",
+        }
+      : undefined,
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
@@ -22,4 +32,4 @@ export default defineConfig({
       },
     },
   },
-});
+}));


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The web UI is a single-page app built with Vite and shipped as a static bundle to every deployment
> - Production bundles carry `console.log` / `console.debug` calls from dev code and `/*! … */` legal-comment banners from third-party packages
> - The console calls leak internals to anyone opening devtools and waste bytes per call site; the legal banners accumulate throughout the bundle
> - Both problems affect every self-hoster, since they all ship the same UI bundle
> - This pull request configures esbuild (via `vite.config.ts`) to strip `console` and `debugger` statements and drop inline legal comments from production builds only

## What Changed

- `ui/vite.config.ts`:
  - Switch to the functional `defineConfig(({ mode }) => …)` form.
  - Add `build.minify: "esbuild"` (explicit — it's the existing default).
  - Add `esbuild.drop: ["console", "debugger"]` and `esbuild.legalComments: "none"`, gated on `mode === "production"` so `vite dev` is unaffected.

## Verification

- `pnpm --filter @paperclipai/ui build` then grep the `ui/dist/assets/*.js` bundle for `console.log` — no occurrences.
- `pnpm --filter @paperclipai/ui dev` — `console.log` calls in source still reach the browser console.
- Bundle size: small reduction (varies with project but measurable on a fresh build).

## Risks

Low. No API surface change. Production code should not depend on `console.*` for side effects; any call that did is now a dead call, which is the same behavior most minifiers apply.

## Model Used

Claude Opus 4.6 (1M context), extended thinking mode.

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model used specified
- [x] Tests run locally and pass
- [x] CI green
- [x] Greptile review addressed