### PR TITLE
fix(heartbeat): align server intervalSec default with UI (0 → 300)

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -501,7 +501,7 @@ export function agentRoutes(db: Db) {
     const heartbeat = asRecord(asRecord(runtimeConfig)?.heartbeat) ?? {};
     return {
       enabled: parseBooleanLike(heartbeat.enabled) ?? false,
-      intervalSec: Math.max(0, parseNumberLike(heartbeat.intervalSec) ?? 0),
+      intervalSec: Math.max(0, parseNumberLike(heartbeat.intervalSec) ?? 300),
     };
   }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2592,7 +2592,7 @@ export function heartbeatService(db: Db) {
 
     return {
       enabled: asBoolean(heartbeat.enabled, false),
-      intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
+      intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 300)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
     };


### PR DESCRIPTION
## Summary
`parseHeartbeatPolicy` ([`server/src/services/heartbeat.ts`](https://github.com/paperclipai/paperclip/blob/master/server/src/services/heartbeat.ts)) and `parseSchedulerHeartbeatPolicy` ([`server/src/routes/agents.ts`](https://github.com/paperclipai/paperclip/blob/master/server/src/routes/agents.ts)) both default `intervalSec` to **0** when missing from `runtimeConfig.heartbeat`. The corresponding UI field in [`ui/src/components/AgentConfigForm.tsx`](https://github.com/paperclipai/paperclip/blob/master/ui/src/components/AgentConfigForm.tsx) defaults to **300**:

```tsx
number={eff("heartbeat", "intervalSec", Number(heartbeat.intervalSec ?? 300))}
```

This PR changes both server defaults to 300 so the server and UI agree.

## Symptom
An agent saved with `heartbeat.enabled = true` but no explicit `intervalSec` appears in the UI as *"Run heartbeat every 300 sec"*, but the server computes `intervalSec = 0`. The scheduler then short-circuits:

```ts
if (!policy.enabled || policy.intervalSec <= 0) continue;   // heartbeat.ts
```

…and `parseSchedulerHeartbeatPolicy` reports `schedulerActive = false` to the dashboard status endpoint, even though the agent appears configured for periodic wakes.

## Scope
- Two one-line defaults in two files.
- `runtimeConfig.heartbeat.intervalSec = 0` set explicitly is still honored — the `Math.max(0, …)` + `<= 0` guard in the scheduler still treats explicit 0 as "disabled".
- No migration: only affects agents whose stored `runtimeConfig.heartbeat` omits `intervalSec`. Those were already behaving as "never fire" despite the UI implying otherwise, so this fixes the divergence rather than introducing new behavior.

## Test plan
- [ ] Create a new agent with heartbeat enabled; confirm the scheduler starts firing at the 300s cadence the UI shows.
- [ ] Existing agent with `runtimeConfig.heartbeat = { enabled: true }` (no intervalSec): verify timer starts firing at 300s after deploy, and the dashboard's `schedulerActive` flag flips to true.
- [ ] Agent with explicit `intervalSec: 0`: still treated as disabled (regression check).