### PR TITLE
fix(skills): preserve root skill file inventory

### DIFF
--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -89,4 +89,36 @@ describeEmbeddedPostgres("companySkillService.list", () => {
       editable: true,
     });
   });
+
+  it("imports local skill roots with full file inventory", async () => {
+    const companyId = randomUUID();
+    const skillDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-import-root-skill-"));
+    cleanupDirs.add(skillDir);
+    await fs.mkdir(path.join(skillDir, "scripts"), { recursive: true });
+    await fs.mkdir(path.join(skillDir, "references"), { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "---\nname: Root Import Skill\n---\n\n# Root Import Skill\n", "utf8");
+    await fs.writeFile(path.join(skillDir, "scripts", "run.sh"), "echo ok\n", "utf8");
+    await fs.writeFile(path.join(skillDir, "references", "guide.md"), "# Guide\n", "utf8");
+    await fs.writeFile(path.join(skillDir, "README.md"), "# Root Import Skill\n", "utf8");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const result = await svc.importFromSource(companyId, skillDir);
+    const skill = result.imported.find((entry) => entry.sourceLocator === skillDir);
+
+    expect(skill).toBeDefined();
+    expect(skill?.fileInventory).toEqual(expect.arrayContaining([
+      { path: "SKILL.md", kind: "skill" },
+      { path: "README.md", kind: "markdown" },
+      { path: "references/guide.md", kind: "markdown" },
+      { path: "scripts/run.sh", kind: "script" },
+    ]));
+    expect(skill?.fileInventory).toHaveLength(4);
+    expect(skill?.trustLevel).toBe("scripts_executables");
+  });
 });

--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -115,7 +115,7 @@ describeEmbeddedPostgres("companySkillService.list", () => {
     expect(skill?.fileInventory).toEqual(expect.arrayContaining([
       { path: "SKILL.md", kind: "skill" },
       { path: "README.md", kind: "markdown" },
-      { path: "references/guide.md", kind: "markdown" },
+      { path: "references/guide.md", kind: "reference" },
       { path: "scripts/run.sh", kind: "script" },
     ]));
     expect(skill?.fileInventory).toHaveLength(4);

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -1002,10 +1002,11 @@ async function readLocalSkillImports(companyId: string, sourcePath: string): Pro
   const imports: ImportedSkill[] = [];
   for (const skillPath of skillPaths) {
     const skillDir = path.posix.dirname(skillPath);
+    const prefix = skillDir === "." ? "" : `${skillDir}/`;
     const inventory = allFiles
-      .filter((entry) => entry === skillPath || entry.startsWith(`${skillDir}/`))
+      .filter((entry) => entry === skillPath || (prefix ? entry.startsWith(prefix) : true))
       .map((entry) => {
-        const relative = entry === skillPath ? "SKILL.md" : entry.slice(skillDir.length + 1);
+        const relative = entry === skillPath ? "SKILL.md" : prefix ? entry.slice(prefix.length) : entry;
         return {
           path: normalizePortablePath(relative),
           kind: classifyInventoryKind(relative),


### PR DESCRIPTION
## Thinking Path

> - Paperclip treats skills as package-like assets that can include `SKILL.md`, scripts, references, assets, and supporting markdown.
> - The company skill import service is responsible for turning a local path into a persisted skill record with an accurate `fileInventory` and `trustLevel`.
> - Issue #3799 reports that importing a path which is already the skill root directory silently collapses the inventory to only `SKILL.md`.
> - In `readLocalSkillImports()`, that root-directory case computes `skillDir === "."`, but the inventory filter still looks for entries starting with `"./"`, which never matches the relative paths produced by `walkLocalFiles()`.
> - This pull request fixes that root-prefix handling so root skill imports keep the full inventory, and adds regression coverage at the service layer.
> - The benefit is that importing a local skill root preserves scripts and support files instead of downgrading the skill to `markdown_only`.

## What Changed

- Fixed `readLocalSkillImports()` so root-level `SKILL.md` imports use an empty prefix instead of `"./"` when collecting inventory entries.
- Kept the existing subdirectory behavior unchanged by continuing to trim nested skill prefixes before classifying inventory entries.
- Added an embedded-Postgres service regression test covering `importFromSource(<skillRoot>)` with `SKILL.md`, `README.md`, `references/*`, and `scripts/*`.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @paperclipai/plugin-sdk build && pnpm --filter @paperclipai/server typecheck`
- Attempted: `pnpm --filter @paperclipai/server exec vitest run src/__tests__/company-skills-service.test.ts`
  This still fails before test collection on the current upstream baseline with `TypeError: undefined is not an object (evaluating z.string)` from `packages/shared/src/adapter-type.ts`, so I did not mark the test run as passing.

## Risks

- Low risk. The change is limited to local skill inventory reconstruction inside `readLocalSkillImports()`.
- Nested multi-skill imports still keep their existing prefix trimming behavior.
- The new behavior only broadens the root skill case to include the files already present on disk and already returned correctly by `readLocalSkillImportFromDirectory()`.

## Model Used

- OpenAI Codex on a GPT-5-class coding model with terminal tool use and local code execution in this workspace.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #3799