### PR TITLE
fix(openclaw-gateway): isolate issue strategy heartbeat sessions

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -26,6 +26,18 @@ describe("resolveSessionKey", () => {
     ).toBe("agent:meridian:paperclip:issue:issue-456");
   });
 
+  it("falls back to a run-scoped key when issue strategy is used without an issue id", () => {
+    expect(
+      resolveSessionKey({
+        strategy: "issue",
+        configuredSessionKey: "paperclip",
+        agentId: "meridian",
+        runId: "run-123",
+        issueId: null,
+      }),
+    ).toBe("agent:meridian:paperclip:run:run-123");
+  });
+
   it("prefixes fixed session keys with the configured agent", () => {
     expect(
       resolveSessionKey({

--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -30,7 +30,7 @@ describe("resolveSessionKey", () => {
     expect(
       resolveSessionKey({
         strategy: "issue",
-        configuredSessionKey: "paperclip",
+        configuredSessionKey: "unused-fixed-session",
         agentId: "meridian",
         runId: "run-123",
         issueId: null,

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -149,8 +149,11 @@ export function resolveSessionKey(input: {
   if (input.strategy === "run") {
     return prefixSessionKeyForAgent(`paperclip:run:${input.runId}`, input.agentId);
   }
-  if (input.strategy === "issue" && input.issueId) {
-    return prefixSessionKeyForAgent(`paperclip:issue:${input.issueId}`, input.agentId);
+  if (input.strategy === "issue") {
+    return prefixSessionKeyForAgent(
+      input.issueId ? `paperclip:issue:${input.issueId}` : `paperclip:run:${input.runId}`,
+      input.agentId,
+    );
   }
   return prefixSessionKeyForAgent(fallback, input.agentId);
 }

--- a/packages/adapters/openclaw-gateway/vitest.config.ts
+++ b/packages/adapters/openclaw-gateway/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     projects: [
       "packages/db",
       "packages/adapters/codex-local",
+      "packages/adapters/openclaw-gateway",
       "packages/adapters/opencode-local",
       "server",
       "ui",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates long-running agent work across issues, routines, and heartbeat wakes.
> - The openclaw-gateway adapter uses session keys to decide whether different wakes should share or isolate conversational context.
> - Issue #3586 reports that `sessionKeyStrategy: "issue"` still pools heartbeat-driven work into one shared session when no `issueId` is attached to the wake.
> - In the current implementation, the `issue` branch only handles the happy path where `issueId` is present, then silently falls through to the fixed shared fallback.
> - That means users who explicitly ask for per-issue isolation still accumulate unrelated heartbeat work in `agent:{agentId}:paperclip`.
> - This pull request keeps `issue` strategy isolated by falling back to a run-scoped session when the wake does not carry an `issueId`.
> - The benefit is that heartbeat-discovered work no longer silently shares one growing session under the `issue` strategy.

## What Changed

- Fixes #3586.
- Updated `packages/adapters/openclaw-gateway/src/server/execute.ts` so `sessionKeyStrategy: "issue"` falls back to `paperclip:run:{runId}` when `issueId` is absent, instead of reusing the shared fixed session key.
- Added a focused regression test in `packages/adapters/openclaw-gateway/src/server/execute.test.ts` for the no-`issueId` heartbeat path.
- Added `packages/adapters/openclaw-gateway/vitest.config.ts` and registered the package in the root `vitest.config.ts` projects list so the regression test is discoverable by the repo test runner.

## Verification

- `pnpm --filter @paperclipai/adapter-openclaw-gateway exec tsc --noEmit`
- `pnpm exec vitest run packages/adapters/openclaw-gateway/src/server/execute.test.ts`

## Risks

- Low risk: the change only affects the fallback branch for `sessionKeyStrategy: "issue"` when `issueId` is missing.
- Existing `run`, `fixed`, and issue-present behavior stays unchanged.
- The test-runner change is limited to registering this adapter package in the existing Vitest workspace.

## Model Used

- OpenAI Codex CLI agent built on a GPT-5-family coding model (exact backend model identifier is not exposed in this workspace).
- Tool-assisted code editing and local command execution in the repository.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
