### PR TITLE
fix(db): add dist build verification for missing client.js

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Verify dist artifacts
+        run: node scripts/verify-dist.mjs
+
   publish_canary:
     if: github.event_name == 'push'
     needs: verify_canary
@@ -150,6 +153,9 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Verify dist artifacts
+        run: node scripts/verify-dist.mjs
 
   preview_stable:
     if: github.event_name == 'workflow_dispatch' && inputs.dry_run

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:stop": "pnpm --filter @paperclipai/server exec tsx ../scripts/dev-service.ts stop",
     "dev:server": "pnpm --filter @paperclipai/server dev",
     "dev:ui": "pnpm --filter @paperclipai/ui dev",
-    "build": "pnpm run preflight:workspace-links && pnpm -r build",
+    "build": "pnpm run preflight:workspace-links && pnpm -r build && node scripts/verify-dist.mjs",
     "typecheck": "pnpm run preflight:workspace-links && pnpm -r typecheck",
     "test": "pnpm run test:run",
     "test:watch": "pnpm run preflight:workspace-links && vitest",

--- a/scripts/verify-dist.mjs
+++ b/scripts/verify-dist.mjs
@@ -1,0 +1,33 @@
+import { existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const CRITICAL_DIST_FILES = [
+  "packages/db/dist/index.js",
+  "packages/db/dist/client.js",
+  "packages/db/dist/migrations",
+  "packages/shared/dist/index.js",
+  "server/dist/index.js",
+];
+
+let failed = false;
+
+for (const file of CRITICAL_DIST_FILES) {
+  const abs = resolve(ROOT, file);
+  if (!existsSync(abs)) {
+    console.error(`MISSING: ${file}`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error(
+    "\nBuild verification failed — critical dist artifacts are missing.\n" +
+      "Run `pnpm build` from the repo root and check for compilation errors.",
+  );
+  process.exit(1);
+}
+
+console.log("Build verification passed — all critical dist artifacts present.");

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,7 +4,7 @@ import { createServer } from "node:http";
 import { resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type { Request as ExpressRequest, RequestHandler } from "express";
 import { and, eq } from "drizzle-orm";
 import {
@@ -810,6 +810,17 @@ function isMainModule(metaUrl: string): boolean {
 }
 
 if (isMainModule(import.meta.url)) {
+  if (process.argv.includes("--preflight")) {
+    const thisDir = resolve(fileURLToPath(import.meta.url), "..");
+    const dbDistClient = resolve(thisDir, "../../packages/db/dist/client.js");
+    if (!existsSync(dbDistClient)) {
+      logger.error("Preflight failed: packages/db/dist/client.js is missing. Run `pnpm build` first.");
+      process.exit(1);
+    }
+    logger.info("Preflight passed — dist artifacts present.");
+    process.exit(0);
+  }
+
   void startServer().catch((err) => {
     logger.error({ err }, "Paperclip server failed to start");
     process.exit(1);


### PR DESCRIPTION
## Summary

- Adds `scripts/verify-dist.mjs` that validates critical dist artifacts (`db/dist/client.js`, `db/dist/index.js`, `db/dist/migrations`, `shared/dist/index.js`, `server/dist/index.js`) exist after build
- Chains verify-dist into root `pnpm build` so every build fails fast when dist artifacts are missing
- Adds explicit "Verify dist artifacts" CI gate in both canary and stable release workflows
- Adds `--preflight` flag to server entry point for control scripts to validate build before startup

Fixes a bug where a missing `packages/db/dist/client.js` would cause production server start to fail, silently falling back to tsx dev mode.

## Test plan

- [x] `node scripts/verify-dist.mjs` passes on current dist
- [x] Server typechecks with `--preflight` flag addition
- [ ] Verify `pnpm build` runs verify-dist at the end
- [ ] Verify `node dist/index.js --preflight` exits 0 when dist is valid
- [ ] Verify `node dist/index.js --preflight` exits 1 when `dist/client.js` is removed

Obsolete PR.
