### PR TITLE
feat(VIB-58): infrastructure health UI + server proxy

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -32,7 +32,7 @@ import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
-import { infrastructureHealthRoutes } from "./routes/infrastructure-health.js";
+import { infrastructureHealthRoutes, PAPERCLIP_HEALTH_URL } from "./routes/infrastructure-health.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
@@ -190,7 +190,9 @@ export async function createApp(
       companyDeletionEnabled: opts.companyDeletionEnabled,
     }),
   );
-  api.use("/infrastructure/health", infrastructureHealthRoutes());
+  if (PAPERCLIP_HEALTH_URL) {
+    api.use("/infrastructure/health", infrastructureHealthRoutes());
+  }
   api.use("/companies", companyRoutes(db, opts.storageService));
   api.use(companySkillRoutes(db));
   api.use(agentRoutes(db));

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -32,6 +32,7 @@ import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
+import { infrastructureHealthRoutes } from "./routes/infrastructure-health.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
@@ -189,6 +190,7 @@ export async function createApp(
       companyDeletionEnabled: opts.companyDeletionEnabled,
     }),
   );
+  api.use("/infrastructure/health", infrastructureHealthRoutes());
   api.use("/companies", companyRoutes(db, opts.storageService));
   api.use(companySkillRoutes(db));
   api.use(agentRoutes(db));

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -6,6 +6,7 @@ import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 import { readPersistedDevServerStatus, toDevServerHealthStatus } from "../dev-server-status.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { serverVersion } from "../version.js";
+import { PAPERCLIP_HEALTH_URL } from "./infrastructure-health.js";
 
 function shouldExposeFullHealthDetails(
   actorType: "none" | "board" | "agent" | null | undefined,
@@ -123,6 +124,7 @@ export function healthRoutes(
       bootstrapInviteActive,
       features: {
         companyDeletionEnabled: opts.companyDeletionEnabled,
+        infrastructureHealthEnabled: !!PAPERCLIP_HEALTH_URL,
       },
       ...(devServer ? { devServer } : {}),
     });

--- a/server/src/routes/infrastructure-health.ts
+++ b/server/src/routes/infrastructure-health.ts
@@ -1,16 +1,30 @@
 import { Router } from "express";
 
-const VIBE_HEALTH_URL = process.env.VIBE_HEALTH_URL ?? "http://vibe:8080";
+/**
+ * Proxies infrastructure health checks to an external health aggregator.
+ *
+ * Enable by setting `PAPERCLIP_HEALTH_URL` to the base URL of a service that
+ * exposes `/api/infrastructure/health` (aggregate) and
+ * `/api/infrastructure/health/:service` (per-service) endpoints returning
+ * standardized JSON:
+ *
+ *   { status: "ok"|"degraded"|"error", services: { ... }, summary: { ... } }
+ *
+ * When the env var is unset these routes are not mounted.
+ */
+
+export const PAPERCLIP_HEALTH_URL = process.env.PAPERCLIP_HEALTH_URL;
 
 export function infrastructureHealthRoutes() {
   const router = Router();
+  const baseUrl = PAPERCLIP_HEALTH_URL!;
 
   router.get("/", async (_req, res) => {
     try {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), 10_000);
       const upstream = await fetch(
-        `${VIBE_HEALTH_URL}/api/infrastructure/health`,
+        `${baseUrl}/api/infrastructure/health`,
         { signal: controller.signal, headers: { Accept: "application/json" } },
       );
       clearTimeout(timer);
@@ -30,7 +44,7 @@ export function infrastructureHealthRoutes() {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), 10_000);
       const upstream = await fetch(
-        `${VIBE_HEALTH_URL}/api/infrastructure/health/${encodeURIComponent(service)}`,
+        `${baseUrl}/api/infrastructure/health/${encodeURIComponent(service)}`,
         { signal: controller.signal, headers: { Accept: "application/json" } },
       );
       clearTimeout(timer);

--- a/server/src/routes/infrastructure-health.ts
+++ b/server/src/routes/infrastructure-health.ts
@@ -1,0 +1,48 @@
+import { Router } from "express";
+
+const VIBE_HEALTH_URL = process.env.VIBE_HEALTH_URL ?? "http://vibe:8080";
+
+export function infrastructureHealthRoutes() {
+  const router = Router();
+
+  router.get("/", async (_req, res) => {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 10_000);
+      const upstream = await fetch(
+        `${VIBE_HEALTH_URL}/api/infrastructure/health`,
+        { signal: controller.signal, headers: { Accept: "application/json" } },
+      );
+      clearTimeout(timer);
+      const data = await upstream.json();
+      res.status(upstream.status).json(data);
+    } catch (err) {
+      res.status(502).json({
+        status: "error",
+        error: "Failed to reach infrastructure health endpoint",
+      });
+    }
+  });
+
+  router.get("/:service", async (req, res) => {
+    const { service } = req.params;
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 10_000);
+      const upstream = await fetch(
+        `${VIBE_HEALTH_URL}/api/infrastructure/health/${encodeURIComponent(service)}`,
+        { signal: controller.signal, headers: { Accept: "application/json" } },
+      );
+      clearTimeout(timer);
+      const data = await upstream.json();
+      res.status(upstream.status).json(data);
+    } catch (err) {
+      res.status(502).json({
+        status: "error",
+        error: `Failed to reach health endpoint for ${service}`,
+      });
+    }
+  });
+
+  return router;
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -44,6 +44,7 @@ import { AuthPage } from "./pages/Auth";
 import { BoardClaimPage } from "./pages/BoardClaim";
 import { CliAuthPage } from "./pages/CliAuth";
 import { InviteLandingPage } from "./pages/InviteLanding";
+import { InfrastructureHealth } from "./pages/InfrastructureHealth";
 import { NotFoundPage } from "./pages/NotFound";
 import { queryKeys } from "./lib/queryKeys";
 import { useCompany } from "./context/CompanyContext";
@@ -126,6 +127,7 @@ function boardRoutes() {
       <Route path="onboarding" element={<OnboardingRoutePage />} />
       <Route path="companies" element={<Companies />} />
       <Route path="company/settings" element={<CompanySettings />} />
+      <Route path="company/infrastructure" element={<InfrastructureHealth />} />
       <Route path="company/export/*" element={<CompanyExport />} />
       <Route path="company/import" element={<CompanyImport />} />
       <Route path="skills/*" element={<CompanySkills />} />

--- a/ui/src/api/health.ts
+++ b/ui/src/api/health.ts
@@ -22,6 +22,7 @@ export type HealthStatus = {
   bootstrapInviteActive?: boolean;
   features?: {
     companyDeletionEnabled?: boolean;
+    infrastructureHealthEnabled?: boolean;
   };
   devServer?: DevServerHealthStatus;
 };

--- a/ui/src/api/infrastructure-health.ts
+++ b/ui/src/api/infrastructure-health.ts
@@ -1,0 +1,36 @@
+export type InfraServiceStatus = {
+  status: "ok" | "degraded" | "error";
+  service: string;
+  label?: string;
+  version: string | null;
+  uptime_seconds: number | null;
+  checks: Record<string, unknown>;
+  error?: string;
+};
+
+export type InfraHealthSummary = {
+  total: number;
+  ok: number;
+  degraded: number;
+  error: number;
+};
+
+export type InfraHealthResponse = {
+  status: "ok" | "degraded" | "error";
+  timestamp: string;
+  services: Record<string, InfraServiceStatus>;
+  summary: InfraHealthSummary;
+};
+
+export const infrastructureHealthApi = {
+  getAll: async (): Promise<InfraHealthResponse> => {
+    const res = await fetch("/api/infrastructure/health", {
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      throw new Error(`Infrastructure health check failed (${res.status})`);
+    }
+    return res.json();
+  },
+};

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -21,6 +21,7 @@ import { SidebarAgents } from "./SidebarAgents";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { heartbeatsApi } from "../api/heartbeats";
+import { healthApi } from "../api/health";
 import { queryKeys } from "../lib/queryKeys";
 import { useInboxBadge } from "../hooks/useInboxBadge";
 import { Button } from "@/components/ui/button";
@@ -37,6 +38,12 @@ export function Sidebar() {
     refetchInterval: 10_000,
   });
   const liveRunCount = liveRuns?.length ?? 0;
+  const { data: health } = useQuery({
+    queryKey: queryKeys.health,
+    queryFn: () => healthApi.get(),
+    retry: false,
+  });
+  const infraHealthEnabled = health?.features?.infrastructureHealthEnabled ?? false;
 
   function openSearch() {
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true }));
@@ -113,7 +120,7 @@ export function Sidebar() {
           <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />
-          <SidebarNavItem to="/company/infrastructure" label="Infrastructure" icon={HeartPulse} />
+          {infraHealthEnabled && <SidebarNavItem to="/company/infrastructure" label="Infrastructure" icon={HeartPulse} />}
           <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
         </SidebarSection>
 

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Boxes,
   Repeat,
   Settings,
+  HeartPulse,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { SidebarSection } from "./SidebarSection";
@@ -112,6 +113,7 @@ export function Sidebar() {
           <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />
+          <SidebarNavItem to="/company/infrastructure" label="Infrastructure" icon={HeartPulse} />
           <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
         </SidebarSection>
 

--- a/ui/src/pages/InfrastructureHealth.tsx
+++ b/ui/src/pages/InfrastructureHealth.tsx
@@ -1,0 +1,223 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import {
+  infrastructureHealthApi,
+  type InfraHealthResponse,
+  type InfraServiceStatus,
+} from "../api/infrastructure-health";
+import {
+  RefreshCw,
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
+  Clock,
+  HeartPulse,
+} from "lucide-react";
+
+const statusConfig = {
+  ok: {
+    icon: CheckCircle2,
+    color: "text-green-600 dark:text-green-400",
+    bg: "bg-green-100 dark:bg-green-900/50",
+    label: "Healthy",
+  },
+  degraded: {
+    icon: AlertTriangle,
+    color: "text-yellow-600 dark:text-yellow-400",
+    bg: "bg-yellow-100 dark:bg-yellow-900/50",
+    label: "Degraded",
+  },
+  error: {
+    icon: XCircle,
+    color: "text-red-600 dark:text-red-400",
+    bg: "bg-red-100 dark:bg-red-900/50",
+    label: "Error",
+  },
+};
+
+const statusOrder: Record<string, number> = { error: 0, degraded: 1, ok: 2 };
+
+function formatUptime(seconds: number): string {
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+function ServiceCard({ service }: { service: InfraServiceStatus }) {
+  const cfg = statusConfig[service.status] ?? statusConfig.error;
+  const StatusIcon = cfg.icon;
+
+  return (
+    <Card className="rounded-lg">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium">
+            {service.label ?? service.service}
+          </CardTitle>
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+              cfg.bg,
+              cfg.color,
+            )}
+          >
+            <StatusIcon className="h-3 w-3" />
+            {cfg.label}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2 text-xs text-muted-foreground">
+        {service.version && (
+          <div className="flex items-center justify-between">
+            <span>Version</span>
+            <span className="font-mono text-foreground">{service.version}</span>
+          </div>
+        )}
+        {service.uptime_seconds != null && (
+          <div className="flex items-center justify-between">
+            <span className="flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              Uptime
+            </span>
+            <span className="font-mono text-foreground">
+              {formatUptime(service.uptime_seconds)}
+            </span>
+          </div>
+        )}
+        {Object.keys(service.checks).length > 0 && (
+          <div className="space-y-1 border-t border-border pt-2">
+            {Object.entries(service.checks).map(([key, value]) => (
+              <div key={key} className="flex items-center justify-between">
+                <span>{key}</span>
+                <span className="font-mono text-foreground">
+                  {typeof value === "object" && value !== null
+                    ? JSON.stringify(value)
+                    : String(value)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+        {service.error && (
+          <div className="rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-400">
+            {service.error}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <Card className="rounded-lg">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+          <div className="h-5 w-16 animate-pulse rounded-full bg-muted" />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="h-3 w-full animate-pulse rounded bg-muted" />
+        <div className="h-3 w-3/4 animate-pulse rounded bg-muted" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function OverallBanner({ data }: { data: InfraHealthResponse }) {
+  const cfg = statusConfig[data.status] ?? statusConfig.error;
+  const StatusIcon = cfg.icon;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg border px-4 py-3",
+        cfg.bg,
+      )}
+    >
+      <StatusIcon className={cn("h-5 w-5", cfg.color)} />
+      <div className="flex-1">
+        <span className={cn("text-sm font-semibold", cfg.color)}>
+          {cfg.label}
+        </span>
+        <span className="ml-3 text-xs text-muted-foreground">
+          {data.summary.ok} ok
+          {data.summary.degraded > 0 && ` · ${data.summary.degraded} degraded`}
+          {data.summary.error > 0 && ` · ${data.summary.error} error`}
+          {` · ${data.summary.total} total`}
+        </span>
+      </div>
+      <span className="text-xs text-muted-foreground">
+        {new Date(data.timestamp).toLocaleTimeString()}
+      </span>
+    </div>
+  );
+}
+
+export function InfrastructureHealth() {
+  const { setBreadcrumbs } = useBreadcrumbs();
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "Infrastructure" }]);
+  }, [setBreadcrumbs]);
+
+  const { data, isLoading, isFetching, error, refetch } = useQuery({
+    queryKey: ["infrastructure-health"],
+    queryFn: () => infrastructureHealthApi.getAll(),
+    refetchInterval: 30_000,
+  });
+
+  const sortedServices: InfraServiceStatus[] = data
+    ? Object.values(data.services).sort(
+        (a, b) => (statusOrder[a.status] ?? 9) - (statusOrder[b.status] ?? 9),
+      )
+    : [];
+
+  return (
+    <div className="flex-1 space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <HeartPulse className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">Infrastructure Health</h1>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => refetch()}
+          disabled={isFetching}
+        >
+          <RefreshCw
+            className={cn("mr-1.5 h-3.5 w-3.5", isFetching && "animate-spin")}
+          />
+          Refresh
+        </Button>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-400">
+          {error instanceof Error
+            ? error.message
+            : "Failed to load infrastructure health"}
+        </div>
+      )}
+
+      {data && <OverallBanner data={data} />}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {isLoading
+          ? Array.from({ length: 6 }).map((_, i) => <SkeletonCard key={i} />)
+          : sortedServices.map((svc) => (
+              <ServiceCard key={svc.service} service={svc} />
+            ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `/api/infrastructure/health` proxy route on Paperclip server that forwards to the Vibe agent's aggregate health endpoint
- Add `InfrastructureHealth` page under **Company > Infrastructure** with auto-refreshing (30s) status grid
- Service cards show status badge, version, uptime, sub-checks, and error messages — sorted with errors first
- Loading skeletons, error banner, and manual refresh button
- Frontend API client with full TypeScript types

## Test plan

- [x] `cd server && npx tsc --noEmit` — no type errors
- [x] `cd ui && npx tsc --noEmit` — no type errors
- [x] Navigate to Company > Infrastructure in the UI
- [x] Verify service cards render with status colors
- [x] Verify auto-refresh updates status every 30s

Companion PR: tmartin2113/Vibe-Stack#TBD (backend probes + Docker healthchecks + Prometheus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)