### PR TITLE
Fix stale execution locks after reassignment

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -929,6 +929,599 @@ describe("heartbeat comment wake batching", () => {
       await gateway.close();
     }
   }, 120_000);
+  it("claims execution review wakes for reviewers who are not the issue assignee", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const developerId = randomUUID();
+    const reviewerId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values([
+        {
+          id: developerId,
+          companyId,
+          name: "Developer",
+          role: "engineer",
+          status: "idle",
+          adapterType: "codex_local",
+          adapterConfig: {},
+          runtimeConfig: {},
+          permissions: {},
+        },
+        {
+          id: reviewerId,
+          companyId,
+          name: "CTO Reviewer",
+          role: "cto",
+          status: "idle",
+          adapterType: "openclaw_gateway",
+          adapterConfig: {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            payloadTemplate: {
+              message: "review now",
+            },
+            waitTimeoutMs: 2_000,
+          },
+          runtimeConfig: {},
+          permissions: {},
+        },
+      ]);
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Review gated work",
+        status: "in_review",
+        priority: "high",
+        assigneeAgentId: developerId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      const executionStage = {
+        wakeRole: "reviewer",
+        stageId: "stage-1",
+        stageType: "review",
+        currentParticipant: { type: "agent", agentId: reviewerId },
+        returnAssignee: { type: "agent", agentId: developerId },
+        lastDecisionOutcome: null,
+        allowedActions: ["approve", "request_changes"],
+      };
+      const run = await heartbeat.wakeup(reviewerId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "execution_review_requested",
+        payload: {
+          issueId,
+          mutation: "update",
+          executionStage,
+        },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "execution_review_requested",
+          source: "issue.execution_stage",
+          executionStage,
+        },
+        requestedByActorType: "agent",
+        requestedByActorId: developerId,
+      });
+
+      expect(run).not.toBeNull();
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      const [claimedRun] = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run!.id));
+      expect(claimedRun?.status).toBe("running");
+
+      const [issue] = await db
+        .select({
+          assigneeAgentId: issues.assigneeAgentId,
+          executionRunId: issues.executionRunId,
+          executionLockedAt: issues.executionLockedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId));
+
+      expect(issue).toMatchObject({
+        assigneeAgentId: developerId,
+        executionRunId: run!.id,
+      });
+      expect(issue?.executionLockedAt).toBeInstanceOf(Date);
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
+  it("does not defer reviewer wakes behind stale queued assignment runs for previous assignees", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const previousAgentId = randomUUID();
+    const developerId = randomUUID();
+    const reviewerId = randomUUID();
+    const issueId = randomUUID();
+    const staleRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values([
+        {
+          id: previousAgentId,
+          companyId,
+          name: "Previous Developer",
+          role: "engineer",
+          status: "idle",
+          adapterType: "codex_local",
+          adapterConfig: {},
+          runtimeConfig: {},
+          permissions: {},
+        },
+        {
+          id: developerId,
+          companyId,
+          name: "Developer",
+          role: "engineer",
+          status: "idle",
+          adapterType: "codex_local",
+          adapterConfig: {},
+          runtimeConfig: {},
+          permissions: {},
+        },
+        {
+          id: reviewerId,
+          companyId,
+          name: "CTO Reviewer",
+          role: "cto",
+          status: "idle",
+          adapterType: "openclaw_gateway",
+          adapterConfig: {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            payloadTemplate: {
+              message: "review now",
+            },
+            waitTimeoutMs: 2_000,
+          },
+          runtimeConfig: {},
+          permissions: {},
+        },
+      ]);
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Review gated work after reassignment",
+        status: "in_review",
+        priority: "high",
+        assigneeAgentId: developerId,
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+      });
+      await db.insert(heartbeatRuns).values({
+        id: staleRunId,
+        companyId,
+        agentId: previousAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "queued",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+      });
+
+      const executionStage = {
+        wakeRole: "reviewer",
+        stageId: "stage-1",
+        stageType: "review",
+        currentParticipant: { type: "agent", agentId: reviewerId },
+        returnAssignee: { type: "agent", agentId: developerId },
+        lastDecisionOutcome: null,
+        allowedActions: ["approve", "request_changes"],
+      };
+      const run = await heartbeat.wakeup(reviewerId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "execution_review_requested",
+        payload: {
+          issueId,
+          mutation: "update",
+          executionStage,
+        },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "execution_review_requested",
+          source: "issue.execution_stage",
+          executionStage,
+        },
+        requestedByActorType: "agent",
+        requestedByActorId: developerId,
+      });
+
+      expect(run).not.toBeNull();
+      expect(run?.id).not.toBe(staleRunId);
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      const [issue] = await db
+        .select({
+          executionRunId: issues.executionRunId,
+          executionLockedAt: issues.executionLockedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId));
+
+      expect(issue?.executionRunId).toBe(run!.id);
+      expect(issue?.executionRunId).not.toBe(staleRunId);
+      expect(issue?.executionLockedAt).toBeInstanceOf(Date);
+
+      const [staleRun] = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, staleRunId));
+      expect(staleRun?.status).toBe("queued");
+
+      const deferredRequests = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(and(eq(agentWakeupRequests.agentId, reviewerId), eq(agentWakeupRequests.status, "deferred_issue_execution")));
+      expect(deferredRequests).toHaveLength(0);
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
+  it("does not defer reviewer wakes behind stale queued review runs for previous participants", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const developerId = randomUUID();
+    const previousReviewerId = randomUUID();
+    const reviewerId = randomUUID();
+    const issueId = randomUUID();
+    const staleRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values([
+        {
+          id: developerId,
+          companyId,
+          name: "Developer",
+          role: "engineer",
+          status: "idle",
+          adapterType: "codex_local",
+          adapterConfig: {},
+          runtimeConfig: {},
+          permissions: {},
+        },
+        {
+          id: previousReviewerId,
+          companyId,
+          name: "Previous CTO Reviewer",
+          role: "cto",
+          status: "idle",
+          adapterType: "codex_local",
+          adapterConfig: {},
+          runtimeConfig: {},
+          permissions: {},
+        },
+        {
+          id: reviewerId,
+          companyId,
+          name: "Current CTO Reviewer",
+          role: "cto",
+          status: "idle",
+          adapterType: "openclaw_gateway",
+          adapterConfig: {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            payloadTemplate: {
+              message: "review now",
+            },
+            waitTimeoutMs: 2_000,
+          },
+          runtimeConfig: {},
+          permissions: {},
+        },
+      ]);
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Review gated work after reviewer change",
+        status: "in_review",
+        priority: "high",
+        assigneeAgentId: developerId,
+        issueNumber: 3,
+        identifier: `${issuePrefix}-3`,
+      });
+
+      const staleExecutionStage = {
+        wakeRole: "reviewer",
+        stageId: "stage-old",
+        stageType: "review",
+        currentParticipant: { type: "agent", agentId: previousReviewerId },
+        returnAssignee: { type: "agent", agentId: developerId },
+        lastDecisionOutcome: null,
+        allowedActions: ["approve", "request_changes"],
+      };
+      await db.insert(heartbeatRuns).values({
+        id: staleRunId,
+        companyId,
+        agentId: previousReviewerId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "queued",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "execution_review_requested",
+          source: "issue.execution_stage",
+          executionStage: staleExecutionStage,
+        },
+      });
+
+      const executionStage = {
+        wakeRole: "reviewer",
+        stageId: "stage-current",
+        stageType: "review",
+        currentParticipant: { type: "agent", agentId: reviewerId },
+        returnAssignee: { type: "agent", agentId: developerId },
+        lastDecisionOutcome: null,
+        allowedActions: ["approve", "request_changes"],
+      };
+      const run = await heartbeat.wakeup(reviewerId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "execution_review_requested",
+        payload: {
+          issueId,
+          mutation: "update",
+          executionStage,
+        },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "execution_review_requested",
+          source: "issue.execution_stage",
+          executionStage,
+        },
+        requestedByActorType: "agent",
+        requestedByActorId: developerId,
+      });
+
+      expect(run).not.toBeNull();
+      expect(run?.id).not.toBe(staleRunId);
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      const [issue] = await db
+        .select({
+          executionRunId: issues.executionRunId,
+          executionLockedAt: issues.executionLockedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId));
+
+      expect(issue?.executionRunId).toBe(run!.id);
+      expect(issue?.executionRunId).not.toBe(staleRunId);
+      expect(issue?.executionLockedAt).toBeInstanceOf(Date);
+
+      const [staleRun] = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, staleRunId));
+      expect(staleRun?.status).toBe("queued");
+
+      const deferredRequests = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(and(eq(agentWakeupRequests.agentId, reviewerId), eq(agentWakeupRequests.status, "deferred_issue_execution")));
+      expect(deferredRequests).toHaveLength(0);
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
+  it("starts the next eligible queued run after cancelling a stale reassignment wake", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const previousAgentId = randomUUID();
+    const agentId = randomUUID();
+    const staleIssueId = randomUUID();
+    const validIssueId = randomUUID();
+    const staleRunId = randomUUID();
+    const validRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values([
+        {
+          id: previousAgentId,
+          companyId,
+          name: "Previous Developer",
+          role: "engineer",
+          status: "idle",
+          adapterType: "codex_local",
+          adapterConfig: {},
+          runtimeConfig: {},
+          permissions: {},
+        },
+        {
+          id: agentId,
+          companyId,
+          name: "Gateway Agent",
+          role: "engineer",
+          status: "idle",
+          adapterType: "openclaw_gateway",
+          adapterConfig: {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            payloadTemplate: {
+              message: "wake now",
+            },
+            waitTimeoutMs: 2_000,
+          },
+          runtimeConfig: {
+            heartbeat: {
+              maxConcurrentRuns: 1,
+            },
+          },
+          permissions: {},
+        },
+      ]);
+
+      await db.insert(issues).values([
+        {
+          id: staleIssueId,
+          companyId,
+          title: "Reassigned away",
+          status: "todo",
+          priority: "high",
+          assigneeAgentId: previousAgentId,
+          issueNumber: 4,
+          identifier: `${issuePrefix}-4`,
+        },
+        {
+          id: validIssueId,
+          companyId,
+          title: "Still assigned",
+          status: "todo",
+          priority: "high",
+          assigneeAgentId: agentId,
+          issueNumber: 5,
+          identifier: `${issuePrefix}-5`,
+        },
+      ]);
+
+      const now = Date.now();
+      await db.insert(heartbeatRuns).values([
+        {
+          id: staleRunId,
+          companyId,
+          agentId,
+          invocationSource: "assignment",
+          triggerDetail: "system",
+          status: "queued",
+          contextSnapshot: {
+            issueId: staleIssueId,
+            taskId: staleIssueId,
+            wakeReason: "issue_assigned",
+          },
+          createdAt: new Date(now - 2_000),
+          updatedAt: new Date(now - 2_000),
+        },
+        {
+          id: validRunId,
+          companyId,
+          agentId,
+          invocationSource: "assignment",
+          triggerDetail: "system",
+          status: "queued",
+          contextSnapshot: {
+            issueId: validIssueId,
+            taskId: validIssueId,
+            wakeReason: "issue_assigned",
+          },
+          createdAt: new Date(now - 1_000),
+          updatedAt: new Date(now - 1_000),
+        },
+      ]);
+
+      await heartbeat.resumeQueuedRuns();
+
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      const runs = await db
+        .select({
+          id: heartbeatRuns.id,
+          status: heartbeatRuns.status,
+          startedAt: heartbeatRuns.startedAt,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId))
+        .orderBy(asc(heartbeatRuns.createdAt));
+
+      expect(runs).toMatchObject([
+        {
+          id: staleRunId,
+          status: "cancelled",
+        },
+        {
+          id: validRunId,
+          status: "running",
+        },
+      ]);
+      expect(runs[1]?.startedAt).toBeInstanceOf(Date);
+
+      const [validIssue] = await db
+        .select({
+          executionRunId: issues.executionRunId,
+          checkoutRunId: issues.checkoutRunId,
+          status: issues.status,
+        })
+        .from(issues)
+        .where(eq(issues.id, validIssueId));
+
+      expect(validIssue).toMatchObject({
+        executionRunId: validRunId,
+        checkoutRunId: validRunId,
+        status: "in_progress",
+      });
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
   it("treats the automatic run summary as fallback-only when the run already posted a comment", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -8,6 +8,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -66,6 +67,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -717,6 +719,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -994,6 +997,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -1179,6 +1183,96 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
       id: parentId,
       assigneeAgentId,
       childIssueIds: [childA, childB],
+    });
+  });
+
+  it("lets the current assignee check out when a queued lock belongs to the previous assignee", async () => {
+    const companyId = randomUUID();
+    const previousAgentId = randomUUID();
+    const nextAgentId = randomUUID();
+    const issueId = randomUUID();
+    const previousRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: previousAgentId,
+        companyId,
+        name: "Previous Agent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: nextAgentId,
+        companyId,
+        name: "Next Agent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    const nextRunId = randomUUID();
+    await db.insert(heartbeatRuns).values([
+      {
+        id: previousRunId,
+        companyId,
+        agentId: previousAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "queued",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+      },
+      {
+        id: nextRunId,
+        companyId,
+        agentId: nextAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Reassigned issue",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: nextAgentId,
+      executionRunId: previousRunId,
+      executionAgentNameKey: "previous-agent",
+      executionLockedAt: new Date(),
+    });
+
+    const checkedOut = await svc.checkout(issueId, nextAgentId, ["todo"], nextRunId);
+
+    expect(checkedOut).toMatchObject({
+      id: issueId,
+      status: "in_progress",
+      assigneeAgentId: nextAgentId,
+      checkoutRunId: nextRunId,
+      executionRunId: nextRunId,
     });
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -898,6 +898,25 @@ function shouldAutoCheckoutIssueForWake(input: {
   return true;
 }
 
+function isIssueWakeAllowedWithoutCurrentAssignment(
+  contextSnapshot: Record<string, unknown> | null | undefined,
+  agentId: string,
+) {
+  const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
+  if (wakeReason === "issue_comment_mentioned") return true;
+
+  const executionStage = parseObject(contextSnapshot?.executionStage);
+  const wakeRole = readNonEmptyString(executionStage.wakeRole);
+  const currentParticipant = parseObject(executionStage.currentParticipant);
+  const participantType = readNonEmptyString(currentParticipant.type);
+  const participantAgentId = readNonEmptyString(currentParticipant.agentId);
+  const isCurrentAgentParticipant = participantType === "agent" && participantAgentId === agentId;
+  if (wakeReason === "execution_review_requested" && wakeRole === "reviewer" && isCurrentAgentParticipant) return true;
+  if (wakeReason === "execution_approval_requested" && wakeRole === "approver" && isCurrentAgentParticipant) return true;
+
+  return false;
+}
+
 function isCheckoutConflictError(error: unknown): boolean {
   return error instanceof HttpError && error.status === 409 && error.message === "Issue checkout conflict";
 }
@@ -2425,25 +2444,48 @@ export function heartbeatService(db: Db) {
     return Number(count ?? 0);
   }
 
-  async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect) {
+  async function claimQueuedRun(
+    run: typeof heartbeatRuns.$inferSelect,
+    opts: { startNextOnCancel?: boolean } = {},
+  ) {
     if (run.status !== "queued") return run;
     const agent = await getAgent(run.agentId);
     if (!agent) {
-      await cancelRunInternal(run.id, "Cancelled because the agent no longer exists");
+      await cancelRunInternal(run.id, "Cancelled because the agent no longer exists", {
+        startNext: opts.startNextOnCancel,
+      });
       return null;
     }
     if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
-      await cancelRunInternal(run.id, "Cancelled because the agent is not invokable");
+      await cancelRunInternal(run.id, "Cancelled because the agent is not invokable", {
+        startNext: opts.startNextOnCancel,
+      });
       return null;
     }
 
     const context = parseObject(run.contextSnapshot);
+    const claimedIssueId = readNonEmptyString(context.issueId);
+    const allowWithoutCurrentAssignment = isIssueWakeAllowedWithoutCurrentAssignment(context, run.agentId);
+    if (claimedIssueId && !allowWithoutCurrentAssignment) {
+      const issue = await db
+        .select({ assigneeAgentId: issues.assigneeAgentId })
+        .from(issues)
+        .where(and(eq(issues.id, claimedIssueId), eq(issues.companyId, run.companyId)))
+        .then((rows) => rows[0] ?? null);
+      if (!issue || issue.assigneeAgentId !== run.agentId) {
+        await cancelRunInternal(run.id, "Cancelled because the issue is no longer assigned to this agent", {
+          startNext: opts.startNextOnCancel,
+        });
+        return null;
+      }
+    }
+
     const budgetBlock = await budgets.getInvocationBlock(run.companyId, run.agentId, {
-      issueId: readNonEmptyString(context.issueId),
+      issueId: claimedIssueId,
       projectId: readNonEmptyString(context.projectId),
     });
     if (budgetBlock) {
-      await cancelRunInternal(run.id, budgetBlock.reason);
+      await cancelRunInternal(run.id, budgetBlock.reason, { startNext: opts.startNextOnCancel });
       return null;
     }
 
@@ -2479,8 +2521,8 @@ export function heartbeatService(db: Db) {
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
 
     // Fix A (lazy locking): stamp executionRunId now that the run is actually running,
-    // not at queue time. Guard is idempotent — safe if called more than once.
-    const claimedIssueId = readNonEmptyString(parseObject(claimed.contextSnapshot).issueId);
+    // not at queue time. Ordinary issue wakes must still match the current
+    // assignee so reassigned queued runs cannot recreate stale execution locks.
     if (claimedIssueId) {
       const claimedAgent = await getAgent(claimed.agentId);
       await db
@@ -2496,6 +2538,7 @@ export function heartbeatService(db: Db) {
             eq(issues.id, claimedIssueId),
             eq(issues.companyId, claimed.companyId),
             or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
+            allowWithoutCurrentAssignment ? sql`true` : eq(issues.assigneeAgentId, claimed.agentId),
           ),
         );
     }
@@ -2996,18 +3039,24 @@ export function heartbeatService(db: Db) {
       const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
       if (availableSlots <= 0) return [];
 
-      const queuedRuns = await db
-        .select()
-        .from(heartbeatRuns)
-        .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")))
-        .orderBy(asc(heartbeatRuns.createdAt))
-        .limit(availableSlots);
-      if (queuedRuns.length === 0) return [];
-
       const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
-      for (const queuedRun of queuedRuns) {
-        const claimed = await claimQueuedRun(queuedRun);
-        if (claimed) claimedRuns.push(claimed);
+      while (claimedRuns.length < availableSlots) {
+        const queuedRuns = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")))
+          .orderBy(asc(heartbeatRuns.createdAt))
+          .limit(Math.max(1, availableSlots - claimedRuns.length));
+        if (queuedRuns.length === 0) break;
+
+        let madeProgress = false;
+        for (const queuedRun of queuedRuns) {
+          const claimed = await claimQueuedRun(queuedRun, { startNextOnCancel: false });
+          madeProgress = true;
+          if (claimed) claimedRuns.push(claimed);
+          if (claimedRuns.length >= availableSlots) break;
+        }
+        if (!madeProgress) break;
       }
       if (claimedRuns.length === 0) return [];
 
@@ -4352,6 +4401,7 @@ export function heartbeatService(db: Db) {
           .select({
             id: issues.id,
             companyId: issues.companyId,
+            assigneeAgentId: issues.assigneeAgentId,
             executionRunId: issues.executionRunId,
             executionAgentNameKey: issues.executionAgentNameKey,
           })
@@ -4401,7 +4451,7 @@ export function heartbeatService(db: Db) {
         }
 
         if (!activeExecutionRun) {
-          const legacyRun = await tx
+          const legacyRunCandidates = await tx
             .select()
             .from(heartbeatRuns)
             .where(
@@ -4415,8 +4465,17 @@ export function heartbeatService(db: Db) {
               sql`case when ${heartbeatRuns.status} = 'running' then 0 else 1 end`,
               asc(heartbeatRuns.createdAt),
             )
-            .limit(1)
-            .then((rows) => rows[0] ?? null);
+            .then((rows) => rows);
+          const legacyRun =
+            legacyRunCandidates.find((candidate) => {
+              if (candidate.agentId === issue.assigneeAgentId) return true;
+              const candidateAllowsWithoutCurrentAssignment = isIssueWakeAllowedWithoutCurrentAssignment(
+                parseObject(candidate.contextSnapshot),
+                candidate.agentId,
+              );
+              if (!candidateAllowsWithoutCurrentAssignment) return false;
+              return candidate.status === "running" || candidate.agentId === agentId;
+            }) ?? null;
 
           if (legacyRun) {
             activeExecutionRun = legacyRun;
@@ -4825,7 +4884,11 @@ export function heartbeatService(db: Db) {
     return wakeupIds.length;
   }
 
-  async function cancelRunInternal(runId: string, reason = "Cancelled by control plane") {
+  async function cancelRunInternal(
+    runId: string,
+    reason = "Cancelled by control plane",
+    opts: { startNext?: boolean } = {},
+  ) {
     const run = await getRun(runId);
     if (!run) throw notFound("Heartbeat run not found");
     if (run.status !== "running" && run.status !== "queued") return run;
@@ -4867,7 +4930,9 @@ export function heartbeatService(db: Db) {
 
     runningProcesses.delete(run.id);
     await finalizeAgentStatus(run.agentId, "cancelled");
-    await startNextQueuedRunForAgent(run.agentId);
+    if (opts.startNext !== false) {
+      await startNextQueuedRunForAgent(run.agentId);
+    }
     return cancelled;
   }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1751,17 +1751,25 @@ export function issueService(db: Db) {
           sql`select id from issues where id = ${id} for update`,
         );
         const preCheckRow = await tx
-          .select({ executionRunId: issues.executionRunId })
+          .select({
+            assigneeAgentId: issues.assigneeAgentId,
+            executionRunId: issues.executionRunId,
+          })
           .from(issues)
           .where(eq(issues.id, id))
           .then((rows) => rows[0] ?? null);
         if (!preCheckRow?.executionRunId) return;
         const lockRun = await tx
-          .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+          .select({ id: heartbeatRuns.id, status: heartbeatRuns.status, agentId: heartbeatRuns.agentId })
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.id, preCheckRow.executionRunId))
           .then((rows) => rows[0] ?? null);
-        if (!lockRun || (lockRun.status !== "queued" && lockRun.status !== "running")) {
+        const isTerminalOrMissing = !lockRun || (lockRun.status !== "queued" && lockRun.status !== "running");
+        const isMismatchedQueuedLock =
+          lockRun?.status === "queued" &&
+          preCheckRow.assigneeAgentId === agentId &&
+          lockRun.agentId !== agentId;
+        if (isTerminalOrMissing || isMismatchedQueuedLock) {
           await tx
             .update(issues)
             .set({ executionRunId: null, executionAgentNameKey: null, executionLockedAt: null, updatedAt: now })


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents by assigning issues, starting heartbeat runs, and tracking execution locks so humans can see and govern work.
> - The affected subsystem is issue execution lifecycle: assignment, queued heartbeat wakeups, checkout recovery, and execution-policy review/approval wakes.
> - Reassignment could leave an issue assigned to one agent while `executionRunId` still pointed at a queued or stale run for another agent.
> - That stale lock blocked the new assignee from checking out the issue and could also defer valid reviewer/approver wakes behind the wrong queued row.
> - The fix needs to preserve single-assignee checkout rules and active execution mutual exclusion while making stale queued rows recoverable.
> - This pull request tightens the lock policy around current assignment and execution-stage participants, then drains past cancelled queue rows.
> - The benefit is that reassignment, reviewer/approver wakes, and queued run recovery remain deterministic without board-only cleanup.

## What Changed

- Clear terminal, missing, and mismatched previous-agent queued execution locks during issue checkout before evaluating checkout conflicts.
- Keep ordinary issue wakes assignee-scoped in heartbeat claiming and lazy execution-lock stamping.
- Allow non-assignee execution review/approval wakes only when the run agent matches `executionStage.currentParticipant.agentId`; mention wakes remain separately allowed.
- Validate legacy active-run candidates using each candidate run's own context and agent before stamping `issues.executionRunId` or deferring a new wake.
- Continue scanning queued heartbeat rows when an ineligible stale row is cancelled so a head-of-queue stale wake does not consume the only available concurrency slot.
- Added focused regressions for stale reassignment locks, valid non-assignee reviewer wakes, stale assignment-run rediscovery, stale reviewer-run rediscovery, and queue draining after cancellation.

## Verification

- `pnpm test:run server/src/__tests__/heartbeat-comment-wake-batching.test.ts` passed: 9 tests.
- `pnpm test:run server/src/__tests__/issues-service.test.ts` passed: 18 tests.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `git diff --check` passed.
- CTO review passed on [CON-101](/CON/issues/CON-101).
- QA black-box verified reassignment checkout recovery and stale queue-drain behavior.
- Board approved a narrow QA exception for the execution-review/approval black-box fixture gap: [bd7b57ee](/CON/approvals/bd7b57ee-4fc5-4524-950f-84e094aae650).
- Durable QA fixture follow-up is tracked as [CON-214](/CON/issues/CON-214).

## Risks

- Medium risk because this changes heartbeat queue and execution-lock behavior around active issue execution.
- The highest-risk edge is accidentally allowing a non-assignee wake to claim an issue lock; coverage now restricts execution review/approval exceptions to the current stage participant.
- Full `pnpm test` was not rerun in the final PR heartbeat. Earlier full-suite runs on this ticket had unrelated environment-sensitive worktree/Tailnet failures; focused affected suites and server typecheck are green.
- No schema or migration changes.

## Model Used

- OpenAI GPT-5.4 through a tool-enabled coding agent workflow, with repository inspection, shell execution, and code editing capabilities.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge