### PR TITLE
fix(server): support lan bind on IPv6-only deployments

### DIFF
--- a/cli/src/__tests__/network-bind.test.ts
+++ b/cli/src/__tests__/network-bind.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveRuntimeBind, validateConfiguredBindMode } from "@paperclipai/shared";
+import { resolveRuntimeBind, validateConfiguredBindMode } from "@paperclipai/shared/network-bind";
 import { buildPresetServerConfig } from "../config/server-bind.js";
 
 describe("network bind helpers", () => {
@@ -12,6 +12,16 @@ describe("network bind helpers", () => {
         host: "0.0.0.0",
       }),
     ).toContain("local_trusted requires server.bind=loopback");
+  });
+
+  it("resolves lan bind to the IPv6 all-interfaces host", () => {
+    const resolved = resolveRuntimeBind({
+      bind: "lan",
+      host: "0.0.0.0",
+    });
+
+    expect(resolved.errors).toEqual([]);
+    expect(resolved.host).toBe("::");
   });
 
   it("resolves tailnet bind using the detected tailscale address", () => {

--- a/cli/src/config/server-bind.ts
+++ b/cli/src/config/server-bind.ts
@@ -5,10 +5,8 @@ import {
   inferBindModeFromHost,
   isAllInterfacesHost,
   isLoopbackHost,
-  type BindMode,
-  type DeploymentExposure,
-  type DeploymentMode,
-} from "@paperclipai/shared";
+} from "@paperclipai/shared/network-bind";
+import type { BindMode, DeploymentExposure, DeploymentMode } from "@paperclipai/shared/constants";
 import type { AuthConfig, ServerConfig } from "./schema.js";
 
 const TAILSCALE_DETECT_TIMEOUT_MS = 3000;

--- a/packages/shared/src/network-bind.ts
+++ b/packages/shared/src/network-bind.ts
@@ -1,7 +1,7 @@
 import type { BindMode, DeploymentExposure, DeploymentMode } from "./constants.js";
 
 export const LOOPBACK_BIND_HOST = "127.0.0.1";
-export const ALL_INTERFACES_BIND_HOST = "0.0.0.0";
+export const ALL_INTERFACES_BIND_HOST = "::";
 
 function normalizeHost(host: string | null | undefined): string | undefined {
   const trimmed = host?.trim();

--- a/server/src/board-claim.ts
+++ b/server/src/board-claim.ts
@@ -68,7 +68,7 @@ export async function initializeBoardClaimChallenge(
 export function getBoardClaimWarningUrl(host: string, port: number): string | null {
   if (!activeChallenge) return null;
   if (activeChallenge.claimedAt || activeChallenge.expiresAt.getTime() <= Date.now()) return null;
-  const visibleHost = host === "0.0.0.0" ? "localhost" : host;
+  const visibleHost = host === "0.0.0.0" || host === "::" ? "localhost" : host;
   return `http://${visibleHost}:${port}/board-claim/${activeChallenge.token}?code=${activeChallenge.code}`;
 }
 

--- a/server/src/startup-banner.ts
+++ b/server/src/startup-banner.ts
@@ -98,7 +98,7 @@ function resolveAgentJwtSecretStatus(
 }
 
 export function printStartupBanner(opts: StartupBannerOptions): void {
-  const baseHost = opts.host === "0.0.0.0" ? "localhost" : opts.host;
+  const baseHost = opts.host === "0.0.0.0" || opts.host === "::" ? "localhost" : opts.host;
   const baseUrl = `http://${baseHost}:${opts.listenPort}`;
   const apiUrl = `${baseUrl}/api`;
   const uiUrl = opts.uiMode === "none" ? "disabled" : baseUrl;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Remote deployments rely on the server bind presets to decide which network interfaces the control plane listens on.
> - The `lan` preset is meant to expose Paperclip on all interfaces, but `ALL_INTERFACES_BIND_HOST` is currently hardcoded to the IPv4-only host `0.0.0.0`.
> - Issue #3832 shows that this breaks IPv6-only deployments because the server never binds to a reachable IPv6 socket.
> - This pull request switches the shared all-interfaces bind host to `::` so `lan` keeps working on IPv6-only machines while still covering dual-stack hosts.
> - It also keeps the startup and board-claim URLs readable by mapping both wildcard hosts to `localhost` in user-facing output.

## What Changed

- Changed `ALL_INTERFACES_BIND_HOST` in `packages/shared/src/network-bind.ts` from `0.0.0.0` to `::` so the `lan` preset resolves to an IPv6-capable wildcard bind host.
- Updated the startup banner and board-claim warning URL helpers to treat both `0.0.0.0` and `::` as `localhost` for display.
- Narrowed the CLI bind helper imports to the specific shared submodules used there.
- Added regression coverage in `cli/src/__tests__/network-bind.test.ts` for `resolveRuntimeBind({ bind: "lan" })`.

## Verification

- `git diff --check`
- `./node_modules/.bin/tsc -p packages/shared/tsconfig.json --noEmit`
- `node --experimental-strip-types --input-type=module -e "import { ALL_INTERFACES_BIND_HOST, resolveRuntimeBind } from './packages/shared/src/network-bind.ts'; const lan = resolveRuntimeBind({ bind: 'lan', host: '0.0.0.0' }); console.log('ALL_INTERFACES_BIND_HOST=' + ALL_INTERFACES_BIND_HOST); console.log(JSON.stringify(lan));"`
  - Observed `ALL_INTERFACES_BIND_HOST=::`
  - Observed `{"bind":"lan","host":"::","errors":[]}`
- `node ./node_modules/vitest/vitest.mjs run cli/src/__tests__/network-bind.test.ts`
  - In this detached worktree, the test runner still resolves `@paperclipai/shared/network-bind` through the main checkout's workspace links, so it reports the pre-change `0.0.0.0` behavior instead of this branch's source. CI should validate the real workspace wiring on the branch.

## Risks

- Low risk: this only changes the wildcard host used by the existing `lan` bind preset.
- Behavior change: `lan` now prefers the IPv6 wildcard host `::`, which is required for IPv6-only deployments and still works for dual-stack hosts.
- User-facing URLs remain unchanged because the startup banner and claim flow still render wildcard binds as `localhost`.

## Model Used

- OpenAI Codex, GPT-5.4 class coding agent, medium reasoning, terminal/git/gh tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
