### PR TITLE
feat(bla-570): agent error alerts with name + restart action

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2687,6 +2687,7 @@ export function heartbeatService(db: Db) {
   async function finalizeAgentStatus(
     agentId: string,
     outcome: "succeeded" | "failed" | "cancelled" | "timed_out",
+    errorMessage?: string | null,
   ) {
     const existing = await getAgent(agentId);
     if (!existing) return;
@@ -2732,6 +2733,7 @@ export function heartbeatService(db: Db) {
             ? new Date(updated.lastHeartbeatAt).toISOString()
             : null,
           outcome,
+          ...(nextStatus === "error" && errorMessage ? { errorMessage } : {}),
         },
       });
     }
@@ -2836,7 +2838,7 @@ export function heartbeatService(db: Db) {
         },
       });
 
-      await finalizeAgentStatus(run.agentId, "failed");
+      await finalizeAgentStatus(run.agentId, "failed", baseMessage);
       await startNextQueuedRunForAgent(run.agentId);
       runningProcesses.delete(run.id);
       reaped.push(run.id);
@@ -4098,7 +4100,11 @@ export function heartbeatService(db: Db) {
           }
         }
       }
-      await finalizeAgentStatus(agent.id, outcome);
+      await finalizeAgentStatus(
+        agent.id,
+        outcome,
+        outcome !== "succeeded" ? (adapterResult.errorMessage ?? null) : null,
+      );
     } catch (err) {
       const message = redactCurrentUserText(
         err instanceof Error ? err.message : "Unknown adapter failure",
@@ -4163,7 +4169,7 @@ export function heartbeatService(db: Db) {
         }
       }
 
-      await finalizeAgentStatus(agent.id, "failed");
+      await finalizeAgentStatus(agent.id, "failed", message);
     }
     } catch (outerErr) {
           // Setup code before adapter.execute threw (e.g. ensureRuntimeState, resolveWorkspaceForRun).
@@ -4197,7 +4203,7 @@ export function heartbeatService(db: Db) {
           }
           // Ensure the agent is not left stuck in "running" if the inner catch handler's
           // DB calls threw (e.g. a transient DB error in finalizeAgentStatus).
-          await finalizeAgentStatus(run.agentId, "failed").catch(() => undefined);
+          await finalizeAgentStatus(run.agentId, "failed", message).catch(() => undefined);
         } finally {
           await releaseRuntimeServicesForRun(run.id).catch(() => undefined);
           activeRunExecutions.delete(run.id);

--- a/ui/src/components/AgentActionButtons.tsx
+++ b/ui/src/components/AgentActionButtons.tsx
@@ -1,4 +1,4 @@
-import { Pause, Play } from "lucide-react";
+import { Pause, Play, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export function RunButton({
@@ -46,6 +46,23 @@ export function PauseResumeButton({
     <Button variant="outline" size={size} onClick={onPause} disabled={disabled}>
       <Pause className="h-3.5 w-3.5 sm:mr-1" />
       <span className="hidden sm:inline">Pause</span>
+    </Button>
+  );
+}
+
+export function RestartButton({
+  onClick,
+  disabled,
+  size = "sm",
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  size?: "sm" | "default";
+}) {
+  return (
+    <Button variant="outline" size={size} onClick={onClick} disabled={disabled}>
+      <RotateCcw className="h-3.5 w-3.5 sm:mr-1" />
+      <span className="hidden sm:inline">Restart</span>
     </Button>
   );
 }

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -538,9 +538,10 @@ function buildAgentStatusToast(
       ? `${name} started`
       : `${name} errored`;
 
+  const errorMessage = readString(payload.errorMessage);
   const agents = queryClient.getQueryData<Agent[]>(queryKeys.agents.list(companyId));
   const agent = agents?.find((a) => a.id === agentId);
-  const body = agent?.title ?? undefined;
+  const body = errorMessage ? truncate(errorMessage, 100) : (agent?.title ?? undefined);
 
   return {
     title,

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -37,7 +37,7 @@ import { CopyText } from "../components/CopyText";
 import { EntityRow } from "../components/EntityRow";
 import { Identity } from "../components/Identity";
 import { PageSkeleton } from "../components/PageSkeleton";
-import { RunButton, PauseResumeButton } from "../components/AgentActionButtons";
+import { RunButton, PauseResumeButton, RestartButton } from "../components/AgentActionButtons";
 import { BudgetPolicyCard } from "../components/BudgetPolicyCard";
 import { PackageFileTree, buildFileTree } from "../components/PackageFileTree";
 import { ScrollToBottom } from "../components/ScrollToBottom";
@@ -762,13 +762,17 @@ export function AgentDetail() {
   }, [agent?.companyId, selectedCompanyId, setSelectedCompanyId]);
 
   const agentAction = useMutation({
-    mutationFn: async (action: "invoke" | "pause" | "resume" | "terminate") => {
+    mutationFn: async (action: "invoke" | "pause" | "resume" | "terminate" | "restart") => {
       if (!agentLookupRef) return Promise.reject(new Error("No agent reference"));
       switch (action) {
         case "invoke": return agentsApi.invoke(agentLookupRef, resolvedCompanyId ?? undefined);
         case "pause": return agentsApi.pause(agentLookupRef, resolvedCompanyId ?? undefined);
         case "resume": return agentsApi.resume(agentLookupRef, resolvedCompanyId ?? undefined);
         case "terminate": return agentsApi.terminate(agentLookupRef, resolvedCompanyId ?? undefined);
+        case "restart": {
+          await agentsApi.resetSession(agentLookupRef, null, resolvedCompanyId ?? undefined);
+          return agentsApi.invoke(agentLookupRef, resolvedCompanyId ?? undefined);
+        }
       }
     },
     onSuccess: (data, action) => {
@@ -783,7 +787,7 @@ export function AgentDetail() {
           queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(resolvedCompanyId, agent.id) });
         }
       }
-      if (action === "invoke" && data && typeof data === "object" && "id" in data) {
+      if ((action === "invoke" || action === "restart") && data && typeof data === "object" && "id" in data) {
         navigate(`/agents/${canonicalAgentRef}/runs/${(data as HeartbeatRun).id}`);
       }
     },
@@ -935,6 +939,14 @@ export function AgentDetail() {
             onClick={() => agentAction.mutate("invoke")}
             disabled={agentAction.isPending || isPendingApproval}
             label="Run Heartbeat"
+          />
+          <RestartButton
+            onClick={() => {
+              if (window.confirm(`Reset session and restart ${agent.name}?`)) {
+                agentAction.mutate("restart");
+              }
+            }}
+            disabled={agentAction.isPending || isPendingApproval}
           />
           <PauseResumeButton
             isPaused={agent.status === "paused"}


### PR DESCRIPTION
## Summary

- **errorMessage forwarding** — `finalizeAgentStatus` in `heartbeat.ts` now accepts an optional `errorMessage` and includes it in the `agent.status` live event when transitioning to `error`. All four error-path call sites (inner catch, outer catch, orphan reaper, success-path failure) now forward the error message.
- **Toast identity** — `buildAgentStatusToast` in `LiveUpdatesProvider.tsx` reads `errorMessage` from the event payload and displays it as the toast body, so the operator sees both **who** errored and **why** on first read.
- **Restart / clear-error action** — New `RestartButton` component (reset-session + invoke heartbeat) added to the agent detail button bar with `window.confirm` guard. Available regardless of agent status.

Resolves the two P1 Greptile findings from the prior review of PR #3868 (missing `errorMessage` forwarding in inner and outer catch paths).

## Test plan

- [ ] Trigger an agent error (e.g. invalid adapter config) and verify the toast shows `"AgentName errored"` with the error reason in the body
- [ ] Confirm error toasts in agent list view are scannable (agent name visible without drilling in)
- [ ] Click Restart on an agent in error state → confirm dialog appears → on confirm, session resets and heartbeat fires
- [ ] Click Restart on idle/paused agent → same confirm + reset + invoke flow
- [ ] Verify double-click is guarded (button disabled while mutation is pending)
- [ ] Verify no regression on existing Pause/Resume/Run Heartbeat buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)