### PR TITLE
feat(import-export): add secrets to company portability

### DIFF
--- a/.claude/skills/LICENSE
+++ b/.claude/skills/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Greptile AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,51 @@
+# greptile skills
+
+[Agent Skills](https://agentskills.io) for automated PR review workflows. Supports GitHub, GitLab, and Perforce. Requires `git` + `gh` CLI (GitHub), `glab` CLI (GitLab), or `p4` CLI (Perforce).
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| [`check-pr`](check-pr/) | Check a PR/MR/CL for unresolved comments, failing checks, incomplete description. Fix and resolve. |
+| [`greploop`](greploop/) | Loop: trigger Greptile review, fix comments, re-review — until 5/5 confidence and zero comments. |
+
+Both skills auto-detect the platform (GitHub, GitLab, or Perforce) from the environment.
+
+## Requirements
+
+| Platform | CLI tool | Install |
+|----------|----------|---------|
+| GitHub | `gh` | [cli.github.com](https://cli.github.com) |
+| GitLab | `glab` | [gitlab.com/gitlab-org/cli](https://gitlab.com/gitlab-org/cli) |
+| Perforce | `p4` | [perforce.com/downloads](https://www.perforce.com/downloads/helix-command-line-client-p4) |
+
+Authenticate before use: `gh auth login`, `glab auth login`, or configure `P4PORT`/`P4USER`/`P4CLIENT` for Perforce.
+
+## Install
+
+```bash
+git clone https://github.com/greptileai/skills.git ~/.claude/skills/greptile
+cd ~/.claude/skills
+ln -s greptile/check-pr check-pr
+ln -s greptile/greploop greploop
+```
+
+Or as a submodule:
+
+```bash
+git submodule add https://github.com/greptileai/skills.git .skills/greptile
+ln -s greptile/check-pr .skills/check-pr
+ln -s greptile/greploop .skills/greploop
+```
+
+Claude Code discovers skills by looking for `SKILL.md` files at `~/.claude/skills/<skill-name>/SKILL.md`. Since this is a multi-skill repo, symlinks are needed to expose each sub-skill at the expected depth.
+
+## Usage
+
+Invoke by name in your agent (e.g. `/check-pr 123` or `/greploop`). If no PR/MR/CL number is given, both skills auto-detect the PR/MR for the current branch, or the pending changelist for Perforce.
+
+For self-hosted GitLab instances whose hostname doesn't contain "gitlab", pass `--vcs gitlab` explicitly. For Perforce, pass `--vcs perforce` if auto-detection fails.
+
+## License
+
+MIT

--- a/.claude/skills/check-pr/SKILL.md
+++ b/.claude/skills/check-pr/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: check-pr
+description: >
+  Checks a GitHub, GitLab, or Perforce (p4) pull request (or merge request, or shelved changelist)
+  for unresolved review comments, failing status checks, and incomplete PR descriptions. Waits for
+  pending checks to complete, categorizes issues as actionable or informational, and optionally fixes
+  and resolves them. Use when the user wants to check a PR/MR/CL, address review feedback, or prepare
+  a change for submission.
+license: MIT
+compatibility: Requires git and gh (GitHub CLI), glab (GitLab CLI), or p4 (Perforce CLI) installed and authenticated.
+metadata:
+  author: greptileai
+  version: "1.2"
+allowed-tools: Bash(gh:*) Bash(glab:*) Bash(git:*) Bash(p4:*)
+---
+
+# Check PR
+
+Analyze a pull request (GitHub), merge request (GitLab), or shelved changelist (Perforce) for review comments, status checks, and description completeness, then help address any issues found.
+
+## Inputs
+
+- **PR/MR/CL number** (optional): If not provided, detect the PR/MR for the current branch, or the default pending changelist for p4.
+
+## Instructions
+
+### 0. Detect platform
+
+First check if the user is working in a Perforce depot by looking for a `.p4config` file or `P4CLIENT`/`P4PORT` environment variables:
+
+```bash
+# Check for Perforce environment
+if p4 info >/dev/null 2>&1; then
+  VCS="perforce"
+else
+  # Fall back to git remote detection
+  REMOTE_URL=$(git remote get-url origin)
+  if echo "$REMOTE_URL" | grep -qi "gitlab"; then
+    VCS="gitlab"
+  else
+    VCS="github"
+  fi
+fi
+```
+
+For self-hosted GitLab instances whose hostname doesn't contain "gitlab", the user can override by passing `--vcs gitlab` as an input. For Perforce, the user can override by passing `--vcs perforce`.
+
+### 1. Identify the PR/MR/CL
+
+If a number was provided, use it. Otherwise, detect it:
+
+**GitHub:**
+```bash
+gh pr view --json number -q .number
+```
+
+**GitLab:**
+```bash
+glab mr view --output json | jq '.iid'
+```
+
+**Perforce:**
+```bash
+# List pending changelists for the current user/client
+p4 changes -s pending -u $P4USER -c $P4CLIENT
+```
+
+Key field differences between platforms:
+- GitHub: `number`, `headRefName`, `headRefOid`
+- GitLab: `iid`, `source_branch`, `sha`
+- Perforce: changelist number (CL), `shelved` files for in-review CLs
+
+### 2. Fetch PR/MR/CL details
+
+**GitHub:**
+```bash
+gh pr view <PR_NUMBER> --json title,body,state,reviews,comments,headRefName,statusCheckRollup
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments
+```
+
+**GitLab:**
+```bash
+glab mr view <MR_IID> --output json
+# Fetch discussions (inline diff comments are type "DiffNote"; general comments have null type)
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions"
+```
+
+For GitLab, paginate discussions if needed (add `?per_page=100&page=N`).
+
+**Perforce:**
+```bash
+# Get changelist description, files, and status
+p4 describe -s <CL_NUMBER>
+
+# Get shelved files (for in-review CLs)
+p4 describe -S <CL_NUMBER>
+
+# Get the diff of the shelved changelist
+p4 diff2 //...@=<CL_NUMBER> //...@=<CL_NUMBER>
+
+# List review comments (if using p4 review workflow)
+p4 review -c <CL_NUMBER>
+```
+
+Key Perforce CL fields:
+- `Change`: changelist number
+- `Status`: `pending`, `submitted`, `shelved`
+- `Description`: the CL description / commit message
+- `Files`: list of files in the CL
+
+### 3. Wait for pending checks
+
+Before analyzing, ensure all status checks have completed. If any checks are `PENDING` or `IN_PROGRESS` (GitHub) / `running` or `pending` (GitLab), poll every 30 seconds until all checks reach a terminal state.
+
+**GitHub:** poll `statusCheckRollup` from `gh pr view`.
+
+**GitLab:**
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines"
+```
+Pipeline statuses: `running`, `pending`, `success`, `failed`, `canceled`, `skipped`. Poll until no pipeline has `running` or `pending` status.
+
+**Perforce:** Perforce doesn't have built-in CI checks natively. If the team uses a review tool (Swarm, etc.) or an external CI triggered by shelve events, check the relevant system. Otherwise, proceed to analysis immediately.
+
+### 4. Analyze the PR/MR
+
+Once all checks are complete, evaluate these areas:
+
+#### A. Status Checks
+
+- Are all CI checks passing?
+- If any are failing, identify which ones and the failure reason.
+
+#### B. PR/MR Description
+
+- Is the description complete and follows team conventions?
+- Are all required sections filled in?
+- Are there TODOs or placeholders that need updating?
+
+#### C. Review Comments
+
+- Inline code review comments that need addressing
+- Look for bot review comments (e.g. from `greptile-apps[bot]` on GitHub, or the Greptile bot user on GitLab, linters, etc.)
+- Human reviewer comments
+- **Perforce:** review comments from `p4 review` or external review tools
+
+#### D. General Comments
+
+- Discussion comments on the PR/MR
+- Bot comments (deploy previews, etc.) — usually informational
+- **Perforce:** CL description should include a clear summary, affected files rationale, and testing notes
+
+### 5. Categorize issues
+
+For each issue found, categorize as:
+
+| Category | Meaning |
+|---|---|
+| **Actionable** | Code changes, test improvements, or fixes needed |
+| **Informational** | Verification notes, questions, or FYIs that don't require changes |
+| **Already addressed** | Issues that appear to be resolved by subsequent commits |
+
+### 6. Report findings
+
+Present a summary table:
+
+| Area | Issue | Status | Action Needed |
+|------|-------|--------|---------------|
+| Status Checks | CI build failing | Failing | Fix type error in `src/api.ts` |
+| Review | "Add null check" — @reviewer | Actionable | Add guard clause |
+| Description | TODO placeholder in test plan | Actionable | Fill in test plan |
+| Review | "Looks good" — @teammate | Informational | None |
+
+### 7. Fix issues (if requested)
+
+If there are actionable items:
+
+1. Switch to the PR/MR's branch (git) or ensure files are open in the correct CL (Perforce) if not already.
+2. Ask the user if they want to fix the issues.
+3. If yes, make the fixes, then:
+
+**GitHub/GitLab:** commit and push:
+```bash
+git add <files>
+git commit -m "address review feedback"
+git push
+```
+
+**Perforce:** open files for edit, make changes, and re-shelve:
+```bash
+p4 edit <file>
+# make changes
+p4 shelve -f -c <CL_NUMBER>
+```
+
+### 8. Resolve review threads
+
+After addressing comments, resolve the corresponding review threads.
+
+**Perforce** — Perforce does not have a native "resolve thread" concept. Instead, mark comments as addressed by updating the CL description or by responding in the review tool being used (Swarm, etc.). If using `p4 review`:
+
+```bash
+# Mark files as reviewed after addressing feedback
+p4 review -c <CL_NUMBER>
+```
+
+**GitHub** — fetch unresolved thread IDs (paginate if needed — see [the GraphQL reference](references/graphql-queries.md)):
+
+```bash
+gh api graphql -f query='
+query($cursor: String) {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { body path }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+If `hasNextPage` is true, repeat with `-f cursor=ENDCURSOR` to get remaining threads.
+
+Then resolve threads that have been addressed or are informational:
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "THREAD_ID"}) {
+    thread { isResolved }
+  }
+}'
+```
+
+Batch multiple resolutions into a single mutation using aliases (`t1`, `t2`, etc.).
+
+**GitLab** — fetch unresolved discussions (see [the GitLab API reference](references/gitlab-api.md)):
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions?per_page=100"
+```
+
+Filter for discussions where `"resolved": false`. Collect each discussion's `id`.
+
+Resolve each discussion individually (GitLab has no batch resolution):
+
+```bash
+glab api --method PUT \
+  "projects/:fullpath/merge_requests/<MR_IID>/discussions/<DISCUSSION_ID>" \
+  --field resolved=true
+```
+
+Repeat for each unresolved discussion ID.
+
+### 9. Multiple PRs/MRs/CLs
+
+If checking a chain of PRs/MRs/CLs, process them sequentially.
+
+**Perforce** — to check multiple changelists at once:
+```bash
+p4 changes -s pending -u $P4USER -c $P4CLIENT -l
+```
+
+## Output format
+
+Summarize:
+- PR/MR/CL title or description and current state
+- Platform detected (GitHub / GitLab / Perforce)
+- Status checks summary (passing/failing/pending) — or N/A for Perforce
+- Total issues found
+- Actionable items with descriptions
+- Items that can be ignored with reasons
+- Recommended next steps

--- a/.claude/skills/check-pr/references/gitlab-api.md
+++ b/.claude/skills/check-pr/references/gitlab-api.md
@@ -1,0 +1,91 @@
+# GitLab API Reference
+
+Useful GitLab REST API calls for working with merge request discussions, using `glab api`.
+
+`glab api` automatically resolves `:fullpath` to the URL-encoded project path from the local git remote.
+
+## Fetch MR details
+
+```bash
+glab mr view <MR_IID> --output json
+```
+
+Key fields (compared to GitHub equivalents):
+- `iid` — internal MR number (use this, not `id`)
+- `source_branch` — equivalent to GitHub's `headRefName`
+- `sha` — HEAD commit SHA, equivalent to GitHub's `headRefOid`
+- `description` — equivalent to GitHub's `body`
+
+## Fetch all discussions (inline + general comments)
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions?per_page=100"
+```
+
+Paginate with `&page=2`, `&page=3`, etc. until the response array length is less than `per_page`.
+
+Each discussion object:
+- `id` — discussion ID (used for resolution)
+- `resolved` — `true` or `false`
+- `notes` — array of note objects
+
+Each note object:
+- `type` — `"DiffNote"` for inline diff comments, `null` for general comments
+- `author.username` — author's username
+- `body` — comment text
+- `position.new_path` — file path (for `DiffNote` type)
+
+## Filter for unresolved inline diff comments
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions?per_page=100" | \
+  jq '[.[] | select(.resolved == false and (.notes[0].type == "DiffNote"))]'
+```
+
+## Resolve a single discussion
+
+```bash
+glab api --method PUT \
+  "projects/:fullpath/merge_requests/<MR_IID>/discussions/<DISCUSSION_ID>" \
+  --field resolved=true
+```
+
+There is no batch resolution in GitLab — issue one PUT per discussion.
+
+## Fetch pipeline status for an MR
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines"
+```
+
+Pipeline statuses: `running`, `pending`, `success`, `failed`, `canceled`, `skipped`.
+
+## Fetch jobs for a specific pipeline
+
+```bash
+glab api "projects/:fullpath/pipelines/<PIPELINE_ID>/jobs"
+```
+
+Each job has `name`, `status`, `stage`, and `web_url`.
+
+## Fetch MR notes (general comments and bot reviews)
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/notes?per_page=100"
+```
+
+Filter by `author.username` to find Greptile bot comments. The exact bot username depends on the Greptile installation — check the first Greptile comment to identify it.
+
+## Post a comment on an MR
+
+```bash
+glab mr note <MR_IID> --message "your message here"
+```
+
+Or via API:
+
+```bash
+glab api --method POST \
+  "projects/:fullpath/merge_requests/<MR_IID>/notes" \
+  --field body="your message here"
+```

--- a/.claude/skills/check-pr/references/graphql-queries.md
+++ b/.claude/skills/check-pr/references/graphql-queries.md
@@ -1,0 +1,74 @@
+# GraphQL Queries Reference
+
+Useful GitHub GraphQL queries for working with PR review threads.
+
+## Fetch unresolved review threads (with pagination)
+
+```graphql
+query($cursor: String) {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          isResolved
+          comments(first: 3) {
+            nodes {
+              body
+              path
+              author { login }
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Pass `-f cursor=ENDCURSOR` on subsequent requests if `hasNextPage` is `true`.
+
+## Resolve a single review thread
+
+```graphql
+mutation {
+  resolveReviewThread(input: {threadId: "THREAD_ID"}) {
+    thread { isResolved }
+  }
+}
+```
+
+## Batch-resolve multiple threads
+
+Use GraphQL aliases to resolve several threads in one request:
+
+```graphql
+mutation {
+  t1: resolveReviewThread(input: {threadId: "THREAD_ID_1"}) {
+    thread { isResolved }
+  }
+  t2: resolveReviewThread(input: {threadId: "THREAD_ID_2"}) {
+    thread { isResolved }
+  }
+  t3: resolveReviewThread(input: {threadId: "THREAD_ID_3"}) {
+    thread { isResolved }
+  }
+}
+```
+
+## Fetch PR details (REST)
+
+```bash
+gh pr view <PR_NUMBER> --json title,body,state,reviews,comments,headRefName,statusCheckRollup
+```
+
+## Fetch inline review comments (REST)
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments
+```

--- a/.claude/skills/greploop/SKILL.md
+++ b/.claude/skills/greploop/SKILL.md
@@ -1,0 +1,423 @@
+---
+name: greploop
+description: >
+  Iteratively improves a PR (GitHub), MR (GitLab), or shelved changelist (Perforce) until Greptile
+  gives it a 5/5 confidence score with zero unresolved comments. Triggers Greptile review, fixes all
+  actionable comments, pushes/re-shelves, re-triggers review, and repeats. Use when the user wants to
+  fully optimize a PR/MR/CL against Greptile's code review standards.
+license: MIT
+compatibility: Requires git, gh (GitHub CLI) or glab (GitLab CLI) authenticated, and Greptile installed on the repo. For Perforce, requires p4 CLI authenticated.
+metadata:
+  author: greptileai
+  version: "1.2"
+allowed-tools: Bash(gh:*) Bash(glab:*) Bash(git:*) Bash(p4:*)
+---
+
+# Greploop
+
+Iteratively fix a PR/MR/CL until Greptile gives a perfect review: 5/5 confidence, zero unresolved comments.
+
+## Inputs
+
+- **PR/MR/CL number** (optional): If not provided, detect the PR/MR for the current branch, or the default pending changelist for p4.
+
+## Instructions
+
+### 0. Detect platform
+
+First check for Perforce, then fall back to git remote detection:
+
+```bash
+# Check for Perforce environment
+if p4 info >/dev/null 2>&1; then
+  VCS="perforce"
+else
+  REMOTE_URL=$(git remote get-url origin)
+  if echo "$REMOTE_URL" | grep -qi "gitlab"; then
+    VCS="gitlab"
+  else
+    VCS="github"
+  fi
+fi
+```
+
+For self-hosted GitLab instances whose hostname doesn't contain "gitlab", the user can override by passing `--vcs gitlab` as an input. For Perforce, pass `--vcs perforce`.
+
+### 1. Identify the PR/MR/CL
+
+**GitHub:**
+```bash
+gh pr view --json number,headRefName -q '{number: .number, branch: .headRefName}'
+```
+
+**GitLab:**
+```bash
+glab mr view --output json | jq '{iid: .iid, branch: .source_branch}'
+```
+
+Switch to the PR/MR branch if not already on it.
+
+**Perforce:**
+```bash
+# List pending changelists for current user/client
+p4 changes -s pending -u $P4USER -c $P4CLIENT
+
+# Describe a specific CL
+p4 describe -s <CL_NUMBER>
+```
+
+Ensure the correct workspace (`p4 client`) is set before proceeding.
+
+Key field differences:
+- GitHub: `number`, `headRefName`, `headRefOid`
+- GitLab: `iid`, `source_branch`, `sha`
+- Perforce: changelist number, `P4CLIENT`, shelved files
+
+### 2. Loop
+
+Repeat the following cycle. **Max 5 iterations** to avoid runaway loops.
+
+#### A. Trigger Greptile review
+
+Push/shelve the latest changes (if any):
+
+**GitHub/GitLab:**
+```bash
+git push
+```
+
+**Perforce:**
+```bash
+# Re-shelve to update the shelved files for review
+p4 shelve -f -c <CL_NUMBER>
+```
+
+Wait for checks to start after push/shelve:
+
+```bash
+sleep 5
+```
+
+**GitHub** — check if Greptile is already running before posting a new trigger comment:
+
+```bash
+GREPTILE_STATE=$(gh pr checks <PR_NUMBER> --json name,state | jq -r '.[] | select(.name | test("greptile"; "i")) | .state')
+```
+
+If Greptile is **not** already running (`PENDING` or `IN_PROGRESS`), request a fresh review:
+
+```bash
+if [ "$GREPTILE_STATE" != "PENDING" ] && [ "$GREPTILE_STATE" != "IN_PROGRESS" ]; then
+  gh pr comment <PR_NUMBER> --body "@greptile review"
+fi
+```
+
+Then poll for the Greptile check run to complete:
+
+```bash
+HEAD_SHA=$(gh pr view <PR_NUMBER> --json headRefOid -q .headRefOid)
+
+while true; do
+  GREPTILE_CHECK=$(gh api "repos/{owner}/{repo}/commits/$HEAD_SHA/check-runs" \
+    --jq '.check_runs[] | select(.name | test("greptile"; "i"))' 2>/dev/null)
+  
+  if [ -z "$GREPTILE_CHECK" ]; then
+    echo "Waiting for Greptile check to appear..."
+    sleep 5
+    continue
+  fi
+  
+  STATUS=$(echo "$GREPTILE_CHECK" | jq -r '.status // "completed"')
+  CONCLUSION=$(echo "$GREPTILE_CHECK" | jq -r '.conclusion // "pending"')
+  
+  if [ "$STATUS" = "completed" ]; then
+    if [ "$CONCLUSION" = "success" ]; then
+      echo "Greptile check passed!"
+    else
+      echo "Greptile check completed with: $CONCLUSION"
+    fi
+    break
+  fi
+  
+  echo "Waiting for Greptile... (status: $STATUS)"
+  sleep 10
+done
+```
+
+**GitLab** — check if Greptile is already running before posting a trigger comment:
+
+```bash
+PIPELINES=$(glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines")
+GREPTILE_RUNNING=$(echo "$PIPELINES" | jq '[.[] | select(.status == "running" or .status == "pending")] | length')
+```
+
+If no pipeline is running, post a trigger comment:
+
+```bash
+if [ "$GREPTILE_RUNNING" = "0" ]; then
+  glab mr note <MR_IID> --message "@greptile review"
+fi
+```
+
+**Perforce** — Perforce does not have native check runs. If Greptile is integrated via a webhook triggered on `p4 shelve`, wait for it to process. Check your Greptile installation's webhook endpoint or dashboard for the review status. Poll by re-fetching the Greptile review comment on the CL until a score appears.
+
+Then poll for the Greptile pipeline job to complete (see [GitLab API reference](references/gitlab-api.md)):
+
+```bash
+HEAD_SHA=$(glab mr view <MR_IID> --output json | jq -r '.sha')
+
+while true; do
+  PIPELINES=$(glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines")
+  # Find the most recent pipeline for this SHA
+  PIPELINE_ID=$(echo "$PIPELINES" | jq -r --arg sha "$HEAD_SHA" \
+    '[.[] | select(.sha == $sha)] | sort_by(.id) | last | .id // empty')
+
+  if [ -z "$PIPELINE_ID" ]; then
+    echo "Waiting for Greptile pipeline to appear..."
+    sleep 5
+    continue
+  fi
+
+  JOBS=$(glab api "projects/:fullpath/pipelines/$PIPELINE_ID/jobs")
+  GREPTILE_JOB=$(echo "$JOBS" | jq '.[] | select(.name | test("greptile"; "i"))')
+
+  if [ -z "$GREPTILE_JOB" ]; then
+    echo "Waiting for Greptile job to appear..."
+    sleep 5
+    continue
+  fi
+
+  JOB_STATUS=$(echo "$GREPTILE_JOB" | jq -r '.status')
+
+  if [ "$JOB_STATUS" = "success" ] || [ "$JOB_STATUS" = "failed" ] || [ "$JOB_STATUS" = "canceled" ]; then
+    echo "Greptile job completed with: $JOB_STATUS"
+    break
+  fi
+
+  echo "Waiting for Greptile... (status: $JOB_STATUS)"
+  sleep 10
+done
+```
+
+#### B. Fetch Greptile review results
+
+Greptile may surface its score in two places — check **both** (three for Perforce):
+
+**GitHub:**
+
+**1. PR description (body):**
+```bash
+gh pr view <PR_NUMBER> --json body -q '.body'
+```
+
+**2. PR reviews:**
+```bash
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/reviews
+```
+
+Look for the most recent entry from `greptile-apps[bot]` or `greptile-apps-staging[bot]`.
+
+**GitLab:**
+
+**1. MR description (body):**
+```bash
+glab mr view <MR_IID> --output json | jq -r '.description'
+```
+
+**2. MR notes (comments):**
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/notes"
+```
+
+Filter for notes from the Greptile bot user (check the `author.username` field — the exact username may vary per installation; verify on first run).
+
+**Perforce:**
+
+**1. CL description:**
+```bash
+p4 describe -s <CL_NUMBER>
+```
+Check the description field for a Greptile-appended score block.
+
+**2. CL comments / review notes:**
+If your installation uses a review tool such as Helix Swarm, fetch comments via its API.
+
+Example (Swarm API):
+GET /api/v11/comments?topic=reviews/<REVIEW_ID>
+
+Response fields of interest typically include:
+- user (author username)
+- body (comment text)
+- flags/state indicating whether the comment is resolved
+
+Filter to comments authored by the Greptile bot:
+- Prefer exact username match if known
+- Otherwise, use a heuristic where the author name contains "greptile" (case-insensitive)
+
+For all platforms, parse the text for:
+- **Confidence score**: a pattern like `3/5` or `5/5` (or `Confidence: 3/5`).
+- **Comment count**: Number of inline review comments noted in the summary.
+
+Use whichever source has the **most recent** score.
+
+Also fetch all unresolved inline comments:
+
+**GitHub:**
+```bash
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments
+```
+
+**GitLab:**
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions"
+```
+
+Filter to `DiffNote` type discussions (`notes[0].type == "DiffNote"`) from Greptile that are on the latest commit and not yet resolved (`"resolved": false`).
+
+**Perforce:**
+If using Swarm:
+
+# Fetch inline diff comments for the review associated with the CL
+GET /api/v11/comments?topic=reviews/<REVIEW_ID>
+
+Filter to comments from the Greptile bot user that have not been marked as resolved/addressed.
+
+#### C. Check exit conditions
+
+Stop the loop if **any** of these are true:
+
+- Confidence score is **5/5** AND there are **zero unresolved comments**
+- Max iterations reached (report current state)
+
+#### D. Fix actionable comments
+
+For each unresolved Greptile comment:
+
+1. Read the file and understand the comment in context.
+2. Determine if it's actionable (code change needed) or informational.
+3. If actionable, make the fix.
+4. If informational or a false positive, note it but still resolve the thread.
+
+#### E. Resolve threads
+
+**GitHub** — fetch unresolved review threads and resolve all that have been addressed (see [GraphQL reference](references/graphql-queries.md)):
+
+```bash
+gh api graphql -f query='
+query($cursor: String) {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { body path author { login } }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Resolve addressed threads:
+
+```bash
+gh api graphql -f query='
+mutation {
+  t1: resolveReviewThread(input: {threadId: "ID1"}) { thread { isResolved } }
+  t2: resolveReviewThread(input: {threadId: "ID2"}) { thread { isResolved } }
+}'
+```
+
+**GitLab** — fetch unresolved discussions and resolve each one (see [GitLab API reference](references/gitlab-api.md)):
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions?per_page=100"
+```
+
+Filter for `"resolved": false` discussions. Then resolve each by its `id`:
+
+```bash
+glab api --method PUT \
+  "projects/:fullpath/merge_requests/<MR_IID>/discussions/<DISCUSSION_ID>" \
+  --field resolved=true
+```
+
+Repeat for each unresolved discussion ID. (GitLab has no batch resolution — loop through each one.)
+
+#### F. Commit and push / re-shelve
+
+**GitHub/GitLab:**
+```bash
+git add -A
+git commit -m "address greptile review feedback (greploop iteration N)"
+git push
+```
+
+**Perforce:**
+```bash
+# Stage changes back into the CL and re-shelve for the next review round
+p4 shelve -f -c <CL_NUMBER>
+```
+
+Wait for checks to start after push/shelve:
+
+```bash
+sleep 5
+```
+
+Then go back to step **A**.
+
+### 3. Report
+
+After exiting the loop, summarize:
+
+| Field              | Value      |
+| ------------------ | ---------- |
+| Platform           | GitHub / GitLab / Perforce |
+| Iterations         | N          |
+| Final confidence   | X/5        |
+| Comments resolved  | N          |
+| Remaining comments | N (if any) |
+
+If the loop exited due to max iterations, list any remaining unresolved comments and suggest next steps.
+
+## Output format
+
+```
+Greploop complete.
+  Platform:      GitHub
+  Iterations:    2
+  Confidence:    5/5
+  Resolved:      7 comments
+  Remaining:     0
+```
+
+If not fully resolved:
+
+```
+Greploop stopped after 5 iterations.
+  Platform:      GitLab
+  Confidence:    4/5
+  Resolved:      12 comments
+  Remaining:     2
+
+Remaining issues:
+  - src/auth.ts:45 — "Consider rate limiting this endpoint"
+  - src/db.ts:112 — "Missing index on user_id column"
+```
+
+**Perforce example:**
+
+```
+Greploop complete.
+  Platform:      Perforce
+  Changelist:    12345
+  Iterations:    3
+  Confidence:    5/5
+  Resolved:      9 comments
+  Remaining:     0
+```

--- a/.claude/skills/greploop/references/gitlab-api.md
+++ b/.claude/skills/greploop/references/gitlab-api.md
@@ -1,0 +1,93 @@
+# GitLab API Reference
+
+Useful GitLab REST API calls for the greploop workflow, using `glab api`.
+
+`glab api` automatically resolves `:fullpath` to the URL-encoded project path from the local git remote.
+
+## Fetch MR details
+
+```bash
+glab mr view <MR_IID> --output json
+```
+
+Key fields:
+- `iid` — internal MR number (use this, not `id`)
+- `source_branch` — equivalent to GitHub's `headRefName`
+- `sha` — HEAD commit SHA
+- `description` — MR body (Greptile may update this with the confidence score)
+
+## Trigger Greptile review
+
+```bash
+glab mr note <MR_IID> --message "@greptile review"
+```
+
+## Fetch pipelines for an MR
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines"
+```
+
+Check `status` field: `running`, `pending`, `success`, `failed`, `canceled`, `skipped`.
+
+## Fetch jobs for a pipeline (to find the Greptile job)
+
+```bash
+glab api "projects/:fullpath/pipelines/<PIPELINE_ID>/jobs"
+```
+
+Filter jobs where `name` matches `greptile` (case-insensitive). Terminal statuses: `success`, `failed`, `canceled`.
+
+## Check if any pipeline is running
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines" | \
+  jq '[.[] | select(.status == "running" or .status == "pending")] | length'
+```
+
+Returns `0` if no pipelines are running/pending.
+
+## Find pipeline for a specific commit SHA
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/pipelines" | \
+  jq -r --arg sha "COMMIT_SHA" '[.[] | select(.sha == $sha)] | sort_by(.id) | last | .id // empty'
+```
+
+## Fetch MR notes (to find Greptile's confidence score)
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/notes?per_page=100&sort=desc&order_by=created_at"
+```
+
+Filter by `author.username` for the Greptile bot. Scan `body` for a confidence pattern like `3/5` or `5/5`.
+
+The Greptile bot username on GitLab may differ from GitHub's `greptile-apps[bot]` — check the first Greptile comment on the MR to identify the exact username.
+
+## Fetch unresolved discussions (inline comments)
+
+```bash
+glab api "projects/:fullpath/merge_requests/<MR_IID>/discussions?per_page=100"
+```
+
+Paginate with `&page=2`, etc. until response array length < `per_page`.
+
+Filter for unresolved inline diff comments from Greptile:
+```bash
+jq '[.[] | select(.resolved == false and (.notes[0].type == "DiffNote") and (.notes[0].author.username == "GREPTILE_BOT_USERNAME"))]'
+```
+
+Each discussion has:
+- `id` — use this for resolution
+- `notes[0].body` — the comment text
+- `notes[0].position.new_path` — file path
+
+## Resolve a discussion
+
+```bash
+glab api --method PUT \
+  "projects/:fullpath/merge_requests/<MR_IID>/discussions/<DISCUSSION_ID>" \
+  --field resolved=true
+```
+
+GitLab has no batch resolution — issue one PUT per discussion.

--- a/.claude/skills/greploop/references/graphql-queries.md
+++ b/.claude/skills/greploop/references/graphql-queries.md
@@ -1,0 +1,36 @@
+# GraphQL Queries Reference
+
+## Fetch unresolved review threads (paginated)
+
+```graphql
+query($cursor: String) {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 3) {
+            nodes {
+              body
+              path
+              author { login }
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Batch-resolve threads
+
+```graphql
+mutation {
+  t1: resolveReviewThread(input: {threadId: "ID1"}) { thread { isResolved } }
+  t2: resolveReviewThread(input: {threadId: "ID2"}) { thread { isResolved } }
+}
+```

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -357,6 +357,7 @@ export type {
   CompanyPortabilityImportRequest,
   CompanyPortabilityImportResult,
   CompanyPortabilityExportRequest,
+  CompanyPortabilitySecretEntry,
   EnvBinding,
   AgentEnvConfig,
   CompanySecret,

--- a/packages/shared/src/types/company-portability.ts
+++ b/packages/shared/src/types/company-portability.ts
@@ -1,4 +1,4 @@
-import type { AgentEnvConfig } from "./secrets.js";
+import type { AgentEnvConfig, SecretProvider } from "./secrets.js";
 import type { RoutineVariable } from "./routine.js";
 
 export interface CompanyPortabilityInclude {
@@ -18,6 +18,8 @@ export interface CompanyPortabilityEnvInput {
   requirement: "required" | "optional";
   defaultValue: string | null;
   portability: "portable" | "system_dependent";
+  secretName?: string | null;
+  secretProvider?: string | null;
 }
 
 export type CompanyPortabilityFileEntry =
@@ -165,6 +167,15 @@ export interface CompanyPortabilityManifest {
   projects: CompanyPortabilityProjectManifestEntry[];
   issues: CompanyPortabilityIssueManifestEntry[];
   envInputs: CompanyPortabilityEnvInput[];
+  secrets?: CompanyPortabilitySecretEntry[];
+}
+
+export interface CompanyPortabilitySecretEntry {
+  name: string;
+  provider: SecretProvider;
+  description: string | null;
+  latestVersion: number;
+  currentValue: string;
 }
 
 export interface CompanyPortabilityExportResult {
@@ -316,4 +327,5 @@ export interface CompanyPortabilityExportRequest {
   selectedFiles?: string[];
   expandReferencedSkills?: boolean;
   sidebarOrder?: Partial<CompanyPortabilitySidebarOrder>;
+  includeSecrets?: boolean;
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -220,6 +220,7 @@ export type {
   CompanyPortabilityImportRequest,
   CompanyPortabilityImportResult,
   CompanyPortabilityExportRequest,
+  CompanyPortabilitySecretEntry,
 } from "./company-portability.js";
 export type {
   JsonSchema,

--- a/packages/shared/src/validators/company-portability.ts
+++ b/packages/shared/src/validators/company-portability.ts
@@ -173,6 +173,13 @@ export const portabilityManifestSchema = z.object({
   projects: z.array(portabilityProjectManifestEntrySchema).default([]),
   issues: z.array(portabilityIssueManifestEntrySchema).default([]),
   envInputs: z.array(portabilityEnvInputSchema).default([]),
+  secrets: z.array(z.object({
+    name: z.string().min(1),
+    provider: z.string().min(1),
+    description: z.string().nullable(),
+    latestVersion: z.number().int().nonnegative(),
+    currentValue: z.string(),
+  })).optional(),
 });
 
 export const portabilitySourceSchema = z.discriminatedUnion("type", [
@@ -215,6 +222,7 @@ export const companyPortabilityExportSchema = z.object({
   selectedFiles: z.array(z.string().min(1)).optional(),
   expandReferencedSkills: z.boolean().optional(),
   sidebarOrder: portabilitySidebarOrderSchema.partial().optional(),
+  includeSecrets: z.boolean().optional(),
 });
 
 export type CompanyPortabilityExport = z.infer<typeof companyPortabilityExportSchema>;

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -16,6 +16,7 @@ const agentSvc = {
   list: vi.fn(),
   create: vi.fn(),
   update: vi.fn(),
+  getById: vi.fn(),
 };
 
 const accessSvc = {
@@ -29,6 +30,7 @@ const projectSvc = {
   list: vi.fn(),
   create: vi.fn(),
   update: vi.fn(),
+  getById: vi.fn(),
   createWorkspace: vi.fn(),
   listWorkspaces: vi.fn(),
 };
@@ -62,6 +64,26 @@ const assetSvc = {
 const secretSvc = {
   normalizeAdapterConfigForPersistence: vi.fn(async (_companyId: string, config: Record<string, unknown>) => config),
   resolveAdapterConfigForRuntime: vi.fn(async (_companyId: string, config: Record<string, unknown>) => ({ config, secretKeys: new Set<string>() })),
+  normalizeEnvBindingsForPersistence: vi.fn(async (_companyId: string, env: unknown) => env as Record<string, unknown>),
+  getById: vi.fn(async (id: string) => {
+    if (id === "secret-1") return { id: "secret-1", name: "anthropic-api-key", provider: "local_encrypted" };
+    if (id === "secret-2") return { id: "secret-2", name: "gh-token", provider: "local_encrypted" };
+    return null;
+  }),
+  resolveSecretValue: vi.fn(async (_companyId: string, secretId: string, _version: "latest") => {
+    if (secretId === "secret-1") return "sk-ant-secret-xxx";
+    if (secretId === "secret-2") return "ghp_secretxxx";
+    throw new Error("Secret not found");
+  }),
+  create: vi.fn(async (companyId: string, input: { name: string; provider: string; value: string; description?: string | null }) => ({
+    id: `new-secret-${input.name}`,
+    companyId,
+    name: input.name,
+    provider: input.provider,
+    description: input.description ?? null,
+    latestVersion: 1,
+  })),
+  getByName: vi.fn(async (_companyId: string, name: string) => null),
 };
 
 const agentInstructionsSvc = {
@@ -1173,6 +1195,8 @@ describe("company portability", () => {
         requirement: "optional",
         defaultValue: "",
         portability: "portable",
+        secretName: "anthropic-api-key",
+        secretProvider: "local_encrypted",
       },
       {
         key: "GH_TOKEN",
@@ -1183,6 +1207,8 @@ describe("company portability", () => {
         requirement: "optional",
         defaultValue: "",
         portability: "portable",
+        secretName: "gh-token",
+        secretProvider: "local_encrypted",
       },
     ]);
   });
@@ -1306,6 +1332,8 @@ describe("company portability", () => {
       requirement: "optional",
       defaultValue: "",
       portability: "portable",
+      secretName: null,
+      secretProvider: null,
     });
   });
 
@@ -2613,5 +2641,190 @@ describe("company portability", () => {
         normalized: "updated",
       },
     }));
+  });
+
+  describe("secret env vars", () => {
+    beforeEach(() => {
+      // Reset create/getByName to ensure clean state per test
+      secretSvc.create.mockReset();
+      secretSvc.getByName.mockReset();
+      secretSvc.getById.mockImplementation(async (id: string) => {
+        if (id === "secret-1") return { id: "secret-1", name: "anthropic-api-key", provider: "local_encrypted" };
+        if (id === "secret-2") return { id: "secret-2", name: "gh-token", provider: "local_encrypted" };
+        return null;
+      });
+      secretSvc.resolveSecretValue.mockImplementation(async (_companyId: string, secretId: string) => {
+        if (secretId === "secret-1") return "sk-ant-secret-xxx";
+        if (secretId === "secret-2") return "ghp_secretxxx";
+        throw new Error("Secret not found");
+      });
+      secretSvc.create.mockImplementation(async (companyId: string, input: { name: string; provider: string; value: string; description?: string | null }) => ({
+        id: `new-secret-${input.name}`,
+        companyId,
+        name: input.name,
+        provider: input.provider,
+        description: input.description ?? null,
+        latestVersion: 1,
+      }));
+      secretSvc.getByName.mockResolvedValue(null);
+    });
+
+    it("exports secret env var metadata with secretName and secretProvider", async () => {
+      const portability = companyPortabilityService({} as any);
+      const exported = await portability.exportBundle("company-1", {
+        include: { agents: true, company: false, projects: false, issues: false, skills: false },
+        agents: ["claudecoder"],
+      });
+      const secretInput = exported.manifest.envInputs.find(
+        (e: any) => e.key === "ANTHROPIC_API_KEY" && e.kind === "secret",
+      );
+      expect(secretInput).toBeDefined();
+      expect(secretInput.secretName).toBe("anthropic-api-key");
+      expect(secretInput.secretProvider).toBe("local_encrypted");
+    });
+
+    it("exports secret values to manifest when includeSecrets is true", async () => {
+      const portability = companyPortabilityService({} as any);
+      const exported = await portability.exportBundle("company-1", {
+        include: { agents: true, company: false, projects: false, issues: false, skills: false },
+        agents: ["claudecoder"],
+        includeSecrets: true,
+      });
+      expect(exported.manifest.secrets).toBeDefined();
+      expect(exported.manifest.secrets).toContainEqual(expect.objectContaining({
+        name: "anthropic-api-key",
+        provider: "local_encrypted",
+        currentValue: "sk-ant-secret-xxx",
+      }));
+    });
+
+    it("omits secrets section when includeSecrets is false", async () => {
+      const portability = companyPortabilityService({} as any);
+      const exported = await portability.exportBundle("company-1", {
+        include: { agents: true, company: false, projects: false, issues: false, skills: false },
+        agents: ["claudecoder"],
+        includeSecrets: false,
+      });
+      expect(exported.manifest.secrets).toBeUndefined();
+    });
+
+    it("writes placeholder when resolveSecretValue throws (cross-instance decryption failure)", async () => {
+      secretSvc.resolveSecretValue.mockImplementation(async () => {
+        throw new Error("Decryption failed: missing master key");
+      });
+      const portability = companyPortabilityService({} as any);
+      const exported = await portability.exportBundle("company-1", {
+        include: { agents: true, company: false, projects: false, issues: false, skills: false },
+        agents: ["claudecoder"],
+        includeSecrets: true,
+      });
+      const secretEntry = exported.manifest.secrets?.find((s: any) => s.name === "anthropic-api-key");
+      expect(secretEntry?.currentValue).toBe("<decryption-key-missing:anthropic-api-key>");
+      expect(exported.warnings).toContainEqual(expect.stringContaining("could not be decrypted during export"));
+    });
+
+    it("imports secrets and remaps secret_ref bindings to new secret IDs", async () => {
+      const portability = companyPortabilityService({} as any);
+      agentSvc.create.mockImplementation(async (companyId: string, patch: Record<string, unknown>) => ({
+        id: "new-agent-1",
+        companyId,
+        ...patch,
+      }));
+      agentSvc.update.mockImplementation(async (id: string, patch: Record<string, unknown>) => patch as any);
+      agentSvc.getById.mockImplementation(async (id: string) => {
+        if (id === "new-agent-1") {
+          return { id: "new-agent-1", adapterConfig: { env: { ANTHROPIC_API_KEY: { type: "secret_ref", secretId: "placeholder-secret" } } } };
+        }
+        return null;
+      });
+      const exported = await portability.exportBundle("company-1", {
+        include: { agents: true, company: false, projects: false, issues: false, skills: false },
+        agents: ["claudecoder"],
+        includeSecrets: true,
+      });
+      const imported = await portability.importBundle({
+        source: { type: "inline", rootPath: exported.rootPath, files: exported.files },
+        include: { agents: true, company: false, projects: false, issues: false, skills: false },
+        target: { mode: "existing_company", companyId: "company-imported" },
+        agents: ["claudecoder"],
+        collisionStrategy: "rename",
+      }, "user-1");
+      expect(secretSvc.create).toHaveBeenCalled();
+      expect(agentSvc.update).toHaveBeenCalledWith(
+        "new-agent-1",
+        expect.any(Object),
+      );
+    });
+
+    it("reuses existing secret on conflict during import", async () => {
+      secretSvc.getByName.mockImplementation(async (_companyId: string, name: string) => {
+        if (name === "anthropic-api-key") return { id: "existing-secret-1", name, provider: "local_encrypted" };
+        return null;
+      });
+      const portability = companyPortabilityService({} as any);
+      agentSvc.create.mockImplementation(async (companyId: string, patch: Record<string, unknown>) => ({
+        id: "new-agent-1",
+        companyId,
+        ...patch,
+      }));
+      agentSvc.update.mockImplementation(async (id: string, patch: Record<string, unknown>) => patch as any);
+      agentSvc.getById.mockImplementation(async (id: string) => {
+        if (id === "new-agent-1") {
+          return { id: "new-agent-1", adapterConfig: { env: { ANTHROPIC_API_KEY: { type: "secret_ref", secretId: "placeholder-secret" } } } };
+        }
+        return null;
+      });
+      const exported = await portability.exportBundle("company-1", {
+        include: { agents: true, company: false, projects: false, issues: false, skills: false },
+        agents: ["claudecoder"],
+        includeSecrets: true,
+      });
+      await portability.importBundle({
+        source: { type: "inline", rootPath: exported.rootPath, files: exported.files },
+        include: { agents: true, company: false, projects: false, issues: false, skills: false },
+        target: { mode: "existing_company", companyId: "company-imported" },
+        agents: ["claudecoder"],
+        collisionStrategy: "rename",
+      }, "user-1");
+      expect(agentSvc.update).toHaveBeenCalled();
+    });
+
+    it("exports plain env vars faithfully", async () => {
+      agentSvc.list.mockResolvedValue([{
+        id: "agent-1",
+        name: "TestAgent",
+        status: "idle",
+        role: "agent",
+        title: null,
+        icon: null,
+        reportsTo: null,
+        capabilities: null,
+        adapterType: "process",
+        adapterConfig: {
+          env: {
+            PLAIN_VAR: { type: "plain", value: "plain-value" },
+            ANOTHER_VAR: { type: "plain", value: "another-value" },
+          },
+        },
+        runtimeConfig: {},
+        permissions: {},
+        budgetMonthlyCents: 0,
+        metadata: null,
+      }]);
+      const portability = companyPortabilityService({} as any);
+      const exported = await portability.exportBundle("company-1", {
+        include: { agents: true, company: false, projects: false, issues: false, skills: false },
+        agents: ["testagent"],
+      });
+      const plainInputs = exported.manifest.envInputs.filter((e: any) => e.kind === "plain");
+      expect(plainInputs).toContainEqual(expect.objectContaining({
+        key: "PLAIN_VAR",
+        defaultValue: "plain-value",
+      }));
+      expect(plainInputs).toContainEqual(expect.objectContaining({
+        key: "ANOTHER_VAR",
+        defaultValue: "another-value",
+      }));
+    });
   });
 });

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -409,7 +409,7 @@ async function extractPortableScopedEnvInputs(
   },
   envValue: unknown,
   warnings: string[],
-  secrets: { getById: (id: string) => Promise<{ name: string; provider: string } | null>; resolveSecretValue: (companyId: string, secretId: string, version: "latest") => Promise<string> },
+  secrets: { getById: (id: string) => Promise<{ name: string; provider: string; description: string | null; latestVersion: number } | null>; resolveSecretValue: (companyId: string, secretId: string, version: "latest") => Promise<string> },
   secretEntries: CompanyPortabilitySecretEntry[],
   includeSecrets: boolean,
   companyId: string,
@@ -439,24 +439,27 @@ async function extractPortableScopedEnvInputs(
         secretProvider: secret?.provider ?? null,
       });
       if (includeSecrets && secret && binding.secretId) {
-        try {
-          const resolvedValue = await secrets.resolveSecretValue(companyId, String(binding.secretId), "latest");
-          secretEntries.push({
-            name: secret.name,
-            provider: secret.provider as SecretProvider,
-            description: null,
-            latestVersion: 1,
-            currentValue: resolvedValue,
-          });
-        } catch {
-          secretEntries.push({
-            name: secret.name,
-            provider: secret.provider as SecretProvider,
-            description: null,
-            latestVersion: 1,
-            currentValue: `<decryption-key-missing:${secret.name}>`,
-          });
-          warnings.push(`Secret "${secret.name}" could not be decrypted during export. Placeholder written.`);
+        const alreadyExported = secretEntries.some((e) => e.name === secret.name);
+        if (!alreadyExported) {
+          try {
+            const resolvedValue = await secrets.resolveSecretValue(companyId, String(binding.secretId), "latest");
+            secretEntries.push({
+              name: secret.name,
+              provider: secret.provider as SecretProvider,
+              description: secret.description,
+              latestVersion: secret.latestVersion,
+              currentValue: resolvedValue,
+            });
+          } catch {
+            secretEntries.push({
+              name: secret.name,
+              provider: secret.provider as SecretProvider,
+              description: secret.description,
+              latestVersion: secret.latestVersion,
+              currentValue: `<decryption-key-missing:${secret.name}>`,
+            });
+            warnings.push(`Secret "${secret.name}" could not be decrypted during export. Placeholder written.`);
+          }
         }
       }
       continue;
@@ -1648,7 +1651,7 @@ async function extractPortableEnvInputs(
   agentSlug: string,
   envValue: unknown,
   warnings: string[],
-  secrets: { getById: (id: string) => Promise<{ name: string; provider: string } | null>; resolveSecretValue: (companyId: string, secretId: string, version: "latest") => Promise<string> },
+  secrets: { getById: (id: string) => Promise<{ name: string; provider: string; description: string | null; latestVersion: number } | null>; resolveSecretValue: (companyId: string, secretId: string, version: "latest") => Promise<string> },
   secretEntries: CompanyPortabilitySecretEntry[],
   includeSecrets: boolean,
   companyId: string,
@@ -1673,7 +1676,7 @@ async function extractPortableProjectEnvInputs(
   projectSlug: string,
   envValue: unknown,
   warnings: string[],
-  secrets: { getById: (id: string) => Promise<{ name: string; provider: string } | null>; resolveSecretValue: (companyId: string, secretId: string, version: "latest") => Promise<string> },
+  secrets: { getById: (id: string) => Promise<{ name: string; provider: string; description: string | null; latestVersion: number } | null>; resolveSecretValue: (companyId: string, secretId: string, version: "latest") => Promise<string> },
   secretEntries: CompanyPortabilitySecretEntry[],
   includeSecrets: boolean,
   companyId: string,

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -4487,15 +4487,6 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
 
     // Remap secret_ref bindings in imported agent/project records to target company secret IDs
     for (const envInput of sourceManifest.envInputs ?? []) {
-      if (envInput.portability === "system_dependent") {
-        const scope = envInput.agentSlug
-          ? ` for agent ${envInput.agentSlug}`
-          : envInput.projectSlug
-            ? ` for project ${envInput.projectSlug}`
-            : "";
-        warnings.push(`Environment input ${envInput.key}${scope} is system-dependent and was not imported. Set manually after import.`);
-        continue;
-      }
       if (envInput.kind !== "secret" || !envInput.secretName) continue;
       const newSecretId = secretNameToId.get(envInput.secretName);
       if (!newSecretId) {

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -2851,7 +2851,6 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     adapterConfig: Record<string, unknown>,
     desiredSkills: string[],
     mode: ImportMode,
-    dummySecretCompanyId?: string,
   ) {
     const effectiveAdapterType = assertKnownImportAdapterType(adapterType);
     if (mode === "agent_safe" && IMPORT_FORBIDDEN_ADAPTER_TYPES.has(effectiveAdapterType)) {
@@ -2864,10 +2863,8 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     delete nextAdapterConfig.instructionsBundleMode;
     delete nextAdapterConfig.instructionsRootPath;
     delete nextAdapterConfig.instructionsEntryFile;
-    // Use a dummy company ID so that secret_ref bindings are preserved as-is.
-    // The remapping step (line 4515) will update them to the correct target-company secrets.
     const normalizedAdapterConfig = await secrets.normalizeAdapterConfigForPersistence(
-      dummySecretCompanyId ?? companyId,
+      companyId,
       nextAdapterConfig,
       { strictMode: strictSecretsMode },
     );
@@ -4268,7 +4265,6 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           baseAdapterConfig,
           desiredSkills,
           mode,
-          "dummy-import-company",
         );
         const patch = {
           name: planAgent.plannedName,

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -2851,6 +2851,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     adapterConfig: Record<string, unknown>,
     desiredSkills: string[],
     mode: ImportMode,
+    dummySecretCompanyId?: string,
   ) {
     const effectiveAdapterType = assertKnownImportAdapterType(adapterType);
     if (mode === "agent_safe" && IMPORT_FORBIDDEN_ADAPTER_TYPES.has(effectiveAdapterType)) {
@@ -2863,8 +2864,10 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     delete nextAdapterConfig.instructionsBundleMode;
     delete nextAdapterConfig.instructionsRootPath;
     delete nextAdapterConfig.instructionsEntryFile;
+    // Use a dummy company ID so that secret_ref bindings are preserved as-is.
+    // The remapping step (line 4515) will update them to the correct target-company secrets.
     const normalizedAdapterConfig = await secrets.normalizeAdapterConfigForPersistence(
-      companyId,
+      dummySecretCompanyId ?? companyId,
       nextAdapterConfig,
       { strictMode: strictSecretsMode },
     );
@@ -4265,6 +4268,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           baseAdapterConfig,
           desiredSkills,
           mode,
+          "dummy-import-company",
         );
         const patch = {
           name: planAgent.plannedName,

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -3013,7 +3013,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     const files: Record<string, CompanyPortabilityFileEntry> = {};
     const warnings: string[] = [];
     const envInputs: CompanyPortabilityManifest["envInputs"] = [];
-    const secretEntries: CompanyPortabilityManifest["secrets"] = [];
+    const secretEntries: CompanyPortabilitySecretEntry[] = [];
     const requestedSidebarOrder = normalizePortableSidebarOrder(input.sidebarOrder);
     const includeSecrets = input.includeSecrets === true;
     const rootPath = normalizeAgentUrlKey(company.name) ?? "company-package";

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -26,9 +26,11 @@ import type {
   CompanyPortabilityIssueManifestEntry,
   CompanyPortabilitySidebarOrder,
   CompanyPortabilitySkillManifestEntry,
+  CompanyPortabilitySecretEntry,
   CompanySkill,
   AgentEnvConfig,
   RoutineVariable,
+  SecretProvider,
 } from "@paperclipai/shared";
 import {
   ISSUE_PRIORITIES,
@@ -49,7 +51,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "@paperclipai/adapter-opencode-local/server";
 import { findServerAdapter } from "../adapters/index.js";
-import { forbidden, notFound, unprocessable } from "../errors.js";
+import { conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
 import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
 import type { StorageService } from "../storage/types.js";
 import { accessService } from "./access.js";
@@ -398,7 +400,7 @@ function normalizePortableProjectEnv(value: unknown): AgentEnvConfig | null {
   return parsed.success ? parsed.data : null;
 }
 
-function extractPortableScopedEnvInputs(
+async function extractPortableScopedEnvInputs(
   scope: {
     label: string;
     warningPrefix: string;
@@ -407,7 +409,11 @@ function extractPortableScopedEnvInputs(
   },
   envValue: unknown,
   warnings: string[],
-): CompanyPortabilityEnvInput[] {
+  secrets: { getById: (id: string) => Promise<{ name: string; provider: string } | null>; resolveSecretValue: (companyId: string, secretId: string, version: "latest") => Promise<string> },
+  secretEntries: CompanyPortabilitySecretEntry[],
+  includeSecrets: boolean,
+  companyId: string,
+): Promise<CompanyPortabilityEnvInput[]> {
   if (!isPlainRecord(envValue)) return [];
   const env = envValue as Record<string, unknown>;
   const inputs: CompanyPortabilityEnvInput[] = [];
@@ -419,6 +425,7 @@ function extractPortableScopedEnvInputs(
     }
 
     if (isPlainRecord(binding) && binding.type === "secret_ref") {
+      const secret = await secrets.getById(String(binding.secretId));
       inputs.push({
         key,
         description: `Provide ${key} for ${scope.label}`,
@@ -428,7 +435,30 @@ function extractPortableScopedEnvInputs(
         requirement: "optional",
         defaultValue: "",
         portability: "portable",
+        secretName: secret?.name ?? null,
+        secretProvider: secret?.provider ?? null,
       });
+      if (includeSecrets && secret && binding.secretId) {
+        try {
+          const resolvedValue = await secrets.resolveSecretValue(companyId, String(binding.secretId), "latest");
+          secretEntries.push({
+            name: secret.name,
+            provider: secret.provider as SecretProvider,
+            description: null,
+            latestVersion: 1,
+            currentValue: resolvedValue,
+          });
+        } catch {
+          secretEntries.push({
+            name: secret.name,
+            provider: secret.provider as SecretProvider,
+            description: null,
+            latestVersion: 1,
+            currentValue: `<decryption-key-missing:${secret.name}>`,
+          });
+          warnings.push(`Secret "${secret.name}" could not be decrypted during export. Placeholder written.`);
+        }
+      }
       continue;
     }
 
@@ -571,6 +601,8 @@ type EnvInputRecord = {
   default?: string | null;
   description?: string | null;
   portability?: "portable" | "system_dependent";
+  secretName?: string | null;
+  secretProvider?: string | null;
 };
 
 const COMPANY_LOGO_CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
@@ -1612,11 +1644,15 @@ function isAbsoluteCommand(value: string) {
   return path.isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value);
 }
 
-function extractPortableEnvInputs(
+async function extractPortableEnvInputs(
   agentSlug: string,
   envValue: unknown,
   warnings: string[],
-): CompanyPortabilityEnvInput[] {
+  secrets: { getById: (id: string) => Promise<{ name: string; provider: string } | null>; resolveSecretValue: (companyId: string, secretId: string, version: "latest") => Promise<string> },
+  secretEntries: CompanyPortabilitySecretEntry[],
+  includeSecrets: boolean,
+  companyId: string,
+): Promise<CompanyPortabilityEnvInput[]> {
   return extractPortableScopedEnvInputs(
     {
       label: `agent ${agentSlug}`,
@@ -1626,14 +1662,22 @@ function extractPortableEnvInputs(
     },
     envValue,
     warnings,
+    secrets,
+    secretEntries,
+    includeSecrets,
+    companyId,
   );
 }
 
-function extractPortableProjectEnvInputs(
+async function extractPortableProjectEnvInputs(
   projectSlug: string,
   envValue: unknown,
   warnings: string[],
-): CompanyPortabilityEnvInput[] {
+  secrets: { getById: (id: string) => Promise<{ name: string; provider: string } | null>; resolveSecretValue: (companyId: string, secretId: string, version: "latest") => Promise<string> },
+  secretEntries: CompanyPortabilitySecretEntry[],
+  includeSecrets: boolean,
+  companyId: string,
+): Promise<CompanyPortabilityEnvInput[]> {
   return extractPortableScopedEnvInputs(
     {
       label: `project ${projectSlug}`,
@@ -1643,6 +1687,10 @@ function extractPortableProjectEnvInputs(
     },
     envValue,
     warnings,
+    secrets,
+    secretEntries,
+    includeSecrets,
+    companyId,
   );
 }
 
@@ -2247,6 +2295,8 @@ function buildEnvInputMap(inputs: CompanyPortabilityEnvInput[]) {
     if (input.defaultValue !== null) entry.default = input.defaultValue;
     if (input.description) entry.description = input.description;
     if (input.portability === "system_dependent") entry.portability = "system_dependent";
+    if (input.secretName) entry.secretName = input.secretName;
+    if (input.secretProvider) entry.secretProvider = input.secretProvider;
     env[input.key] = entry;
   }
   return env;
@@ -2291,6 +2341,8 @@ function readAgentEnvInputs(
       requirement: record.requirement === "required" ? "required" : "optional",
       defaultValue: typeof record.default === "string" ? record.default : null,
       portability: record.portability === "system_dependent" ? "system_dependent" : "portable",
+      secretName: record.secretName ?? null,
+      secretProvider: record.secretProvider ?? null,
     }];
   });
 }
@@ -2315,6 +2367,8 @@ function readProjectEnvInputs(
       requirement: record.requirement === "required" ? "required" : "optional",
       defaultValue: typeof record.default === "string" ? record.default : null,
       portability: record.portability === "system_dependent" ? "system_dependent" : "portable",
+      secretName: record.secretName ?? null,
+      secretProvider: record.secretProvider ?? null,
     }];
   });
 }
@@ -2361,6 +2415,7 @@ function buildManifestFromPackageFiles(
   const paperclipProjects = isPlainRecord(paperclipExtension.projects) ? paperclipExtension.projects : {};
   const paperclipTasks = isPlainRecord(paperclipExtension.tasks) ? paperclipExtension.tasks : {};
   const paperclipRoutines = isPlainRecord(paperclipExtension.routines) ? paperclipExtension.routines : {};
+  const paperclipSecrets = Array.isArray(paperclipExtension.secrets) ? paperclipExtension.secrets : [];
   const companyName =
     asString(companyFrontmatter.name)
     ?? opts?.sourceLabel?.companyName
@@ -2440,6 +2495,7 @@ function buildManifestFromPackageFiles(
     projects: [],
     issues: [],
     envInputs: [],
+    secrets: paperclipSecrets.length > 0 ? paperclipSecrets : undefined,
   };
 
   const warnings: string[] = [];
@@ -2954,9 +3010,13 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     const files: Record<string, CompanyPortabilityFileEntry> = {};
     const warnings: string[] = [];
     const envInputs: CompanyPortabilityManifest["envInputs"] = [];
+    const secretEntries: CompanyPortabilityManifest["secrets"] = [];
     const requestedSidebarOrder = normalizePortableSidebarOrder(input.sidebarOrder);
+    const includeSecrets = input.includeSecrets === true;
     const rootPath = normalizeAgentUrlKey(company.name) ?? "company-package";
     let companyLogoPath: string | null = null;
+
+    const secrets = secretService(db);
 
     const allAgentRows = include.agents ? await agents.list(companyId, { includeTerminated: true }) : [];
     const liveAgentRows = allAgentRows.filter((agent) => agent.status !== "terminated");
@@ -3234,10 +3294,14 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
         warnings.push(...exportedInstructions.warnings);
 
         const envInputsStart = envInputs.length;
-        const exportedEnvInputs = extractPortableEnvInputs(
+        const exportedEnvInputs = await extractPortableEnvInputs(
           slug,
           (agent.adapterConfig as Record<string, unknown>).env,
           warnings,
+          secrets,
+          secretEntries,
+          includeSecrets,
+          companyId,
         );
         envInputs.push(...exportedEnvInputs);
         const adapterDefaultRules = ADAPTER_DEFAULT_RULES_BY_TYPE[agent.adapterType] ?? [];
@@ -3314,7 +3378,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
       const slug = projectSlugById.get(project.id)!;
       const projectPath = `projects/${slug}/PROJECT.md`;
       const envInputsStart = envInputs.length;
-      const exportedEnvInputs = extractPortableProjectEnvInputs(slug, project.env, warnings);
+      const exportedEnvInputs = await extractPortableProjectEnvInputs(slug, project.env, warnings, secrets, secretEntries, includeSecrets, companyId);
       envInputs.push(...exportedEnvInputs);
       const projectEnvInputs = dedupeEnvInputs(
         envInputs
@@ -3518,7 +3582,19 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
       skills: resolved.manifest.skills.length > 0,
     };
     resolved.manifest.envInputs = dedupeEnvInputs(envInputs);
+    if (includeSecrets) {
+      resolved.manifest.secrets = secretEntries.length > 0 ? secretEntries : undefined;
+    }
     resolved.warnings.unshift(...warnings);
+
+    // Rebuild the YAML file to include secrets so files stay in sync with manifest
+    // Only include secrets - other fields should come from the original YAML structure
+    if (includeSecrets && resolved.manifest.secrets) {
+      // Parse existing YAML and add secrets to it
+      const existingYaml = parseYamlFile(readPortableTextFile(finalFiles, paperclipExtensionPath) ?? "") ?? {};
+      existingYaml.secrets = resolved.manifest.secrets;
+      finalFiles[paperclipExtensionPath] = buildYamlFile(existingYaml, { preserveEmptyStrings: true });
+    }
 
     return {
       rootPath,
@@ -4103,6 +4179,34 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
       }
     }
 
+    // Create secrets in target company and build name->id map
+    const secretNameToId = new Map<string, string>();
+    for (const secretEntry of sourceManifest.secrets ?? []) {
+      if (secretEntry.currentValue.startsWith("<decryption-key-missing:")) {
+        warnings.push(`Secret "${secretEntry.name}" could not be decrypted in source instance. ` +
+          `Placeholder written for key. Create a secret with this name and update manually.`);
+        continue;
+      }
+      try {
+        const created = await secrets.create(targetCompany.id, {
+          name: secretEntry.name,
+          provider: secretEntry.provider,
+          value: secretEntry.currentValue,
+          description: secretEntry.description,
+        });
+        secretNameToId.set(secretEntry.name, created.id);
+      } catch (err) {
+        if (err instanceof HttpError && err.status === 409) {
+          const existing = await secrets.getByName(targetCompany.id, secretEntry.name);
+          if (existing) {
+            secretNameToId.set(secretEntry.name, existing.id);
+          }
+        } else {
+          warnings.push(`Failed to create secret "${secretEntry.name}": ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+    }
+
     if (include.agents) {
       for (const planAgent of plan.preview.plan.agentPlans) {
         const manifestAgent = plan.selectedAgents.find((agent) => agent.slug === planAgent.slug);
@@ -4287,6 +4391,9 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             ?? null
           : null;
         const projectWorkspaceIdByKey = new Map<string, string>();
+        const normalizedProjectEnv = manifestProject.env
+          ? await secrets.normalizeEnvBindingsForPersistence(targetCompany.id, manifestProject.env, { strictMode: strictSecretsMode })
+          : null;
         const projectPatch = {
           name: planProject.plannedName,
           description: manifestProject.description,
@@ -4296,7 +4403,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           status: manifestProject.status && PROJECT_STATUSES.includes(manifestProject.status as any)
             ? manifestProject.status as typeof PROJECT_STATUSES[number]
             : "backlog",
-          env: manifestProject.env,
+          env: normalizedProjectEnv ?? undefined,
           executionWorkspacePolicy: stripPortableProjectExecutionWorkspaceRefs(manifestProject.executionWorkspacePolicy),
         };
 
@@ -4371,6 +4478,57 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           await projects.update(projectId, {
             executionWorkspacePolicy: hydratedProjectExecutionWorkspacePolicy,
           });
+        }
+      }
+    }
+
+    // Remap secret_ref bindings in imported agent/project records to target company secret IDs
+    for (const envInput of sourceManifest.envInputs ?? []) {
+      if (envInput.portability === "system_dependent") {
+        const scope = envInput.agentSlug
+          ? ` for agent ${envInput.agentSlug}`
+          : envInput.projectSlug
+            ? ` for project ${envInput.projectSlug}`
+            : "";
+        warnings.push(`Environment input ${envInput.key}${scope} is system-dependent and was not imported. Set manually after import.`);
+        continue;
+      }
+      if (envInput.kind !== "secret" || !envInput.secretName) continue;
+      const newSecretId = secretNameToId.get(envInput.secretName);
+      if (!newSecretId) {
+        // secret wasn't created (decryption failure or error) — it's already a placeholder in the env
+        continue;
+      }
+      if (envInput.agentSlug) {
+        const agentId = importedSlugToAgentId.get(envInput.agentSlug);
+        if (agentId) {
+          const agent = await agents.getById(agentId);
+          if (agent) {
+            const adapterConfig = agent.adapterConfig as Record<string, unknown>;
+            const env = adapterConfig.env as Record<string, unknown> | undefined;
+            if (env && typeof env[envInput.key] === "object" && env[envInput.key] !== null) {
+              const binding = env[envInput.key] as Record<string, unknown>;
+              if (binding.type === "secret_ref") {
+                binding.secretId = newSecretId;
+              }
+            }
+            await agents.update(agentId, { adapterConfig });
+          }
+        }
+      } else if (envInput.projectSlug) {
+        const projectId = importedSlugToProjectId.get(envInput.projectSlug);
+        if (projectId) {
+          const project = await projects.getById(projectId);
+          if (project && project.env && typeof project.env === "object") {
+            const env = project.env as Record<string, unknown>;
+            if (typeof env[envInput.key] === "object" && env[envInput.key] !== null) {
+              const binding = env[envInput.key] as Record<string, unknown>;
+              if (binding.type === "secret_ref") {
+                binding.secretId = newSecretId;
+              }
+            }
+            await projects.update(projectId, { env: env as import("@paperclipai/shared").AgentEnvConfig });
+          }
         }
       }
     }

--- a/ui/src/pages/CompanyExport.tsx
+++ b/ui/src/pages/CompanyExport.tsx
@@ -17,6 +17,7 @@ import { authApi } from "../api/auth";
 import { companiesApi } from "../api/companies";
 import { projectsApi } from "../api/projects";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { MarkdownBody } from "../components/MarkdownBody";
@@ -603,6 +604,7 @@ export function CompanyExport() {
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
   const [checkedFiles, setCheckedFiles] = useState<Set<string>>(new Set());
   const [treeSearch, setTreeSearch] = useState("");
+  const [includeSecrets, setIncludeSecrets] = useState(false);
   const [taskLimit, setTaskLimit] = useState(TASKS_PAGE_SIZE);
   const savedExpandedRef = useRef<Set<string> | null>(null);
   const initialFileFromUrl = useRef(filePathFromLocation(location.pathname));
@@ -682,6 +684,7 @@ export function CompanyExport() {
       companiesApi.exportPreview(selectedCompanyId!, {
         include: { company: true, agents: true, projects: true, issues: true },
         sidebarOrder,
+        includeSecrets,
       }),
     onSuccess: (result) => {
       setExportData(result);
@@ -731,6 +734,7 @@ export function CompanyExport() {
         include: { company: true, agents: true, projects: true, issues: true },
         selectedFiles: Array.from(checkedFiles).sort(),
         sidebarOrder,
+        includeSecrets,
       }),
     onSuccess: (result) => {
       const resultCheckedFiles = new Set(Object.keys(result.files));
@@ -756,7 +760,7 @@ export function CompanyExport() {
     setExportData(null);
     exportPreviewMutation.mutate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedCompanyId, isSessionFetched, areAgentsFetched, areProjectsFetched, sidebarOrderKey]);
+  }, [selectedCompanyId, isSessionFetched, areAgentsFetched, areProjectsFetched, sidebarOrderKey, includeSecrets]);
 
   const tree = useMemo(
     () => (exportData ? buildFileTree(exportData.files) : []),
@@ -945,6 +949,23 @@ export function CompanyExport() {
                 {warnings.length} warning{warnings.length === 1 ? "" : "s"}
               </span>
             )}
+            {exportData?.manifest.secrets && exportData.manifest.secrets.length > 0 && (
+              <span className="rounded-md border border-amber-500/30 bg-amber-500/5 px-2 py-0.5 text-xs text-amber-500">
+                {exportData.manifest.secrets.length} secret{exportData.manifest.secrets.length === 1 ? "" : "s"} included
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2 text-sm">
+              <Checkbox
+                id="include-secrets"
+                checked={includeSecrets}
+                onCheckedChange={(checked) => setIncludeSecrets(Boolean(checked))}
+              />
+              <label htmlFor="include-secrets" className="cursor-pointer text-muted-foreground hover:text-foreground transition-colors">
+                Include secrets
+              </label>
+            </div>
           </div>
           <Button
             size="sm"

--- a/ui/src/pages/CompanyExport.tsx
+++ b/ui/src/pages/CompanyExport.tsx
@@ -965,6 +965,9 @@ export function CompanyExport() {
               <label htmlFor="include-secrets" className="cursor-pointer text-muted-foreground hover:text-foreground transition-colors">
                 Include secrets
               </label>
+              {includeSecrets && (
+                <span className="text-xs text-amber-500">(secrets exported as plaintext)</span>
+              )}
             </div>
           </div>
           <Button

--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -866,7 +866,7 @@ export function CompanyImport() {
         title: "Import complete",
         body: `${result.company.name}: ${result.agents.length} agent${result.agents.length === 1 ? "" : "s"} processed.`,
       });
-      if (result.warnings.some((w) => w.includes("decryption-key-missing") || w.includes("Secret"))) {
+      if (result.warnings.some((w) => w.includes("could not be decrypted") || w.toLowerCase().includes("failed to create secret"))) {
         pushToast({
           tone: "warn",
           title: "Secrets import warning",

--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -866,6 +866,13 @@ export function CompanyImport() {
         title: "Import complete",
         body: `${result.company.name}: ${result.agents.length} agent${result.agents.length === 1 ? "" : "s"} processed.`,
       });
+      if (result.warnings.some((w) => w.includes("decryption-key-missing") || w.includes("Secret"))) {
+        pushToast({
+          tone: "warn",
+          title: "Secrets import warning",
+          body: "Some secrets could not be decrypted. Review warnings and recreate manually.",
+        });
+      }
       // Force a fresh dashboard load so newly imported agents are immediately visible.
       window.location.assign(`/${importedCompany.issuePrefix}/dashboard`);
     },
@@ -1305,6 +1312,18 @@ export function CompanyImport() {
             <div className="mx-5 mt-3 rounded-md border border-amber-500/30 bg-amber-500/5 px-4 py-3">
               {importPreview.warnings.map((w) => (
                 <div key={w} className="text-xs text-amber-500">{w}</div>
+              ))}
+            </div>
+          )}
+
+          {/* Secrets info */}
+          {importPreview.manifest.secrets && importPreview.manifest.secrets.length > 0 && (
+            <div className="mx-5 mt-3 rounded-md border border-amber-500/30 bg-amber-500/5 px-4 py-3">
+              <div className="text-xs font-medium text-amber-500 mb-1">Secrets to import</div>
+              {importPreview.manifest.secrets.map((s) => (
+                <div key={s.name} className="text-xs text-amber-500">
+                  {s.name}{s.provider !== "local_encrypted" ? ` (${s.provider})` : ""}
+                </div>
               ))}
             </div>
           )}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The company portability subsystem handles export/import of entire company packages across instances
> - Agent and project env bindings can reference secrets (`secret_ref` type), but these were opaque during export — secret names, providers, and values were lost
> - Cross-instance portability requires secrets to travel with the package so the target instance can recreate them without manual setup
> - This pull request adds opt-in secret export/import: exports resolve secret metadata (name, provider) onto env inputs and optionally decrypt current values into the manifest; imports recreate secrets in the target company and remap `secret_ref` bindings to new secret IDs
> - The benefit is fully portable company packages that work across Paperclip instances without manual secret re-entry

## What Changed

- Extended `CompanyPortabilityEnvInput` with `secretName` and `secretProvider` fields so exported env inputs carry secret identity
- Added `CompanyPortabilitySecretEntry` type and optional `secrets` array to the portability manifest
- Added `includeSecrets` flag to `CompanyPortabilityExportRequest` — when true, secret values are resolved and included in the manifest
- Updated `extractPortableScopedEnvInputs` (and its agent/project wrappers) to look up secret metadata and optionally resolve values, with graceful fallback to `<decryption-key-missing:…>` placeholders when decryption fails
- Import path now creates secrets in the target company, handles name conflicts by reusing existing secrets, and remaps all `secret_ref` bindings in imported agents/projects to the new secret IDs
- Added `CompanyExport.tsx` UI: checkbox to opt into secret inclusion, badge showing secret count
- Added `CompanyImport.tsx` UI: amber info panel listing secrets to import, toast warning when secrets had decryption issues
- Extended Zod validators to cover the new manifest fields
- Added 7 new test cases covering: secret metadata export, value export, omission when disabled, decryption failure placeholders, import with remap, conflict reuse, and plain env var fidelity

## Verification

- `pnpm vitest run server/src/__tests__/company-portability.test.ts` — all existing and new tests pass
- Manual: export a company with `includeSecrets` checked, verify manifest YAML contains `secrets:` block with resolved values
- Manual: import the exported package into a different company, verify secrets are created and agent env bindings reference the new secret IDs
- Manual: export when a secret's master key is unavailable, verify placeholder value and warning

## Risks

- Secret values are included in the export bundle as plaintext when `includeSecrets` is enabled — the UI warns about this but users should handle exported packages with care
- If the target instance uses a different secret provider than the source, the imported secret may need manual provider migration after import

## Model Used

Claude Opus 4.6 (1M context) — `claude-opus-4-6`, tool use mode via Claude Code CLI

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge