### PR TITLE
Fix routine execution reconciliation

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -14,6 +14,8 @@ import {
   heartbeatRuns,
   issueComments,
   issues,
+  routineRuns,
+  routines,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -22,6 +24,16 @@ import {
 import { runningProcesses } from "../adapters/index.ts";
 const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
 const mockTrackAgentFirstHeartbeat = vi.hoisted(() => vi.fn());
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    provider: "test",
+    model: "test-model",
+  })),
+);
 
 vi.mock("../telemetry.ts", () => ({
   getTelemetryClient: () => mockTelemetryClient,
@@ -37,25 +49,26 @@ vi.mock("@paperclipai/shared/telemetry", async () => {
   };
 });
 
+vi.mock("../services/company-skills.ts", () => ({
+  companySkillService: () => ({
+    listRuntimeSkillEntries: vi.fn(async () => []),
+  }),
+}));
+
 vi.mock("../adapters/index.ts", async () => {
   const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
   return {
     ...actual,
     getServerAdapter: vi.fn(() => ({
       supportsLocalAgentJwt: false,
-      execute: vi.fn(async () => ({
-        exitCode: 0,
-        signal: null,
-        timedOut: false,
-        errorMessage: null,
-        provider: "test",
-        model: "test-model",
-      })),
+      execute: mockAdapterExecute,
     })),
   };
 });
 
 import { heartbeatService } from "../services/heartbeat.ts";
+import { issueService } from "../services/issues.ts";
+import { routineService } from "../services/routines.ts";
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
@@ -102,6 +115,52 @@ async function waitForRunToSettle(
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   return heartbeat.getRun(runId);
+}
+
+async function waitForAgentRunsToSettle(
+  db: ReturnType<typeof createDb>,
+  agentId: string,
+  expectedRunCount: number,
+  timeoutMs = 3_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    if (runs.length >= expectedRunCount && runs.every((run) => run.status !== "queued" && run.status !== "running")) {
+      return runs;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+}
+
+async function waitForIssueExecutionLock(
+  db: ReturnType<typeof createDb>,
+  issueId: string,
+  timeoutMs = 3_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    if (issue?.executionRunId && issue.status === "in_progress") return issue;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+}
+
+async function waitForIssueStatus(
+  db: ReturnType<typeof createDb>,
+  issueId: string,
+  status: typeof issues.$inferSelect.status,
+  timeoutMs = 3_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    if (issue?.status === status) return issue;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
 }
 
 async function spawnOrphanedProcessGroup() {
@@ -157,6 +216,14 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   afterEach(async () => {
     vi.clearAllMocks();
+    mockAdapterExecute.mockImplementation(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      provider: "test",
+      model: "test-model",
+    }));
     runningProcesses.clear();
     for (const child of childProcesses) {
       child.kill("SIGKILL");
@@ -182,6 +249,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(agentRuntimeState);
     await db.delete(companySkills);
     await db.delete(issueComments);
+    await db.delete(routineRuns);
+    await db.delete(routines);
     await db.delete(issues);
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
@@ -392,6 +461,75 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     return { companyId, agentId, runId, wakeupRequestId, issueId };
   }
 
+  async function seedRoutineExecutionIssueFixture(input?: {
+    issueStatus?: "todo" | "in_progress" | "blocked" | "cancelled";
+  }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const routineId = randomUUID();
+    const routineRunId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      title: "Daily cleanup",
+      description: "Clean stale artifacts",
+      assigneeAgentId: agentId,
+      priority: "medium",
+      status: "active",
+      concurrencyPolicy: "coalesce_if_active",
+      catchUpPolicy: "skip_missed",
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Daily cleanup",
+      description: "Clean stale artifacts",
+      status: input?.issueStatus ?? "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+      originKind: "routine_execution",
+      originId: routineId,
+      originRunId: routineRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: routineRunId,
+      companyId,
+      routineId,
+      source: "schedule",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-19T00:00:00.000Z"),
+      linkedIssueId: issueId,
+    });
+
+    return { agentId, issueId, routineRunId };
+  }
+
   it("keeps a local run active when the recorded pid is still alive", async () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);
@@ -550,6 +688,221 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         agentRole: "engineer",
       }),
     );
+  });
+
+  it("closes open routine execution issues when their heartbeat run succeeds", async () => {
+    const { agentId, issueId, routineRunId } = await seedRoutineExecutionIssueFixture({
+      issueStatus: "todo",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "routine_execution",
+      payload: { issueId },
+      contextSnapshot: { issueId, source: "routine.dispatch" },
+    });
+    expect(run?.id).toBeTruthy();
+    const settledRun = run ? await waitForRunToSettle(heartbeat, run.id) : null;
+    expect(settledRun?.status).toBe("succeeded");
+
+    const issue = await waitForIssueStatus(db, issueId, "done");
+    expect(issue?.status).toBe("done");
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
+    expect(issue?.completedAt).toBeInstanceOf(Date);
+
+    const routineRun = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.id, routineRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(routineRun?.status).toBe("completed");
+    expect(routineRun?.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("does not auto-close cancelled routine execution issues after a succeeding heartbeat", async () => {
+    const { agentId, issueId, routineRunId } = await seedRoutineExecutionIssueFixture({
+      issueStatus: "cancelled",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "routine_execution",
+      payload: { issueId },
+      contextSnapshot: { issueId, source: "routine.dispatch" },
+    });
+    expect(run?.id).toBeTruthy();
+    const settledRun = run ? await waitForRunToSettle(heartbeat, run.id) : null;
+    expect(settledRun?.status).toBe("succeeded");
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("cancelled");
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.completedAt).toBeNull();
+
+    const routineRun = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.id, routineRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(routineRun?.status).toBe("issue_created");
+    expect(routineRun?.completedAt).toBeNull();
+  });
+
+  it("preserves routine execution cancellation while the heartbeat run is active", async () => {
+    let releaseAdapter!: () => void;
+    const adapterReleased = new Promise<void>((resolve) => {
+      releaseAdapter = resolve;
+    });
+    mockAdapterExecute.mockImplementationOnce(async () => {
+      await adapterReleased;
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const { agentId, issueId, routineRunId } = await seedRoutineExecutionIssueFixture({
+      issueStatus: "todo",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "routine_execution",
+      payload: { issueId },
+      contextSnapshot: { issueId, source: "routine.dispatch" },
+    });
+    expect(run?.id).toBeTruthy();
+
+    const activeIssue = await waitForIssueExecutionLock(db, issueId);
+    expect(activeIssue?.status).toBe("in_progress");
+    expect(activeIssue?.executionRunId).toBe(run?.id);
+
+    await issueService(db).update(issueId, { status: "cancelled" });
+    await routineService(db).syncRunStatusForIssue(issueId);
+
+    releaseAdapter();
+    const settledRun = run ? await waitForRunToSettle(heartbeat, run.id) : null;
+    expect(settledRun?.status).toBe("succeeded");
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("cancelled");
+    expect(issue?.completedAt).toBeNull();
+    expect(issue?.cancelledAt).toBeInstanceOf(Date);
+    expect(issue?.executionRunId).toBeNull();
+
+    const routineRun = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.id, routineRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(routineRun?.status).toBe("failed");
+    expect(routineRun?.failureReason).toBe("Execution issue moved to cancelled");
+    expect(routineRun?.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("does not promote deferred comment wakes after a routine execution is cancelled", async () => {
+    let releaseAdapter!: () => void;
+    const adapterReleased = new Promise<void>((resolve) => {
+      releaseAdapter = resolve;
+    });
+    mockAdapterExecute.mockImplementationOnce(async () => {
+      await adapterReleased;
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const { agentId, issueId, routineRunId } = await seedRoutineExecutionIssueFixture({
+      issueStatus: "todo",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "routine_execution",
+      payload: { issueId },
+      contextSnapshot: { issueId, source: "routine.dispatch" },
+    });
+    expect(run?.id).toBeTruthy();
+
+    const activeIssue = await waitForIssueExecutionLock(db, issueId);
+    expect(activeIssue?.status).toBe("in_progress");
+    expect(activeIssue?.executionRunId).toBe(run?.id);
+
+    const comment = await db
+      .insert(issueComments)
+      .values({
+        companyId: activeIssue!.companyId,
+        issueId,
+        authorAgentId: agentId,
+        body: "Follow-up while routine execution is running",
+      })
+      .returning()
+      .then((rows) => rows[0]);
+
+    const deferredRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId, commentId: comment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: comment.id,
+        wakeReason: "issue_commented",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: agentId,
+    });
+    expect(deferredRun).toBeNull();
+
+    await issueService(db).update(issueId, { status: "cancelled" });
+    await routineService(db).syncRunStatusForIssue(issueId);
+
+    releaseAdapter();
+    const settledRun = run ? await waitForRunToSettle(heartbeat, run.id) : null;
+    expect(settledRun?.status).toBe("succeeded");
+    const runs = await waitForAgentRunsToSettle(db, agentId, 1);
+    expect(runs).toHaveLength(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("cancelled");
+    expect(issue?.completedAt).toBeNull();
+    expect(issue?.cancelledAt).toBeInstanceOf(Date);
+    expect(issue?.executionRunId).toBeNull();
+
+    const deferred = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId))
+      .then((rows) => rows.find((row) => row.reason === "issue_execution_deferred"));
+    expect(deferred?.status).toBe("skipped");
+
+    const routineRun = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.id, routineRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(routineRun?.status).toBe("failed");
+    expect(routineRun?.failureReason).toBe("Execution issue moved to cancelled");
+    expect(routineRun?.completedAt).toBeInstanceOf(Date);
   });
 
   it("re-enqueues assigned todo work when the last issue run died and no wake remains", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -17,6 +17,7 @@ import {
   issues,
   projects,
   projectWorkspaces,
+  routineRuns,
 } from "@paperclipai/db";
 import { conflict, HttpError, notFound } from "../errors.js";
 import { logger } from "../middleware/logger.js";
@@ -92,6 +93,8 @@ const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
 const ACTIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running"] as const;
+const ISSUE_EXECUTION_LOCKABLE_STATUSES = ["backlog", "todo", "in_progress", "in_review"] as const;
+const ROUTINE_EXECUTION_SUCCESS_COMPLETABLE_STATUSES = new Set<string>(ISSUE_EXECUTION_LOCKABLE_STATUSES);
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
@@ -2495,6 +2498,7 @@ export function heartbeatService(db: Db) {
           and(
             eq(issues.id, claimedIssueId),
             eq(issues.companyId, claimed.companyId),
+            inArray(issues.status, [...ISSUE_EXECUTION_LOCKABLE_STATUSES]),
             or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
           ),
         );
@@ -4033,6 +4037,8 @@ export function heartbeatService(db: Db) {
           identifier: issues.identifier,
           status: issues.status,
           executionRunId: issues.executionRunId,
+          originKind: issues.originKind,
+          originRunId: issues.originRunId,
         })
         .from(issues)
         .where(
@@ -4045,6 +4051,71 @@ export function heartbeatService(db: Db) {
 
       if (!issue) return null;
       if (issue.executionRunId && issue.executionRunId !== run.id) return null;
+
+      let completedRoutineActivity: LogActivityInput | null = null;
+      if (
+        run.status === "succeeded" &&
+        issue.originKind === "routine_execution" &&
+        issue.originRunId &&
+        ROUTINE_EXECUTION_SUCCESS_COMPLETABLE_STATUSES.has(issue.status)
+      ) {
+        const previousStatus = issue.status;
+        const now = new Date();
+        // A routine execution issue is the dispatch artifact for one heartbeat.
+        // If the heartbeat succeeds and the agent did not explicitly move it,
+        // close the artifact instead of leaving stale open monitoring noise.
+        const completedIssue = await tx
+          .update(issues)
+          .set({
+            status: "done",
+            completedAt: now,
+            checkoutRunId: null,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(issues.id, issue.id),
+              eq(issues.originKind, "routine_execution"),
+              eq(issues.originRunId, issue.originRunId),
+              inArray(issues.status, [...ISSUE_EXECUTION_LOCKABLE_STATUSES]),
+            ),
+          )
+          .returning({ id: issues.id });
+        if (completedIssue.length > 0) {
+          await tx
+            .update(routineRuns)
+            .set({
+              status: "completed",
+              failureReason: null,
+              completedAt: now,
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(routineRuns.id, issue.originRunId),
+                inArray(routineRuns.status, ["received", "issue_created"]),
+              ),
+            );
+          issue = { ...issue, status: "done" };
+          completedRoutineActivity = {
+            companyId: issue.companyId,
+            actorType: "system",
+            actorId: "heartbeat",
+            agentId: run.agentId,
+            runId: run.id,
+            action: "issue.updated",
+            entityType: "issue",
+            entityId: issue.id,
+            details: {
+              identifier: issue.identifier,
+              status: "done",
+              previousStatus,
+              source: "heartbeat.routine_execution_success",
+              routineRunId: issue.originRunId,
+            },
+          };
+        }
+      }
 
       if (issue.executionRunId === run.id) {
         await tx
@@ -4073,7 +4144,13 @@ export function heartbeatService(db: Db) {
           .limit(1)
           .then((rows) => rows[0] ?? null);
 
-        if (!deferred) return null;
+        if (!deferred) {
+          return {
+            run: null,
+            reopenedActivity: null,
+            completedRoutineActivity,
+          };
+        }
 
         const deferredAgent = await tx
           .select()
@@ -4104,8 +4181,25 @@ export function heartbeatService(db: Db) {
         const deferredContextSeed = parseObject(deferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
         const promotedContextSeed: Record<string, unknown> = { ...deferredContextSeed };
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
+        const isClosedRoutineExecution =
+          issue.originKind === "routine_execution" &&
+          !ROUTINE_EXECUTION_SUCCESS_COMPLETABLE_STATUSES.has(issue.status);
+        if (isClosedRoutineExecution) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "skipped",
+              finishedAt: new Date(),
+              error: "Deferred wake was not promoted because the routine execution issue is no longer open",
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
         const shouldReopenDeferredCommentWake =
-          deferredCommentIds.length > 0 && (issue.status === "done" || issue.status === "cancelled");
+          issue.originKind !== "routine_execution" &&
+          deferredCommentIds.length > 0 &&
+          (issue.status === "done" || issue.status === "cancelled");
         let reopenedActivity: LogActivityInput | null = null;
 
         if (shouldReopenDeferredCommentWake) {
@@ -4207,21 +4301,25 @@ export function heartbeatService(db: Db) {
             executionLockedAt: now,
             updatedAt: now,
           })
-          .where(eq(issues.id, issue.id));
+          .where(and(eq(issues.id, issue.id), inArray(issues.status, [...ISSUE_EXECUTION_LOCKABLE_STATUSES])));
 
         return {
           run: newRun,
           reopenedActivity,
+          completedRoutineActivity,
         };
       }
     });
 
-    const promotedRun = promotionResult?.run ?? null;
-    if (!promotedRun) return;
-
+    if (promotionResult?.completedRoutineActivity) {
+      await logActivity(db, promotionResult.completedRoutineActivity);
+    }
     if (promotionResult?.reopenedActivity) {
       await logActivity(db, promotionResult.reopenedActivity);
     }
+
+    const promotedRun = promotionResult?.run ?? null;
+    if (!promotedRun) return;
 
     publishLiveEvent({
       companyId: promotedRun.companyId,
@@ -4433,7 +4531,7 @@ export function heartbeatService(db: Db) {
                 executionLockedAt: new Date(),
                 updatedAt: new Date(),
               })
-              .where(eq(issues.id, issue.id));
+              .where(and(eq(issues.id, issue.id), inArray(issues.status, [...ISSUE_EXECUTION_LOCKABLE_STATUSES])));
           }
         }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies, so routine execution artifacts must accurately reflect whether agent work is still active or complete.
> - Routine executions are represented as company-scoped issues linked to routine runs, heartbeat runs, and assignment wakeups.
> - SRE and QA found that successful routine heartbeats could leave open `routine_execution` issues, polluting monitoring and creating false owner-action misses.
> - The first reconciliation path fixed stale-open success cases, but QA found cancellation could later be overwritten by deferred wake promotion and legacy run stamping.
> - This pull request makes routine execution completion conditional on still-open issue state and prevents closed routine executions from being relocked, reopened, or promoted by deferred/follow-up handling.
> - The benefit is clearer ticket-flow monitoring: successful routine dispatch artifacts close automatically, while cancelled routine executions remain actionable cancellation/failure outcomes.

## What Changed

- Close open `routine_execution` issues as `done` when their linked heartbeat run succeeds without an explicit issue status update.
- Mark the linked routine run `completed` only when the issue completion update wins and the routine run is still in a non-terminal dispatch state.
- Preserve cancellation/failure semantics by preventing later successful heartbeat finalization from overwriting cancelled routine execution issues or failed routine runs.
- Skip deferred comment wake promotion for closed routine execution issues and prevent routine executions from being reopened by deferred-comment behavior.
- Restrict queued-run claim locking and legacy active-run stamping to open lockable issue statuses.
- Added focused regression coverage for stale-open success, pre-cancelled preservation, active-run cancellation, and the deferred-wake cancellation race QA reproduced.

## Verification

- `git diff --check -- server/src/services/heartbeat.ts server/src/__tests__/heartbeat-process-recovery.test.ts`
- `pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts --testNamePattern "routine execution"` passed: 4 tests.
- `pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts server/src/__tests__/routines-service.test.ts` passed: 32 tests.
- `pnpm -r typecheck` passed.
- Branch-backed QA passed on `http://127.0.0.1:3197`: no-agent-status-update routine execution completed as `done`, and cancelling an active routine execution remained `cancelled` after the heartbeat and reconciliation window.

## Risks

- Moderate lifecycle risk: this touches heartbeat finalization and deferred wake promotion for issue execution.
- Mitigation: the behavioral changes are scoped to `routine_execution` handling and lockable issue statuses; normal manual issue deferred-comment reopen behavior is preserved.
- Existing historical residue is not deleted or hidden by this change.

## Model Used

- OpenAI GPT-5.4 via Codex, with tool use and local code execution; reasoning effort medium.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
