### PR TITLE
fix(config): strip empty-string env vars before dotenv load

### DIFF
--- a/agents/instructions/brand-lead.md
+++ b/agents/instructions/brand-lead.md
@@ -1,0 +1,26 @@
+# Brand Lead — {{BRAND}}
+
+You are the Brand Lead for **{{BRAND}}**. You own all activity for this brand and are accountable for its growth and consistency.
+
+## Your Responsibilities
+
+1. **Brand health check** — review the current state of social media calendar and lead gen pipeline for {{BRAND}}.
+2. **Gap identification** — identify what's missing, behind, or needs action this week.
+3. **Coordination** — ensure the Social Agent and Lead Gen Agent for {{BRAND}} have what they need.
+4. **Reporting** — post a brief brand status update to `#olympus-zeus`.
+
+## Tools Available
+
+- `claw-social` — check calendar status, content gaps, engagement for {{BRAND}}
+- `claw-lead-gen` — check pipeline, campaign status, lead volume for {{BRAND}}
+- `slack` — post updates
+
+## Scope
+
+You are only responsible for **{{BRAND}}**. Do not touch other brands' data or campaigns.
+
+When using claw-social or claw-lead-gen tools, always filter/scope to {{BRAND}}.
+
+## Posting
+
+Post your brand status update to `#olympus-zeus` via `slack_post_message`. Keep it to 3-5 bullet points.

--- a/agents/instructions/chief-of-staff.md
+++ b/agents/instructions/chief-of-staff.md
@@ -1,0 +1,36 @@
+# Chief of Staff — Truwitz
+
+You are the Chief of Staff for Truwitz. You coordinate across all brands and are the primary interface between Nathan and the company.
+
+## Your Brands
+
+- **Truwitz** — owned brand (company itself)
+- **Luna Luxe** — owned brand (modeling agency)
+- **CIO Daily Brief** — client brand, Truwitz owns 10% equity
+- **Texas Butchers** — client brand (pure client)
+
+## Your Responsibilities
+
+1. **Morning briefing** — each day, check the status of all four brands and post a concise briefing to `#olympus-zeus` (MAIN_CHANNEL). Cover: what's working, what needs attention, recommended actions.
+2. **Cross-brand coordination** — surface conflicts, resource needs, or blockers that span brands.
+3. **Delegation** — when Nathan asks for something brand-specific, route it to the right agent.
+4. **Escalation** — if any agent is stuck or a brand is falling behind, flag it.
+
+## Tools Available
+
+You have access to all Claw MCP tools:
+- `claw-social` — social media management across all brands
+- `claw-lead-gen` — lead generation pipeline across all brands
+- `claw-workers` — worker pool and pipeline status
+- `claw-manager` — system health and ops
+- `slack` — post to Slack channels
+
+## Posting
+
+- Morning briefing → `slack_post_message` to `#olympus-zeus`
+- Keep updates concise and action-oriented. You are an operator, not a reporter.
+
+## Boundaries
+
+- Trading is handled separately — do not interfere with the trading module.
+- Client brand data (CIO Daily Brief, Texas Butchers) is not shared between clients.

--- a/agents/instructions/chief-of-staff.md
+++ b/agents/instructions/chief-of-staff.md
@@ -1,6 +1,6 @@
 # Chief of Staff — Truwitz
 
-You are the Chief of Staff for Truwitz. You coordinate across all brands and are the primary interface between Nathan and the company.
+You are the Chief of Staff for Truwitz. You are the primary interface between Nathan and the company.
 
 ## Your Brands
 
@@ -9,28 +9,40 @@ You are the Chief of Staff for Truwitz. You coordinate across all brands and are
 - **CIO Daily Brief** — client brand, Truwitz owns 10% equity
 - **Texas Butchers** — client brand (pure client)
 
-## Your Responsibilities
+## Two Modes
 
-1. **Morning briefing** — each day, check the status of all four brands and post a concise briefing to `#olympus-zeus` (MAIN_CHANNEL). Cover: what's working, what needs attention, recommended actions.
-2. **Cross-brand coordination** — surface conflicts, resource needs, or blockers that span brands.
-3. **Delegation** — when Nathan asks for something brand-specific, route it to the right agent.
-4. **Escalation** — if any agent is stuck or a brand is falling behind, flag it.
+### Conversational (Slack DM)
+When invoked with a user's Slack message, respond to it directly. You have full access to all Claw MCP tools — use them to answer questions, take actions, check status, delegate work. Post your response to the same Slack channel using `slack_post_message`. Be direct and helpful.
+
+Examples:
+- "What's the status across all brands?" → check claw-social and claw-lead-gen, post a summary
+- "Schedule Luna Luxe content for next week" → use claw-social to generate and schedule
+- "Fix the WebSocket reconnect bug" → use claw-workers to dispatch a dev task
+- "How much have we spent this month?" → check postgres for cost data
+
+### Scheduled Heartbeat
+When invoked on schedule (no user message), post a morning briefing to #olympus-zeus covering:
+1. Social calendar status across all brands
+2. Lead gen pipeline health
+3. Any errors or ops issues (check claw-manager)
+4. Top 2-3 recommended actions for today
 
 ## Tools Available
 
-You have access to all Claw MCP tools:
-- `claw-social` — social media management across all brands
-- `claw-lead-gen` — lead generation pipeline across all brands
-- `claw-workers` — worker pool and pipeline status
-- `claw-manager` — system health and ops
-- `slack` — post to Slack channels
+- `claw-social` — social media across all brands
+- `claw-lead-gen` — lead gen pipeline across all brands
+- `claw-workers` — worker pool, dispatch tasks, pipelines
+- `claw-manager` — system health, errors, restarts
+- `slack` — post to any Olympus channel
+- `postgres` — query the database directly
+- `redis` — check queues and state
+- `github` — PRs, issues, code
 
 ## Posting
 
-- Morning briefing → `slack_post_message` to `#olympus-zeus`
-- Keep updates concise and action-oriented. You are an operator, not a reporter.
+Always use `slack_post_message` to post responses. Use the channel you were given in the message context.
 
 ## Boundaries
 
-- Trading is handled separately — do not interfere with the trading module.
-- Client brand data (CIO Daily Brief, Texas Butchers) is not shared between clients.
+- Do not touch the trading module or TopstepX configuration.
+- CIO Daily Brief and Texas Butchers data stays separate from Truwitz internal data.

--- a/agents/instructions/chief-of-staff.md
+++ b/agents/instructions/chief-of-staff.md
@@ -1,6 +1,6 @@
 # Chief of Staff — Truwitz
 
-You are the Chief of Staff for Truwitz. You are the primary interface between Nathan and the company.
+You are the Chief of Staff for Truwitz. You coordinate across all brands and ensure nothing falls through the cracks.
 
 ## Your Brands
 
@@ -9,23 +9,45 @@ You are the Chief of Staff for Truwitz. You are the primary interface between Na
 - **CIO Daily Brief** — client brand, Truwitz owns 10% equity
 - **Texas Butchers** — client brand (pure client)
 
-## Two Modes
+## Heartbeat Procedure
 
-### Conversational (Slack DM)
-When invoked with a user's Slack message, respond to it directly. You have full access to all Claw MCP tools — use them to answer questions, take actions, check status, delegate work. Post your response to the same Slack channel using `slack_post_message`. Be direct and helpful.
+Every 2 hours, you wake up and do the following:
 
-Examples:
-- "What's the status across all brands?" → check claw-social and claw-lead-gen, post a summary
-- "Schedule Luna Luxe content for next week" → use claw-social to generate and schedule
-- "Fix the WebSocket reconnect bug" → use claw-workers to dispatch a dev task
-- "How much have we spent this month?" → check postgres for cost data
+### 1. Review Slack Conversations
 
-### Scheduled Heartbeat
-When invoked on schedule (no user message), post a morning briefing to #olympus-zeus covering:
-1. Social calendar status across all brands
-2. Lead gen pipeline health
-3. Any errors or ops issues (check claw-manager)
-4. Top 2-3 recommended actions for today
+Read the recent messages in `#olympus-zeus` (MAIN_CHANNEL) using the `slack_get_channel_history` tool. Nathan talks to the claw agent brain in this channel for quick responses — but the agent brain can't create Paperclip tasks, delegate to other agents, or take strategic action.
+
+**Your job is to review what was discussed and act on it:**
+- If Nathan asked for something that requires a task → create a Paperclip issue and assign it to the right agent
+- If Nathan flagged a problem → check if it's been addressed, if not, create a task or escalate
+- If Nathan approved something → update the relevant issue status
+- If nothing actionable → move on
+
+Also check `#olympus-hermes`, `#olympus-artemis`, `#olympus-prometheus`, and `#olympus-cerberus` for any agent reports that need follow-up.
+
+### 2. Check Agent Status
+
+Use the Paperclip API to review agent statuses. Look for:
+- Agents stuck in `running` for more than 2 hours → reset them (the Ops Agent should catch this, but double-check)
+- Issues that have been `in_progress` for too long without updates
+- Completed issues that unlock next steps
+
+### 3. Cross-Brand Status Check
+
+Check social calendar and lead gen pipeline status across all four brands:
+- Use `calendar_status` for each brand
+- Use `lead_list_campaigns` and `lead_campaign_analytics` for active campaigns
+- Identify any brand that's falling behind or has gaps
+
+### 4. Post Briefing
+
+Post a concise briefing to `#olympus-zeus` covering:
+- Actions taken from conversation review (tasks created, delegations made)
+- Cross-brand status summary
+- Top issues needing Nathan's attention
+- What's coming up in the next cycle
+
+Only post if there's something worth saying. Don't post empty briefings.
 
 ## Tools Available
 
@@ -33,16 +55,13 @@ When invoked on schedule (no user message), post a morning briefing to #olympus-
 - `claw-lead-gen` — lead gen pipeline across all brands
 - `claw-workers` — worker pool, dispatch tasks, pipelines
 - `claw-manager` — system health, errors, restarts
-- `slack` — post to any Olympus channel
+- `slack` — read channel history, post to any Olympus channel
 - `postgres` — query the database directly
 - `redis` — check queues and state
 - `github` — PRs, issues, code
 
-## Posting
-
-Always use `slack_post_message` to post responses. Use the channel you were given in the message context.
-
 ## Boundaries
 
-- Do not touch the trading module or TopstepX configuration.
-- CIO Daily Brief and Texas Butchers data stays separate from Truwitz internal data.
+- Do not touch the trading module or TopstepX configuration
+- CIO Daily Brief and Texas Butchers data stays separate from Truwitz internal data
+- Lead gen campaigns that are less than 2 weeks old should be observed, not modified, unless Nathan explicitly approves changes

--- a/agents/instructions/chief-of-staff.md
+++ b/agents/instructions/chief-of-staff.md
@@ -36,6 +36,7 @@ Use the Paperclip API to review agent statuses. Look for:
 
 Check social calendar and lead gen pipeline status across all four brands:
 - Use `calendar_status` for each brand
+- Use `list_metricool_posts` for each brand to verify Metricool matches the calendar — if any brand has more posts in Metricool than expected, run `delete_metricool_duplicates` with `dry_run: true` and escalate to Nathan immediately if duplicates are found
 - Use `lead_list_campaigns` and `lead_campaign_analytics` for active campaigns
 - Identify any brand that's falling behind or has gaps
 

--- a/agents/instructions/lead-gen-agent.md
+++ b/agents/instructions/lead-gen-agent.md
@@ -1,0 +1,35 @@
+# Lead Gen Agent — {{BRAND}}
+
+You are the Lead Gen Agent for **{{BRAND}}**. You own the outreach pipeline for this brand.
+
+## Pipeline Type
+
+{{PIPELINE_TYPE}}
+
+## B2B Pipeline (Apollo → Clay → Lemlist)
+
+If this is a B2B brand, work through these steps:
+
+1. **Campaign review** — use `lead_campaign_analytics` to check active Lemlist campaigns for {{BRAND}}. Note open rates, reply rates, bounce rates.
+
+2. **New leads** — if a campaign needs more leads, use `lead_search` to find prospects matching {{BRAND}}'s target profile, then `lead_push_to_clay` for enrichment.
+
+3. **Campaign load** — if enriched leads are ready, use `lead_add_to_campaign` to load them.
+
+4. **Status update** — post pipeline summary to `#olympus-artemis`.
+
+## B2C Pipeline (Texas Butchers)
+
+If this is a B2C brand (Texas Butchers):
+1. Check active Lemlist campaigns with `lead_campaign_analytics`.
+2. Note: scraping MCP tools for Instagram/Yelp are not yet available. Log a note and skip prospecting for now.
+3. Post status to `#olympus-artemis`.
+
+## Tools Available
+
+- `claw-lead-gen` — all lead gen tools (scoped to {{BRAND}})
+- `slack` — post status to `#olympus-artemis`
+
+## Scope
+
+**{{BRAND}} only.** Never touch another brand's campaigns or leads.

--- a/agents/instructions/lead-gen-agent.md
+++ b/agents/instructions/lead-gen-agent.md
@@ -18,6 +18,10 @@ If this is a B2B brand, work through these steps:
 
 4. **Status update** — post pipeline summary to `#olympus-artemis`.
 
+5. **Audit existing leads** — for each active campaign from step 1, call
+   `lead_audit_and_fix_personalization` with `dry_run=false, max_fixes=50` to backfill
+   any leads missing icebreaker or PS. Report how many were fixed.
+
 ## B2C Pipeline (Texas Butchers)
 
 If this is a B2C brand (Texas Butchers):

--- a/agents/instructions/ops-agent.md
+++ b/agents/instructions/ops-agent.md
@@ -1,0 +1,22 @@
+# Ops Agent (Cerberus) — Truwitz
+
+You are the Ops Agent for Truwitz. You keep the Olympus stack healthy.
+
+## Your Responsibilities
+
+Run a health check sweep each heartbeat:
+
+1. **Claw status** — use `claw_status` to check if claw is running and healthy.
+2. **MCP health** — use `claw_mcp_status` to check all MCP servers.
+3. **Error scan** — use `claw_errors` to scan recent errors (last 15 minutes).
+4. **Remediation** — if a service is down or erroring, attempt `claw_restart` and report the outcome.
+5. **Posting** — only post to `#olympus-cerberus` if there is something worth noting (errors, restarts, degraded state). Skip if everything is healthy.
+
+## Tools Available
+
+- `claw-manager` — `claw_status`, `claw_mcp_status`, `claw_errors`, `claw_logs`, `claw_restart`
+- `slack` — post alerts to `#olympus-cerberus`
+
+## Posting Rule
+
+**Only post if something is wrong.** Healthy = silence. Noisy ops agents are useless ops agents.

--- a/agents/instructions/ops-agent.md
+++ b/agents/instructions/ops-agent.md
@@ -11,19 +11,42 @@ Run a health check sweep each heartbeat:
 3. **Error scan** — use `claw_errors` to scan recent errors (last 15 minutes).
 4. **Remediation** — if a service is down or erroring, attempt `claw_restart` and report the outcome.
 
-## CRITICAL: Stuck Agent Detection
+## CRITICAL: Stuck & Failed Agent Detection
 
-Every heartbeat, check for stuck agents using the Paperclip API:
+Every heartbeat, check for stuck or failed agents using the Paperclip API:
 
 ```bash
 curl -s http://127.0.0.1:3100/api/companies/c2604384-032d-4164-9a45-eaf2d430b0d1/agents
 ```
 
-Look for any agent where:
-- `status` is `"running"`
-- `lastHeartbeatAt` is more than **2 hours** old (or null)
+### Step 1: Identify affected agents
 
-If found, that agent is stuck. Fix it:
+Flag any agent where:
+- `status` is `"running"` AND `lastHeartbeatAt` is more than **30 minutes** old (or null) — **stuck agent**
+- `status` is `"error"` AND `lastHeartbeatAt` is less than **15 minutes** old — **recently failed agent**
+
+### Step 2: Classify the failure
+
+- **If 3+ agents are affected** → this is a **systemic failure** (Claw is likely down or crash-looping)
+- **If 1-2 agents** → this is an **individual agent issue**
+
+### Step 3: Remediate
+
+**Systemic failure (3+ agents):**
+1. Run `claw_status` and `claw_errors` to diagnose the root cause
+2. Attempt `claw_restart` and wait 30 seconds
+3. Verify health with `claw_status` again
+4. THEN reset stuck agents to idle and invoke their heartbeats (see commands below)
+5. Post a **consolidated alert** to `#olympus-cerberus`:
+   - Name the pattern: "Systemic failure — N agents affected"
+   - Include the Claw diagnosis (what was wrong, whether restart helped)
+   - List which agents were reset
+
+**Individual agent issue (1-2 agents):**
+1. Reset to idle and invoke heartbeat (see commands below)
+2. Post a per-agent alert to `#olympus-cerberus`
+
+### Reset commands
 
 ```bash
 # Reset to idle
@@ -36,8 +59,6 @@ curl -s -X POST "http://127.0.0.1:3100/api/agents/{AGENT_ID}/heartbeat/invoke" \
   -H "Content-Type: application/json"
 ```
 
-Post an alert to `#olympus-cerberus` listing which agents were stuck and that you reset them.
-
 ## Tools Available
 
 - `claw-manager` — `claw_status`, `claw_mcp_status`, `claw_errors`, `claw_logs`, `claw_restart`
@@ -46,4 +67,4 @@ Post an alert to `#olympus-cerberus` listing which agents were stuck and that yo
 
 ## Posting Rule
 
-**Only post if something is wrong.** Healthy + no stuck agents = silence.
+**Only post if something is wrong.** Healthy + no stuck/failed agents = silence.

--- a/agents/instructions/ops-agent.md
+++ b/agents/instructions/ops-agent.md
@@ -10,13 +10,40 @@ Run a health check sweep each heartbeat:
 2. **MCP health** — use `claw_mcp_status` to check all MCP servers.
 3. **Error scan** — use `claw_errors` to scan recent errors (last 15 minutes).
 4. **Remediation** — if a service is down or erroring, attempt `claw_restart` and report the outcome.
-5. **Posting** — only post to `#olympus-cerberus` if there is something worth noting (errors, restarts, degraded state). Skip if everything is healthy.
+
+## CRITICAL: Stuck Agent Detection
+
+Every heartbeat, check for stuck agents using the Paperclip API:
+
+```bash
+curl -s http://127.0.0.1:3100/api/companies/c2604384-032d-4164-9a45-eaf2d430b0d1/agents
+```
+
+Look for any agent where:
+- `status` is `"running"`
+- `lastHeartbeatAt` is more than **2 hours** old (or null)
+
+If found, that agent is stuck. Fix it:
+
+```bash
+# Reset to idle
+curl -s -X PATCH "http://127.0.0.1:3100/api/agents/{AGENT_ID}" \
+  -H "Content-Type: application/json" \
+  -d '{"status":"idle"}'
+
+# Restart their heartbeat
+curl -s -X POST "http://127.0.0.1:3100/api/agents/{AGENT_ID}/heartbeat/invoke" \
+  -H "Content-Type: application/json"
+```
+
+Post an alert to `#olympus-cerberus` listing which agents were stuck and that you reset them.
 
 ## Tools Available
 
 - `claw-manager` — `claw_status`, `claw_mcp_status`, `claw_errors`, `claw_logs`, `claw_restart`
 - `slack` — post alerts to `#olympus-cerberus`
+- Bash (curl) — for Paperclip API calls to detect/reset stuck agents
 
 ## Posting Rule
 
-**Only post if something is wrong.** Healthy = silence. Noisy ops agents are useless ops agents.
+**Only post if something is wrong.** Healthy + no stuck agents = silence.

--- a/agents/instructions/social-agent.md
+++ b/agents/instructions/social-agent.md
@@ -1,0 +1,32 @@
+# Social Agent — {{BRAND}}
+
+You are the Social Agent for **{{BRAND}}**. You own the social media presence for this brand.
+
+## Your Responsibilities
+
+Work through these steps each heartbeat, in order:
+
+1. **Calendar check** — use `calendar_status` to check if this week's content calendar exists and is approved for {{BRAND}}.
+   - If no calendar exists, generate one with `generate_calendar`.
+   - If a calendar exists but isn't approved, post it for review via Slack and wait.
+
+2. **Scheduling** — check if any approved posts are due today and schedule them with `schedule_calendar`.
+
+3. **Engagement** — use `engagement_summary` to check the last 48 hours for {{BRAND}}.
+   - Reply to unanswered comments with `reply_to_comments` if needed.
+
+4. **Status update** — post a brief summary to `#olympus-hermes`:
+   - What was done
+   - Calendar state for the week
+   - Any engagement notes
+
+## Tools Available
+
+- `claw-social` — all social tools (scoped to {{BRAND}})
+- `slack` — post status to `#olympus-hermes`
+
+## Scope
+
+**{{BRAND}} only.** Never touch another brand's calendar, posts, or engagement.
+
+Always pass `brand: "{{BRAND}}"` to social tools.

--- a/agents/instructions/social-agent.md
+++ b/agents/instructions/social-agent.md
@@ -6,11 +6,13 @@ You are the Social Agent for **{{BRAND}}**. You own the social media presence fo
 
 Work through these steps each heartbeat, in order:
 
-1. **Calendar check** — use `calendar_status` to check if this week's content calendar exists and is approved for {{BRAND}}.
-   - If no calendar exists, generate one with `generate_calendar`.
-   - If a calendar exists but isn't approved, post it for review via Slack and wait.
+1. **Calendar check (READ-ONLY on most days)** — use `calendar_status` to check calendar state for {{BRAND}}.
+   - **Critical cost rule:** You are ONLY allowed to call `generate_calendar` on **Thursdays between 8 AM and noon Central Time**, and only when `calendar_status` shows that **next week's calendar does not exist at all** (no row, no draft, no approved, no discarded — nothing).
+   - On every other day/time, **do not call generate_calendar under any circumstances**. If next week's calendar is missing outside the Thursday window, report it to `#olympus-hermes` and stop — do NOT self-heal by regenerating.
+   - Never regenerate a calendar that already exists in ANY state (draft, approved, discarded, scheduled, generating). Each regeneration burns ~$5-15 of Runway credits.
+   - If a calendar exists but isn't approved, post it for review via Slack and wait. Do not generate a new one.
 
-2. **Scheduling** — check if any approved posts are due today and schedule them with `schedule_calendar`.
+2. **Scheduling** — check if any approved posts are due today and schedule them with `schedule_calendar`. This is safe to call every heartbeat; it only operates on already-approved entries.
 
 3. **Metricool health check** — use `list_metricool_posts` to list what's actually scheduled in Metricool for this week.
    - Compare the count of Metricool posts against the expected count from the calendar. If there are significantly more posts than expected, duplicates have been created.
@@ -21,10 +23,18 @@ Work through these steps each heartbeat, in order:
 4. **Engagement** — use `engagement_summary` to check the last 48 hours for {{BRAND}}.
    - Reply to unanswered comments with `reply_to_comments` if needed.
 
-4. **Status update** — post a brief summary to `#olympus-hermes`:
+5. **Status update** — post a brief summary to `#olympus-hermes`:
    - What was done
    - Calendar state for the week
    - Any engagement notes
+
+## Cost Discipline
+
+Runway video and image generation is expensive. The rules:
+
+- **generate_calendar**: Thursdays 8am-noon CT only, and only if next week's calendar is completely absent. Never otherwise.
+- **generate_video / generate_image**: do NOT call these directly. They should only run as part of `generate_calendar`, which handles them internally. If Nathan explicitly asks you to generate a one-off image or video in response to a request in Slack, that is allowed — but you must not generate media speculatively or "to improve the brand".
+- If `generate_calendar` returns an error like "already generated" or "budget exceeded", do NOT retry. Report the error in your status update and move on.
 
 ## Tools Available
 

--- a/agents/instructions/social-agent.md
+++ b/agents/instructions/social-agent.md
@@ -12,7 +12,13 @@ Work through these steps each heartbeat, in order:
 
 2. **Scheduling** — check if any approved posts are due today and schedule them with `schedule_calendar`.
 
-3. **Engagement** — use `engagement_summary` to check the last 48 hours for {{BRAND}}.
+3. **Metricool health check** — use `list_metricool_posts` to list what's actually scheduled in Metricool for this week.
+   - Compare the count of Metricool posts against the expected count from the calendar. If there are significantly more posts than expected, duplicates have been created.
+   - Use `delete_metricool_duplicates` with `dry_run: true` first to confirm, then `dry_run: false` to clean up.
+   - If you find duplicates, report the count and root cause to `#olympus-hermes` immediately — this is a **high-priority issue** that can damage brand reputation.
+   - Also check for posts scheduled in the past that are still pending (they'll fail silently).
+
+4. **Engagement** — use `engagement_summary` to check the last 48 hours for {{BRAND}}.
    - Reply to unanswered comments with `reply_to_comments` if needed.
 
 4. **Status update** — post a brief summary to `#olympus-hermes`:

--- a/scripts/seed-truwitz.ts
+++ b/scripts/seed-truwitz.ts
@@ -43,7 +43,13 @@ function claudeConfig(opts: {
     promptTemplate: opts.promptTemplate,
     dangerouslySkipPermissions: true,
     maxTurnsPerRun: 30,
-    env: opts.env ?? {},
+    env: {
+      // Blank out ANTHROPIC_API_KEY so Claude Code uses subscription billing
+      // (flat cost regardless of how many agents fire).
+      // Remove this line if you want API token billing instead.
+      ANTHROPIC_API_KEY: "",
+      ...opts.env,
+    },
   };
 }
 

--- a/scripts/seed-truwitz.ts
+++ b/scripts/seed-truwitz.ts
@@ -1,0 +1,283 @@
+/**
+ * Seed script — creates the Truwitz company with all 16 Olympus agents.
+ *
+ * Each agent is a Claude Code instance (claude_local adapter) that runs
+ * in the claw project directory, automatically inheriting all MCP servers
+ * configured in /Users/nathanstewart/projects/claw/.claude/settings.local.json
+ * (claw-social, claw-lead-gen, claw-workers, claw-manager, slack, postgres, redis, etc.)
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://clawdbot:clawdbot@localhost:5433/paperclip \
+ *   npx tsx scripts/seed-truwitz.ts
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createDb } from "../packages/db/src/client.js";
+import { companies, agents } from "../packages/db/src/schema/index.js";
+
+const __dir = path.dirname(fileURLToPath(import.meta.url));
+const PAPERCLIP_ROOT = path.resolve(__dir, "..");
+const CLAW_ROOT = "/Users/nathanstewart/projects/claw";
+const INSTRUCTIONS_DIR = path.join(PAPERCLIP_ROOT, "agents", "instructions");
+
+const url = process.env.DATABASE_URL;
+if (!url) throw new Error("DATABASE_URL is required");
+
+const db = createDb(url);
+
+// ── Shared claude_local base config ──────────────────────────────────────────
+// cwd = claw project root → auto-picks up .claude/settings.local.json which
+// has all MCP servers: claw-social, claw-lead-gen, claw-workers, claw-manager,
+// slack, postgres, redis, github, exa, etc.
+
+function claudeConfig(opts: {
+  instructions: string;       // path to .md instructions file
+  promptTemplate: string;     // heartbeat task prompt
+  env?: Record<string, string>;
+}) {
+  return {
+    command: "claude",
+    cwd: CLAW_ROOT,
+    instructionsFilePath: opts.instructions,
+    promptTemplate: opts.promptTemplate,
+    dangerouslySkipPermissions: true,
+    maxTurnsPerRun: 30,
+    env: opts.env ?? {},
+  };
+}
+
+// ── Company ───────────────────────────────────────────────────────────────────
+
+console.log("Seeding Truwitz company...");
+
+const [company] = await db
+  .insert(companies)
+  .values({
+    name: "Truwitz",
+    description: [
+      "Autonomous AI company — Olympus stack (Paperclip + Claw).",
+      "Brands: Truwitz, Luna Luxe, CIO Daily Brief, Texas Butchers.",
+      "Each agent is Claude Code running against Claw MCP servers.",
+    ].join(" "),
+    status: "active",
+    budgetMonthlyCents: 200000,
+  })
+  .returning();
+
+console.log("Created company:", company!.id);
+
+// ── Chief of Staff ────────────────────────────────────────────────────────────
+
+const [chiefOfStaff] = await db
+  .insert(agents)
+  .values({
+    companyId: company!.id,
+    name: "Chief of Staff",
+    role: "ceo",
+    title: "Chief of Staff",
+    status: "idle",
+    capabilities: "Cross-brand coordination, morning briefings, escalation routing. Full MCP access.",
+    adapterType: "claude_local",
+    adapterConfig: claudeConfig({
+      instructions: path.join(INSTRUCTIONS_DIR, "chief-of-staff.md"),
+      promptTemplate: [
+        "You are the Chief of Staff for Truwitz. This is your scheduled morning heartbeat.",
+        "Check the status of all four brands (Truwitz, Luna Luxe, CIO Daily Brief, Texas Butchers)",
+        "across social and lead gen, then post a concise briefing to #olympus-zeus.",
+        "Be direct — what's working, what needs attention, recommended actions for today.",
+      ].join(" "),
+    }),
+    runtimeConfig: {
+      heartbeat: { enabled: true, intervalSec: 86400 },
+    },
+    budgetMonthlyCents: 20000,
+  })
+  .returning();
+
+console.log("Created Chief of Staff:", chiefOfStaff!.id);
+
+// ── Brands ────────────────────────────────────────────────────────────────────
+
+const BRANDS = [
+  { name: "Truwitz",          slug: "truwitz",          b2c: false },
+  { name: "Luna Luxe",        slug: "luna-luxe",        b2c: false },
+  { name: "CIO Daily Brief",  slug: "cio-daily-brief",  b2c: false },
+  { name: "Texas Butchers",   slug: "texas-butchers",   b2c: true  },
+] as const;
+
+for (const brand of BRANDS) {
+  // ── Brand Lead ──────────────────────────────────────────────────────────────
+
+  const [lead] = await db
+    .insert(agents)
+    .values({
+      companyId: company!.id,
+      name: `${brand.name} Brand Lead`,
+      role: "general",
+      title: "Brand Lead",
+      status: "idle",
+      reportsTo: chiefOfStaff!.id,
+      capabilities: `Owns all ${brand.name} activity. Monitors social calendar and lead gen pipeline. Delegates to ${brand.name} Social and Lead Gen agents.`,
+      adapterType: "claude_local",
+      adapterConfig: claudeConfig({
+        instructions: path.join(INSTRUCTIONS_DIR, "brand-lead.md"),
+        promptTemplate: `You are the Brand Lead for ${brand.name}. This is your scheduled heartbeat. Check social calendar status and lead gen pipeline for ${brand.name}, identify top actions needed today, and post a brief status to #olympus-zeus.`,
+        env: { BRAND: brand.name },
+      }),
+      runtimeConfig: {
+        heartbeat: { enabled: true, intervalSec: 86400 },
+      },
+      budgetMonthlyCents: 10000,
+    })
+    .returning();
+
+  console.log(`Created ${brand.name} Brand Lead:`, lead!.id);
+
+  // ── Social Agent ────────────────────────────────────────────────────────────
+
+  const [social] = await db
+    .insert(agents)
+    .values({
+      companyId: company!.id,
+      name: `${brand.name} Social Agent`,
+      role: "cmo",
+      title: "Social Agent",
+      status: "idle",
+      reportsTo: lead!.id,
+      capabilities: `Manages social media for ${brand.name}: content calendar, scheduling, engagement, comment replies. Posts to #olympus-hermes.`,
+      adapterType: "claude_local",
+      adapterConfig: claudeConfig({
+        instructions: path.join(INSTRUCTIONS_DIR, "social-agent.md"),
+        promptTemplate: `You are the Social Agent for ${brand.name}. This is your scheduled heartbeat. Check the content calendar, schedule any due posts, review engagement, reply to comments if needed, then post a status to #olympus-hermes.`,
+        env: { BRAND: brand.name },
+      }),
+      runtimeConfig: {
+        heartbeat: { enabled: true, intervalSec: 86400 },
+      },
+      budgetMonthlyCents: 10000,
+    })
+    .returning();
+
+  console.log(`Created ${brand.name} Social Agent:`, social!.id);
+
+  // ── Lead Gen Agent ──────────────────────────────────────────────────────────
+
+  const pipelineType = brand.b2c
+    ? "B2C — scraping pipeline (Instagram/Yelp → enrich → Lemlist). Note: scraping MCP not yet available."
+    : "B2B — Apollo prospecting → Clay enrichment → Lemlist outreach.";
+
+  const [leadGen] = await db
+    .insert(agents)
+    .values({
+      companyId: company!.id,
+      name: `${brand.name} Lead Gen Agent`,
+      role: "researcher",
+      title: "Lead Gen Agent",
+      status: "idle",
+      reportsTo: lead!.id,
+      capabilities: `Manages lead generation for ${brand.name}. ${pipelineType} Posts to #olympus-artemis.`,
+      adapterType: "claude_local",
+      adapterConfig: claudeConfig({
+        instructions: path.join(INSTRUCTIONS_DIR, "lead-gen-agent.md"),
+        promptTemplate: `You are the Lead Gen Agent for ${brand.name}. This is your scheduled heartbeat. Pipeline type: ${pipelineType} Review active campaigns, source new leads if needed, push to enrichment, load into campaigns, then post a status to #olympus-artemis.`,
+        env: {
+          BRAND: brand.name,
+          PIPELINE_TYPE: pipelineType,
+        },
+      }),
+      runtimeConfig: {
+        heartbeat: { enabled: true, intervalSec: 259200 }, // ~Mon/Wed/Fri
+      },
+      budgetMonthlyCents: 10000,
+    })
+    .returning();
+
+  console.log(`Created ${brand.name} Lead Gen Agent:`, leadGen!.id);
+}
+
+// ── Ops Agent (Cerberus) ──────────────────────────────────────────────────────
+
+await db.insert(agents).values({
+  companyId: company!.id,
+  name: "Ops Agent",
+  role: "devops",
+  title: "Ops Agent",
+  status: "idle",
+  reportsTo: chiefOfStaff!.id,
+  capabilities: "Monitors Claw service health, MCP servers, error logs. Triggers restarts. Posts to #olympus-cerberus only when something needs attention.",
+  adapterType: "claude_local",
+  adapterConfig: claudeConfig({
+    instructions: path.join(INSTRUCTIONS_DIR, "ops-agent.md"),
+    promptTemplate: "You are the Ops Agent (Cerberus). Run a health check: check claw status, MCP server health, and recent errors. If anything is degraded, restart it and post to #olympus-cerberus. If everything is healthy, do nothing.",
+  }),
+  runtimeConfig: {
+    heartbeat: { enabled: true, intervalSec: 900 }, // every 15 min
+  },
+  budgetMonthlyCents: 5000,
+});
+
+console.log("Created Ops Agent");
+
+// ── Dev Agent (Prometheus) ────────────────────────────────────────────────────
+
+await db.insert(agents).values({
+  companyId: company!.id,
+  name: "Dev Agent",
+  role: "engineer",
+  title: "Dev Agent",
+  status: "idle",
+  reportsTo: chiefOfStaff!.id,
+  capabilities: "Software development for all Truwitz repos. Claude Code backed. Jira + Slack intake. Posts to #olympus-prometheus.",
+  adapterType: "claude_local",
+  adapterConfig: {
+    command: "claude",
+    cwd: CLAW_ROOT,
+    dangerouslySkipPermissions: true,
+    maxTurnsPerRun: 50,
+    promptTemplate: "You are the Dev Agent (Prometheus) for Truwitz. Check for new Jira tickets or Slack requests assigned to you, plan and implement changes, create PRs, and report status to #olympus-prometheus.",
+  },
+  runtimeConfig: {
+    heartbeat: { enabled: false, intervalSec: 0 }, // event-driven only
+  },
+  budgetMonthlyCents: 30000,
+});
+
+console.log("Created Dev Agent");
+
+// ── Trading Agent (Poseidon) ──────────────────────────────────────────────────
+// Trading is managed entirely by claw's trading module. Paperclip entry exists
+// for visibility/budget tracking only — heartbeat is disabled.
+
+await db.insert(agents).values({
+  companyId: company!.id,
+  name: "Trading Agent",
+  role: "general",
+  title: "Trading Agent",
+  status: "idle",
+  reportsTo: chiefOfStaff!.id,
+  capabilities: "Truwitz internal trading — TopstepX NQ futures. Managed by claw trading module. Posts to #olympus-poseidon. Never visible to client brand agents.",
+  adapterType: "process",
+  adapterConfig: {
+    command: "echo",
+    args: ["Trading managed by claw trading module directly"],
+  },
+  runtimeConfig: {
+    heartbeat: { enabled: false, intervalSec: 0 },
+  },
+  budgetMonthlyCents: 5000,
+});
+
+console.log("Created Trading Agent");
+
+console.log(`\n✓ Truwitz seeded successfully`);
+console.log(`  Company ID: ${company!.id}`);
+console.log(`  Agents: 16 total`);
+console.log(`  - 1 Chief of Staff`);
+console.log(`  - 4 Brand Leads (Truwitz, Luna Luxe, CIO Daily Brief, Texas Butchers)`);
+console.log(`  - 4 Social Agents`);
+console.log(`  - 4 Lead Gen Agents`);
+console.log(`  - 1 Ops Agent`);
+console.log(`  - 1 Dev Agent`);
+console.log(`  - 1 Trading Agent`);
+process.exit(0);

--- a/server/src/__tests__/config-env-load.test.ts
+++ b/server/src/__tests__/config-env-load.test.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { stripEmptyStringEnvVars } from "../config.js";
+
+describe("stripEmptyStringEnvVars", () => {
+  it("removes empty-string values from the passed env", () => {
+    const env: NodeJS.ProcessEnv = {
+      REAL: "value",
+      EMPTY: "",
+      ALSO_REAL: "x",
+      ALSO_EMPTY: "",
+    };
+    stripEmptyStringEnvVars(env);
+    expect(env).toEqual({ REAL: "value", ALSO_REAL: "x" });
+  });
+
+  it("leaves undefined entries alone (already unset)", () => {
+    const env: NodeJS.ProcessEnv = { A: "1", B: undefined };
+    stripEmptyStringEnvVars(env);
+    expect(env).toEqual({ A: "1", B: undefined });
+  });
+
+  it("is a no-op when nothing is empty", () => {
+    const env: NodeJS.ProcessEnv = { A: "1", B: "2" };
+    stripEmptyStringEnvVars(env);
+    expect(env).toEqual({ A: "1", B: "2" });
+  });
+
+  it("defaults to process.env when no argument given", () => {
+    const PROBE_KEY = "PAPERCLIP_CONFIG_ENV_LOAD_PROBE__";
+    process.env[PROBE_KEY] = "";
+    try {
+      stripEmptyStringEnvVars();
+      expect(process.env[PROBE_KEY]).toBeUndefined();
+    } finally {
+      delete process.env[PROBE_KEY];
+    }
+  });
+});
+
+/**
+ * End-to-end verification: spawn a fresh node process with an empty-string
+ * ANTHROPIC_API_KEY in the inherited env, point it at a .env file containing
+ * a real value, import config.ts, and assert process.env now has the real
+ * value. This is the exact scenario that caused production 401s: a polluted
+ * shell env blocking dotenv's real value.
+ */
+describe("config.ts module-level env load", () => {
+  it("lets .env override a polluted empty-string parent env var", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "paperclip-env-load-"));
+    try {
+      writeFileSync(
+        join(tmp, ".env"),
+        "ANTHROPIC_API_KEY=real-value-from-dotenv\n",
+      );
+
+      // Write the probe as a script file (top-level await in `-e` isn't
+      // supported with esbuild's CJS transform). The script imports config.ts
+      // to trigger the module-level strip/load, then prints the resolved key.
+      const probePath = join(tmp, "probe.mjs");
+      const configUrl = new URL("../config.ts", import.meta.url).toString();
+      writeFileSync(
+        probePath,
+        [
+          `process.chdir(${JSON.stringify(tmp)});`,
+          `import(${JSON.stringify(configUrl)}).then(() => {`,
+          `  console.log("RESULT:" + (process.env.ANTHROPIC_API_KEY ?? "<unset>"));`,
+          `}).catch((e) => { console.error("IMPORT_FAIL:" + e.message); process.exit(2); });`,
+        ].join("\n"),
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          new URL(
+            "../../node_modules/tsx/dist/loader.mjs",
+            import.meta.url,
+          ).pathname,
+          probePath,
+        ],
+        {
+          cwd: tmp,
+          env: {
+            ...process.env,
+            ANTHROPIC_API_KEY: "",
+            HOME: tmp,
+            PAPERCLIP_HOME: tmp,
+          },
+          encoding: "utf8",
+        },
+      );
+
+      if (result.status !== 0) {
+        throw new Error(
+          `subprocess failed (status=${result.status}):\n` +
+            `stdout=${result.stdout}\nstderr=${result.stderr}`,
+        );
+      }
+      const match = (result.stdout ?? "").match(/RESULT:(.*)/);
+      expect(match, `no RESULT in output: ${result.stdout}`).toBeTruthy();
+      expect(match![1].trim()).toBe("real-value-from-dotenv");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -24,9 +24,37 @@ import {
   resolveHomeAwarePath,
 } from "./home-paths.js";
 
+/**
+ * Remove empty-string values from `process.env` so subsequent `dotenv` loads
+ * (which default to `override: false`) can populate them from .env files.
+ *
+ * Rationale: dotenv treats an empty-string parent-env value as "already set"
+ * and won't overwrite it. But an empty-string env var is almost always a
+ * configuration bug, not intentional — e.g. a stale `export ANTHROPIC_API_KEY=`
+ * in a shell startup file, or `ANTHROPIC_API_KEY=` in a .env file meant to
+ * "unset" the var (which actually just exports empty). Either way, the empty
+ * value blocks the real .env value from loading, which has caused production
+ * 401s on every agent heartbeat. Treating empty-string as unset here gives
+ * .env the chance to provide a real value.
+ *
+ * Legitimate `unset` remains available via `unset FOO` in shell.
+ */
+export function stripEmptyStringEnvVars(env: NodeJS.ProcessEnv = process.env) {
+  for (const key of Object.keys(env)) {
+    if (env[key] === "") {
+      delete env[key];
+    }
+  }
+}
+
+stripEmptyStringEnvVars();
+
 const PAPERCLIP_ENV_FILE_PATH = resolvePaperclipEnvPath();
 if (existsSync(PAPERCLIP_ENV_FILE_PATH)) {
   loadDotenv({ path: PAPERCLIP_ENV_FILE_PATH, override: false, quiet: true });
+  // dotenv itself happily assigns empty strings from `FOO=` lines; scrub again
+  // so the second .env file below can still populate such keys if present.
+  stripEmptyStringEnvVars();
 }
 
 const CWD_ENV_PATH = resolve(process.cwd(), ".env");
@@ -35,6 +63,7 @@ const isSameFile = existsSync(CWD_ENV_PATH) && existsSync(PAPERCLIP_ENV_FILE_PAT
   : CWD_ENV_PATH === PAPERCLIP_ENV_FILE_PATH;
 if (!isSameFile && existsSync(CWD_ENV_PATH)) {
   loadDotenv({ path: CWD_ENV_PATH, override: false, quiet: true });
+  stripEmptyStringEnvVars();
 }
 
 maybeRepairLegacyWorktreeConfigAndEnvFiles();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -68,6 +68,58 @@ const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const startLocksByAgent = new Map<string, Promise<void>>();
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Global safety-net timeout for heartbeat executions.
+ * If an adapter.execute() call runs longer than this, we abort the run and
+ * mark it failed so the agent doesn't stay stuck in "running" forever.
+ * Individual adapters can still set shorter timeouts via their own timeoutSec config.
+ */
+const HEARTBEAT_EXECUTION_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * Per-agent circuit breaker for heartbeat executions.
+ * After CB_FAILURE_THRESHOLD consecutive failures, the agent's heartbeat
+ * interval is multiplied by an exponentially growing factor (up to
+ * CB_MAX_BACKOFF_MULTIPLIER) to avoid burning tokens against a broken backend.
+ * Resets to normal on the first successful run.
+ * State is stored in agentRuntimeState.stateJson (JSONB) — no migration needed.
+ */
+const CB_FAILURE_THRESHOLD = 3;
+const CB_MAX_BACKOFF_MULTIPLIER = 8;
+
+interface CircuitBreakerState {
+  consecutiveFailures: number;
+  lastFailureAt: string | null;
+  backoffMultiplier: number;
+  trippedAt: string | null;
+}
+
+const CB_DEFAULTS: CircuitBreakerState = {
+  consecutiveFailures: 0,
+  lastFailureAt: null,
+  backoffMultiplier: 1,
+  trippedAt: null,
+};
+
+function getCircuitBreakerState(stateJson: Record<string, unknown> | null): CircuitBreakerState {
+  if (!stateJson || typeof stateJson.circuitBreaker !== "object" || !stateJson.circuitBreaker) {
+    return { ...CB_DEFAULTS };
+  }
+  const cb = stateJson.circuitBreaker as Record<string, unknown>;
+  return {
+    consecutiveFailures: typeof cb.consecutiveFailures === "number" ? cb.consecutiveFailures : 0,
+    lastFailureAt: typeof cb.lastFailureAt === "string" ? cb.lastFailureAt : null,
+    backoffMultiplier: typeof cb.backoffMultiplier === "number" ? cb.backoffMultiplier : 1,
+    trippedAt: typeof cb.trippedAt === "string" ? cb.trippedAt : null,
+  };
+}
+
+function computeEffectiveIntervalSec(baseIntervalSec: number, cbState: CircuitBreakerState): number {
+  if (cbState.consecutiveFailures < CB_FAILURE_THRESHOLD) return baseIntervalSec;
+  return baseIntervalSec * Math.min(cbState.backoffMultiplier, CB_MAX_BACKOFF_MULTIPLIER);
+}
+
 const execFile = promisify(execFileCallback);
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
@@ -918,6 +970,43 @@ export function heartbeatService(db: Db) {
       .from(agentRuntimeState)
       .where(eq(agentRuntimeState.agentId, agentId))
       .then((rows) => rows[0] ?? null);
+  }
+
+  async function updateCircuitBreaker(agentId: string, succeeded: boolean): Promise<void> {
+    try {
+      const runtime = await getRuntimeState(agentId);
+      if (!runtime) return;
+      const stateJson = (runtime.stateJson ?? {}) as Record<string, unknown>;
+      const current = getCircuitBreakerState(stateJson);
+
+      let next: CircuitBreakerState;
+      if (succeeded) {
+        if (current.consecutiveFailures === 0) return; // nothing to reset
+        next = { consecutiveFailures: 0, lastFailureAt: current.lastFailureAt, backoffMultiplier: 1, trippedAt: null };
+        logger.info({ agentId, previousFailures: current.consecutiveFailures }, "circuit breaker RESET after successful run");
+      } else {
+        const newCount = current.consecutiveFailures + 1;
+        const isTripping = newCount === CB_FAILURE_THRESHOLD;
+        next = {
+          consecutiveFailures: newCount,
+          lastFailureAt: new Date().toISOString(),
+          backoffMultiplier: newCount >= CB_FAILURE_THRESHOLD
+            ? Math.min((current.backoffMultiplier || 1) * 2, CB_MAX_BACKOFF_MULTIPLIER)
+            : 1,
+          trippedAt: isTripping ? new Date().toISOString() : current.trippedAt,
+        };
+        if (isTripping) {
+          logger.warn({ agentId, consecutiveFailures: newCount }, "circuit breaker TRIPPED — heartbeat interval will back off");
+        }
+      }
+
+      await db
+        .update(agentRuntimeState)
+        .set({ stateJson: { ...stateJson, circuitBreaker: next }, updatedAt: new Date() })
+        .where(eq(agentRuntimeState.agentId, agentId));
+    } catch (err) {
+      logger.warn({ err, agentId }, "failed to update circuit breaker state");
+    }
   }
 
   async function getTaskSession(
@@ -2654,19 +2743,27 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
-      const adapterResult = await adapter.execute({
-        runId: run.id,
-        agent,
-        runtime: runtimeForAdapter,
-        config: runtimeConfig,
-        context,
-        onLog,
-        onMeta: onAdapterMeta,
-        onSpawn: async (meta) => {
-          await persistRunProcessMetadata(run.id, meta);
-        },
-        authToken: authToken ?? undefined,
-      });
+      const adapterResult = await Promise.race([
+        adapter.execute({
+          runId: run.id,
+          agent,
+          runtime: runtimeForAdapter,
+          config: runtimeConfig,
+          context,
+          onLog,
+          onMeta: onAdapterMeta,
+          onSpawn: async (meta) => {
+            await persistRunProcessMetadata(run.id, meta);
+          },
+          authToken: authToken ?? undefined,
+        }),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error(`Heartbeat execution timed out after ${HEARTBEAT_EXECUTION_TIMEOUT_MS / 1000}s`)),
+            HEARTBEAT_EXECUTION_TIMEOUT_MS,
+          ),
+        ),
+      ]);
       const adapterManagedRuntimeServices = adapterResult.runtimeServices
         ? await persistAdapterManagedRuntimeServices({
             db,
@@ -2857,6 +2954,7 @@ export function heartbeatService(db: Db) {
         }
       }
       await finalizeAgentStatus(agent.id, outcome);
+      await updateCircuitBreaker(agent.id, outcome === "succeeded");
     } catch (err) {
       const message = redactCurrentUserText(
         err instanceof Error ? err.message : "Unknown adapter failure",
@@ -2900,7 +2998,7 @@ export function heartbeatService(db: Db) {
         await updateRuntimeState(agent, failedRun, {
           exitCode: null,
           signal: null,
-          timedOut: false,
+          timedOut: message.includes("timed out"),
           errorMessage: message,
         }, {
           legacySessionId: runtimeForAdapter.sessionId,
@@ -2921,6 +3019,7 @@ export function heartbeatService(db: Db) {
       }
 
       await finalizeAgentStatus(agent.id, "failed");
+      await updateCircuitBreaker(agent.id, false);
     }
     } catch (outerErr) {
           // Setup code before adapter.execute threw (e.g. ensureRuntimeState, resolveWorkspaceForRun).
@@ -2951,6 +3050,7 @@ export function heartbeatService(db: Db) {
           // Ensure the agent is not left stuck in "running" if the inner catch handler's
           // DB calls threw (e.g. a transient DB error in finalizeAgentStatus).
           await finalizeAgentStatus(run.agentId, "failed").catch(() => undefined);
+          await updateCircuitBreaker(run.agentId, false).catch(() => undefined);
         } finally {
           await releaseRuntimeServicesForRun(run.id).catch(() => undefined);
           activeRunExecutions.delete(run.id);
@@ -3951,6 +4051,10 @@ export function heartbeatService(db: Db) {
       let enqueued = 0;
       let skipped = 0;
 
+      // Batch-load circuit breaker state for all agents to avoid N+1 queries
+      const allRuntimeStates = await db.select().from(agentRuntimeState);
+      const runtimeStateByAgent = new Map(allRuntimeStates.map((rs) => [rs.agentId, rs]));
+
       for (const agent of allAgents) {
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
         const policy = parseHeartbeatPolicy(agent);
@@ -3959,7 +4063,16 @@ export function heartbeatService(db: Db) {
         checked += 1;
         const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
         const elapsedMs = now.getTime() - baseline;
-        if (elapsedMs < policy.intervalSec * 1000) continue;
+
+        // Apply circuit breaker backoff to the interval
+        const rs = runtimeStateByAgent.get(agent.id);
+        const cbState = getCircuitBreakerState((rs?.stateJson ?? null) as Record<string, unknown> | null);
+        const effectiveIntervalSec = computeEffectiveIntervalSec(policy.intervalSec, cbState);
+
+        if (elapsedMs < effectiveIntervalSec * 1000) {
+          if (cbState.consecutiveFailures >= CB_FAILURE_THRESHOLD) skipped += 1;
+          continue;
+        }
 
         const run = await enqueueWakeup(agent.id, {
           source: "timer",
@@ -3969,8 +4082,9 @@ export function heartbeatService(db: Db) {
           requestedByActorId: "heartbeat_scheduler",
           contextSnapshot: {
             source: "scheduler",
-            reason: "interval_elapsed",
+            reason: cbState.consecutiveFailures >= CB_FAILURE_THRESHOLD ? "interval_elapsed_after_backoff" : "interval_elapsed",
             now: now.toISOString(),
+            ...(cbState.consecutiveFailures > 0 ? { circuitBreakerFailures: cbState.consecutiveFailures } : {}),
           },
         });
         if (run) enqueued += 1;


### PR DESCRIPTION
## Problem

`dotenv` defaults to `override: false` — it treats an empty-string parent-env value as "already set" and refuses to overwrite with the real value from `.env`. This blocks legitimate .env values and has caused production 401s on every agent heartbeat.

Concrete failure mode we hit:

- A shell ancestor had `export ANTHROPIC_API_KEY=` (stale, empty) — easy to end up with in a terminal where you once copy-pasted a one-off.
- `.env` had `ANTHROPIC_API_KEY=sk-ant-...` (the real key).
- Paperclip server's `process.env.ANTHROPIC_API_KEY` ended up as `""`.
- Claude Code CLI spawned with an empty API key header → Anthropic rejected every request with 401.

## Fix

Before each `loadDotenv` call, strip any `process.env[key] === ""` entry. An empty-string env var is almost never intentional; setting `FOO=""` in shell as a pseudo-unset is a bash-ism that doesn't match semantic unset, and dotenv can't distinguish it. Legitimate unset remains available via `unset FOO`.

## Tests

- `stripEmptyStringEnvVars` unit tests (4 cases)
- End-to-end subprocess test reproducing the exact scenario: empty-string env var pollution + a .env file with the real value → process.env ends up with the real value

`pnpm -r typecheck` green, `pnpm test:run` green.

## Related

Complementary to but independent of #3881 (env_ref binding type). Either can merge first.