### PR TITLE
fix: don't overwrite PAPERCLIP_API_URL when already configured

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -554,7 +554,13 @@ export async function startServer(): Promise<StartedServer> {
       : runtimeListenHost;
   process.env.PAPERCLIP_LISTEN_HOST = runtimeListenHost;
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
-  process.env.PAPERCLIP_API_URL = `http://${runtimeApiHost}:${listenPort}`;
+  // Only derive PAPERCLIP_API_URL from the listen host/port when the
+  // operator hasn't configured one explicitly. Any deployment behind a
+  // reverse proxy or with a public URL needs to advertise that URL to
+  // adapters/sandboxes, not the internal listen address.
+  if (!process.env.PAPERCLIP_API_URL) {
+    process.env.PAPERCLIP_API_URL = `http://${runtimeApiHost}:${listenPort}`;
+  }
   
   setupLiveEventsWebSocketServer(server, db as any, {
     deploymentMode: config.deploymentMode,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Adapters and sandboxes call back into the Paperclip API using `PAPERCLIP_API_URL` to read/write state
> - For local single-process dev, that URL is trivially `http://<listenHost>:<listenPort>`
> - For any deployment where the public URL differs from the listen address (behind an ingress, reverse proxy, or docker-compose service mesh) the operator must configure `PAPERCLIP_API_URL` themselves
> - Startup unconditionally overwrites that configured value with the derived listen-address URL
> - Adapters then advertise an unreachable URL, callbacks fail, and users see mysterious runtime errors
> - This pull request only derives the default when `PAPERCLIP_API_URL` is unset, preserving operator intent

## What Changed

- `server/src/index.ts` — wrap the `process.env.PAPERCLIP_API_URL = …` assignment in a guard that runs only if the variable is not already set.

## Verification

- `PAPERCLIP_API_URL=https://paperclip.example.com pnpm start` — the variable is preserved after startup.
- `pnpm start` (unset) — the variable is derived to `http://<listenHost>:<listenPort>`, as before.
- Existing tests pass.

## Risks

Minimal. No behavior change for any deployment that doesn't export `PAPERCLIP_API_URL`.

## Model Used

Claude Opus 4.6 (1M context), extended thinking mode.

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model used specified
- [x] Tests run locally and pass
- [x] CI green
- [x] Greptile review addressed