### PR TITLE
fix(server): wrap absolute path in pathToFileURL for Windows ESM import

### DIFF
--- a/server/src/adapters/plugin-loader.ts
+++ b/server/src/adapters/plugin-loader.ts
@@ -11,6 +11,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { ServerAdapterModule } from "./types.js";
 import { logger } from "../middleware/logger.js";
 
@@ -177,7 +178,7 @@ export async function loadExternalAdapterPackage(
 
   logger.info({ packageName, packageDir, entryPoint, modulePath, hasUiParser: !!uiParserSource }, "Loading external adapter package");
 
-  const mod = await import(modulePath);
+  const mod = await import(pathToFileURL(modulePath).href);
   const adapterModule = validateAdapterModule(mod, packageName);
 
   if (uiParserSource) {
@@ -212,7 +213,7 @@ export async function reloadExternalAdapter(
   const packageDir = resolvePackageDir(record);
   const entryPoint = resolvePackageEntryPoint(packageDir);
   const modulePath = path.resolve(packageDir, entryPoint);
-  const fileUrl = `file://${modulePath}`;
+  const fileUrl = pathToFileURL(modulePath).href;
 
   // Bust ESM module cache so re-import loads fresh code from disk.
   // Query-string trick (?t=...) works in Node; Bun may need the file:// URL

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -29,7 +29,7 @@ import { readdir, readFile, rm, stat } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import type { Db } from "@paperclipai/db";
 import type {
@@ -927,7 +927,7 @@ export function pluginLoader(
 
     try {
       // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests
-      const mod = await import(manifestPath) as Record<string, unknown>;
+      const mod = await import(pathToFileURL(manifestPath).href) as Record<string, unknown>;
       // The manifest may be the default export or the module itself
       raw = mod["default"] ?? mod;
     } catch (err) {


### PR DESCRIPTION
## Problem

On Windows, `await import(absolutePath)` fails with `ERR_UNSUPPORTED_ESM_URL_SCHEME` when the absolute path has a drive letter (e.g., `C:\Users\...\plugin.js`). Node's ESM loader only accepts `file://` URLs for dynamic imports of absolute paths on Windows; POSIX accepts both.

This breaks external plugin loading on Windows entirely. Every plugin adapter hits it on server start.

## Fix

Wrap the absolute path in `pathToFileURL(path).href` at every dynamic-import-of-absolute-path site in `server/src/`.

Sites patched:
- `server/src/adapters/plugin-loader.ts` — primary dynamic import + malformed `file://${path}` template literal in `reloadExternalAdapter` (the latter was constructing `file://C:\...` which is also invalid)
- `server/src/services/plugin-loader.ts` — plugin manifest dynamic import

## Verification

- `pnpm -C server typecheck` passes clean
- Grepped `server/src/` for remaining dynamic imports of absolute paths — none
- Tested locally on Windows (Paperclip COO instance): Telegram plugin loads without `ERR_UNSUPPORTED_ESM_URL_SCHEME`

## Compat

POSIX behavior is unchanged: `pathToFileURL` produces the same valid `file://` URL there.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>