### PR TITLE
feat(adapters): widen onLog stream type to include "system"

### DIFF
--- a/docs/adapters/creating-an-adapter.md
+++ b/docs/adapters/creating-an-adapter.md
@@ -101,7 +101,7 @@ interface AdapterExecutionContext {
   runtime: { sessionId: string | null; sessionParams: Record<string, unknown> | null };
   config: Record<string, unknown>;      // agent's adapterConfig
   context: Record<string, unknown>;      // task, wake reason, etc.
-  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  onLog: (stream: "stdout" | "stderr" | "system", chunk: string) => Promise<void>;
   onMeta?: (meta: AdapterInvocationMeta) => Promise<void>;
   onSpawn?: (meta: { pid: number; startedAt: string }) => Promise<void>;
 }

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1069,7 +1069,7 @@ export async function runChildProcess(
     env: Record<string, string>;
     timeoutSec: number;
     graceSec: number;
-    onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+    onLog: (stream: "stdout" | "stderr" | "system", chunk: string) => Promise<void>;
     onLogError?: (err: unknown, runId: string, message: string) => void;
     onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
     stdin?: string;

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -118,7 +118,7 @@ export interface AdapterExecutionContext {
   runtime: AdapterRuntime;
   config: Record<string, unknown>;
   context: Record<string, unknown>;
-  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  onLog: (stream: "stdout" | "stderr" | "system", chunk: string) => Promise<void>;
   onMeta?: (meta: AdapterInvocationMeta) => Promise<void>;
   onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
   authToken?: string;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -264,7 +264,7 @@ export async function runClaudeLogin(input: {
   config: Record<string, unknown>;
   context?: Record<string, unknown>;
   authToken?: string;
-  onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  onLog?: (stream: "stdout" | "stderr" | "system", chunk: string) => Promise<void>;
 }) {
   const onLog = input.onLog ?? (async () => {});
   const runtime = await buildClaudeRuntimeConfig({

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -384,9 +384,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     // Buffer stdout by lines to handle partial JSON chunks
     let stdoutBuffer = "";
-    const bufferedOnLog = async (stream: "stdout" | "stderr", chunk: string) => {
-      if (stream === "stderr") {
-        // Pass stderr through immediately (not JSONL)
+    const bufferedOnLog = async (stream: "stdout" | "stderr" | "system", chunk: string) => {
+      if (stream !== "stdout") {
+        // Pass stderr/system through immediately (not JSONL)
         await onLog(stream, chunk);
         return;
       }

--- a/server/src/adapters/utils.ts
+++ b/server/src/adapters/utils.ts
@@ -83,7 +83,7 @@ export async function runChildProcess(
     env: Record<string, string>;
     timeoutSec: number;
     graceSec: number;
-    onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+    onLog: (stream: "stdout" | "stderr" | "system", chunk: string) => Promise<void>;
   },
 ): Promise<RunProcessResult> {
   return _runChildProcess(runId, command, args, {

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -295,9 +295,9 @@ export function executionWorkspaceRoutes(db: Db) {
           }));
         }
 
-        const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
+        const onLog = async (stream: "stdout" | "stderr" | "system", chunk: string) => {
           if (stream === "stdout") stdout.push(chunk);
-          else stderr.push(chunk);
+          else if (stream === "stderr") stderr.push(chunk);
         };
 
         if (action === "stop" || action === "restart") {

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -409,9 +409,9 @@ export function projectRoutes(db: Db) {
           }));
         }
 
-        const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
+        const onLog = async (stream: "stdout" | "stderr" | "system", chunk: string) => {
           if (stream === "stdout") stdout.push(chunk);
-          else stderr.push(chunk);
+          else if (stream === "stderr") stderr.push(chunk);
         };
 
         if (action === "stop" || action === "restart") {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3551,7 +3551,7 @@ export function heartbeatService(db: Db) {
         .where(eq(heartbeatRuns.id, runId));
 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
-      const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
+      const onLog = async (stream: "stdout" | "stderr" | "system", chunk: string) => {
         const sanitizedChunk = compactRunLogChunk(
           redactCurrentUserText(chunk, currentUserRedactionOptions),
         );

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -242,7 +242,7 @@ function findServerWorkspaceLinkMismatches(rootDir: string): WorkspaceLinkMismat
 export async function ensureServerWorkspaceLinksCurrent(
   startCwd: string,
   opts?: {
-    onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+    onLog?: (stream: "stdout" | "stderr" | "system", chunk: string) => Promise<void>;
   },
 ) {
   const workspaceRoot = findWorkspaceRoot(startCwd);
@@ -1900,7 +1900,7 @@ async function startLocalRuntimeService(input: {
   executionWorkspaceId?: string | null;
   adapterEnv: Record<string, string>;
   service: Record<string, unknown>;
-  onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  onLog?: (stream: "stdout" | "stderr" | "system", chunk: string) => Promise<void>;
   reuseKey: string | null;
   scopeType: "project_workspace" | "execution_workspace" | "run" | "agent";
   scopeId: string | null;
@@ -2310,7 +2310,7 @@ export async function ensureRuntimeServicesForRun(input: {
   executionWorkspaceId?: string | null;
   config: Record<string, unknown>;
   adapterEnv: Record<string, string>;
-  onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  onLog?: (stream: "stdout" | "stderr" | "system", chunk: string) => Promise<void>;
 }): Promise<RuntimeServiceRef[]> {
   const rawServices = readRuntimeServiceEntries(input.config);
   const acquiredServiceIds: string[] = [];
@@ -2392,7 +2392,7 @@ export async function startRuntimeServicesForWorkspaceControl(input: {
   executionWorkspaceId?: string | null;
   config: Record<string, unknown>;
   adapterEnv: Record<string, string>;
-  onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  onLog?: (stream: "stdout" | "stderr" | "system", chunk: string) => Promise<void>;
   serviceIndex?: number | null;
   respectDesiredStates?: boolean;
 }): Promise<RuntimeServiceRef[]> {


### PR DESCRIPTION
## Problem

The log storage and presentation layers already accept \`\"system\"\` as a stream value:

- \`server/src/services/run-log-store.ts\`
- \`server/src/services/workspace-operation-log-store.ts\`
- \`server/src/services/workspace-operations.ts\`
- \`packages/shared/src/types/heartbeat.ts\`
- \`packages/plugins/sdk/src/types.ts\`
- \`ui/src/adapters/transcript.ts\` / \`ui/src/pages/AgentDetail.tsx\`
- \`cli/src/commands/heartbeat-run.ts\`
- \`doc/spec/agent-runs.md\`

But the callbacks adapters are actually handed — \`AdapterExecutionContext.onLog\` and the \`runChildProcess\` onLog — are still the narrow \`\"stdout\" | \"stderr\"\`. There's no typed way for an adapter to emit a system-level line (setup, cleanup, injection notices, internal state transitions) distinct from the target process's stdout/stderr, which means adapter authors end up smuggling those through stderr with a prefix.

## Fix

Widen the adapter-facing \`onLog\` signatures to \`\"stdout\" | \"stderr\" | \"system\"\` and propagate the widening through:

- \`packages/adapter-utils/src/types.ts\` (\`AdapterExecutionContext.onLog\`)
- \`packages/adapter-utils/src/server-utils.ts\` (\`runChildProcess\` opts)
- \`server/src/adapters/utils.ts\` (the re-exported wrapper)
- \`server/src/services/heartbeat.ts\` (the callback heartbeatService builds)
- \`server/src/services/workspace-runtime.ts\` (ensure/link helpers)
- \`server/src/routes/projects.ts\`, \`server/src/routes/execution-workspaces.ts\` (callsite onLog accumulators)
- \`packages/adapters/claude-local/src/server/execute.ts\` (\`runClaudeLogin\` input)
- \`packages/adapters/pi-local/src/server/execute.ts\` (\`bufferedOnLog\` — JSONL buffering only applies to stdout, so \"system\" passes through immediately like stderr did before)
- \`docs/adapters/creating-an-adapter.md\`

## Risk

No behavioral change for adapters or routes that only emit stdout/stderr; the third variant is ignored by existing callers. Adapters that want to emit system-level events can now do so without the string value being rejected at the type layer.