### PR TITLE
feat: optional Redis pub/sub for cross-replica live events

### DIFF
--- a/server/src/services/live-events.ts
+++ b/server/src/services/live-events.ts
@@ -74,9 +74,12 @@ async function initRedis(): Promise<void> {
   const sub = new (Redis as any)(url) as SubscribeClient;
   attachErrorLogger(pub, "publisher");
   attachErrorLogger(sub, "subscriber");
-  redisPub = pub;
-  redisSub = sub;
-  await sub.subscribe(CHANNEL);
+  // Install the message listener and complete the subscription BEFORE
+  // publishing anything. If we assigned redisPub first, the publisher
+  // could race the subscribe(): events published in that narrow window
+  // land in Redis on a channel this replica isn't yet listening to,
+  // and if subscribe() then throws, redisPub stays non-null until the
+  // outer .catch() runs — more events go to Redis with no local sub.
   sub.on("message", (_channel: unknown, message: unknown) => {
     try {
       const envelope = JSON.parse(message as string) as {
@@ -97,6 +100,12 @@ async function initRedis(): Promise<void> {
       // delivery for everyone else.
     }
   });
+  await sub.subscribe(CHANNEL);
+  // Only expose the publisher once we're actually receiving from the
+  // channel. If subscribe() threw above we would never reach this line
+  // and redisPub would stay null — the outer .catch() handles the log.
+  redisPub = pub;
+  redisSub = sub;
 }
 
 // Non-blocking best-effort init on module load. If ioredis isn't

--- a/server/src/services/live-events.ts
+++ b/server/src/services/live-events.ts
@@ -24,7 +24,8 @@ let nextEventId = 0;
 //
 // ioredis is imported dynamically so self-hosters without the env var
 // set don't pay the dependency cost — and the type is intentionally
-// kept loose so ioredis can be an optionalDependency.
+// kept loose so operators who want this feature install `ioredis`
+// themselves without forcing a global dependency update.
 type PublishClient = { publish(channel: string, message: string): Promise<unknown> };
 type SubscribeClient = {
   subscribe(channel: string): Promise<unknown>;
@@ -48,42 +49,52 @@ function resolveRedisUrl(): string | null {
 async function initRedis(): Promise<void> {
   const url = resolveRedisUrl();
   if (!url) return;
-  try {
-    const ioredis = await import("ioredis");
-    const Redis = (ioredis as { default?: unknown }).default ?? ioredis;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    redisPub = new (Redis as any)(url);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    redisSub = new (Redis as any)(url);
-    await redisSub!.subscribe(CHANNEL);
-    redisSub!.on("message", (_channel: unknown, message: unknown) => {
-      try {
-        const envelope = JSON.parse(message as string) as {
-          origin: string;
-          event: LiveEvent;
-        };
-        if (envelope.origin === originId) return;
-        emitter.emit(envelope.event.companyId, envelope.event);
+  // @ts-expect-error ioredis is an optional runtime dependency
+  const ioredis = await import("ioredis");
+  const Redis = (ioredis as { default?: unknown }).default ?? ioredis;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  redisPub = new (Redis as any)(url);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  redisSub = new (Redis as any)(url);
+  await redisSub!.subscribe(CHANNEL);
+  redisSub!.on("message", (_channel: unknown, message: unknown) => {
+    try {
+      const envelope = JSON.parse(message as string) as {
+        origin: string;
+        event: LiveEvent;
+      };
+      if (envelope.origin === originId) return;
+      // Mirror the routing in publishLiveEvent / publishGlobalLiveEvent:
+      // global events go to "*" listeners; company-scoped events go only
+      // to that company's listeners.
+      if (envelope.event.companyId === "*") {
         emitter.emit("*", envelope.event);
-      } catch {
-        // ignore malformed messages — a single bad payload shouldn't
-        // take down cross-replica delivery for everyone else
+      } else {
+        emitter.emit(envelope.event.companyId, envelope.event);
       }
-    });
-  } catch {
-    // ioredis not installed or connection failed — fall back to
-    // local-only events without surfacing an error: live events are
-    // best-effort.
-    redisPub = null;
-    redisSub = null;
-  }
+    } catch {
+      // A single malformed message shouldn't take down cross-replica
+      // delivery for everyone else.
+    }
+  });
 }
 
-// Non-blocking best-effort init on module load.
+// Non-blocking best-effort init on module load. If ioredis isn't
+// installed or the server fails to connect we surface a single warning
+// and fall back to local-only delivery so the misconfiguration is
+// visible instead of silently degrading.
 if (resolveRedisUrl()) {
   redisInit = initRedis();
-  redisInit.catch(() => {
-    /* logged indirectly via failed subscribe */
+  redisInit.catch((err) => {
+    redisPub = null;
+    redisSub = null;
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[paperclip] live-events: Redis transport init failed, falling back to " +
+        "single-replica delivery. Install `ioredis` and verify the redis URL " +
+        "(PAPERCLIP_LIVE_EVENTS_REDIS_URL / PAPERCLIP_REDIS_URL).",
+      err,
+    );
   });
 }
 

--- a/server/src/services/live-events.ts
+++ b/server/src/services/live-events.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
 import type { LiveEvent, LiveEventType } from "@paperclipai/shared";
 
 type LiveEventPayload = Record<string, unknown>;
@@ -8,6 +9,83 @@ const emitter = new EventEmitter();
 emitter.setMaxListeners(0);
 
 let nextEventId = 0;
+
+// Optional Redis pub/sub for cross-replica event distribution.
+//
+// In a single-process deployment (the self-hosted default) this module
+// just uses an in-memory EventEmitter, identical to previous behavior.
+//
+// When `PAPERCLIP_LIVE_EVENTS_REDIS_URL` is set (or the generic
+// `PAPERCLIP_REDIS_URL` as a fallback), events are also published to a
+// Redis channel so WebSocket clients connected to other replicas see
+// them. Each process tags outgoing messages with a unique origin id
+// and skips its own messages when they come back over the channel, so
+// there is no double-emission.
+//
+// ioredis is imported dynamically so self-hosters without the env var
+// set don't pay the dependency cost — and the type is intentionally
+// kept loose so ioredis can be an optionalDependency.
+type PublishClient = { publish(channel: string, message: string): Promise<unknown> };
+type SubscribeClient = {
+  subscribe(channel: string): Promise<unknown>;
+  on(event: string, cb: (...args: unknown[]) => void): void;
+};
+
+const CHANNEL = "paperclip:live-events";
+const originId = `${process.pid}-${randomUUID()}`;
+
+let redisPub: PublishClient | null = null;
+let redisSub: SubscribeClient | null = null;
+let redisInit: Promise<void> | null = null;
+
+function resolveRedisUrl(): string | null {
+  const explicit = process.env.PAPERCLIP_LIVE_EVENTS_REDIS_URL?.trim();
+  if (explicit) return explicit;
+  const shared = process.env.PAPERCLIP_REDIS_URL?.trim();
+  return shared || null;
+}
+
+async function initRedis(): Promise<void> {
+  const url = resolveRedisUrl();
+  if (!url) return;
+  try {
+    const ioredis = await import("ioredis");
+    const Redis = (ioredis as { default?: unknown }).default ?? ioredis;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    redisPub = new (Redis as any)(url);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    redisSub = new (Redis as any)(url);
+    await redisSub!.subscribe(CHANNEL);
+    redisSub!.on("message", (_channel: unknown, message: unknown) => {
+      try {
+        const envelope = JSON.parse(message as string) as {
+          origin: string;
+          event: LiveEvent;
+        };
+        if (envelope.origin === originId) return;
+        emitter.emit(envelope.event.companyId, envelope.event);
+        emitter.emit("*", envelope.event);
+      } catch {
+        // ignore malformed messages — a single bad payload shouldn't
+        // take down cross-replica delivery for everyone else
+      }
+    });
+  } catch {
+    // ioredis not installed or connection failed — fall back to
+    // local-only events without surfacing an error: live events are
+    // best-effort.
+    redisPub = null;
+    redisSub = null;
+  }
+}
+
+// Non-blocking best-effort init on module load.
+if (resolveRedisUrl()) {
+  redisInit = initRedis();
+  redisInit.catch(() => {
+    /* logged indirectly via failed subscribe */
+  });
+}
 
 function toLiveEvent(input: {
   companyId: string;
@@ -24,6 +102,14 @@ function toLiveEvent(input: {
   };
 }
 
+function publishToRedis(event: LiveEvent) {
+  if (!redisPub) return;
+  const envelope = JSON.stringify({ origin: originId, event });
+  redisPub.publish(CHANNEL, envelope).catch(() => {
+    /* best-effort cross-replica delivery */
+  });
+}
+
 export function publishLiveEvent(input: {
   companyId: string;
   type: LiveEventType;
@@ -31,6 +117,7 @@ export function publishLiveEvent(input: {
 }) {
   const event = toLiveEvent(input);
   emitter.emit(input.companyId, event);
+  publishToRedis(event);
   return event;
 }
 
@@ -40,6 +127,7 @@ export function publishGlobalLiveEvent(input: {
 }) {
   const event = toLiveEvent({ companyId: "*", type: input.type, payload: input.payload });
   emitter.emit("*", event);
+  publishToRedis(event);
   return event;
 }
 

--- a/server/src/services/live-events.ts
+++ b/server/src/services/live-events.ts
@@ -26,10 +26,14 @@ let nextEventId = 0;
 // set don't pay the dependency cost — and the type is intentionally
 // kept loose so operators who want this feature install `ioredis`
 // themselves without forcing a global dependency update.
-type PublishClient = { publish(channel: string, message: string): Promise<unknown> };
-type SubscribeClient = {
-  subscribe(channel: string): Promise<unknown>;
+type RedisEventClient = {
   on(event: string, cb: (...args: unknown[]) => void): void;
+};
+type PublishClient = RedisEventClient & {
+  publish(channel: string, message: string): Promise<unknown>;
+};
+type SubscribeClient = RedisEventClient & {
+  subscribe(channel: string): Promise<unknown>;
 };
 
 const CHANNEL = "paperclip:live-events";
@@ -46,6 +50,18 @@ function resolveRedisUrl(): string | null {
   return shared || null;
 }
 
+function attachErrorLogger(client: RedisEventClient, role: "publisher" | "subscriber") {
+  // ioredis extends EventEmitter and emits `error` on its own schedule (network
+  // blip, auth expiry, redis restart). Without a listener, node promotes that
+  // to an uncaught exception and crashes the server — which would defeat the
+  // whole "best-effort, fall back to local-only" contract of this transport.
+  // A single warn-level log is enough; ioredis will auto-reconnect.
+  client.on("error", (err: unknown) => {
+    // eslint-disable-next-line no-console
+    console.warn(`[paperclip] live-events: redis ${role} error`, err);
+  });
+}
+
 async function initRedis(): Promise<void> {
   const url = resolveRedisUrl();
   if (!url) return;
@@ -53,11 +69,15 @@ async function initRedis(): Promise<void> {
   const ioredis = await import("ioredis");
   const Redis = (ioredis as { default?: unknown }).default ?? ioredis;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  redisPub = new (Redis as any)(url);
+  const pub = new (Redis as any)(url) as PublishClient;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  redisSub = new (Redis as any)(url);
-  await redisSub!.subscribe(CHANNEL);
-  redisSub!.on("message", (_channel: unknown, message: unknown) => {
+  const sub = new (Redis as any)(url) as SubscribeClient;
+  attachErrorLogger(pub, "publisher");
+  attachErrorLogger(sub, "subscriber");
+  redisPub = pub;
+  redisSub = sub;
+  await sub.subscribe(CHANNEL);
+  sub.on("message", (_channel: unknown, message: unknown) => {
     try {
       const envelope = JSON.parse(message as string) as {
         origin: string;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The web UI is kept live via a WebSocket bus that streams `LiveEvent`s — run progress, status changes, transcript deltas
> - Today that bus is an in-process `EventEmitter`, which is fine for single-replica deployments
> - Any self-hoster running more than one server replica (a typical k8s Deployment with `replicas: 2`) sees events silently drop for clients whose WebSocket landed on a different pod than the one executing the run
> - The current workaround is pod affinity / sticky sessions, which defeats half the reason for multi-replica in the first place
> - This pull request adds an optional Redis pub/sub transport that mirrors local events to every replica, gated on env vars and using a dynamically-imported `ioredis` so single-process deployments pay no dependency cost

## What Changed

- `server/src/services/live-events.ts`:
  - Add a Redis pub/sub transport for cross-replica delivery. Activates when `PAPERCLIP_LIVE_EVENTS_REDIS_URL` (or the generic `PAPERCLIP_REDIS_URL` fallback) is set.
  - Each process tags outgoing envelopes with `pid + randomUUID()` and drops messages whose origin matches, so events are never emitted twice on the publisher.
  - Incoming cross-replica messages are routed exactly like the in-process `publishLiveEvent` / `publishGlobalLiveEvent` functions — global events go to `"*"` listeners only, company-scoped events go only to that company's listeners.
  - `ioredis` is imported via dynamic `import()` guarded by `@ts-expect-error` so the module type-checks when the package is not in `node_modules`. Operators install `ioredis` themselves when they opt in.
  - Failures in the outer init path are surfaced via a single `console.warn` so a misconfigured Redis URL is visible rather than silently degrading to single-replica delivery.

## Verification

- Two-replica local setup sharing a Redis instance: issue a mutation against pod A, observe the WebSocket event on a client pinned to pod B.
- Single-replica (no env var): live events behave exactly as before — in-process only.
- Env var set but Redis unreachable or `ioredis` not installed: single warning at startup, no crash, no cross-replica delivery.

## Risks

Low. The module's public surface (`publishLiveEvent`, `publishGlobalLiveEvent`, `subscribeCompanyLiveEvents`, `subscribeGlobalLiveEvents`) is unchanged. No default dependency added. Cross-replica delivery is best-effort — any failure path falls back to single-replica in-process behavior.

## Model Used

Claude Opus 4.6 (1M context), extended thinking mode.

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model used specified
- [x] Tests run locally and pass
- [x] CI green
- [x] Greptile review addressed