### PR TITLE
fix(server): suppress blocked issue status wakeups

### DIFF
--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -158,6 +158,131 @@ describe("issue dependency wakeups in issue routes", () => {
     });
   });
 
+  it("does not wake a blocked issue on status change while blockers are still unresolved", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: "issue-2",
+      companyId: "company-1",
+      identifier: "PAP-102",
+      title: "Blocked child",
+      description: null,
+      status: "blocked",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-2",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    mockIssueService.update.mockResolvedValue({
+      id: "issue-2",
+      companyId: "company-1",
+      identifier: "PAP-102",
+      title: "Blocked child",
+      description: null,
+      status: "todo",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-2",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [{
+        id: "issue-1",
+        identifier: "PAP-101",
+        title: "Still blocked",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: "agent-1",
+        assigneeUserId: null,
+      }],
+      blocks: [],
+    });
+
+    const res = await request(await createApp()).patch("/api/issues/issue-2").send({ status: "todo" });
+    expect(res.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(mockWakeup).not.toHaveBeenCalled();
+    });
+  });
+
+  it("wakes a blocked issue on status change after all blockers are done", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: "issue-2",
+      companyId: "company-1",
+      identifier: "PAP-102",
+      title: "Blocked child",
+      description: null,
+      status: "blocked",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-2",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    mockIssueService.update.mockResolvedValue({
+      id: "issue-2",
+      companyId: "company-1",
+      identifier: "PAP-102",
+      title: "Blocked child",
+      description: null,
+      status: "todo",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-2",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [{
+        id: "issue-1",
+        identifier: "PAP-101",
+        title: "Done blocker",
+        status: "done",
+        priority: "medium",
+        assigneeAgentId: "agent-1",
+        assigneeUserId: null,
+      }],
+      blocks: [],
+    });
+
+    const res = await request(await createApp()).patch("/api/issues/issue-2").send({ status: "todo" });
+    expect(res.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(mockWakeup).toHaveBeenCalledWith(
+        "agent-2",
+        expect.objectContaining({
+          reason: "issue_status_changed",
+          payload: expect.objectContaining({
+            issueId: "issue-2",
+            mutation: "update",
+          }),
+          contextSnapshot: expect.objectContaining({
+            issueId: "issue-2",
+            source: "issue.status_change",
+          }),
+        }),
+      );
+    });
+  });
+
   it("wakes the parent when all direct children become terminal", async () => {
     mockIssueService.getById.mockResolvedValue({
       id: "child-1",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1820,23 +1820,33 @@ export function issueRoutes(
       }
 
       if (!assigneeChanged && (statusChangedFromBacklog || statusChangedFromBlockedToTodo) && issue.assigneeAgentId) {
-        addWakeup(issue.assigneeAgentId, {
-          source: "automation",
-          triggerDetail: "system",
-          reason: "issue_status_changed",
-          payload: {
-            issueId: issue.id,
-            mutation: "update",
-            ...(interruptedRunId ? { interruptedRunId } : {}),
-          },
-          requestedByActorType: actor.actorType,
-          requestedByActorId: actor.actorId,
-          contextSnapshot: {
-            issueId: issue.id,
-            source: "issue.status_change",
-            ...(interruptedRunId ? { interruptedRunId } : {}),
-          },
-        });
+        let hasUnresolvedBlockers = false;
+        try {
+          const relations = await svc.getRelationSummaries(issue.id);
+          hasUnresolvedBlockers = relations.blockedBy.some((blocker) => blocker.status !== "done");
+        } catch (err) {
+          logger.warn({ err, issueId: issue.id }, "failed to resolve blockers before status-change wakeup");
+        }
+
+        if (!hasUnresolvedBlockers) {
+          addWakeup(issue.assigneeAgentId, {
+            source: "automation",
+            triggerDetail: "system",
+            reason: "issue_status_changed",
+            payload: {
+              issueId: issue.id,
+              mutation: "update",
+              ...(interruptedRunId ? { interruptedRunId } : {}),
+            },
+            requestedByActorType: actor.actorType,
+            requestedByActorId: actor.actorId,
+            contextSnapshot: {
+              issueId: issue.id,
+              source: "issue.status_change",
+              ...(interruptedRunId ? { interruptedRunId } : {}),
+            },
+          });
+        }
       }
 
       if (commentBody && comment) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issue wakeups are part of the heartbeat control plane because status changes are one of the core signals that tell an assigned agent when to start work
> - The current `issue_status_changed` path wakes the assignee when an issue moves from `backlog` or `blocked` into a runnable state, but it does not check whether the issue is still blocked by another unresolved dependency
> - That means agents can be launched for issues that still have unfinished blockers, which wastes runs and adds avoidable queue noise
> - This pull request checks the issue's current blocker summaries before enqueuing the status-change wakeup and suppresses that wakeup while any blocker remains unresolved
> - The benefit is that blocked issues stop consuming agent runs until their dependency graph is actually ready

## What Changed

- Added a blocker check before `issue_status_changed` wakeups are enqueued for an assignee on status transitions
- Suppressed the status-change wakeup when `getRelationSummaries(issue.id)` reports any `blockedBy` issue whose status is not `done`
- Preserved the existing wakeup behavior when all blockers are resolved, and preserved the previous behavior if the blocker lookup itself fails
- Added regression coverage for both cases: unresolved blockers suppress the wakeup, resolved blockers allow it
- Fixes #3636

## Verification

- `pnpm --filter @paperclipai/server exec tsc --noEmit`
- Attempted: `pnpm exec vitest run src/__tests__/issue-dependency-wakeups-routes.test.ts` (run from `server/`)
  In this local environment, the existing test harness fails before assertions execute because `vi.importActual("../routes/issues.js")` cannot be resolved by Vitest from that test file. I left the failure mode unchanged and limited this PR to the wakeup behavior plus regression assertions.

## Risks

- Low risk. This only affects one wakeup path in the issue update route.
- The main behavioral change is intentional: issues that still have unresolved blockers will no longer trigger `issue_status_changed` wakeups just because their own status changed.
- If relation lookup fails, the route keeps the previous behavior and still enqueues the wakeup rather than blocking execution on a secondary read failure.

## Model Used

- OpenAI Codex, GPT-5-based coding agent with terminal tool use and local code execution. Exact internal deployment ID and exposed context-window size were not surfaced in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
