### PR TITLE
fix(heartbeat): emit documented plugin run lifecycle events

### DIFF
--- a/server/src/__tests__/heartbeat-plugin-events.test.ts
+++ b/server/src/__tests__/heartbeat-plugin-events.test.ts
@@ -57,7 +57,7 @@ if (!embeddedPostgresSupport.supported) {
   );
 }
 
-async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 5_000, intervalMs = 50) {
+async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 10_000, intervalMs = 50) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
     if (await condition()) return;
@@ -205,6 +205,46 @@ describeEmbeddedPostgres("heartbeat plugin events", () => {
       agentId,
       status: "failed",
       error: "adapter exploded",
+    });
+  });
+
+  it("emits failed plugin events with normalized status for timed out runs", async () => {
+    const { agentId } = await seedAgent();
+    const heartbeat = heartbeatService(db);
+
+    mockExecute.mockResolvedValueOnce({
+      exitCode: null,
+      signal: null,
+      timedOut: true,
+      errorMessage: null,
+      provider: "test",
+      model: "test-model",
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      reason: "manual_test",
+      requestedByActorType: "system",
+      requestedByActorId: "test",
+    });
+
+    expect(run).not.toBeNull();
+
+    await waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      return latest?.status === "timed_out";
+    });
+
+    expect(emittedEvents.map((event) => event.eventType)).toEqual([
+      "agent.run.started",
+      "agent.run.failed",
+    ]);
+    expect(emittedEvents[1]?.payload).toMatchObject({
+      runId: run!.id,
+      agentId,
+      status: "failed",
+      error: "Timed out",
+      errorCode: "timeout",
     });
   });
 

--- a/server/src/__tests__/heartbeat-plugin-events.test.ts
+++ b/server/src/__tests__/heartbeat-plugin-events.test.ts
@@ -1,0 +1,245 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  agentRuntimeState,
+  agentWakeupRequests,
+  agents,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockExecute = vi.hoisted(() => vi.fn());
+const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
+const mockTrackAgentFirstHeartbeat = vi.hoisted(() => vi.fn());
+
+vi.mock("../telemetry.ts", () => ({
+  getTelemetryClient: () => mockTelemetryClient,
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: mockTrackAgentFirstHeartbeat,
+  };
+});
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockExecute,
+    })),
+  };
+});
+
+import { type PluginEvent } from "@paperclipai/plugin-sdk";
+import { setPluginEventBus } from "../services/activity-log.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat plugin event tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 5_000, intervalMs = 50) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+describeEmbeddedPostgres("heartbeat plugin events", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let emittedEvents: PluginEvent[] = [];
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-plugin-events-");
+    db = createDb(tempDb.connectionString);
+    setPluginEventBus({
+      emit: vi.fn(async (event: PluginEvent) => {
+        emittedEvents.push(event);
+        return { errors: [] };
+      }),
+      forPlugin: vi.fn(),
+      clearPlugin: vi.fn(),
+    } as never);
+  }, 20_000);
+
+  beforeEach(() => {
+    emittedEvents = [];
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    return { companyId, agentId };
+  }
+
+  it("emits started and finished plugin events for successful runs", async () => {
+    const { agentId } = await seedAgent();
+    const heartbeat = heartbeatService(db);
+
+    mockExecute.mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      provider: "test",
+      model: "test-model",
+      resultJson: { summary: "done" },
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      reason: "manual_test",
+      requestedByActorType: "system",
+      requestedByActorId: "test",
+    });
+
+    expect(run).not.toBeNull();
+
+    await waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      return latest?.status === "succeeded";
+    });
+
+    expect(emittedEvents.map((event) => event.eventType)).toEqual([
+      "agent.run.started",
+      "agent.run.finished",
+    ]);
+    expect(emittedEvents[1]?.payload).toMatchObject({
+      runId: run!.id,
+      agentId,
+      status: "succeeded",
+    });
+  });
+
+  it("emits started and failed plugin events for failed runs", async () => {
+    const { agentId } = await seedAgent();
+    const heartbeat = heartbeatService(db);
+
+    mockExecute.mockResolvedValueOnce({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: "adapter exploded",
+      errorCode: "adapter_failed",
+      provider: "test",
+      model: "test-model",
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      reason: "manual_test",
+      requestedByActorType: "system",
+      requestedByActorId: "test",
+    });
+
+    expect(run).not.toBeNull();
+
+    await waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      return latest?.status === "failed";
+    });
+
+    expect(emittedEvents.map((event) => event.eventType)).toEqual([
+      "agent.run.started",
+      "agent.run.failed",
+    ]);
+    expect(emittedEvents[1]?.payload).toMatchObject({
+      runId: run!.id,
+      agentId,
+      status: "failed",
+      error: "adapter exploded",
+    });
+  });
+
+  it("emits cancelled plugin events when queued runs are cancelled", async () => {
+    const { companyId, agentId } = await seedAgent();
+    const heartbeat = heartbeatService(db);
+    const runId = randomUUID();
+    const wakeupRequestId = randomUUID();
+
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId,
+      source: "on_demand",
+      reason: "manual_test",
+      status: "queued",
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "on_demand",
+      status: "queued",
+      wakeupRequestId,
+      contextSnapshot: {},
+    });
+
+    await heartbeat.cancelRun(runId);
+
+    expect(emittedEvents.map((event) => event.eventType)).toEqual([
+      "agent.run.cancelled",
+    ]);
+    expect(emittedEvents[0]?.payload).toMatchObject({
+      runId,
+      agentId,
+      status: "cancelled",
+    });
+  });
+});

--- a/server/src/__tests__/heartbeat-plugin-events.test.ts
+++ b/server/src/__tests__/heartbeat-plugin-events.test.ts
@@ -4,6 +4,7 @@ import {
   agentRuntimeState,
   agentWakeupRequests,
   agents,
+  companySkills,
   companies,
   createDb,
   heartbeatRunEvents,
@@ -94,6 +95,7 @@ describeEmbeddedPostgres("heartbeat plugin events", () => {
     await db.delete(agentWakeupRequests);
     await db.delete(agentRuntimeState);
     await db.delete(agents);
+    await db.delete(companySkills);
     await db.delete(companies);
   });
 

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -22,6 +22,16 @@ export function setPluginEventBus(bus: PluginEventBus): void {
   _pluginEventBus = bus;
 }
 
+export function emitPluginEvent(event: PluginEvent): void {
+  if (!_pluginEventBus) return;
+
+  void _pluginEventBus.emit(event).then(({ errors }) => {
+    for (const { pluginId, error } of errors) {
+      logger.warn({ pluginId, eventType: event.eventType, err: error }, "plugin event handler failed");
+    }
+  }).catch(() => {});
+}
+
 export interface LogActivityInput {
   companyId: string;
   actorType: "agent" | "user" | "system";
@@ -85,10 +95,6 @@ export async function logActivity(db: Db, input: LogActivityInput) {
         runId: input.runId ?? null,
       },
     };
-    void _pluginEventBus.emit(event).then(({ errors }) => {
-      for (const { pluginId, error } of errors) {
-        logger.warn({ pluginId, eventType: event.eventType, err: error }, "plugin event handler failed");
-      }
-    }).catch(() => {});
+    emitPluginEvent(event);
   }
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -109,6 +109,7 @@ function emitAgentRunPluginEvent(
   run: typeof heartbeatRuns.$inferSelect,
   eventType: "agent.run.started" | "agent.run.finished" | "agent.run.failed" | "agent.run.cancelled",
 ) {
+  const publicStatus = run.status === "timed_out" ? "failed" : run.status;
   emitPluginEvent({
     eventId: randomUUID(),
     eventType,
@@ -122,7 +123,7 @@ function emitAgentRunPluginEvent(
       runId: run.id,
       agentId: run.agentId,
       companyId: run.companyId,
-      status: run.status,
+      status: publicStatus,
       invocationSource: run.invocationSource,
       triggerDetail: run.triggerDetail,
       error: run.error ?? null,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, or, sql } from "drizzle-orm";
@@ -40,7 +41,7 @@ import {
   HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES,
   mergeHeartbeatRunResultJson,
 } from "./heartbeat-run-summary.js";
-import { logActivity, type LogActivityInput } from "./activity-log.js";
+import { emitPluginEvent, logActivity, type LogActivityInput } from "./activity-log.js";
 import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
@@ -103,6 +104,34 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "pi_local",
 ]);
 const INLINE_BASE64_IMAGE_DATA_RE = /("type":"image","source":\{"type":"base64","data":")([A-Za-z0-9+/=]{1024,})(")/g;
+
+function emitAgentRunPluginEvent(
+  run: typeof heartbeatRuns.$inferSelect,
+  eventType: "agent.run.started" | "agent.run.finished" | "agent.run.failed" | "agent.run.cancelled",
+) {
+  emitPluginEvent({
+    eventId: randomUUID(),
+    eventType,
+    occurredAt: new Date().toISOString(),
+    actorType: "system",
+    actorId: "heartbeat",
+    entityId: run.id,
+    entityType: "run",
+    companyId: run.companyId,
+    payload: {
+      runId: run.id,
+      agentId: run.agentId,
+      companyId: run.companyId,
+      status: run.status,
+      invocationSource: run.invocationSource,
+      triggerDetail: run.triggerDetail,
+      error: run.error ?? null,
+      errorCode: run.errorCode ?? null,
+      startedAt: run.startedAt ? new Date(run.startedAt).toISOString() : null,
+      finishedAt: run.finishedAt ? new Date(run.finishedAt).toISOString() : null,
+    },
+  });
+}
 
 type RuntimeConfigSecretResolver = Pick<
   ReturnType<typeof secretService>,
@@ -2152,6 +2181,14 @@ export function heartbeatService(db: Db) {
           finishedAt: updated.finishedAt ? new Date(updated.finishedAt).toISOString() : null,
         },
       });
+
+      if (updated.status === "succeeded") {
+        emitAgentRunPluginEvent(updated, "agent.run.finished");
+      } else if (updated.status === "failed" || updated.status === "timed_out") {
+        emitAgentRunPluginEvent(updated, "agent.run.failed");
+      } else if (updated.status === "cancelled") {
+        emitAgentRunPluginEvent(updated, "agent.run.cancelled");
+      }
     }
 
     return updated;
@@ -2655,6 +2692,7 @@ export function heartbeatService(db: Db) {
         finishedAt: claimed.finishedAt ? new Date(claimed.finishedAt).toISOString() : null,
       },
     });
+    emitAgentRunPluginEvent(claimed, "agent.run.started");
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
 


### PR DESCRIPTION
## Thinking Path

Fixes #3789

> - Paperclip orchestrates AI agents and plugins around agent execution, lifecycle state, and automation hooks
> - The plugin subsystem documents core event subscriptions so plugins can react to agent and run lifecycle changes
> - `agent.run.started`, `agent.run.finished`, `agent.run.failed`, and `agent.run.cancelled` are declared as subscribable core events in the shared constants and plugin SDK docs
> - The heartbeat service already publishes live UI events for run status changes, but it never forwards the corresponding run lifecycle events through the plugin event bus
> - That leaves plugins without an event-driven way to react to run completion or cancellation even though the API contract says those events exist
> - This pull request wires the heartbeat run lifecycle into the plugin event bus at the points where runs start or transition to terminal states
> - The benefit is that plugins can subscribe to documented run lifecycle events without polling heartbeat run status endpoints

## What Changed

- Added a reusable `emitPluginEvent()` helper in `server/src/services/activity-log.ts` so non-activity code can safely publish plugin bus events through the same guarded path
- Emitted `agent.run.started` when a queued heartbeat run is claimed and transitions to `running`
- Emitted `agent.run.finished`, `agent.run.failed`, and `agent.run.cancelled` from `setRunStatus()` when heartbeat runs reach terminal states, including mapping `timed_out` runs onto the documented failed event channel
- Added `server/src/__tests__/heartbeat-plugin-events.test.ts` to cover successful, failed, and cancelled run event emission paths

## Verification

- `pnpm --filter @paperclipai/shared build`
- `pnpm --filter @paperclipai/plugin-sdk build`
- `pnpm --filter @paperclipai/server exec tsc --noEmit`
- `pnpm exec vitest run server/src/__tests__/heartbeat-plugin-events.test.ts` currently hits the same pre-existing local baseline failure already present on this checkout: `TypeError: undefined is not an object (evaluating 'z.string')` from `packages/shared/src/adapter-type.ts`

## Risks

- Low risk. The change is narrow and additive: it only emits documented plugin events alongside existing heartbeat run status updates and does not alter heartbeat execution control flow.

## Model Used

- OpenAI Codex on GPT-5 class reasoning model with tool use and local code execution in this workspace

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
