### PR TITLE
fix(heartbeat): default intervalSec to 300, deep-merge runtimeConfig on PATCH

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2020,6 +2020,12 @@ export function agentRoutes(db: Db) {
       );
     }
 
+    if (hasOwn(patchData, "runtimeConfig")) {
+      const existingRuntimeConfig = asRecord(existing.runtimeConfig) ?? {};
+      const requestedRuntimeConfig = asRecord(patchData.runtimeConfig) ?? {};
+      patchData.runtimeConfig = { ...existingRuntimeConfig, ...requestedRuntimeConfig };
+    }
+
     const actor = getActorInfo(req);
     const agent = await svc.update(id, patchData, {
       recordRevision: {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2591,7 +2591,7 @@ export function heartbeatService(db: Db) {
 
     return {
       enabled: asBoolean(heartbeat.enabled, false),
-      intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
+      intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 300)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
     };


### PR DESCRIPTION
Two related fixes.

## 1. Default `intervalSec` 0 → 300

`parseHeartbeatPolicy` fell back to `0` when heartbeat was enabled but no interval was configured. That caused the scheduler to fire in a tight loop. The UI already defaults to 300 (`AgentConfigForm.tsx: Number(heartbeat.intervalSec ?? 300)`), so this aligns the server default with the client default.

## 2. Deep-merge `runtimeConfig` on PATCH

`PATCH /api/agents/:id` was replacing `runtimeConfig` wholesale when it was present in the patch body. Partial UI submits (e.g. saving only a heartbeat field) were clobbering sibling fields in `runtimeConfig`.

Now: when `runtimeConfig` is present on the patch, merge `{ ...existing, ...requested }` before handing to `svc.update()`.

Shallow merge only — matches the expected UX where users submit a top-level replacement for a single config group (`heartbeat`, `workspace`, etc.) and the rest is preserved.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)