### PR TITLE
feat(heartbeat): proactive self-assignment toggle with scope selector

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5715,11 +5715,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const runtimeConfig = parseObject(agent.runtimeConfig);
     const heartbeat = parseObject(runtimeConfig.heartbeat);
 
+    const proactiveAssignmentScope = readNonEmptyString(
+      heartbeat.proactiveAssignmentScope as string | undefined,
+    );
+    const validScopes = ["todo", "backlog", "both"] as const;
+    type ProactiveScope = typeof validScopes[number];
+    const normalizedScope: ProactiveScope =
+      validScopes.includes(proactiveAssignmentScope as ProactiveScope)
+        ? (proactiveAssignmentScope as ProactiveScope)
+        : "backlog";
+
     return {
       enabled: asBoolean(heartbeat.enabled, false),
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      proactiveAssignment: asBoolean(heartbeat.proactiveAssignment, false),
+      proactiveAssignmentScope: normalizedScope,
     };
   }
 
@@ -7089,9 +7101,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       runScopedMentionedSkillKeys,
     );
     const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId);
+    const heartbeatPolicy = parseHeartbeatPolicy(agent);
     let runtimeConfig = {
       ...effectiveResolvedConfig,
       paperclipRuntimeSkills: runtimeSkillEntries,
+      proactiveAssignment: heartbeatPolicy.proactiveAssignment,
+      proactiveAssignmentScope: heartbeatPolicy.proactiveAssignmentScope,
     };
     const workspaceOperationRecorder = workspaceOperationsSvc.createRecorder({
       companyId: agent.companyId,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -26,6 +26,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { FolderOpen, Heart, ChevronDown, X } from "lucide-react";
 import { asBoolean, asFiniteNumber, asObject, cn } from "../lib/utils";
@@ -1211,6 +1218,44 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 numberHint={help.intervalSec}
                 showNumber={eff("heartbeat", "enabled", heartbeat.enabled === true)}
               />
+              {eff("heartbeat", "enabled", heartbeat.enabled === true) && (
+                <>
+                  <ToggleField
+                    label="Proactive self-assignment"
+                    hint="When no issues are assigned and the heartbeat fires, agent will scan for and claim unassigned work."
+                    checked={eff(
+                      "heartbeat",
+                      "proactiveAssignment",
+                      !!heartbeat.proactiveAssignment,
+                    )}
+                    onChange={(v) => mark("heartbeat", "proactiveAssignment", v)}
+                  />
+                  {eff("heartbeat", "proactiveAssignment", !!heartbeat.proactiveAssignment) && (
+                    <Field
+                      label="Self-assignment scope of unassigned issues"
+                      hint="Which issue statuses to scan for unassigned work."
+                    >
+                      <Select
+                        value={eff(
+                          "heartbeat",
+                          "proactiveAssignmentScope",
+                          (heartbeat.proactiveAssignmentScope as string) || "backlog",
+                        )}
+                        onValueChange={(v: string) => mark("heartbeat", "proactiveAssignmentScope", v)}
+                      >
+                        <SelectTrigger className="w-full h-8 text-sm font-mono">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="backlog">Backlog only</SelectItem>
+                          <SelectItem value="todo">Todo only</SelectItem>
+                          <SelectItem value="both">Todo then backlog</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                  )}
+                </>
+              )}
             </div>
             <CollapsibleSection
               title="Advanced Run Policy"


### PR DESCRIPTION
Supersedes #3767 with a clean, master-based reimplementation.

## Summary
Adds opt-in proactive self-assignment to the heartbeat policy. When `runtimeConfig.heartbeat.proactiveAssignment` is enabled and the heartbeat fires with no issues currently assigned, the agent scans for and claims unassigned work within the configured scope.

## Changes
- `server/src/services/heartbeat.ts`
  - `parseHeartbeatPolicy` parses `proactiveAssignment` (default `false`) and `proactiveAssignmentScope` (`todo` | `backlog` | `both`, default `backlog`) from `runtimeConfig.heartbeat`.
  - Invalid scope strings are normalized to `backlog`.
  - Both fields are plumbed into the `runtimeConfig` passed to the adapter execution.
- `ui/src/components/AgentConfigForm.tsx`
  - Adds a checkbox + Radix `<Select>` scope dropdown directly under the "Heartbeat on interval" toggle, shown only when the heartbeat is enabled.
  - No structural changes to the surrounding Run Policy section.

Both fields default off / `backlog`, so existing agents behave identically.

## Rationale for supersede
#3767 was opened from a local branch entangled with unrelated heartbeat bug fixes and a CollapsibleSection restructure. This PR isolates the proactive-assignment feature onto a clean branch off current master (~60 LOC across 2 files), making review straightforward.

## Test plan
- [ ] Agent with no proactiveAssignment field in runtimeConfig behaves as before.
- [ ] Agent with proactiveAssignment=true, scope=backlog receives both values in its runtimeConfig.
- [ ] UI checkbox + scope select round-trip through PATCH /api/agents/:id.