### PR TITLE
feat(ui): database backup settings page under Instance Settings

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -423,6 +423,10 @@ export {
   instanceExperimentalSettingsSchema,
   patchInstanceExperimentalSettingsSchema,
   type PatchInstanceExperimentalSettings,
+  instanceBackupSettingsSchema,
+  patchInstanceBackupSettingsSchema,
+  type InstanceBackupSettings,
+  type PatchInstanceBackupSettings,
 } from "./validators/index.js";
 
 export {

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -7,6 +7,10 @@ export {
   patchInstanceExperimentalSettingsSchema,
   type InstanceExperimentalSettings,
   type PatchInstanceExperimentalSettings,
+  instanceBackupSettingsSchema,
+  patchInstanceBackupSettingsSchema,
+  type InstanceBackupSettings,
+  type PatchInstanceBackupSettings,
 } from "./instance.js";
 
 export {

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -39,7 +39,18 @@ export const instanceExperimentalSettingsSchema = z.object({
 
 export const patchInstanceExperimentalSettingsSchema = instanceExperimentalSettingsSchema.partial();
 
+export const instanceBackupSettingsSchema = z.object({
+  enabled: z.boolean(),
+  intervalMinutes: z.number().int().min(1).max(10080),
+  retentionDays: z.number().int().min(1).max(3650),
+  dir: z.string().min(1),
+}).strict();
+
+export const patchInstanceBackupSettingsSchema = instanceBackupSettingsSchema.partial();
+
 export type InstanceGeneralSettings = z.infer<typeof instanceGeneralSettingsSchema>;
 export type PatchInstanceGeneralSettings = z.infer<typeof patchInstanceGeneralSettingsSchema>;
 export type InstanceExperimentalSettings = z.infer<typeof instanceExperimentalSettingsSchema>;
 export type PatchInstanceExperimentalSettings = z.infer<typeof patchInstanceExperimentalSettingsSchema>;
+export type InstanceBackupSettings = z.infer<typeof instanceBackupSettingsSchema>;
+export type PatchInstanceBackupSettings = z.infer<typeof patchInstanceBackupSettingsSchema>;

--- a/server/src/config-store.ts
+++ b/server/src/config-store.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { paperclipConfigSchema, type PaperclipConfig } from "@paperclipai/shared";
+import { resolvePaperclipConfigPath } from "./paths.js";
+
+function parseJson(filePath: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  } catch (err) {
+    throw new Error(`Failed to parse JSON at ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+function formatValidationError(err: unknown): string {
+  const issues = (err as { issues?: Array<{ path?: unknown; message?: unknown }> })?.issues;
+  if (Array.isArray(issues) && issues.length > 0) {
+    return issues
+      .map((issue) => {
+        const pathParts = Array.isArray(issue.path) ? issue.path.map(String) : [];
+        const issuePath = pathParts.length > 0 ? pathParts.join(".") : "config";
+        const message = typeof issue.message === "string" ? issue.message : "Invalid value";
+        return `${issuePath}: ${message}`;
+      })
+      .join("; ");
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function readConfigFile(): PaperclipConfig | null {
+  const filePath = resolvePaperclipConfigPath();
+  if (!fs.existsSync(filePath)) return null;
+  const raw = parseJson(filePath);
+  const parsed = paperclipConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Invalid config at ${filePath}: ${formatValidationError(parsed.error)}`);
+  }
+  return parsed.data;
+}
+
+export function writeConfigFile(config: PaperclipConfig): void {
+  const filePath = resolvePaperclipConfigPath();
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+
+  // Backup existing config before overwriting
+  if (fs.existsSync(filePath)) {
+    const backupPath = filePath + ".backup";
+    fs.copyFileSync(filePath, backupPath);
+    fs.chmodSync(backupPath, 0o600);
+  }
+
+  fs.writeFileSync(filePath, JSON.stringify(config, null, 2) + "\n", {
+    mode: 0o600,
+  });
+}
+
+export function updateConfigFile(updater: (config: PaperclipConfig) => PaperclipConfig): PaperclipConfig {
+  const current = readConfigFile();
+  if (!current) {
+    throw new Error("No config file found. Run `paperclipai onboard` first.");
+  }
+  const updated = updater({
+    ...current,
+    $meta: {
+      ...current.$meta,
+      updatedAt: new Date().toISOString(),
+      source: "configure",
+    },
+  });
+  writeConfigFile(updated);
+  return updated;
+}

--- a/server/src/routes/instance-settings.ts
+++ b/server/src/routes/instance-settings.ts
@@ -1,10 +1,17 @@
 import { Router, type Request } from "express";
 import type { Db } from "@paperclipai/db";
-import { patchInstanceExperimentalSettingsSchema, patchInstanceGeneralSettingsSchema } from "@paperclipai/shared";
+import {
+  patchInstanceExperimentalSettingsSchema,
+  patchInstanceGeneralSettingsSchema,
+  patchInstanceBackupSettingsSchema,
+  type InstanceBackupSettings,
+} from "@paperclipai/shared";
 import { forbidden } from "../errors.js";
 import { validate } from "../middleware/validate.js";
 import { instanceSettingsService, logActivity } from "../services/index.js";
 import { getActorInfo } from "./authz.js";
+import { readConfigFile, updateConfigFile } from "../config-store.js";
+import { loadConfig } from "../config.js";
 
 function assertCanManageInstanceSettings(req: Request) {
   if (req.actor.type !== "board") {
@@ -95,6 +102,75 @@ export function instanceSettingsRoutes(db: Db) {
         ),
       );
       res.json(updated.experimental);
+    },
+  );
+
+  router.get("/instance/settings/backup", async (req, res) => {
+    assertCanManageInstanceSettings(req);
+    // Read from runtime config (reflects env vars + config file)
+    const runtimeConfig = loadConfig();
+    const backup: InstanceBackupSettings = {
+      enabled: runtimeConfig.databaseBackupEnabled,
+      intervalMinutes: runtimeConfig.databaseBackupIntervalMinutes,
+      retentionDays: runtimeConfig.databaseBackupRetentionDays,
+      dir: runtimeConfig.databaseBackupDir,
+    };
+    // Also include whether config file exists for UI feedback
+    const configFile = readConfigFile();
+    res.json({
+      ...backup,
+      configFileExists: configFile !== null,
+      requiresRestart: true,
+    });
+  });
+
+  router.patch(
+    "/instance/settings/backup",
+    validate(patchInstanceBackupSettingsSchema),
+    async (req, res) => {
+      assertCanManageInstanceSettings(req);
+      const configFile = readConfigFile();
+      if (!configFile) {
+        res.status(400).json({
+          error: "No config file found. Run `paperclipai onboard` first.",
+        });
+        return;
+      }
+      const updated = updateConfigFile((config) => ({
+        ...config,
+        database: {
+          ...config.database,
+          backup: {
+            ...config.database.backup,
+            ...req.body,
+          },
+        },
+      }));
+      const actor = getActorInfo(req);
+      const companyIds = await svc.listCompanyIds();
+      await Promise.all(
+        companyIds.map((companyId) =>
+          logActivity(db, {
+            companyId,
+            actorType: actor.actorType,
+            actorId: actor.actorId,
+            agentId: actor.agentId,
+            runId: actor.runId,
+            action: "instance.settings.backup_updated",
+            entityType: "instance_settings",
+            entityId: "backup",
+            details: {
+              backup: updated.database.backup,
+              changedKeys: Object.keys(req.body).sort(),
+            },
+          }),
+        ),
+      );
+      res.json({
+        ...updated.database.backup,
+        configFileExists: true,
+        requiresRestart: true,
+      });
     },
   );
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -30,6 +30,7 @@ import { CompanyExport } from "./pages/CompanyExport";
 import { CompanyImport } from "./pages/CompanyImport";
 import { DesignGuide } from "./pages/DesignGuide";
 import { InstanceGeneralSettings } from "./pages/InstanceGeneralSettings";
+import { InstanceBackupSettings } from "./pages/InstanceBackupSettings";
 import { InstanceSettings } from "./pages/InstanceSettings";
 import { InstanceExperimentalSettings } from "./pages/InstanceExperimentalSettings";
 import { PluginManager } from "./pages/PluginManager";
@@ -324,6 +325,7 @@ export function App() {
           <Route path="instance/settings" element={<Layout />}>
             <Route index element={<Navigate to="general" replace />} />
             <Route path="general" element={<InstanceGeneralSettings />} />
+            <Route path="backups" element={<InstanceBackupSettings />} />
             <Route path="heartbeats" element={<InstanceSettings />} />
             <Route path="experimental" element={<InstanceExperimentalSettings />} />
             <Route path="plugins" element={<PluginManager />} />

--- a/ui/src/api/instanceSettings.ts
+++ b/ui/src/api/instanceSettings.ts
@@ -1,10 +1,17 @@
 import type {
   InstanceExperimentalSettings,
   InstanceGeneralSettings,
+  InstanceBackupSettings,
   PatchInstanceGeneralSettings,
   PatchInstanceExperimentalSettings,
+  PatchInstanceBackupSettings,
 } from "@paperclipai/shared";
 import { api } from "./client";
+
+export type InstanceBackupSettingsResponse = InstanceBackupSettings & {
+  configFileExists: boolean;
+  requiresRestart: boolean;
+};
 
 export const instanceSettingsApi = {
   getGeneral: () =>
@@ -15,4 +22,8 @@ export const instanceSettingsApi = {
     api.get<InstanceExperimentalSettings>("/instance/settings/experimental"),
   updateExperimental: (patch: PatchInstanceExperimentalSettings) =>
     api.patch<InstanceExperimentalSettings>("/instance/settings/experimental", patch),
+  getBackup: () =>
+    api.get<InstanceBackupSettingsResponse>("/instance/settings/backup"),
+  updateBackup: (patch: PatchInstanceBackupSettings) =>
+    api.patch<InstanceBackupSettingsResponse>("/instance/settings/backup", patch),
 };

--- a/ui/src/components/InstanceSidebar.tsx
+++ b/ui/src/components/InstanceSidebar.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Clock3, Cpu, FlaskConical, Puzzle, Settings, SlidersHorizontal } from "lucide-react";
+import { Clock3, Cpu, Database, FlaskConical, Puzzle, Settings, SlidersHorizontal } from "lucide-react";
 import { NavLink } from "@/lib/router";
 import { pluginsApi } from "@/api/plugins";
 import { queryKeys } from "@/lib/queryKeys";
@@ -24,6 +24,7 @@ export function InstanceSidebar() {
       <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide flex flex-col gap-4 px-3 py-2">
         <div className="flex flex-col gap-0.5">
           <SidebarNavItem to="/instance/settings/general" label="General" icon={SlidersHorizontal} end />
+          <SidebarNavItem to="/instance/settings/backups" label="Backups" icon={Database} end />
           <SidebarNavItem to="/instance/settings/heartbeats" label="Heartbeats" icon={Clock3} end />
           <SidebarNavItem to="/instance/settings/experimental" label="Experimental" icon={FlaskConical} />
           <SidebarNavItem to="/instance/settings/plugins" label="Plugins" icon={Puzzle} />

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -106,6 +106,7 @@ export const queryKeys = {
     generalSettings: ["instance", "general-settings"] as const,
     schedulerHeartbeats: ["instance", "scheduler-heartbeats"] as const,
     experimentalSettings: ["instance", "experimental-settings"] as const,
+    backupSettings: ["instance", "backup-settings"] as const,
   },
   health: ["health"] as const,
   secrets: {

--- a/ui/src/pages/InstanceBackupSettings.tsx
+++ b/ui/src/pages/InstanceBackupSettings.tsx
@@ -116,9 +116,26 @@ export function InstanceBackupSettings() {
       </div>
 
       {!configFileExists && (
-        <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-          No config file found. Run <code className="font-mono">paperclipai onboard</code> first to
-          create one, or set backup settings via environment variables.
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/5 px-4 py-3 text-sm space-y-2">
+          <p className="font-medium text-amber-600 dark:text-amber-400">
+            No config file found — settings are read-only
+          </p>
+          <p className="text-muted-foreground">
+            Unlike other Instance Settings (which are stored in the database), backup settings are read from{" "}
+            <code className="font-mono text-xs bg-muted px-1 py-0.5 rounded">config.json</code> at server startup.
+            Your instance is currently running on defaults.
+          </p>
+          <p className="text-muted-foreground">
+            To enable editing, either:
+          </p>
+          <ul className="list-disc list-inside text-muted-foreground ml-2 space-y-1">
+            <li>
+              Run <code className="font-mono text-xs bg-muted px-1 py-0.5 rounded">paperclipai onboard</code> to create a config file
+            </li>
+            <li>
+              Or set values via environment variables (see below)
+            </li>
+          </ul>
         </div>
       )}
 

--- a/ui/src/pages/InstanceBackupSettings.tsx
+++ b/ui/src/pages/InstanceBackupSettings.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Database, AlertTriangle } from "lucide-react";
+import { instanceSettingsApi } from "@/api/instanceSettings";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { queryKeys } from "../lib/queryKeys";
+import { Button } from "@/components/ui/button";
+import {
+  Field,
+  ToggleField,
+  HintIcon,
+} from "../components/agent-config-primitives";
+
+export function InstanceBackupSettings() {
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const queryClient = useQueryClient();
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pendingSave, setPendingSave] = useState(false);
+
+  // Local form state
+  const [enabled, setEnabled] = useState(true);
+  const [intervalMinutes, setIntervalMinutes] = useState(60);
+  const [retentionDays, setRetentionDays] = useState(30);
+  const [dir, setDir] = useState("");
+
+  useEffect(() => {
+    setBreadcrumbs([
+      { label: "Instance Settings" },
+      { label: "Backups" },
+    ]);
+  }, [setBreadcrumbs]);
+
+  const backupQuery = useQuery({
+    queryKey: queryKeys.instance.backupSettings,
+    queryFn: () => instanceSettingsApi.getBackup(),
+  });
+
+  // Sync form state from query
+  useEffect(() => {
+    if (backupQuery.data) {
+      setEnabled(backupQuery.data.enabled);
+      setIntervalMinutes(backupQuery.data.intervalMinutes);
+      setRetentionDays(backupQuery.data.retentionDays);
+      setDir(backupQuery.data.dir);
+    }
+  }, [backupQuery.data]);
+
+  const isDirty =
+    backupQuery.data &&
+    (enabled !== backupQuery.data.enabled ||
+      intervalMinutes !== backupQuery.data.intervalMinutes ||
+      retentionDays !== backupQuery.data.retentionDays ||
+      dir !== backupQuery.data.dir);
+
+  const updateMutation = useMutation({
+    mutationFn: async () => {
+      setPendingSave(true);
+      return instanceSettingsApi.updateBackup({
+        enabled,
+        intervalMinutes,
+        retentionDays,
+        dir,
+      });
+    },
+    onSuccess: async () => {
+      setActionError(null);
+      setPendingSave(false);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.instance.backupSettings });
+    },
+    onError: (error) => {
+      setPendingSave(false);
+      setActionError(error instanceof Error ? error.message : "Failed to update backup settings.");
+    },
+  });
+
+  if (backupQuery.isLoading) {
+    return <div className="text-sm text-muted-foreground">Loading backup settings...</div>;
+  }
+
+  if (backupQuery.error) {
+    return (
+      <div className="text-sm text-destructive">
+        {backupQuery.error instanceof Error
+          ? backupQuery.error.message
+          : "Failed to load backup settings."}
+      </div>
+    );
+  }
+
+  const configFileExists = backupQuery.data?.configFileExists ?? false;
+
+  return (
+    <div className="max-w-4xl space-y-6">
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Database className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">Database Backups</h1>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Configure automatic database backup schedule and retention policy.
+        </p>
+      </div>
+
+      {/* Restart warning */}
+      <div className="flex items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/5 px-4 py-3">
+        <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0 mt-0.5" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-amber-600 dark:text-amber-400">
+            Server restart required
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Changes to backup settings are saved to the config file but only take effect after
+            restarting the Paperclip server. The current running settings are shown below.
+          </p>
+        </div>
+      </div>
+
+      {!configFileExists && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          No config file found. Run <code className="font-mono">paperclipai onboard</code> first to
+          create one, or set backup settings via environment variables.
+        </div>
+      )}
+
+      {actionError && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          {actionError}
+        </div>
+      )}
+
+      {updateMutation.isSuccess && !isDirty && (
+        <div className="rounded-md border border-green-500/40 bg-green-500/5 px-3 py-2 text-sm text-green-600 dark:text-green-400">
+          Settings saved to config file. Restart the server to apply changes.
+        </div>
+      )}
+
+      <section className="rounded-xl border border-border bg-card p-5 space-y-5">
+        <ToggleField
+          label="Enable automatic backups"
+          hint="When enabled, the database is backed up automatically on a schedule."
+          checked={enabled}
+          onChange={setEnabled}
+        />
+
+        <Field
+          label="Backup interval"
+          hint="How often to create a new backup (1-10080 minutes, i.e., up to 7 days)."
+        >
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              min={1}
+              max={10080}
+              value={intervalMinutes}
+              onChange={(e) => setIntervalMinutes(Math.max(1, Math.min(10080, Number(e.target.value) || 1)))}
+              className="w-24 rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none"
+            />
+            <span className="text-sm text-muted-foreground">minutes</span>
+            <span className="text-xs text-muted-foreground ml-2">
+              ({Math.floor(intervalMinutes / 60)}h {intervalMinutes % 60}m)
+            </span>
+          </div>
+        </Field>
+
+        <Field
+          label="Retention period"
+          hint="How long to keep old backups before automatic deletion (1-3650 days)."
+        >
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              min={1}
+              max={3650}
+              value={retentionDays}
+              onChange={(e) => setRetentionDays(Math.max(1, Math.min(3650, Number(e.target.value) || 1)))}
+              className="w-24 rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none"
+            />
+            <span className="text-sm text-muted-foreground">days</span>
+          </div>
+        </Field>
+
+        <Field
+          label="Backup directory"
+          hint="Where backup files are stored. Supports ~ for home directory."
+        >
+          <input
+            type="text"
+            value={dir}
+            onChange={(e) => setDir(e.target.value)}
+            placeholder="~/.paperclip/instances/default/data/backups"
+            className="w-full rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm font-mono outline-none"
+          />
+        </Field>
+      </section>
+
+      {/* Alternative: Environment Variables */}
+      <section className="rounded-xl border border-border bg-card/50 p-5 space-y-3">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold">Alternative: Environment Variables</h2>
+          <HintIcon text="Environment variables override config file settings and also require a server restart." />
+        </div>
+        <p className="text-sm text-muted-foreground">
+          You can also configure backups via environment variables. These take precedence over the config file.
+        </p>
+        <div className="rounded-md bg-muted/30 p-3 font-mono text-xs space-y-1">
+          <div><span className="text-muted-foreground">PAPERCLIP_DB_BACKUP_ENABLED=</span>true</div>
+          <div><span className="text-muted-foreground">PAPERCLIP_DB_BACKUP_INTERVAL_MINUTES=</span>60</div>
+          <div><span className="text-muted-foreground">PAPERCLIP_DB_BACKUP_RETENTION_DAYS=</span>30</div>
+          <div><span className="text-muted-foreground">PAPERCLIP_DB_BACKUP_DIR=</span>~/.paperclip/instances/default/data/backups</div>
+        </div>
+      </section>
+
+      {/* Save button */}
+      {configFileExists && (
+        <div className="flex items-center gap-3">
+          <Button
+            onClick={() => updateMutation.mutate()}
+            disabled={!isDirty || pendingSave}
+          >
+            {pendingSave ? "Saving..." : "Save to config file"}
+          </Button>
+          {isDirty && (
+            <span className="text-xs text-muted-foreground">
+              You have unsaved changes
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Motivation

Users asked for a UI to configure the automatic database backup schedule instead of editing `config.json` or env vars manually.

## What's in it

- **New page:** `Instance Settings → Backups` with fields for interval, retention days, and directory
- **New config-store** on the server persists backup settings to `config.json` (the settings still require a server restart to take effect — clearly messaged in the UI to set expectations)
- **New API:** `GET/PATCH /api/instance-settings/backups`
- **Sidebar entry** under Instance Settings

## Limitations (documented in the UI)

- Changes require server restart — existing backup scheduler reads config at boot
- If no `config.json` exists, settings are read-only (UI surfaces this clearly)

## PR notes

Rebased onto current master. Reconciled conflicts in `packages/shared/src/index.ts`, `packages/shared/src/validators/index.ts` (added the new `instanceBackupSettingsSchema` exports on top of upstream's evolved export lists), and `ui/src/components/InstanceSidebar.tsx` (merged the new `Database` icon import with upstream's `Cpu` addition).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)