### PR TITLE
fix(cli): revoke stale local-cli API keys before creating new one

### DIFF
--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -239,8 +239,19 @@ export function registerAgentCommands(program: Command): void {
             throw new Error(`Agent not found: ${agentRef}`);
           }
 
-          const now = new Date().toISOString().replaceAll(":", "-");
-          const keyName = opts.keyName?.trim() ? opts.keyName.trim() : `local-cli-${now}`;
+          const keyName = opts.keyName?.trim() ? opts.keyName.trim() : "local-cli";
+
+          // Revoke existing keys with the same name to prevent accumulation
+          const existingKeys =
+            (await ctx.api.get<Array<{ id: string; name: string; revokedAt: string | null }>>(
+              `/api/agents/${agentRow.id}/keys`,
+            )) ?? [];
+          for (const existing of existingKeys) {
+            if (existing.name === keyName && !existing.revokedAt) {
+              await ctx.api.delete(`/api/agents/${agentRow.id}/keys/${existing.id}`);
+            }
+          }
+
           const key = await ctx.api.post<CreatedAgentKey>(`/api/agents/${agentRow.id}/keys`, { name: keyName });
           if (!key) {
             throw new Error("Failed to create API key");


### PR DESCRIPTION
## Summary

- **Bug**: Each `paperclipai agent local-cli` invocation creates a new persistent API key named `local-cli` that never gets cleaned up, causing unbounded key accumulation (12+ keys/day observed)
- **Fix**: Before creating a new key, list existing agent keys via `GET /api/agents/:id/keys`, delete any active ones matching the key name, then create fresh
- **Bonus**: Removed the timestamp-suffixed fallback name (`local-cli-${now}`) — the key name is now consistently `local-cli` (or the user-provided `--key-name` value)

## Test plan

- [ ] Run `paperclipai agent local-cli <agent> -C <company>` twice — verify only 1 active `local-cli` key exists after both runs
- [ ] Run with `--key-name custom` — verify only `custom`-named keys are rotated, not `local-cli` ones
- [ ] Verify existing stale keys from before this fix are cleaned up on next invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)