### PR TITLE
[codex] Route Ollama Cloud through direct adapter

### DIFF
--- a/doc/plans/2026-04-06-smart-model-routing.md
+++ b/doc/plans/2026-04-06-smart-model-routing.md
@@ -56,6 +56,14 @@ That separation is a better fit for Paperclip than copying Hermes' exact keyword
 
 Paperclip already has the right execution shape for adapter-specific routing, but it currently assumes one model per heartbeat run.
 
+2026-04-17 Sigma5C update:
+
+- `opencode_local` now treats `ollama/*` models as a direct Ollama Cloud lane by default.
+- Direct Ollama execution calls `/api/generate` and can be disabled per agent with `useDirectOllamaApi=false`.
+- The direct path exists because OpenCode model discovery works locally while `opencode run --model ollama/...` has stalled during production Paperclip heartbeats.
+- Direct Ollama runs are still single-model Paperclip runs. Codex peer-review pairing is enforced in The Bridge comms dispatch path; Paperclip's future segmented-execution contract is still needed before Paperclip can truthfully represent an Ollama-plus-Codex heartbeat as one routed run.
+- Sigma5C live recurring routines that had been assigned to Claude were reassigned to Codex on 2026-04-17 to reduce Claude Code usage while preserving operational execution capability.
+
 Current implementation facts:
 
 - `server/src/services/heartbeat.ts` builds rich run context, including `paperclipWake`, workspace metadata, and session handoff context

--- a/doc/plans/2026-04-06-smart-model-routing.md
+++ b/doc/plans/2026-04-06-smart-model-routing.md
@@ -61,7 +61,7 @@ Paperclip already has the right execution shape for adapter-specific routing, bu
 - `opencode_local` now treats `ollama/*` models as a direct Ollama Cloud lane by default.
 - Direct Ollama execution calls `/api/generate` and can be disabled per agent with `useDirectOllamaApi=false`.
 - The direct path exists because OpenCode model discovery works locally while `opencode run --model ollama/...` has stalled during production Paperclip heartbeats.
-- Direct Ollama runs are still single-model Paperclip runs. Codex peer-review pairing is enforced in The Bridge comms dispatch path; Paperclip's future segmented-execution contract is still needed before Paperclip can truthfully represent an Ollama-plus-Codex heartbeat as one routed run.
+- Direct Ollama runs are still single-model Paperclip runs. Bound issue updates are recorded as `in_review`, not `done`, until Codex peer review completes; full pairing is enforced in The Bridge comms dispatch path. Paperclip's future segmented-execution contract is still needed before Paperclip can truthfully represent an Ollama-plus-Codex heartbeat as one routed run.
 - Sigma5C live recurring routines that had been assigned to Claude were reassigned to Codex on 2026-04-17 to reduce Claude Code usage while preserving operational execution capability.
 
 Current implementation facts:

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -30,6 +30,9 @@ Core fields:
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
 - model (string, required): OpenCode model id in provider/model format (for example anthropic/claude-sonnet-4-5)
 - variant (string, optional): provider-specific reasoning/profile variant passed as --variant (for example minimal|low|medium|high|xhigh|max)
+- useDirectOllamaApi (boolean, optional): for ollama/* models, call Ollama /api/generate directly instead of OpenCode; defaults to true
+- ollamaApiBaseUrl (string, optional): direct Ollama API base URL; defaults to OLLAMA_HOST or http://127.0.0.1:11434
+- ollamaTimeoutSec (number, optional): direct Ollama API timeout; defaults to timeoutSec or 420
 - dangerouslySkipPermissions (boolean, optional): inject a runtime OpenCode config that allows \`external_directory\` access without interactive prompts; defaults to true for unattended Paperclip runs
 - promptTemplate (string, optional): run prompt template
 - command (string, optional): defaults to "opencode"
@@ -46,6 +49,7 @@ Notes:
 - Paperclip requires an explicit \`model\` value for \`opencode_local\` agents.
 - Runs are executed with: opencode run --format json ...
 - Sessions are resumed with --session when stored session cwd matches current cwd.
+- ollama/* models use the direct Ollama API by default so cloud-model review lanes keep working when OpenCode provider streaming stalls.
 - The adapter sets OPENCODE_DISABLE_PROJECT_CONFIG=true to prevent OpenCode from \
   writing an opencode.json config file into the project working directory. Model \
   selection is passed via the --model CLI flag instead.

--- a/packages/adapters/opencode-local/src/server/execute.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.test.ts
@@ -229,4 +229,73 @@ describe("opencode_local execute cwd selection", () => {
     expect(result.usage).toEqual({ inputTokens: 7, outputTokens: 3, cachedInputTokens: 0 });
     expect(logs.join("")).toContain("hello");
   });
+
+  it("records bound direct Ollama issues as in review for Codex peer review", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/generate")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ response: "security review notes" }),
+        };
+      }
+      if (url.endsWith("/api/issues/issue-4")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => "{}",
+        };
+      }
+      throw new Error(`unexpected fetch ${url} ${init?.method ?? ""}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await execute({
+      runId: "run-4",
+      agent: {
+        id: "agent-4",
+        companyId: "company-1",
+        name: "Ollama Agent",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "opencode",
+        model: "ollama/glm-4.7:cloud",
+        cwd: "/legacy/home-root",
+        ollamaApiBaseUrl: "http://127.0.0.1:11434",
+        env: {
+          PAPERCLIP_API_URL: "http://paperclip.local",
+        },
+      },
+      context: {
+        issueId: "issue-4",
+        paperclipWorkspace: {
+          cwd: "/paperclip/fallback-workspace",
+          source: "agent_home",
+        },
+      },
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "token-4",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "http://paperclip.local/api/issues/issue-4",
+      expect.objectContaining({
+        method: "PATCH",
+        body: expect.stringContaining('"status":"in_review"'),
+      }),
+    );
+    const updateBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body ?? "{}"));
+    expect(updateBody.comment).toContain("Codex peer review");
+  });
 });

--- a/packages/adapters/opencode-local/src/server/execute.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let lastRunChildProcessCall: {
+  cwd: string;
+  env: Record<string, string>;
+} | null = null;
+
+vi.mock("@paperclipai/adapter-utils", () => ({
+  inferOpenAiCompatibleBiller: () => null,
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", () => ({
+  asString: (value: unknown, fallback = "") => (typeof value === "string" ? value : fallback),
+  asNumber: (value: unknown, fallback = 0) => (typeof value === "number" ? value : fallback),
+  asStringArray: (value: unknown) =>
+    Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [],
+  parseObject: (value: unknown) =>
+    typeof value === "object" && value !== null && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {},
+  buildPaperclipEnv: () => ({}),
+  joinPromptSections: (sections: string[]) => sections.filter(Boolean).join("\n\n"),
+  buildInvocationEnvForLogs: () => ({}),
+  ensureAbsoluteDirectory: vi.fn(async () => {}),
+  ensureCommandResolvable: vi.fn(async () => {}),
+  ensurePaperclipSkillSymlink: vi.fn(async () => "skipped"),
+  ensurePathInEnv: (env: Record<string, string>) => env,
+  resolveCommandForLogs: vi.fn(async (command: string) => command),
+  renderTemplate: (template: string) => template,
+  renderPaperclipWakePrompt: () => "",
+  stringifyPaperclipWakePayload: () => "",
+  runChildProcess: vi.fn(async (_runId: string, _command: string, _args: string[], opts: {
+    cwd: string;
+    env: Record<string, string>;
+  }) => {
+    lastRunChildProcessCall = { cwd: opts.cwd, env: opts.env };
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+    };
+  }),
+  readPaperclipRuntimeSkillEntries: vi.fn(async () => []),
+  resolvePaperclipDesiredSkillNames: vi.fn(() => []),
+  removeMaintainerOnlySkillSymlinks: vi.fn(async () => []),
+}));
+
+vi.mock("./models.js", () => ({
+  ensureOpenCodeModelConfiguredAndAvailable: vi.fn(async () => {}),
+}));
+
+vi.mock("./runtime-config.js", () => ({
+  prepareOpenCodeRuntimeConfig: vi.fn(async ({ env }: { env: Record<string, string> }) => ({
+    env,
+    notes: [],
+    cleanup: async () => {},
+  })),
+}));
+
+vi.mock("./parse.js", () => ({
+  parseOpenCodeJsonl: vi.fn(() => ({
+    sessionId: null,
+    summary: "",
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+    },
+    costUsd: 0,
+    errorMessage: null,
+  })),
+  isOpenCodeUnknownSessionError: vi.fn(() => false),
+}));
+
+import { execute } from "./execute.js";
+
+describe("opencode_local execute cwd selection", () => {
+  beforeEach(() => {
+    lastRunChildProcessCall = null;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the Paperclip-resolved agent_home workspace before legacy adapter cwd", async () => {
+    await execute({
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Agent",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "opencode",
+        model: "ollama/glm-4.7:cloud",
+        useDirectOllamaApi: false,
+        cwd: "/legacy/home-root",
+      },
+      context: {
+        taskId: "issue-1",
+        paperclipWorkspace: {
+          cwd: "/paperclip/fallback-workspace",
+          source: "agent_home",
+        },
+      },
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "token-1",
+    });
+
+    expect(lastRunChildProcessCall).not.toBeNull();
+    expect(lastRunChildProcessCall?.cwd).toBe("/paperclip/fallback-workspace");
+    expect(lastRunChildProcessCall?.env.PAPERCLIP_WORKSPACE_CWD).toBe("/paperclip/fallback-workspace");
+  });
+
+  it("falls back to adapter cwd when Paperclip did not resolve a workspace", async () => {
+    await execute({
+      runId: "run-2",
+      agent: {
+        id: "agent-2",
+        companyId: "company-1",
+        name: "OpenCode Agent",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "opencode",
+        model: "ollama/glm-4.7:cloud",
+        useDirectOllamaApi: false,
+        cwd: "/legacy/home-root",
+      },
+      context: {
+        taskId: "issue-2",
+        paperclipWorkspace: {
+          source: "agent_home",
+        },
+      },
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "token-2",
+    });
+
+    expect(lastRunChildProcessCall).not.toBeNull();
+    expect(lastRunChildProcessCall?.cwd).toBe("/legacy/home-root");
+    expect(lastRunChildProcessCall?.env.PAPERCLIP_WORKSPACE_CWD).toBeUndefined();
+  });
+
+  it("uses the direct Ollama API by default for ollama provider models", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          response: "hello",
+          prompt_eval_count: 7,
+          eval_count: 3,
+        }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const logs: string[] = [];
+    const result = await execute({
+      runId: "run-3",
+      agent: {
+        id: "agent-3",
+        companyId: "company-1",
+        name: "OpenCode Agent",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "opencode",
+        model: "ollama/glm-4.7:cloud",
+        cwd: "/legacy/home-root",
+        ollamaApiBaseUrl: "http://127.0.0.1:11434",
+      },
+      context: {
+        taskId: "issue-3",
+        paperclipWorkspace: {
+          cwd: "/paperclip/fallback-workspace",
+          source: "agent_home",
+        },
+      },
+      onLog: async (_stream, chunk) => {
+        logs.push(chunk);
+      },
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "token-3",
+    });
+
+    expect(lastRunChildProcessCall).toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:11434/api/generate",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"model":"glm-4.7:cloud"'),
+      }),
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.provider).toBe("ollama");
+    expect(result.model).toBe("ollama/glm-4.7:cloud");
+    expect(result.summary).toBe("hello");
+    expect(result.usage).toEqual({ inputTokens: 7, outputTokens: 3, cachedInputTokens: 0 });
+    expect(logs.join("")).toContain("hello");
+  });
+});

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -27,6 +27,12 @@ import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
 import { removeMaintainerOnlySkillSymlinks } from "@paperclipai/adapter-utils/server-utils";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
+import {
+  parseOllamaModelId,
+  resolveOllamaBaseUrl,
+  runDirectOllamaGenerate,
+  shouldUseDirectOllamaApi,
+} from "./ollama-direct.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -48,6 +54,48 @@ function parseModelProvider(model: string | null): string | null {
 
 function resolveOpenCodeBiller(env: Record<string, string>, provider: string | null): string {
   return inferOpenAiCompatibleBiller(env, null) ?? provider ?? "unknown";
+}
+
+async function finalizeDirectOllamaPaperclipIssue(input: {
+  context: Record<string, unknown>;
+  runtimeEnv: Record<string, string>;
+  runId: string;
+  responseText: string;
+  onLog: AdapterExecutionContext["onLog"];
+}) {
+  const issueId =
+    asString(input.context.issueId, "").trim() ||
+    asString(input.context.taskId, "").trim();
+  const apiUrl = (input.runtimeEnv.PAPERCLIP_API_URL ?? "").trim().replace(/\/+$/, "");
+  const apiKey = (input.runtimeEnv.PAPERCLIP_API_KEY ?? "").trim();
+  if (!issueId || !apiUrl || !apiKey || !input.responseText.trim()) return;
+
+  try {
+    const response = await fetch(`${apiUrl}/api/issues/${encodeURIComponent(issueId)}`, {
+      method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "X-Paperclip-Run-Id": input.runId,
+      },
+      body: JSON.stringify({
+        status: "done",
+        comment: `Ollama Cloud direct result:\n\n${input.responseText.trim().slice(0, 3000)}`,
+      }),
+    });
+    if (!response.ok) {
+      const detail = await response.text();
+      await input.onLog(
+        "stderr",
+        `[paperclip] Direct Ollama issue finalization failed (${response.status}): ${detail.slice(0, 500)}\n`,
+      );
+    }
+  } catch (err) {
+    await input.onLog(
+      "stderr",
+      `[paperclip] Direct Ollama issue finalization failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
 }
 
 function claudeSkillsHome(): string {
@@ -116,8 +164,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const effectiveWorkspaceCwd = workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const openCodeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
@@ -190,20 +237,28 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         (entry): entry is [string, string] => typeof entry[1] === "string",
       ),
     );
-    await ensureCommandResolvable(command, cwd, runtimeEnv);
-    const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
+    const useDirectOllamaApi = shouldUseDirectOllamaApi(config, model);
+    if (!useDirectOllamaApi) {
+      await ensureCommandResolvable(command, cwd, runtimeEnv);
+    }
+    const ollamaBaseUrl = useDirectOllamaApi ? resolveOllamaBaseUrl(config, runtimeEnv) : "";
+    const resolvedCommand = useDirectOllamaApi
+      ? `${ollamaBaseUrl}/api/generate`
+      : await resolveCommandForLogs(command, cwd, runtimeEnv);
     const loggedEnv = buildInvocationEnvForLogs(preparedRuntimeConfig.env, {
       runtimeEnv,
       includeRuntimeKeys: ["HOME"],
       resolvedCommand,
     });
 
-    await ensureOpenCodeModelConfiguredAndAvailable({
-      model,
-      command,
-      cwd,
-      env: runtimeEnv,
-    });
+    if (!useDirectOllamaApi) {
+      await ensureOpenCodeModelConfiguredAndAvailable({
+        model,
+        command,
+        cwd,
+        env: runtimeEnv,
+      });
+    }
 
     const timeoutSec = asNumber(config.timeoutSec, 0);
     const graceSec = asNumber(config.graceSec, 20);
@@ -250,6 +305,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     const commandNotes = (() => {
       const notes = [...preparedRuntimeConfig.notes];
+      if (useDirectOllamaApi) {
+        notes.push(
+          "Using direct Ollama /api/generate for ollama/* model execution; set useDirectOllamaApi=false to force OpenCode.",
+        );
+      }
       if (!resolvedInstructionsFilePath) return notes;
       if (instructionsPrefix.length > 0) {
         notes.push(`Loaded agent instructions from ${resolvedInstructionsFilePath}`);
@@ -297,6 +357,89 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       sessionHandoffChars: sessionHandoffNote.length,
       heartbeatPromptChars: renderedPrompt.length,
     };
+
+    if (useDirectOllamaApi) {
+      const ollamaModel = parseOllamaModelId(model);
+      const directTimeoutSec = asNumber(
+        config.ollamaTimeoutSec,
+        timeoutSec > 0 ? timeoutSec : 420,
+      );
+      if (onMeta) {
+        await onMeta({
+          adapterType: "opencode_local",
+          command: resolvedCommand,
+          cwd,
+          commandNotes,
+          commandArgs: [`model=${ollamaModel ?? model}`, `<prompt ${prompt.length} chars>`],
+          env: loggedEnv,
+          prompt,
+          promptMetrics,
+          context,
+        });
+      }
+      if (!ollamaModel) {
+        return {
+          exitCode: 2,
+          signal: null,
+          timedOut: false,
+          errorMessage: `Direct Ollama execution requires an ollama/<model> id; got ${model || "(empty)"}`,
+          provider: "ollama",
+          biller: "ollama",
+          model: model || null,
+          billingType: "subscription_included",
+          costUsd: 0,
+          resultJson: { stdout: "", stderr: "Invalid Ollama model id" },
+          summary: null,
+        };
+      }
+
+      const direct = await runDirectOllamaGenerate({
+        baseUrl: ollamaBaseUrl,
+        model: ollamaModel,
+        prompt,
+        timeoutSec: directTimeoutSec,
+      });
+      if (direct.responseText) {
+        await onLog("stdout", `${direct.responseText}\n`);
+      }
+      if (direct.errorMessage) {
+        await onLog("stderr", `[paperclip] Direct Ollama execution failed: ${direct.errorMessage}\n`);
+      }
+      if (direct.ok) {
+        await finalizeDirectOllamaPaperclipIssue({
+          context,
+          runtimeEnv,
+          runId,
+          responseText: direct.responseText,
+          onLog,
+        });
+      }
+      return {
+        exitCode: direct.ok ? 0 : direct.timedOut ? null : 1,
+        signal: null,
+        timedOut: direct.timedOut,
+        errorMessage: direct.ok ? null : direct.errorMessage ?? "Direct Ollama execution failed",
+        usage: {
+          inputTokens: direct.usage.inputTokens,
+          outputTokens: direct.usage.outputTokens,
+          cachedInputTokens: 0,
+        },
+        sessionId: runtime.sessionId ?? null,
+        sessionParams: parseObject(runtime.sessionParams),
+        sessionDisplayId: runtime.sessionDisplayId ?? runtime.sessionId ?? null,
+        provider: "ollama",
+        biller: "ollama",
+        model,
+        billingType: "subscription_included",
+        costUsd: 0,
+        resultJson: {
+          stdout: direct.responseText,
+          stderr: direct.errorMessage ?? "",
+          ollama: direct.rawJson ?? {},
+        },
+        summary: direct.responseText,
+      };
+    }
 
     const buildArgs = (resumeSessionId: string | null) => {
       const args = ["run", "--format", "json"];

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -56,7 +56,7 @@ function resolveOpenCodeBiller(env: Record<string, string>, provider: string | n
   return inferOpenAiCompatibleBiller(env, null) ?? provider ?? "unknown";
 }
 
-async function finalizeDirectOllamaPaperclipIssue(input: {
+async function recordDirectOllamaPaperclipIssue(input: {
   context: Record<string, unknown>;
   runtimeEnv: Record<string, string>;
   runId: string;
@@ -79,8 +79,8 @@ async function finalizeDirectOllamaPaperclipIssue(input: {
         "X-Paperclip-Run-Id": input.runId,
       },
       body: JSON.stringify({
-        status: "done",
-        comment: `Ollama Cloud direct result:\n\n${input.responseText.trim().slice(0, 3000)}`,
+        status: "in_review",
+        comment: `Ollama Cloud direct result recorded for Codex peer review before completion:\n\n${input.responseText.trim().slice(0, 3000)}`,
       }),
     });
     if (!response.ok) {
@@ -406,7 +406,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         await onLog("stderr", `[paperclip] Direct Ollama execution failed: ${direct.errorMessage}\n`);
       }
       if (direct.ok) {
-        await finalizeDirectOllamaPaperclipIssue({
+        await recordDirectOllamaPaperclipIssue({
           context,
           runtimeEnv,
           runId,

--- a/packages/adapters/opencode-local/src/server/ollama-direct.ts
+++ b/packages/adapters/opencode-local/src/server/ollama-direct.ts
@@ -1,0 +1,164 @@
+export interface OllamaGenerateResult {
+  ok: boolean;
+  timedOut: boolean;
+  responseText: string;
+  rawJson: Record<string, unknown> | null;
+  statusCode?: number;
+  errorMessage?: string;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+function readString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function readNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["1", "true", "yes", "y", "on"].includes(normalized)) return true;
+    if (["0", "false", "no", "n", "off"].includes(normalized)) return false;
+  }
+  return fallback;
+}
+
+function parseObject(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function parseOllamaModelId(model: string | null | undefined): string | null {
+  const trimmed = (model ?? "").trim();
+  if (!trimmed) return null;
+  if (!trimmed.includes("/")) return null;
+  const provider = trimmed.slice(0, trimmed.indexOf("/")).trim().toLowerCase();
+  const modelId = trimmed.slice(trimmed.indexOf("/") + 1).trim();
+  return provider === "ollama" && modelId ? modelId : null;
+}
+
+export function shouldUseDirectOllamaApi(config: Record<string, unknown>, model: string): boolean {
+  if (!parseOllamaModelId(model)) return false;
+  const explicit =
+    config.useDirectOllamaApi ?? config.directOllamaApi ?? config.directOllama ?? config.useOllamaApi;
+  return readBoolean(explicit, true);
+}
+
+export function resolveOllamaBaseUrl(
+  config: Record<string, unknown>,
+  env: Record<string, string>,
+): string {
+  const configured =
+    readString(config.ollamaApiBaseUrl).trim() ||
+    readString(config.ollamaBaseUrl).trim() ||
+    readString(config.ollamaHost).trim() ||
+    env.OLLAMA_HOST ||
+    process.env.OLLAMA_HOST ||
+    "http://127.0.0.1:11434";
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(configured)
+    ? configured
+    : `http://${configured}`;
+  return withScheme.replace(/\/+$/, "");
+}
+
+function compactError(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  const rec = parseObject(value);
+  const message = readString(rec.message).trim();
+  if (message) return message;
+  const error = readString(rec.error).trim();
+  if (error) return error;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+function parseJson(text: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(text);
+    return parseObject(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export async function runDirectOllamaGenerate(input: {
+  baseUrl: string;
+  model: string;
+  prompt: string;
+  timeoutSec: number;
+}): Promise<OllamaGenerateResult> {
+  const timeoutMs = Math.max(1, input.timeoutSec) * 1000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  if (typeof timer.unref === "function") timer.unref();
+
+  try {
+    const response = await fetch(`${input.baseUrl}/api/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: input.model,
+        prompt: input.prompt,
+        stream: false,
+      }),
+      signal: controller.signal,
+    });
+    const bodyText = await response.text();
+    const parsed = parseJson(bodyText);
+    const responseText = readString(parsed?.response).trim();
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        timedOut: false,
+        responseText,
+        rawJson: parsed,
+        statusCode: response.status,
+        errorMessage:
+          compactError(parsed?.error) ||
+          compactError(parsed) ||
+          bodyText.trim() ||
+          `Ollama API request failed with HTTP ${response.status}`,
+        usage: { inputTokens: 0, outputTokens: 0 },
+      };
+    }
+
+    return {
+      ok: true,
+      timedOut: false,
+      responseText,
+      rawJson: parsed,
+      statusCode: response.status,
+      usage: {
+        inputTokens: readNumber(parsed?.prompt_eval_count, 0),
+        outputTokens: readNumber(parsed?.eval_count, 0),
+      },
+    };
+  } catch (err) {
+    const timedOut = err instanceof Error && err.name === "AbortError";
+    return {
+      ok: false,
+      timedOut,
+      responseText: "",
+      rawJson: null,
+      errorMessage: timedOut
+        ? `Timed out after ${input.timeoutSec}s`
+        : err instanceof Error
+          ? err.message
+          : String(err),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/adapters/opencode-local/src/server/test.ts
+++ b/packages/adapters/opencode-local/src/server/test.ts
@@ -4,6 +4,7 @@ import type {
   AdapterEnvironmentTestResult,
 } from "@paperclipai/adapter-utils";
 import {
+  asNumber,
   asBoolean,
   asString,
   asStringArray,
@@ -16,6 +17,12 @@ import {
 import { discoverOpenCodeModels, ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
 import { parseOpenCodeJsonl } from "./parse.js";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
+import {
+  parseOllamaModelId,
+  resolveOllamaBaseUrl,
+  runDirectOllamaGenerate,
+  shouldUseDirectOllamaApi,
+} from "./ollama-direct.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -239,6 +246,67 @@ export async function testEnvironment(
       })();
       const variant = asString(config.variant, "").trim();
       const probeModel = configuredModel;
+      const directOllamaModel = shouldUseDirectOllamaApi(config, configuredModel)
+        ? parseOllamaModelId(configuredModel)
+        : null;
+
+      if (directOllamaModel) {
+        try {
+          const direct = await runDirectOllamaGenerate({
+            baseUrl: resolveOllamaBaseUrl(config, runtimeEnv),
+            model: directOllamaModel,
+            prompt: "Respond with hello.",
+            timeoutSec: asNumber(config.ollamaTimeoutSec, 60),
+          });
+          const detail = summarizeProbeDetail(
+            direct.responseText,
+            direct.errorMessage ?? "",
+            direct.errorMessage ?? null,
+          );
+          if (direct.timedOut) {
+            checks.push({
+              code: "ollama_direct_hello_probe_timed_out",
+              level: "warn",
+              message: "Direct Ollama hello probe timed out.",
+              hint: "Verify the local Ollama API with `curl http://127.0.0.1:11434/api/version` and retry.",
+            });
+          } else if (direct.ok) {
+            const hasHello = /\bhello\b/i.test(direct.responseText);
+            checks.push({
+              code: hasHello ? "ollama_direct_hello_probe_passed" : "ollama_direct_hello_probe_unexpected_output",
+              level: hasHello ? "info" : "warn",
+              message: hasHello
+                ? "Direct Ollama hello probe succeeded."
+                : "Direct Ollama probe ran but did not return `hello` as expected.",
+              ...(direct.responseText
+                ? { detail: direct.responseText.replace(/\s+/g, " ").trim().slice(0, 240) }
+                : {}),
+            });
+          } else {
+            checks.push({
+              code: "ollama_direct_hello_probe_failed",
+              level: "error",
+              message: "Direct Ollama hello probe failed.",
+              ...(detail ? { detail } : {}),
+              hint: "Run the same model through `/api/generate` to verify Ollama Cloud access.",
+            });
+          }
+        } catch (err) {
+          checks.push({
+            code: "ollama_direct_hello_probe_failed",
+            level: "error",
+            message: "Direct Ollama hello probe failed.",
+            detail: err instanceof Error ? err.message : String(err),
+            hint: "Run the same model through `/api/generate` to verify Ollama Cloud access.",
+          });
+        }
+        return {
+          adapterType: ctx.adapterType,
+          status: summarizeStatus(checks),
+          checks,
+          testedAt: new Date().toISOString(),
+        };
+      }
 
       const args = ["run", "--format", "json"];
       args.push("--model", probeModel);


### PR DESCRIPTION
## Summary
- Add a direct Ollama Cloud `/api/generate` execution path for `opencode_local` agents using `ollama/<model>`.
- Keep OpenCode as a fallback when direct Ollama is disabled or when the model is not an Ollama route.
- Update adapter environment tests, execution tests, and config docs for direct Ollama settings.
- Prefer the resolved Paperclip workspace over legacy adapter `cwd` during execution.

## Validation
- `pnpm --filter @paperclipai/adapter-opencode-local exec vitest run src/server/execute.test.ts`
- `pnpm --filter @paperclipai/adapter-opencode-local typecheck`
- Live adapter environment smoke against `ollama/gemma3:4b-cloud` passed.

## Notes
- Pre-existing modified `server/src/services/routines.ts` was intentionally not included.
