### PR TITLE
fix: resolve CJK character encoding corruption on Windows

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -59,6 +59,26 @@ function signalRunningProcess(
 
 export const runningProcesses = new Map<string, RunningProcess>();
 export const MAX_CAPTURE_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Decode a Buffer as UTF-8, falling back to GBK on Windows if UTF-8 fails.
+ * This handles the case where child processes on Chinese Windows output GBK-encoded text.
+ */
+function decodeBufferWithFallback(buf: Buffer): string {
+  try {
+    const decoder = new TextDecoder("utf-8", { fatal: true });
+    return decoder.decode(buf);
+  } catch {
+    try {
+      // GBK fallback — Node.js built-in ICU supports 'gbk' natively
+      const gbkDecoder = new TextDecoder("gbk");
+      return gbkDecoder.decode(buf);
+    } catch {
+      // ICU doesn't know GBK (small-icu build); return lossy UTF-8 string
+      return buf.toString("utf8");
+    }
+  }
+}
 export const MAX_EXCERPT_BYTES = 32 * 1024;
 const SENSITIVE_ENV_KEY = /(key|token|secret|password|passwd|authorization|cookie)/i;
 const PAPERCLIP_SKILL_ROOT_RELATIVE_CANDIDATES = [
@@ -1095,6 +1115,11 @@ export async function runChildProcess(
       delete rawMerged[key];
     }
 
+    // Encourage child processes on Windows to output UTF-8 instead of GBK
+    if (process.platform === "win32") {
+      rawMerged.PYTHONIOENCODING = "utf-8";
+    }
+
     const mergedEnv = ensurePathInEnv(rawMerged);
     void resolveSpawnTarget(command, args, opts.cwd, mergedEnv)
       .then((target) => {
@@ -1120,6 +1145,12 @@ export async function runChildProcess(
         let timedOut = false;
         let stdout = "";
         let stderr = "";
+        // On Windows, collect raw Buffers for GBK→UTF-8 fallback decoding
+        const useBufferCapture = process.platform === "win32";
+        const stdoutBufs: Buffer[] = [];
+        const stderrBufs: Buffer[] = [];
+        let stdoutBufBytes = 0;
+        let stderrBufBytes = 0;
         let logChain: Promise<void> = Promise.resolve();
 
         const timeout =
@@ -1134,7 +1165,12 @@ export async function runChildProcess(
             : null;
 
         child.stdout?.on("data", (chunk: unknown) => {
-          const text = String(chunk);
+          const rawBuf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+          if (useBufferCapture && stdoutBufBytes < MAX_CAPTURE_BYTES) {
+            stdoutBufs.push(rawBuf.subarray(0, MAX_CAPTURE_BYTES - stdoutBufBytes));
+            stdoutBufBytes += rawBuf.length;
+          }
+          const text = useBufferCapture ? rawBuf.toString("utf8") : String(chunk);
           stdout = appendWithCap(stdout, text);
           logChain = logChain
             .then(() => opts.onLog("stdout", text))
@@ -1142,7 +1178,12 @@ export async function runChildProcess(
         });
 
         child.stderr?.on("data", (chunk: unknown) => {
-          const text = String(chunk);
+          const rawBuf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+          if (useBufferCapture && stderrBufBytes < MAX_CAPTURE_BYTES) {
+            stderrBufs.push(rawBuf.subarray(0, MAX_CAPTURE_BYTES - stderrBufBytes));
+            stderrBufBytes += rawBuf.length;
+          }
+          const text = useBufferCapture ? rawBuf.toString("utf8") : String(chunk);
           stderr = appendWithCap(stderr, text);
           logChain = logChain
             .then(() => opts.onLog("stderr", text))
@@ -1174,12 +1215,23 @@ export async function runChildProcess(
           if (timeout) clearTimeout(timeout);
           runningProcesses.delete(runId);
           void logChain.finally(() => {
+            // On Windows, re-decode stdout/stderr with GBK fallback if UTF-8 fails
+            let finalStdout = stdout;
+            let finalStderr = stderr;
+            if (useBufferCapture) {
+              if (stdoutBufs.length > 0) {
+                finalStdout = decodeBufferWithFallback(Buffer.concat(stdoutBufs));
+              }
+              if (stderrBufs.length > 0) {
+                finalStderr = decodeBufferWithFallback(Buffer.concat(stderrBufs));
+              }
+            }
             resolve({
               exitCode: code,
               signal,
               timedOut,
-              stdout,
-              stderr,
+              stdout: finalStdout,
+              stderr: finalStderr,
               pid: child.pid ?? null,
               startedAt,
             });

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1167,8 +1167,9 @@ export async function runChildProcess(
         child.stdout?.on("data", (chunk: unknown) => {
           const rawBuf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
           if (useBufferCapture && stdoutBufBytes < MAX_CAPTURE_BYTES) {
-            stdoutBufs.push(rawBuf.subarray(0, MAX_CAPTURE_BYTES - stdoutBufBytes));
-            stdoutBufBytes += rawBuf.length;
+            const sliceLen = Math.min(rawBuf.length, MAX_CAPTURE_BYTES - stdoutBufBytes);
+            stdoutBufs.push(rawBuf.subarray(0, sliceLen));
+            stdoutBufBytes += sliceLen;
           }
           const text = useBufferCapture ? rawBuf.toString("utf8") : String(chunk);
           stdout = appendWithCap(stdout, text);
@@ -1180,8 +1181,9 @@ export async function runChildProcess(
         child.stderr?.on("data", (chunk: unknown) => {
           const rawBuf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
           if (useBufferCapture && stderrBufBytes < MAX_CAPTURE_BYTES) {
-            stderrBufs.push(rawBuf.subarray(0, MAX_CAPTURE_BYTES - stderrBufBytes));
-            stderrBufBytes += rawBuf.length;
+            const sliceLen = Math.min(rawBuf.length, MAX_CAPTURE_BYTES - stderrBufBytes);
+            stderrBufs.push(rawBuf.subarray(0, sliceLen));
+            stderrBufBytes += sliceLen;
           }
           const text = useBufferCapture ? rawBuf.toString("utf8") : String(chunk);
           stderr = appendWithCap(stderr, text);

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -70,8 +70,9 @@ function renderApiAccessNote(env: Record<string, string>): string {
     "Use run_shell_command with curl to make Paperclip API requests.",
     "GET example:",
     `  run_shell_command({ command: "curl -s -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" \\"$PAPERCLIP_API_URL/api/agents/me\\"" })`,
-    "POST/PATCH example:",
-    `  run_shell_command({ command: "curl -s -X POST -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" -H 'Content-Type: application/json' -H \\"X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID\\" -d '{...}' \\"$PAPERCLIP_API_URL/api/issues/{id}/checkout\\"" })`,
+    "POST/PATCH example — always pipe JSON through stdin to avoid encoding issues on Windows:",
+    `  run_shell_command({ command: "echo '{\\"agentId\\":\\"YOUR_AGENT_ID\\"}' | curl -s -X POST -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" -H 'Content-Type: application/json' -H \\"X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID\\" -d @- \\"$PAPERCLIP_API_URL/api/issues/{id}/checkout\\"" })`,
+    "For JSON with non-ASCII content, always use: jq -n --arg key value '{...}' | curl -d @-",
     "",
     "",
   ].join("\n");

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -71,7 +71,7 @@ function renderApiAccessNote(env: Record<string, string>): string {
     "GET example:",
     `  run_shell_command({ command: "curl -s -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" \\"$PAPERCLIP_API_URL/api/agents/me\\"" })`,
     "POST/PATCH example — always pipe JSON through stdin to avoid encoding issues on Windows:",
-    `  run_shell_command({ command: "echo '{\\"agentId\\":\\"YOUR_AGENT_ID\\"}' | curl -s -X POST -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" -H 'Content-Type: application/json' -H \\"X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID\\" -d @- \\"$PAPERCLIP_API_URL/api/issues/{id}/checkout\\"" })`,
+    `  run_shell_command({ command: "jq -n --arg agentId \\"YOUR_AGENT_ID\\" '{agentId:$agentId}' | curl -s -X POST -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" -H \\"Content-Type: application/json\\" -H \\"X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID\\" -d @- \\"$PAPERCLIP_API_URL/api/issues/{id}/checkout\\"" })`,
     "For JSON with non-ASCII content, always use: jq -n --arg key value '{...}' | curl -d @-",
     "",
     "",

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -46,7 +46,7 @@ export type MigrationState =
     };
 
 export function createDb(url: string) {
-  const sql = postgres(url);
+  const sql = postgres(url, { connection: { client_encoding: "UTF8" } });
   return drizzlePg(sql, { schema });
 }
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -140,7 +140,7 @@ export async function createApp(
   if (process.platform === "win32") {
     app.use((req: ExpressRequest, _res: Response, next: NextFunction) => {
       const raw = (req as unknown as { rawBody?: Buffer }).rawBody;
-      if (raw && raw.length > 0 && (req.method === "POST" || req.method === "PATCH" || req.method === "PUT")) {
+      if (raw && raw.length > 0 && (req.method === "POST" || req.method === "PATCH" || req.method === "PUT") && req.is("application/json")) {
         try {
           req.body = JSON.parse(raw.toString("utf8"));
         } catch {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,4 +1,4 @@
-import express, { Router, type Request as ExpressRequest } from "express";
+import express, { Router, type Request as ExpressRequest, type Response, type NextFunction } from "express";
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -134,6 +134,23 @@ export async function createApp(
       (req as unknown as { rawBody: Buffer }).rawBody = buf;
     },
   }));
+
+  // On Windows, body-parser's iconv.decode corrupts UTF-8 CJK characters.
+  // Re-parse the raw Buffer using Node.js native UTF-8 decoding instead.
+  if (process.platform === "win32") {
+    app.use((req: ExpressRequest, _res: Response, next: NextFunction) => {
+      const raw = (req as unknown as { rawBody?: Buffer }).rawBody;
+      if (raw && raw.length > 0 && (req.method === "POST" || req.method === "PATCH" || req.method === "PUT")) {
+        try {
+          req.body = JSON.parse(raw.toString("utf8"));
+        } catch {
+          // keep original body if re-parse fails
+        }
+      }
+      next();
+    });
+  }
+
   app.use(httpLogger);
   const privateHostnameGateEnabled = shouldEnablePrivateHostnameGuard({
     deploymentMode: opts.deploymentMode,

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -23,6 +23,32 @@ Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli
 
 **Run audit trail:** You MUST include `-H 'X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID'` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
 
+## Curl Encoding (Critical)
+
+On Windows, `curl -d '...'` with inline JSON containing non-ASCII characters (CJK, emoji, special chars) gets corrupted. Windows `CreateProcess` converts command-line arguments through the system locale (GBK/CP936 on Chinese Windows), mangling UTF-8 bytes before curl even sees them.
+
+**Always pipe JSON payloads through stdin instead of inlining in `-d`:**
+
+```bash
+# CORRECT — pipe through stdin, bytes never touch command-line encoding
+jq -n --arg body "中文评论" '{comment:$body}' | curl -sS -X PATCH \
+  "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H "Content-Type: application/json" \
+  -d @-
+
+# CORRECT — use the helper script (handles multiline too)
+scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done <<'MD'
+Done — 中文内容正常显示
+MD
+
+# WRONG — inline -d with non-ASCII (corrupted on Windows)
+curl -d '{"comment":"中文评论"}' ...
+```
+
+This applies to **all** POST/PATCH requests with JSON bodies, not just comments. For GET requests (no body), plain curl is fine.
+
 ## The Heartbeat Procedure
 
 Follow these steps every time you wake up:


### PR DESCRIPTION
## Summary

Fixes #3940

CJK characters (Chinese, Japanese, Korean) in agent comments and issue updates appear as garbled text (Mojibake) when running Paperclip on Windows with a Chinese locale (code page 936 / GBK).

## Thinking Path

**Root cause: Windows `CreateProcess` corrupts `curl -d` command-line arguments containing non-ASCII characters.**

On Windows, `CreateProcess` converts command-line arguments through the system locale (GBK/CP936 on Chinese Windows). When an agent executes:

```bash
curl -d '{"comment":"中文评论"}' ...
```

The UTF-8 bytes of `中文评论` are mangled through GBK encoding *before curl even sees them*. The bytes never reach the server correctly — it's not a server-side encoding issue, it's a client-side command construction issue.

**Secondary issue**: The Express body-parser's `iconv.decode(buffer, charset)` path (triggered when a `verify` callback is present) can also corrupt multi-byte UTF-8 sequences. And child process stdout on Windows may be GBK-encoded instead of UTF-8.

## What Changed

### Primary fix — source-level prevention

Agents are instructed to **pipe JSON payloads through stdin** instead of inlining them in `curl -d`:

```bash
# CORRECT — bytes never touch command-line encoding
jq -n --arg body "中文评论" '{comment:$body}' | curl -d @- ...

# WRONG — inline -d with non-ASCII (corrupted on Windows)
curl -d '{"comment":"中文评论"}' ...
```

Changes:
- **`skills/paperclip/SKILL.md`**: New "Curl Encoding (Critical)" section documenting the root cause and mandating the pipe pattern
- **`packages/adapters/gemini-local/src/server/execute.ts`**: Updated `renderApiAccessNote()` to demonstrate stdin pipe pattern instead of inline `-d`

### Defense-in-depth — server-side safety nets

- **`packages/adapter-utils/src/server-utils.ts`**:
  - Buffer-based stdout/stderr capture on Windows with GBK→UTF-8 fallback decoding (`decodeBufferWithFallback`)
  - Guards against `RangeError` on small-icu Node.js builds
  - Sets `PYTHONIOENCODING=utf-8` for child processes
  - Caps buffer accumulation at `MAX_CAPTURE_BYTES` (4MB)

- **`server/src/app.ts`**: Windows-only middleware that re-parses request bodies from `rawBody` using strict UTF-8, bypassing body-parser's iconv-lite corruption path

- **`packages/db/src/client.ts`**: Sets `client_encoding: "UTF8"` via postgres.js connection option (applied to every pool connection, not just the first)

## Verification
### Before UI 
<img width="1890" height="928" alt="Error" src="https://github.com/user-attachments/assets/c7e972d9-b2e1-4ddb-a2d4-f04c4801a4e9" />
### After UI
<img width="1920" height="928" alt="nice1" src="https://github.com/user-attachments/assets/f35b345e-2b92-4b15-bdff-cef608a2c5c9" />
<img width="1920" height="928" alt="nice2" src="https://github.com/user-attachments/assets/ca5ac10a-b323-4219-83ce-f1936d3db16b" />


## Test Plan

- [x] Unit test for `decodeBufferWithFallback()` with GBK and UTF-8 byte sequences
- [x] Unit test for GBK TextDecoder fallback when ICU is unavailable (small-icu)
- [x] Buffer accumulation capped at `MAX_CAPTURE_BYTES`
- [x] Manual test on Windows with Chinese locale: create issue with Chinese title, trigger agent heartbeat with Chinese comment, verify display
- [ ] Verify no regression on Linux/macOS (`pnpm test`)
- [ ] Verify encoding middleware is not loaded on non-Windows platforms