### PR TITLE
feat(openclaw-gateway): forward config.model + populate model list + NewIssueDialog support

### DIFF
--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -1,7 +1,18 @@
 export const type = "openclaw_gateway";
 export const label = "OpenClaw Gateway";
 
-export const models: { id: string; label: string }[] = [];
+export const models: { id: string; label: string }[] = [
+  { id: "anthropic/claude-opus-4-6", label: "Claude Opus 4.6" },
+  { id: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+  { id: "anthropic/claude-opus-4-5", label: "Claude Opus 4.5" },
+  { id: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+  { id: "anthropic/claude-haiku-4-5", label: "Claude Haiku 4.5" },
+  { id: "openai-codex/gpt-5.4", label: "GPT-5.4" },
+  { id: "openai-codex/gpt-5.4-mini", label: "GPT-5.4 Mini" },
+  { id: "openai-codex/gpt-5.3-codex", label: "GPT-5.3 Codex" },
+  { id: "openai-codex/gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark" },
+  { id: "google/gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+];
 
 export const agentConfigurationDoc = `# openclaw_gateway agent configuration
 

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1092,6 +1092,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const headers = toStringRecord(ctx.config.headers);
   const authToken = resolveAuthToken(parseObject(ctx.config), headers);
   const password = nonEmpty(ctx.config.password);
+  const model = nonEmpty(ctx.config.model);
   const deviceToken = nonEmpty(ctx.config.deviceToken);
 
   if (authToken && !headerMapHasIgnoreCase(headers, "authorization")) {
@@ -1148,6 +1149,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   if (typeof agentParams.timeout !== "number") {
     agentParams.timeout = waitTimeoutMs;
+  }
+
+  if (model && !("model" in agentParams)) {
+    agentParams.model = model;
   }
 
   if (ctx.onMeta) {

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -133,6 +133,9 @@ const ISSUE_THINKING_EFFORT_OPTIONS = {
     { value: "xhigh", label: "X-High" },
     { value: "max", label: "Max" },
   ],
+  openclaw_gateway: [
+    { value: "", label: "Default" },
+  ],
 } as const;
 
 function isIssueWorkMode(value: unknown): value is IssueWorkMode {
@@ -866,7 +869,9 @@ export function NewIssueDialog() {
         ? ISSUE_THINKING_EFFORT_OPTIONS.codex_local
         : assigneeAdapterType === "opencode_local"
           ? ISSUE_THINKING_EFFORT_OPTIONS.opencode_local
-          : ISSUE_THINKING_EFFORT_OPTIONS.claude_local;
+          : assigneeAdapterType === "openclaw_gateway"
+            ? ISSUE_THINKING_EFFORT_OPTIONS.openclaw_gateway
+            : ISSUE_THINKING_EFFORT_OPTIONS.claude_local;
     if (!validThinkingValues.some((option) => option.value === assigneeThinkingEffort)) {
       setAssigneeThinkingEffort("");
     }
@@ -1100,13 +1105,17 @@ export function NewIssueDialog() {
         ? "Codex options"
         : assigneeAdapterType === "opencode_local"
           ? "OpenCode options"
-        : "Agent options";
+          : assigneeAdapterType === "openclaw_gateway"
+            ? "OpenClaw options"
+            : "Agent options";
   const thinkingEffortOptions =
     assigneeAdapterType === "codex_local"
       ? ISSUE_THINKING_EFFORT_OPTIONS.codex_local
       : assigneeAdapterType === "opencode_local"
         ? ISSUE_THINKING_EFFORT_OPTIONS.opencode_local
-      : ISSUE_THINKING_EFFORT_OPTIONS.claude_local;
+        : assigneeAdapterType === "openclaw_gateway"
+          ? ISSUE_THINKING_EFFORT_OPTIONS.openclaw_gateway
+          : ISSUE_THINKING_EFFORT_OPTIONS.claude_local;
   const recentAssigneeIds = useMemo(() => getRecentAssigneeIds(), [newIssueOpen]);
   const recentAssigneeOptionIds = useMemo(
     () => recentAssigneeIds.map((id) => assigneeValueFromSelection({ assigneeAgentId: id })),

--- a/ui/src/lib/issue-assignee-overrides.ts
+++ b/ui/src/lib/issue-assignee-overrides.ts
@@ -2,6 +2,7 @@ export const ISSUE_OVERRIDE_ADAPTER_TYPES = new Set([
   "claude_local",
   "codex_local",
   "opencode_local",
+  "openclaw_gateway",
 ]);
 
 export type IssueModelLane = "primary" | "cheap" | "custom";


### PR DESCRIPTION
Enables per-issue model selection for OpenClaw gateway agents dispatched from Paperclip.

## Changes

- **`packages/adapters/openclaw-gateway/src/index.ts`:** populate the static models list (Claude, GPT, Gemini variants) so the UI model picker has options for this adapter type
- **`packages/adapters/openclaw-gateway/src/server/execute.ts`:** extract `config.model` and forward it into `agentParams` so the remote OpenClaw agent receives the per-issue override
- **`ui/src/components/NewIssueDialog.tsx`:** add `openclaw_gateway` to `ISSUE_OVERRIDE_ADAPTER_TYPES`, the thinking-effort option chain, and the model-override dropdown label/option chains

With these, creating an issue assigned to an OpenClaw gateway agent shows the model picker in the UI, and the chosen model is forwarded to the remote agent at dispatch time.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)