### PR TITLE
server: add assignee wake telemetry for non-invokable agents

### DIFF
--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "../errors.js";
+import { logger } from "../middleware/logger.js";
+import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+
+describe("queueIssueAssignmentWakeup", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs info with assignee status for non-invokable assignee conflicts", async () => {
+    const wakeup = vi
+      .fn()
+      .mockRejectedValue(new HttpError(409, "Agent is not invokable in its current state", { status: "paused" }));
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+
+    const result = await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: { id: "issue-1", assigneeAgentId: "agent-1", status: "todo" },
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "issue.create",
+    });
+
+    expect(result).toBeNull();
+    expect(wakeup).toHaveBeenCalledOnce();
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issueId: "issue-1",
+        assigneeAgentId: "agent-1",
+        assigneeStatus: "paused",
+      }),
+      "skipped assignee wake on issue assignment: assignee not invokable",
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs warn for unexpected wakeup failures", async () => {
+    const wakeup = vi.fn().mockRejectedValue(new Error("boom"));
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+
+    const result = await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: { id: "issue-2", assigneeAgentId: "agent-2", status: "todo" },
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "issue.create",
+    });
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -1,4 +1,5 @@
 import { logger } from "../middleware/logger.js";
+import { HttpError } from "../errors.js";
 
 type WakeupTriggerDetail = "manual" | "ping" | "callback" | "system";
 type WakeupSource = "timer" | "assignment" | "on_demand" | "automation";
@@ -16,6 +17,15 @@ export interface IssueAssignmentWakeupDeps {
       contextSnapshot?: Record<string, unknown>;
     },
   ) => Promise<unknown>;
+}
+
+function readInvokableConflictStatus(err: unknown): string | null {
+  if (!(err instanceof HttpError)) return null;
+  if (err.status !== 409 || err.message !== "Agent is not invokable in its current state") return null;
+  const details = err.details;
+  if (!details || typeof details !== "object") return null;
+  const status = (details as { status?: unknown }).status;
+  return typeof status === "string" && status.trim().length > 0 ? status : null;
 }
 
 export function queueIssueAssignmentWakeup(input: {
@@ -41,7 +51,33 @@ export function queueIssueAssignmentWakeup(input: {
       contextSnapshot: { issueId: input.issue.id, source: input.contextSource },
     })
     .catch((err) => {
-      logger.warn({ err, issueId: input.issue.id }, "failed to wake assignee on issue assignment");
+      const assigneeStatus = readInvokableConflictStatus(err);
+      if (assigneeStatus) {
+        logger.info(
+          {
+            issueId: input.issue.id,
+            assigneeAgentId: input.issue.assigneeAgentId,
+            assigneeStatus,
+            mutation: input.mutation,
+            reason: input.reason,
+            contextSource: input.contextSource,
+          },
+          "skipped assignee wake on issue assignment: assignee not invokable",
+        );
+        if (input.rethrowOnError) throw err;
+        return null;
+      }
+      logger.warn(
+        {
+          err,
+          issueId: input.issue.id,
+          assigneeAgentId: input.issue.assigneeAgentId,
+          mutation: input.mutation,
+          reason: input.reason,
+          contextSource: input.contextSource,
+        },
+        "failed to wake assignee on issue assignment",
+      );
       if (input.rethrowOnError) throw err;
       return null;
     });


### PR DESCRIPTION
## Summary\n- handle known 409 `Agent is not invokable in its current state` conflicts in assignment wake path\n- downgrade that expected path from warn to structured info telemetry with issue/agent/status context\n- keep warn logging for unexpected wake errors\n- add targeted unit tests for the new behavior\n\n## Validation\n- pnpm vitest run server/src/__tests__/issue-assignment-wakeup.test.ts\n- pnpm -s tsc -p server/tsconfig.json --noEmit\n\nRefs: GEA-783 / schmelli/gearshack-winterberry#760