### PR TITLE
feat: template gallery

### DIFF
--- a/docs/templates/registry.json
+++ b/docs/templates/registry.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "generated_at": "2026-04-16T14:00:00Z",
+  "source": "https://github.com/paperclipai/companies",
+  "companies": [
+    {
+      "slug": "trail-of-bits-security",
+      "name": "Trail of Bits Security",
+      "description": "Security auditing and pentesting agents modeled on Trail of Bits' practices.",
+      "agents_count": 28,
+      "skills_count": 35,
+      "tags": ["security", "audit", "pentesting"],
+      "url": "https://github.com/paperclipai/companies/tree/main/trail-of-bits-security"
+    },
+    {
+      "slug": "fullstack-forge",
+      "name": "Fullstack Forge",
+      "description": "Software development team covering frontend, backend, infra, and lead roles.",
+      "agents_count": 49,
+      "skills_count": 66,
+      "tags": ["engineering", "fullstack"],
+      "url": "https://github.com/paperclipai/companies/tree/main/fullstack-forge"
+    },
+    {
+      "slug": "kdense-science-lab",
+      "name": "K-Dense Science Lab",
+      "description": "Research-oriented scientific lab — biology, chemistry, biomedical, cheminformatics.",
+      "agents_count": 54,
+      "skills_count": 177,
+      "tags": ["science", "research", "biology"],
+      "url": "https://github.com/paperclipai/companies/tree/main/kdense-science-lab"
+    },
+    {
+      "slug": "agency-agents",
+      "name": "Agency Agents",
+      "description": "Full-service AI agency with 167 specialist agents across domains.",
+      "agents_count": 167,
+      "skills_count": 0,
+      "tags": ["agency", "general"],
+      "url": "https://github.com/paperclipai/companies/tree/main/agency-agents"
+    }
+  ]
+}

--- a/packages/shared/src/__tests__/registry-file.test.ts
+++ b/packages/shared/src/__tests__/registry-file.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { templateRegistrySchema } from "../template-types.js";
+
+describe("docs/templates/registry.json", () => {
+  it("conforms to the schema", () => {
+    const registryPath = fileURLToPath(
+      new URL("../../../../docs/templates/registry.json", import.meta.url),
+    );
+    const raw = JSON.parse(readFileSync(registryPath, "utf-8"));
+    expect(() => templateRegistrySchema.parse(raw)).not.toThrow();
+  });
+});

--- a/packages/shared/src/__tests__/template-types.test.ts
+++ b/packages/shared/src/__tests__/template-types.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { templateRegistrySchema, type TemplateRegistry } from "../template-types.js";
+
+describe("templateRegistrySchema", () => {
+  it("accepts a valid registry", () => {
+    const valid: TemplateRegistry = {
+      version: 1,
+      generated_at: "2026-04-16T14:00:00Z",
+      source: "https://github.com/paperclipai/companies",
+      companies: [
+        {
+          slug: "trail-of-bits-security",
+          name: "Trail of Bits Security",
+          description: "Security auditing",
+          agents_count: 28,
+          skills_count: 35,
+          tags: ["security"],
+          url: "https://github.com/paperclipai/companies/tree/main/trail-of-bits-security",
+        },
+      ],
+    };
+    expect(() => templateRegistrySchema.parse(valid)).not.toThrow();
+  });
+
+  it("rejects registry with invalid version", () => {
+    expect(() => templateRegistrySchema.parse({ version: 0, companies: [] })).toThrow();
+  });
+
+  it("rejects company without slug", () => {
+    const bad = { version: 1, generated_at: "2026-04-16T14:00:00Z", source: "x", companies: [{ name: "x" }] };
+    expect(() => templateRegistrySchema.parse(bad)).toThrow();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -718,3 +718,5 @@ export {
   type SecretsLocalEncryptedConfig,
   type ConfigMeta,
 } from "./config-schema.js";
+
+export * from "./template-types.js";

--- a/packages/shared/src/template-types.ts
+++ b/packages/shared/src/template-types.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const templateCompanySchema = z.object({
+  slug: z.string().min(1).regex(/^[a-z0-9-]+$/),
+  name: z.string().min(1),
+  description: z.string(),
+  agents_count: z.number().int().nonnegative(),
+  skills_count: z.number().int().nonnegative(),
+  tags: z.array(z.string()).default([]),
+  url: z.string().url(),
+  readme_excerpt: z.string().optional(),
+});
+
+export const templateRegistrySchema = z.object({
+  version: z.literal(1),
+  generated_at: z.string(),
+  source: z.string().url(),
+  companies: z.array(templateCompanySchema),
+});
+
+export type TemplateCompany = z.infer<typeof templateCompanySchema>;
+export type TemplateRegistry = z.infer<typeof templateRegistrySchema>;
+
+export interface TemplateInstallRequest {
+  slug: string;
+}
+
+export interface TemplateInstallResponse {
+  companyId: string;
+  name: string;
+  agentsCreated: number;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,6 +704,15 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.7
         version: 4.1.18(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
@@ -733,6 +742,9 @@ packages:
 
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -3377,6 +3389,32 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -3667,6 +3705,14 @@ packages:
   anser@2.3.5:
     resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
 
@@ -3676,6 +3722,13 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
@@ -3981,6 +4034,9 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -4237,6 +4293,12 @@ packages:
   diff@5.2.2:
     resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dompurify@3.3.2:
     resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
@@ -4651,6 +4713,10 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -5137,6 +5203,10 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -5356,6 +5426,10 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -5512,6 +5586,10 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -5689,6 +5767,10 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
@@ -6188,6 +6270,8 @@ packages:
 snapshots:
 
   '@acemir/cssom@0.9.31': {}
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -9364,6 +9448,38 @@ snapshots:
       '@tanstack/query-core': 5.90.20
       react: 19.2.4
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.0
@@ -9726,6 +9842,10 @@ snapshots:
 
   anser@2.3.5: {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   append-field@1.0.0: {}
 
   argparse@2.0.1: {}
@@ -9733,6 +9853,12 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   asap@2.0.6: {}
 
@@ -9999,6 +10125,8 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   cssstyle@6.2.0:
@@ -10263,6 +10391,10 @@ snapshots:
       wrappy: 1.0.2
 
   diff@5.2.2: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dompurify@3.3.2:
     optionalDependencies:
@@ -10725,6 +10857,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
+
+  indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -11466,6 +11600,8 @@ snapshots:
 
   mime@2.6.0: {}
 
+  min-indent@1.0.1: {}
+
   minimist@1.2.8: {}
 
   mlly@1.8.1:
@@ -11691,6 +11827,12 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prismjs@1.30.0: {}
 
   process-warning@5.0.0: {}
@@ -11896,6 +12038,11 @@ snapshots:
   readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   remark-gfm@4.0.1:
     dependencies:
@@ -12159,6 +12306,10 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@5.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,15 +704,6 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.7
         version: 4.1.18(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
-      '@testing-library/dom':
-        specifier: ^10.4.1
-        version: 10.4.1
-      '@testing-library/jest-dom':
-        specifier: ^6.9.1
-        version: 6.9.1
-      '@testing-library/react':
-        specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
@@ -742,9 +733,6 @@ packages:
 
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
-
-  '@adobe/css-tools@4.4.4':
-    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -3389,32 +3377,6 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@testing-library/dom@10.4.1':
-    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
-    engines: {node: '>=18'}
-
-  '@testing-library/jest-dom@6.9.1':
-    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
-    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
-
-  '@testing-library/react@16.3.2':
-    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@testing-library/dom': ^10.0.0
-      '@types/react': ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^18.0.0 || ^19.0.0
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@types/aria-query@5.0.4':
-    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
-
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -3705,14 +3667,6 @@ packages:
   anser@2.3.5:
     resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
 
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-
-  ansi-styles@5.2.0:
-    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
-    engines: {node: '>=10'}
-
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
 
@@ -3722,13 +3676,6 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
-
-  aria-query@5.3.0:
-    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
-
-  aria-query@5.3.2:
-    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
-    engines: {node: '>= 0.4'}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
@@ -4034,9 +3981,6 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
-  css.escape@1.5.1:
-    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
-
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -4293,12 +4237,6 @@ packages:
   diff@5.2.2:
     resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
     engines: {node: '>=0.3.1'}
-
-  dom-accessibility-api@0.5.16:
-    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
-
-  dom-accessibility-api@0.6.3:
-    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dompurify@3.3.2:
     resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
@@ -4713,10 +4651,6 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  indent-string@4.0.0:
-    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
-    engines: {node: '>=8'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -5203,10 +5137,6 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
-  min-indent@1.0.1:
-    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
-    engines: {node: '>=4'}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -5426,10 +5356,6 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
-  pretty-format@27.5.1:
-    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -5586,10 +5512,6 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
-
-  redent@3.0.0:
-    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
-    engines: {node: '>=8'}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -5767,10 +5689,6 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
-
-  strip-indent@3.0.0:
-    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
-    engines: {node: '>=8'}
 
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
@@ -6270,8 +6188,6 @@ packages:
 snapshots:
 
   '@acemir/cssom@0.9.31': {}
-
-  '@adobe/css-tools@4.4.4': {}
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -9448,38 +9364,6 @@ snapshots:
       '@tanstack/query-core': 5.90.20
       react: 19.2.4
 
-  '@testing-library/dom@10.4.1':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.6
-      '@types/aria-query': 5.0.4
-      aria-query: 5.3.0
-      dom-accessibility-api: 0.5.16
-      lz-string: 1.5.0
-      picocolors: 1.1.1
-      pretty-format: 27.5.1
-
-  '@testing-library/jest-dom@6.9.1':
-    dependencies:
-      '@adobe/css-tools': 4.4.4
-      aria-query: 5.3.2
-      css.escape: 1.5.1
-      dom-accessibility-api: 0.6.3
-      picocolors: 1.1.1
-      redent: 3.0.0
-
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@testing-library/dom': 10.4.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@types/aria-query@5.0.4': {}
-
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.0
@@ -9842,10 +9726,6 @@ snapshots:
 
   anser@2.3.5: {}
 
-  ansi-regex@5.0.1: {}
-
-  ansi-styles@5.2.0: {}
-
   append-field@1.0.0: {}
 
   argparse@2.0.1: {}
@@ -9853,12 +9733,6 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
-
-  aria-query@5.3.0:
-    dependencies:
-      dequal: 2.0.3
-
-  aria-query@5.3.2: {}
 
   asap@2.0.6: {}
 
@@ -10125,8 +9999,6 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
-  css.escape@1.5.1: {}
-
   cssesc@3.0.0: {}
 
   cssstyle@6.2.0:
@@ -10391,10 +10263,6 @@ snapshots:
       wrappy: 1.0.2
 
   diff@5.2.2: {}
-
-  dom-accessibility-api@0.5.16: {}
-
-  dom-accessibility-api@0.6.3: {}
 
   dompurify@3.3.2:
     optionalDependencies:
@@ -10857,8 +10725,6 @@ snapshots:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
-
-  indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -11600,8 +11466,6 @@ snapshots:
 
   mime@2.6.0: {}
 
-  min-indent@1.0.1: {}
-
   minimist@1.2.8: {}
 
   mlly@1.8.1:
@@ -11827,12 +11691,6 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
-  pretty-format@27.5.1:
-    dependencies:
-      ansi-regex: 5.0.1
-      ansi-styles: 5.2.0
-      react-is: 17.0.2
-
   prismjs@1.30.0: {}
 
   process-warning@5.0.0: {}
@@ -12038,11 +11896,6 @@ snapshots:
   readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
-
-  redent@3.0.0:
-    dependencies:
-      indent-string: 4.0.0
-      strip-indent: 3.0.0
 
   remark-gfm@4.0.1:
     dependencies:
@@ -12306,10 +12159,6 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
-
-  strip-indent@3.0.0:
-    dependencies:
-      min-indent: 1.0.1
 
   strip-json-comments@5.0.3: {}
 

--- a/server/src/__tests__/template-registry.test.ts
+++ b/server/src/__tests__/template-registry.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createTemplateRegistry } from "../services/template-registry.js";
+
+function writeRegistry(dir: string, payload: unknown) {
+  writeFileSync(path.join(dir, "registry.json"), JSON.stringify(payload));
+}
+
+describe("createTemplateRegistry", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "tpl-registry-"));
+  });
+
+  it("loads a valid registry file", async () => {
+    writeRegistry(dir, {
+      version: 1,
+      generated_at: "2026-04-16T14:00:00Z",
+      source: "https://github.com/paperclipai/companies",
+      companies: [
+        { slug: "a", name: "A", description: "x", agents_count: 1, skills_count: 0, tags: [], url: "https://example.com" },
+      ],
+    });
+    const registry = createTemplateRegistry(path.join(dir, "registry.json"));
+    const loaded = await registry.get();
+    expect(loaded.companies).toHaveLength(1);
+    expect(loaded.companies[0].slug).toBe("a");
+  });
+
+  it("throws when file missing", async () => {
+    const registry = createTemplateRegistry(path.join(dir, "missing.json"));
+    await expect(registry.get()).rejects.toThrow(/not found/i);
+  });
+
+  it("throws when schema invalid", async () => {
+    writeRegistry(dir, { version: 99, companies: [] });
+    const registry = createTemplateRegistry(path.join(dir, "registry.json"));
+    await expect(registry.get()).rejects.toThrow();
+  });
+
+  it("caches the parsed result between calls", async () => {
+    writeRegistry(dir, {
+      version: 1,
+      generated_at: "2026-04-16T14:00:00Z",
+      source: "https://github.com/paperclipai/companies",
+      companies: [],
+    });
+    const registry = createTemplateRegistry(path.join(dir, "registry.json"));
+    const first = await registry.get();
+    // Corrupt the file; cached result must still return.
+    writeFileSync(path.join(dir, "registry.json"), "not json");
+    const second = await registry.get();
+    expect(second).toBe(first);
+  });
+
+  it("invalidate() forces a fresh read", async () => {
+    writeRegistry(dir, { version: 1, generated_at: "x", source: "https://x.example", companies: [] });
+    const registry = createTemplateRegistry(path.join(dir, "registry.json"));
+    await registry.get();
+    writeRegistry(dir, {
+      version: 1,
+      generated_at: "y",
+      source: "https://x.example",
+      companies: [{ slug: "b", name: "B", description: "x", agents_count: 0, skills_count: 0, tags: [], url: "https://example.com" }],
+    });
+    registry.invalidate();
+    const fresh = await registry.get();
+    expect(fresh.companies).toHaveLength(1);
+  });
+});

--- a/server/src/__tests__/templates-routes.test.ts
+++ b/server/src/__tests__/templates-routes.test.ts
@@ -53,3 +53,43 @@ describe("GET /api/templates/companies", () => {
     expect(res.status).toBe(503);
   });
 });
+
+describe("POST /api/templates/companies/install", () => {
+  it("returns 401 unauthenticated", async () => {
+    const res = await request(mkApp({ actor: "none" })).post("/api/templates/companies/install").send({ slug: "a" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when slug missing", async () => {
+    const res = await request(mkApp({ actor: "board" })).post("/api/templates/companies/install").send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when slug not in registry", async () => {
+    const res = await request(mkApp({ actor: "board" })).post("/api/templates/companies/install").send({ slug: "unknown" });
+    expect(res.status).toBe(404);
+  });
+
+  it("delegates to portability.importBundle with github source and returns companyId", async () => {
+    let received: any = null;
+    const portability = {
+      importBundle: async (payload: any, _userId: string | null) => {
+        received = payload;
+        return { company: { id: "new-co", name: "A" }, agents: [{ slug: "x" }], warnings: [] };
+      },
+    };
+    const res = await request(mkApp({ actor: "board", portability })).post("/api/templates/companies/install").send({ slug: "a" });
+    expect(res.status).toBe(200);
+    expect(res.body.companyId).toBe("new-co");
+    expect(res.body.agentsCreated).toBe(1);
+    expect(received.source).toEqual({ type: "github", url: "https://example.com" });
+    expect(received.target.mode).toBe("new");
+  });
+
+  it("returns 422 when importBundle throws", async () => {
+    const portability = { importBundle: async () => { throw new Error("bad bundle"); } };
+    const res = await request(mkApp({ actor: "board", portability })).post("/api/templates/companies/install").send({ slug: "a" });
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBeTruthy();
+  });
+});

--- a/server/src/__tests__/templates-routes.test.ts
+++ b/server/src/__tests__/templates-routes.test.ts
@@ -93,3 +93,21 @@ describe("POST /api/templates/companies/install", () => {
     expect(res.body.error).toBeTruthy();
   });
 });
+
+describe("POST /api/templates/refresh", () => {
+  it("returns 403 for non-admin board users", async () => {
+    const res = await request(mkApp({ actor: "board" })).post("/api/templates/refresh");
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 and invalidates cache for admins", async () => {
+    let invalidated = false;
+    const registry: TemplateRegistryService = {
+      get: async () => validRegistry,
+      invalidate: () => { invalidated = true; },
+    };
+    const res = await request(mkApp({ actor: "admin", registry })).post("/api/templates/refresh");
+    expect(res.status).toBe(200);
+    expect(invalidated).toBe(true);
+  });
+});

--- a/server/src/__tests__/templates-routes.test.ts
+++ b/server/src/__tests__/templates-routes.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import { templateRoutes } from "../routes/templates.js";
+import type { TemplateRegistryService } from "../services/template-registry.js";
+import type { TemplateRegistry } from "@paperclipai/shared";
+
+const validRegistry: TemplateRegistry = {
+  version: 1,
+  generated_at: "2026-04-16T14:00:00Z",
+  source: "https://github.com/paperclipai/companies",
+  companies: [
+    { slug: "a", name: "A", description: "x", agents_count: 1, skills_count: 0, tags: [], url: "https://example.com" },
+  ],
+};
+
+function mkRegistry(registry: TemplateRegistry = validRegistry): TemplateRegistryService {
+  return { get: async () => registry, invalidate: () => {} };
+}
+
+function mkApp(opts: { actor?: "board" | "admin" | "none"; registry?: TemplateRegistryService; portability?: unknown }) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (opts.actor === "board") (req as any).actor = { type: "board", userId: "u1", isInstanceAdmin: false, source: "session", companyIds: [] };
+    else if (opts.actor === "admin") (req as any).actor = { type: "board", userId: "u1", isInstanceAdmin: true, source: "session", companyIds: [] };
+    else (req as any).actor = { type: "none" };
+    next();
+  });
+  app.use("/api/templates", templateRoutes({
+    registry: opts.registry ?? mkRegistry(),
+    portability: (opts.portability as any) ?? { importBundle: async () => ({ company: { id: "new" }, agents: [], warnings: [] }) },
+  }));
+  return app;
+}
+
+describe("GET /api/templates/companies", () => {
+  it("returns 401 for unauthenticated requests", async () => {
+    const res = await request(mkApp({ actor: "none" })).get("/api/templates/companies");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns registry companies for board users", async () => {
+    const res = await request(mkApp({ actor: "board" })).get("/api/templates/companies");
+    expect(res.status).toBe(200);
+    expect(res.body.companies).toHaveLength(1);
+    expect(res.body.companies[0].slug).toBe("a");
+  });
+
+  it("returns 503 when registry load fails", async () => {
+    const failing: TemplateRegistryService = { get: async () => { throw new Error("boom"); }, invalidate: () => {} };
+    const res = await request(mkApp({ actor: "board", registry: failing })).get("/api/templates/companies");
+    expect(res.status).toBe(503);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,6 +11,9 @@ import { boardMutationGuard } from "./middleware/board-mutation-guard.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "./middleware/private-hostname-guard.js";
 import { healthRoutes } from "./routes/health.js";
 import { companyRoutes } from "./routes/companies.js";
+import { templateRoutes } from "./routes/templates.js";
+import { createTemplateRegistry } from "./services/template-registry.js";
+import { companyPortabilityService } from "./services/company-portability.js";
 import { companySkillRoutes } from "./routes/company-skills.js";
 import { agentRoutes } from "./routes/agents.js";
 import { projectRoutes } from "./routes/projects.js";
@@ -189,7 +192,15 @@ export async function createApp(
       companyDeletionEnabled: opts.companyDeletionEnabled,
     }),
   );
-  api.use("/companies", companyRoutes(db, opts.storageService));
+  const portabilityService = companyPortabilityService(db, opts.storageService);
+  const templateRegistry = createTemplateRegistry(
+    path.resolve(process.cwd(), "docs/templates/registry.json"),
+  );
+  api.use("/companies", companyRoutes(db, opts.storageService, portabilityService));
+  api.use("/templates", templateRoutes({
+    registry: templateRegistry,
+    portability: portabilityService,
+  }));
   api.use(companySkillRoutes(db));
   api.use(agentRoutes(db));
   api.use(assetRoutes(db, opts.storageService));

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -193,8 +193,9 @@ export async function createApp(
     }),
   );
   const portabilityService = companyPortabilityService(db, opts.storageService);
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const templateRegistry = createTemplateRegistry(
-    path.resolve(process.cwd(), "docs/templates/registry.json"),
+    path.resolve(__dirname, "../../docs/templates/registry.json"),
   );
   api.use("/companies", companyRoutes(db, opts.storageService, portabilityService));
   api.use("/templates", templateRoutes({
@@ -301,7 +302,6 @@ export async function createApp(
     localPluginDir: opts.localPluginDir ?? DEFAULT_LOCAL_PLUGIN_DIR,
   }));
 
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
   if (opts.uiMode === "static") {
     // Try published location first (server/ui-dist/), then monorepo dev location (../../ui/dist)
     const candidates = [

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -26,11 +26,15 @@ import {
 import type { StorageService } from "../storage/types.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 
-export function companyRoutes(db: Db, storage?: StorageService) {
+export function companyRoutes(
+  db: Db,
+  storage?: StorageService,
+  portabilityOverride?: ReturnType<typeof companyPortabilityService>,
+) {
   const router = Router();
   const svc = companyService(db);
   const agents = agentService(db);
-  const portability = companyPortabilityService(db, storage);
+  const portability = portabilityOverride ?? companyPortabilityService(db, storage);
   const access = accessService(db);
   const budgets = budgetService(db);
   const feedback = feedbackService(db);

--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -42,6 +42,48 @@ export function templateRoutes(deps: {
     }
   });
 
+  router.post("/companies/install", requireBoard, async (req, res) => {
+    const slug = typeof req.body?.slug === "string" ? req.body.slug : null;
+    if (!slug) {
+      res.status(400).json({ error: "slug required" });
+      return;
+    }
+
+    let registry;
+    try {
+      registry = await deps.registry.get();
+    } catch (err) {
+      res.status(503).json({ error: "registry unavailable" });
+      return;
+    }
+
+    const tpl = registry.companies.find((c) => c.slug === slug);
+    if (!tpl) {
+      res.status(404).json({ error: `unknown template: ${slug}` });
+      return;
+    }
+
+    const payload = {
+      source: { type: "github" as const, url: tpl.url },
+      target: { mode: "new" as const, newCompanyName: tpl.name },
+      include: ["company", "agents", "skills"],
+      collision: "skip" as const,
+    };
+
+    try {
+      const actor = (req as any).actor;
+      const userId = actor?.type === "board" ? actor.userId : null;
+      const result = await deps.portability.importBundle(payload, userId);
+      res.json({
+        companyId: result.company.id,
+        name: result.company.name ?? tpl.name,
+        agentsCreated: result.agents.length,
+      });
+    } catch (err) {
+      res.status(422).json({ error: "import failed", detail: (err as Error).message });
+    }
+  });
+
   // Reserved for Task 6 (admin-only template import).
   void requireAdmin;
 

--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -1,0 +1,49 @@
+import { Router, type Request, type Response, type NextFunction } from "express";
+import type { TemplateRegistryService } from "../services/template-registry.js";
+
+export interface TemplatePortabilityAdapter {
+  importBundle(payload: unknown, userId: string | null): Promise<{
+    company: { id: string; name?: string };
+    agents: Array<{ slug: string }>;
+    warnings: unknown[];
+  }>;
+}
+
+function requireBoard(req: Request, res: Response, next: NextFunction) {
+  const actor = (req as any).actor;
+  if (!actor || actor.type !== "board") {
+    res.status(401).json({ error: "Board authentication required" });
+    return;
+  }
+  next();
+}
+
+function requireAdmin(req: Request, res: Response, next: NextFunction) {
+  const actor = (req as any).actor;
+  if (!actor || actor.type !== "board" || !actor.isInstanceAdmin) {
+    res.status(403).json({ error: "Instance admin required" });
+    return;
+  }
+  next();
+}
+
+export function templateRoutes(deps: {
+  registry: TemplateRegistryService;
+  portability: TemplatePortabilityAdapter;
+}) {
+  const router = Router();
+
+  router.get("/companies", requireBoard, async (_req, res) => {
+    try {
+      const registry = await deps.registry.get();
+      res.json({ companies: registry.companies });
+    } catch (err) {
+      res.status(503).json({ error: "registry unavailable", detail: (err as Error).message });
+    }
+  });
+
+  // Reserved for Task 6 (admin-only template import).
+  void requireAdmin;
+
+  return router;
+}

--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -84,8 +84,15 @@ export function templateRoutes(deps: {
     }
   });
 
-  // Reserved for Task 6 (admin-only template import).
-  void requireAdmin;
+  router.post("/refresh", requireAdmin, async (_req, res) => {
+    deps.registry.invalidate();
+    try {
+      const registry = await deps.registry.get();
+      res.json({ ok: true, companies: registry.companies.length });
+    } catch (err) {
+      res.status(503).json({ error: "registry reload failed", detail: (err as Error).message });
+    }
+  });
 
   return router;
 }

--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -38,7 +38,7 @@ export function templateRoutes(deps: {
       const registry = await deps.registry.get();
       res.json({ companies: registry.companies });
     } catch (err) {
-      res.status(503).json({ error: "registry unavailable", detail: (err as Error).message });
+      res.status(503).json({ error: "registry unavailable" });
     }
   });
 
@@ -90,7 +90,7 @@ export function templateRoutes(deps: {
       const registry = await deps.registry.get();
       res.json({ ok: true, companies: registry.companies.length });
     } catch (err) {
-      res.status(503).json({ error: "registry reload failed", detail: (err as Error).message });
+      res.status(503).json({ error: "registry reload failed" });
     }
   });
 

--- a/server/src/services/template-registry.ts
+++ b/server/src/services/template-registry.ts
@@ -1,0 +1,29 @@
+import { readFile } from "node:fs/promises";
+import { templateRegistrySchema, type TemplateRegistry } from "@paperclipai/shared";
+
+export interface TemplateRegistryService {
+  get(): Promise<TemplateRegistry>;
+  invalidate(): void;
+}
+
+export function createTemplateRegistry(filePath: string): TemplateRegistryService {
+  let cached: TemplateRegistry | null = null;
+
+  return {
+    async get() {
+      if (cached) return cached;
+      let raw: string;
+      try {
+        raw = await readFile(filePath, "utf-8");
+      } catch (err) {
+        throw new Error(`Template registry not found at ${filePath}`);
+      }
+      const parsed = JSON.parse(raw);
+      cached = templateRegistrySchema.parse(parsed);
+      return cached;
+    },
+    invalidate() {
+      cached = null;
+    },
+  };
+}

--- a/tests/e2e/templates-gallery.spec.ts
+++ b/tests/e2e/templates-gallery.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E: Template Gallery install flow (smoke test).
+ *
+ * Navigates to /templates, clicks the first "Install" button, and waits for
+ * the UI to redirect to the installed company's dashboard. The install path
+ * performs a real GitHub fetch + bundle import via the portability service,
+ * which is why the redirect wait allows up to 120s.
+ *
+ * Auth: the e2e webServer runs in local_trusted deployment mode (see
+ * playwright.config.ts), so board-level routes like /templates require no
+ * explicit login — same convention as tests/e2e/onboarding.spec.ts.
+ */
+
+test.describe("Template Gallery", () => {
+  test("lists templates and installs one", async ({ page }) => {
+    await page.goto("/templates");
+
+    await expect(
+      page.getByRole("heading", { name: /template gallery/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const firstInstall = page.getByRole("button", { name: /install/i }).first();
+    await expect(firstInstall).toBeVisible();
+
+    await firstInstall.click();
+
+    // Install kicks off a real GitHub fetch + bundle import; allow up to 120s
+    // for the redirect to /<companyId>/dashboard. The companyId segment is a
+    // DB-generated id (not an uppercase issuePrefix), so match any non-empty
+    // path segment before /dashboard.
+    await page.waitForURL(/\/[^/]+\/dashboard(\/|$|\?)/, { timeout: 120_000 });
+  });
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -61,6 +61,9 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.7",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25.2.3",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -28,6 +28,7 @@ import { CompanySettings } from "./pages/CompanySettings";
 import { CompanySkills } from "./pages/CompanySkills";
 import { CompanyExport } from "./pages/CompanyExport";
 import { CompanyImport } from "./pages/CompanyImport";
+import { TemplatesPage } from "./pages/TemplatesPage";
 import { DesignGuide } from "./pages/DesignGuide";
 import { InstanceGeneralSettings } from "./pages/InstanceGeneralSettings";
 import { InstanceSettings } from "./pages/InstanceSettings";
@@ -321,6 +322,9 @@ export function App() {
           <Route index element={<CompanyRootRedirect />} />
           <Route path="onboarding" element={<OnboardingRoutePage />} />
           <Route path="instance" element={<Navigate to="/instance/settings/general" replace />} />
+          <Route path="templates" element={<Layout />}>
+            <Route index element={<TemplatesPage />} />
+          </Route>
           <Route path="instance/settings" element={<Layout />}>
             <Route index element={<Navigate to="general" replace />} />
             <Route path="general" element={<InstanceGeneralSettings />} />

--- a/ui/src/api/templates.ts
+++ b/ui/src/api/templates.ts
@@ -1,0 +1,13 @@
+import type {
+  TemplateCompany,
+  TemplateInstallRequest,
+  TemplateInstallResponse,
+} from "@paperclipai/shared";
+import { api } from "./client";
+
+export const templatesApi = {
+  list: () => api.get<{ companies: TemplateCompany[] }>("/templates/companies"),
+  install: (body: TemplateInstallRequest) =>
+    api.post<TemplateInstallResponse>("/templates/companies/install", body),
+  refresh: () => api.post<{ ok: true; companies: number }>("/templates/refresh", {}),
+};

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Boxes,
   Repeat,
   Settings,
+  LayoutGrid,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { SidebarSection } from "./SidebarSection";
@@ -112,6 +113,7 @@ export function Sidebar() {
           <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />
+          <SidebarNavItem to="/templates" label="Templates" icon={LayoutGrid} />
           <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
         </SidebarSection>
 

--- a/ui/src/components/templates/CompanyCard.test.tsx
+++ b/ui/src/components/templates/CompanyCard.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CompanyCard } from "./CompanyCard";
+
+const fakeCompany = {
+  slug: "trail-of-bits-security",
+  name: "Trail of Bits Security",
+  description: "Security auditing and pentesting.",
+  agents_count: 28,
+  skills_count: 35,
+  tags: ["security"],
+  url: "https://github.com/paperclipai/companies/tree/main/trail-of-bits-security",
+};
+
+describe("CompanyCard", () => {
+  it("renders name, description, and agent count", () => {
+    render(<CompanyCard company={fakeCompany} onInstall={() => {}} installing={false} />);
+    expect(screen.getByText("Trail of Bits Security")).toBeInTheDocument();
+    expect(screen.getByText(/28 agents/i)).toBeInTheDocument();
+  });
+
+  it("calls onInstall when install button clicked", () => {
+    const onInstall = vi.fn();
+    render(<CompanyCard company={fakeCompany} onInstall={onInstall} installing={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /install/i }));
+    expect(onInstall).toHaveBeenCalledWith("trail-of-bits-security");
+  });
+
+  it("shows loading state and disables button when installing", () => {
+    render(<CompanyCard company={fakeCompany} onInstall={() => {}} installing={true} />);
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+    expect(button.textContent).toMatch(/installing/i);
+  });
+});

--- a/ui/src/components/templates/CompanyCard.tsx
+++ b/ui/src/components/templates/CompanyCard.tsx
@@ -5,9 +5,10 @@ interface Props {
   company: TemplateCompany;
   onInstall: (slug: string) => void;
   installing: boolean;
+  disabled?: boolean;
 }
 
-export function CompanyCard({ company, onInstall, installing }: Props) {
+export function CompanyCard({ company, onInstall, installing, disabled = false }: Props) {
   return (
     <div className="rounded-lg border p-4 flex flex-col gap-3">
       <div>
@@ -28,7 +29,7 @@ export function CompanyCard({ company, onInstall, installing }: Props) {
       )}
       <Button
         onClick={() => onInstall(company.slug)}
-        disabled={installing}
+        disabled={installing || disabled}
         className="mt-auto"
       >
         {installing ? "Installing…" : "Install"}

--- a/ui/src/components/templates/CompanyCard.tsx
+++ b/ui/src/components/templates/CompanyCard.tsx
@@ -1,0 +1,38 @@
+import { Button } from "@/components/ui/button";
+import type { TemplateCompany } from "@paperclipai/shared";
+
+interface Props {
+  company: TemplateCompany;
+  onInstall: (slug: string) => void;
+  installing: boolean;
+}
+
+export function CompanyCard({ company, onInstall, installing }: Props) {
+  return (
+    <div className="rounded-lg border p-4 flex flex-col gap-3">
+      <div>
+        <h3 className="text-lg font-semibold">{company.name}</h3>
+        <p className="text-sm text-muted-foreground">{company.description}</p>
+      </div>
+      <div className="text-sm text-muted-foreground">
+        {company.agents_count} agents · {company.skills_count} skills
+      </div>
+      {company.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {company.tags.map((tag) => (
+            <span key={tag} className="text-xs px-2 py-0.5 rounded bg-secondary">
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+      <Button
+        onClick={() => onInstall(company.slug)}
+        disabled={installing}
+        className="mt-auto"
+      >
+        {installing ? "Installing…" : "Install"}
+      </Button>
+    </div>
+  );
+}

--- a/ui/src/pages/TemplatesPage.test.tsx
+++ b/ui/src/pages/TemplatesPage.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import type React from "react";
+import { TemplatesPage } from "./TemplatesPage";
+import { templatesApi } from "../api/templates";
+
+vi.mock("../api/templates", () => ({
+  templatesApi: {
+    list: vi.fn(),
+    install: vi.fn(),
+    refresh: vi.fn(),
+  },
+}));
+
+function renderWithProviders(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("TemplatesPage", () => {
+  beforeEach(() => {
+    vi.mocked(templatesApi.list).mockReset();
+    vi.mocked(templatesApi.install).mockReset();
+  });
+
+  it("renders loading state initially", () => {
+    vi.mocked(templatesApi.list).mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<TemplatesPage />);
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it("renders fetched companies", async () => {
+    vi.mocked(templatesApi.list).mockResolvedValue({
+      companies: [
+        { slug: "a", name: "A Corp", description: "x", agents_count: 5, skills_count: 2, tags: [], url: "https://example.com" },
+      ],
+    });
+    renderWithProviders(<TemplatesPage />);
+    await waitFor(() => expect(screen.getByText("A Corp")).toBeInTheDocument());
+  });
+
+  it("triggers install mutation on click", async () => {
+    vi.mocked(templatesApi.list).mockResolvedValue({
+      companies: [
+        { slug: "a", name: "A Corp", description: "x", agents_count: 5, skills_count: 2, tags: [], url: "https://example.com" },
+      ],
+    });
+    vi.mocked(templatesApi.install).mockResolvedValue({ companyId: "new-1", name: "A Corp", agentsCreated: 5 });
+    renderWithProviders(<TemplatesPage />);
+    await waitFor(() => screen.getByRole("button", { name: /install/i }));
+    fireEvent.click(screen.getByRole("button", { name: /install/i }));
+    await waitFor(() => expect(templatesApi.install).toHaveBeenCalledWith({ slug: "a" }));
+  });
+});

--- a/ui/src/pages/TemplatesPage.tsx
+++ b/ui/src/pages/TemplatesPage.tsx
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { templatesApi } from "../api/templates";
+import { CompanyCard } from "../components/templates/CompanyCard";
+
+export function TemplatesPage() {
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["templates", "companies"],
+    queryFn: () => templatesApi.list(),
+  });
+
+  const install = useMutation({
+    mutationFn: (slug: string) => templatesApi.install({ slug }),
+    onSuccess: (result) => {
+      qc.invalidateQueries({ queryKey: ["companies"] });
+      navigate(`/${result.companyId}/dashboard`);
+    },
+  });
+
+  if (isLoading) return <div className="p-6">Loading templates…</div>;
+  if (error) return <div className="p-6 text-destructive">Failed to load templates.</div>;
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-2">Template Gallery</h1>
+      <p className="text-sm text-muted-foreground mb-6">
+        Curated companies from paperclipai/companies. One click to install.
+      </p>
+      {install.isError && (
+        <div className="mb-4 p-3 rounded border border-destructive text-destructive text-sm">
+          Install failed: {(install.error as Error).message}
+        </div>
+      )}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {data?.companies.map((company) => (
+          <CompanyCard
+            key={company.slug}
+            company={company}
+            onInstall={(slug) => install.mutate(slug)}
+            installing={install.isPending && install.variables === company.slug}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/TemplatesPage.tsx
+++ b/ui/src/pages/TemplatesPage.tsx
@@ -41,6 +41,7 @@ export function TemplatesPage() {
             company={company}
             onInstall={(slug) => install.mutate(slug)}
             installing={install.isPending && install.variables === company.slug}
+            disabled={install.isPending}
           />
         ))}
       </div>

--- a/ui/src/test-setup.ts
+++ b/ui/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -10,5 +10,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    globals: true,
+    setupFiles: ["./src/test-setup.ts"],
   },
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Onboarding a new company today requires an operator to hand-author every agent, role, and governance rule from scratch
> - That first-run experience is the steepest cliff for new users — there is no "shipping team in 5 minutes" path
> - A curated template gallery gives users a one-click install of a pre-configured multi-agent company
> - This pull request adds a server-side template registry (JSON-backed, cached), install + refresh endpoints, and a `/templates` UI that lists and installs them
> - The benefit is that new users can go from empty Paperclip instance to a functioning agent org in seconds, using battle-tested configurations

## What Changed

- **Shared types** for the template registry schema (`packages/shared`)
- **Docs:** seed `docs/templates/registry.json` with four curated companies
- **Server:**
  - Template registry loader service with in-memory caching
  - `GET /api/templates/companies` — list templates
  - `POST /api/templates/companies/install` — install selected template
  - `POST /api/templates/refresh` — admin-only cache invalidate
  - Templates router mounted in `app.ts`
- **UI (`ui` package):**
  - Templates API client module
  - `CompanyCard` component (with jest-dom / vitest setup for the UI package)
  - `TemplatesPage` with React Query + per-card install mutation → redirects to new company's dashboard
  - Route `/templates` registered and nav link added to Sidebar (Company section)
- **E2E:** Playwright smoke test that lists templates and installs one end-to-end

## Verification

- `pnpm test:run` — full UI test suite: **85/85 files, 446 tests** passing on this branch
- `pnpm typecheck` — clean (requires `NODE_OPTIONS=--max-old-space-size=8192` on the templates-gallery UI package due to project size, unchanged from master)
- `pnpm exec playwright test --config tests/e2e/playwright.config.ts tests/e2e/templates-gallery.spec.ts --list` — spec registers correctly
- Manual smoke on staging (`maestro.trifti.ch`) planned post-merge per spec §Task 13

## Risks

- **Low risk** overall. New surface area only; no changes to existing endpoints, schemas, or user data flows.
- Install endpoint performs a real outbound fetch during company import; bounded by the registry contents. If GitHub is unreachable, the E2E test will time out at 120s (acceptable, surfaces the problem clearly).
- `POST /api/templates/refresh` is admin-gated. Non-admin boards cannot invalidate the registry cache.

## Model Used

- Provider: Anthropic Claude
- Model: claude-opus-4-7 (Opus 4.7), 1M context window
- Reasoning mode: standard
- Capabilities: tool use (file edits, shell, subagents)
- Workflow: 13-task phased implementation plan, each task shipped by a dispatched subagent with verification before commit

## Spec

Implements `/root/docs/superpowers/plans/2026-04-16-paperclip-templates-gallery.md` and the companion design spec `2026-04-16-paperclip-templates-gallery-design.md`.