### PR TITLE
docs: update Opus model examples to 4.7

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -46,7 +46,7 @@
   Required. Specify which AI model was used to produce or assist with
   this change. Be as descriptive as possible — include:
     • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
-    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
+    • Exact model ID or version (e.g., claude-opus-4-7, gpt-4-turbo-2024-04-09)
     • Context window size if relevant (e.g., 1M context)
     • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
     • Any other relevant capability details (e.g., tool use, code execution)

--- a/doc/RELEASING.md
+++ b/doc/RELEASING.md
@@ -146,7 +146,7 @@ Recommended local generation flow:
 
 ```bash
 VERSION="$(./scripts/release.sh stable --date 2026-03-18 --print-version)"
-claude --print --output-format stream-json --verbose --dangerously-skip-permissions --model claude-opus-4-6 "Use the release-changelog skill to draft or update releases/v${VERSION}.md for Paperclip. Read doc/RELEASING.md and .agents/skills/release-changelog/SKILL.md, then generate the stable changelog for v${VERSION} from commits since the last stable tag. Do not create a canary changelog."
+claude --print --output-format stream-json --verbose --dangerously-skip-permissions --model claude-opus-4-7 "Use the release-changelog skill to draft or update releases/v${VERSION}.md for Paperclip. Read doc/RELEASING.md and .agents/skills/release-changelog/SKILL.md, then generate the stable changelog for v${VERSION} from commits since the last stable tag. Do not create a canary changelog."
 ```
 
 The repo intentionally does not run this through GitHub Actions because:

--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -15,7 +15,7 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `cwd` | string | Yes | Working directory for the agent process (absolute path; created automatically if missing when permissions allow) |
-| `model` | string | No | Claude model to use (e.g. `claude-opus-4-6`) |
+| `model` | string | No | Claude model to use (e.g. `claude-opus-4-7`) |
 | `promptTemplate` | string | No | Prompt used for all runs |
 | `env` | object | No | Environment variables (supports secret refs) |
 | `timeoutSec` | number | No | Process timeout (0 = no timeout) |

--- a/docs/companies/companies-spec.md
+++ b/docs/companies/companies-spec.md
@@ -450,7 +450,7 @@ agents:
     adapter:
       type: claude_local
       config:
-        model: claude-opus-4-6
+        model: claude-opus-4-7
     inputs:
       env:
         ANTHROPIC_API_KEY:

--- a/docs/specs/cliphub-plan.md
+++ b/docs/specs/cliphub-plan.md
@@ -112,7 +112,7 @@ interface Listing {
 
   // Compatibility
   compatibleAdapters: string[];    // ['claude_local', 'codex_local', ...]
-  requiredModels: string[];        // ['claude-opus-4-6', 'claude-sonnet-4-6']
+  requiredModels: string[];        // ['claude-opus-4-7', 'claude-sonnet-4-6']
   paperclipVersionMin: string;     // Minimum Paperclip version
 
   // Social proof


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; the `claude_local` adapter just gained `claude-opus-4-7` in #3828, but the rest of the docs still use `claude-opus-4-6` as the canonical example.
> - Stale examples in user-facing docs (adapter reference, companies spec, cliphub plan), the PR template, and the local release-changelog script send mixed signals about the recommended current-generation Opus model.
> - This PR updates only documentation/example strings to `claude-opus-4-7`. No code paths, schemas, or runtime defaults change.
> - Bedrock model list (`packages/adapters/claude-local/src/server/models.ts`) and the `ollolla` blueprint are intentionally **not** touched here — Bedrock awaits an ID confirmation (per #3828's risks section), and blueprint migration belongs in a follow-up canary rollout.

## What Changed

- `docs/adapters/claude-local.md` — `model` example: `claude-opus-4-6` → `claude-opus-4-7`
- `docs/companies/companies-spec.md` — yaml example agent config
- `docs/specs/cliphub-plan.md` — `requiredModels` example
- `.github/PULL_REQUEST_TEMPLATE.md` — Model Used section example
- `doc/RELEASING.md` — local release-changelog generation script `--model` flag

5 files, +5/-5, all single-line example string updates.

## Verification

- `git diff` confirms only the 5 expected single-line changes.
- No code/test files touched → no `pnpm typecheck` / `pnpm test:run` impact (verified by file list).
- `claude-opus-4-7` is already a valid id in the `claude_local` model list since #3828, so the release script change resolves to a real model.

## Risks

- Very low. Doc-only changes. The release script in `doc/RELEASING.md` is run manually by maintainers; if Opus 4.7 is unavailable for some user, the script fails fast with a clear error and can be edited locally — no automated dependency.
- Bedrock and blueprint migrations are deliberately deferred. Bedrock needs the region-qualified id confirmed; the `ollolla` blueprint's 17 agents are best migrated after a short canary on a single agent.

## Model Used

- Claude Opus 4.7 (1M context, extended thinking)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass (N/A — doc-only)
- [x] I have added or updated tests where applicable (N/A — doc-only)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — no UI changes)
- [x] I have updated relevant documentation to reflect my changes (this PR is the doc update)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge