### PR TITLE
fix: safe UTF-8 truncation for SQL_ASCII embedded clusters

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -56,6 +56,7 @@ import { issueService } from "./issues.js";
 import { executionWorkspaceService, mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { workspaceOperationService } from "./workspace-operations.js";
 import { isProcessGroupAlive, terminateLocalService } from "./local-service-supervisor.js";
+import { utf8Trunc } from "./sql-utils.js";
 import {
   buildExecutionWorkspaceAdapterConfig,
   gateProjectExecutionWorkspacePolicy,
@@ -412,12 +413,6 @@ const heartbeatRunListContextColumns = {
   contextWakeTriggerDetail: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'wakeTriggerDetail'`.as("contextWakeTriggerDetail"),
 } as const;
 
-// SQL_ASCII clusters count bytes not chars in left()/length(). Round-tripping through
-// convert_to/convert_from forces UTF-8 character semantics so the cut never splits a
-// multi-byte sequence and avoids "invalid byte sequence for encoding UTF8" 500 errors.
-function utf8Trunc(expr: SQL, maxChars: number): SQL<string | null> {
-  return sql<string | null>`left(convert_from(convert_to(${expr}, 'SQL_ASCII'), 'UTF8'), ${maxChars})`;
-}
 
 const heartbeatRunListResultColumns = {
   resultSummary: utf8Trunc(sql`${heartbeatRuns.resultJson} ->> 'summary'`, HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS).as("resultSummary"),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, or, sql, type SQL } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import type { BillingType, ExecutionWorkspace, ExecutionWorkspaceConfig } from "@paperclipai/shared";
 import {
@@ -412,11 +412,18 @@ const heartbeatRunListContextColumns = {
   contextWakeTriggerDetail: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'wakeTriggerDetail'`.as("contextWakeTriggerDetail"),
 } as const;
 
+// SQL_ASCII clusters count bytes not chars in left()/length(). Round-tripping through
+// convert_to/convert_from forces UTF-8 character semantics so the cut never splits a
+// multi-byte sequence and avoids "invalid byte sequence for encoding UTF8" 500 errors.
+function utf8Trunc(expr: SQL, maxChars: number): SQL<string | null> {
+  return sql<string | null>`left(convert_from(convert_to(${expr}, 'SQL_ASCII'), 'UTF8'), ${maxChars})`;
+}
+
 const heartbeatRunListResultColumns = {
-  resultSummary: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'summary', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultSummary"),
-  resultResult: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'result', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultResult"),
-  resultMessage: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'message', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultMessage"),
-  resultError: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'error', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultError"),
+  resultSummary: utf8Trunc(sql`${heartbeatRuns.resultJson} ->> 'summary'`, HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS).as("resultSummary"),
+  resultResult: utf8Trunc(sql`${heartbeatRuns.resultJson} ->> 'result'`, HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS).as("resultResult"),
+  resultMessage: utf8Trunc(sql`${heartbeatRuns.resultJson} ->> 'message'`, HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS).as("resultMessage"),
+  resultError: utf8Trunc(sql`${heartbeatRuns.resultJson} ->> 'error'`, HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS).as("resultError"),
   resultTotalCostUsd: sql<string | null>`${heartbeatRuns.resultJson} ->> 'total_cost_usd'`.as("resultTotalCostUsd"),
   resultCostUsd: sql<string | null>`${heartbeatRuns.resultJson} ->> 'cost_usd'`.as("resultCostUsd"),
   resultCostUsdCamel: sql<string | null>`${heartbeatRuns.resultJson} ->> 'costUsd'`.as("resultCostUsdCamel"),
@@ -429,19 +436,19 @@ const heartbeatRunSafeResultJsonColumn = sql<Record<string, unknown> | null>`
       then ${heartbeatRuns.resultJson}
     else jsonb_strip_nulls(
       jsonb_build_object(
-        'summary', left(${heartbeatRuns.resultJson} ->> 'summary', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS}),
-        'result', left(${heartbeatRuns.resultJson} ->> 'result', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS}),
-        'message', left(${heartbeatRuns.resultJson} ->> 'message', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS}),
-        'error', left(${heartbeatRuns.resultJson} ->> 'error', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS}),
-        'stdout', left(${heartbeatRuns.resultJson} ->> 'stdout', ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS}),
-        'stderr', left(${heartbeatRuns.resultJson} ->> 'stderr', ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS}),
+        'summary', ${utf8Trunc(sql`${heartbeatRuns.resultJson} ->> 'summary'`, HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS)},
+        'result', ${utf8Trunc(sql`${heartbeatRuns.resultJson} ->> 'result'`, HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS)},
+        'message', ${utf8Trunc(sql`${heartbeatRuns.resultJson} ->> 'message'`, HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS)},
+        'error', ${utf8Trunc(sql`${heartbeatRuns.resultJson} ->> 'error'`, HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS)},
+        'stdout', ${utf8Trunc(sql`${heartbeatRuns.resultJson} ->> 'stdout'`, HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS)},
+        'stderr', ${utf8Trunc(sql`${heartbeatRuns.resultJson} ->> 'stderr'`, HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS)},
         'stdoutTruncated', case
-          when length(${heartbeatRuns.resultJson} ->> 'stdout') > ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS}
+          when char_length(convert_from(convert_to(${heartbeatRuns.resultJson} ->> 'stdout', 'SQL_ASCII'), 'UTF8')) > ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS}
             then to_jsonb(true)
           else null
         end,
         'stderrTruncated', case
-          when length(${heartbeatRuns.resultJson} ->> 'stderr') > ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS}
+          when char_length(convert_from(convert_to(${heartbeatRuns.resultJson} ->> 'stderr', 'SQL_ASCII'), 'UTF8')) > ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS}
             then to_jsonb(true)
           else null
         end,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -539,7 +539,7 @@ const issueListSelect = {
   description: sql<string | null>`
     CASE
       WHEN ${issues.description} IS NULL THEN NULL
-      ELSE substring(${issues.description} FROM 1 FOR ${ISSUE_LIST_DESCRIPTION_MAX_CHARS})
+      ELSE left(convert_from(convert_to(${issues.description}, 'SQL_ASCII'), 'UTF8'), ${ISSUE_LIST_DESCRIPTION_MAX_CHARS})
     END
   `,
   status: issues.status,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -35,6 +35,7 @@ import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
 import { getDefaultCompanyGoal } from "./goals.js";
+import { utf8Trunc } from "./sql-utils.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
@@ -536,12 +537,7 @@ const issueListSelect = {
   goalId: issues.goalId,
   parentId: issues.parentId,
   title: issues.title,
-  description: sql<string | null>`
-    CASE
-      WHEN ${issues.description} IS NULL THEN NULL
-      ELSE left(convert_from(convert_to(${issues.description}, 'SQL_ASCII'), 'UTF8'), ${ISSUE_LIST_DESCRIPTION_MAX_CHARS})
-    END
-  `,
+  description: utf8Trunc(sql`${issues.description}`, ISSUE_LIST_DESCRIPTION_MAX_CHARS),
   status: issues.status,
   priority: issues.priority,
   assigneeAgentId: issues.assigneeAgentId,

--- a/server/src/services/sql-utils.ts
+++ b/server/src/services/sql-utils.ts
@@ -1,0 +1,8 @@
+import { sql, type SQL } from "drizzle-orm";
+
+// SQL_ASCII clusters count bytes not chars in left()/length(). Round-tripping through
+// convert_to/convert_from forces UTF-8 character semantics so the cut never splits a
+// multi-byte sequence and avoids "invalid byte sequence for encoding UTF8" 500 errors.
+export function utf8Trunc(expr: SQL, maxChars: number): SQL<string | null> {
+  return sql<string | null>`left(convert_from(convert_to(${expr}, 'SQL_ASCII'), 'UTF8'), ${maxChars})`;
+}


### PR DESCRIPTION
## Summary

Fixes #3829 and #3841.

Both endpoints 500 with `invalid byte sequence for encoding "UTF8"` on Paperclip instances running with the default embedded PostgreSQL cluster (which initialises as `SQL_ASCII`).

**Root cause:** In SQL_ASCII mode, PostgreSQL treats every byte as one character. `left(text, N)` and `substring(text FROM 1 FOR N)` therefore cut at byte `N`, not code-point `N`. When a multi-byte UTF-8 sequence (e.g. em-dash `—` = `0xe2 0x80 0x94`) starts at the boundary byte, the result contains an incomplete, invalid sequence. postgres.js rejects it on the wire and the endpoint returns a 500.

**Fix:** Wrap each truncated expression with `convert_from(convert_to(expr, 'SQL_ASCII'), 'UTF8')` before applying `left()`. The round-trip extracts raw bytes and re-interprets them as proper UTF-8 text so that `left()` and `char_length()` count Unicode code points and can never split a sequence. No change to the truncation limits or downstream types.

**Files changed:**
- `server/src/services/heartbeat.ts` — adds `utf8Trunc()` helper and applies it to `heartbeatRunListResultColumns` (resultSummary/Result/Message/Error) and the oversized-result-json fallback stdout/stderr fields; replaces `length()` with `char_length()` on the same `convert_from/convert_to` expression for the `stdoutTruncated`/`stderrTruncated` flags
- `server/src/services/issues.ts` — replaces `substring(description FROM 1 FOR N)` with the same `left(convert_from(...), N)` pattern in `issueListSelect`

The fix is safe on native UTF-8 clusters too: `convert_to(text, 'SQL_ASCII')` on a UTF-8 server just returns the raw bytes unchanged, and `convert_from(bytes, 'UTF8')` re-validates them; `left()` behaviour is identical to before.

## Test plan

- [ ] Confirm `GET /api/companies/:id/issues` no longer 500s when any issue description contains a multi-byte UTF-8 character starting at byte 1200
- [ ] Confirm `GET /api/companies/:id/heartbeat-runs` no longer 500s when a run's `result_json` fields contain multi-byte UTF-8 characters at the 500-byte boundary
- [ ] Confirm both endpoints return correct truncated text (not garbled) on an embedded-postgres instance
- [ ] TypeScript compiles cleanly (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)