### PR TITLE
feat: notify human via Discord/Telegram when agent is blocked or needs help

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -86,6 +86,9 @@ export interface Config {
   heartbeatSchedulerIntervalMs: number;
   companyDeletionEnabled: boolean;
   telemetryEnabled: boolean;
+  notificationDiscordWebhookUrl: string | undefined;
+  notificationTelegramBotToken: string | undefined;
+  notificationTelegramChatId: string | undefined;
 }
 
 function detectTailnetBindHost(): string | undefined {
@@ -331,5 +334,8 @@ export function loadConfig(): Config {
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
     companyDeletionEnabled,
     telemetryEnabled: fileConfig?.telemetry?.enabled ?? true,
+    notificationDiscordWebhookUrl: process.env.PAPERCLIP_NOTIFICATION_DISCORD_WEBHOOK_URL || undefined,
+    notificationTelegramBotToken: process.env.PAPERCLIP_NOTIFICATION_TELEGRAM_BOT_TOKEN || undefined,
+    notificationTelegramChatId: process.env.PAPERCLIP_NOTIFICATION_TELEGRAM_CHAT_ID || undefined,
   };
 }

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -9,6 +9,7 @@ import { sanitizeRecord } from "../redaction.js";
 import { logger } from "../middleware/logger.js";
 import type { PluginEventBus } from "./plugin-event-bus.js";
 import { instanceSettingsService } from "./instance-settings.js";
+import { dispatchNotification } from "./notification-dispatcher.js";
 
 const PLUGIN_EVENT_SET: ReadonlySet<string> = new Set(PLUGIN_EVENT_TYPES);
 
@@ -90,5 +91,49 @@ export async function logActivity(db: Db, input: LogActivityInput) {
         logger.warn({ pluginId, eventType: event.eventType, err: error }, "plugin event handler failed");
       }
     }).catch(() => {});
+  }
+
+  // Notify human when agent needs help
+  void dispatchHumanEscalation(input).catch(() => {});
+}
+
+const HELP_KEYWORDS = /\b(need(?:s)? help|blocked|stuck|cannot proceed|human (?:input|needed|required)|escalat)/i;
+
+async function dispatchHumanEscalation(input: LogActivityInput): Promise<void> {
+  const details = input.details as Record<string, unknown> | null;
+  if (!details) return;
+
+  const identifier = (details.identifier as string) ?? null;
+  const issueTitle = (details.title as string) ?? (details.issueTitle as string) ?? null;
+
+  // Trigger 1: Issue status changed to "blocked" by an agent
+  if (
+    input.action === "issue.updated" &&
+    input.actorType === "agent" &&
+    details.status === "blocked"
+  ) {
+    await dispatchNotification({
+      title: "Agent blocked — needs human input",
+      body: `An agent marked ${identifier ?? input.entityId.slice(0, 8)} as blocked.`,
+      issueIdentifier: identifier,
+      issueTitle,
+    });
+    return;
+  }
+
+  // Trigger 2: Agent comment contains help-seeking keywords
+  if (
+    input.action === "issue.comment_added" &&
+    input.actorType === "agent" &&
+    typeof details.bodySnippet === "string" &&
+    HELP_KEYWORDS.test(details.bodySnippet)
+  ) {
+    await dispatchNotification({
+      title: "Agent requesting help",
+      body: `${(details.bodySnippet as string).slice(0, 200)}`,
+      issueIdentifier: identifier,
+      issueTitle,
+    });
+    return;
   }
 }

--- a/server/src/services/notification-dispatcher.ts
+++ b/server/src/services/notification-dispatcher.ts
@@ -1,0 +1,74 @@
+import { loadConfig } from "../config.js";
+import { logger } from "../middleware/logger.js";
+
+interface NotificationPayload {
+  title: string;
+  body: string;
+  issueIdentifier?: string | null;
+  issueTitle?: string | null;
+  agentName?: string | null;
+  url?: string;
+}
+
+async function postDiscord(webhookUrl: string, payload: NotificationPayload) {
+  const embed = {
+    title: payload.title,
+    description: payload.body,
+    color: 0xff6b6b, // red-ish for attention
+    fields: [
+      ...(payload.issueIdentifier
+        ? [{ name: "Issue", value: payload.issueIdentifier, inline: true }]
+        : []),
+      ...(payload.agentName
+        ? [{ name: "Agent", value: payload.agentName, inline: true }]
+        : []),
+    ],
+    timestamp: new Date().toISOString(),
+  };
+
+  await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ embeds: [embed] }),
+  });
+}
+
+async function postTelegram(botToken: string, chatId: string, payload: NotificationPayload) {
+  const text = [
+    `*${payload.title}*`,
+    payload.body,
+    payload.issueIdentifier ? `Issue: \`${payload.issueIdentifier}\`` : null,
+    payload.agentName ? `Agent: ${payload.agentName}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: "Markdown" }),
+  });
+}
+
+export async function dispatchNotification(payload: NotificationPayload): Promise<void> {
+  const config = loadConfig();
+  const promises: Promise<void>[] = [];
+
+  if (config.notificationDiscordWebhookUrl) {
+    promises.push(
+      postDiscord(config.notificationDiscordWebhookUrl, payload).catch((err) =>
+        logger.warn({ err }, "failed to send Discord notification"),
+      ),
+    );
+  }
+
+  if (config.notificationTelegramBotToken && config.notificationTelegramChatId) {
+    promises.push(
+      postTelegram(config.notificationTelegramBotToken, config.notificationTelegramChatId, payload).catch(
+        (err) => logger.warn({ err }, "failed to send Telegram notification"),
+      ),
+    );
+  }
+
+  await Promise.allSettled(promises);
+}


### PR DESCRIPTION
Optional human-escalation notifications. Opt-in via env vars; no-op when unset.

## Motivation

When an agent marks an issue `blocked` or posts a comment with help-seeking keywords ("stuck", "need help", etc.), there's no signal to the human operator other than checking the UI. This adds a push-style notification so operators don't have to poll.

## How it works

New `notification-dispatcher` service fires when `activity-log` records specific events (status → blocked, help-keywords in comments). Supports Discord webhook and/or Telegram bot in parallel — both optional.

## Configuration

All env-var driven; no DB settings:

- `PAPERCLIP_NOTIFICATION_DISCORD_WEBHOOK_URL`
- `PAPERCLIP_NOTIFICATION_TELEGRAM_BOT_TOKEN` + `PAPERCLIP_NOTIFICATION_TELEGRAM_CHAT_ID`

When none set, no HTTP calls are made.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)