### PR TITLE
fix: proactive session rotation + role-based max turns

### DIFF
--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -27,13 +27,14 @@ const DEFAULT_SESSION_COMPACTION_POLICY: SessionCompactionPolicy = {
   maxSessionAgeHours: 72,
 };
 
-// Adapters with native context management still participate in session resume,
-// but Paperclip should not rotate them using threshold-based compaction.
+// Adapters with native context management still participate in session resume.
+// Paperclip rotates sessions proactively before the runtime's own compaction
+// kicks in, avoiding expensive Haiku compaction calls on long contexts.
 const ADAPTER_MANAGED_SESSION_POLICY: SessionCompactionPolicy = {
   enabled: true,
-  maxSessionRuns: 0,
-  maxRawInputTokens: 0,
-  maxSessionAgeHours: 0,
+  maxSessionRuns: 8,
+  maxRawInputTokens: 400_000,
+  maxSessionAgeHours: 24,
 };
 
 export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -305,7 +305,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const model = asString(config.model, "");
   const effort = asString(config.effort, "");
   const chrome = asBoolean(config.chrome, false);
-  const maxTurns = asNumber(config.maxTurnsPerRun, 0);
+  const maxTurns = asNumber(config.maxTurnsPerRun, 0) || 1000;
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -153,7 +153,7 @@ export async function testEnvironment(
       const model = asString(config.model, "").trim();
       const effort = asString(config.effort, "").trim();
       const chrome = asBoolean(config.chrome, false);
-      const maxTurns = asNumber(config.maxTurnsPerRun, 0);
+      const maxTurns = asNumber(config.maxTurnsPerRun, 0) || 1000;
       const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
       const extraArgs = (() => {
         const fromExtraArgs = asStringArray(config.extraArgs);

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -494,18 +494,18 @@ describe("prioritizeProjectWorkspaceCandidatesForRun", () => {
 });
 
 describe("parseSessionCompactionPolicy", () => {
-  it("disables Paperclip-managed rotation by default for codex and claude local", () => {
+  it("applies proactive rotation thresholds by default for codex and claude local", () => {
     expect(parseSessionCompactionPolicy(buildAgent("codex_local"))).toEqual({
       enabled: true,
-      maxSessionRuns: 0,
-      maxRawInputTokens: 0,
-      maxSessionAgeHours: 0,
+      maxSessionRuns: 8,
+      maxRawInputTokens: 400_000,
+      maxSessionAgeHours: 24,
     });
     expect(parseSessionCompactionPolicy(buildAgent("claude_local"))).toEqual({
       enabled: true,
-      maxSessionRuns: 0,
-      maxRawInputTokens: 0,
-      maxSessionAgeHours: 0,
+      maxSessionRuns: 8,
+      maxRawInputTokens: 400_000,
+      maxSessionAgeHours: 24,
     });
   });
 
@@ -540,7 +540,7 @@ describe("parseSessionCompactionPolicy", () => {
       enabled: true,
       maxSessionRuns: 25,
       maxRawInputTokens: 500_000,
-      maxSessionAgeHours: 0,
+      maxSessionAgeHours: 24,
     });
   });
 });

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -25,7 +25,7 @@ export const defaultCreateValues: CreateConfigValues = {
   workspaceBranchTemplate: "",
   worktreeParentDir: "",
   runtimeServicesJson: "",
-  maxTurnsPerRun: 1000,
+  maxTurnsPerRun: 200,
   heartbeatEnabled: false,
   intervalSec: 300,
 };


### PR DESCRIPTION
## Summary

- **Ensure `--max-turns` is always passed to Claude Code** — When `maxTurnsPerRun` was unset/0, the flag was omitted, causing Claude Code to use its internal default of 50 turns
- **Proactive session rotation** — Enable Paperclip-managed session rotation thresholds (8 runs / 400k tokens / 24h) for claude_local and codex_local, avoiding expensive Haiku compaction calls
- **Lower UI default maxTurnsPerRun** from 1000 to 200 for new agents

## Test plan

- [x] `pnpm -r typecheck` passes
- [x] `pnpm test:run` — session compaction tests updated and passing (33/33)
- [ ] Monitor usage dashboard for reduced Haiku calls over next few days
- [ ] Verify agent work quality is maintained (issues progress normally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)