### PR TITLE
fix(routes): accept parentIssueId on company issues list

### DIFF
--- a/server/src/__tests__/issue-list-routes.test.ts
+++ b/server/src/__tests__/issue-list-routes.test.ts
@@ -102,4 +102,31 @@ describe("issue list routes", () => {
       parentId: parentIssueId,
     }));
   });
+
+  it("continues to pass through parentId on the company issues list route", async () => {
+    const parentId = "22222222-2222-4222-8222-222222222222";
+
+    const res = await request(await createApp())
+      .get("/api/companies/company-1/issues")
+      .query({ parentId });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith("company-1", expect.objectContaining({
+      parentId,
+    }));
+  });
+
+  it("prefers parentId over parentIssueId when both are supplied", async () => {
+    const parentId = "33333333-3333-4333-8333-333333333333";
+    const parentIssueId = "44444444-4444-4444-8444-444444444444";
+
+    const res = await request(await createApp())
+      .get("/api/companies/company-1/issues")
+      .query({ parentId, parentIssueId });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith("company-1", expect.objectContaining({
+      parentId,
+    }));
+  });
 });

--- a/server/src/__tests__/issue-list-routes.test.ts
+++ b/server/src/__tests__/issue-list-routes.test.ts
@@ -1,0 +1,105 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+    resolveByReference: vi.fn(),
+  }),
+  documentService: () => ({
+    getIssueDocumentPayload: vi.fn(async () => ({})),
+  }),
+  executionWorkspaceService: () => ({
+    getById: vi.fn(),
+  }),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+  }),
+  goalService: () => ({
+    getById: vi.fn(),
+    getDefaultCompanyGoal: vi.fn(),
+  }),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    })),
+    listCompanyIds: vi.fn(async () => ["company-1"]),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({
+    getById: vi.fn(),
+    listByIds: vi.fn(async () => []),
+  }),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({
+    listForIssue: vi.fn(async () => []),
+  }),
+}));
+
+async function createApp() {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue list routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.resetAllMocks();
+    mockIssueService.list.mockResolvedValue([]);
+  });
+
+  it("treats parentIssueId as an alias for parentId on the company issues list route", async () => {
+    const parentIssueId = "11111111-1111-4111-8111-111111111111";
+
+    const res = await request(await createApp())
+      .get("/api/companies/company-1/issues")
+      .query({ parentIssueId });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith("company-1", expect.objectContaining({
+      parentId: parentIssueId,
+    }));
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -595,6 +595,9 @@ export function issueRoutes(
   router.get("/companies/:companyId/issues", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
+    const parentIdQuery =
+      (req.query.parentId as string | undefined)
+      ?? (req.query.parentIssueId as string | undefined);
     const assigneeUserFilterRaw = req.query.assigneeUserId as string | undefined;
     const touchedByUserFilterRaw = req.query.touchedByUserId as string | undefined;
     const inboxArchivedByUserFilterRaw = req.query.inboxArchivedByUserId as string | undefined;
@@ -650,7 +653,7 @@ export function issueRoutes(
       unreadForUserId,
       projectId: req.query.projectId as string | undefined,
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
-      parentId: req.query.parentId as string | undefined,
+      parentId: parentIdQuery,
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,
       originId: req.query.originId as string | undefined,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents that coordinate work through the server API.
> - The company issues list route is part of that core task-discovery path.
> - Child-task lookup depends on filtering issues by their parent relationship.
> - Issue #3846 reports that callers using `parentIssueId` get the full company issue list instead of filtered children.
> - The underlying issues service already supports `parentId`, so the gap is at the route query-mapping layer rather than in the database query itself.
> - This pull request makes the route accept `parentIssueId` as an alias for `parentId` and locks that behavior in with a focused regression test.
> - The benefit is that agents can reliably query child issues without fetching and filtering the entire company issue list client-side.

## What Changed

- Added a small query normalization step in `GET /api/companies/:companyId/issues` so `parentIssueId` is treated as an alias for `parentId`.
- Added a route regression test covering `parentIssueId` and asserting that the route forwards it to `issueService.list` as `parentId`.

## Verification

- Added targeted regression coverage in `server/src/__tests__/issue-list-routes.test.ts`.
- Attempted to run: `pnpm -C /Users/leongong/Desktop/LeonProjects/gho_workspace/paperclip-pr-3846 run test:run -- server/src/__tests__/issue-list-routes.test.ts -t "parentIssueId"`
- Local execution in this isolated worktree is currently blocked by the local dependency/runtime setup rather than the route change itself.

## Risks

- Low risk. The change only broadens accepted query input by mapping `parentIssueId` to the existing `parentId` filter.
- Existing `parentId` behavior is preserved.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex on GPT-5-class coding model with tool use and code execution in a local git worktree.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #3846
