### PR TITLE
fix(claude-local): use direct 4.5 model aliases

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -5,8 +5,8 @@ export const models = [
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
   { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
   { id: "claude-haiku-4-6", label: "Claude Haiku 4.6" },
-  { id: "claude-sonnet-4-5-20250929", label: "Claude Sonnet 4.5" },
-  { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
+  { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
 ];
 
 export const agentConfigurationDoc = `# claude_local agent configuration


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The `claude_local` adapter is the control-plane surface that turns Paperclip agent settings into concrete Claude CLI invocations.
> - Issue #3777 reports that selecting Claude Haiku 4.5 from the Paperclip UI causes Claude Code to request `claude-haiku-4-5-20251001`, which some enterprise-scoped keys are not allowed to access.
> - In the current adapter model list, the direct Anthropic 4.5 entries are version-pinned IDs, unlike the 4.6 entries which already use the stable short aliases.
> - This pull request switches the direct 4.5 `claude_local` model options to the short aliases Claude Code account access expects, while leaving Bedrock-native IDs unchanged in the Bedrock-specific model list.
> - The benefit is that selecting Claude Sonnet 4.5 or Claude Haiku 4.5 from Paperclip no longer forces the CLI onto a more restrictive versioned direct model name.

## What Changed

- Updated the direct `claude_local` adapter model list to use `claude-sonnet-4-5` instead of `claude-sonnet-4-5-20250929`.
- Updated the direct `claude_local` adapter model list to use `claude-haiku-4-5` instead of `claude-haiku-4-5-20251001`.
- Left the Bedrock-specific model IDs in `src/server/models.ts` unchanged so AWS Bedrock routing still uses region-qualified native IDs.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @paperclipai/adapter-claude-local typecheck`
- Confirmed the only source change is `packages/adapters/claude-local/src/index.ts`.

## Risks

- Low risk. This only changes the direct `claude_local` model IDs advertised by Paperclip for the two 4.5 options.
- Bedrock behavior is unchanged because the Bedrock-native identifiers are defined separately and were not modified in this PR.
- Existing 4.6 model options are untouched.

## Model Used

- OpenAI Codex on a GPT-5-class coding model with terminal tool use and local code execution in this workspace.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #3777