### PR TITLE
fix: prevent agent comment retrigger loops and fix system comment display

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1843,7 +1843,16 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+        // Defensive: also treat a comment as a self-comment when its createdByRunId
+        // matches the issue's active execution run. This prevents retrigger loops when
+        // agent auth falls through to board-user context (e.g. missing JWT secret in
+        // local mode) but the run ID header is still present and correct.
+        const runLinkedSelfComment =
+          !selfComment &&
+          comment.createdByRunId &&
+          issue.executionRunId &&
+          comment.createdByRunId === issue.executionRunId;
+        const skipAssigneeCommentWake = selfComment || runLinkedSelfComment || isClosed;
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {
@@ -2435,7 +2444,14 @@ export function issueRoutes(
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;
-      const skipWake = selfComment || isClosed;
+      // Defensive: also treat a comment as a self-comment when its createdByRunId
+      // matches the issue's active execution run (same rationale as PATCH route).
+      const runLinkedSelfComment =
+        !selfComment &&
+        comment.createdByRunId &&
+        currentIssue.executionRunId &&
+        comment.createdByRunId === currentIssue.executionRunId;
+      const skipWake = selfComment || runLinkedSelfComment || isClosed;
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
           wakeups.set(assigneeId, {

--- a/ui/src/lib/issue-chat-messages.ts
+++ b/ui/src/lib/issue-chat-messages.ts
@@ -276,7 +276,7 @@ function authorNameForComment(
     return agentMap?.get(comment.authorAgentId)?.name ?? comment.authorAgentId.slice(0, 8);
   }
   const authorUserId = comment.authorUserId ?? null;
-  if (!authorUserId) return "You";
+  if (!authorUserId) return "System";
   const userLabel = userLabelMap?.get(authorUserId)?.trim();
   if (userLabel) return userLabel;
   return formatAssigneeUserLabel(authorUserId, currentUserId, userLabelMap) ?? "You";


### PR DESCRIPTION
## Summary

Fixes agent completion comments being misattributed to the board user, causing retrigger loops.

Closes #3817

## Root Cause

1. **Wake-skip logic only checks actor identity** (`server/src/routes/issues.ts`): when an agent's JWT fails or is missing, the request falls through to the implicit board-user actor. The self-comment check fails, triggering a wake loop.

2. **System comments show as "You"** (`ui/src/lib/issue-chat-messages.ts`): comments with no author display as "You" instead of "System".

## Changes

- **Defensive wake-skip**: if `comment.createdByRunId` matches the issue's `executionRunId`, treat as self-comment regardless of actor type (both PATCH and POST comment routes)
- **UI label fix**: show "System" instead of "You" for comments with no author

## Verification

- `pnpm -r typecheck` — pass
- `pnpm test:run` — pass (4 pre-existing timeout failures unrelated)
- `pnpm build` — pass
- Related test suites pass: `heartbeat-comment-wake-batching`, `issue-update-comment-wakeup-routes`, `issue-comment-cancel-routes`