### PR TITLE
fix(server): guard blocked orphan reroute on recovery markers (WEB-1823)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -308,6 +308,13 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     runStatus: "failed" | "timed_out" | "cancelled" | "succeeded";
     retryReason?: "assignment_recovery" | "issue_continuation_needed" | null;
     assignToUser?: boolean;
+    blockedAssigneeMode?: "agent" | "user" | "none";
+    blockedCheckoutRunId?: boolean;
+    agentName?: string;
+    issueTitle?: string;
+    runErrorCode?: string | null;
+    runError?: string | null;
+    createdByAgentId?: string | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -327,7 +334,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.insert(agents).values({
       id: agentId,
       companyId,
-      name: "CodexCoder",
+      name: input.agentName ?? "CodexCoder",
       role: "engineer",
       status: "idle",
       adapterType: "codex_local",
@@ -348,7 +355,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       runId,
       claimedAt: now,
       finishedAt: new Date("2026-03-19T00:05:00.000Z"),
-      error: input.runStatus === "succeeded" ? null : "run failed before issue advanced",
+      error: input.runError ?? (input.runStatus === "succeeded" ? null : "run failed before issue advanced"),
     });
 
     await db.insert(heartbeatRuns).values({
@@ -370,20 +377,38 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       startedAt: now,
       finishedAt: new Date("2026-03-19T00:05:00.000Z"),
       updatedAt: new Date("2026-03-19T00:05:00.000Z"),
-      errorCode: input.runStatus === "succeeded" ? null : "process_lost",
-      error: input.runStatus === "succeeded" ? null : "run failed before issue advanced",
+      errorCode: input.runErrorCode ?? (input.runStatus === "succeeded" ? null : "process_lost"),
+      error: input.runError ?? (input.runStatus === "succeeded" ? null : "run failed before issue advanced"),
     });
 
     await db.insert(issues).values({
       id: issueId,
       companyId,
-      title: "Recover stranded assigned work",
+      title: input.issueTitle ?? "Recover stranded assigned work",
       status: input.status,
       priority: "medium",
-      assigneeAgentId: input.assignToUser ? null : agentId,
-      assigneeUserId: input.assignToUser ? "user-1" : null,
-      checkoutRunId: input.status === "in_progress" ? runId : null,
-      executionRunId: null,
+      assigneeAgentId:
+        input.status === "blocked"
+          ? (input.blockedAssigneeMode ?? "none") === "agent"
+            ? agentId
+            : null
+          : input.assignToUser
+            ? null
+            : agentId,
+      assigneeUserId:
+        input.status === "blocked"
+          ? (input.blockedAssigneeMode ?? "none") === "user"
+            ? "user-1"
+            : null
+          : input.assignToUser
+            ? "user-1"
+            : null,
+      checkoutRunId:
+        input.status === "in_progress" || (input.status === "blocked" && input.blockedCheckoutRunId)
+          ? runId
+          : null,
+      executionRunId: input.runStatus === "running" ? runId : null,
+      createdByAgentId: input.createdByAgentId === undefined ? agentId : input.createdByAgentId,
       issueNumber: 1,
       identifier: `${issuePrefix}-1`,
       startedAt: input.status === "in_progress" ? now : null,
@@ -669,5 +694,141 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
+  });
+  it("does not reroute blocked issues that never had a recovery marker", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "failed",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.blockedRerouted).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    expect(issue?.assigneeAgentId).toBeNull();
+    expect(issue?.assigneeUserId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
+  });
+
+  it("reroutes blocked user-owned recovery issues back to an agent owner", async () => {
+    const { issueId, agentId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "failed",
+      blockedAssigneeMode: "user",
+      blockedCheckoutRunId: true,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.blockedRerouted).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(agentId);
+    expect(issue?.assigneeUserId).toBeNull();
+  });
+
+  it("reroutes blocked orphaned issues even when a deferred execution wakeup still exists", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "failed",
+      blockedCheckoutRunId: true,
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      status: "deferred_issue_execution",
+    });
+
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.blockedRerouted).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(agentId);
+    expect(issue?.assigneeUserId).toBeNull();
+  });
+
+  it("keeps blocked ownership intact while a live execution run still exists", async () => {
+    const { issueId, agentId, runId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "running",
+      blockedAssigneeMode: "agent",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.blockedRerouted).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(agentId);
+    expect(issue?.executionRunId).toBe(runId);
+  });
+
+  it("keeps blocked review-manager review ownership intact after the assignee is cleared", async () => {
+    const { issueId, runId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "failed",
+      blockedAssigneeMode: "agent",
+      agentName: "Review Manager",
+      issueTitle: "[REVIEW-GPT] Verify adapter_failed continuation routing",
+      runErrorCode: "adapter_failed",
+      runError: "reviewer adapter unavailable",
+      blockedCheckoutRunId: true,
+    });
+    const heartbeat = heartbeatService(db);
+
+    await db
+      .update(issues)
+      .set({
+        assigneeAgentId: null,
+      })
+      .where(eq(issues.id, issueId));
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.blockedRerouted).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    expect(issue?.assigneeAgentId).toBeNull();
+    expect(issue?.assigneeUserId).toBeNull();
+    expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it("restores the checkout agent on blocked issues during terminal run cleanup without waiting for the periodic sweep", async () => {
+    const { issueId, runId, agentId } = await seedRunFixture();
+    const heartbeat = heartbeatService(db);
+
+    await db
+      .update(issues)
+      .set({
+        status: "blocked",
+        checkoutRunId: null,
+        executionRunId: null,
+      })
+      .where(eq(issues.id, issueId));
+
+    await heartbeat.cancelRun(runId);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    expect(issue?.assigneeAgentId).toBe(agentId);
+    expect(issue?.assigneeUserId).toBeNull();
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1403,6 +1403,28 @@ function normalizeAgentNameKey(value: string | null | undefined) {
   return normalized.length > 0 ? normalized : null;
 }
 
+function isReviewManagerNameKey(value: string | null | undefined) {
+  const normalized = normalizeAgentNameKey(value);
+  return normalized === "review manager" || normalized === "review-manager";
+}
+
+function isReviewManagerBlockerIssue(input: {
+  title: string | null | undefined;
+  ownerAgentName: string | null | undefined;
+}) {
+  if (!isReviewManagerNameKey(input.ownerAgentName)) return false;
+  if (typeof input.title !== "string") return false;
+  return input.title.trim().toLowerCase().startsWith("[review");
+}
+
+function isAssignableRecoveryAgent(agent: {
+  companyId: string;
+  status: string;
+} | null | undefined, companyId: string) {
+  if (!agent) return false;
+  if (agent.companyId !== companyId) return false;
+  return agent.status !== "pending_approval" && agent.status !== "terminated";
+}
 const defaultSessionCodec: AdapterSessionCodec = {
   deserialize(raw: unknown) {
     const asObj = parseObject(raw);
@@ -2883,18 +2905,7 @@ export function heartbeatService(db: Db) {
 
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
     const [run, deferredWake] = await Promise.all([
-      db
-        .select({ id: heartbeatRuns.id })
-        .from(heartbeatRuns)
-        .where(
-          and(
-            eq(heartbeatRuns.companyId, companyId),
-            inArray(heartbeatRuns.status, [...ACTIVE_HEARTBEAT_RUN_STATUSES]),
-            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
-          ),
-        )
-        .limit(1)
-        .then((rows) => rows[0] ?? null),
+      hasActiveExecutionRun(companyId, issueId),
       db
         .select({ id: agentWakeupRequests.id })
         .from(agentWakeupRequests)
@@ -2910,6 +2921,187 @@ export function heartbeatService(db: Db) {
     ]);
 
     return Boolean(run || deferredWake);
+  }
+
+  async function hasActiveExecutionRun(companyId: string, issueId: string) {
+    return db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          inArray(heartbeatRuns.status, [...ACTIVE_HEARTBEAT_RUN_STATUSES]),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function findCompanyFallbackRecoveryAgent(companyId: string) {
+    const candidates = await db
+      .select({
+        id: agents.id,
+        companyId: agents.companyId,
+        status: agents.status,
+        role: agents.role,
+      })
+      .from(agents)
+      .where(eq(agents.companyId, companyId))
+      .orderBy(
+        sql`case
+          when ${agents.role} = 'cto' then 0
+          when ${agents.role} = 'ceo' then 1
+          else 2
+        end`,
+        asc(agents.createdAt),
+        asc(agents.id),
+      );
+
+    return candidates.find((candidate) => isAssignableRecoveryAgent(candidate, companyId)) ?? null;
+  }
+
+  async function resolveBlockedIssueRecoveryAgentId(input: {
+    companyId: string;
+    parentId?: string | null;
+    createdByAgentId?: string | null;
+    preferredAgentId?: string | null;
+  }) {
+    const candidateIds: string[] = [];
+    if (input.preferredAgentId) candidateIds.push(input.preferredAgentId);
+    if (input.createdByAgentId) candidateIds.push(input.createdByAgentId);
+
+    let currentParentId = input.parentId ?? null;
+    const visitedParentIds = new Set<string>();
+    while (currentParentId && !visitedParentIds.has(currentParentId)) {
+      visitedParentIds.add(currentParentId);
+      const parent = await db
+        .select({
+          id: issues.id,
+          parentId: issues.parentId,
+          assigneeAgentId: issues.assigneeAgentId,
+          createdByAgentId: issues.createdByAgentId,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, input.companyId), eq(issues.id, currentParentId)))
+        .then((rows) => rows[0] ?? null);
+      if (!parent) break;
+      if (parent.assigneeAgentId) candidateIds.push(parent.assigneeAgentId);
+      if (parent.createdByAgentId) candidateIds.push(parent.createdByAgentId);
+      currentParentId = parent.parentId ?? null;
+    }
+
+    const seenAgentIds = new Set<string>();
+    for (const candidateId of candidateIds) {
+      if (!candidateId || seenAgentIds.has(candidateId)) continue;
+      seenAgentIds.add(candidateId);
+      const candidate = await getAgent(candidateId);
+      if (isAssignableRecoveryAgent(candidate, input.companyId)) {
+        return candidate.id;
+      }
+    }
+
+    const fallback = await findCompanyFallbackRecoveryAgent(input.companyId);
+    return fallback?.id ?? null;
+  }
+
+  async function rerouteBlockedIssueOwnership(input: {
+    issue: Pick<
+      typeof issues.$inferSelect,
+      | "id"
+      | "companyId"
+      | "identifier"
+      | "title"
+      | "status"
+      | "assigneeAgentId"
+      | "assigneeUserId"
+      | "checkoutRunId"
+      | "executionRunId"
+      | "parentId"
+      | "createdByAgentId"
+    >;
+    source: string;
+    tx?: any;
+    runId?: string | null;
+    preferredAgentId?: string | null;
+  }) {
+    if (input.issue.status !== "blocked") return null;
+
+    const ownerAgentIds = [
+      input.issue.assigneeAgentId,
+      input.issue.createdByAgentId,
+    ].filter((value): value is string => typeof value === "string" && value.length > 0);
+
+    const recoveryRunId = input.issue.checkoutRunId ?? input.issue.executionRunId ?? null;
+    if (recoveryRunId) {
+      const recoveryRun = await db
+        .select({ agentId: heartbeatRuns.agentId })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, recoveryRunId))
+        .then((rows) => rows[0] ?? null);
+      if (recoveryRun?.agentId) ownerAgentIds.push(recoveryRun.agentId);
+    }
+
+    for (const ownerAgentId of ownerAgentIds) {
+      const ownerAgent = await getAgent(ownerAgentId);
+      if (
+        ownerAgent &&
+        isReviewManagerBlockerIssue({
+          title: input.issue.title,
+          ownerAgentName: ownerAgent.name,
+        })
+      ) {
+        return null;
+      }
+    }
+
+    const recoveryAgentId = await resolveBlockedIssueRecoveryAgentId({
+      companyId: input.issue.companyId,
+      parentId: input.issue.parentId ?? null,
+      createdByAgentId: input.issue.createdByAgentId ?? null,
+      preferredAgentId: input.preferredAgentId ?? null,
+    });
+    if (!recoveryAgentId) return null;
+    if (
+      input.issue.assigneeAgentId === recoveryAgentId &&
+      input.issue.assigneeUserId == null
+    ) {
+      return null;
+    }
+
+    const executor: any = input.tx ?? db;
+    const updated = await issuesSvc.update(
+      input.issue.id,
+      {
+        assigneeAgentId: recoveryAgentId,
+        assigneeUserId: null,
+      },
+      executor,
+    );
+    if (!updated) return null;
+
+    await logActivity(executor, {
+      companyId: input.issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: input.runId ?? null,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: input.issue.id,
+      details: {
+        identifier: input.issue.identifier,
+        status: "blocked",
+        source: input.source,
+        ownershipRerouted: true,
+        reroutedAssigneeAgentId: recoveryAgentId,
+        previousAssigneeAgentId: input.issue.assigneeAgentId,
+        previousAssigneeUserId: input.issue.assigneeUserId,
+        previousCheckoutRunId: input.issue.checkoutRunId ?? null,
+      },
+    });
+
+    return updated;
   }
 
   async function enqueueStrandedIssueRecovery(input: {
@@ -3009,6 +3201,7 @@ export function heartbeatService(db: Db) {
     const result = {
       dispatchRequeued: 0,
       continuationRequeued: 0,
+      blockedRerouted: 0,
       escalated: 0,
       skipped: 0,
       issueIds: [] as string[],
@@ -3119,6 +3312,54 @@ export function heartbeatService(db: Db) {
       }
     }
 
+    const blockedCandidates = await db
+      .select({
+        id: issues.id,
+        companyId: issues.companyId,
+        identifier: issues.identifier,
+        title: issues.title,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        parentId: issues.parentId,
+        createdByAgentId: issues.createdByAgentId,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.status, "blocked"),
+          sql`${issues.assigneeAgentId} is null`,
+          or(
+            sql`${issues.checkoutRunId} is not null`,
+            sql`${issues.executionRunId} is not null`,
+          ),
+        ),
+      );
+
+    for (const issue of blockedCandidates) {
+      if (await hasActiveExecutionRun(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      try {
+        const rerouted = await rerouteBlockedIssueOwnership({
+          issue,
+          source: "heartbeat.blocked_orphan_assignee_sweep",
+        });
+        if (rerouted) {
+          result.blockedRerouted += 1;
+          result.issueIds.push(issue.id);
+        } else {
+          result.skipped += 1;
+        }
+      } catch (err) {
+        logger.error({ err, issueId: issue.id }, "failed to reroute blocked orphan issue ownership");
+        result.skipped += 1;
+      }
+    }
     return result;
   }
 


### PR DESCRIPTION
WEB-1823

Scope:
- Restrict blocked-orphan reroute to issues with explicit recovery markers.
- Preserve Review Manager blockers using stored ownership signals.
- Split blocked cleanup from deferred wakeups by checking active runs only for the orphan drain path.

Verification:
- pnpm --dir /repos/paperclip/server exec tsc --noEmit ✅
- pnpm --dir /repos/paperclip/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts was blocked by the embedded-Postgres probe on this host, which skips when its startup check fails. The changed code compiles cleanly.

Risk:
- Low. The change narrows reroute behavior to explicit recovery cases and keeps the Review Manager exception tied to owner metadata.