### PR TITLE
fix(agents): preserve sibling keys of runtimeConfig on partial PATCH

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2020,6 +2020,18 @@ export function agentRoutes(db: Db) {
       );
     }
 
+    // Preserve sibling keys of runtimeConfig across partial PATCHes.
+    // The column is stored as a single JSONB blob, so writing a partial
+    // object would drop any top-level keys the caller didn't include.
+    // Spread the existing row's runtimeConfig first, then overlay the
+    // patch — callers sending only { heartbeat: {...} } keep their
+    // adapter/env/etc. sibling keys intact.
+    if (Object.prototype.hasOwnProperty.call(patchData, "runtimeConfig")) {
+      const existingRuntimeConfig = asRecord(existing.runtimeConfig) ?? {};
+      const requestedRuntimeConfig = asRecord(patchData.runtimeConfig) ?? {};
+      patchData.runtimeConfig = { ...existingRuntimeConfig, ...requestedRuntimeConfig };
+    }
+
     const actor = getActorInfo(req);
     const agent = await svc.update(id, patchData, {
       recordRevision: {


### PR DESCRIPTION
## Summary
`PATCH /api/agents/:id` shallow-replaces `runtimeConfig` today: any call that sends only a subset of the top-level keys silently drops the rest. Mirroring the existing `adapterConfig` merge pattern from the same handler fixes this with a 5-line spread.

## Symptom
An agent persisted with:

```json
{
  "runtimeConfig": {
    "heartbeat": { "enabled": true, "intervalSec": 300 },
    "workspaceRuntime": { ... }
  }
}
```

…on receiving `PATCH { "runtimeConfig": { "heartbeat": { "enabled": false } } }`, is stored as:

```json
{
  "runtimeConfig": { "heartbeat": { "enabled": false } }
}
```

Both `workspaceRuntime` and `heartbeat.intervalSec` are gone. The column is a single JSONB blob, so partial writes without a merge drop top-level siblings.

## Precedent already in the same handler
`adapterConfig` already handles this correctly at [server/src/routes/agents.ts line ~1983](https://github.com/paperclipai/paperclip/blob/master/server/src/routes/agents.ts#L1983):

```ts
if (requestedAdapterConfig && !changingAdapterType && !replaceAdapterConfig) {
  rawEffectiveAdapterConfig = { ...existingAdapterConfig, ...requestedAdapterConfig };
}
```

This PR applies the same pattern to `runtimeConfig`, just before the `svc.update(id, patchData, ...)` call.

## Scope
Intentionally minimal: **shallow merge at the top level of `runtimeConfig`**, not a recursive deep merge. A caller that sends a complete sub-object (e.g. the UI always sends the full `heartbeat` shape) still replaces it wholesale — that matches typical PATCH semantics and avoids making opinionated decisions about arrays, nulls-as-deletes, etc.

## Test plan
- [ ] PATCH with `{ runtimeConfig: { heartbeat: { enabled: false } } }` on an agent that has `{ heartbeat, workspaceRuntime }` — confirm `workspaceRuntime` survives after the patch.
- [ ] PATCH with the full UI-shaped payload (existing behavior) — regression check; should still replace the whole `runtimeConfig` shape the UI sent.
- [ ] PATCH with no `runtimeConfig` field — regression check; should not touch the stored `runtimeConfig`.
- [ ] Tests intentionally not added in this PR — current suite has no happy-path PATCH `/api/agents/:id` coverage (the `adapterConfig` merge precedent also ships untested), and building out that harness would balloon scope beyond the 5-line fix. Happy to add tests in a follow-up if the maintainers want them; flagging transparently.

## Compatibility
No schema migration. No UI change (UI already sends the full shape on save). Clients that relied on PATCH overwriting the entire `runtimeConfig` can still do so by sending the full shape; only behavior for _partial_ payloads changes, and the change aligns with the adapterConfig precedent.