### PR TITLE
fix(opencode): prevent rg race on short-lived lock files

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,10 @@
+# opencode CLI runtime state, cache, share, config directories.
+# Paperclip's runner invokes `rg` with CWD=$HOME where these dirs live.
+# Lock files under .local/state/opencode/locks/ appear and disappear in
+# milliseconds, causing rg to ENOENT during directory traversal
+# (shown as "Permission denied (os error 2)"). Scanning these dirs
+# serves no purpose — they are internal CLI state, not user code.
+.local/state/opencode/
+.local/share/opencode/
+.cache/opencode/
+.config/opencode/

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -26,4 +26,26 @@ if [ "$changed" = "1" ]; then
     chown -R node:node /paperclip
 fi
 
+# --- Ensure opencode state dirs are not scanned by rg and owned by runtime user ---
+# Background: opencode CLI (invoked by paperclip runner) creates short-lived
+# lock files under $HOME/.local/state/opencode/locks/. When the runner invokes
+# rg from $HOME, recursive traversal races on these files and the tool-call
+# fails with ENOENT (misrendered as "Permission denied"). See commit body.
+PAPERCLIP_HOME="${PAPERCLIP_HOME:-/paperclip}"
+if [ -d "$PAPERCLIP_HOME" ]; then
+    if [ ! -f "$PAPERCLIP_HOME/.rgignore" ]; then
+        cat > "$PAPERCLIP_HOME/.rgignore" <<RGIGNORE
+.local/state/opencode/
+.local/share/opencode/
+.cache/opencode/
+.config/opencode/
+RGIGNORE
+    fi
+    # Normalize ownership so runtime user can always clean up its own locks.
+    for d in .local/state/opencode .local/share/opencode .cache/opencode .config/opencode .rgignore; do
+        [ -e "$PAPERCLIP_HOME/$d" ] && chown -R "$PUID:$PGID" "$PAPERCLIP_HOME/$d" 2>/dev/null || true
+    done
+fi
+# --- end opencode rg race guard ---
+
 exec gosu node "$@"


### PR DESCRIPTION
## Problem

Paperclip invokes \`rg\` during tool-calls (e.g. \`glob\`) with CWD=\$HOME=/paperclip, and opencode itself creates short-lived lock files under \`.local/state/opencode/locks/\`. Recursive scans race on those files and fail with ENOENT (displayed as "Permission denied (os error 2)"). The adapter treats the non-zero rg exit + non-empty stderr as a failed tool-call → run fails as \`adapter_failed\`.

Observed: run \`60858e19\` (CTO agent, gpt-5.4), 2026-04-17.

## Fix

1. Repo-root \`.rgignore\` excludes opencode state/cache/share/config dirs.
2. Entrypoint guarantees \`.rgignore\` exists on the runtime volume and chowns opencode state to the runtime user (PUID:PGID). Runs before \`exec gosu node\`, so it can correct historical root-owned lock directories observed during the incident.

Both changes are idempotent.

## Not in this PR

Root cause is that opencode is invoked with CWD=\$HOME rather than the per-job workspace. Fixing that in the runner eliminates this class of problem entirely and deserves its own PR.

## Verification on a live deployment

Equivalent fix applied manually earlier:
- \`rg --files\` inside container no longer emits any path under \`opencode/locks\`
- all lock subdirs now owned by the runtime user