### PR TITLE
fix: throw 404 when project name cannot be resolved in API route

### DIFF
--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -13,7 +13,7 @@ import {
 import { trackProjectCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
 import { projectService, logActivity, secretService, workspaceOperationService } from "../services/index.js";
-import { conflict } from "../errors.js";
+import { conflict, notFound } from "../errors.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import {
   buildWorkspaceRuntimeDesiredStatePatch,
@@ -61,7 +61,10 @@ export function projectRoutes(db: Db) {
     if (resolved.ambiguous) {
       throw conflict("Project shortname is ambiguous in this company. Use the project ID.");
     }
-    return resolved.project?.id ?? rawId;
+    if (!resolved.project) {
+      throw notFound(`Project not found`);
+    }
+    return resolved.project.id;
   }
 
   router.param("id", async (req, _res, next, rawId) => {

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -56,7 +56,7 @@ export function projectRoutes(db: Db) {
   async function normalizeProjectReference(req: Request, rawId: string) {
     if (isUuidLike(rawId)) return rawId;
     const companyId = await resolveCompanyIdForProjectReference(req);
-    if (!companyId) return rawId;
+    if (!companyId) throw notFound("Project not found");
     const resolved = await svc.resolveByReference(companyId, rawId);
     if (resolved.ambiguous) {
       throw conflict("Project shortname is ambiguous in this company. Use the project ID.");


### PR DESCRIPTION
## Thinking Path

> - Paperclip routes API requests through Express to service handlers
> - The `projectRoutes` function handles `/api/projects/:id`
> - A `router.param("id")` middleware normalizes project references (name → UUID)
> - `normalizeProjectReference` returns the raw string when resolution fails
> - The route handler calls `getById()` which passes the raw string to PostgreSQL
> - PostgreSQL expects a UUID but receives `"board-issues-and-requests"` → 500 error
> - This pull request throws a 404 when the project cannot be found instead of passing through the raw string
> - The benefit is users get a correct 404 instead of a confusing 500 PostgreSQL error

## What Changed

- Modified `normalizeProjectReference` in `server/src/routes/projects.ts`
- Added check for `resolved.project` being null and throw 404 instead of returning raw string
- Imported `notFound` error helper from `../errors.js`

## Verification

- [ ] `GET /api/projects/board-issues-and-requests?companyId=<uuid>` returns 404 (not 500)
- [ ] `GET /api/projects/<valid-uuid>` still works
- [ ] `GET /api/projects/<valid-project-name>?companyId=<uuid>` still works
- [ ] No change to behavior when project is found by name

## Risks

- Low risk. Only affects the error path when a project name cannot be resolved. Normal project lookups by UUID or valid name are unaffected.

## Model Used

- Provider: OpenRouter (via OpenClaw)
- Model: Minimax M2.7 (minimax/MiniMax-M2.7)
- Mode: Direct API call to Minimax messages endpoint
- Role: AI assistant (Claude-like) acting as agent for Thomas Tomiczek
- Note: This PR was authored by an AI assistant; Thomas Tomiczek is the human contributor
