### PR TITLE
fix(server): respect configured host when probing ports

### DIFF
--- a/server/src/__tests__/port-detection.test.ts
+++ b/server/src/__tests__/port-detection.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { detectPortMock } = vi.hoisted(() => ({
+  detectPortMock: vi.fn(),
+}));
+
+vi.mock("detect-port", () => ({
+  default: detectPortMock,
+}));
+
+import { detectAvailablePort } from "../port-detection.js";
+
+describe("detectAvailablePort", () => {
+  beforeEach(() => {
+    detectPortMock.mockReset();
+  });
+
+  it("probes only the configured host when one is provided", async () => {
+    detectPortMock.mockResolvedValue(3100);
+
+    await expect(detectAvailablePort(3100, "127.0.0.1")).resolves.toBe(3100);
+
+    expect(detectPortMock).toHaveBeenCalledWith({
+      port: 3100,
+      hostname: "127.0.0.1",
+    });
+  });
+
+  it("falls back to default detect-port probing when host is blank", async () => {
+    detectPortMock.mockResolvedValue(3101);
+
+    await expect(detectAvailablePort(3100, "  ")).resolves.toBe(3101);
+
+    expect(detectPortMock).toHaveBeenCalledWith(3100);
+  });
+});

--- a/server/src/__tests__/port-detection.test.ts
+++ b/server/src/__tests__/port-detection.test.ts
@@ -33,4 +33,12 @@ describe("detectAvailablePort", () => {
 
     expect(detectPortMock).toHaveBeenCalledWith(3100);
   });
+
+  it("falls back to default detect-port probing when host is undefined", async () => {
+    detectPortMock.mockResolvedValue(3102);
+
+    await expect(detectAvailablePort(3100)).resolves.toBe(3102);
+
+    expect(detectPortMock).toHaveBeenCalledWith(3100);
+  });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -10,7 +10,10 @@ const {
 } = vi.hoisted(() => {
   const createAppMock = vi.fn(async () => ((_: unknown, __: unknown) => {}) as never);
   const createDbMock = vi.fn(() => ({}) as never);
-  const detectPortMock = vi.fn(async (port: number) => port);
+  const detectPortMock = vi.fn(
+    async (input: number | { port: number; hostname: string }) =>
+      typeof input === "number" ? input : input.port,
+  );
   const feedbackExportServiceMock = {
     flushPendingFeedbackTraces: vi.fn(async () => ({ attempted: 0, sent: 0, failed: 0 })),
   };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -23,10 +23,10 @@ import {
   companyMemberships,
   instanceUserRoles,
 } from "@paperclipai/db";
-import detectPort from "detect-port";
 import { createApp } from "./app.js";
 import { loadConfig } from "./config.js";
 import { logger } from "./middleware/logger.js";
+import { detectAvailablePort } from "./port-detection.js";
 import { setupLiveEventsWebSocketServer } from "./realtime/live-events-ws.js";
 import {
   feedbackService,
@@ -362,7 +362,7 @@ export async function startServer(): Promise<StartedServer> {
           `Embedded PostgreSQL appears to already be reachable without a pid file; reusing existing server on configured port ${configuredPort}`,
         );
       } catch {
-        const detectedPort = await detectPort(configuredPort);
+        const detectedPort = await detectAvailablePort(configuredPort, "127.0.0.1");
         if (detectedPort !== configuredPort) {
           logger.warn(`Embedded PostgreSQL port is in use; using next free port (requestedPort=${configuredPort}, selectedPort=${detectedPort})`);
         }
@@ -502,7 +502,7 @@ export async function startServer(): Promise<StartedServer> {
     authReady = true;
   }
   
-  const listenPort = await detectPort(config.port);
+  const listenPort = await detectAvailablePort(config.port, config.host);
   if (listenPort !== config.port) {
     config.port = listenPort;
   }

--- a/server/src/port-detection.ts
+++ b/server/src/port-detection.ts
@@ -1,0 +1,11 @@
+import detectPort from "detect-port";
+
+export async function detectAvailablePort(port: number, hostname?: string): Promise<number> {
+  const normalizedHostname = hostname?.trim();
+
+  if (!normalizedHostname) {
+    return detectPort(port);
+  }
+
+  return detectPort({ port, hostname: normalizedHostname });
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Server startup is part of the local-first control plane because operators depend on predictable host/port binding for the API, UI, and local integrations
> - The current startup path asks `detect-port` to probe `config.port` without the configured hostname, so the library checks wildcard and non-loopback addresses in addition to the address Paperclip will actually bind
> - That makes Paperclip silently bump to the next port when an unrelated interface listener conflicts on `0.0.0.0` or another address, even if the configured bind host is still free
> - This pull request routes startup port probing through a small helper that passes the configured hostname, and applies the same loopback-only probe to the embedded Postgres fallback path
> - The benefit is that Paperclip now probes the same address it intends to bind, so loopback deployments keep their configured port instead of unexpectedly shifting to `port + 1`

## What Changed

- Added a small `detectAvailablePort` helper that passes `{ port, hostname }` to `detect-port` when a bind host is known
- Updated server startup to probe `config.port` against `config.host` instead of using the library's multi-address fallback
- Updated the embedded Postgres fallback probe to use `127.0.0.1`, matching the actual local-only bind path there as well
- Added a focused regression test covering both host-aware probing and the blank-host fallback behavior
- Fixes #3747

## Verification

- `pnpm --filter @paperclipai/server exec tsc --noEmit`
- `pnpm exec vitest run src/__tests__/port-detection.test.ts` (run from `server/`)

## Risks

- Low risk. This only changes how startup probes port availability before binding.
- The main behavioral change is intentional: loopback-host deployments stop treating wildcard or unrelated-interface listeners as conflicts.
- When `config.host` is blank, the helper keeps the previous `detect-port(port)` behavior.

## Model Used

- OpenAI Codex, GPT-5-based coding agent with terminal tool use and local code execution. Exact internal deployment ID and exposed context-window size were not surfaced in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
