### PR TITLE
[codex] fix(ui): guard malformed live run payloads

### DIFF
--- a/ui/src/api/heartbeats.test.ts
+++ b/ui/src/api/heartbeats.test.ts
@@ -67,6 +67,7 @@ describe("heartbeatsApi live run sanitization", () => {
   });
 
   it("returns null for malformed active run payloads", async () => {
+    mockApi.get.mockResolvedValueOnce(null);
     mockApi.get.mockResolvedValueOnce({ id: null, status: "running" });
     mockApi.get.mockResolvedValueOnce({
       id: "run-3",
@@ -82,6 +83,7 @@ describe("heartbeatsApi live run sanitization", () => {
       issueId: "issue-3",
     });
 
+    await expect(heartbeatsApi.activeRunForIssue("issue-null")).resolves.toBeNull();
     await expect(heartbeatsApi.activeRunForIssue("issue-1")).resolves.toBeNull();
     await expect(heartbeatsApi.activeRunForIssue("issue-3")).resolves.toEqual(
       expect.objectContaining({ id: "run-3", agentId: "agent-3" }),

--- a/ui/src/api/heartbeats.test.ts
+++ b/ui/src/api/heartbeats.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockApi = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock("./client", () => ({
+  api: mockApi,
+}));
+
+import { heartbeatsApi } from "./heartbeats";
+
+describe("heartbeatsApi live run sanitization", () => {
+  beforeEach(() => {
+    mockApi.get.mockReset();
+  });
+
+  it("filters malformed live run records for issue and company requests", async () => {
+    mockApi.get.mockResolvedValueOnce([
+      null,
+      {
+        id: "run-1",
+        status: "running",
+        invocationSource: "automation",
+        triggerDetail: "system",
+        startedAt: "2026-04-18T10:47:42.553Z",
+        finishedAt: null,
+        createdAt: "2026-04-18T10:47:42.545Z",
+        agentId: "agent-1",
+        agentName: "Founding Engineer",
+        adapterType: "claude_local",
+        issueId: "issue-1",
+      },
+      {
+        id: "",
+        status: "running",
+        invocationSource: "automation",
+        createdAt: "2026-04-18T10:47:42.545Z",
+        agentId: "agent-2",
+        agentName: "Broken",
+        adapterType: "claude_local",
+      },
+    ]);
+    mockApi.get.mockResolvedValueOnce([
+      {
+        id: "run-2",
+        status: "queued",
+        invocationSource: "manual",
+        triggerDetail: null,
+        startedAt: null,
+        finishedAt: null,
+        createdAt: "2026-04-18T10:50:00.000Z",
+        agentId: "agent-2",
+        agentName: "Reviewer",
+        adapterType: "codex_local",
+        issueId: null,
+      },
+      { foo: "bar" },
+    ]);
+
+    await expect(heartbeatsApi.liveRunsForIssue("issue-1")).resolves.toEqual([
+      expect.objectContaining({ id: "run-1", agentId: "agent-1" }),
+    ]);
+    await expect(heartbeatsApi.liveRunsForCompany("company-1")).resolves.toEqual([
+      expect.objectContaining({ id: "run-2", agentId: "agent-2" }),
+    ]);
+  });
+
+  it("returns null for malformed active run payloads", async () => {
+    mockApi.get.mockResolvedValueOnce({ id: null, status: "running" });
+    mockApi.get.mockResolvedValueOnce({
+      id: "run-3",
+      status: "running",
+      invocationSource: "automation",
+      triggerDetail: "system",
+      startedAt: "2026-04-18T10:47:42.553Z",
+      finishedAt: null,
+      createdAt: "2026-04-18T10:47:42.545Z",
+      agentId: "agent-3",
+      agentName: "Founder",
+      adapterType: "claude_local",
+      issueId: "issue-3",
+    });
+
+    await expect(heartbeatsApi.activeRunForIssue("issue-1")).resolves.toBeNull();
+    await expect(heartbeatsApi.activeRunForIssue("issue-3")).resolves.toEqual(
+      expect.objectContaining({ id: "run-3", agentId: "agent-3" }),
+    );
+  });
+});

--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -29,6 +29,35 @@ export interface LiveRunForIssue {
   issueId?: string | null;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isLiveRunRecord(value: unknown): value is LiveRunForIssue {
+  if (!isRecord(value)) return false;
+  return isNonEmptyString(value.id)
+    && isNonEmptyString(value.status)
+    && isNonEmptyString(value.invocationSource)
+    && isNonEmptyString(value.agentId)
+    && isNonEmptyString(value.agentName)
+    && isNonEmptyString(value.adapterType)
+    && isNonEmptyString(value.createdAt);
+}
+
+function sanitizeLiveRuns(value: unknown): LiveRunForIssue[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isLiveRunRecord);
+}
+
+function sanitizeActiveRun(value: unknown): ActiveRunForIssue | null {
+  if (value === null) return null;
+  return isLiveRunRecord(value) ? value : null;
+}
+
 export const heartbeatsApi = {
   list: (companyId: string, agentId?: string, limit?: number) => {
     const searchParams = new URLSearchParams();
@@ -54,11 +83,11 @@ export const heartbeatsApi = {
     ),
   cancel: (runId: string) => api.post<void>(`/heartbeat-runs/${runId}/cancel`, {}),
   liveRunsForIssue: (issueId: string) =>
-    api.get<LiveRunForIssue[]>(`/issues/${issueId}/live-runs`),
+    api.get<unknown>(`/issues/${issueId}/live-runs`).then(sanitizeLiveRuns),
   activeRunForIssue: (issueId: string) =>
-    api.get<ActiveRunForIssue | null>(`/issues/${issueId}/active-run`),
+    api.get<unknown>(`/issues/${issueId}/active-run`).then(sanitizeActiveRun),
   liveRunsForCompany: (companyId: string, minCount?: number) =>
-    api.get<LiveRunForIssue[]>(`/companies/${companyId}/live-runs${minCount ? `?minCount=${minCount}` : ""}`),
+    api.get<unknown>(`/companies/${companyId}/live-runs${minCount ? `?minCount=${minCount}` : ""}`).then(sanitizeLiveRuns),
   listInstanceSchedulerAgents: () =>
     api.get<InstanceSchedulerHeartbeatAgent[]>("/instance/scheduler-heartbeats"),
 };

--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -53,9 +53,13 @@ function sanitizeLiveRuns(value: unknown): LiveRunForIssue[] {
   return value.filter(isLiveRunRecord);
 }
 
+function isActiveRunRecord(value: unknown): value is ActiveRunForIssue {
+  return isLiveRunRecord(value);
+}
+
 function sanitizeActiveRun(value: unknown): ActiveRunForIssue | null {
   if (value === null) return null;
-  return isLiveRunRecord(value) ? value : null;
+  return isActiveRunRecord(value) ? value : null;
 }
 
 export const heartbeatsApi = {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The board UI relies on heartbeat live-run and active-run APIs to render issue and company execution state
> - Those client helpers currently trust `/issues/:id/live-runs`, `/issues/:id/active-run`, and `/companies/:id/live-runs` payloads as fully well-formed
> - On affected installs, malformed or null live-run entries can still reach the frontend during heartbeat error conditions or partial responses
> - Downstream UI code expects every live run to have an `id`, so a single bad entry can trigger `Cannot read properties of null (reading 'id')` and blank the page
> - This pull request sanitizes live-run payloads at the API boundary and adds a regression test for malformed/null records
> - The benefit is that the UI drops invalid live-run entries instead of crashing the page

## What Changed

- Added narrow shape guards in `ui/src/api/heartbeats.ts` for live-run records returned by the issue/company heartbeat helpers
- Updated `liveRunsForIssue(...)` and `liveRunsForCompany(...)` to filter malformed entries before they reach React state
- Updated `activeRunForIssue(...)` to return `null` for malformed payloads instead of passing an invalid object through to the UI
- Added `ui/src/api/heartbeats.test.ts` covering null and malformed live-run / active-run payloads

## Verification

- `npx vitest run ui/src/api/heartbeats.test.ts`
- `pnpm -r typecheck`
- `pnpm build`
- No before/after screenshots included: this fix is a defensive guard around malformed API payloads rather than a stable visual redesign, and the regression test exercises the failure mode directly

## Risks

- Low risk. This is a UI-only guard that preserves valid payloads and only narrows malformed data to `[]` or `null`.
- If a server-side contract regresses in a new way, this client-side sanitization may hide some bad rows instead of surfacing them loudly. The added regression test keeps the current accepted shape explicit.

## Model Used

- OpenAI Codex coding agent based on GPT-5, via Codex CLI with terminal tool use, git operations, and local verification. Exact internal model ID is not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
