### PR TITLE
fix(server): serialize issue comment cursor timestamp

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2092,15 +2092,16 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        const anchorCreatedAt = anchor.createdAt.toISOString();
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorCreatedAt}::timestamptz
+                OR (${issueComments.createdAt} = ${anchorCreatedAt}::timestamptz AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorCreatedAt}::timestamptz
+                OR (${issueComments.createdAt} = ${anchorCreatedAt}::timestamptz AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The issue service powers agent and UI access to issue comments, including incremental comment fetches.
> - Issue #3661 reports that `GET /api/issues/:id/comments?after=...` returns a 500 instead of paginating.
> - In `listComments`, the cursor anchor comes back from Drizzle as a `Date`, but the keyset SQL condition interpolates it as if it were already a string value.
> - That type mismatch can surface as the reported runtime `TypeError` when the `after` cursor path is exercised.
> - This pull request serializes the anchor timestamp to an ISO string before using it in the SQL predicate.
> - The benefit is that cursor-based comment pagination keeps its existing ordering logic without tripping the server-side type error.

## What Changed

- Fixes #3661.
- Updated `server/src/services/issues.ts` so the `afterCommentId` anchor timestamp is converted to ISO text before being used in the cursor comparison SQL.
- Kept the existing ascending/descending ordering and comment-ID tie-break behavior unchanged.

## Verification

- `pnpm --filter @paperclipai/server exec tsc --noEmit`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-service.test.ts` *(currently fails before test collection because of a pre-existing workspace import problem in `packages/shared/src/adapter-type.ts`: `TypeError: undefined is not an object (evaluating 'z.string')`)*

## Risks

- Low risk: this only changes how the existing cursor timestamp is serialized before SQL interpolation.
- No API contract, schema, or ordering behavior is intentionally changed.
- I did not add new tests in this PR to keep the fix single-file and tightly scoped.

## Model Used

- OpenAI Codex CLI agent built on a GPT-5-family coding model (exact backend model identifier is not exposed in this workspace).
- Tool-assisted code editing and command execution in the local repository.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
