### PR TITLE
fix(heartbeat): skip deferred wakeup promotion when issue reached terminal state

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4250,6 +4250,28 @@ export function heartbeatService(db: Db) {
           .where(eq(issues.id, issue.id));
       }
 
+      // If the issue reached a terminal state during the run (e.g. agent marked
+      // it done and then posted a comment which queued a deferred wakeup), skip
+      // all deferred wakeups — there is no work left to promote.
+      if (issue.status === "done" || issue.status === "cancelled") {
+        await tx
+          .update(agentWakeupRequests)
+          .set({
+            status: "skipped",
+            finishedAt: new Date(),
+            error: "Issue already in terminal state; deferred promotion skipped",
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, issue.companyId),
+              eq(agentWakeupRequests.status, "deferred_issue_execution"),
+              sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}`,
+            ),
+          );
+        return null;
+      }
+
       while (true) {
         const deferred = await tx
           .select()


### PR DESCRIPTION
## Problem

When an agent marks an issue `done`/`cancelled` during a run and then posts a finishing comment, the comment can queue a `deferred_issue_execution` wakeup. The end-of-run promotion path was then promoting that wakeup to a ready run, re-waking the agent on already-completed work.

## Fix

In the end-of-run transaction that promotes deferred wakeups (`heartbeat.ts` around the `while (true)` loop over `deferred_issue_execution` requests), check the issue status first. If `done` or `cancelled`, mark all deferred wakeup requests for that issue as `skipped` with an explanatory error and return early — no promotion happens.

## Testing notes

Issue status is already selected in upstream's current query, so this is purely additive logic before the promotion loop.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)