### PR TITLE
fix(heartbeat): keep adapter_failed continuation blockers on Review Manager (WEB-1550)

### DIFF
--- a/packages/db/src/test-embedded-postgres.ts
+++ b/packages/db/src/test-embedded-postgres.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { applyPendingMigrations, ensurePostgresDatabase } from "./client.js";
 
 type EmbeddedPostgresInstance = {
@@ -32,6 +33,17 @@ export type EmbeddedPostgresTestDatabase = {
 };
 
 let embeddedPostgresSupportPromise: Promise<EmbeddedPostgresTestSupport> | null = null;
+
+function ensureDirectoryOwnedByPostgres(dataDir: string) {
+  if (process.platform === "win32") return;
+  if (typeof process.getuid === "function" && process.getuid() !== 0) return;
+
+  try {
+    execFileSync("chown", ["-R", "postgres:postgres", dataDir]);
+  } catch {
+    // If the host cannot chown the temp directory, fall back to the existing behavior.
+  }
+}
 
 async function getEmbeddedPostgresCtor(): Promise<EmbeddedPostgresCtor> {
   const mod = await import("embedded-postgres");
@@ -66,6 +78,7 @@ function formatEmbeddedPostgresError(error: unknown): string {
 
 async function probeEmbeddedPostgresSupport(): Promise<EmbeddedPostgresTestSupport> {
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-embedded-postgres-probe-"));
+  ensureDirectoryOwnedByPostgres(dataDir);
   const port = await getAvailablePort();
   const EmbeddedPostgres = await getEmbeddedPostgresCtor();
   const instance = new EmbeddedPostgres({
@@ -105,6 +118,7 @@ export async function startEmbeddedPostgresTestDatabase(
   tempDirPrefix: string,
 ): Promise<EmbeddedPostgresTestDatabase> {
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), tempDirPrefix));
+  ensureDirectoryOwnedByPostgres(dataDir);
   const port = await getAvailablePort();
   const EmbeddedPostgres = await getEmbeddedPostgresCtor();
   const instance = new EmbeddedPostgres({

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -308,6 +308,12 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     runStatus: "failed" | "timed_out" | "cancelled" | "succeeded";
     retryReason?: "assignment_recovery" | "issue_continuation_needed" | null;
     assignToUser?: boolean;
+    blockedAssigneeMode?: "agent" | "user" | "none";
+    agentName?: string;
+    issueTitle?: string;
+    runErrorCode?: string | null;
+    runError?: string | null;
+    createdByAgentId?: string | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -374,16 +380,35 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       error: input.runStatus === "succeeded" ? null : "run failed before issue advanced",
     });
 
+    const blockedAssigneeMode = input.blockedAssigneeMode ?? "none";
+    const assigneeAgentId =
+      input.status === "blocked"
+        ? blockedAssigneeMode === "agent"
+          ? agentId
+          : null
+        : input.assignToUser
+          ? null
+          : agentId;
+    const assigneeUserId =
+      input.status === "blocked"
+        ? blockedAssigneeMode === "user"
+          ? "user-1"
+          : null
+        : input.assignToUser
+          ? "user-1"
+          : null;
+
     await db.insert(issues).values({
       id: issueId,
       companyId,
       title: "Recover stranded assigned work",
       status: input.status,
       priority: "medium",
-      assigneeAgentId: input.assignToUser ? null : agentId,
-      assigneeUserId: input.assignToUser ? "user-1" : null,
+      assigneeAgentId,
+      assigneeUserId,
       checkoutRunId: input.status === "in_progress" ? runId : null,
-      executionRunId: null,
+      executionRunId: input.runStatus === "running" ? runId : null,
+      createdByAgentId: input.createdByAgentId === undefined ? agentId : input.createdByAgentId,
       issueNumber: 1,
       identifier: `${issuePrefix}-1`,
       startedAt: input.status === "in_progress" ? now : null,
@@ -669,5 +694,102 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
+  });
+
+  it("reroutes blocked orphaned issues back to their creator agent when no active execution run remains", async () => {
+    const { issueId, agentId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "failed",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.blockedRerouted).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    expect(issue?.assigneeAgentId).toBe(agentId);
+    expect(issue?.assigneeUserId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
+  });
+
+  it("reroutes blocked user-owned issues back to an agent owner", async () => {
+    const { issueId, agentId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "failed",
+      blockedAssigneeMode: "user",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.blockedRerouted).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(agentId);
+    expect(issue?.assigneeUserId).toBeNull();
+  });
+
+  it("keeps blocked ownership intact while a live execution run still exists", async () => {
+    const { issueId, agentId, runId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "running",
+      blockedAssigneeMode: "agent",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.blockedRerouted).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(agentId);
+    expect(issue?.executionRunId).toBe(runId);
+  });
+
+  it("keeps blocked review-manager review ownership intact without a live run", async () => {
+    const { issueId, agentId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "failed",
+      blockedAssigneeMode: "agent",
+      agentName: "Review Manager",
+      issueTitle: "[REVIEW] Verify adapter_failed continuation routing",
+      runErrorCode: "adapter_failed",
+      runError: "reviewer adapter unavailable",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.blockedRerouted).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    expect(issue?.assigneeAgentId).toBe(agentId);
+  });
+
+  it("restores the checkout agent on blocked issues during terminal run cleanup without waiting for the periodic sweep", async () => {
+    const { issueId, runId, agentId } = await seedRunFixture();
+    const heartbeat = heartbeatService(db);
+
+    await db
+      .update(issues)
+      .set({
+        status: "blocked",
+        checkoutRunId: null,
+        executionRunId: null,
+      })
+      .where(eq(issues.id, issueId));
+
+    await heartbeat.cancelRun(runId);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    expect(issue?.assigneeAgentId).toBe(agentId);
+    expect(issue?.assigneeUserId).toBeNull();
   });
 });

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -333,7 +333,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.insert(agents).values({
       id: agentId,
       companyId,
-      name: "CodexCoder",
+      name: input.agentName ?? "CodexCoder",
       role: "engineer",
       status: "idle",
       adapterType: "codex_local",
@@ -376,8 +376,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       startedAt: now,
       finishedAt: new Date("2026-03-19T00:05:00.000Z"),
       updatedAt: new Date("2026-03-19T00:05:00.000Z"),
-      errorCode: input.runStatus === "succeeded" ? null : "process_lost",
-      error: input.runStatus === "succeeded" ? null : "run failed before issue advanced",
+      errorCode: input.runErrorCode ?? (input.runStatus === "succeeded" ? null : "process_lost"),
+      error: input.runError ?? (input.runStatus === "succeeded" ? null : "run failed before issue advanced"),
     });
 
     const blockedAssigneeMode = input.blockedAssigneeMode ?? "none";
@@ -401,7 +401,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.insert(issues).values({
       id: issueId,
       companyId,
-      title: "Recover stranded assigned work",
+      title: input.issueTitle ?? "Recover stranded assigned work",
       status: input.status,
       priority: "medium",
       assigneeAgentId,
@@ -757,7 +757,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       runStatus: "failed",
       blockedAssigneeMode: "agent",
       agentName: "Review Manager",
-      issueTitle: "[REVIEW] Verify adapter_failed continuation routing",
+      issueTitle: "[REVIEW-GPT] Verify adapter_failed continuation routing",
       runErrorCode: "adapter_failed",
       runError: "reviewer adapter unavailable",
     });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -590,6 +590,7 @@ export async function startServer(): Promise<StartedServer> {
         if (
           reconciled.dispatchRequeued > 0 ||
           reconciled.continuationRequeued > 0 ||
+          reconciled.blockedRerouted > 0 ||
           reconciled.escalated > 0
         ) {
           logger.warn({ ...reconciled }, "startup stranded-issue reconciliation changed assigned issue state");
@@ -631,6 +632,7 @@ export async function startServer(): Promise<StartedServer> {
           if (
             reconciled.dispatchRequeued > 0 ||
             reconciled.continuationRequeued > 0 ||
+            reconciled.blockedRerouted > 0 ||
             reconciled.escalated > 0
           ) {
             logger.warn({ ...reconciled }, "periodic stranded-issue reconciliation changed assigned issue state");

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1414,7 +1414,8 @@ function isReviewManagerBlockerIssue(input: {
 }) {
   if (!isReviewManagerNameKey(input.assigneeAgentName)) return false;
   if (typeof input.title !== "string") return false;
-  return input.title.trim().toLowerCase().startsWith("[review]");
+  const normalizedTitle = input.title.trim().toLowerCase();
+  return normalizedTitle.startsWith("[review]") || normalizedTitle.startsWith("[review-");
 }
 
 function isAssignableRecoveryAgent(agent: {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1403,6 +1403,28 @@ function normalizeAgentNameKey(value: string | null | undefined) {
   return normalized.length > 0 ? normalized : null;
 }
 
+function isReviewManagerNameKey(value: string | null | undefined) {
+  const normalized = normalizeAgentNameKey(value);
+  return normalized === "review manager" || normalized === "review-manager";
+}
+
+function isReviewManagerBlockerIssue(input: {
+  title: string | null | undefined;
+  assigneeAgentName: string | null | undefined;
+}) {
+  if (!isReviewManagerNameKey(input.assigneeAgentName)) return false;
+  if (typeof input.title !== "string") return false;
+  return input.title.trim().toLowerCase().startsWith("[review]");
+}
+
+function isAssignableRecoveryAgent(agent: {
+  companyId: string;
+  status: string;
+} | null | undefined, companyId: string) {
+  if (!agent) return false;
+  if (agent.companyId !== companyId) return false;
+  return agent.status !== "pending_approval" && agent.status !== "terminated";
+}
 const defaultSessionCodec: AdapterSessionCodec = {
   deserialize(raw: unknown) {
     const asObj = parseObject(raw);
@@ -2912,6 +2934,156 @@ export function heartbeatService(db: Db) {
     return Boolean(run || deferredWake);
   }
 
+  async function findCompanyFallbackRecoveryAgent(companyId: string) {
+    const candidates = await db
+      .select({
+        id: agents.id,
+        companyId: agents.companyId,
+        status: agents.status,
+        role: agents.role,
+      })
+      .from(agents)
+      .where(eq(agents.companyId, companyId))
+      .orderBy(
+        sql`case
+          when ${agents.role} = 'cto' then 0
+          when ${agents.role} = 'ceo' then 1
+          else 2
+        end`,
+        asc(agents.createdAt),
+        asc(agents.id),
+      );
+
+    return candidates.find((candidate) => isAssignableRecoveryAgent(candidate, companyId)) ?? null;
+  }
+
+  async function resolveBlockedIssueRecoveryAgentId(input: {
+    companyId: string;
+    parentId?: string | null;
+    createdByAgentId?: string | null;
+    preferredAgentId?: string | null;
+  }) {
+    const candidateIds: string[] = [];
+    if (input.preferredAgentId) candidateIds.push(input.preferredAgentId);
+    if (input.createdByAgentId) candidateIds.push(input.createdByAgentId);
+
+    let currentParentId = input.parentId ?? null;
+    const visitedParentIds = new Set<string>();
+    while (currentParentId && !visitedParentIds.has(currentParentId)) {
+      visitedParentIds.add(currentParentId);
+      const parent = await db
+        .select({
+          id: issues.id,
+          parentId: issues.parentId,
+          assigneeAgentId: issues.assigneeAgentId,
+          createdByAgentId: issues.createdByAgentId,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, input.companyId), eq(issues.id, currentParentId)))
+        .then((rows) => rows[0] ?? null);
+      if (!parent) break;
+      if (parent.assigneeAgentId) candidateIds.push(parent.assigneeAgentId);
+      if (parent.createdByAgentId) candidateIds.push(parent.createdByAgentId);
+      currentParentId = parent.parentId ?? null;
+    }
+
+    const seenAgentIds = new Set<string>();
+    for (const candidateId of candidateIds) {
+      if (!candidateId || seenAgentIds.has(candidateId)) continue;
+      seenAgentIds.add(candidateId);
+      const candidate = await getAgent(candidateId);
+      if (isAssignableRecoveryAgent(candidate, input.companyId)) {
+        return candidate.id;
+      }
+    }
+
+    const fallback = await findCompanyFallbackRecoveryAgent(input.companyId);
+    return fallback?.id ?? null;
+  }
+
+  async function rerouteBlockedIssueOwnership(input: {
+    issue: Pick<
+      typeof issues.$inferSelect,
+      | "id"
+      | "companyId"
+      | "identifier"
+      | "title"
+      | "status"
+      | "assigneeAgentId"
+      | "assigneeUserId"
+      | "checkoutRunId"
+      | "parentId"
+      | "createdByAgentId"
+    >;
+    source: string;
+    tx?: any;
+    runId?: string | null;
+    preferredAgentId?: string | null;
+  }) {
+    if (input.issue.status !== "blocked") return null;
+
+    if (input.issue.assigneeAgentId) {
+      const assigneeAgent = await getAgent(input.issue.assigneeAgentId);
+      if (
+        assigneeAgent &&
+        isReviewManagerBlockerIssue({
+          title: input.issue.title,
+          assigneeAgentName: assigneeAgent.name,
+        })
+      ) {
+        return null;
+      }
+    }
+
+    const recoveryAgentId = await resolveBlockedIssueRecoveryAgentId({
+      companyId: input.issue.companyId,
+      parentId: input.issue.parentId ?? null,
+      createdByAgentId: input.issue.createdByAgentId ?? null,
+      preferredAgentId: input.preferredAgentId ?? null,
+    });
+    if (!recoveryAgentId) return null;
+    if (
+      input.issue.assigneeAgentId === recoveryAgentId &&
+      input.issue.assigneeUserId == null
+    ) {
+      return null;
+    }
+
+    const executor: any = input.tx ?? db;
+    const updated = await issuesSvc.update(
+      input.issue.id,
+      {
+        assigneeAgentId: recoveryAgentId,
+        assigneeUserId: null,
+      },
+      executor,
+    );
+    if (!updated) return null;
+
+    await logActivity(executor, {
+      companyId: input.issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: input.runId ?? null,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: input.issue.id,
+      details: {
+        identifier: input.issue.identifier,
+        status: "blocked",
+        source: input.source,
+        ownershipRerouted: true,
+        reroutedAssigneeAgentId: recoveryAgentId,
+        previousAssigneeAgentId: input.issue.assigneeAgentId,
+        previousAssigneeUserId: input.issue.assigneeUserId,
+        previousCheckoutRunId: input.issue.checkoutRunId ?? null,
+      },
+    });
+
+    return updated;
+  }
+
   async function enqueueStrandedIssueRecovery(input: {
     issueId: string;
     agentId: string;
@@ -3009,6 +3181,7 @@ export function heartbeatService(db: Db) {
     const result = {
       dispatchRequeued: 0,
       continuationRequeued: 0,
+      blockedRerouted: 0,
       escalated: 0,
       skipped: 0,
       issueIds: [] as string[],
@@ -3119,6 +3292,49 @@ export function heartbeatService(db: Db) {
       }
     }
 
+    const blockedCandidates = await db
+      .select({
+        id: issues.id,
+        companyId: issues.companyId,
+        identifier: issues.identifier,
+        title: issues.title,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+        checkoutRunId: issues.checkoutRunId,
+        parentId: issues.parentId,
+        createdByAgentId: issues.createdByAgentId,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.status, "blocked"),
+          sql`${issues.assigneeAgentId} is null`,
+        ),
+      );
+
+    for (const issue of blockedCandidates) {
+      if (await hasActiveExecutionPath(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      try {
+        const rerouted = await rerouteBlockedIssueOwnership({
+          issue,
+          source: "heartbeat.blocked_orphan_assignee_sweep",
+        });
+        if (rerouted) {
+          result.blockedRerouted += 1;
+          result.issueIds.push(issue.id);
+        } else {
+          result.skipped += 1;
+        }
+      } catch (err) {
+        logger.error({ err, issueId: issue.id }, "failed to reroute blocked orphan issue ownership");
+        result.skipped += 1;
+      }
+    }
     return result;
   }
 
@@ -4224,7 +4440,13 @@ export function heartbeatService(db: Db) {
           id: issues.id,
           companyId: issues.companyId,
           identifier: issues.identifier,
+          title: issues.title,
           status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+          checkoutRunId: issues.checkoutRunId,
+          parentId: issues.parentId,
+          createdByAgentId: issues.createdByAgentId,
           executionRunId: issues.executionRunId,
         })
         .from(issues)
@@ -4266,7 +4488,16 @@ export function heartbeatService(db: Db) {
           .limit(1)
           .then((rows) => rows[0] ?? null);
 
-        if (!deferred) return null;
+        if (!deferred) {
+          await rerouteBlockedIssueOwnership({
+            issue,
+            source: "heartbeat.run_completion_release",
+            tx,
+            runId: run.id,
+            preferredAgentId: run.agentId,
+          });
+          return null;
+        }
 
         const deferredAgent = await tx
           .select()


### PR DESCRIPTION
WEB-1550\n\nScope:\n- Keep parent review tickets on Review Manager when a reviewer continuation fails with adapter_failed.\n- Reroute blocked orphaned issues back to the most appropriate agent owner instead of dropping them from blocked ownership.\n- Preserve the blocked Review Manager exception so review gates remain visible.\n- Add regression coverage for blocked reroute behavior and the continuation blocker path.\n- Fix embedded Postgres temp dir ownership for root-run test environments.\n\nTests:\n- pnpm test -- --run server/src/__tests__/heartbeat-process-recovery.test.ts\n- pnpm --filter @paperclipai/server typecheck\n\nRisks:\n- The blocked reroute sweep now reassigns blocked issues to a fallback agent when no live execution path remains, so the ownership heuristic should stay conservative.\n- Existing Review Manager-owned review blockers are intentionally exempted from the generic blocked sweep.