### PR TITLE
fix(agents): resolve "me" sentinel so PATCH /agents/me works (#3831)

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -34,6 +34,7 @@ const mockAgentService = vi.hoisted(() => ({
   getById: vi.fn(),
   list: vi.fn(),
   create: vi.fn(),
+  update: vi.fn(),
   updatePermissions: vi.fn(),
   getChainOfCommand: vi.fn(),
   resolveByReference: vi.fn(),
@@ -166,6 +167,7 @@ describe("agent permission routes", () => {
     mockAgentService.getChainOfCommand.mockResolvedValue([]);
     mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: baseAgent });
     mockAgentService.create.mockResolvedValue(baseAgent);
+    mockAgentService.update.mockResolvedValue(baseAgent);
     mockAgentService.updatePermissions.mockResolvedValue(baseAgent);
     mockAccessService.getMembership.mockResolvedValue({
       id: "membership-1",
@@ -637,5 +639,60 @@ describe("agent permission routes", () => {
 
     expect(res.status).toBe(403);
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
+  });
+
+  it("resolves PATCH /agents/me to the authenticated agent", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await request(app)
+      .patch("/api/agents/me")
+      .send({ metadata: { lastHeartbeatNote: "ok" } });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(agentId);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({ metadata: { lastHeartbeatNote: "ok" } }),
+      expect.any(Object),
+    );
+  });
+
+  it("rejects PATCH /agents/me without agent authentication", async () => {
+    const app = await createApp({ type: "none", source: "none" });
+
+    const res = await request(app)
+      .patch("/api/agents/me")
+      .send({ metadata: { lastHeartbeatNote: "ok" } });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain("agent authentication");
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+  });
+
+  it("still resolves PATCH /agents/:uuid by direct id", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${agentId}`)
+      .send({ metadata: { lastHeartbeatNote: "direct" } });
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({ metadata: { lastHeartbeatNote: "direct" } }),
+      expect.any(Object),
+    );
   });
 });

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -671,7 +671,7 @@ describe("agent permission routes", () => {
       .send({ metadata: { lastHeartbeatNote: "ok" } });
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toContain("agent authentication");
+    expect(res.body.error).toBe("Agent authentication required");
     expect(mockAgentService.update).not.toHaveBeenCalled();
   });
 

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -44,7 +44,7 @@ import {
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
 } from "../services/index.js";
-import { conflict, forbidden, notFound, unprocessable } from "../errors.js";
+import { conflict, forbidden, notFound, unauthorized, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import {
   assertNoAgentHostWorkspaceCommandMutation,
@@ -414,6 +414,12 @@ export function agentRoutes(db: Db) {
 
   async function normalizeAgentReference(req: Request, rawId: string): Promise<string> {
     const raw = rawId.trim();
+    // The "me" sentinel resolves to the authenticated agent. Auth middleware
+    // runs before router.param, so req.actor is populated by the time we get here.
+    if (raw === "me") {
+      if (req.actor?.type === "agent" && req.actor.agentId) return req.actor.agentId;
+      throw unauthorized("'me' requires agent authentication");
+    }
     if (isUuidLike(raw)) return raw;
 
     const companyId = await resolveCompanyIdForAgentReference(req);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -418,7 +418,7 @@ export function agentRoutes(db: Db) {
     // runs before router.param, so req.actor is populated by the time we get here.
     if (raw === "me") {
       if (req.actor?.type === "agent" && req.actor.agentId) return req.actor.agentId;
-      throw unauthorized("'me' requires agent authentication");
+      throw unauthorized("Agent authentication required");
     }
     if (isUuidLike(raw)) return raw;
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents authenticate with their own bearer token and identify themselves via `/agents/me`
> - `GET /agents/me` is explicitly routed and uses `req.actor.agentId`, but other verbs have no `/me` variant
> - A `PATCH /agents/me` falls through to `PATCH /agents/:id`, where the `router.param("id")` handler calls `normalizeAgentReference("me")`
> - That helper treats `"me"` as a shortname, finds no match, and throws `notFound` — so every agent self-update via `PATCH /agents/me` is silently 404'd (issue #3831 reports thousands of these over weeks)
> - This PR teaches `normalizeAgentReference` to resolve the `"me"` sentinel from `req.actor.agentId` when the caller is an authenticated agent
> - The benefit is that PATCH/DELETE/POST on `/agents/me/*` now all behave consistently with `GET /agents/me`, with a 4-line change to one function

## What Changed

- `server/src/routes/agents.ts`: extend `normalizeAgentReference` to resolve the `"me"` sentinel to `req.actor.agentId` for agent-authenticated callers; throw `unauthorized` otherwise. Import `unauthorized` from `../errors.js`.
- `server/src/__tests__/agent-permissions-routes.test.ts`: add three cases — PATCH `/agents/me` as authenticated agent (200 + `svc.update` called with the resolved id), PATCH `/agents/me` with no agent auth (401), and a regression check that PATCH `/agents/:uuid` still works by direct id. Add `update: vi.fn()` to the hoisted agent-service mock.

## Verification

- `cd server && npx vitest run src/__tests__/agent-permissions-routes.test.ts` → 20/20 pass (3 new + 17 existing)
- Ran the adjacent auth/authz/shortname suites to confirm no regressions:
  `npx vitest run src/__tests__/agent-auth-jwt.test.ts src/__tests__/agent-cross-tenant-authz-routes.test.ts src/__tests__/agent-shortname-collision.test.ts src/__tests__/agent-permissions-routes.test.ts` → 38/38 pass.
- `npx tsc --noEmit` in `server/` produces no new errors in the changed files (pre-existing unrelated errors in `plugin-host-services.ts` / `plugin-sdk` module resolution remain).
- Manual, against a running instance:
  `curl -X PATCH -H "Authorization: Bearer <agent-jwt>" -H "Content-Type: application/json" -d '{"metadata":{"lastHeartbeatNote":"ok"}}' http://127.0.0.1:3100/api/agents/me` → 200 with updated agent row (previously 404).

## Risks

- Low. The `"me"` token was already effectively reserved by the explicit `GET /agents/me` route; any caller that literally named an agent `"me"` via shortname would be shadowed, which is vanishingly unlikely and matches the existing UX contract.
- The check runs inside `router.param("id")`, which fires only after the auth middleware has populated `req.actor` (the existing `GET /agents/me` handler already depends on this ordering).
- A non-agent actor (board/user/none) hitting `/agents/me/*` now gets a cleaner 401 instead of a misleading 404. This is a strictly more accurate status code.

## Model Used

- Claude Opus 4.7 (1M context), extended reasoning mode, tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only)
- [x] I have updated relevant documentation to reflect my changes — N/A, behavior matches existing `GET /agents/me` contract
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge