### PR TITLE
fix(server): add JWT token redaction to log-redaction.ts

### DIFF
--- a/server/src/__tests__/log-redaction.test.ts
+++ b/server/src/__tests__/log-redaction.test.ts
@@ -3,6 +3,8 @@ import {
   maskUserNameForLogs,
   redactCurrentUserText,
   redactCurrentUserValue,
+  redactJwtTokens,
+  REDACTED_JWT_TOKEN,
 } from "../log-redaction.js";
 
 describe("log redaction", () => {
@@ -70,5 +72,45 @@ describe("log redaction", () => {
   it("skips redaction when disabled", () => {
     const input = "cwd=/Users/paperclipuser/paperclip";
     expect(redactCurrentUserText(input, { enabled: false })).toBe(input);
+  });
+
+  it("redacts JWT tokens embedded in text", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const input = `Authorization: Bearer ${jwt}`;
+    const result = redactCurrentUserText(input, { userNames: [], homeDirs: [] });
+    expect(result).toBe(`Authorization: Bearer ${REDACTED_JWT_TOKEN}`);
+    expect(result).not.toContain(jwt);
+  });
+
+  it("redacts multiple JWTs in the same text", () => {
+    const jwt1 =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    const jwt2 =
+      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJvbGUiOiJzZXJ2aWNlX3JvbGUifQ.abc123def456ghi789jkl012mno345pqr678stu901vwx";
+    const input = `token1=${jwt1} and token2=${jwt2}`;
+    const result = redactJwtTokens(input);
+    expect(result).not.toContain(jwt1);
+    expect(result).not.toContain(jwt2);
+    expect(result).toBe(`token1=${REDACTED_JWT_TOKEN} and token2=${REDACTED_JWT_TOKEN}`);
+  });
+
+  it("does not redact short dot-separated strings", () => {
+    const input = "version=1.2.3 and node.js.runtime";
+    const result = redactJwtTokens(input);
+    expect(result).toBe(input);
+  });
+
+  it("redacts JWTs in nested values via redactCurrentUserValue", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const result = redactCurrentUserValue(
+      { auth: `Bearer ${jwt}`, nested: { key: jwt } },
+      { userNames: [], homeDirs: [] },
+    );
+    expect(result).toEqual({
+      auth: `Bearer ${REDACTED_JWT_TOKEN}`,
+      nested: { key: REDACTED_JWT_TOKEN },
+    });
   });
 });

--- a/server/src/log-redaction.ts
+++ b/server/src/log-redaction.ts
@@ -1,6 +1,10 @@
 import os from "node:os";
 
 export const CURRENT_USER_REDACTION_TOKEN = "*";
+export const REDACTED_JWT_TOKEN = "***JWT_REDACTED***";
+
+const JWT_TEXT_RE =
+  /[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}(?:\.[A-Za-z0-9_-]{20,})?/g;
 
 export interface CurrentUserRedactionOptions {
   enabled?: boolean;
@@ -104,6 +108,11 @@ function resolveCurrentUserCandidates(opts?: CurrentUserRedactionOptions) {
   return { userNames, homeDirs, replacement };
 }
 
+export function redactJwtTokens(input: string): string {
+  if (!input) return input;
+  return input.replace(JWT_TEXT_RE, REDACTED_JWT_TOKEN);
+}
+
 export function redactCurrentUserText(input: string, opts?: CurrentUserRedactionOptions) {
   if (!input) return input;
   if (opts?.enabled === false) return input;
@@ -125,6 +134,8 @@ export function redactCurrentUserText(input: string, opts?: CurrentUserRedaction
     const pattern = new RegExp(`(?<![A-Za-z0-9._-])${escapeRegExp(userName)}(?![A-Za-z0-9._-])`, "g");
     result = result.replace(pattern, maskUserNameForLogs(userName, replacement));
   }
+
+  result = redactJwtTokens(result);
 
   return result;
 }


### PR DESCRIPTION
## Summary

- Adds text-level JWT redaction to `server/src/log-redaction.ts` — JWTs (three+ base64url segments, 20+ chars each) are replaced with `***JWT_REDACTED***`
- Integrates into `redactCurrentUserText` so all existing call sites (heartbeat log chunks, event messages/payloads, workspace ops) get JWT scrubbing automatically
- Exports `redactJwtTokens` for standalone use and `REDACTED_JWT_TOKEN` constant
- Adds 4 new tests covering embedded JWTs, multiple JWTs, false-positive avoidance, and nested value redaction

## Context

Supabase service_role keys, n8n API tokens, and Paperclip run JWTs were leaking into run log NDJSON files because log-redaction only scrubbed usernames and home directories. The existing `redaction.ts` catches JWTs in structured key-value payloads, but `log-redaction.ts` missed JWTs in free-text log output.

## Test plan

- [x] All 8 log-redaction tests pass (`npx vitest run server/src/__tests__/log-redaction.test.ts`)
- [x] Short dot-separated strings (version numbers, etc.) are not falsely redacted
- [x] Redaction works through `redactCurrentUserValue` for nested objects


🤖 Generated with [Claude Code](https://claude.com/claude-code)