### PR TITLE
feat(heartbeat): proactive self-assignment toggle with scope selector

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2589,11 +2589,23 @@ export function heartbeatService(db: Db) {
     const runtimeConfig = parseObject(agent.runtimeConfig);
     const heartbeat = parseObject(runtimeConfig.heartbeat);
 
+    const proactiveAssignmentScopeRaw = typeof heartbeat.proactiveAssignmentScope === "string"
+      ? heartbeat.proactiveAssignmentScope
+      : undefined;
+    const validScopes = ["todo", "backlog", "both"] as const;
+    type ProactiveScope = typeof validScopes[number];
+    const normalizedScope: ProactiveScope =
+      validScopes.includes(proactiveAssignmentScopeRaw as ProactiveScope)
+        ? (proactiveAssignmentScopeRaw as ProactiveScope)
+        : "backlog";
+
     return {
       enabled: asBoolean(heartbeat.enabled, false),
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      proactiveAssignment: asBoolean(heartbeat.proactiveAssignment, false),
+      proactiveAssignmentScope: normalizedScope,
     };
   }
 
@@ -3408,9 +3420,12 @@ export function heartbeatService(db: Db) {
       runScopedMentionedSkillKeys,
     );
     const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId);
+    const heartbeatPolicy = parseHeartbeatPolicy(agent);
     const runtimeConfig = {
       ...effectiveResolvedConfig,
       paperclipRuntimeSkills: runtimeSkillEntries,
+      proactiveAssignment: heartbeatPolicy.proactiveAssignment,
+      proactiveAssignmentScope: heartbeatPolicy.proactiveAssignmentScope,
     };
     const workspaceOperationRecorder = workspaceOperationsSvc.createRecorder({
       companyId: agent.companyId,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -21,6 +21,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { FolderOpen, Heart, ChevronDown, X } from "lucide-react";
 import { cn } from "../lib/utils";
@@ -904,6 +911,33 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 )}
                 onChange={(v) => mark("heartbeat", "wakeOnDemand", v)}
               />
+              <ToggleField
+                label="Proactive self-assignment"
+                hint="When no issues are assigned and the heartbeat fires, agent will scan for and claim unassigned work."
+                checked={eff(
+                  "heartbeat",
+                  "proactiveAssignment",
+                  !!heartbeat.proactiveAssignment,
+                )}
+                onChange={(v) => mark("heartbeat", "proactiveAssignment", v)}
+              />
+              {eff("heartbeat", "proactiveAssignment", !!heartbeat.proactiveAssignment) && (
+                <Field label="Self-assignment scope of unassigned issues" hint="Which issue statuses to scan for unassigned work.">
+                  <Select
+                    value={eff("heartbeat", "proactiveAssignmentScope", (heartbeat.proactiveAssignmentScope as string) || "backlog")}
+                    onValueChange={(v) => mark("heartbeat", "proactiveAssignmentScope", v)}
+                  >
+                    <SelectTrigger className="w-full h-8 text-sm font-mono">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="backlog">Backlog only</SelectItem>
+                      <SelectItem value="todo">Todo only</SelectItem>
+                      <SelectItem value="both">Todo then backlog</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </Field>
+              )}
               <Field label="Cooldown (sec)" hint={help.cooldownSec}>
                 <DraftNumberInput
                   value={eff(


### PR DESCRIPTION
Adds a new heartbeat policy option: when a heartbeat fires and the agent has no assigned work, optionally scan for unassigned issues and claim one. Off by default.

## Configuration (on the agent, `runtimeConfig.heartbeat`)

- `proactiveAssignment: boolean` — enable the feature
- `proactiveAssignmentScope: "todo" | "backlog" | "both"` — which issue statuses to scan. Default `backlog`.

## Changes

- **`server/src/services/heartbeat.ts`:** parse both fields in `parseHeartbeatPolicy` and plumb them into the `runtimeConfig` passed to the adapter so agents see the policy in their context
- **`ui/src/components/AgentConfigForm.tsx`:** new `ToggleField` + Radix `Select` under the Advanced Run Policy section

The actual proactive-claim logic lives in agent runtime code (not in this PR) — this PR is the config plumbing needed to surface the toggle/scope to an agent runtime that implements the behavior.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)