### PR TITLE
fix(issues): avoid Date bind crash in comment pagination

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1297,3 +1297,91 @@ describeEmbeddedPostgres("issueService.findMentionedProjectIds", () => {
     ]);
   });
 });
+
+describeEmbeddedPostgres("issueService.listComments cursor pagination", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-comments-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("paginates comments after a cursor without passing a Date bind param", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const firstCommentId = randomUUID();
+    const secondCommentId = randomUUID();
+    const thirdCommentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Cursor pagination",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        id: firstCommentId,
+        companyId,
+        issueId,
+        body: "first",
+        createdAt: new Date("2026-04-17T00:00:00.000Z"),
+      },
+      {
+        id: secondCommentId,
+        companyId,
+        issueId,
+        body: "second",
+        createdAt: new Date("2026-04-17T00:00:01.000Z"),
+      },
+      {
+        id: thirdCommentId,
+        companyId,
+        issueId,
+        body: "third",
+        createdAt: new Date("2026-04-17T00:00:02.000Z"),
+      },
+    ]);
+
+    await expect(
+      svc.listComments(issueId, {
+        afterCommentId: firstCommentId,
+        order: "asc",
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: secondCommentId, body: "second" }),
+      expect.objectContaining({ id: thirdCommentId, body: "third" }),
+    ]);
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1384,4 +1384,61 @@ describeEmbeddedPostgres("issueService.listComments cursor pagination", () => {
       expect.objectContaining({ id: thirdCommentId, body: "third" }),
     ]);
   });
+
+  it("paginates descending comments after a cursor without passing a Date bind param", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const firstCommentId = randomUUID();
+    const secondCommentId = randomUUID();
+    const thirdCommentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Cursor pagination desc",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        id: firstCommentId,
+        companyId,
+        issueId,
+        body: "first",
+        createdAt: new Date("2026-04-17T00:00:00.000Z"),
+      },
+      {
+        id: secondCommentId,
+        companyId,
+        issueId,
+        body: "second",
+        createdAt: new Date("2026-04-17T00:00:01.000Z"),
+      },
+      {
+        id: thirdCommentId,
+        companyId,
+        issueId,
+        body: "third",
+        createdAt: new Date("2026-04-17T00:00:02.000Z"),
+      },
+    ]);
+
+    await expect(
+      svc.listComments(issueId, {
+        afterCommentId: thirdCommentId,
+        order: "desc",
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: secondCommentId, body: "second" }),
+      expect.objectContaining({ id: firstCommentId, body: "first" }),
+    ]);
+  });
 });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2092,15 +2092,17 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        const anchorCreatedAt =
+          anchor.createdAt instanceof Date ? anchor.createdAt.toISOString() : anchor.createdAt;
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2092,8 +2092,7 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
-        const anchorCreatedAt =
-          anchor.createdAt instanceof Date ? anchor.createdAt.toISOString() : anchor.createdAt;
+        const anchorCreatedAt = anchor.createdAt.toISOString();
         conditions.push(
           order === "asc"
             ? sql<boolean>`(


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issue comments are part of the core task execution and oversight loop
> - The comments pagination path supports cursor-based reads via `GET /api/issues/:id/comments?after=...`
> - That path currently binds the anchor comment `createdAt` as a JavaScript `Date`, which crashes inside postgres.js before the query runs
> - This pull request normalizes the cursor timestamp before it is bound and adds a regression test for the paginated comment path
> - The benefit is that cursor-based comment pagination stops returning 500s for agents and UI clients using `after` pagination

## What Changed

- Normalized the comment cursor anchor timestamp in `server/src/services/issues.ts` before binding it into the comparison SQL used by `listComments`
- Added an embedded Postgres regression test in `server/src/__tests__/issues-service.test.ts` covering `afterCommentId + order=asc` pagination
- Kept the patch scoped to the comments cursor path only

## Verification

- `node server/node_modules/vitest/vitest.mjs run server/src/__tests__/issues-service.test.ts`
  - Blocked before test execution by an existing local environment/runtime issue unrelated to this patch:
  - `TypeError: undefined is not an object (evaluating z.string)`
  - Source reported by Vitest during suite collection: `packages/shared/src/adapter-type.ts:4`
- Code-path verification:
  - The fix changes only the `listComments` cursor comparison path in `server/src/services/issues.ts`
  - The regression test exercises pagination after a known cursor and asserts the later comments are returned in ascending order

## Risks

- Low risk: the change only affects the comment cursor comparison path when `after` / `afterCommentId` is provided
- The new normalization preserves the existing comparison semantics while avoiding the postgres.js bind crash

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI agent (GPT-5-based coding model; exact backend model identifier is not exposed in this session), tool-enabled code editing and shell execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #3830
