### PR TITLE
fix(db): use calendar month boundaries for backup retention

### DIFF
--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import postgres from "postgres";
-import { createBufferedTextFileWriter, runDatabaseBackup, runDatabaseRestore } from "./backup-lib.js";
+import {
+  createBufferedTextFileWriter,
+  monthlyRetentionCutoff,
+  runDatabaseBackup,
+  runDatabaseRestore,
+} from "./backup-lib.js";
 import { ensurePostgresDatabase } from "./client.js";
 import {
   getEmbeddedPostgresTestSupport,
@@ -70,6 +75,16 @@ describe("createBufferedTextFileWriter", () => {
     await writer.close();
 
     expect(fs.readFileSync(outputPath, "utf8")).toBe(lines.join("\n"));
+  });
+});
+
+describe("monthlyRetentionCutoff", () => {
+  it("anchors monthly retention at the start of the retained calendar month", () => {
+    const now = new Date(2026, 2, 31, 12, 0, 0).getTime();
+
+    expect(monthlyRetentionCutoff(now, 2)).toBe(new Date(2026, 0, 1, 0, 0, 0, 0).getTime());
+    expect(new Date(2026, 0, 28, 12, 0, 0).getTime()).toBeGreaterThanOrEqual(monthlyRetentionCutoff(now, 2));
+    expect(new Date(2025, 11, 31, 23, 59, 59).getTime()).toBeLessThan(monthlyRetentionCutoff(now, 2));
   });
 });
 

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -98,6 +98,14 @@ function monthKey(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
 }
 
+export function monthlyRetentionCutoff(nowMs: number, monthlyMonths: number): number {
+  const cutoff = new Date(nowMs);
+  cutoff.setHours(0, 0, 0, 0);
+  cutoff.setDate(1);
+  cutoff.setMonth(cutoff.getMonth() - Math.max(1, monthlyMonths));
+  return cutoff.getTime();
+}
+
 /**
  * Tiered backup pruning:
  * - Daily tier: keep ALL backups from the last `dailyDays` days
@@ -111,7 +119,7 @@ function pruneOldBackups(backupDir: string, retention: BackupRetentionPolicy, fi
   const now = Date.now();
   const dailyCutoff = now - Math.max(1, retention.dailyDays) * 24 * 60 * 60 * 1000;
   const weeklyCutoff = now - Math.max(1, retention.weeklyWeeks) * 7 * 24 * 60 * 60 * 1000;
-  const monthlyCutoff = now - Math.max(1, retention.monthlyMonths) * 30 * 24 * 60 * 60 * 1000;
+  const monthlyCutoff = monthlyRetentionCutoff(now, retention.monthlyMonths);
 
   type BackupEntry = { name: string; fullPath: string; mtimeMs: number };
   const entries: BackupEntry[] = [];


### PR DESCRIPTION
## Thinking Path

> - Paperclip includes automatic database backups as part of its instance durability story.
> - The retention logic lives in `packages/db`, where backups are thinned from daily to weekly to monthly buckets.
> - Issue #3713 points out that the monthly tier currently approximates each month as 30 days.
> - That breaks the documented calendar-month behavior in longer months and can prune backups from a still-retained month too early.
> - This pull request switches the monthly cutoff to the start of the retained calendar month instead of a fixed day multiplier.
> - The benefit is that monthly retention now matches the calendar-month bucketing the pruning code already uses.

## What Changed

- Replaced the fixed `monthlyMonths * 30 days` cutoff with a calendar-month cutoff anchored to the first day of the retained month.
- Added a focused regression test for the month-boundary calculation covering a 31-day month case.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run packages/db/src/backup-lib.test.ts`
- `pnpm --filter @paperclipai/db exec tsc --noEmit`

## Risks

- Low risk. The change is isolated to backup pruning cutoff math in `packages/db` and only affects the monthly retention window.

## Model Used

- OpenAI Codex on a GPT-5-class coding model with tool use and local code execution in this workspace.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #3713
