### PR TITLE
fix(skills): atomic upsert to eliminate /skills duplicate-key race (#3845)

### DIFF
--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { promises as fs } from "node:fs";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
 import { companies, companySkills, createDb } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -88,5 +89,41 @@ describeEmbeddedPostgres("companySkillService.list", () => {
       sourceBadge: "local",
       editable: true,
     });
+  });
+
+  it("survives concurrent createLocalSkill calls with the same key (#3845)", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    // Fan out many service instances hitting upsertImportedSkills for the
+    // same (companyId, key) without sharing the in-process dedup map. This
+    // reproduces the multi-replica race where two callers both see
+    // getByKey → null and both attempt INSERT. Before #3845's fix, at least
+    // one call threw a PostgresError on the (company_id, key) unique index.
+    const parallelism = 16;
+    const request = { name: "Race", slug: "race", description: null, markdown: null };
+    const results = await Promise.all(
+      Array.from({ length: parallelism }, () =>
+        companySkillService(db).createLocalSkill(companyId, request),
+      ),
+    );
+
+    for (const result of results) {
+      expect(result.key).toBe(`company/${companyId}/race`);
+    }
+
+    const rows = await db
+      .select()
+      .from(companySkills)
+      .where(eq(companySkills.companyId, companyId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].key).toBe(`company/${companyId}/race`);
+
+    cleanupDirs.add(path.dirname(rows[0].sourceLocator as string));
   });
 });

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2335,18 +2335,18 @@ export function companySkillService(db: Db) {
         metadata,
         updatedAt: new Date(),
       };
-      const row = existing
-        ? await db
-          .update(companySkills)
-          .set(values)
-          .where(eq(companySkills.id, existing.id))
-          .returning()
-          .then((rows) => rows[0] ?? null)
-        : await db
-          .insert(companySkills)
-          .values(values)
-          .returning()
-          .then((rows) => rows[0] ?? null);
+      // Single idempotent upsert keyed on the unique (company_id, key) index.
+      // Previously this was a check-then-insert race that tripped the unique
+      // constraint when two callers inserted the same key concurrently (#3845).
+      const row = await db
+        .insert(companySkills)
+        .values(values)
+        .onConflictDoUpdate({
+          target: [companySkills.companyId, companySkills.key],
+          set: values,
+        })
+        .returning()
+        .then((rows) => rows[0] ?? null);
       if (!row) throw notFound("Failed to persist company skill");
       out.push(toCompanySkill(row));
     }

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2319,9 +2319,7 @@ export function companySkillService(db: Db) {
         ...(skill.metadata ?? {}),
         skillKey: skill.key,
       };
-      const values = {
-        companyId,
-        key: skill.key,
+      const mutableValues = {
         slug: skill.slug,
         name: skill.name,
         description: skill.description,
@@ -2340,10 +2338,10 @@ export function companySkillService(db: Db) {
       // constraint when two callers inserted the same key concurrently (#3845).
       const row = await db
         .insert(companySkills)
-        .values(values)
+        .values({ companyId, key: skill.key, ...mutableValues })
         .onConflictDoUpdate({
           target: [companySkills.companyId, companySkills.key],
-          set: values,
+          set: mutableValues,
         })
         .returning()
         .then((rows) => rows[0] ?? null);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each company has an inventory of skills (bundled, local, or imported from GitHub)
> - On every `GET /api/companies/:companyId/skills`, the service eagerly refreshes the inventory via `ensureSkillInventoryCurrent` → `ensureBundledSkills` → `upsertImportedSkills`
> - That upsert used a manual check-then-insert (getByKey → branch on existing), which races on the `(company_id, key)` unique constraint when two callers beat each other to the INSERT — turning a read-only endpoint into a 500 (issue #3845)
> - This PR replaces the branch with a single idempotent `onConflictDoUpdate` keyed on the same columns as the unique index
> - The benefit is a concurrency-safe `/skills` read path that matches the existing drizzle upsert idioms in this codebase

## What Changed

- `server/src/services/company-skills.ts`: in `upsertImportedSkills`, collapse the `existing ? update : insert` branch (previously lines 2338–2349) into a single `db.insert(...).onConflictDoUpdate({ target: [companySkills.companyId, companySkills.key], set: values })`. The bundled-vs-github short-circuit above (paperclip_bundled rows are preserved when the incoming skill comes from the upstream GitHub repo) is unchanged.
- `server/src/__tests__/company-skills-service.test.ts`: add a regression test that fans out 16 concurrent `createLocalSkill` calls from 16 fresh service instances (distinct in-process dedup maps) targeting the same skill key. Import `eq` from `drizzle-orm` for the post-assertion DB read.

## Verification

- Ran the new test against the pre-fix code and reliably reproduced the exact `PostgresError: duplicate key value violates unique constraint "company_skills_company_key_idx"` from the issue report.
- With the fix in place: `cd server && npx vitest run src/__tests__/company-skills-service.test.ts` → 2/2 pass.
- Adjacent suite: `npx vitest run src/__tests__/company-skills-service.test.ts src/__tests__/company-skills-routes.test.ts` → 9/9 pass.
- `npx tsc --noEmit` in `server/` produces no new errors in the changed files.

## Risks

- Low. `onConflictDoUpdate` with `target: [companyId, key]` matches the exact columns of the existing `company_skills_company_key_idx` unique index, so there's no mismatch risk. The `set: values` payload is the same object the `UPDATE` branch wrote before, so behavior on conflict is unchanged except that the write is now race-safe.
- The bundled-vs-github short-circuit at the top of the loop still uses `getByKey(companyId, skill.key)` and behaves identically to before.
- `updatedAt` is still refreshed on every upsert (existing behavior).

## Model Used

- Claude Opus 4.7 (1M context), extended reasoning mode, tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only)
- [x] I have updated relevant documentation to reflect my changes — N/A
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge