### PR TITLE
fix(cli): doctor port check respects configured bind host

### DIFF
--- a/cli/src/__tests__/port-check.test.ts
+++ b/cli/src/__tests__/port-check.test.ts
@@ -1,0 +1,67 @@
+import net from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { checkPort } from "../utils/net.js";
+
+type Listener = { server: net.Server; port: number; host: string };
+
+async function listenOn(host: string): Promise<Listener> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, host, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("unexpected server address shape"));
+        return;
+      }
+      resolve({ server, port: address.port, host });
+    });
+  });
+}
+
+function close(listener: Listener): Promise<void> {
+  return new Promise((resolve) => listener.server.close(() => resolve()));
+}
+
+describe("checkPort", () => {
+  const openListeners: Listener[] = [];
+
+  afterEach(async () => {
+    await Promise.all(openListeners.splice(0).map(close));
+  });
+
+  it("returns available=true for a free port on the default host", async () => {
+    const tmp = await listenOn("127.0.0.1");
+    const freePort = tmp.port;
+    await close(tmp);
+
+    const result = await checkPort(freePort);
+    expect(result.available).toBe(true);
+  });
+
+  it("returns available=false when the port is bound on the requested host", async () => {
+    const listener = await listenOn("127.0.0.1");
+    openListeners.push(listener);
+
+    const result = await checkPort(listener.port, "127.0.0.1");
+    expect(result.available).toBe(false);
+    expect(result.error).toMatch(/already in use/);
+  });
+
+  it("treats distinct loopback hosts independently", async () => {
+    let ipv6: Listener;
+    try {
+      ipv6 = await listenOn("::1");
+    } catch {
+      return;
+    }
+    openListeners.push(ipv6);
+
+    const ipv4Result = await checkPort(ipv6.port, "127.0.0.1");
+    expect(ipv4Result.available).toBe(true);
+
+    const ipv6Result = await checkPort(ipv6.port, "::1");
+    expect(ipv6Result.available).toBe(false);
+  });
+});

--- a/cli/src/checks/port-check.ts
+++ b/cli/src/checks/port-check.ts
@@ -3,22 +3,22 @@ import { checkPort } from "../utils/net.js";
 import type { CheckResult } from "./index.js";
 
 export async function portCheck(config: PaperclipConfig): Promise<CheckResult> {
-  const port = config.server.port;
-  const result = await checkPort(port);
+  const { host, port } = config.server;
+  const result = await checkPort(port, host);
 
   if (result.available) {
     return {
       name: "Server port",
       status: "pass",
-      message: `Port ${port} is available`,
+      message: `Port ${port} is available on ${host}`,
     };
   }
 
   return {
     name: "Server port",
     status: "warn",
-    message: result.error ?? `Port ${port} is not available`,
+    message: result.error ?? `Port ${port} is not available on ${host}`,
     canRepair: false,
-    repairHint: `Check what's using port ${port} with: lsof -i :${port}`,
+    repairHint: `Check what's using ${host}:${port} with: lsof -i @${host}:${port}`,
   };
 }

--- a/cli/src/utils/net.ts
+++ b/cli/src/utils/net.ts
@@ -1,6 +1,9 @@
 import net from "node:net";
 
-export function checkPort(port: number): Promise<{ available: boolean; error?: string }> {
+export function checkPort(
+  port: number,
+  host: string = "127.0.0.1",
+): Promise<{ available: boolean; error?: string }> {
   return new Promise((resolve) => {
     const server = net.createServer();
     server.once("error", (err: NodeJS.ErrnoException) => {
@@ -13,6 +16,6 @@ export function checkPort(port: number): Promise<{ available: boolean; error?: s
     server.once("listening", () => {
       server.close(() => resolve({ available: true }));
     });
-    server.listen(port, "127.0.0.1");
+    server.listen(port, host);
   });
 }


### PR DESCRIPTION
## Problem

`checkPort` in `cli/src/utils/net.ts` hardcoded `127.0.0.1` when probing availability. The caller `portCheck` in `cli/src/checks/port-check.ts` pulls `config.server.port` but not `config.server.host`.

Result: when paperclip is configured with `bind: tailnet` (or anything that resolves `server.host` to a non-loopback address), the doctor's port check always reports **PASS** — even when the server is happily listening on the configured tailnet IP. Operators running `pnpm paperclipai doctor` on a live instance see `✓ Server port: Port 3100 is available`, which is misleading.

Reproduced against a live tailnet-bound instance: `ss -tlnp` showed `LISTEN ... 100.x.y.z:3100`, `curl http://100.x.y.z:3100/api/health` returned 200, and `doctor` still claimed the port was free because it was probing `127.0.0.1:3100` (which indeed was free).

## Fix

- `checkPort(port, host = "127.0.0.1")` now accepts the bind host.
- `portCheck` passes `config.server.host` through.
- Pass / warn messages include the host, and the repair hint uses `lsof -i @host:port` so it actually inspects the right interface.

Semantics for existing localhost-bound deployments are unchanged (default is still `127.0.0.1`). Tailnet / LAN / `0.0.0.0` deployments now report reality.

## Tests

Added `cli/src/__tests__/port-check.test.ts`:
- Free port returns `available: true`.
- Port bound on `127.0.0.1` returns `available: false` with the in-use error.
- Distinct loopback hosts (`127.0.0.1` vs `::1`) are probed independently — proves host-awareness. Gracefully skips if `::1` isn't available on the runner.

`pnpm --filter paperclipai exec vitest run src/__tests__/port-check.test.ts src/__tests__/doctor.test.ts` — 4 passed. Doctor output snapshot confirms the new message shape: `✓ Server port: Port 3199 is available on 127.0.0.1`.

`tsc --noEmit` on the changed files is clean.