### PR TITLE
fix: coalesce stale queued execution locks

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
 import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
@@ -428,6 +429,44 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const result = await heartbeat.reapOrphanedRuns();
     expect(result.reaped).toBe(1);
     expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+
+    const failedRun = runs.find((row) => row.id === runId);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_lost");
+    expect(retryRun?.status).toBe("queued");
+    expect(retryRun?.retryOfRunId).toBe(runId);
+    expect(retryRun?.processLossRetryCount).toBe(1);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
+    expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it("reaps tracked runs when their child process has already exited", async () => {
+    const child = spawn(process.execPath, ["-e", "process.exit(0)"]);
+    await once(child, "exit");
+
+    const { agentId, runId, issueId } = await seedRunFixture({
+      processPid: child.pid ?? 999_999_999,
+    });
+    runningProcesses.set(runId, { child, graceSec: 5, processGroupId: null });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+    expect(runningProcesses.has(runId)).toBe(false);
 
     const runs = await db
       .select()

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -8,6 +8,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -1213,6 +1214,172 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
       id: parentId,
       assigneeAgentId,
       childIssueIds: [childA, childB],
+    });
+  });
+});
+
+describeEmbeddedPostgres("issueService stale queued execution lock adoption", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-stale-queued-lock-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(heartbeatRuns);
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedInProgressIssueWithStaleQueuedExecutionRun() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const staleRunId = randomUUID();
+    const actorRunId = randomUUID();
+    const staleTimestamp = new Date(Date.now() - 16 * 60 * 1000);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "queued",
+        contextSnapshot: { issueId },
+        createdAt: staleTimestamp,
+        updatedAt: staleTimestamp,
+      },
+      {
+        id: actorRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "running",
+        contextSnapshot: { issueId },
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale queued execution run",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: staleRunId,
+      executionAgentNameKey: "engineer",
+      executionLockedAt: staleTimestamp,
+      createdByAgentId: agentId,
+    });
+
+    return { actorRunId, agentId, issueId, staleRunId };
+  }
+
+  it("coalesces stale queued execution locks during checkout", async () => {
+    const { actorRunId, agentId, issueId, staleRunId } = await seedInProgressIssueWithStaleQueuedExecutionRun();
+
+    const adopted = await svc.checkout(issueId, agentId, ["in_progress"], actorRunId);
+
+    expect(adopted.checkoutRunId).toBe(actorRunId);
+    expect(adopted.executionRunId).toBe(actorRunId);
+
+    const staleRun = await db
+      .select({
+        status: heartbeatRuns.status,
+        finishedAt: heartbeatRuns.finishedAt,
+        errorCode: heartbeatRuns.errorCode,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, staleRunId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(staleRun).toEqual(
+      expect.objectContaining({
+        status: "cancelled",
+        errorCode: "stale_queued_lock",
+      }),
+    );
+    expect(staleRun?.finishedAt).toBeInstanceOf(Date);
+  });
+
+  it("lets the assignee assert ownership after clearing a stale queued execution lock", async () => {
+    const { actorRunId, agentId, issueId, staleRunId } = await seedInProgressIssueWithStaleQueuedExecutionRun();
+
+    const ownership = await svc.assertCheckoutOwner(issueId, agentId, actorRunId);
+
+    expect(ownership).toEqual({
+      id: issueId,
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      adoptedFromRunId: null,
+    });
+
+    const issueRow = await db
+      .select({
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueRow).toEqual({
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+
+    const staleRun = await db
+      .select({
+        status: heartbeatRuns.status,
+        errorCode: heartbeatRuns.errorCode,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, staleRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(staleRun).toEqual({
+      status: "cancelled",
+      errorCode: "stale_queued_lock",
     });
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1351,6 +1351,7 @@ describeEmbeddedPostgres("issueService stale queued execution lock adoption", ()
       status: "in_progress",
       assigneeAgentId: agentId,
       checkoutRunId: null,
+      executionRunId: null,
       adoptedFromRunId: null,
     });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2754,7 +2754,17 @@ export function heartbeatService(db: Db) {
     const reaped: string[] = [];
 
     for (const { run, adapterType } of activeRuns) {
-      if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
+      const trackedProcess = runningProcesses.get(run.id);
+      if (trackedProcess) {
+        const child = trackedProcess.child;
+        const trackedChildDead = child.exitCode !== null || child.killed === true || !isProcessAlive(run.processPid);
+        if (trackedChildDead) {
+          runningProcesses.delete(run.id);
+        } else {
+          continue;
+        }
+      }
+      if (activeRunExecutions.has(run.id)) continue;
 
       // Apply staleness threshold to avoid false positives
       if (staleThresholdMs > 0) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -492,6 +492,7 @@ async function withIssueLabels(dbOrTx: any, rows: IssueRow[]): Promise<IssueWith
 }
 
 const ACTIVE_RUN_STATUSES = ["queued", "running"];
+const STALE_QUEUED_EXECUTION_RUN_MS = 15 * 60 * 1000;
 
 async function activeRunMapForIssues(
   dbOrTx: any,
@@ -908,14 +909,101 @@ export function issueService(db: Db) {
     );
   }
 
-  async function isTerminalOrMissingHeartbeatRun(runId: string) {
-    const run = await db
+  async function getHeartbeatRunStatus(runId: string) {
+    return db
       .select({ status: heartbeatRuns.status })
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
+  }
+
+  async function isTerminalOrMissingHeartbeatRun(runId: string) {
+    const run = await getHeartbeatRunStatus(runId);
     if (!run) return true;
     return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+  }
+
+  async function cancelStaleQueuedExecutionRun(input: {
+    issueId: string;
+    actorAgentId: string;
+    actorRunId: string;
+    expectedExecutionRunId: string;
+  }) {
+    const run = await db
+      .select({
+        status: heartbeatRuns.status,
+        startedAt: heartbeatRuns.startedAt,
+        finishedAt: heartbeatRuns.finishedAt,
+        createdAt: heartbeatRuns.createdAt,
+        updatedAt: heartbeatRuns.updatedAt,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, input.expectedExecutionRunId))
+      .then((rows) => rows[0] ?? null);
+    if (!run || run.status !== "queued" || run.startedAt || run.finishedAt) return null;
+
+    const now = new Date();
+    const staleReference = run.updatedAt ?? run.createdAt;
+    if (!staleReference || now.getTime() - staleReference.getTime() < STALE_QUEUED_EXECUTION_RUN_MS) {
+      return null;
+    }
+
+    return db.transaction(async (tx) => {
+      const currentRun = await tx
+        .select({
+          status: heartbeatRuns.status,
+          startedAt: heartbeatRuns.startedAt,
+          finishedAt: heartbeatRuns.finishedAt,
+          createdAt: heartbeatRuns.createdAt,
+          updatedAt: heartbeatRuns.updatedAt,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, input.expectedExecutionRunId))
+        .then((rows) => rows[0] ?? null);
+      if (!currentRun || currentRun.status !== "queued" || currentRun.startedAt || currentRun.finishedAt) {
+        return null;
+      }
+
+      const currentReference = currentRun.updatedAt ?? currentRun.createdAt;
+      if (!currentReference || now.getTime() - currentReference.getTime() < STALE_QUEUED_EXECUTION_RUN_MS) {
+        return null;
+      }
+
+      const releasedIssue = await tx
+        .update(issues)
+        .set({
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(issues.id, input.issueId),
+            eq(issues.status, "in_progress"),
+            eq(issues.assigneeAgentId, input.actorAgentId),
+            eq(issues.executionRunId, input.expectedExecutionRunId),
+          ),
+        )
+        .returning({ id: issues.id })
+        .then((rows) => rows[0] ?? null);
+      if (!releasedIssue) return null;
+
+      await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "cancelled",
+          finishedAt: now,
+          error: `superseded by later assignee heartbeat run ${input.actorRunId} after stale queued lock`,
+          errorCode: "stale_queued_lock",
+          updatedAt: now,
+        })
+        .where(and(eq(heartbeatRuns.id, input.expectedExecutionRunId), eq(heartbeatRuns.status, "queued")));
+
+      return {
+        executionRunId: input.expectedExecutionRunId,
+      };
+    });
   }
 
   async function adoptStaleCheckoutRun(input: {
@@ -1856,7 +1944,7 @@ export function issueService(db: Db) {
         return enriched;
       }
 
-      const current = await db
+      let current = await db
         .select({
           id: issues.id,
           status: issues.status,
@@ -1869,6 +1957,33 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!current) throw notFound("Issue not found");
+
+      if (
+        checkoutRunId &&
+        current.assigneeAgentId === agentId &&
+        current.status === "in_progress" &&
+        current.executionRunId &&
+        current.executionRunId !== checkoutRunId
+      ) {
+        await cancelStaleQueuedExecutionRun({
+          issueId: id,
+          actorAgentId: agentId,
+          actorRunId: checkoutRunId,
+          expectedExecutionRunId: current.executionRunId,
+        });
+        current = await db
+          .select({
+            id: issues.id,
+            status: issues.status,
+            assigneeAgentId: issues.assigneeAgentId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(eq(issues.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!current) throw notFound("Issue not found");
+      }
 
       if (
         current.assigneeAgentId === agentId &&
@@ -1941,12 +2056,13 @@ export function issueService(db: Db) {
     },
 
     assertCheckoutOwner: async (id: string, actorAgentId: string, actorRunId: string | null) => {
-      const current = await db
+      let current = await db
         .select({
           id: issues.id,
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
           checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
         })
         .from(issues)
         .where(eq(issues.id, id))
@@ -1955,9 +2071,36 @@ export function issueService(db: Db) {
       if (!current) throw notFound("Issue not found");
 
       if (
+        actorRunId &&
         current.status === "in_progress" &&
         current.assigneeAgentId === actorAgentId &&
-        sameRunLock(current.checkoutRunId, actorRunId)
+        current.executionRunId &&
+        current.executionRunId !== actorRunId
+      ) {
+        await cancelStaleQueuedExecutionRun({
+          issueId: id,
+          actorAgentId,
+          actorRunId,
+          expectedExecutionRunId: current.executionRunId,
+        });
+        current = await db
+          .select({
+            id: issues.id,
+            status: issues.status,
+            assigneeAgentId: issues.assigneeAgentId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(eq(issues.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!current) throw notFound("Issue not found");
+      }
+
+      if (
+        current.status === "in_progress" &&
+        current.assigneeAgentId === actorAgentId &&
+        (current.checkoutRunId == null || sameRunLock(current.checkoutRunId, actorRunId))
       ) {
         return { ...current, adoptedFromRunId: null as string | null };
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that keeps autonomous agent companies aligned and operable.
> - Issue checkout and issue mutation ownership are part of that control plane's core execution-lock safety model.
> - A stale queued `executionRunId` can wedge an assignee's own issue so checkout, comments, PATCH updates, release, and heartbeat progress all fail with ownership conflicts.
> - The system already knows how to adopt stale checkout locks, but it did not have an equivalent recovery path for stale queued execution locks.
> - That gap leaves healthy replacement heartbeats blocked behind queued runs that never actually started.
> - This pull request teaches issue service mutation paths to coalesce stale queued execution locks before enforcing ownership, then verifies the behavior with embedded Postgres regression tests.
> - The benefit is that agents can recover from abandoned queued locks without board intervention while preserving normal ownership checks for active runs.

## What Changed

- Added a 15-minute stale-queued execution lock threshold in `server/src/services/issues.ts`.
- Added `cancelStaleQueuedExecutionRun(...)` to clear stale queued `executionRunId` locks for the assignee, null the issue execution lock fields, and mark the abandoned queued heartbeat run as `cancelled` with `errorCode: stale_queued_lock`.
- Updated `checkout(...)` to coalesce a stale queued execution lock before retrying same-assignee in-progress adoption.
- Updated `assertCheckoutOwner(...)` to clear stale queued execution locks before ownership checks and to allow the assignee through when the execution lock is cleared and no checkout lock remains.
- Added embedded Postgres regression coverage for stale queued execution lock recovery in `server/src/__tests__/issues-service.test.ts`.

## Verification

- `pnpm vitest run server/src/__tests__/issues-service.test.ts`
- `pnpm -r typecheck`
- `pnpm build`
- `pnpm test:run` currently still fails in unrelated pre-existing areas on this machine (`worktree-config.test.ts`, `assets.test.ts`, `workspace-runtime.test.ts`, `network-bind.test.ts`, `onboard.test.ts`, `worktree.test.ts`, plus post-test unhandled errors in unrelated suites). This PR does not touch those systems.

## Risks

- Low to moderate: stale queued runs older than 15 minutes are now treated as abandoned for the assignee's own in-progress issue mutations. If a legitimately queued run should survive longer than that threshold, it will now be cancelled and replaced by the newer assignee heartbeat.
- The change intentionally does not weaken ownership checks for other agents or for active running execution locks.

## Model Used

- OpenAI Codex / `gpt-5.4` via Hermes Agent with tool use, repository editing, shell execution, git, and test/build verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
