### PR TITLE
fix(server): avoid redundant UPDATE in PATCH with status+comment

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1733,7 +1733,7 @@ export function issueRoutes(
         agentId: actor.agentId ?? undefined,
         userId: actor.actorType === "user" ? actor.actorId : undefined,
         runId: actor.runId,
-      });
+      }, { skipUpdatedAt: true }); // Issue already updated above, skip redundant UPDATE to avoid contention
 
       await logActivity(db, {
         companyId: issue.companyId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2138,6 +2138,7 @@ export function issueService(db: Db) {
       issueId: string,
       body: string,
       actor: { agentId?: string; userId?: string; runId?: string | null },
+      options?: { skipUpdatedAt?: boolean },
     ) => {
       const issue = await db
         .select({ companyId: issues.companyId })
@@ -2164,10 +2165,13 @@ export function issueService(db: Db) {
         .returning();
 
       // Update issue's updatedAt so comment activity is reflected in recency sorting
-      await db
-        .update(issues)
-        .set({ updatedAt: new Date() })
-        .where(eq(issues.id, issueId));
+      // Skip if caller already updated the issue (e.g., PATCH with status+comment)
+      if (!options?.skipUpdatedAt) {
+        await db
+          .update(issues)
+          .set({ updatedAt: new Date() })
+          .where(eq(issues.id, issueId));
+      }
 
       return redactIssueComment(comment, currentUserRedactionOptions.enabled);
     },


### PR DESCRIPTION
Resubmit of #3196 (auto-closed when head branch was deleted; [gardener bot marked ALIGNED](https://github.com/paperclipai/paperclip/pull/3196) before closure). Rebased onto current master with reconciled `addComment` signature for the `runId` param upstream added in the meantime.

## Problem

When `PATCH /api/issues/:id` receives both `status` and `comment`, `svc.update()` already sets `updatedAt`. The subsequent `addComment()` was doing a second UPDATE on the same row, causing lock contention that could hang the request indefinitely. Reported in prod by an agent dispatch pathway.

## Fix

Added an optional `{ skipUpdatedAt?: boolean }` options param to `addComment()`. The PATCH handler passes `{ skipUpdatedAt: true }` when the issue was already updated by the same handler, avoiding the redundant UPDATE.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)