### PR TITLE
fix(server): no-op release for terminal done/cancelled issues

### DIFF
--- a/server/src/__tests__/issues-release-terminal.test.ts
+++ b/server/src/__tests__/issues-release-terminal.test.ts
@@ -1,0 +1,205 @@
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  createDb,
+  executionWorkspaces,
+  instanceSettings,
+  issueComments,
+  issueInboxArchives,
+  issueRelations,
+  issues,
+  projectWorkspaces,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { issueService } from "../services/issues.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function ensureIssueRelationsTable(db: ReturnType<typeof createDb>) {
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS "issue_relations" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "company_id" uuid NOT NULL,
+      "issue_id" uuid NOT NULL,
+      "related_issue_id" uuid NOT NULL,
+      "type" text NOT NULL,
+      "created_by_agent_id" uuid,
+      "created_by_user_id" text,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "updated_at" timestamptz NOT NULL DEFAULT now()
+    );
+  `));
+}
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue release tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issueService.release terminal states", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-release-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("is a no-op for done issues (preserves status and assignee)", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Shipped",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      createdByAgentId: agentId,
+    });
+
+    const before = await db.select().from(issues).where(eq(issues.id, issueId)).then((r) => r[0]!);
+
+    const released = await svc.release(issueId, agentId, randomUUID());
+    expect(released).not.toBeNull();
+    expect(released!.status).toBe("done");
+    expect(released!.assigneeAgentId).toBe(agentId);
+
+    const after = await db.select().from(issues).where(eq(issues.id, issueId)).then((r) => r[0]!);
+    expect(after.status).toBe(before.status);
+    expect(after.assigneeAgentId).toBe(before.assigneeAgentId);
+    expect(after.updatedAt.getTime()).toBe(before.updatedAt.getTime());
+  });
+
+  it("is a no-op for cancelled issues", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Wontfix",
+      status: "cancelled",
+      priority: "low",
+      assigneeAgentId: agentId,
+      createdByAgentId: agentId,
+    });
+
+    const released = await svc.release(issueId, agentId, randomUUID());
+    expect(released!.status).toBe("cancelled");
+    expect(released!.assigneeAgentId).toBe(agentId);
+  });
+
+  it("still clears checkout for in_progress issues", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Active",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      createdByAgentId: agentId,
+    });
+
+    const released = await svc.release(issueId, agentId, randomUUID());
+    expect(released!.status).toBe("todo");
+    expect(released!.assigneeAgentId).toBeNull();
+    expect(released!.checkoutRunId).toBeNull();
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2090,6 +2090,8 @@ export function issueRoutes(
     const actorRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !actorRunId) return;
 
+    const terminalReleaseNoOp = existing.status === "done" || existing.status === "cancelled";
+
     const released = await svc.release(
       id,
       req.actor.type === "agent" ? req.actor.agentId : undefined,
@@ -2101,16 +2103,18 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId: released.companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      runId: actor.runId,
-      action: "issue.released",
-      entityType: "issue",
-      entityId: released.id,
-    });
+    if (!terminalReleaseNoOp) {
+      await logActivity(db, {
+        companyId: released.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "issue.released",
+        entityType: "issue",
+        entityId: released.id,
+      });
+    }
 
     res.json(released);
   });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2020,6 +2020,12 @@ export function issueService(db: Db) {
         });
       }
 
+      // Terminal lifecycle issues must not be reopened or unassigned by release.
+      if (existing.status === "done" || existing.status === "cancelled") {
+        const [enriched] = await withIssueLabels(db, [existing]);
+        return enriched;
+      }
+
       const updated = await db
         .update(issues)
         .set({


### PR DESCRIPTION
## Summary

- `issueService.release` now **no-ops** for terminal **`done`** / **`cancelled`** issues so `POST /api/issues/:id/release` cannot regress lifecycle state or clear assignees.
- Adds embedded Postgres coverage in `server/src/__tests__/issues-release-terminal.test.ts`.

## Test plan

- [x] `pnpm exec vitest run server/src/__tests__/issues-release-terminal.test.ts`

Ship path: fork PR because direct push to `paperclipai/paperclip` is not permitted from this environment.

Made with [Cursor](https://cursor.com)