### PR TITLE
fix(issues): parse mentionedAgentIds to enable explicit agent wakeups on comments

### DIFF
--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -150,6 +150,7 @@ export const updateIssueSchema = createIssueSchema.partial().extend({
   reopen: z.boolean().optional(),
   interrupt: z.boolean().optional(),
   hiddenAt: z.string().datetime().nullable().optional(),
+  mentionedAgentIds: z.array(z.string().uuid()).optional(),
 });
 
 export type UpdateIssue = z.infer<typeof updateIssueSchema>;
@@ -166,6 +167,7 @@ export const addIssueCommentSchema = z.object({
   body: z.string().min(1),
   reopen: z.boolean().optional(),
   interrupt: z.boolean().optional(),
+  mentionedAgentIds: z.array(z.string().uuid()).optional(),
 });
 
 export type AddIssueComment = z.infer<typeof addIssueCommentSchema>;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1775,9 +1775,11 @@ export function issueRoutes(
           });
         }
 
-        let mentionedIds: string[] = [];
+        let mentionedIds: string[] = req.body.mentionedAgentIds || [];
         try {
-          mentionedIds = await svc.findMentionedAgents(issue.companyId, commentBody);
+          if (mentionedIds.length === 0) {
+            mentionedIds = await svc.findMentionedAgents(issue.companyId, commentBody);
+          }
         } catch (err) {
           logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
         }
@@ -2319,7 +2321,10 @@ export function issueRoutes(
 
       let mentionedIds: string[] = [];
       try {
-        mentionedIds = await svc.findMentionedAgents(issue.companyId, req.body.body);
+        mentionedIds = (req.body as any).mentionedAgentIds || [];
+        if (mentionedIds.length === 0) {
+          mentionedIds = await svc.findMentionedAgents(issue.companyId, req.body.body);
+        }
       } catch (err) {
         logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
       }


### PR DESCRIPTION
Fixes GSTA-3584. The updated Handoff Protocol instructed agents to explicitly include `mentionedAgentIds` in their API POST payload when assigning or tagging each other. However, `addIssueCommentSchema` on the backend did not accept this field. This commit allows it, and routes it directly to wakeups.