### PR TITLE
fix(approvals): wake requester on reject and request revision

### DIFF
--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -252,6 +252,53 @@ describe("approval routes idempotent retries", () => {
     expect(mockApprovalService.reject).toHaveBeenCalledWith("approval-5", "user-1", "not now");
   });
 
+  it("wakes the requesting agent after reject is applied", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-5b",
+      companyId: "company-1",
+      type: "hire_agent",
+      status: "pending",
+      payload: {},
+      requestedByAgentId: "agent-9",
+    });
+    mockApprovalService.reject.mockResolvedValue({
+      approval: {
+        id: "approval-5b",
+        companyId: "company-1",
+        type: "hire_agent",
+        status: "rejected",
+        payload: {},
+        requestedByAgentId: "agent-9",
+      },
+      applied: true,
+    });
+
+    const res = await request(await createApp())
+      .post("/api/approvals/approval-5b/reject")
+      .send({ decisionNote: "not now" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueApprovalService.listIssuesForApproval).toHaveBeenCalledWith("approval-5b");
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "agent-9",
+      expect.objectContaining({
+        reason: "approval_rejected",
+        payload: expect.objectContaining({
+          approvalId: "approval-5b",
+          approvalStatus: "rejected",
+          issueId: "issue-1",
+          issueIds: ["issue-1"],
+        }),
+        contextSnapshot: expect.objectContaining({
+          source: "approval.rejected",
+          wakeReason: "approval_rejected",
+          issueId: "issue-1",
+          issueIds: ["issue-1"],
+        }),
+      }),
+    );
+  });
+
   it("derives approval attribution from the authenticated actor on request revision", async () => {
     mockApprovalService.getById.mockResolvedValue({
       id: "approval-6",
@@ -277,6 +324,50 @@ describe("approval routes idempotent retries", () => {
       "approval-6",
       "user-1",
       "Need changes",
+    );
+  });
+
+  it("wakes the requesting agent after request revision", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-6b",
+      companyId: "company-1",
+      type: "hire_agent",
+      status: "pending",
+      payload: {},
+      requestedByAgentId: "agent-7",
+    });
+    mockApprovalService.requestRevision.mockResolvedValue({
+      id: "approval-6b",
+      companyId: "company-1",
+      type: "hire_agent",
+      status: "revision_requested",
+      payload: {},
+      requestedByAgentId: "agent-7",
+    });
+
+    const res = await request(await createApp())
+      .post("/api/approvals/approval-6b/request-revision")
+      .send({ decisionNote: "Need changes" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueApprovalService.listIssuesForApproval).toHaveBeenCalledWith("approval-6b");
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "agent-7",
+      expect.objectContaining({
+        reason: "approval_revision_requested",
+        payload: expect.objectContaining({
+          approvalId: "approval-6b",
+          approvalStatus: "revision_requested",
+          issueId: "issue-1",
+          issueIds: ["issue-1"],
+        }),
+        contextSnapshot: expect.objectContaining({
+          source: "approval.revision_requested",
+          wakeReason: "approval_revision_requested",
+          issueId: "issue-1",
+          issueIds: ["issue-1"],
+        }),
+      }),
     );
   });
 

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -43,6 +43,89 @@ export function approvalRoutes(db: Db) {
     return approval;
   }
 
+  async function queueRequesterWakeup(
+    req: Request,
+    approval: Awaited<ReturnType<typeof svc.getById>> extends infer T ? NonNullable<T> : never,
+    opts: {
+      sourceAction: "approval.approved" | "approval.rejected" | "approval.revision_requested";
+      wakeReason: "approval_approved" | "approval_rejected" | "approval_revision_requested";
+      linkedIssueIds?: string[];
+    },
+  ) {
+    if (!approval.requestedByAgentId) {
+      return;
+    }
+
+    const linkedIssueIds =
+      opts.linkedIssueIds
+      ?? (await issueApprovalsSvc.listIssuesForApproval(approval.id)).map((issue) => issue.id);
+    const primaryIssueId = linkedIssueIds[0] ?? null;
+
+    try {
+      const wakeRun = await heartbeat.wakeup(approval.requestedByAgentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: opts.wakeReason,
+        payload: {
+          approvalId: approval.id,
+          approvalStatus: approval.status,
+          issueId: primaryIssueId,
+          issueIds: linkedIssueIds,
+        },
+        requestedByActorType: "user",
+        requestedByActorId: req.actor.userId ?? "board",
+        contextSnapshot: {
+          source: opts.sourceAction,
+          approvalId: approval.id,
+          approvalStatus: approval.status,
+          issueId: primaryIssueId,
+          issueIds: linkedIssueIds,
+          taskId: primaryIssueId,
+          wakeReason: opts.wakeReason,
+        },
+      });
+
+      await logActivity(db, {
+        companyId: approval.companyId,
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
+        action: "approval.requester_wakeup_queued",
+        entityType: "approval",
+        entityId: approval.id,
+        details: {
+          requesterAgentId: approval.requestedByAgentId,
+          wakeRunId: wakeRun?.id ?? null,
+          wakeReason: opts.wakeReason,
+          linkedIssueIds,
+        },
+      });
+    } catch (err) {
+      logger.warn(
+        {
+          err,
+          approvalId: approval.id,
+          requestedByAgentId: approval.requestedByAgentId,
+          wakeReason: opts.wakeReason,
+        },
+        "failed to queue requester wakeup after approval update",
+      );
+      await logActivity(db, {
+        companyId: approval.companyId,
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
+        action: "approval.requester_wakeup_failed",
+        entityType: "approval",
+        entityId: approval.id,
+        details: {
+          requesterAgentId: approval.requestedByAgentId,
+          wakeReason: opts.wakeReason,
+          linkedIssueIds,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
+    }
+  }
+
   router.get("/companies/:companyId/approvals", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -156,68 +239,11 @@ export function approvalRoutes(db: Db) {
         },
       });
 
-      if (approval.requestedByAgentId) {
-        try {
-          const wakeRun = await heartbeat.wakeup(approval.requestedByAgentId, {
-            source: "automation",
-            triggerDetail: "system",
-            reason: "approval_approved",
-            payload: {
-              approvalId: approval.id,
-              approvalStatus: approval.status,
-              issueId: primaryIssueId,
-              issueIds: linkedIssueIds,
-            },
-            requestedByActorType: "user",
-            requestedByActorId: req.actor.userId ?? "board",
-            contextSnapshot: {
-              source: "approval.approved",
-              approvalId: approval.id,
-              approvalStatus: approval.status,
-              issueId: primaryIssueId,
-              issueIds: linkedIssueIds,
-              taskId: primaryIssueId,
-              wakeReason: "approval_approved",
-            },
-          });
-
-          await logActivity(db, {
-            companyId: approval.companyId,
-            actorType: "user",
-            actorId: req.actor.userId ?? "board",
-            action: "approval.requester_wakeup_queued",
-            entityType: "approval",
-            entityId: approval.id,
-            details: {
-              requesterAgentId: approval.requestedByAgentId,
-              wakeRunId: wakeRun?.id ?? null,
-              linkedIssueIds,
-            },
-          });
-        } catch (err) {
-          logger.warn(
-            {
-              err,
-              approvalId: approval.id,
-              requestedByAgentId: approval.requestedByAgentId,
-            },
-            "failed to queue requester wakeup after approval",
-          );
-          await logActivity(db, {
-            companyId: approval.companyId,
-            actorType: "user",
-            actorId: req.actor.userId ?? "board",
-            action: "approval.requester_wakeup_failed",
-            entityType: "approval",
-            entityId: approval.id,
-            details: {
-              requesterAgentId: approval.requestedByAgentId,
-              linkedIssueIds,
-              error: err instanceof Error ? err.message : String(err),
-            },
-          });
-        }
-      }
+      await queueRequesterWakeup(req, approval, {
+        sourceAction: "approval.approved",
+        wakeReason: "approval_approved",
+        linkedIssueIds,
+      });
     }
 
     res.json(redactApprovalPayload(approval));
@@ -242,6 +268,11 @@ export function approvalRoutes(db: Db) {
         entityType: "approval",
         entityId: approval.id,
         details: { type: approval.type },
+      });
+
+      await queueRequesterWakeup(req, approval, {
+        sourceAction: "approval.rejected",
+        wakeReason: "approval_rejected",
       });
     }
 
@@ -269,6 +300,11 @@ export function approvalRoutes(db: Db) {
         entityType: "approval",
         entityId: approval.id,
         details: { type: approval.type },
+      });
+
+      await queueRequesterWakeup(req, approval, {
+        sourceAction: "approval.revision_requested",
+        wakeReason: "approval_revision_requested",
       });
 
       res.json(redactApprovalPayload(approval));


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The approvals subsystem is part of the control-plane loop between board users and requesting agents
> - `approve` already wakes the requesting agent so the agent can continue after a decision is made
> - `reject` and `request-revision` changed approval state and logged activity, but they did not wake the requesting agent
> - That left revision and rejection flows stuck until a later timer heartbeat, which breaks the approval feedback loop for reactive agents
> - This pull request extends the existing requester-wakeup pattern to `reject` and `request-revision` without changing approval semantics
> - The benefit is that approval outcomes reach the requesting agent immediately instead of waiting for a later poll

## What Changed

- Added a small approval-route helper that queues requester wakeups for approval decisions using the same payload/context shape as the existing approve flow
- Wired `POST /api/approvals/:id/reject` to wake the requesting agent with `reason: "approval_rejected"` after a newly applied rejection
- Wired `POST /api/approvals/:id/request-revision` to wake the requesting agent with `reason: "approval_revision_requested"`
- Kept the existing `approve` wakeup behavior, but routed it through the shared helper so the decision paths stay aligned
- Added regression assertions covering requester wakeups for both reject and request-revision routes
- Fixes #3780

## Verification

- `pnpm --filter @paperclipai/server exec tsc --noEmit`
- Attempted: `pnpm exec vitest run server/src/__tests__/approval-routes-idempotency.test.ts`
  Current local `master` checkout fails before executing the suite because Vitest cannot resolve the existing dynamic import path in that test harness (`Cannot find module ../middleware/index.js`), so I could not get a clean local pass from that file in this environment

## Risks

- Low risk. This is limited to approval route wakeup behavior and does not change approval state transitions.
- The main behavioral change is that requesting agents now receive immediate wakeups on rejection and revision requests instead of waiting for a later timer heartbeat.
- `approve` now shares the same helper path as the other approval decisions; the helper preserves the existing wake payload/context shape and avoids an extra linked-issue lookup on the approve path.

## Model Used

- OpenAI Codex, GPT-5-based coding agent with terminal tool use and local code execution. Exact internal deployment ID and exposed context-window size were not surfaced in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
