### PR TITLE
fix(server): allow paused wakeups (WEB-1389)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -548,9 +548,82 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       mockTelemetryClient,
       expect.objectContaining({
         agentRole: "engineer",
-        agentId,
-      }),
+      agentId,
+    }),
     );
+  });
+
+  it("queues wakeups for paused agents instead of rejecting them", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Paused Agent",
+      role: "engineer",
+      status: "paused",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Paused wakeup",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+      requestedByActorType: "system",
+      requestedByActorId: null,
+    });
+
+    expect(run).not.toBeNull();
+    expect(run?.status).toBe("queued");
+
+    const persistedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, run!.id))
+      .then((rows) => rows[0] ?? null);
+    expect(persistedRun?.status).toBe("queued");
+
+    const wakeupRequest = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, run!.wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(wakeupRequest).toMatchObject({
+      status: "queued",
+      runId: run?.id,
+    });
   });
 
   it("re-enqueues assigned todo work when the last issue run died and no wake remains", async () => {

--- a/server/src/__tests__/heartbeat-wakeup-status-guard.test.ts
+++ b/server/src/__tests__/heartbeat-wakeup-status-guard.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { shouldRejectWakeupForAgentStatus } from "../services/heartbeat.ts";
+
+describe("heartbeat wakeup status guard", () => {
+  it("allows paused agents to queue wakeups while still rejecting terminal states", () => {
+    expect(shouldRejectWakeupForAgentStatus("paused")).toBe(false);
+    expect(shouldRejectWakeupForAgentStatus("terminated")).toBe(true);
+    expect(shouldRejectWakeupForAgentStatus("pending_approval")).toBe(true);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -520,6 +520,10 @@ function normalizeMaxConcurrentRuns(value: unknown) {
   return Math.max(HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
 }
 
+export function shouldRejectWakeupForAgentStatus(status: string | null | undefined) {
+  return status === "terminated" || status === "pending_approval";
+}
+
 async function withAgentStartLock<T>(agentId: string, fn: () => Promise<T>) {
   const previous = startLocksByAgent.get(agentId) ?? Promise.resolve();
   const run = previous.then(fn);
@@ -4511,11 +4515,7 @@ export function heartbeatService(db: Db) {
       });
     }
 
-    if (
-      agent.status === "paused" ||
-      agent.status === "terminated" ||
-      agent.status === "pending_approval"
-    ) {
+    if (shouldRejectWakeupForAgentStatus(agent.status)) {
       throw conflict("Agent is not invokable in its current state", { status: agent.status });
     }
 


### PR DESCRIPTION
WEB-1389\n\nScope:\n- Stop treating paused agents as an immediate wakeup conflict in server/src/services/heartbeat.ts\n- Add a regression test that paused agents can queue wakeups without throwing\n- Add a pure unit test for the wakeup status guard\n\nTests:\n- pnpm test -- server/src/__tests__/heartbeat-wakeup-status-guard.test.ts\n- pnpm test -- server/src/__tests__/heartbeat-process-recovery.test.ts -t "queues wakeups for paused agents instead of rejecting them" (embedded Postgres suite skipped on this host because init script failed)\n\nRisk:\n- Paused agents can now accumulate queued wakeups, but claim/start still blocks execution until the agent resumes