### PR TITLE
feat(ui): collapsible sidebar with icon-only mode and zen reading

### DIFF
--- a/ui/src/components/InstanceSidebar.tsx
+++ b/ui/src/components/InstanceSidebar.tsx
@@ -6,24 +6,43 @@ import { queryKeys } from "@/lib/queryKeys";
 import { SIDEBAR_SCROLL_RESET_STATE } from "@/lib/navigation-scroll";
 import { SidebarNavItem } from "./SidebarNavItem";
 import { SidebarCompanyMenu } from "./SidebarCompanyMenu";
+import { useSidebar } from "../context/SidebarContext";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "../lib/utils";
 
 export function InstanceSidebar() {
+  const { collapsed } = useSidebar();
   const { data: plugins } = useQuery({
     queryKey: queryKeys.plugins.all,
     queryFn: () => pluginsApi.list(),
   });
 
   return (
-    <aside className="w-60 h-full min-h-0 border-r border-border bg-background flex flex-col">
+    <aside className={cn("h-full min-h-0 border-r border-border bg-background flex flex-col", collapsed ? "w-12" : "w-60")}>
+      {!collapsed && (
       <div className="flex items-center gap-1 px-3 h-12 shrink-0">
         <SidebarCompanyMenu />
       </div>
-      <div className="flex items-center gap-2 px-5 pb-3 shrink-0">
-        <Settings className="h-4 w-4 text-muted-foreground shrink-0" />
-        <span className="flex-1 truncate text-sm font-bold text-foreground">Instance Settings</span>
+      )}
+      <div className={cn("flex items-center shrink-0", collapsed ? "h-12 justify-center px-1" : "gap-2 px-5 pb-3")}>
+        {collapsed ? (
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+              <Settings className="h-4 w-4 text-muted-foreground shrink-0 cursor-default" />
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={8}>Instance Settings</TooltipContent>
+          </Tooltip>
+        ) : (
+          <>
+            <Settings className="h-4 w-4 text-muted-foreground shrink-0 ml-1" />
+            <span className="flex-1 text-sm font-bold text-foreground truncate">
+              Instance Settings
+            </span>
+          </>
+        )}
       </div>
 
-      <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide flex flex-col gap-4 px-3 py-2">
+      <nav className={cn("flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide flex flex-col gap-4 py-2", collapsed ? "px-1" : "px-3")}>
         <div className="flex flex-col gap-0.5">
           <SidebarNavItem to="/instance/settings/profile" label="Profile" icon={UserRoundPen} end />
           <SidebarNavItem to="/instance/settings/general" label="General" icon={SlidersHorizontal} end />
@@ -32,7 +51,7 @@ export function InstanceSidebar() {
           <SidebarNavItem to="/instance/settings/experimental" label="Experimental" icon={FlaskConical} />
           <SidebarNavItem to="/instance/settings/plugins" label="Plugins" icon={Puzzle} />
           <SidebarNavItem to="/instance/settings/adapters" label="Adapters" icon={Cpu} />
-          {(plugins ?? []).length > 0 ? (
+          {!collapsed && (plugins ?? []).length > 0 ? (
             <div className="ml-4 mt-1 flex flex-col gap-0.5 border-l border-border/70 pl-3">
               {(plugins ?? []).map((plugin) => (
                 <NavLink

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Outlet, useLocation, useNavigate, useNavigationType, useParams } from "@/lib/router";
+import { CompanyRail } from "./CompanyRail";
 import { Sidebar } from "./Sidebar";
 import { InstanceSidebar } from "./InstanceSidebar";
 import { CompanySettingsSidebar } from "./CompanySettingsSidebar";
@@ -350,14 +351,15 @@ export function Layout() {
             />
           </div>
         ) : (
-          <div className="flex h-full flex-col shrink-0">
-            <div className="flex flex-1 min-h-0">
-              <div
-                className={cn(
-                  "overflow-hidden transition-[width] duration-100 ease-out",
-                  sidebarOpen ? "w-60" : "w-0"
-                )}
-              >
+          <div className="flex h-full shrink-0">
+            <CompanyRail />
+            <div
+              className={cn(
+                "flex flex-col overflow-hidden transition-[width] duration-150 ease-out",
+                sidebarOpen ? "w-60" : "w-12"
+              )}
+            >
+              <div className="flex-1 min-h-0">
                 {isInstanceSettingsRoute ? (
                   <InstanceSidebar />
                 ) : isCompanySettingsRoute ? (
@@ -366,12 +368,12 @@ export function Layout() {
                   <Sidebar />
                 )}
               </div>
+              <SidebarAccountMenu
+                deploymentMode={health?.deploymentMode}
+                instanceSettingsTarget={instanceSettingsTarget}
+                version={health?.version}
+              />
             </div>
-            <SidebarAccountMenu
-              deploymentMode={health?.deploymentMode}
-              instanceSettingsTarget={instanceSettingsTarget}
-              version={health?.version}
-            />
           </div>
         )}
 

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -20,17 +20,21 @@ import { SidebarProjects } from "./SidebarProjects";
 import { SidebarAgents } from "./SidebarAgents";
 import { useDialogActions } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
+import { useSidebar } from "../context/SidebarContext";
 import { heartbeatsApi } from "../api/heartbeats";
 import { instanceSettingsApi } from "../api/instanceSettings";
 import { queryKeys } from "../lib/queryKeys";
 import { useInboxBadge } from "../hooks/useInboxBadge";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { PluginSlotOutlet } from "@/plugins/slots";
 import { SidebarCompanyMenu } from "./SidebarCompanyMenu";
+import { cn } from "../lib/utils";
 
 export function Sidebar() {
   const { openNewIssue } = useDialogActions();
   const { selectedCompanyId, selectedCompany } = useCompany();
+  const { collapsed } = useSidebar();
   const inboxBadge = useInboxBadge(selectedCompanyId);
   const { data: experimentalSettings } = useQuery({
     queryKey: queryKeys.instance.experimentalSettings,
@@ -55,30 +59,62 @@ export function Sidebar() {
   };
 
   return (
-    <aside className="w-60 h-full min-h-0 border-r border-border bg-background flex flex-col">
-      {/* Top bar: Company name (bold) + Search — aligned with top sections (no visible border) */}
-      <div className="flex items-center gap-1 px-3 h-12 shrink-0">
-        <SidebarCompanyMenu />
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="text-muted-foreground shrink-0"
-          onClick={openSearch}
-        >
-          <Search className="h-4 w-4" />
-        </Button>
+    <aside className="w-full h-full min-h-0 border-r border-border bg-background flex flex-col">
+      <div className={cn("flex items-center shrink-0 h-12", collapsed ? "justify-center px-1" : "gap-1 px-3")}>
+        {collapsed ? (
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+              {selectedCompany?.brandColor ? (
+                <div
+                  className="w-6 h-6 rounded-sm shrink-0 cursor-default"
+                  style={{ backgroundColor: selectedCompany.brandColor }}
+                />
+              ) : (
+                <span className="text-sm font-bold text-foreground cursor-default">
+                  {(selectedCompany?.name ?? "?")[0]}
+                </span>
+              )}
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={8}>{selectedCompany?.name ?? "Company"}</TooltipContent>
+          </Tooltip>
+        ) : (
+          <>
+            <SidebarCompanyMenu />
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="text-muted-foreground shrink-0"
+              onClick={openSearch}
+            >
+              <Search className="h-4 w-4" />
+            </Button>
+          </>
+        )}
       </div>
 
-      <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide flex flex-col gap-4 px-3 py-2">
+      <nav className={cn("flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide flex flex-col gap-4 py-2", collapsed ? "px-1" : "px-3")}>
         <div className="flex flex-col gap-0.5">
-          {/* New Issue button aligned with nav items */}
-          <button
-            onClick={() => openNewIssue()}
-            className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
-          >
-            <SquarePen className="h-4 w-4 shrink-0" />
-            <span className="truncate">New Issue</span>
-          </button>
+          {collapsed ? (
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => openNewIssue()}
+                  className="flex items-center justify-center py-2 text-[13px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+                >
+                  <SquarePen className="h-4 w-4 shrink-0" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right" sideOffset={8}>New Issue</TooltipContent>
+            </Tooltip>
+          ) : (
+            <button
+              onClick={() => openNewIssue()}
+              className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+            >
+              <SquarePen className="h-4 w-4 shrink-0" />
+              <span className="truncate">New Issue</span>
+            </button>
+          )}
           <SidebarNavItem to="/dashboard" label="Dashboard" icon={LayoutDashboard} liveCount={liveRunCount} />
           <SidebarNavItem
             to="/inbox"
@@ -88,13 +124,15 @@ export function Sidebar() {
             badgeTone={inboxBadge.failedRuns > 0 ? "danger" : "default"}
             alert={inboxBadge.failedRuns > 0}
           />
-          <PluginSlotOutlet
-            slotTypes={["sidebar"]}
-            context={pluginContext}
-            className="flex flex-col gap-0.5"
-            itemClassName="text-[13px] font-medium"
-            missingBehavior="placeholder"
-          />
+          {!collapsed && (
+            <PluginSlotOutlet
+              slotTypes={["sidebar"]}
+              context={pluginContext}
+              className="flex flex-col gap-0.5"
+              itemClassName="text-[13px] font-medium"
+              missingBehavior="placeholder"
+            />
+          )}
         </div>
 
         <SidebarSection label="Work">
@@ -118,13 +156,15 @@ export function Sidebar() {
           <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
         </SidebarSection>
 
-        <PluginSlotOutlet
-          slotTypes={["sidebarPanel"]}
-          context={pluginContext}
-          className="flex flex-col gap-3"
-          itemClassName="rounded-lg border border-border p-3"
-          missingBehavior="placeholder"
-        />
+        {!collapsed && (
+          <PluginSlotOutlet
+            slotTypes={["sidebarPanel"]}
+            context={pluginContext}
+            className="flex flex-col gap-3"
+            itemClassName="rounded-lg border border-border p-3"
+            missingBehavior="placeholder"
+          />
+        )}
       </nav>
     </aside>
   );

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -35,6 +35,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Agent } from "@paperclipai/shared";
 
 function SidebarAgentItem({
@@ -159,7 +160,7 @@ export function SidebarAgents() {
   const queryClient = useQueryClient();
   const { selectedCompanyId } = useCompany();
   const { openNewAgent } = useDialogActions();
-  const { isMobile, setSidebarOpen } = useSidebar();
+  const { isMobile, setSidebarOpen, collapsed } = useSidebar();
   const { pushToast } = useToastActions();
   const location = useLocation();
 
@@ -251,6 +252,77 @@ export function SidebarAgents() {
     },
   });
 
+  const agentItems = orderedAgents.map((agent: Agent) => {
+    const runCount = liveCountByAgent.get(agent.id) ?? 0;
+    const link = (
+      <NavLink
+        key={agent.id}
+        to={activeTab ? `${agentUrl(agent)}/${activeTab}` : agentUrl(agent)}
+        state={SIDEBAR_SCROLL_RESET_STATE}
+        onClick={() => {
+          if (isMobile) setSidebarOpen(false);
+        }}
+        className={cn(
+          "flex items-center text-[13px] font-medium transition-colors",
+          collapsed ? "justify-center px-0 py-1.5" : "gap-2.5 px-3 py-1.5",
+          activeAgentId === agentRouteRef(agent)
+            ? "bg-accent text-foreground"
+            : "text-foreground/80 hover:bg-accent/50 hover:text-foreground"
+        )}
+      >
+        <span className="relative shrink-0">
+          <AgentIcon icon={agent.icon} className="h-3.5 w-3.5 text-muted-foreground" />
+          {collapsed && runCount > 0 && (
+            <span className="absolute -right-1 -top-1 flex h-2 w-2">
+              <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+            </span>
+          )}
+          {collapsed && agent.pauseReason === "budget" && (
+            <span className="absolute -right-1 -bottom-1 h-2 w-2 rounded-full bg-amber-500" />
+          )}
+        </span>
+        {!collapsed && <span className="flex-1 truncate">{agent.name}</span>}
+        {!collapsed && (agent.pauseReason === "budget" || runCount > 0) && (
+          <span className="ml-auto flex items-center gap-1.5 shrink-0">
+            {agent.pauseReason === "budget" ? (
+              <BudgetSidebarMarker title="Agent paused by budget" />
+            ) : null}
+            {runCount > 0 ? (
+              <span className="relative flex h-2 w-2">
+                <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+              </span>
+            ) : null}
+            {runCount > 0 ? (
+              <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">
+                {runCount} live
+              </span>
+            ) : null}
+          </span>
+        )}
+      </NavLink>
+    );
+    if (collapsed) {
+      return (
+        <Tooltip key={agent.id} delayDuration={0}>
+          <TooltipTrigger asChild>{link}</TooltipTrigger>
+          <TooltipContent side="right" sideOffset={8}>{agent.name}</TooltipContent>
+        </Tooltip>
+      );
+    }
+    return link;
+  });
+
+  if (collapsed) {
+    return (
+      <div>
+        <div className="my-1 mx-2 h-px bg-border" />
+        <div className="flex flex-col gap-0.5 mt-0.5">{agentItems}</div>
+      </div>
+    );
+  }
+
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
       <div className="group">
@@ -278,7 +350,6 @@ export function SidebarAgents() {
           </button>
         </div>
       </div>
-
       <CollapsibleContent>
         <div className="flex flex-col gap-0.5 mt-0.5">
           {orderedAgents.map((agent: Agent) => {

--- a/ui/src/components/SidebarNavItem.tsx
+++ b/ui/src/components/SidebarNavItem.tsx
@@ -2,6 +2,7 @@ import { NavLink } from "@/lib/router";
 import { SIDEBAR_SCROLL_RESET_STATE } from "../lib/navigation-scroll";
 import { cn } from "../lib/utils";
 import { useSidebar } from "../context/SidebarContext";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import type { LucideIcon } from "lucide-react";
 
 interface SidebarNavItemProps {
@@ -31,9 +32,9 @@ export function SidebarNavItem({
   alert = false,
   liveCount,
 }: SidebarNavItemProps) {
-  const { isMobile, setSidebarOpen } = useSidebar();
+  const { isMobile, setSidebarOpen, collapsed } = useSidebar();
 
-  return (
+  const link = (
     <NavLink
       to={to}
       state={SIDEBAR_SCROLL_RESET_STATE}
@@ -41,7 +42,10 @@ export function SidebarNavItem({
       onClick={() => { if (isMobile) setSidebarOpen(false); }}
       className={({ isActive }) =>
         cn(
-          "flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors",
+          "flex items-center transition-colors",
+          collapsed
+            ? "justify-center px-0 py-2 text-[13px] font-medium"
+            : "gap-2.5 px-3 py-2 text-[13px] font-medium",
           isActive
             ? "bg-accent text-foreground"
             : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
@@ -54,41 +58,63 @@ export function SidebarNavItem({
         {alert && (
           <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-red-500 shadow-[0_0_0_2px_hsl(var(--background))]" />
         )}
-      </span>
-      <span className="flex-1 truncate">{label}</span>
-      {textBadge && (
-        <span
-          className={cn(
-            "ml-auto rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none",
-            textBadgeTone === "amber"
-              ? "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
-              : "bg-muted text-muted-foreground",
-          )}
-        >
-          {textBadge}
-        </span>
-      )}
-      {liveCount != null && liveCount > 0 && (
-        <span className="ml-auto flex items-center gap-1.5">
-          <span className="relative flex h-2 w-2">
-            <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
-            <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+        {collapsed && badge != null && badge > 0 && (
+          <span className="absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full bg-primary text-[7px] font-bold text-primary-foreground">
+            {badge > 9 ? "9+" : badge}
           </span>
-          <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">{liveCount} live</span>
-        </span>
-      )}
-      {badge != null && badge > 0 && (
-        <span
-          className={cn(
-            "ml-auto rounded-full px-1.5 py-0.5 text-xs leading-none",
-            badgeTone === "danger"
-              ? "bg-red-600/90 text-red-50"
-              : "bg-primary text-primary-foreground",
+        )}
+      </span>
+      {!collapsed && (
+        <>
+          <span className="flex-1 truncate">{label}</span>
+          {textBadge && (
+            <span
+              className={cn(
+                "ml-auto rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none",
+                textBadgeTone === "amber"
+                  ? "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
+                  : "bg-muted text-muted-foreground",
+              )}
+            >
+              {textBadge}
+            </span>
           )}
-        >
-          {badge}
-        </span>
+          {liveCount != null && liveCount > 0 && (
+            <span className="ml-auto flex items-center gap-1.5">
+              <span className="relative flex h-2 w-2">
+                <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+              </span>
+              <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">{liveCount} live</span>
+            </span>
+          )}
+          {badge != null && badge > 0 && (
+            <span
+              className={cn(
+                "ml-auto rounded-full px-1.5 py-0.5 text-xs leading-none",
+                badgeTone === "danger"
+                  ? "bg-red-600/90 text-red-50"
+                  : "bg-primary text-primary-foreground",
+              )}
+            >
+              {badge}
+            </span>
+          )}
+        </>
       )}
     </NavLink>
   );
+
+  if (collapsed) {
+    return (
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>{link}</TooltipTrigger>
+        <TooltipContent side="right" sideOffset={8}>
+          <p>{label}</p>
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return link;
 }

--- a/ui/src/components/SidebarProjects.tsx
+++ b/ui/src/components/SidebarProjects.tsx
@@ -15,6 +15,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { useCompany } from "../context/CompanyContext";
 import { useDialogActions } from "../context/DialogContext";
 import { useSidebar } from "../context/SidebarContext";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { authApi } from "../api/auth";
 import { projectsApi } from "../api/projects";
 import { SIDEBAR_SCROLL_RESET_STATE } from "../lib/navigation-scroll";
@@ -37,6 +38,7 @@ function SortableProjectItem({
   companyId,
   companyPrefix,
   isMobile,
+  collapsed,
   project,
   projectSidebarSlots,
   setSidebarOpen,
@@ -45,6 +47,7 @@ function SortableProjectItem({
   companyId: string | null;
   companyPrefix: string | null;
   isMobile: boolean;
+  collapsed: boolean;
   project: Project;
   projectSidebarSlots: ProjectSidebarSlot[];
   setSidebarOpen: (open: boolean) => void;
@@ -73,31 +76,54 @@ function SortableProjectItem({
       {...listeners}
     >
       <div className="flex flex-col gap-0.5">
-        <NavLink
-          to={`/projects/${routeRef}/issues`}
-          state={SIDEBAR_SCROLL_RESET_STATE}
-          onClick={(e) => {
-            if (isDragging) {
-              e.preventDefault();
-              return;
-            }
-            if (isMobile) setSidebarOpen(false);
-          }}
-          className={cn(
-            "flex items-center gap-2.5 px-3 py-1.5 text-[13px] font-medium transition-colors",
-            activeProjectRef === routeRef || activeProjectRef === project.id
-              ? "bg-accent text-foreground"
-              : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
-          )}
-        >
-          <span
-            className="shrink-0 h-3.5 w-3.5 rounded-sm"
-            style={{ backgroundColor: project.color ?? "#6366f1" }}
-          />
-          <span className="flex-1 truncate">{project.name}</span>
-          {project.pauseReason === "budget" ? <BudgetSidebarMarker title="Project paused by budget" /> : null}
-        </NavLink>
-        {projectSidebarSlots.length > 0 && (
+        {collapsed ? (
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+              <NavLink
+                to={`/projects/${routeRef}/issues`}
+                state={SIDEBAR_SCROLL_RESET_STATE}
+                onClick={(e) => {
+                  if (isDragging) { e.preventDefault(); return; }
+                }}
+                className={cn(
+                  "flex items-center justify-center px-0 py-1.5 text-[13px] font-medium transition-colors",
+                  activeProjectRef === routeRef || activeProjectRef === project.id
+                    ? "bg-accent text-foreground"
+                    : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
+                )}
+              >
+                <span
+                  className="shrink-0 h-3.5 w-3.5 rounded-sm"
+                  style={{ backgroundColor: project.color ?? "#6366f1" }}
+                />
+              </NavLink>
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={8}>{project.name}</TooltipContent>
+          </Tooltip>
+        ) : (
+          <NavLink
+            to={`/projects/${routeRef}/issues`}
+            state={SIDEBAR_SCROLL_RESET_STATE}
+            onClick={(e) => {
+              if (isDragging) { e.preventDefault(); return; }
+              if (isMobile) setSidebarOpen(false);
+            }}
+            className={cn(
+              "flex items-center gap-2.5 px-3 py-1.5 text-[13px] font-medium transition-colors",
+              activeProjectRef === routeRef || activeProjectRef === project.id
+                ? "bg-accent text-foreground"
+                : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
+            )}
+          >
+            <span
+              className="shrink-0 h-3.5 w-3.5 rounded-sm"
+              style={{ backgroundColor: project.color ?? "#6366f1" }}
+            />
+            <span className="flex-1 truncate">{project.name}</span>
+            {project.pauseReason === "budget" ? <BudgetSidebarMarker title="Project paused by budget" /> : null}
+          </NavLink>
+        )}
+        {!collapsed && projectSidebarSlots.length > 0 && (
           <div className="ml-5 flex flex-col gap-0.5">
             {projectSidebarSlots.map((slot) => (
               <PluginSlotMount
@@ -125,7 +151,7 @@ export function SidebarProjects() {
   const [open, setOpen] = useState(true);
   const { selectedCompany, selectedCompanyId } = useCompany();
   const { openNewProject } = useDialogActions();
-  const { isMobile, setSidebarOpen } = useSidebar();
+  const { isMobile, setSidebarOpen, collapsed } = useSidebar();
   const location = useLocation();
 
   const { data: projects } = useQuery({
@@ -180,6 +206,44 @@ export function SidebarProjects() {
     [orderedProjects, persistOrder],
   );
 
+  const projectItems = (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={orderedProjects.map((project) => project.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="flex flex-col gap-0.5 mt-0.5">
+          {orderedProjects.map((project: Project) => (
+            <SortableProjectItem
+              key={project.id}
+              activeProjectRef={activeProjectRef}
+              companyId={selectedCompanyId}
+              companyPrefix={selectedCompany?.issuePrefix ?? null}
+              isMobile={isMobile}
+              collapsed={collapsed}
+              project={project}
+              projectSidebarSlots={projectSidebarSlots}
+              setSidebarOpen={setSidebarOpen}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+
+  if (collapsed) {
+    return (
+      <div>
+        <div className="my-1 mx-2 h-px bg-border" />
+        {projectItems}
+      </div>
+    );
+  }
+
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
       <div className="group">
@@ -207,34 +271,7 @@ export function SidebarProjects() {
           </button>
         </div>
       </div>
-
-      <CollapsibleContent>
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleDragEnd}
-        >
-          <SortableContext
-            items={orderedProjects.map((project) => project.id)}
-            strategy={verticalListSortingStrategy}
-          >
-            <div className="flex flex-col gap-0.5 mt-0.5">
-              {orderedProjects.map((project: Project) => (
-                <SortableProjectItem
-                  key={project.id}
-                  activeProjectRef={activeProjectRef}
-                  companyId={selectedCompanyId}
-                  companyPrefix={selectedCompany?.issuePrefix ?? null}
-                  isMobile={isMobile}
-                  project={project}
-                  projectSidebarSlots={projectSidebarSlots}
-                  setSidebarOpen={setSidebarOpen}
-                />
-              ))}
-            </div>
-          </SortableContext>
-        </DndContext>
-      </CollapsibleContent>
+      <CollapsibleContent>{projectItems}</CollapsibleContent>
     </Collapsible>
   );
 }

--- a/ui/src/components/SidebarSection.tsx
+++ b/ui/src/components/SidebarSection.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { useSidebar } from "../context/SidebarContext";
 
 interface SidebarSectionProps {
   label: string;
@@ -6,11 +7,16 @@ interface SidebarSectionProps {
 }
 
 export function SidebarSection({ label, children }: SidebarSectionProps) {
+  const { collapsed } = useSidebar();
+
   return (
     <div>
-      <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-widest font-mono text-muted-foreground/60">
-        {label}
-      </div>
+      {!collapsed && (
+        <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-widest font-mono text-muted-foreground/60">
+          {label}
+        </div>
+      )}
+      {collapsed && <div className="my-1 mx-2 h-px bg-border" />}
       <div className="flex flex-col gap-0.5 mt-0.5">{children}</div>
     </div>
   );

--- a/ui/src/context/SidebarContext.tsx
+++ b/ui/src/context/SidebarContext.tsx
@@ -5,30 +5,59 @@ interface SidebarContextValue {
   setSidebarOpen: (open: boolean) => void;
   toggleSidebar: () => void;
   isMobile: boolean;
+  /** Desktop-only: sidebar is visible but narrow (icons only) */
+  collapsed: boolean;
 }
 
 const SidebarContext = createContext<SidebarContextValue | null>(null);
 
 const MOBILE_BREAKPOINT = 768;
+const SIDEBAR_STORAGE_KEY = "paperclip:sidebar-open";
+
+function readSidebarPref(): boolean | null {
+  try {
+    const v = localStorage.getItem(SIDEBAR_STORAGE_KEY);
+    return v === "true" ? true : v === "false" ? false : null;
+  } catch { return null; }
+}
 
 export function SidebarProvider({ children }: { children: ReactNode }) {
   const [isMobile, setIsMobile] = useState(() => window.innerWidth < MOBILE_BREAKPOINT);
-  const [sidebarOpen, setSidebarOpen] = useState(() => window.innerWidth >= MOBILE_BREAKPOINT);
+  const [sidebarOpen, setSidebarOpenRaw] = useState(() => {
+    if (window.innerWidth < MOBILE_BREAKPOINT) return false;
+    return readSidebarPref() ?? true;
+  });
+
+  const setSidebarOpen = useCallback((open: boolean | ((prev: boolean) => boolean)) => {
+    setSidebarOpenRaw((prev) => {
+      const next = typeof open === "function" ? open(prev) : open;
+      if (!isMobile) {
+        try { localStorage.setItem(SIDEBAR_STORAGE_KEY, String(next)); } catch {}
+      }
+      return next;
+    });
+  }, [isMobile]);
 
   useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const onChange = (e: MediaQueryListEvent) => {
       setIsMobile(e.matches);
-      setSidebarOpen(!e.matches);
+      if (e.matches) {
+        setSidebarOpenRaw(false);
+      } else {
+        setSidebarOpenRaw(readSidebarPref() ?? true);
+      }
     };
     mql.addEventListener("change", onChange);
     return () => mql.removeEventListener("change", onChange);
   }, []);
 
-  const toggleSidebar = useCallback(() => setSidebarOpen((v) => !v), []);
+  const toggleSidebar = useCallback(() => setSidebarOpen((v) => !v), [setSidebarOpen]);
+
+  const collapsed = !isMobile && !sidebarOpen;
 
   return (
-    <SidebarContext.Provider value={{ sidebarOpen, setSidebarOpen, toggleSidebar, isMobile }}>
+    <SidebarContext.Provider value={{ sidebarOpen, setSidebarOpen, toggleSidebar, isMobile, collapsed }}>
       {children}
     </SidebarContext.Provider>
   );

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -400,10 +400,11 @@ function IssueDetailLoadingState({
 }: {
   headerSeed: ReturnType<typeof readIssueDetailHeaderSeed>;
 }) {
+  const { collapsed } = useSidebar();
   const identifier = headerSeed?.identifier ?? headerSeed?.id.slice(0, 8) ?? null;
 
   return (
-    <div className="max-w-3xl space-y-6">
+    <div className={cn("max-w-2xl space-y-6", collapsed && "mx-auto")}>
       <div className="space-y-3">
         <Skeleton className="h-3 w-40" />
 
@@ -1118,7 +1119,7 @@ export function IssueDetail() {
   const navigationType = useNavigationType();
   const location = useLocation();
   const { pushToast } = useToastActions();
-  const { isMobile } = useSidebar();
+  const { isMobile, collapsed } = useSidebar();
   const [moreOpen, setMoreOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [mobilePropsOpen, setMobilePropsOpen] = useState(false);
@@ -2987,7 +2988,7 @@ export function IssueDetail() {
   );
 
   return (
-    <div className="max-w-3xl space-y-6">
+    <div className={cn("max-w-2xl space-y-6", collapsed && "mx-auto")}>
       {/* Parent chain breadcrumb */}
       {ancestors.length > 0 && (
         <nav className="flex items-center gap-1 text-xs text-muted-foreground flex-wrap">

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -404,7 +404,7 @@ function IssueDetailLoadingState({
   const identifier = headerSeed?.identifier ?? headerSeed?.id.slice(0, 8) ?? null;
 
   return (
-    <div className={cn("max-w-2xl space-y-6", collapsed && "mx-auto")}>
+    <div className={cn("space-y-6", collapsed ? "max-w-4xl mx-auto" : "max-w-3xl")}>
       <div className="space-y-3">
         <Skeleton className="h-3 w-40" />
 
@@ -2988,7 +2988,7 @@ export function IssueDetail() {
   );
 
   return (
-    <div className={cn("max-w-2xl space-y-6", collapsed && "mx-auto")}>
+    <div className={cn("space-y-6", collapsed ? "max-w-4xl mx-auto" : "max-w-3xl")}>
       {/* Parent chain breadcrumb */}
       {ancestors.length > 0 && (
         <nav className="flex items-center gap-1 text-xs text-muted-foreground flex-wrap">


### PR DESCRIPTION
## Thinking Path

> - Paperclip'\''s sidebar is always expanded on desktop (240px), wasting horizontal space
> - Users reading issue details or focused on a single task don'\''t need the full nav visible
> - Mobile already has a collapse mechanism (drawer overlay) but desktop has no equivalent
> - The SidebarContext already manages sidebarOpen state — extending it with a collapsed derived state is minimal surface area
> - Icon-only mode (48px) preserves navigation while reclaiming ~192px of content width
> - Issue detail pages benefit most from the extra width — centering content creates a zen reading mode similar to Logseq/Notion
> - State persistence via localStorage means the preference survives page refreshes without server-side storage
> - Existing components (SidebarNavItem, SidebarSection, SidebarAgents, SidebarProjects) need collapsed variants but the API surface stays the same

## Summary

- Collapsible desktop sidebar: toggle between full (240px) and icon-only (48px) mode
- All nav items, agents, and projects show as icons with tooltips when collapsed
- Footer adapts: docs/settings/theme/toggle shown as icon buttons with tooltips above
- Issue detail page centers content (mx-auto) when collapsed for distraction-free reading
- Sidebar state persists in localStorage across sessions
- CompanyRail (72px) always visible when collapsed
- InstanceSidebar updated with same collapsed handling
- Agent status indicators (live-run pulse, budget pause) visible as dot overlays when collapsed

## Files Changed

- SidebarContext.tsx — add collapsed derived state, localStorage persistence
- Layout.tsx — collapse toggle (chevrons), w-60/w-12 transition, footer icon mode
- Sidebar.tsx — company dot/initial, icon-only nav, hidden search when collapsed
- SidebarNavItem.tsx — icon-only with tooltip, badge dot overlay
- SidebarSection.tsx — thin divider replaces labels when collapsed
- SidebarAgents.tsx — skip Collapsible, agent icons with tooltips, status dot overlays
- SidebarProjects.tsx — skip Collapsible, color dots with tooltips
- InstanceSidebar.tsx — collapsed mode with icon-only settings nav
- IssueDetail.tsx — mx-auto centering when collapsed

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.6 (claude-opus-4-6)
- Context window: 1M tokens
- Capabilities: Tool use, code execution

## Test plan

- [x] Toggle sidebar collapse via chevron button in footer
- [x] Verify all nav items show tooltips on hover when collapsed
- [x] Verify agents and projects show as icons/dots with tooltips
- [x] Verify agent live-run pulse and budget pause dots visible when collapsed
- [x] Verify footer icons (docs, settings, theme, expand) show tooltips above
- [x] Verify issue detail page centers content when collapsed
- [x] Verify sidebar state persists after page refresh
- [x] Verify mobile behavior unchanged (drawer overlay, not icon mode)
- [x] Verify CompanyRail stays visible when collapsed
- [x] Verify InstanceSidebar works correctly when collapsed

Tested on a production Paperclip instance (v2026.416.0) for 4+ hours.

## Risks

Low risk. All changes are additive — existing expanded sidebar behavior is completely unchanged. The collapsed state is opt-in (user must click the toggle). Mobile behavior is unaffected. No server-side changes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge