### PR TITLE
fix(ui): allow commas in extra args field

### DIFF
--- a/ui/src/adapters/schema-config-fields.tsx
+++ b/ui/src/adapters/schema-config-fields.tsx
@@ -495,7 +495,8 @@ export function buildSchemaAdapterConfig(
 
   if (values.extraArgs) {
     ac.extraArgs = values.extraArgs
-      .split(/\s+/)
+      .split(",")
+      .map((s) => s.trim())
       .filter(Boolean);
   }
 

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -784,7 +784,6 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       ? set!({ extraArgs: v })
                       : mark("adapterConfig", "extraArgs", v?.trim() ? parseCommaArgs(v) : null)
                   }
-                  immediate
                   className={inputClass}
                   placeholder="e.g. --verbose, --foo=bar"
                 />


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each agent is backed by an adapter (Hermes, Claude, Codex, etc.) whose CLI invocation can be tuned per-agent
> - Operators configure that tuning in the agent config form, including an "Extra args (comma-separated)" field that feeds through to the spawned CLI
> - Today that field silently eats commas and trailing spaces, so --profile, social becomes one garbled arg and --flag value can't even be typed
> - Result: operators can't pass multi-token CLI args to local adapters at all, which blocks legitimate configurations like running a second Hermes profile
> - This pull request fixes the input so the field actually behaves like its label claims
> - The benefit is that operators can finally configure extra CLI args on local adapter agents without working around the UI

## What Changed

  - ui/src/components/AgentConfigForm.tsx: removed immediate from the extra-args DraftInput. It was committing on every keystroke, which round-tripped the draft through parseCommaArgs + formatArgList. That
  normalization trimmed trailing spaces and dropped bare commas via filter(Boolean), so the input visually erased characters as the user typed. Committing on blur instead keeps the draft stable while typing and
  still parses correctly when the field loses focus.
  - ui/src/adapters/schema-config-fields.tsx: buildSchemaAdapterConfig was splitting extraArgs on /\s+/ while the field label, hint, placeholder, and edit-mode parser (parseCommaArgs) all say comma-separated.
  Switched it to split on ,, trim each segment, and drop empties — matching the label and edit-mode behavior, and giving create-mode/edit-mode parity.

## Verification

  - pnpm typecheck — passes
  - pnpm exec vitest run --project '@paperclipai/ui' — 95 files, 470 tests, all passing
  - Manual: on an existing agent, typing --profile, social into the field now preserves both the comma and the space; on blur the value persists as two args (["--profile", "social"]). Creating a new agent with the
  same input also yields two args (previously yielded one mangled arg --profile,).

## Risks

  - Low risk. The change is scoped to the extra-args input on the agent config form and doesn't touch adapter runtime code. Edit-mode parsing was already comma-based, so existing configurations are unaffected. The
  only behavioral change at create time is that whitespace-only separators no longer work — but they weren't documented anywhere and the label explicitly says comma-separated, so anyone relying on that was already
  seeing broken output in edit mode.

## Model Used

  - Claude Opus 4.7 (1M context window), Anthropic, via Claude Code CLI. Tool use for code search/edit; no extended-thinking mode beyond default.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
