### PR TITLE
fix: include server port in derived auth trusted origins

### DIFF
--- a/server/src/__tests__/derive-auth-trusted-origins.test.ts
+++ b/server/src/__tests__/derive-auth-trusted-origins.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { deriveAuthTrustedOrigins } from "../auth/better-auth.js";
+import type { Config } from "../config.js";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    deploymentMode: "authenticated",
+    deploymentExposure: "private",
+    bind: "all",
+    customBindHost: undefined,
+    host: "0.0.0.0",
+    port: 3100,
+    allowedHostnames: ["localhost"],
+    authBaseUrlMode: "auto",
+    authPublicBaseUrl: undefined,
+    authDisableSignUp: false,
+    databaseMode: "embedded-postgres",
+    databaseUrl: undefined,
+    embeddedPostgresDataDir: "/tmp/db",
+    embeddedPostgresPort: 5432,
+    databaseBackupEnabled: false,
+    databaseBackupIntervalMinutes: 60,
+    databaseBackupRetentionDays: 7,
+    databaseBackupDir: "/tmp/backups",
+    loggingMode: "pretty",
+    logDir: "/tmp/logs",
+    serveUi: true,
+    telemetryEnabled: false,
+    storageProvider: "local_disk",
+    localDiskBaseDir: "/tmp/storage",
+    s3Bucket: "",
+    s3Region: "",
+    s3Prefix: "",
+    s3ForcePathStyle: false,
+    secretsProvider: "local_encrypted",
+    secretsStrictMode: false,
+    localEncryptedKeyFilePath: "/tmp/key",
+    ...overrides,
+  } as Config;
+}
+
+describe("deriveAuthTrustedOrigins", () => {
+  it("includes port for non-standard ports", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({ port: 3100, allowedHostnames: ["localhost", "10.0.0.1"] }),
+    );
+    expect(origins).toContain("http://localhost:3100");
+    expect(origins).toContain("https://localhost:3100");
+    expect(origins).toContain("http://10.0.0.1:3100");
+    expect(origins).toContain("https://10.0.0.1:3100");
+  });
+
+  it("omits port suffix for HTTP on port 80", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({ port: 80, allowedHostnames: ["example.com"] }),
+    );
+    expect(origins).toContain("http://example.com");
+    expect(origins).toContain("https://example.com:80");
+  });
+
+  it("omits port suffix for HTTPS on port 443", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({ port: 443, allowedHostnames: ["example.com"] }),
+    );
+    expect(origins).toContain("https://example.com");
+    expect(origins).toContain("http://example.com:443");
+  });
+
+  it("respects explicit port in hostname", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({ port: 3100, allowedHostnames: ["myhost:8080"] }),
+    );
+    expect(origins).toContain("http://myhost:8080");
+    expect(origins).toContain("https://myhost:8080");
+    // Should NOT double-append the config port
+    expect(origins).not.toContain("http://myhost:8080:3100");
+  });
+
+  it("handles IPv6 literals without false port detection", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({ port: 3100, allowedHostnames: ["[::1]"] }),
+    );
+    expect(origins).toContain("http://[::1]:3100");
+    expect(origins).toContain("https://[::1]:3100");
+  });
+
+  it("handles IPv6 literal with explicit port", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({ port: 3100, allowedHostnames: ["[::1]:8080"] }),
+    );
+    expect(origins).toContain("http://[::1]:8080");
+    expect(origins).toContain("https://[::1]:8080");
+    expect(origins).not.toContain("http://[::1]:8080:3100");
+  });
+
+  it("handles bare IPv6 address (without brackets)", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({ port: 3100, allowedHostnames: ["::1"] }),
+    );
+    // Bare IPv6 should get the port appended, not be mistaken for host:port
+    expect(origins).toContain("http://::1:3100");
+    expect(origins).toContain("https://::1:3100");
+  });
+
+  it("includes explicit baseUrl origin", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({
+        authBaseUrlMode: "explicit",
+        authPublicBaseUrl: "https://paperclip.example.com:443",
+        allowedHostnames: ["localhost"],
+        port: 3100,
+      }),
+    );
+    expect(origins).toContain("https://paperclip.example.com");
+    expect(origins).toContain("http://localhost:3100");
+  });
+
+  it("returns empty for local_trusted mode", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({ deploymentMode: "local_trusted", allowedHostnames: ["localhost"] }),
+    );
+    expect(origins).toEqual([]);
+  });
+
+  it("skips empty hostnames", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({ port: 3100, allowedHostnames: ["localhost", "", "  "] }),
+    );
+    expect(origins).toHaveLength(2); // http + https for localhost only
+  });
+});

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -54,11 +54,25 @@ export function deriveAuthTrustedOrigins(config: Config): string[] {
     }
   }
   if (config.deploymentMode === "authenticated") {
+    const port = config.port;
     for (const hostname of config.allowedHostnames) {
       const trimmed = hostname.trim().toLowerCase();
       if (!trimmed) continue;
-      trustedOrigins.add(`https://${trimmed}`);
-      trustedOrigins.add(`http://${trimmed}`);
+      // Detect whether the hostname already carries an explicit port.
+      // IPv6 literals use colons in the address (e.g. "::1", "[::1]"),
+      // so only treat a colon as a port separator when it follows a
+      // closing bracket (IPv6 with port) or appears in a non-IPv6 host.
+      const isIPv6 = trimmed.includes("[") || /^[0-9a-f:]+$/.test(trimmed);
+      const hasExplicitPort = isIPv6
+        ? trimmed.includes("]:") // e.g. "[::1]:3100"
+        : trimmed.includes(":");  // e.g. "localhost:3100"
+      const httpSuffix = hasExplicitPort || port === 80 ? "" : `:${port}`;
+      const httpsSuffix = hasExplicitPort || port === 443 ? "" : `:${port}`;
+      // Note: for reverse-proxy setups where the browser-facing port differs
+      // from config.port, use auth.baseUrlMode="explicit" with authPublicBaseUrl
+      // instead — those origins are handled by the baseUrl block above.
+      trustedOrigins.add(`https://${trimmed}${httpsSuffix}`);
+      trustedOrigins.add(`http://${trimmed}${httpSuffix}`);
     }
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Humans oversee agents via a web UI that requires authentication in non-local deployments
> - Authentication uses Better Auth, which validates browser requests against a list of trusted origins
> - Trusted origins are derived from config.allowedHostnames in deriveAuthTrustedOrigins
> - But the derivation omitted the server port, producing origins like http://localhost instead of http://localhost:3100
> - Better Auth does strict origin matching including port, so every sign-in/sign-up on a non-standard port returned 403
> - This PR appends config.port to derived origins, with correct handling for standard ports, IPv6, and explicit ports
> - The benefit is that authenticated mode works out of the box on any port without env var workarounds

## What Changed

- `server/src/auth/better-auth.ts`: Append `config.port` to each derived trusted origin. Skip for standard ports (80/443). Detect IPv6 literals so their colons aren't mistaken for a port separator. Leave hostnames with explicit ports unchanged.
- `server/src/__tests__/derive-auth-trusted-origins.test.ts`: New test file — 10 cases covering non-standard ports, standard ports, explicit port in hostname, IPv6 with/without brackets, explicit baseUrl, local_trusted mode, and empty hostnames.

## Verification

```bash
npx vitest run server/src/__tests__/derive-auth-trusted-origins.test.ts
```

Manual repro:
1. Set deploymentMode: "authenticated", host: "0.0.0.0", port: 3100
2. Add localhost and a LAN IP to allowedHostnames
3. Start server, open http://localhost:3100
4. Attempt sign-in — before: 403 "Invalid origin". After: succeeds.

## Risks

Low risk. Only affects deriveAuthTrustedOrigins output. Reverse-proxy setups where browser port differs from config.port should use auth.baseUrlMode="explicit" — that path is unaffected. BETTER_AUTH_TRUSTED_ORIGINS env var still works as fallback.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.6 (claude-opus-4-6)
- Context: 1M
- Capabilities: extended thinking, tool use
- Human-supervised: all changes and text reviewed and approved by contributor
- Independent review: Codex CLI (gpt-5.3-codex) reviewed the diff pre-submission

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge