### PR TITLE
feat: add paperclip-dev skill with optional bundled skill support

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -708,6 +708,20 @@ export async function resolvePaperclipSkillsDir(
   return null;
 }
 
+async function readSkillRequired(skillDir: string): Promise<boolean> {
+  try {
+    const content = await fs.readFile(path.join(skillDir, "SKILL.md"), "utf8");
+    const normalized = content.replace(/\r\n/g, "\n");
+    if (!normalized.startsWith("---\n")) return true;
+    const closing = normalized.indexOf("\n---\n", 4);
+    if (closing < 0) return true;
+    const frontmatter = normalized.slice(4, closing);
+    return !/^\s*required\s*:\s*false\s*$/m.test(frontmatter);
+  } catch {
+    return true;
+  }
+}
+
 export async function listPaperclipSkillEntries(
   moduleDir: string,
   additionalCandidates: string[] = [],
@@ -717,15 +731,20 @@ export async function listPaperclipSkillEntries(
 
   try {
     const entries = await fs.readdir(root, { withFileTypes: true });
-    return entries
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => ({
+    const dirs = entries.filter((entry) => entry.isDirectory());
+    return Promise.all(dirs.map(async (entry) => {
+      const skillDir = path.join(root, entry.name);
+      const required = await readSkillRequired(skillDir);
+      return {
         key: `paperclipai/paperclip/${entry.name}`,
         runtimeName: entry.name,
-        source: path.join(root, entry.name),
-        required: true,
-        requiredReason: "Bundled Paperclip skills are always available for local adapters.",
-      }));
+        source: skillDir,
+        required,
+        requiredReason: required
+          ? "Bundled Paperclip skills are always available for local adapters."
+          : null,
+      };
+    }));
   } catch {
     return [];
   }

--- a/server/src/__tests__/paperclip-skill-utils.test.ts
+++ b/server/src/__tests__/paperclip-skill-utils.test.ts
@@ -35,6 +35,34 @@ describe("paperclip skill utils", () => {
     expect(entries[0]?.source).toBe(path.join(root, "skills", "paperclip"));
   });
 
+  it("marks skills with required: false in SKILL.md frontmatter as optional", async () => {
+    const root = await makeTempDir("paperclip-skill-optional-");
+    cleanupDirs.add(root);
+
+    const moduleDir = path.join(root, "a", "b", "c", "d", "e");
+    await fs.mkdir(moduleDir, { recursive: true });
+
+    // Required skill (no frontmatter flag)
+    const requiredDir = path.join(root, "skills", "paperclip");
+    await fs.mkdir(requiredDir, { recursive: true });
+    await fs.writeFile(path.join(requiredDir, "SKILL.md"), "---\nname: paperclip\n---\n\n# Paperclip\n");
+
+    // Optional skill (required: false)
+    const optionalDir = path.join(root, "skills", "paperclip-dev");
+    await fs.mkdir(optionalDir, { recursive: true });
+    await fs.writeFile(path.join(optionalDir, "SKILL.md"), "---\nname: paperclip-dev\nrequired: false\n---\n\n# Dev\n");
+
+    const entries = await listPaperclipSkillEntries(moduleDir);
+    entries.sort((a, b) => a.runtimeName.localeCompare(b.runtimeName));
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]?.runtimeName).toBe("paperclip");
+    expect(entries[0]?.required).toBe(true);
+    expect(entries[1]?.runtimeName).toBe("paperclip-dev");
+    expect(entries[1]?.required).toBe(false);
+    expect(entries[1]?.requiredReason).toBeNull();
+  });
+
   it("removes stale maintainer-only symlinks from a shared skills home", async () => {
     const root = await makeTempDir("paperclip-skill-cleanup-");
     cleanupDirs.add(root);

--- a/skills/paperclip-dev/SKILL.md
+++ b/skills/paperclip-dev/SKILL.md
@@ -12,357 +12,85 @@ description: >
 
 This skill covers the day-to-day workflows for developing and operating a local Paperclip instance. It assumes the repo lives at `~/workspace/paperclip` (or the current checkout) with `origin` pointing to `git@github.com:paperclipai/paperclip.git`.
 
-## Starting and Stopping the Server
+> **MANDATORY:** Before running any CLI command, building, testing, or managing worktrees, you MUST read `doc/DEVELOPING.md` in the Paperclip repo. It is the canonical reference for all `paperclipai` CLI commands, their options, build/test workflows, database operations, worktree management, and diagnostics. Do NOT guess at flags or options — read the doc first.
 
-### Quick start (recommended)
+## Quick Command Reference
 
-```bash
-npx paperclipai run
-```
+These are the most common commands. For full option tables and details, see `doc/DEVELOPING.md`.
 
-Runs onboarding (if first time), doctor checks, and then starts the Paperclip server. This is the single command that gets everything running.
-
-**Options:**
-
-| Flag | Description |
-|------|-------------|
-| `-c, --config <path>` | Path to config file |
-| `-d, --data-dir <path>` | Paperclip data directory root (isolates state from `~/.paperclip`) |
-| `-i, --instance <id>` | Local instance id (default: `default`) |
-| `--bind <mode>` | Reachability preset: `loopback`, `lan`, or `tailnet` |
-| `--repair` / `--no-repair` | Attempt automatic repairs during doctor (default: true) |
-
-### Development mode (hot reload)
-
-```bash
-pnpm dev          # watches for changes and restarts
-pnpm dev:once     # single dev run without watch
-pnpm dev:server   # server only (no agent processes)
-pnpm dev:ui       # UI dev server only
-```
-
-### Stopping
-
-```bash
-pnpm dev:stop     # stop the dev service
-pnpm dev:list     # list running dev services
-```
+| Task | Command |
+|------|---------|
+| Start server (first time or normal) | `npx paperclipai run` |
+| Dev mode with hot reload | `pnpm dev` |
+| Stop dev server | `pnpm dev:stop` |
+| Build | `pnpm build` |
+| Type-check | `pnpm typecheck` |
+| Run tests | `pnpm test` |
+| Run migrations | `pnpm db:migrate` |
+| Regenerate Drizzle client | `pnpm db:generate` |
+| Back up database | `npx paperclipai db:backup` |
+| Health check | `npx paperclipai doctor --repair` |
+| Print env vars | `npx paperclipai env` |
+| Trigger agent heartbeat | `npx paperclipai heartbeat run --agent-id <id>` |
+| Install agent skills locally | `npx paperclipai agent local-cli <agent> --company-id <id>` |
 
 ## Pulling from Master
 
 ```bash
-cd ~/workspace/paperclip
-git fetch origin
-git pull origin master       # or merge/rebase as appropriate
-pnpm install                # pick up dependency changes
-pnpm build                  # rebuild all packages
+git fetch origin && git pull origin master
+pnpm install && pnpm build
 ```
 
-After pulling, if schema changes landed:
-
-```bash
-pnpm db:generate            # regenerate Drizzle client from schema
-pnpm db:migrate             # run pending migrations
-```
-
-## Building and Testing
-
-```bash
-pnpm build                  # full monorepo build
-pnpm typecheck              # type-check all packages
-pnpm test                   # run all tests (vitest)
-pnpm test:watch             # run tests in watch mode
-```
-
-## Database Operations
-
-### Migrations
-
-```bash
-pnpm db:generate            # generate Drizzle client from schema changes
-pnpm db:migrate             # apply pending migrations
-```
-
-### Backups
-
-```bash
-npx paperclipai db:backup
-```
-
-**Options:**
-
-| Flag | Description |
-|------|-------------|
-| `-c, --config <path>` | Path to config file |
-| `-d, --data-dir <path>` | Paperclip data directory root |
-| `--dir <path>` | Backup output directory (overrides config) |
-| `--retention-days <days>` | Retention window for pruning old backups |
-| `--filename-prefix <prefix>` | Backup filename prefix (default: `paperclip`) |
-| `--json` | Print backup metadata as JSON |
-
-## Diagnostics
-
-```bash
-npx paperclipai doctor              # check setup health
-npx paperclipai doctor --repair     # check and auto-fix issues
-npx paperclipai env                 # print current environment variables
-```
-
-## Agent Operations (Local)
-
-### Trigger a heartbeat
-
-```bash
-npx paperclipai heartbeat run --agent-id <agent-id>
-```
-
-### Install skills and get agent env vars
-
-```bash
-npx paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>
-```
-
-Installs Paperclip skills for Claude/Codex and prints shell exports for that agent identity.
-
-### List agents
-
-```bash
-npx paperclipai agent list --company-id <company-id>
-```
-
----
+If schema changes landed, also run `pnpm db:generate && pnpm db:migrate`.
 
 ## Worktrees
 
-Paperclip worktrees combine git worktrees with isolated Paperclip instances. Each worktree gets its own database, server port, and full Paperclip environment seeded from the primary instance.
+Paperclip worktrees combine git worktrees with isolated Paperclip instances — each gets its own database, server port, and environment seeded from the primary instance.
+
+> **MANDATORY:** Before creating or managing worktrees, you MUST read the "Worktree-local Instances" and "Worktree CLI Reference" sections in `doc/DEVELOPING.md`. That is the canonical reference for all worktree commands, their options, seed modes, and environment variables.
 
 ### When to Use Worktrees
 
 - Starting a feature branch that needs its own Paperclip environment
 - Running parallel agent work without cross-contaminating the primary instance
 - Testing Paperclip changes in isolation before merging
-- Cleaning up after a completed branch
 
-### Commands
+### Command Overview
 
-All commands use `npx paperclipai`. The CLI has two tiers:
+The CLI has two tiers (see `doc/DEVELOPING.md` for full option tables):
 
-1. **Top-level shortcuts** (`worktree:make`, `worktree:list`, `worktree:cleanup`, `worktree:merge-history`) -- end-to-end lifecycle commands
-2. **Subcommands** (`worktree init`, `worktree env`, `worktree reseed`, `worktree repair`) -- lower-level instance management within an existing worktree
+| Command | Purpose |
+|---------|---------|
+| `worktree:make <name>` | Create worktree + isolated instance in one step |
+| `worktree:list` | List worktrees and their Paperclip status |
+| `worktree:merge-history` | Preview/import issue history between worktrees |
+| `worktree:cleanup <name>` | Remove worktree, branch, and instance data |
+| `worktree init` | Bootstrap instance inside existing worktree |
+| `worktree env` | Print shell exports for worktree instance |
+| `worktree reseed` | Refresh worktree DB from another instance |
+| `worktree repair` | Fix broken/missing worktree instance metadata |
 
----
-
-### Create a Worktree
-
-```bash
-npx paperclipai worktree:make <name>
-```
-
-Creates `~/paperclip-<name>` as a git worktree with a new branch, then bootstraps an isolated Paperclip instance inside it. The name is auto-prefixed with `paperclip-` if needed.
-
-**Options:**
-
-| Flag | Description |
-|------|-------------|
-| `--start-point <ref>` | Remote ref to base the new branch on (env: `PAPERCLIP_WORKTREE_START_POINT`) |
-| `--instance <id>` | Explicit isolated instance id |
-| `--home <path>` | Home root for worktree instances (env: `PAPERCLIP_WORKTREES_DIR`, default: `~/.paperclip-worktrees`) |
-| `--from-config <path>` | Source config.json to seed from |
-| `--from-data-dir <path>` | Source `PAPERCLIP_HOME` used when deriving the source config |
-| `--from-instance <id>` | Source instance id (default: `default`) |
-| `--server-port <port>` | Preferred server port |
-| `--db-port <port>` | Preferred embedded Postgres port |
-| `--seed-mode <mode>` | `minimal` or `full` (default: `minimal`) |
-| `--no-seed` | Skip database seeding from the source instance |
-| `--force` | Replace existing repo-local config and isolated instance data |
-
-**Example -- start a feature worktree based on main:**
-
-```bash
-npx paperclipai worktree:make auth-refactor --start-point origin/main
-```
-
----
-
-### List Worktrees
-
-```bash
-npx paperclipai worktree:list
-```
-
-Lists all git worktrees visible from the current repo and indicates which ones have a Paperclip instance configured.
-
-| Flag | Description |
-|------|-------------|
-| `--json` | Print JSON output instead of text |
-
----
-
-### Initialize a Worktree Instance (Low-Level)
-
-```bash
-npx paperclipai worktree init
-```
-
-Run this inside an existing git worktree to create repo-local config/env and bootstrap an isolated Paperclip instance. This is the lower-level equivalent of what `worktree:make` does automatically.
-
-**Options:**
-
-| Flag | Description |
-|------|-------------|
-| `--name <name>` | Display name used to derive the instance id |
-| `--instance <id>` | Explicit isolated instance id |
-| `--home <path>` | Home root (env: `PAPERCLIP_WORKTREES_DIR`, default: `~/.paperclip-worktrees`) |
-| `--from-config <path>` | Source config.json to seed from |
-| `--from-data-dir <path>` | Source `PAPERCLIP_HOME` for deriving config |
-| `--from-instance <id>` | Source instance id (default: `default`) |
-| `--server-port <port>` | Preferred server port |
-| `--db-port <port>` | Preferred embedded Postgres port |
-| `--seed-mode <mode>` | `minimal` or `full` (default: `minimal`) |
-| `--no-seed` | Skip database seeding |
-| `--force` | Replace existing config and instance data |
-
----
-
-### Print Worktree Environment
-
-```bash
-npx paperclipai worktree env
-```
-
-Prints shell exports (`PAPERCLIP_API_URL`, `PAPERCLIP_HOME`, etc.) for the current worktree-local instance.
-
-| Flag | Description |
-|------|-------------|
-| `-c, --config <path>` | Path to config file |
-| `--json` | Print JSON instead of shell exports |
-
-**Example -- source the environment in your shell:**
-
-```bash
-eval "$(npx paperclipai worktree env)"
-```
-
----
-
-### Reseed a Worktree
-
-```bash
-npx paperclipai worktree reseed
-```
-
-Re-seeds an existing worktree-local instance from another Paperclip instance. Use this to refresh a stale worktree with current data.
-
-**Options:**
-
-| Flag | Description |
-|------|-------------|
-| `--from <worktree>` | Source worktree path, directory name, branch name, or `current` |
-| `--to <worktree>` | Target worktree (defaults to `current`) |
-| `--from-config <path>` | Source config.json |
-| `--from-data-dir <path>` | Source `PAPERCLIP_HOME` |
-| `--from-instance <id>` | Source instance id |
-| `--seed-mode <mode>` | `minimal` or `full` (default: `full`) |
-| `--yes` | Skip the destructive confirmation prompt |
-| `--allow-live-target` | Override the guard requiring the target DB to be stopped |
-
-**Important:** Stop the target worktree's database before reseeding unless using `--allow-live-target`.
-
----
-
-### Repair a Worktree Instance
-
-```bash
-npx paperclipai worktree repair
-```
-
-Creates or repairs a linked worktree-local Paperclip instance without touching the primary checkout.
-
-**Options:**
-
-| Flag | Description |
-|------|-------------|
-| `--branch <name>` | Branch/worktree selector to repair |
-| `--home <path>` | Home root (env: `PAPERCLIP_WORKTREES_DIR`, default: `~/.paperclip-worktrees`) |
-| `--from-config <path>` | Source config.json |
-| `--from-data-dir <path>` | Source `PAPERCLIP_HOME` |
-| `--from-instance <id>` | Source instance id (default: `default`) |
-| `--seed-mode <mode>` | `minimal` or `full` (default: `minimal`) |
-| `--no-seed` | Repair metadata only, skip reseeding |
-| `--allow-live-target` | Override the stopped-DB guard |
-
----
-
-### Merge Issue History Between Worktrees
-
-```bash
-npx paperclipai worktree:merge-history [source]
-```
-
-Previews or imports issue and comment history from one worktree's Paperclip instance into another.
-
-**Options:**
-
-| Flag | Description |
-|------|-------------|
-| `--from <worktree>` | Source worktree path, directory name, branch name, or `current` |
-| `--to <worktree>` | Target worktree (defaults to `current`) |
-| `--company <id-or-prefix>` | Shared company id or issue prefix |
-| `--scope <items>` | Comma-separated: `issues`, `comments` (default: `issues,comments`) |
-| `--apply` | Apply the import after preview |
-| `--dry` | Preview only |
-| `--yes` | Skip interactive confirmation |
-
----
-
-### Clean Up a Worktree
-
-```bash
-npx paperclipai worktree:cleanup <name>
-```
-
-Removes a worktree, its git branch, and its isolated Paperclip instance data. The name is auto-prefixed with `paperclip-` if needed.
-
-| Flag | Description |
-|------|-------------|
-| `--instance <id>` | Explicit instance id (if different from the worktree name) |
-| `--home <path>` | Home root (env: `PAPERCLIP_WORKTREES_DIR`, default: `~/.paperclip-worktrees`) |
-| `--force` | Bypass safety checks (uncommitted changes, unique commits) |
-
-**Safety:** Without `--force`, the command checks for uncommitted changes and unique (unmerged) commits before removing. Always merge or push important work before cleanup.
-
----
-
-### Typical Worktree Workflow
+### Typical Workflow
 
 ```bash
 # 1. Create a worktree for a feature
 npx paperclipai worktree:make my-feature --start-point origin/main
 
-# 2. Move into it
+# 2. Move into it and source the environment
 cd ~/paperclip-my-feature
-
-# 3. Source the Paperclip environment
 eval "$(npx paperclipai worktree env)"
 
-# 4. Start the isolated Paperclip server
+# 3. Start the isolated Paperclip server
 npx paperclipai run
 
-# 5. Do your work -- agents use the isolated instance
+# 4. Do your work
 
-# 6. When done, merge history back if needed
+# 5. When done, merge history back if needed
 npx paperclipai worktree:merge-history --from paperclip-my-feature --to current --apply
 
-# 7. Clean up
+# 6. Clean up
 npx paperclipai worktree:cleanup my-feature
 ```
-
-## Key Concepts
-
-- **Instance isolation:** Each worktree gets its own database, server port, and config. Agents in one worktree don't interfere with another.
-- **Seeding:** New worktrees are seeded from an existing instance. `minimal` copies config (company, agents, skills). `full` copies everything including issues.
-- **Home directory:** Worktree instance data lives under `~/.paperclip-worktrees/` by default (configurable via `PAPERCLIP_WORKTREES_DIR`).
-- **History merging:** Issue and comment history can be selectively merged between worktrees before cleanup.
 
 ## Pull Requests
 

--- a/skills/paperclip-dev/SKILL.md
+++ b/skills/paperclip-dev/SKILL.md
@@ -121,6 +121,44 @@ If any section is missing or empty, do NOT submit the PR. Go back and fill it in
 
 Only after completing Steps 1 and 2, run `gh pr create`. Use the template contents as the structure for `--body` — do not write a freeform summary.
 
+## Hard Rules — Do NOT Bypass
+
+These rules exist because agents have caused real damage by improvising around CLI failures. Follow them exactly.
+
+1. **CLI is the only interface to worktrees and databases.** All worktree and database operations MUST go through `npx paperclipai` / `pnpm paperclipai` commands. You MUST NOT:
+   - Run `pg_dump`, `pg_restore`, `psql`, `createdb`, `dropdb`, or any raw postgres commands
+   - Manually set `DATABASE_URL` to point a worktree server at another instance's database
+   - Run `rm -rf` on any `.paperclip/`, `.paperclip-worktrees/`, or `db/` directory
+   - Directly manipulate embedded postgres data directories
+   - Kill postgres processes by PID
+
+2. **If a CLI command fails, stop and report.** Do NOT attempt workarounds. If `worktree:make`, `worktree reseed`, `worktree init`, `worktree:cleanup`, or any other `paperclipai` command fails:
+   - Report the exact error message in your task comment
+   - Set the task to `blocked`
+   - Suggest running `npx paperclipai doctor --repair` or recreating the worktree from scratch
+   - Do NOT try to manually replicate what the CLI does
+
+3. **Never share databases between instances.** Each worktree instance gets its own isolated database. Never override `DATABASE_URL` to point one instance at another's database. This destroys isolation and can corrupt production data.
+
+4. **Starting a dev server in a worktree requires setup first.** The correct sequence is:
+   ```bash
+   # If the worktree already exists but has no running instance:
+   cd <worktree-path>
+   eval "$(npx paperclipai worktree env)"
+   pnpm install && pnpm build
+   npx paperclipai run          # or pnpm dev
+
+   # If the worktree needs a fresh database:
+   npx paperclipai worktree reseed --seed-mode full
+
+   # If the worktree is broken beyond repair:
+   npx paperclipai worktree:cleanup <name>
+   npx paperclipai worktree:make <name> --seed-mode full
+   ```
+   If any step fails, follow rule 2 — stop and report.
+
+5. **Seeding is a CLI operation.** When asked to seed a worktree database from the main instance, use `worktree reseed` or recreate with `worktree:make --seed-mode full`. Read `doc/DEVELOPING.md` for the full option tables. Never attempt manual database copying.
+
 ## Common Mistakes
 
 | Mistake | Fix |
@@ -132,3 +170,5 @@ Only after completing Steps 1 and 2, run `gh pr create`. Use the template conten
 | Reseeding while target DB is running | Stop the target server first, or use `--allow-live-target` |
 | Cleaning up with unmerged commits | Merge or push first, or use `--force` if intentionally discarding |
 | Running agents against wrong instance | Verify `PAPERCLIP_API_URL` points to the correct port |
+| CLI command fails | Do NOT work around it — report the error and block (see Hard Rules above) |
+| Agent tries manual postgres operations | NEVER do this — all DB ops go through the CLI (see Hard Rules above) |

--- a/skills/paperclip-dev/SKILL.md
+++ b/skills/paperclip-dev/SKILL.md
@@ -174,7 +174,7 @@ eval "$(npx paperclipai worktree env)"   # skip if using the primary instance
 tmux new-session -d -s <session-name> 'pnpm dev'
 
 # Example with a descriptive name:
-tmux new-session -d -s papa81-auth-3102 'pnpm dev'
+tmux new-session -d -s auth-fix-3102 'pnpm dev'
 ```
 
 ### Managing the session
@@ -197,14 +197,10 @@ curl -sf http://127.0.0.1:<port>/api/health && echo "Server is up"
 lsof -nP -iTCP:<port> -sTCP:LISTEN
 ```
 
-### Why this matters
-
-In PAPA-81, the dev server was started with `pnpm dev` directly from the agent shell. It appeared healthy during the heartbeat, but died as soon as the heartbeat exited. QA repeatedly found the port unreachable seconds later. Switching to a detached `tmux` session solved the problem — the server survived across heartbeats and remained available for manual testing.
-
 ### Key rules
 
-1. **Always use `tmux` (or equivalent)** when a dev server needs to stay running after the heartbeat ends.
-2. **Name the session descriptively** — include the issue or worktree name and port (e.g., `papa81-auth-3102`).
+1. **Always use `tmux` (or equivalent)** when a dev server needs to stay running after the heartbeat ends. A server started directly from the agent shell will die when the heartbeat exits, even if it appeared healthy moments before.
+2. **Name the session descriptively** — include the worktree name and port (e.g., `auth-fix-3102`).
 3. **Verify the server is listening** before reporting the URL to anyone.
 4. **Do not use `nohup` or `&` alone** — these are unreliable for agent shells that may have their entire process group killed.
 5. **Clean up when done** — kill the tmux session when the testing is complete.

--- a/skills/paperclip-dev/SKILL.md
+++ b/skills/paperclip-dev/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 # Paperclip Dev
 
-This skill covers the day-to-day workflows for developing and operating a local Paperclip instance. It assumes the repo lives at `~/workspace/paperclip` (or the current checkout) with `origin` pointing to `git@github.com:paperclipai/paperclip.git`.
+This skill covers the day-to-day workflows for developing and operating a local Paperclip instance. It assumes you are working inside the Paperclip repo checkout with `origin` pointing to `git@github.com:paperclipai/paperclip.git`.
 
 > **MANDATORY:** Before running any CLI command, building, testing, or managing worktrees, you MUST read `doc/DEVELOPING.md` in the Paperclip repo. It is the canonical reference for all `paperclipai` CLI commands, their options, build/test workflows, database operations, worktree management, and diagnostics. Do NOT guess at flags or options — read the doc first.
 
@@ -76,8 +76,8 @@ The CLI has two tiers (see `doc/DEVELOPING.md` for full option tables):
 # 1. Create a worktree for a feature
 npx paperclipai worktree:make my-feature --start-point origin/main
 
-# 2. Move into it and source the environment
-cd ~/paperclip-my-feature
+# 2. Move into the worktree (path printed by worktree:make) and source the environment
+cd <worktree-path>
 eval "$(npx paperclipai worktree env)"
 
 # 3. Start the isolated Paperclip server

--- a/skills/paperclip-dev/SKILL.md
+++ b/skills/paperclip-dev/SKILL.md
@@ -1,0 +1,406 @@
+---
+name: paperclip-dev
+required: false
+description: >
+  Develop and operate a local Paperclip instance — start and stop servers,
+  pull updates from master, run builds and tests, manage worktrees, back up
+  databases, and diagnose problems. Use whenever you need to work on the
+  Paperclip codebase itself or keep a running instance healthy.
+---
+
+# Paperclip Dev
+
+This skill covers the day-to-day workflows for developing and operating a local Paperclip instance. It assumes the repo lives at `~/workspace/paperclip` (or the current checkout) with `origin` pointing to `git@github.com:paperclipai/paperclip.git`.
+
+## Starting and Stopping the Server
+
+### Quick start (recommended)
+
+```bash
+npx paperclipai run
+```
+
+Runs onboarding (if first time), doctor checks, and then starts the Paperclip server. This is the single command that gets everything running.
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-c, --config <path>` | Path to config file |
+| `-d, --data-dir <path>` | Paperclip data directory root (isolates state from `~/.paperclip`) |
+| `-i, --instance <id>` | Local instance id (default: `default`) |
+| `--bind <mode>` | Reachability preset: `loopback`, `lan`, or `tailnet` |
+| `--repair` / `--no-repair` | Attempt automatic repairs during doctor (default: true) |
+
+### Development mode (hot reload)
+
+```bash
+pnpm dev          # watches for changes and restarts
+pnpm dev:once     # single dev run without watch
+pnpm dev:server   # server only (no agent processes)
+pnpm dev:ui       # UI dev server only
+```
+
+### Stopping
+
+```bash
+pnpm dev:stop     # stop the dev service
+pnpm dev:list     # list running dev services
+```
+
+## Pulling from Master
+
+```bash
+cd ~/workspace/paperclip
+git fetch origin
+git pull origin master       # or merge/rebase as appropriate
+pnpm install                # pick up dependency changes
+pnpm build                  # rebuild all packages
+```
+
+After pulling, if schema changes landed:
+
+```bash
+pnpm db:generate            # regenerate Drizzle client from schema
+pnpm db:migrate             # run pending migrations
+```
+
+## Building and Testing
+
+```bash
+pnpm build                  # full monorepo build
+pnpm typecheck              # type-check all packages
+pnpm test                   # run all tests (vitest)
+pnpm test:watch             # run tests in watch mode
+```
+
+## Database Operations
+
+### Migrations
+
+```bash
+pnpm db:generate            # generate Drizzle client from schema changes
+pnpm db:migrate             # apply pending migrations
+```
+
+### Backups
+
+```bash
+npx paperclipai db:backup
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-c, --config <path>` | Path to config file |
+| `-d, --data-dir <path>` | Paperclip data directory root |
+| `--dir <path>` | Backup output directory (overrides config) |
+| `--retention-days <days>` | Retention window for pruning old backups |
+| `--filename-prefix <prefix>` | Backup filename prefix (default: `paperclip`) |
+| `--json` | Print backup metadata as JSON |
+
+## Diagnostics
+
+```bash
+npx paperclipai doctor              # check setup health
+npx paperclipai doctor --repair     # check and auto-fix issues
+npx paperclipai env                 # print current environment variables
+```
+
+## Agent Operations (Local)
+
+### Trigger a heartbeat
+
+```bash
+npx paperclipai heartbeat run --agent-id <agent-id>
+```
+
+### Install skills and get agent env vars
+
+```bash
+npx paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>
+```
+
+Installs Paperclip skills for Claude/Codex and prints shell exports for that agent identity.
+
+### List agents
+
+```bash
+npx paperclipai agent list --company-id <company-id>
+```
+
+---
+
+## Worktrees
+
+Paperclip worktrees combine git worktrees with isolated Paperclip instances. Each worktree gets its own database, server port, and full Paperclip environment seeded from the primary instance.
+
+### When to Use Worktrees
+
+- Starting a feature branch that needs its own Paperclip environment
+- Running parallel agent work without cross-contaminating the primary instance
+- Testing Paperclip changes in isolation before merging
+- Cleaning up after a completed branch
+
+### Commands
+
+All commands use `npx paperclipai`. The CLI has two tiers:
+
+1. **Top-level shortcuts** (`worktree:make`, `worktree:list`, `worktree:cleanup`, `worktree:merge-history`) -- end-to-end lifecycle commands
+2. **Subcommands** (`worktree init`, `worktree env`, `worktree reseed`, `worktree repair`) -- lower-level instance management within an existing worktree
+
+---
+
+### Create a Worktree
+
+```bash
+npx paperclipai worktree:make <name>
+```
+
+Creates `~/paperclip-<name>` as a git worktree with a new branch, then bootstraps an isolated Paperclip instance inside it. The name is auto-prefixed with `paperclip-` if needed.
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--start-point <ref>` | Remote ref to base the new branch on (env: `PAPERCLIP_WORKTREE_START_POINT`) |
+| `--instance <id>` | Explicit isolated instance id |
+| `--home <path>` | Home root for worktree instances (env: `PAPERCLIP_WORKTREES_DIR`, default: `~/.paperclip-worktrees`) |
+| `--from-config <path>` | Source config.json to seed from |
+| `--from-data-dir <path>` | Source `PAPERCLIP_HOME` used when deriving the source config |
+| `--from-instance <id>` | Source instance id (default: `default`) |
+| `--server-port <port>` | Preferred server port |
+| `--db-port <port>` | Preferred embedded Postgres port |
+| `--seed-mode <mode>` | `minimal` or `full` (default: `minimal`) |
+| `--no-seed` | Skip database seeding from the source instance |
+| `--force` | Replace existing repo-local config and isolated instance data |
+
+**Example -- start a feature worktree based on main:**
+
+```bash
+npx paperclipai worktree:make auth-refactor --start-point origin/main
+```
+
+---
+
+### List Worktrees
+
+```bash
+npx paperclipai worktree:list
+```
+
+Lists all git worktrees visible from the current repo and indicates which ones have a Paperclip instance configured.
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Print JSON output instead of text |
+
+---
+
+### Initialize a Worktree Instance (Low-Level)
+
+```bash
+npx paperclipai worktree init
+```
+
+Run this inside an existing git worktree to create repo-local config/env and bootstrap an isolated Paperclip instance. This is the lower-level equivalent of what `worktree:make` does automatically.
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--name <name>` | Display name used to derive the instance id |
+| `--instance <id>` | Explicit isolated instance id |
+| `--home <path>` | Home root (env: `PAPERCLIP_WORKTREES_DIR`, default: `~/.paperclip-worktrees`) |
+| `--from-config <path>` | Source config.json to seed from |
+| `--from-data-dir <path>` | Source `PAPERCLIP_HOME` for deriving config |
+| `--from-instance <id>` | Source instance id (default: `default`) |
+| `--server-port <port>` | Preferred server port |
+| `--db-port <port>` | Preferred embedded Postgres port |
+| `--seed-mode <mode>` | `minimal` or `full` (default: `minimal`) |
+| `--no-seed` | Skip database seeding |
+| `--force` | Replace existing config and instance data |
+
+---
+
+### Print Worktree Environment
+
+```bash
+npx paperclipai worktree env
+```
+
+Prints shell exports (`PAPERCLIP_API_URL`, `PAPERCLIP_HOME`, etc.) for the current worktree-local instance.
+
+| Flag | Description |
+|------|-------------|
+| `-c, --config <path>` | Path to config file |
+| `--json` | Print JSON instead of shell exports |
+
+**Example -- source the environment in your shell:**
+
+```bash
+eval "$(npx paperclipai worktree env)"
+```
+
+---
+
+### Reseed a Worktree
+
+```bash
+npx paperclipai worktree reseed
+```
+
+Re-seeds an existing worktree-local instance from another Paperclip instance. Use this to refresh a stale worktree with current data.
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--from <worktree>` | Source worktree path, directory name, branch name, or `current` |
+| `--to <worktree>` | Target worktree (defaults to `current`) |
+| `--from-config <path>` | Source config.json |
+| `--from-data-dir <path>` | Source `PAPERCLIP_HOME` |
+| `--from-instance <id>` | Source instance id |
+| `--seed-mode <mode>` | `minimal` or `full` (default: `full`) |
+| `--yes` | Skip the destructive confirmation prompt |
+| `--allow-live-target` | Override the guard requiring the target DB to be stopped |
+
+**Important:** Stop the target worktree's database before reseeding unless using `--allow-live-target`.
+
+---
+
+### Repair a Worktree Instance
+
+```bash
+npx paperclipai worktree repair
+```
+
+Creates or repairs a linked worktree-local Paperclip instance without touching the primary checkout.
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--branch <name>` | Branch/worktree selector to repair |
+| `--home <path>` | Home root (env: `PAPERCLIP_WORKTREES_DIR`, default: `~/.paperclip-worktrees`) |
+| `--from-config <path>` | Source config.json |
+| `--from-data-dir <path>` | Source `PAPERCLIP_HOME` |
+| `--from-instance <id>` | Source instance id (default: `default`) |
+| `--seed-mode <mode>` | `minimal` or `full` (default: `minimal`) |
+| `--no-seed` | Repair metadata only, skip reseeding |
+| `--allow-live-target` | Override the stopped-DB guard |
+
+---
+
+### Merge Issue History Between Worktrees
+
+```bash
+npx paperclipai worktree:merge-history [source]
+```
+
+Previews or imports issue and comment history from one worktree's Paperclip instance into another.
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--from <worktree>` | Source worktree path, directory name, branch name, or `current` |
+| `--to <worktree>` | Target worktree (defaults to `current`) |
+| `--company <id-or-prefix>` | Shared company id or issue prefix |
+| `--scope <items>` | Comma-separated: `issues`, `comments` (default: `issues,comments`) |
+| `--apply` | Apply the import after preview |
+| `--dry` | Preview only |
+| `--yes` | Skip interactive confirmation |
+
+---
+
+### Clean Up a Worktree
+
+```bash
+npx paperclipai worktree:cleanup <name>
+```
+
+Removes a worktree, its git branch, and its isolated Paperclip instance data. The name is auto-prefixed with `paperclip-` if needed.
+
+| Flag | Description |
+|------|-------------|
+| `--instance <id>` | Explicit instance id (if different from the worktree name) |
+| `--home <path>` | Home root (env: `PAPERCLIP_WORKTREES_DIR`, default: `~/.paperclip-worktrees`) |
+| `--force` | Bypass safety checks (uncommitted changes, unique commits) |
+
+**Safety:** Without `--force`, the command checks for uncommitted changes and unique (unmerged) commits before removing. Always merge or push important work before cleanup.
+
+---
+
+### Typical Worktree Workflow
+
+```bash
+# 1. Create a worktree for a feature
+npx paperclipai worktree:make my-feature --start-point origin/main
+
+# 2. Move into it
+cd ~/paperclip-my-feature
+
+# 3. Source the Paperclip environment
+eval "$(npx paperclipai worktree env)"
+
+# 4. Start the isolated Paperclip server
+npx paperclipai run
+
+# 5. Do your work -- agents use the isolated instance
+
+# 6. When done, merge history back if needed
+npx paperclipai worktree:merge-history --from paperclip-my-feature --to current --apply
+
+# 7. Clean up
+npx paperclipai worktree:cleanup my-feature
+```
+
+## Key Concepts
+
+- **Instance isolation:** Each worktree gets its own database, server port, and config. Agents in one worktree don't interfere with another.
+- **Seeding:** New worktrees are seeded from an existing instance. `minimal` copies config (company, agents, skills). `full` copies everything including issues.
+- **Home directory:** Worktree instance data lives under `~/.paperclip-worktrees/` by default (configurable via `PAPERCLIP_WORKTREES_DIR`).
+- **History merging:** Issue and comment history can be selectively merged between worktrees before cleanup.
+
+## Pull Requests
+
+> **MANDATORY PRE-FLIGHT:** Before creating ANY pull request, you MUST read the canonical source files listed below. Do NOT run `gh pr create` until you have read these files and verified your PR body matches every required section.
+
+### Step 1 — Read the canonical files
+
+You MUST read all three of these files before creating a PR:
+
+1. **`.github/PULL_REQUEST_TEMPLATE.md`** — the required PR body structure
+2. **`CONTRIBUTING.md`** — contribution conventions, PR requirements, and thinking-path examples
+3. **`.github/workflows/pr.yml`** — CI checks that gate merge
+
+### Step 2 — Validate your PR body against this checklist
+
+After reading the template, verify your `--body` includes every one of these sections (names must match exactly):
+
+- [ ] `## Thinking Path` — blockquote style, 5-8 reasoning steps
+- [ ] `## What Changed` — bullet list of concrete changes
+- [ ] `## Verification` — how a reviewer confirms this works
+- [ ] `## Risks` — what could go wrong
+- [ ] `## Model Used` — provider, model ID, version, capabilities
+- [ ] `## Checklist` — copied from the template, items checked off
+
+If any section is missing or empty, do NOT submit the PR. Go back and fill it in.
+
+### Step 3 — Create the PR
+
+Only after completing Steps 1 and 2, run `gh pr create`. Use the template contents as the structure for `--body` — do not write a freeform summary.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Server won't start | Run `npx paperclipai doctor --repair` to diagnose and auto-fix |
+| Forgetting to source worktree env | Run `eval "$(npx paperclipai worktree env)"` after cd-ing into the worktree |
+| Stale dependencies after pull | Run `pnpm install && pnpm build` after pulling |
+| Schema out of date after pull | Run `pnpm db:generate && pnpm db:migrate` |
+| Reseeding while target DB is running | Stop the target server first, or use `--allow-live-target` |
+| Cleaning up with unmerged commits | Merge or push first, or use `--force` if intentionally discarding |
+| Running agents against wrong instance | Verify `PAPERCLIP_API_URL` points to the correct port |

--- a/skills/paperclip-dev/SKILL.md
+++ b/skills/paperclip-dev/SKILL.md
@@ -159,6 +159,56 @@ These rules exist because agents have caused real damage by improvising around C
 
 5. **Seeding is a CLI operation.** When asked to seed a worktree database from the main instance, use `worktree reseed` or recreate with `worktree:make --seed-mode full`. Read `doc/DEVELOPING.md` for the full option tables. Never attempt manual database copying.
 
+## Persistent Dev Servers (for Manual Testing)
+
+When an agent needs to start a dev server that outlives the current heartbeat — for example, so a human or QA agent can manually test against it — the server process **must** be launched in a detached session. A process started directly from a heartbeat shell is killed when the heartbeat exits.
+
+### Use `tmux` for persistent servers
+
+```bash
+# 1. cd into the worktree (or main repo) and source the environment
+cd <worktree-path>
+eval "$(npx paperclipai worktree env)"   # skip if using the primary instance
+
+# 2. Start the dev server in a named, detached tmux session
+tmux new-session -d -s <session-name> 'pnpm dev'
+
+# Example with a descriptive name:
+tmux new-session -d -s papa81-auth-3102 'pnpm dev'
+```
+
+### Managing the session
+
+| Task | Command |
+|------|---------|
+| Check if the session is alive | `tmux has-session -t <session-name> 2>/dev/null && echo running` |
+| View server output | `tmux capture-pane -t <session-name> -p` |
+| Kill the session | `tmux kill-session -t <session-name>` |
+| List all tmux sessions | `tmux list-sessions` |
+
+### Verifying the server is reachable
+
+After launching, confirm the port is listening before reporting success:
+
+```bash
+# Wait briefly for startup, then verify
+sleep 3
+curl -sf http://127.0.0.1:<port>/api/health && echo "Server is up"
+lsof -nP -iTCP:<port> -sTCP:LISTEN
+```
+
+### Why this matters
+
+In PAPA-81, the dev server was started with `pnpm dev` directly from the agent shell. It appeared healthy during the heartbeat, but died as soon as the heartbeat exited. QA repeatedly found the port unreachable seconds later. Switching to a detached `tmux` session solved the problem — the server survived across heartbeats and remained available for manual testing.
+
+### Key rules
+
+1. **Always use `tmux` (or equivalent)** when a dev server needs to stay running after the heartbeat ends.
+2. **Name the session descriptively** — include the issue or worktree name and port (e.g., `papa81-auth-3102`).
+3. **Verify the server is listening** before reporting the URL to anyone.
+4. **Do not use `nohup` or `&` alone** — these are unreliable for agent shells that may have their entire process group killed.
+5. **Clean up when done** — kill the tmux session when the testing is complete.
+
 ## Common Mistakes
 
 | Mistake | Fix |
@@ -172,3 +222,4 @@ These rules exist because agents have caused real damage by improvising around C
 | Running agents against wrong instance | Verify `PAPERCLIP_API_URL` points to the correct port |
 | CLI command fails | Do NOT work around it — report the error and block (see Hard Rules above) |
 | Agent tries manual postgres operations | NEVER do this — all DB ops go through the CLI (see Hard Rules above) |
+| Dev server dies between heartbeats | Launch in a detached `tmux` session — see "Persistent Dev Servers" above |


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents working on the Paperclip codebase itself need guidance on dev workflows: server lifecycle, worktrees, builds, database ops, diagnostics
> - There was no bundled skill covering these workflows — agents had to figure it out from scratch each time
> - Additionally, not every skill should be force-installed on every agent — a dev-focused skill should be opt-in
> - This PR adds a `paperclip-dev` skill with `required: false` frontmatter so it ships with Paperclip but isn't auto-installed
> - The skill's PR section references canonical files (`.github/PULL_REQUEST_TEMPLATE.md`, `CONTRIBUTING.md`) instead of duplicating their content, with gated instructions that force agents to read those files before creating any PR
> - The benefit is that developers (human or agent) can opt in to structured dev guidance without polluting the default agent skill set or creating drift between duplicated docs

## What Changed

- Added `skills/paperclip-dev/SKILL.md` covering server management, worktree lifecycle, builds, database ops, diagnostics, agent operations, and common mistakes
- The Pull Requests section uses gated, reference-based instructions — agents MUST read `.github/PULL_REQUEST_TEMPLATE.md` and `CONTRIBUTING.md` before running `gh pr create`, with a brief checklist of required section names (no content duplication)
- Updated `packages/adapter-utils/src/server-utils.ts` to respect `required: false` frontmatter — optional skills are bundled but not auto-installed on agents
- Added test in `server/src/__tests__/paperclip-skill-utils.test.ts` verifying that optional skills are excluded from the default install set

## Verification

```bash
# Run tests
pnpm test

# Manual verification: create a fresh worktree without seeding
npx paperclipai worktree:make test-optional-skill --no-seed
cd ~/paperclip-test-optional-skill
eval "$(npx paperclipai worktree env)"
npx paperclipai run

# Verify paperclip-dev appears in company skill library but is NOT auto-assigned
# Call listPaperclipSkillEntries() — paperclip-dev should show required: false
# Call resolvePaperclipDesiredSkillNames() — paperclip-dev should NOT be in the default set

# Cleanup
npx paperclipai worktree:cleanup test-optional-skill
```

## Risks

- Low risk. The `required` field defaults to `true` when absent, so all existing skills behave identically. Only the new `paperclip-dev` skill sets `required: false`.

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`) via Claude Code, with tool use and extended context.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge