### PR TITLE
fix(adapter-utils): bound codex_local session compaction defaults

### DIFF
--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -54,8 +54,8 @@ export const ADAPTER_SESSION_MANAGEMENT: Record<string, AdapterSessionManagement
   },
   codex_local: {
     supportsSessionResume: true,
-    nativeContextManagement: "confirmed",
-    defaultSessionCompaction: ADAPTER_MANAGED_SESSION_POLICY,
+    nativeContextManagement: "unknown",
+    defaultSessionCompaction: DEFAULT_SESSION_COMPACTION_POLICY,
   },
   cursor: {
     supportsSessionResume: true,

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -456,13 +456,7 @@ describe("prioritizeProjectWorkspaceCandidatesForRun", () => {
 });
 
 describe("parseSessionCompactionPolicy", () => {
-  it("disables Paperclip-managed rotation by default for codex and claude local", () => {
-    expect(parseSessionCompactionPolicy(buildAgent("codex_local"))).toEqual({
-      enabled: true,
-      maxSessionRuns: 0,
-      maxRawInputTokens: 0,
-      maxSessionAgeHours: 0,
-    });
+  it("disables Paperclip-managed rotation by default for claude local", () => {
     expect(parseSessionCompactionPolicy(buildAgent("claude_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 0,
@@ -471,7 +465,13 @@ describe("parseSessionCompactionPolicy", () => {
     });
   });
 
-  it("keeps conservative defaults for adapters without confirmed native compaction", () => {
+  it("keeps conservative defaults for codex_local and adapters without confirmed native compaction", () => {
+    expect(parseSessionCompactionPolicy(buildAgent("codex_local"))).toEqual({
+      enabled: true,
+      maxSessionRuns: 200,
+      maxRawInputTokens: 2_000_000,
+      maxSessionAgeHours: 72,
+    });
     expect(parseSessionCompactionPolicy(buildAgent("cursor"))).toEqual({
       enabled: true,
       maxSessionRuns: 200,

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -502,7 +502,7 @@ describe("parseSessionCompactionPolicy", () => {
       enabled: true,
       maxSessionRuns: 25,
       maxRawInputTokens: 500_000,
-      maxSessionAgeHours: 0,
+      maxSessionAgeHours: 72,
     });
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Long-running heartbeats rely on adapter session compaction defaults to decide when Paperclip should rotate a reused session.
> - `codex_local` is currently marked as having confirmed native context management in `@paperclipai/adapter-utils`.
> - That default disables Paperclip-managed rotation thresholds, so a reused Codex session can keep growing without a bounded safety valve.
> - Issue #3813 shows this is happening in production, with `rawInputTokens` growing into the hundreds of millions before any rotation occurs.
> - This pull request restores conservative default thresholds for `codex_local` and updates the existing heartbeat session regression expectations around that contract.

## What Changed

- Changed `codex_local` session management defaults in `packages/adapter-utils/src/session-compaction.ts` from adapter-managed rotation to the standard conservative Paperclip thresholds.
- Updated `server/src/__tests__/heartbeat-workspace-session.test.ts` so the existing regression coverage now expects bounded defaults for `codex_local` while leaving `claude_local` on adapter-managed rotation.

## Verification

- `pnpm install`
- `pnpm --filter @paperclipai/adapter-utils exec tsc --noEmit`
- Ran a one-off `node --experimental-strip-types` assertion script to verify both behaviors:
  - default `codex_local` policy resolves to `enabled=true`, `maxSessionRuns=200`, `maxRawInputTokens=2_000_000`, `maxSessionAgeHours=72`
  - explicit `heartbeat.sessionCompaction` overrides still win over the new default
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-workspace-session.test.ts` currently hits an existing baseline import failure in this checkout: `TypeError: undefined is not an object (evaluating 'z.string')` from `packages/shared/src/adapter-type.ts`

## Risks

- Low risk: this only changes the default rotation policy for `codex_local`; it does not affect adapters that still report confirmed native context management.
- Behavior change: long-lived Codex sessions will rotate sooner under default settings, which is the intended guardrail for the unbounded growth reported in #3813.
- Explicit per-agent `heartbeat.sessionCompaction` overrides still win over the new default and were re-validated during local verification.

## Model Used

- OpenAI Codex (GPT-5.4 class coding agent), medium reasoning, terminal/git/gh tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
