### PR TITLE
[codex] Fix stranded issue fail-closed recovery

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -10,9 +10,12 @@ import {
   companySkills,
   companies,
   createDb,
+  documents,
   heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
+  issueDocuments,
+  issueRelations,
   issues,
 } from "@paperclipai/db";
 import {
@@ -181,7 +184,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(activityLog);
     await db.delete(agentRuntimeState);
     await db.delete(companySkills);
+    await db.delete(issueRelations);
     await db.delete(issueComments);
+    await db.delete(issueDocuments);
+    await db.delete(documents);
     await db.delete(issues);
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
@@ -308,6 +314,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     runStatus: "failed" | "timed_out" | "cancelled" | "succeeded";
     retryReason?: "assignment_recovery" | "issue_continuation_needed" | null;
     assignToUser?: boolean;
+    issueDescription?: string | null;
+    commentBodies?: string[];
+    documentBodies?: Array<{ key: string; title?: string | null; body: string }>;
+    blockerCount?: number;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -378,6 +388,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       id: issueId,
       companyId,
       title: "Recover stranded assigned work",
+      description: input.issueDescription ?? null,
       status: input.status,
       priority: "medium",
       assigneeAgentId: input.assignToUser ? null : agentId,
@@ -388,6 +399,51 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       identifier: `${issuePrefix}-1`,
       startedAt: input.status === "in_progress" ? now : null,
     });
+
+    for (const body of input.commentBodies ?? []) {
+      await db.insert(issueComments).values({
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        body,
+      });
+    }
+
+    for (const [index, document] of (input.documentBodies ?? []).entries()) {
+      const documentId = randomUUID();
+      await db.insert(documents).values({
+        id: documentId,
+        companyId,
+        title: document.title ?? `Document ${index + 1}`,
+        latestBody: document.body,
+      });
+      await db.insert(issueDocuments).values({
+        companyId,
+        issueId,
+        documentId,
+        key: document.key,
+      });
+    }
+
+    for (let index = 0; index < (input.blockerCount ?? 0); index += 1) {
+      const blockerId = randomUUID();
+      await db.insert(issues).values({
+        id: blockerId,
+        companyId,
+        title: `Repair handle ${index + 1}`,
+        status: "todo",
+        priority: "medium",
+        issueNumber: index + 2,
+        identifier: `${issuePrefix}-${index + 2}`,
+      });
+      await db.insert(issueRelations).values({
+        companyId,
+        issueId,
+        relatedIssueId: blockerId,
+        type: "blocks",
+        createdByAgentId: agentId,
+      });
+    }
 
     return { companyId, agentId, runId, wakeupRequestId, issueId };
   }
@@ -579,11 +635,32 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
-  it("blocks assigned todo work after the one automatic dispatch recovery was already used", async () => {
+  it("preserves assigned todo work after the automatic dispatch recovery when no defect or repair handle exists", async () => {
     const { issueId } = await seedStrandedIssueFixture({
       status: "todo",
       runStatus: "failed",
       retryReason: "assignment_recovery",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
+
+  it("blocks assigned todo work after the automatic dispatch recovery when a concrete repair handle already exists", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+      blockerCount: 1,
     });
     const heartbeat = heartbeatService(db);
 
@@ -628,11 +705,72 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
-  it("blocks stranded in-progress work after the continuation retry was already used", async () => {
+  it("preserves stranded in-progress work after the continuation retry when no defect or repair handle exists", async () => {
     const { issueId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "failed",
       retryReason: "issue_continuation_needed",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
+
+  it("preserves stranded in-progress work when a closeout-ready signal already exists", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      commentBodies: [
+        "## Option A Closeout Readiness\n\nTreat this issue as closeout-ready under the reduced contract.",
+      ],
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("preserves stranded in-progress work when completion evidence is already attached", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      commentBodies: [
+        "## Update\n\n검증도 보강했습니다.\n- `python -m pytest -q tests/example.py` -> `7 passed`\n- `bash -n scripts/example.sh` -> PASS",
+      ],
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("blocks stranded in-progress work after the continuation retry when a concrete repair handle already exists", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      blockerCount: 1,
     });
     const heartbeat = heartbeatService(db);
 
@@ -648,6 +786,26 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("retried continuation");
     expect(comments[0]?.body).toContain("Latest retry failure: `process_lost` - run failed before issue advanced.");
+  });
+
+  it("blocks stranded in-progress work after the continuation retry when an exact defect is already named", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      commentBodies: [
+        "## Runtime continuity defect identified\n\n### Exact defect\n- checkoutRunId is null while the issue still looks runnable.",
+      ],
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
   });
 
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11,9 +11,12 @@ import {
   agentTaskSessions,
   agentWakeupRequests,
   companySkills as companySkillsTable,
+  documents,
   heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
+  issueDocuments,
+  issueRelations,
   issues,
   projects,
   projectWorkspaces,
@@ -104,6 +107,31 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "pi_local",
 ]);
 const INLINE_BASE64_IMAGE_DATA_RE = /("type":"image","source":\{"type":"base64","data":")([A-Za-z0-9+/=]{1024,})(")/g;
+const STRANDED_ISSUE_CLOSEOUT_READY_PATTERNS = [
+  /\bcloseout[- ]ready\b/iu,
+  /\breview\/closeout[- ]ready\b/iu,
+  /\bcloseout recommendation\b/iu,
+  /\bcloseout basis\b/iu,
+  /\bready for closeout\b/iu,
+];
+const STRANDED_ISSUE_COMPLETION_EVIDENCE_PATTERNS = [
+  /\bcompletion signal\b/iu,
+  /\bcompletion evidence\b/iu,
+  /\bexecution evidence already posted\b/iu,
+  /\bmanifest-backed artifact\b/iu,
+  /\b산출물과 검증은 이미 수용 기준을 충족\b/u,
+  /\b수용 기준을 충족\b/u,
+];
+const STRANDED_ISSUE_EXACT_DEFECT_PATTERNS = [
+  /\bexact defect\b/iu,
+  /\bruntime continuity defect identified\b/iu,
+  /\bworktree\/runtime defect\b/iu,
+];
+const STRANDED_ISSUE_NEGATED_EXACT_DEFECT_PATTERNS = [
+  /\bno exact [^\n.]*defect\b/iu,
+  /\bwithout an exact defect\b/iu,
+  /\bno exact runtime\/workspace defect\b/iu,
+];
 
 type RuntimeConfigSecretResolver = Pick<
   ReturnType<typeof secretService>,
@@ -146,6 +174,86 @@ export function extractMentionedSkillIdsFromSources(
     }
   }
   return [...mentionedIds];
+}
+
+function normalizeStrandedIssueSignalTexts(
+  sources: Array<string | null | undefined>,
+): string[] {
+  return sources
+    .map((value) => (typeof value === "string" ? value.trim() : ""))
+    .filter((value) => value.length > 0);
+}
+
+function matchesStrandedIssueSignal(
+  sources: string[],
+  patterns: RegExp[],
+): boolean {
+  return sources.some((source) => patterns.some((pattern) => pattern.test(source)));
+}
+
+function hasVerificationPacketEvidenceSignal(sources: string[]): boolean {
+  const combined = sources.join("\n");
+  return (
+    /\b(verification|revalidation|re-verification)\b/iu.test(combined) ||
+    /검증/u.test(combined)
+  ) && (/\b\d+\s+passed\b/iu.test(combined) || /\bpass\b/iu.test(combined));
+}
+
+async function getStrandedIssueRecoverySignals(
+  db: Db,
+  issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "title" | "description">,
+) {
+  const [commentRows, documentRows, blockerRows] = await Promise.all([
+    db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, issue.companyId),
+          eq(issueComments.issueId, issue.id),
+        ),
+      ),
+    db
+      .select({ body: documents.latestBody })
+      .from(issueDocuments)
+      .innerJoin(documents, eq(documents.id, issueDocuments.documentId))
+      .where(
+        and(
+          eq(issueDocuments.companyId, issue.companyId),
+          eq(issueDocuments.issueId, issue.id),
+        ),
+      ),
+    db
+      .select({ relatedIssueId: issueRelations.relatedIssueId })
+      .from(issueRelations)
+      .where(
+        and(
+          eq(issueRelations.companyId, issue.companyId),
+          eq(issueRelations.issueId, issue.id),
+          eq(issueRelations.type, "blocks"),
+        ),
+      )
+      .limit(1),
+  ]);
+
+  const texts = normalizeStrandedIssueSignalTexts([
+    issue.title,
+    issue.description ?? "",
+    ...commentRows.map((row) => row.body),
+    ...documentRows.map((row) => row.body),
+  ]);
+  const hasExactDefectSignal =
+    matchesStrandedIssueSignal(texts, STRANDED_ISSUE_EXACT_DEFECT_PATTERNS) &&
+    !matchesStrandedIssueSignal(texts, STRANDED_ISSUE_NEGATED_EXACT_DEFECT_PATTERNS);
+
+  return {
+    hasCloseoutReadySignal: matchesStrandedIssueSignal(texts, STRANDED_ISSUE_CLOSEOUT_READY_PATTERNS),
+    hasCompletionEvidenceSignal:
+      matchesStrandedIssueSignal(texts, STRANDED_ISSUE_COMPLETION_EVIDENCE_PATTERNS) ||
+      hasVerificationPacketEvidenceSignal(texts),
+    hasExactDefectSignal,
+    hasConcreteRepairHandle: blockerRows.length > 0,
+  };
 }
 
 export function applyRunScopedMentionedSkillKeys(
@@ -3039,6 +3147,10 @@ export function heartbeatService(db: Db) {
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
       const latestContext = parseObject(latestRun?.contextSnapshot);
       const latestRetryReason = readNonEmptyString(latestContext.retryReason);
+      const recoverySignals =
+        latestRetryReason === "assignment_recovery" || latestRetryReason === "issue_continuation_needed"
+          ? await getStrandedIssueRecoverySignals(db, issue)
+          : null;
 
       if (issue.status === "todo") {
         if (!latestRun || latestRun.status === "succeeded") {
@@ -3047,6 +3159,15 @@ export function heartbeatService(db: Db) {
         }
 
         if (latestRetryReason === "assignment_recovery") {
+          if (
+            recoverySignals &&
+            !recoverySignals.hasExactDefectSignal &&
+            !recoverySignals.hasConcreteRepairHandle
+          ) {
+            result.skipped += 1;
+            continue;
+          }
+
           const failureSummary = summarizeRunFailureForIssueComment(latestRun);
           const updated = await escalateStrandedAssignedIssue({
             issue,
@@ -3084,6 +3205,22 @@ export function heartbeatService(db: Db) {
       }
 
       if (latestRetryReason === "issue_continuation_needed") {
+        if (
+          recoverySignals?.hasCloseoutReadySignal ||
+          recoverySignals?.hasCompletionEvidenceSignal
+        ) {
+          result.skipped += 1;
+          continue;
+        }
+        if (
+          recoverySignals &&
+          !recoverySignals.hasExactDefectSignal &&
+          !recoverySignals.hasConcreteRepairHandle
+        ) {
+          result.skipped += 1;
+          continue;
+        }
+
         const failureSummary = summarizeRunFailureForIssueComment(latestRun);
         const updated = await escalateStrandedAssignedIssue({
           issue,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that keeps autonomous-agent companies governable and auditable.
> - Heartbeat recovery is part of that control plane because it decides whether stranded assigned work should retry, stay live, or become explicitly blocked.
> - `reconcileStrandedAssignedIssues()` currently auto-blocks repeated lost continuations too aggressively.
> - That behavior turns closeout-ready or evidence-complete work into false `blocked` drift and hides the distinction between missing execution handles and real repair lanes.
> - The issue contract for ACN-530 is to fail closed: do not auto-block unless a concrete blocker or named defect already exists.
> - This pull request teaches the recovery path to inspect blocker relations and attached closeout/completion signals before downgrading status.
> - The benefit is safer stranded-work recovery with less status flap and clearer intervention semantics.

## What Changed

- Added stranded-recovery signal detection in `server/src/services/heartbeat.ts` for closeout-ready text, completion evidence, named exact-defect markers, and first-class blocker relations.
- Changed repeated `assignment_recovery` / `issue_continuation_needed` handling so Paperclip preserves `todo` / `in_progress` unless a concrete repair handle or exact defect is already attached.
- Preserved the existing first automatic retry behavior for both dispatch recovery and continuation recovery.
- Expanded `server/src/__tests__/heartbeat-process-recovery.test.ts` to cover no-handle preserve cases, closeout-ready preserve, completion-evidence preserve, blocker-backed blocking, and exact-defect-backed blocking.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`
- `PATH="$(mktemp -d):$PATH"` shimmed to `corepack pnpm` for script recursion, then:
- `corepack pnpm --filter @paperclipai/db typecheck`
- `corepack pnpm --filter @paperclipai/server typecheck`
- `corepack pnpm --filter @paperclipai/server build`

## Risks

- Low to medium: the new preservation logic relies on issue text/doc signals plus first-class blocker relations, so unusually worded closeout/evidence comments may still fall back to the conservative no-auto-block path.
- This intentionally biases toward preserving `in_progress` rather than downgrading to `blocked` without an explicit repair lane.

## Model Used

- OpenAI Codex, GPT-5-based coding agent in the Codex environment with tool use and code execution. Exact deployed model ID/context window is not exposed in this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
