### PR TITLE
fix(db): refuse side-started embedded migration instances

### DIFF
--- a/packages/db/src/migration-runtime.test.ts
+++ b/packages/db/src/migration-runtime.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getEmbeddedPostgresTestSupport } from "./test-embedded-postgres.js";
+import { resolveMigrationConnection } from "./migration-runtime.js";
+
+type EmbeddedPostgresInstance = {
+  initialise(): Promise<void>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+};
+
+type EmbeddedPostgresCtor = new (opts: {
+  databaseDir: string;
+  user: string;
+  password: string;
+  port: number;
+  persistent: boolean;
+  initdbFlags?: string[];
+  onLog?: (message: unknown) => void;
+  onError?: (message: unknown) => void;
+}) => EmbeddedPostgresInstance;
+
+const ORIGINAL_CWD = process.cwd();
+const ORIGINAL_ENV = { ...process.env };
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function getEmbeddedPostgresCtor(): Promise<EmbeddedPostgresCtor> {
+  const mod = await import("embedded-postgres");
+  return mod.default as EmbeddedPostgresCtor;
+}
+
+async function getAvailablePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to allocate test port")));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(port);
+      });
+    });
+  });
+}
+
+afterEach(() => {
+  process.chdir(ORIGINAL_CWD);
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping migration runtime tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("resolveMigrationConnection", () => {
+  it(
+    "refuses to side-start a second embedded postgres when the preferred port belongs to another data dir",
+    async () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-migration-runtime-"));
+      const runningDataDir = path.join(tempRoot, "running-db");
+      const resolvedDataDir = path.join(tempRoot, "resolved-db");
+      const configPath = path.join(tempRoot, "instance", "config.json");
+      const port = await getAvailablePort();
+      const EmbeddedPostgres = await getEmbeddedPostgresCtor();
+      const instance = new EmbeddedPostgres({
+        databaseDir: runningDataDir,
+        user: "paperclip",
+        password: "paperclip",
+        port,
+        persistent: true,
+        initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
+        onLog: () => {},
+        onError: () => {},
+      });
+
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          database: {
+            mode: "embedded-postgres",
+            embeddedPostgresDataDir: resolvedDataDir,
+            embeddedPostgresPort: port,
+          },
+        }, null, 2),
+      );
+
+      process.env.PAPERCLIP_CONFIG = configPath;
+
+      try {
+        await instance.initialise();
+        await instance.start();
+
+        await expect(resolveMigrationConnection()).rejects.toThrow(
+          new RegExp(`Another embedded PostgreSQL instance is already running on port ${port}`),
+        );
+        expect(fs.existsSync(path.join(resolvedDataDir, "PG_VERSION"))).toBe(false);
+      } finally {
+        await instance.stop().catch(() => {});
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+      }
+    },
+    20_000,
+  );
+});

--- a/packages/db/src/migration-runtime.test.ts
+++ b/packages/db/src/migration-runtime.test.ts
@@ -72,6 +72,63 @@ if (!embeddedPostgresSupport.supported) {
 
 describeEmbeddedPostgres("resolveMigrationConnection", () => {
   it(
+    "adopts the running embedded postgres when the preferred port matches the resolved data dir but postmaster.pid is missing",
+    async () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-migration-runtime-"));
+      const dataDir = path.join(tempRoot, "running-db");
+      const configPath = path.join(tempRoot, "instance", "config.json");
+      const postmasterPidPath = path.join(dataDir, "postmaster.pid");
+      const hiddenPidPath = path.join(dataDir, "postmaster.pid.hidden");
+      const port = await getAvailablePort();
+      const EmbeddedPostgres = await getEmbeddedPostgresCtor();
+      const instance = new EmbeddedPostgres({
+        databaseDir: dataDir,
+        user: "paperclip",
+        password: "paperclip",
+        port,
+        persistent: true,
+        initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
+        onLog: () => {},
+        onError: () => {},
+      });
+
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          database: {
+            mode: "embedded-postgres",
+            embeddedPostgresDataDir: dataDir,
+            embeddedPostgresPort: port,
+          },
+        }, null, 2),
+      );
+
+      process.env.PAPERCLIP_CONFIG = configPath;
+
+      try {
+        await instance.initialise();
+        await instance.start();
+
+        fs.renameSync(postmasterPidPath, hiddenPidPath);
+
+        const connection = await resolveMigrationConnection();
+        expect(connection.source).toBe(`embedded-postgres@${port}`);
+        expect(connection.connectionString).toBe(`postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`);
+
+        await connection.stop();
+      } finally {
+        if (fs.existsSync(hiddenPidPath) && !fs.existsSync(postmasterPidPath)) {
+          fs.renameSync(hiddenPidPath, postmasterPidPath);
+        }
+        await instance.stop().catch(() => {});
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+      }
+    },
+    20_000,
+  );
+
+  it(
     "refuses to side-start a second embedded postgres when the preferred port belongs to another data dir",
     async () => {
       const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-migration-runtime-"));
@@ -110,7 +167,7 @@ describeEmbeddedPostgres("resolveMigrationConnection", () => {
         await instance.start();
 
         await expect(resolveMigrationConnection()).rejects.toThrow(
-          new RegExp(`Another embedded PostgreSQL instance is already running on port ${port}`),
+          new RegExp(`Port ${port} is already in use with data_directory=`),
         );
         expect(fs.existsSync(path.join(resolvedDataDir, "PG_VERSION"))).toBe(false);
       } finally {

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -118,9 +118,11 @@ async function ensureEmbeddedPostgresConnection(
   if (!runningPid && await isPortInUse(preferredPort)) {
     const { matchesDataDir, actualDataDir } = await inspectExistingPostgresAtPort(dataDir, preferredPort);
     if (!matchesDataDir) {
-      const actual = actualDataDir ?? "unknown";
+      const detail = actualDataDir
+        ? `with data_directory=${actualDataDir}`
+        : "(unable to query data_directory - the port may be held by a non-PostgreSQL process)";
       throw new Error(
-        `Another embedded PostgreSQL instance is already running on port ${preferredPort} with data_directory=${actual}, but migrations resolved dataDir=${path.resolve(dataDir)}. Refusing to start a side instance; align PAPERCLIP_HOME/PAPERCLIP_CONFIG or stop the running server first.`,
+        `Port ${preferredPort} is already in use ${detail}, but migrations resolved dataDir=${path.resolve(dataDir)}. Refusing to start a side instance; align PAPERCLIP_HOME/PAPERCLIP_CONFIG or stop the running server first.`,
       );
     }
 

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -87,29 +87,61 @@ async function loadEmbeddedPostgresCtor(): Promise<EmbeddedPostgresCtor> {
   }
 }
 
+async function inspectExistingPostgresAtPort(
+  expectedDataDir: string,
+  port: number,
+): Promise<{
+  matchesDataDir: boolean;
+  actualDataDir: string | null;
+}> {
+  const adminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
+  const actualDataDir = await getPostgresDataDirectory(adminConnectionString);
+  return {
+    matchesDataDir:
+      typeof actualDataDir === "string" &&
+      path.resolve(actualDataDir) === path.resolve(expectedDataDir),
+    actualDataDir,
+  };
+}
+
 async function ensureEmbeddedPostgresConnection(
   dataDir: string,
   preferredPort: number,
 ): Promise<MigrationConnection> {
   const EmbeddedPostgres = await loadEmbeddedPostgresCtor();
-  const selectedPort = await findAvailablePort(preferredPort);
   const postmasterPidFile = path.resolve(dataDir, "postmaster.pid");
   const pgVersionFile = path.resolve(dataDir, "PG_VERSION");
   const runningPid = readRunningPostmasterPid(postmasterPidFile);
   const runningPort = readPidFilePort(postmasterPidFile);
-  const preferredAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${preferredPort}/postgres`;
   const logBuffer = createEmbeddedPostgresLogBuffer();
+
+  if (!runningPid && await isPortInUse(preferredPort)) {
+    const { matchesDataDir, actualDataDir } = await inspectExistingPostgresAtPort(dataDir, preferredPort);
+    if (!matchesDataDir) {
+      const actual = actualDataDir ?? "unknown";
+      throw new Error(
+        `Another embedded PostgreSQL instance is already running on port ${preferredPort} with data_directory=${actual}, but migrations resolved dataDir=${path.resolve(dataDir)}. Refusing to start a side instance; align PAPERCLIP_HOME/PAPERCLIP_CONFIG or stop the running server first.`,
+      );
+    }
+
+    await ensurePostgresDatabase(`postgres://paperclip:paperclip@127.0.0.1:${preferredPort}/postgres`, "paperclip");
+    process.emitWarning(
+      `Adopting an existing PostgreSQL instance on port ${preferredPort} for embedded data dir ${dataDir} because postmaster.pid is missing.`,
+    );
+    return {
+      connectionString: `postgres://paperclip:paperclip@127.0.0.1:${preferredPort}/paperclip`,
+      source: `embedded-postgres@${preferredPort}`,
+      stop: async () => {},
+    };
+  }
 
   if (!runningPid && existsSync(pgVersionFile)) {
     try {
-      const actualDataDir = await getPostgresDataDirectory(preferredAdminConnectionString);
-      const matchesDataDir =
-        typeof actualDataDir === "string" &&
-        path.resolve(actualDataDir) === path.resolve(dataDir);
+      const { matchesDataDir } = await inspectExistingPostgresAtPort(dataDir, preferredPort);
       if (!matchesDataDir) {
         throw new Error("reachable postgres does not use the expected embedded data directory");
       }
-      await ensurePostgresDatabase(preferredAdminConnectionString, "paperclip");
+      await ensurePostgresDatabase(`postgres://paperclip:paperclip@127.0.0.1:${preferredPort}/postgres`, "paperclip");
       process.emitWarning(
         `Adopting an existing PostgreSQL instance on port ${preferredPort} for embedded data dir ${dataDir} because postmaster.pid is missing.`,
       );
@@ -134,6 +166,7 @@ async function ensureEmbeddedPostgresConnection(
     };
   }
 
+  const selectedPort = await findAvailablePort(preferredPort);
   const instance = new EmbeddedPostgres({
     databaseDir: dataDir,
     user: "paperclip",


### PR DESCRIPTION
## Thinking Path

> - Paperclip can run against an embedded PostgreSQL instance for local and self-hosted setups.
> - `pnpm db:migrate` relies on `resolveMigrationConnection()` to attach to that database.
> - When the shell resolves a different Paperclip home than the already running server, the migration runtime can currently side-start a second embedded Postgres on the next free port.
> - That makes migrations report success against the wrong database while the live server stays stale.
> - This is an existing bug in the embedded migration path, not new feature work.
> - This pull request makes the runtime refuse that side-start scenario and adds coverage for the mismatched data-dir case.
> - The benefit is safer migrations and clearer operator feedback instead of silent split-brain database state.

## What Changed

- Added a port-in-use adoption/refusal check before starting a new embedded Postgres instance.
- When the preferred port is already serving a different embedded data directory, the migration runtime now throws a clear error instead of starting a second cluster.
- Added an embedded-postgres test covering the mismatched data-dir refusal path.

## Verification

- `pnpm --filter @paperclipai/db exec vitest run src/migration-runtime.test.ts`
- `pnpm --filter @paperclipai/db exec tsc --noEmit`

## Risks

- Low risk. This only changes the embedded migration startup path and makes an unsafe fallback fail fast with a clearer error.

## Model Used

- OpenAI Codex `gpt-5.4` with local code execution and repository inspection.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
