### PR TITLE
fix(auth): drop non-UUID x-paperclip-run-id header to avoid PATCH 500s

### DIFF
--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -26,7 +26,15 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         ? { type: "board", userId: "local-board", isInstanceAdmin: true, source: "local_implicit" }
         : { type: "none", source: "none" };
 
-    const runIdHeader = req.header("x-paperclip-run-id");
+    const rawRunIdHeader = req.header("x-paperclip-run-id");
+    // Drop the header if it's not a valid UUID — activity_log.run_id is a UUID FK
+    // to heartbeat_runs.id, so any non-UUID value (e.g. cortextos audit IDs like
+    // "cortextos_20260415T175447_ceo") will 500 the whole PATCH at insert time.
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const runIdHeader = rawRunIdHeader && UUID_RE.test(rawRunIdHeader) ? rawRunIdHeader : undefined;
+    if (rawRunIdHeader && !runIdHeader) {
+      logger.debug({ rawRunIdHeader }, "dropping non-UUID x-paperclip-run-id header");
+    }
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {


### PR DESCRIPTION
## Summary

`PATCH /api/issues/:id` returns `500 Internal server error` when the request carries an `X-Paperclip-Run-Id` header whose value is not a valid UUID. `POST /issues` with the same header works fine — the failure is specific to mutations that flow through `logActivity`.

## Root cause

`activity_log.run_id` is defined as `uuid("run_id").references(() => heartbeatRuns.id)` (`packages/db/src/schema/activity_log.ts:17`). The actor middleware stores the raw header value on `req.actor.runId`, and the PATCH issues handler passes it to `logActivity` which inserts it directly into the UUID column. Any non-UUID string (e.g. an external audit tag like `cortextos_20260415T175447_ceo`) triggers a Postgres error at insert time, surfacing as a 500.

## Fix

Validate the header against a UUID regex in `actorMiddleware` and drop it if invalid. Log a `debug` line noting the drop so clients can see why their header was ignored without breaking the request. The `run_id` column simply stays `null` on activity rows — the mutation still succeeds.

## Why POST wasn't affected

POST `/issues` writes the run id via a separate path (`originRunId`), which isn't a FK to `heartbeat_runs`. Only the `logActivity → activity_log` path hits the UUID constraint.

## Verification

```bash
# Before the fix (bug reproduction)
curl -X PATCH http://localhost:3100/api/issues/<uuid> \
  -H "X-Paperclip-Run-Id: not-a-uuid" \
  -H "Content-Type: application/json" \
  -d '{"status":"todo"}'
# → 500 Internal server error

# After the fix
curl -X PATCH http://localhost:3100/api/issues/<uuid> \
  -H "X-Paperclip-Run-Id: not-a-uuid" \
  -H "Content-Type: application/json" \
  -d '{"status":"todo"}'
# → 200 OK, issue updated, activity_log row written with run_id = null
```

Confirmed locally on a dev instance running from `tsx watch src/index.ts`.

## Scope

- Only `server/src/middleware/auth.ts` (9 additions, 1 deletion)
- No schema changes, no breaking changes to the API surface
- Clients sending valid UUIDs are unaffected
- Clients sending invalid UUIDs previously got 500s and now get 200s with the header silently dropped (arguably a behavior change, but the prior behavior was a crash)

## Context

Hit this while wiring a non-Paperclip system (a monitoring agent) that was passing its own semantic run identifiers through the header for audit trail purposes. The strict UUID FK means those external IDs can't be stored in `activity_log.run_id` without a schema change, so dropping-on-invalid is the safest loopback-mode behavior. A longer-term fix could be a separate nullable `external_run_ref` text column, but that's a bigger conversation.
