### PR TITLE
fix: add ssh client and jq to production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ ARG USER_GID=1000
 WORKDIR /app
 COPY --chown=node:node --from=build /app /app
 RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends openssh-client jq \
+  && rm -rf /var/lib/apt/lists/* \
   && mkdir -p /paperclip \
   && chown node:node /paperclip
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that runs long-lived AI-agent work in production.
> - The production container image is the runtime boundary for agent tools and shell access.
> - In our deployment, Paperclip agents now need a native SSH client and `jq` available inside the final runtime container.
> - Installing those tools only via ai-rig entrypoint hacks is brittle and drifts from the image source of truth.
> - This pull request updates the production Docker image itself so the required binaries are present whenever the image is built.
> - The change is intentionally scoped to the final production stage so build/deps stages do not gain extra packages unnecessarily.
> - The benefit is a cleaner, reproducible runtime image with fewer deploy-specific workarounds.

## What Changed

- Added `openssh-client` to the production Docker image stage.
- Added `jq` to the production Docker image stage.
- Kept the package install in the final `production` stage instead of the shared base stage to minimize scope.

## Verification

- Reviewed the final Dockerfile diff to confirm the packages are installed in the `production` stage only.
- Attempted local image build with:
  - `docker build --target production -t paperclip:ssh-jq-test .`
- Local build could not be completed in this environment because the local Docker daemon was unavailable:
  - `Cannot connect to the Docker daemon at unix:///Users/roman/.docker/run/docker.sock. Is the docker daemon running?`

## Risks

- Low risk: image footprint increases slightly because two Debian packages are added.
- `openssh-client` expands runtime capability, so this is appropriate only because the deployed Paperclip runtime explicitly needs SSH access.

## Model Used

- OpenAI Codex / `gpt-5.4`
- Tool-using agent workflow via Hermes
- Context from local repository inspection, git, and shell tooling

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
