### PR TITLE
fix(openclaw-gateway): write the claimed Paperclip run token before wake dispatch

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,5 +1,37 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { resolveSessionKey } from "./execute.js";
+
+async function writeClaimedApiKeyFileForTest(claimedApiKeyPath: string, authToken: string): Promise<void> {
+  const module = await import("./execute.js");
+  return (module as unknown as { writeClaimedApiKeyFile: (p: string, t: string) => Promise<void> }).writeClaimedApiKeyFile(
+    claimedApiKeyPath,
+    authToken,
+  );
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("writeClaimedApiKeyFile", () => {
+  it("writes the run token JSON to the configured claimed key path", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-openclaw-gateway-"));
+    tempDirs.push(tempDir);
+    const targetPath = path.join(tempDir, "paperclip-claimed-api-key.json");
+
+    await writeClaimedApiKeyFileForTest(targetPath, "token-123");
+
+    expect(JSON.parse(fs.readFileSync(targetPath, "utf8"))).toEqual({ token: "token-123" });
+  });
+});
 
 describe("resolveSessionKey", () => {
   it("prefixes run-scoped session keys with the configured agent", () => {

--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -2,15 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { resolveSessionKey } from "./execute.js";
-
-async function writeClaimedApiKeyFileForTest(claimedApiKeyPath: string, authToken: string): Promise<void> {
-  const module = await import("./execute.js");
-  return (module as unknown as { writeClaimedApiKeyFile: (p: string, t: string) => Promise<void> }).writeClaimedApiKeyFile(
-    claimedApiKeyPath,
-    authToken,
-  );
-}
+import { resolveSessionKey, writeClaimedApiKeyFile } from "./execute.js";
 
 const tempDirs: string[] = [];
 
@@ -27,9 +19,31 @@ describe("writeClaimedApiKeyFile", () => {
     tempDirs.push(tempDir);
     const targetPath = path.join(tempDir, "paperclip-claimed-api-key.json");
 
-    await writeClaimedApiKeyFileForTest(targetPath, "token-123");
+    await writeClaimedApiKeyFile(targetPath, "token-123");
 
     expect(JSON.parse(fs.readFileSync(targetPath, "utf8"))).toEqual({ token: "token-123" });
+  });
+
+  it("expands tilde-prefixed paths under the current home directory", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-openclaw-home-"));
+    tempDirs.push(tempDir);
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempDir;
+
+    try {
+      const targetPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+      const expandedPath = path.join(tempDir, ".openclaw", "workspace", "paperclip-claimed-api-key.json");
+
+      await writeClaimedApiKeyFile(targetPath, "token-tilde");
+
+      expect(JSON.parse(fs.readFileSync(expandedPath, "utf8"))).toEqual({ token: "token-tilde" });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
   });
 });
 

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -12,6 +12,9 @@ import {
   stringifyPaperclipWakePayload,
 } from "@paperclipai/adapter-utils/server-utils";
 import crypto, { randomUUID } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
 import { WebSocket } from "ws";
 
 type SessionKeyStrategy = "fixed" | "issue" | "run";
@@ -362,8 +365,8 @@ function buildWakeText(
   payload: WakePayload,
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,
+  claimedApiKeyPath: string,
 ): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -441,6 +444,17 @@ function buildWakeText(
     "Complete the workflow in this run.",
   ];
   return lines.join("\n");
+}
+
+export async function writeClaimedApiKeyFile(claimedApiKeyPath: string, authToken: string): Promise<void> {
+  const expandedPath = claimedApiKeyPath.startsWith("~/")
+    ? path.join(os.homedir(), claimedApiKeyPath.slice(2))
+    : claimedApiKeyPath === "~"
+      ? os.homedir()
+      : path.resolve(claimedApiKeyPath);
+
+  await fs.mkdir(path.dirname(expandedPath), { recursive: true });
+  await fs.writeFile(expandedPath, JSON.stringify({ token: authToken }, null, 2) + "\n", "utf8");
 }
 
 function appendWakeText(baseText: string, wakeText: string): string {
@@ -1101,6 +1115,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const wakePayload = buildWakePayload(ctx);
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
+  const claimedApiKeyPath = resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath);
+  if (ctx.authToken && ctx.authToken.trim().length > 0) {
+    await writeClaimedApiKeyFile(claimedApiKeyPath, ctx.authToken.trim());
+  }
   const structuredWakePrompt = renderPaperclipWakePrompt(ctx.context.paperclipWake);
   const structuredWakeJson = stringifyPaperclipWakePayload(ctx.context.paperclipWake);
   const wakeText = buildWakeText(
@@ -1109,6 +1127,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     structuredWakeJson
       ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
       : structuredWakePrompt,
+    claimedApiKeyPath,
   );
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);


### PR DESCRIPTION
Closes #3894

This fixes a mismatch in the OpenClaw gateway adapter.

Right now the local adapters inject `PAPERCLIP_API_KEY` and `PAPERCLIP_RUN_ID` directly into the run environment, but the OpenClaw gateway adapter only mentions the claimed key file in wake text. That means native OpenClaw plugins can get told to load a run-scoped token from disk even when the adapter never wrote the current run token there.

What changed:
- write the current run-scoped Paperclip auth token to the configured claimed API key path before dispatching the wake
- pass the resolved claimed key path into wake text so the instructions stay aligned with what was actually written
- add a focused adapter test that verifies the claimed token file is created with the expected JSON payload

Why this helps:
- native plugins now have a reliable place to read the current run token from during OpenClaw gateway executions
- mutating Paperclip calls stop depending on a stale manually-claimed token file
- keeps the gateway adapter behavior closer to the local adapters, which already inject run-scoped auth directly

Verification:
- `npx pnpm --filter @paperclipai/adapter-openclaw-gateway test`
- `npx pnpm --filter @paperclipai/adapter-openclaw-gateway exec tsc --noEmit`

## Thinking Path
> - Paperclip uses adapters to wake agents across different runtimes while keeping Paperclip-specific auth and context attached to each run.
> - The OpenClaw gateway adapter is the bridge used when Paperclip dispatches work over the OpenClaw WebSocket gateway instead of a local subprocess runtime.
> - Local runtimes like Codex and Claude inject `PAPERCLIP_API_KEY` and `PAPERCLIP_RUN_ID` directly into the child process environment, so native tools can make authenticated Paperclip API calls with the current run context.
> - The gateway adapter did not have that same direct env injection path, so it relied on wake text that told the agent to read a claimed token file from disk.
> - The problem is that the adapter never wrote the current run token to that file, which means native plugins could read a stale token or no token at all.
> - This pull request closes that gap by writing the current run-scoped token to the configured claimed key path before the wake is sent.
> - The benefit is that native OpenClaw plugins get a real, current token source that matches the wake instructions and preserves run-aware mutating API behavior.
