### PR TITLE
Fix company home cleanup after deletion

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -183,6 +183,40 @@ For `codex_local`, Paperclip also manages a per-company Codex home under the ins
 
 If the `codex` CLI is not installed or not on `PATH`, `codex_local` agent runs fail at execution time with a clear adapter error. Quota polling uses a short-lived `codex app-server` subprocess: when `codex` cannot be spawned, that provider reports `ok: false` in aggregated quota results and the API server keeps running (it must not exit on a missing binary).
 
+## Managed Company Homes
+
+Paperclip treats `~/.paperclip/instances/<instance-id>/companies/<company-id>/` as managed, derived runtime state for one live company. Adapter homes, prompt caches, and managed agent instruction bundles may be materialized under that directory.
+
+Lifecycle:
+
+- Archiving a company preserves the managed company home.
+- Deleting a company removes its database rows and then recursively removes only that company's managed home directory.
+- If database deletion succeeds but managed-home cleanup fails, the delete API still reports `ok: true` and includes a `companyHomeCleanup` warning/result. The company is deleted; the stale derived directory should be handled with the manual audit/backup flow below.
+- Cleanup is constrained to the configured instance `companies/` root and refuses unsafe company path segments.
+- Existing orphaned company homes should be audited and backed up before manual removal.
+
+Operator-safe orphan audit:
+
+```sh
+curl -fsS http://localhost:3100/api/companies | jq -r '.[].id' | sort > /tmp/paperclip-live-companies.txt
+find ~/.paperclip/instances/default/companies -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort > /tmp/paperclip-fs-companies.txt
+comm -23 /tmp/paperclip-fs-companies.txt /tmp/paperclip-live-companies.txt
+```
+
+Before removing any orphan listed by the audit, take a filesystem backup:
+
+```sh
+tar -C ~/.paperclip/instances/default -czf ~/paperclip-company-homes-backup-$(date +%Y%m%d-%H%M%S).tgz companies
+```
+
+Then remove only reviewed orphan ids, never active company ids:
+
+```sh
+while read -r company_id; do
+  rm -rf -- ~/.paperclip/instances/default/companies/"$company_id"
+done < /tmp/reviewed-paperclip-orphan-companies.txt
+```
+
 ## Worktree-local Instances
 
 When developing from multiple git worktrees, do not point two Paperclip servers at the same embedded PostgreSQL data directory.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -163,6 +163,8 @@ export {
 
 export type {
   Company,
+  DeleteCompanyResult,
+  ManagedCompanyHomeCleanupResult,
   FeedbackVote,
   FeedbackDataSharingPreference,
   FeedbackTargetType,

--- a/packages/shared/src/types/company.ts
+++ b/packages/shared/src/types/company.ts
@@ -22,3 +22,16 @@ export interface Company {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export interface ManagedCompanyHomeCleanupResult {
+  path: string | null;
+  removed: boolean;
+  status: "removed" | "missing" | "failed";
+  error?: string;
+}
+
+export interface DeleteCompanyResult {
+  ok: true;
+  companyHomeCleanup: ManagedCompanyHomeCleanupResult;
+  warning?: string;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { Company } from "./company.js";
+export type { Company, DeleteCompanyResult, ManagedCompanyHomeCleanupResult } from "./company.js";
 export type {
   FeedbackVote,
   FeedbackDataSharingPreference,

--- a/server/src/__tests__/cleanup-removal-service.test.ts
+++ b/server/src/__tests__/cleanup-removal-service.test.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { eq } from "drizzle-orm";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
   agents,
@@ -32,6 +35,8 @@ if (!embeddedPostgresSupport.supported) {
 describeEmbeddedPostgres("cleanup removal services", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  const originalPaperclipHome = process.env.PAPERCLIP_HOME;
+  const originalPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-cleanup-removal-");
@@ -39,6 +44,11 @@ describeEmbeddedPostgres("cleanup removal services", () => {
   }, 20_000);
 
   afterEach(async () => {
+    if (originalPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+    else process.env.PAPERCLIP_HOME = originalPaperclipHome;
+    if (originalPaperclipInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+    else process.env.PAPERCLIP_INSTANCE_ID = originalPaperclipInstanceId;
+
     await db.delete(activityLog);
     await db.delete(issueReadStates);
     await db.delete(issueComments);
@@ -180,9 +190,91 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     const removed = await companyService(db).remove(companyId);
 
     expect(removed?.id).toBe(companyId);
+    expect(removed?.companyHomeCleanup).toMatchObject({
+      removed: false,
+      status: "missing",
+    });
     await expect(db.select().from(companies).where(eq(companies.id, companyId))).resolves.toHaveLength(0);
     await expect(db.select().from(issues).where(eq(issues.id, issueId))).resolves.toHaveLength(0);
     await expect(db.select().from(issueReadStates).where(eq(issueReadStates.companyId, companyId))).resolves.toHaveLength(0);
     await expect(db.select().from(activityLog).where(eq(activityLog.companyId, companyId))).resolves.toHaveLength(0);
+  });
+
+  it("removes the deleted company's managed company-home directory only", async () => {
+    const { companyId, issueId } = await seedFixture();
+    const activeCompanyId = randomUUID();
+    const paperclipHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-company-home-cleanup-"));
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "cleanup-test";
+
+    const companiesRoot = path.join(paperclipHome, "instances", "cleanup-test", "companies");
+    const deletedCompanyHome = path.join(companiesRoot, companyId);
+    const activeCompanyHome = path.join(companiesRoot, activeCompanyId);
+    await fs.mkdir(path.join(deletedCompanyHome, "codex-home", "sessions"), { recursive: true });
+    await fs.mkdir(path.join(deletedCompanyHome, "agents", "agent-1", "instructions"), { recursive: true });
+    await fs.writeFile(path.join(deletedCompanyHome, "codex-home", "sessions", "session.jsonl"), "{}\n", "utf8");
+    await fs.writeFile(path.join(deletedCompanyHome, "agents", "agent-1", "instructions", "AGENTS.md"), "# Agent\n", "utf8");
+    await fs.mkdir(activeCompanyHome, { recursive: true });
+    await fs.writeFile(path.join(activeCompanyHome, "keep.txt"), "active\n", "utf8");
+
+    try {
+      const removed = await companyService(db).remove(companyId);
+
+      expect(removed?.id).toBe(companyId);
+      expect(removed?.companyHomeCleanup).toMatchObject({
+        path: deletedCompanyHome,
+        removed: true,
+        status: "removed",
+      });
+      await expect(db.select().from(companies).where(eq(companies.id, companyId))).resolves.toHaveLength(0);
+      await expect(db.select().from(issues).where(eq(issues.id, issueId))).resolves.toHaveLength(0);
+      await expect(fs.lstat(deletedCompanyHome)).rejects.toThrow();
+      await expect(fs.readFile(path.join(activeCompanyHome, "keep.txt"), "utf8")).resolves.toBe("active\n");
+    } finally {
+      await fs.rm(paperclipHome, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps deletion idempotent when managed company-home cleanup fails", async () => {
+    const { companyId, issueId } = await seedFixture();
+    const activeCompanyId = randomUUID();
+    const paperclipHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-company-home-cleanup-failure-"));
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "cleanup-test";
+
+    const companiesRoot = path.join(paperclipHome, "instances", "cleanup-test", "companies");
+    const deletedCompanyHome = path.join(companiesRoot, companyId);
+    const activeCompanyHome = path.join(companiesRoot, activeCompanyId);
+    await fs.mkdir(path.join(deletedCompanyHome, "codex-home"), { recursive: true });
+    await fs.writeFile(path.join(deletedCompanyHome, "codex-home", "session.jsonl"), "{}\n", "utf8");
+    await fs.mkdir(activeCompanyHome, { recursive: true });
+    await fs.writeFile(path.join(activeCompanyHome, "keep.txt"), "active\n", "utf8");
+
+    const originalRm = fs.rm.bind(fs);
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (target === deletedCompanyHome) {
+        throw new Error("simulated cleanup failure");
+      }
+      return originalRm(target, options);
+    });
+
+    try {
+      const removed = await companyService(db).remove(companyId);
+
+      expect(removed?.id).toBe(companyId);
+      expect(removed?.companyHomeCleanup).toMatchObject({
+        path: deletedCompanyHome,
+        removed: false,
+        status: "failed",
+        error: "simulated cleanup failure",
+      });
+      await expect(db.select().from(companies).where(eq(companies.id, companyId))).resolves.toHaveLength(0);
+      await expect(db.select().from(issues).where(eq(issues.id, issueId))).resolves.toHaveLength(0);
+      await expect(fs.readFile(path.join(deletedCompanyHome, "codex-home", "session.jsonl"), "utf8")).resolves.toBe("{}\n");
+      await expect(fs.readFile(path.join(activeCompanyHome, "keep.txt"), "utf8")).resolves.toBe("active\n");
+    } finally {
+      rmSpy.mockRestore();
+      await fs.rm(paperclipHome, { recursive: true, force: true });
+    }
   });
 });

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -62,6 +62,14 @@ export function resolveDefaultAgentWorkspaceDir(agentId: string): string {
   return path.resolve(resolvePaperclipInstanceRoot(), "workspaces", trimmed);
 }
 
+export function resolveManagedCompanyHomeDir(companyId: string): string {
+  const trimmed = companyId.trim();
+  if (!PATH_SEGMENT_RE.test(trimmed)) {
+    throw new Error(`Invalid company id for company home path '${companyId}'.`);
+  }
+  return path.resolve(resolvePaperclipInstanceRoot(), "companies", trimmed);
+}
+
 function sanitizeFriendlyPathSegment(value: string | null | undefined, fallback = "_default"): string {
   const trimmed = value?.trim() ?? "";
   if (!trimmed) return fallback;

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -406,7 +406,13 @@ export function companyRoutes(db: Db, storage?: StorageService) {
       res.status(404).json({ error: "Company not found" });
       return;
     }
-    res.json({ ok: true });
+    res.json({
+      ok: true,
+      companyHomeCleanup: company.companyHomeCleanup,
+      ...(company.companyHomeCleanup.status === "failed"
+        ? { warning: "Company was deleted, but managed company-home cleanup failed." }
+        : {}),
+    });
   });
 
   return router;

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -29,6 +29,10 @@ import {
   companySkills,
 } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
+import {
+  type ManagedCompanyHomeCleanupResult,
+  removeManagedCompanyHome,
+} from "./company-home.js";
 
 export function companyService(db: Db) {
   const ISSUE_PREFIX_FALLBACK = "CMP";
@@ -257,8 +261,8 @@ export function companyService(db: Db) {
         return enrichCompany(hydrated);
       }),
 
-    remove: (id: string) =>
-      db.transaction(async (tx) => {
+    remove: async (id: string) => {
+      const removed = await db.transaction(async (tx) => {
         // Delete from child tables in dependency order
         await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.companyId, id));
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.companyId, id));
@@ -290,7 +294,26 @@ export function companyService(db: Db) {
           .where(eq(companies.id, id))
           .returning();
         return rows[0] ?? null;
-      }),
+      });
+      if (removed) {
+        let companyHomeCleanup: ManagedCompanyHomeCleanupResult;
+        try {
+          companyHomeCleanup = await removeManagedCompanyHome(id);
+        } catch (error) {
+          companyHomeCleanup = {
+            path: null,
+            removed: false,
+            status: "failed",
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+        return {
+          ...removed,
+          companyHomeCleanup,
+        };
+      }
+      return removed;
+    },
 
     stats: () =>
       Promise.all([

--- a/server/src/services/company-home.ts
+++ b/server/src/services/company-home.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ManagedCompanyHomeCleanupResult } from "@paperclipai/shared";
+import { resolveManagedCompanyHomeDir, resolvePaperclipInstanceRoot } from "../home-paths.js";
+
+export type { ManagedCompanyHomeCleanupResult };
+
+function assertWithinCompaniesRoot(targetPath: string): void {
+  const companiesRoot = path.resolve(resolvePaperclipInstanceRoot(), "companies");
+  const resolvedTarget = path.resolve(targetPath);
+  const relative = path.relative(companiesRoot, resolvedTarget);
+  if (!relative || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`Refusing to remove path outside managed companies root: ${targetPath}`);
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error as { code?: string }).code === "ENOENT";
+}
+
+export async function removeManagedCompanyHome(companyId: string): Promise<ManagedCompanyHomeCleanupResult> {
+  const companyHome = resolveManagedCompanyHomeDir(companyId);
+  assertWithinCompaniesRoot(companyHome);
+
+  try {
+    await fs.lstat(companyHome);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return { path: companyHome, removed: false, status: "missing" };
+    }
+    return {
+      path: companyHome,
+      removed: false,
+      status: "failed",
+      error: errorMessage(error),
+    };
+  }
+
+  try {
+    await fs.rm(companyHome, { recursive: true, force: true });
+    return { path: companyHome, removed: true, status: "removed" };
+  } catch (error) {
+    return {
+      path: companyHome,
+      removed: false,
+      status: "failed",
+      error: errorMessage(error),
+    };
+  }
+}

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -1,5 +1,6 @@
 import type {
   Company,
+  DeleteCompanyResult,
   CompanyPortabilityExportRequest,
   CompanyPortabilityExportPreviewResult,
   CompanyPortabilityExportResult,
@@ -42,7 +43,7 @@ export const companiesApi = {
   updateBranding: (companyId: string, data: UpdateCompanyBranding) =>
     api.patch<Company>(`/companies/${companyId}/branding`, data),
   archive: (companyId: string) => api.post<Company>(`/companies/${companyId}/archive`, {}),
-  remove: (companyId: string) => api.delete<{ ok: true }>(`/companies/${companyId}`),
+  remove: (companyId: string) => api.delete<DeleteCompanyResult>(`/companies/${companyId}`),
   exportBundle: (
     companyId: string,
     data: CompanyPortabilityExportRequest,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies, including the runtime filesystem state used by each company and its agents.
> - Company deletion is a company-scoped lifecycle operation, so it must clean up derived company-owned artifacts without crossing instance or company boundaries.
> - Imported/deleted companies were leaving managed homes under `~/.paperclip/instances/<instance>/companies/<companyId>`, which made operators see stale company clones after the database rows were gone.
> - The database delete must remain the source-of-truth operation, and filesystem cleanup must happen afterward so a cleanup failure cannot roll back or misrepresent the company deletion.
> - This pull request adds a guarded managed-home cleanup path, exposes cleanup metadata in the delete response, and documents the operator-safe audit/removal procedure for existing orphans.
> - The benefit is a clearer company deletion lifecycle with safer partial-failure behavior and better operator recovery guidance.

## What Changed

- Added managed company-home path resolution under the configured Paperclip instance `companies/` root with company-id validation and containment checks.
- Updated company deletion to remove database rows first, then remove the deleted company managed home as derived runtime state.
- Changed `DELETE /api/companies/:companyId` to return `companyHomeCleanup` metadata and an operator-readable warning when cleanup fails after successful DB deletion.
- Tightened cleanup error handling so only `ENOENT` is treated as a missing home; unexpected filesystem errors are surfaced as failed cleanup results.
- Added shared/UI company delete response types for the cleanup result contract.
- Added focused regression coverage for missing homes, successful deletion cleanup, sibling-home preservation, and cleanup failure after DB deletion.
- Documented managed company-home lifecycle plus DB-vs-filesystem audit, backup, and reviewed manual orphan removal in `doc/DEVELOPING.md`.

## Verification

- `pnpm vitest run server/src/__tests__/cleanup-removal-service.test.ts`
- `pnpm -r typecheck`
- QA black-box validation passed on `task/CON-96-company-home-cleanup...fork/task/CON-96-company-home-cleanup` at commit `2d596af0` in an isolated local-trusted instance on `http://127.0.0.1:3310`.
- QA verified disposable company deletion via the public API, `companyHomeCleanup.status: "removed"`, missing-home behavior, forced cleanup failure behavior, sibling-home preservation, and the documented orphan audit flow.

## Risks

- Low operational risk: cleanup is constrained to the configured instance company-home root and validates company path segments before removal.
- If filesystem cleanup fails after DB deletion, stale derived files remain for manual cleanup; the API now reports `ok: true` with `companyHomeCleanup.status: "failed"` and a warning instead of implying the company delete failed.
- This changes the company delete response shape by adding metadata, with shared/UI types updated accordingly.

## Model Used

- OpenAI GPT-5.4 via Codex coding agent, medium reasoning, with repository editing, local test execution, and GitHub CLI tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
