### PR TITLE
feat(ui): agent name in error toasts + restart/clear-error action

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2687,6 +2687,7 @@ export function heartbeatService(db: Db) {
   async function finalizeAgentStatus(
     agentId: string,
     outcome: "succeeded" | "failed" | "cancelled" | "timed_out",
+    opts?: { errorMessage?: string | null },
   ) {
     const existing = await getAgent(agentId);
     if (!existing) return;
@@ -2732,6 +2733,9 @@ export function heartbeatService(db: Db) {
             ? new Date(updated.lastHeartbeatAt).toISOString()
             : null,
           outcome,
+          ...(nextStatus === "error" && opts?.errorMessage != null
+            ? { errorMessage: opts.errorMessage }
+            : {}),
         },
       });
     }
@@ -4098,7 +4102,9 @@ export function heartbeatService(db: Db) {
           }
         }
       }
-      await finalizeAgentStatus(agent.id, outcome);
+      await finalizeAgentStatus(agent.id, outcome, {
+        errorMessage: outcome !== "succeeded" ? (adapterResult.errorMessage ?? null) : null,
+      });
     } catch (err) {
       const message = redactCurrentUserText(
         err instanceof Error ? err.message : "Unknown adapter failure",

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -526,7 +526,10 @@ function buildAgentStatusToast(
 
   const agents = queryClient.getQueryData<Agent[]>(queryKeys.agents.list(companyId));
   const agent = agents?.find((a) => a.id === agentId);
-  const body = agent?.title ?? undefined;
+  const errorMessage = readString(payload.errorMessage);
+  const body = status === "error"
+    ? (errorMessage ? truncate(errorMessage, 120) : agent?.title ?? undefined)
+    : (agent?.title ?? undefined);
 
   return {
     title,

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -72,6 +72,7 @@ import {
   ArrowLeft,
   HelpCircle,
   FolderOpen,
+  AlertTriangle,
 } from "lucide-react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -628,6 +629,7 @@ export function AgentDetail() {
   const navigate = useNavigate();
   const [actionError, setActionError] = useState<string | null>(null);
   const [moreOpen, setMoreOpen] = useState(false);
+  const [confirmClearError, setConfirmClearError] = useState(false);
   const activeView = urlRunId ? "runs" as AgentDetailView : parseAgentDetailView(urlTab ?? null);
   const needsDashboardData = activeView === "dashboard";
   const needsRunData = activeView === "runs" || Boolean(urlRunId);
@@ -834,6 +836,33 @@ export function AgentDetail() {
     },
   });
 
+  const clearErrorAndRestart = useMutation({
+    mutationFn: async () => {
+      if (!agentLookupRef) throw new Error("No agent reference");
+      await agentsApi.resetSession(agentLookupRef, null, resolvedCompanyId ?? undefined);
+      await agentsApi.update(agentLookupRef, { status: "idle", pauseReason: null, pausedAt: null }, resolvedCompanyId ?? undefined);
+      return agentsApi.invoke(agentLookupRef, resolvedCompanyId ?? undefined);
+    },
+    onSuccess: (data) => {
+      setActionError(null);
+      setConfirmClearError(false);
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(routeAgentRef) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentLookupRef) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.runtimeState(agentLookupRef) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.taskSessions(agentLookupRef) });
+      if (resolvedCompanyId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(resolvedCompanyId) });
+      }
+      if (data && typeof data === "object" && "id" in data) {
+        navigate(`/agents/${canonicalAgentRef}/runs/${(data as HeartbeatRun).id}`);
+      }
+    },
+    onError: (err) => {
+      setConfirmClearError(false);
+      setActionError(err instanceof Error ? err.message : "Failed to restart agent");
+    },
+  });
+
   const updatePermissions = useMutation({
     mutationFn: (permissions: AgentPermissionUpdate) =>
       agentsApi.updatePermissions(agentLookupRef, permissions, resolvedCompanyId ?? undefined),
@@ -942,6 +971,43 @@ export function AgentDetail() {
             onResume={() => agentAction.mutate("resume")}
             disabled={agentAction.isPending || isPendingApproval}
           />
+          {agent.status === "error" && (
+            confirmClearError ? (
+              <div className="flex items-center gap-1">
+                <span className="text-xs text-destructive font-medium hidden sm:inline">Restart?</span>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  disabled={clearErrorAndRestart.isPending}
+                  onClick={() => clearErrorAndRestart.mutate()}
+                >
+                  {clearErrorAndRestart.isPending ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    "Confirm"
+                  )}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={clearErrorAndRestart.isPending}
+                  onClick={() => setConfirmClearError(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={clearErrorAndRestart.isPending}
+                onClick={() => setConfirmClearError(true)}
+              >
+                <AlertTriangle className="h-3.5 w-3.5 text-destructive sm:mr-1" />
+                <span className="hidden sm:inline">Restart Agent</span>
+              </Button>
+            )
+          )}
           <span className="hidden sm:inline"><StatusBadge status={agent.status} /></span>
           {mobileLiveRun && (
             <Link


### PR DESCRIPTION
## Summary

- **Error toast identity**: `finalizeAgentStatus` now forwards `errorMessage` into the `agent.status` live event; `buildAgentStatusToast` uses it as the toast body for error-state transitions (falls back to `agent.title` when no message)
- **Restart Agent button**: `AgentDetail` action bar renders a two-tap "Restart Agent" button when `agent.status === "error"`; confirms before chaining `resetSession → PATCH status:idle → invoke heartbeat`

## Motivation

Recovering an errored agent from the dashboard was painful: the toast showed no name/reason so the operator had to `curl` the agents endpoint to identify the agent, and clearing error state required CLI tooling since there was no in-dashboard action. Fixes both gaps.

## Files changed

- `server/src/services/heartbeat.ts` — pass `errorMessage` into `finalizeAgentStatus`, include in live event payload
- `ui/src/context/LiveUpdatesProvider.tsx` — prefer `errorMessage` from payload as toast body on agent error
- `ui/src/pages/AgentDetail.tsx` — `clearErrorAndRestart` mutation + "Restart Agent" button with two-tap confirm

## Test plan
- [ ] Trigger an agent run failure; verify toast title shows agent name and body shows the error reason
- [ ] In agent detail, confirm "Restart Agent" button appears when agent is in error state
- [ ] Confirm two-tap: first click shows Restart?/Confirm/Cancel, second click fires restart sequence
- [ ] Confirm redirect to new run after successful restart
- [ ] Verify button does not appear for idle/paused/running agents

Obsolete PR.
