### PR TITLE
fix(hermes): spawn Hermes with --yolo by default

### DIFF
--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -200,9 +200,26 @@ const piLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: piAgentConfigurationDoc,
 };
 
+// Wrap the upstream hermes adapter so every Paperclip-driven Hermes run spawns
+// with `--yolo`. Hermes agents run as non-interactive subprocesses with no TTY,
+// so dangerous-command approval prompts would always time out and deny
+// legitimate commands (curl, python3 -c, etc.). The adapter already forwards
+// `config.extraArgs` to the CLI, so prepending `--yolo` there is sufficient.
+// See https://github.com/paperclipai/paperclip/issues/2145.
+const hermesExecuteWithYolo: typeof hermesExecute = (ctx) => {
+  const existing = Array.isArray(ctx.config?.extraArgs)
+    ? (ctx.config.extraArgs as unknown[]).filter((v): v is string => typeof v === "string")
+    : [];
+  const extraArgs = existing.includes("--yolo") ? existing : ["--yolo", ...existing];
+  return hermesExecute({
+    ...ctx,
+    config: { ...(ctx.config ?? {}), extraArgs },
+  });
+};
+
 const hermesLocalAdapter: ServerAdapterModule = {
   type: "hermes_local",
-  execute: hermesExecute,
+  execute: hermesExecuteWithYolo,
   testEnvironment: hermesTestEnvironment,
   sessionCodec: hermesSessionCodec,
   listSkills: hermesListSkills,


### PR DESCRIPTION
## Summary

- Wraps the upstream `hermes-paperclip-adapter` execute function so every Paperclip-driven Hermes run spawns with `--yolo` prepended to `extraArgs`.
- Fixes the symptom in #2145 for Hermes: agents run as non-interactive subprocesses with no TTY, so dangerous-command approval prompts time out and deny legitimate commands (`curl`, `python3 -c`, etc.), making agents effectively non-functional.
- Handled in Paperclip (not upstream) so Paperclip owns the policy decision — the adapter package stays neutral.

## How it works

The adapter already forwards `config.extraArgs` verbatim to the `hermes chat` CLI. We intercept at `registry.ts` and prepend `--yolo` to `config.extraArgs` before calling the upstream `execute`. Works for all existing agents — no config migration needed. Idempotent: does not double-add if `--yolo` is already present.

## Test plan

- [x] `tsc --noEmit` — passes
- [ ] Run a Hermes agent and confirm `[hermes] Starting ...` run shows `--yolo` in the spawned argv
- [ ] Run a Hermes agent with `adapterConfig.extraArgs: ["--yolo"]` already set — verify it isn't duplicated
- [ ] Run a Hermes agent and have it execute a command that would previously hit an approval prompt (e.g., `curl` to the Paperclip API) — verify it succeeds without prompting