### PR TITLE
feat: support TRUST_PROXY env var for correct client IP behind proxies

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -122,15 +122,28 @@ export async function createApp(
   // logs, abuse detection) groups every user behind the same proxy into
   // a single bucket.
   //
-  // Accepted values (see Express docs):
-  //   - number  — trust N hops of proxies (e.g. "1" for a single ingress)
-  //   - "true"  — trust all proxies (use only when deployment guarantees
-  //               X-Forwarded-For cannot be spoofed)
-  //   - unset / "" / "false" / "0" — disable (default)
+  // Accepted values (strict — anything else is an error so we never
+  // silently escalate to trust-all):
+  //   - positive integer — trust N hops of proxies (e.g. "1" for a
+  //     single ingress)
+  //   - "true"            — trust all proxies. Only safe when the
+  //     deployment guarantees X-Forwarded-For cannot be spoofed.
+  //   - unset / "" / "false" / "0" — disabled (default)
   const trustProxy = process.env.TRUST_PROXY;
   if (trustProxy && trustProxy !== "false" && trustProxy !== "0") {
-    const parsed = Number.parseInt(trustProxy, 10);
-    app.set("trust proxy", Number.isFinite(parsed) && parsed > 0 ? parsed : true);
+    if (trustProxy === "true") {
+      app.set("trust proxy", true);
+    } else {
+      const parsed = Number.parseInt(trustProxy, 10);
+      if (Number.isFinite(parsed) && parsed > 0 && String(parsed) === trustProxy) {
+        app.set("trust proxy", parsed);
+      } else {
+        throw new Error(
+          `Invalid TRUST_PROXY value "${trustProxy}". ` +
+            `Expected a positive integer (e.g. "1") or "true".`,
+        );
+      }
+    }
   }
 
   app.use(express.json({

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -115,6 +115,24 @@ export async function createApp(
 ) {
   const app = express();
 
+  // Trust reverse proxies (ingress controllers, load balancers) so that
+  // req.ip and related helpers return the real client IP from
+  // X-Forwarded-For instead of the proxy's internal address. Without
+  // this, any downstream logic keyed on req.ip (rate limiting, audit
+  // logs, abuse detection) groups every user behind the same proxy into
+  // a single bucket.
+  //
+  // Accepted values (see Express docs):
+  //   - number  — trust N hops of proxies (e.g. "1" for a single ingress)
+  //   - "true"  — trust all proxies (use only when deployment guarantees
+  //               X-Forwarded-For cannot be spoofed)
+  //   - unset / "" / "false" / "0" — disable (default)
+  const trustProxy = process.env.TRUST_PROXY;
+  if (trustProxy && trustProxy !== "false" && trustProxy !== "0") {
+    const parsed = Number.parseInt(trustProxy, 10);
+    app.set("trust proxy", Number.isFinite(parsed) && parsed > 0 ? parsed : true);
+  }
+
   app.use(express.json({
     // Company import/export payloads can inline full portable packages.
     limit: "10mb",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Most deployments sit behind a reverse proxy (Kubernetes Ingress, Nginx, Traefik, Cloudflare, an ALB, or a docker-compose proxy sidecar)
> - Behind any such proxy, `req.ip` is the proxy's address unless Express's `trust proxy` setting is configured
> - Any downstream logic that keys on `req.ip` — rate limiting, audit logs, abuse detection — groups every user behind the same proxy into a single bucket, which is both a correctness bug and a latent security issue
> - Express's `trust proxy` accepts multiple formats; the only safe defaults without user input are `false` (don't trust) or a positive integer (trust N hops)
> - This pull request adds a `TRUST_PROXY` env var that drives Express's setting, with strict validation that rejects unrecognized values instead of silently falling through to trust-all

## What Changed

- `server/src/app.ts`:
  - Read `TRUST_PROXY` from the environment immediately after `const app = express()`.
  - `"true"` → `app.set("trust proxy", true)`. Reserved for deployments that guarantee `X-Forwarded-For` can't be spoofed.
  - Positive-integer strings → `app.set("trust proxy", n)`. The integer must round-trip to the same string so leading-zero / whitespace-laden values are rejected.
  - Unset / `""` / `"false"` / `"0"` → disabled (unchanged default).
  - Anything else throws at startup with a clear error message.

## Verification

- `TRUST_PROXY=1 pnpm dev` behind a local Nginx: `req.ip` in a request-logging middleware reports the real client IP instead of 127.0.0.1.
- `TRUST_PROXY=loopback pnpm dev`: server refuses to start with `Invalid TRUST_PROXY value "loopback". Expected a positive integer (e.g. "1") or "true".`.
- `TRUST_PROXY` unset: unchanged.

## Risks

Low. Strict validation means accidental misconfiguration (typos, Express's named subnet strings) fail loud at startup rather than silently weakening proxy trust. No behavior change when the env var is unset.

## Model Used

Claude Opus 4.6 (1M context), extended thinking mode.

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model used specified
- [x] Tests run locally and pass
- [x] CI green
- [x] Greptile review addressed