### PR TITLE
fix(docker): install jq in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-trixie-slim AS base
 ARG USER_UID=1000
 ARG USER_GID=1000
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates gosu curl git wget ripgrep python3 \
+  && apt-get install -y --no-install-recommends ca-certificates gosu curl git wget ripgrep python3 jq \
   && mkdir -p -m 755 /etc/apt/keyrings \
   && wget -nv -O/etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
   && echo "20e0125d6f6e077a9ad46f03371bc26d90b04939fb95170f5a1905099cc6bcc0  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \


### PR DESCRIPTION
Fixes #3803

## Thinking Path

> - Paperclip ships a containerized runtime that bundles the tools its built-in skills and helper scripts depend on.
> - The `paperclip` shipped skill documents a multiline issue-update flow that relies on `scripts/paperclip-issue-update.sh`.
> - That helper requires `jq` to JSON-encode multiline markdown without collapsing line breaks.
> - The current base image installs several CLI dependencies, but it does not install `jq`.
> - That leaves the documented multiline comment path broken in the default container image even though the helper is shipped.
> - This pull request adds `jq` to the base image so the shipped helper works as documented.
> - The benefit is that multiline issue comments keep their formatting in default Paperclip container deployments.

## What Changed

- Added `jq` to the base `apt-get install` list in `Dockerfile`.

## Verification

- Confirmed `skills/paperclip/SKILL.md` documents `jq --arg` for multiline issue comments.
- Confirmed `scripts/paperclip-issue-update.sh` hard-requires `jq` before building the JSON payload.
- Ran `git diff --check`.
- Docker image build was not run locally because the Docker daemon was unavailable on this machine.

## Risks

- Low risk. This only adds a missing runtime dependency to the existing base image package list.

## Model Used

- OpenAI Codex, GPT-5-based coding agent with local tool use in the Codex CLI environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
