### PR TITLE
feat(claude-local): add Opus 4.7 to adapter model dropdown

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -2,6 +2,7 @@ export const type = "claude_local";
 export const label = "Claude Code (local)";
 
 export const models = [
+  { id: "claude-opus-4-7", label: "Claude Opus 4.7" },
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
   { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
   { id: "claude-haiku-4-6", label: "Claude Haiku 4.6" },


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each adapter advertises a model list that powers the agent config UI dropdown
> - The `claude_local` adapter's dropdown is sourced from the hard-coded `models` array in `packages/adapters/claude-local/src/index.ts`
> - Anthropic recently released Opus 4.7, the newest current-generation Opus model
> - Without a list entry, users cannot discover or select Opus 4.7 from the dropdown (they can still type it manually, since the field is creatable, but discoverability is poor)
> - This pull request adds `claude-opus-4-7` to the `claude_local` model list so new agents can be configured with the latest model by default
> - The benefit is out-of-the-box access to the newest Opus model, consistent with how every other current-generation Claude model is already listed

## What Changed

- Added `{ id: "claude-opus-4-7", label: "Claude Opus 4.7" }` as the **first** entry of the `models` array in `packages/adapters/claude-local/src/index.ts`. Newest-first ordering matches the convention already used for 4.6.

## Verification

- `pnpm --filter @paperclipai/adapter-claude-local typecheck` → passes.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-models.test.ts src/__tests__/claude-local-adapter.test.ts` → 12/12 passing (both directly-related files).
- No existing test pins the `claude_local` models array (see `server/src/__tests__/adapter-models.test.ts`), so appending a new entry is non-breaking.
- Manual check of UI consumer: `AgentConfigForm.tsx` fetches the list via `agentsApi.adapterModels()` and renders it in a creatable popover — no hard-coded expectations anywhere in the UI layer.
- Screenshots: single new option appears at the top of the Claude Code (local) model dropdown; existing options unchanged.

## Risks

- Low risk. Purely additive: one new entry in a list consumed by a UI dropdown. No behavior change for existing agents, no schema change, no migration, no env var.
- `BEDROCK_MODELS` in `packages/adapters/claude-local/src/server/models.ts` is intentionally **not** touched — the exact region-qualified Bedrock id for Opus 4.7 is not yet confirmed, and shipping a guessed id could produce a broken option for Bedrock users. Tracked as a follow-up on the linked issue.

## Model Used

- None — human-authored.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (no tests needed: existing suite already covers the list-consumer paths)
- [x] If this change affects the UI, I have included before/after screenshots (dropdown gains one new top entry; all other entries unchanged)
- [x] I have updated relevant documentation to reflect my changes (no doc update needed: `docs/adapters/claude-local.md` uses `claude-opus-4-6` only as an example, still valid)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #3827