### PR TITLE
feat(agents): let budget-paused agents self-resume once spend is back under budget

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -93,6 +93,18 @@ POST /api/agents/{agentId}/resume
 
 Resumes heartbeats for a paused agent.
 
+**Authorization**
+
+- **Board users** (session or board API key) may resume any agent in a company they can manage.
+- **Agent tokens** may resume the *same* agent they authenticate as, and only when:
+  - the agent is `paused`,
+  - `pauseReason === "budget"`, and
+  - `spentMonthlyCents < budgetMonthlyCents` (monthly budget non-zero).
+
+  This covers the case where an agent was auto-paused at budget and either the calendar month rolled over or the budget was raised. Agents can never resume peers — cross-agent lifecycle control still requires board access.
+
+Activity-log entries for self-resume include `details.selfResume: true` along with the budget and spend snapshot at the time of the call.
+
 ## Terminate Agent
 
 ```

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -47,6 +47,46 @@ No authentication required. All requests are treated as the local board operator
 
 Board operators authenticate via Better Auth sessions (cookie-based). The web UI handles login/logout flows automatically.
 
+### Board API Keys (for CLI and orchestration)
+
+Board users can mint long-lived API tokens to drive board-scoped endpoints (`/api/agents/:id/pause`, `/resume`, `/terminate`, budget updates, etc.) without a browser session. Agent tokens cannot reach these endpoints — board-only routes call `assertBoard()` which rejects `actor.type === "agent"`.
+
+**Obtain a token with the CLI:**
+
+```sh
+pnpm paperclipai auth login
+```
+
+This creates a challenge on the server, opens your browser to the approval page, and on approval stores a `pcp_*` token in `~/.paperclip/auth.json` (permissions `0600`, keyed by API base). Subsequent CLI calls pick it up automatically.
+
+**Use a token directly:**
+
+```
+Authorization: Bearer <board-api-token>
+```
+
+Activity-log entries produced with a board API key record `actorType: "user"` and `actorId = <user that minted the key>`, so audit trails remain attributable to a human operator.
+
+**Revoke / inspect:**
+
+```sh
+pnpm paperclipai auth logout    # revokes current key and removes local credential
+pnpm paperclipai auth whoami    # shows user, instance-admin flag, accessible companies
+```
+
+Or `POST /api/cli-auth/revoke-current` with the key in the `Authorization` header.
+
+#### When to use which
+
+| Need | Use |
+|------|-----|
+| Agent managing its own issues, comments, cost reporting | Agent JWT (`PAPERCLIP_API_KEY` from heartbeat) |
+| Agent operating long-lived outside a heartbeat | Agent API key (`POST /api/agents/:id/keys`) |
+| Operator scripts calling board-only endpoints | Board API key via `paperclipai auth login` |
+| Interactive board user | Web UI session |
+
+Agents — including a Coordinator-style orchestrator — **cannot** hold a board API key. Self-service lifecycle control for agents is limited to the budget-paused self-resume path documented in [Managing Agents](../guides/board-operator/managing-agents); anything broader (e.g., an orchestrator resuming a peer) requires a human-owned board token.
+
 ## Company Scoping
 
 All entities belong to a company. The API enforces company boundaries:

--- a/docs/cli/setup-commands.md
+++ b/docs/cli/setup-commands.md
@@ -91,6 +91,23 @@ pnpm paperclipai env
 
 This now includes bind-oriented deployment settings such as `PAPERCLIP_BIND` and `PAPERCLIP_BIND_HOST` when configured.
 
+## `paperclipai auth`
+
+Manage the board-user credential the CLI uses against a remote API. Use when Paperclip is running in `authenticated` mode and you want the CLI (or orchestration scripts using the same credential store) to call board-scoped endpoints without an interactive browser session.
+
+```sh
+# Mint a board API token — opens a browser approval page, stores the result at ~/.paperclip/auth.json
+pnpm paperclipai auth login [--api-base https://paperclip.example.com] [--company <companyId>] [--instance-admin]
+
+# Show the current identity for this API base
+pnpm paperclipai auth whoami
+
+# Revoke the stored token server-side and remove the local credential
+pnpm paperclipai auth logout
+```
+
+Tokens created this way authenticate as the approving user, so activity-log entries remain attributable to a human operator. See [API › Authentication](../api/authentication#board-api-keys-for-cli-and-orchestration) for guidance on when to use a board API key vs. an agent token.
+
 ## `paperclipai allowed-hostname`
 
 Allow a private hostname for authenticated/private mode:

--- a/docs/guides/board-operator/managing-agents.md
+++ b/docs/guides/board-operator/managing-agents.md
@@ -65,6 +65,29 @@ POST /api/agents/{agentId}/resume
 
 Agents are also auto-paused when they hit 100% of their monthly budget.
 
+### Calling these from scripts or outside the UI
+
+The `pause`, `resume`, `terminate`, and budget-update endpoints require board access — an agent token cannot reach them. For orchestration scripts, on-call runbooks, or any non-interactive use, mint a board API key with the CLI:
+
+```sh
+pnpm paperclipai auth login --api-base "$PAPERCLIP_API_BASE"
+
+# Read the token for this API base out of the credential store:
+PAPERCLIP_BOARD_TOKEN="$(
+  jq -r --arg base "$PAPERCLIP_API_BASE" \
+    '.credentials[$base].token' ~/.paperclip/auth.json
+)"
+
+curl -X POST -H "Authorization: Bearer $PAPERCLIP_BOARD_TOKEN" \
+  "$PAPERCLIP_API_BASE/api/agents/$AGENT_ID/resume"
+```
+
+Activity-log entries will record the approving user as the actor. Revoke with `pnpm paperclipai auth logout` when you're done. See [API › Authentication](../../api/authentication#board-api-keys-for-cli-and-orchestration) for details. Direct DB writes against the `agents` table are no longer required for this flow.
+
+### Budget-paused agents can self-resume
+
+If an agent was paused because it hit its monthly budget (`pauseReason = "budget"`), it is allowed to call `POST /api/agents/{agentId}/resume` against **itself** once `spentMonthlyCents < budgetMonthlyCents` — for example, after the calendar month rolls over or you raise the budget. All other `resume` calls (a different agent, a different pause reason, still over budget) continue to require board access.
+
 ## Terminating Agents
 
 Termination is permanent and irreversible:

--- a/server/src/__tests__/agent-self-resume-routes.test.ts
+++ b/server/src/__tests__/agent-self-resume-routes.test.ts
@@ -1,0 +1,281 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { agentRoutes } from "../routes/agents.js";
+
+const agentId = "11111111-1111-4111-8111-111111111111";
+const otherAgentId = "44444444-4444-4444-8444-444444444444";
+const companyId = "22222222-2222-4222-8222-222222222222";
+
+const baseAgent = {
+  id: agentId,
+  companyId,
+  name: "Builder",
+  urlKey: "builder",
+  role: "engineer",
+  title: "Builder",
+  icon: null,
+  status: "paused" as const,
+  reportsTo: null,
+  capabilities: null,
+  adapterType: "process",
+  adapterConfig: {},
+  runtimeConfig: {},
+  budgetMonthlyCents: 10_000,
+  spentMonthlyCents: 2_000,
+  pauseReason: "budget" as const,
+  pausedAt: new Date("2026-04-11T00:00:00.000Z"),
+  permissions: { canCreateAgents: false },
+  lastHeartbeatAt: null,
+  metadata: null,
+  createdAt: new Date("2026-04-11T00:00:00.000Z"),
+  updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+};
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  pause: vi.fn(),
+  resume: vi.fn(),
+  terminate: vi.fn(),
+  remove: vi.fn(),
+  listKeys: vi.fn(),
+  createApiKey: vi.fn(),
+  getKeyById: vi.fn(),
+  revokeKey: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+  getMembership: vi.fn(),
+  ensureMembership: vi.fn(),
+  listPrincipalGrants: vi.fn(),
+  setPrincipalPermission: vi.fn(),
+}));
+
+const mockApprovalService = vi.hoisted(() => ({
+  create: vi.fn(),
+  getById: vi.fn(),
+}));
+
+const mockBudgetService = vi.hoisted(() => ({
+  upsertPolicy: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  cancelActiveForAgent: vi.fn(),
+}));
+
+const mockIssueApprovalService = vi.hoisted(() => ({
+  linkManyForApproval: vi.fn(),
+}));
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const mockSecretService = vi.hoisted(() => ({
+  normalizeAdapterConfigForPersistence: vi.fn(),
+  resolveAdapterConfigForRuntime: vi.fn(),
+}));
+
+const mockAgentInstructionsService = vi.hoisted(() => ({
+  materializeManagedBundle: vi.fn(),
+}));
+
+const mockCompanySkillService = vi.hoisted(() => ({
+  listRuntimeSkillEntries: vi.fn(),
+  resolveRequestedSkillKeys: vi.fn(),
+}));
+
+const mockWorkspaceOperationService = vi.hoisted(() => ({}));
+const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentCreated: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: mockGetTelemetryClient,
+}));
+
+vi.mock("../services/index.js", () => ({
+  agentService: () => mockAgentService,
+  agentInstructionsService: () => mockAgentInstructionsService,
+  accessService: () => mockAccessService,
+  approvalService: () => mockApprovalService,
+  companySkillService: () => mockCompanySkillService,
+  budgetService: () => mockBudgetService,
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => mockIssueApprovalService,
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  secretService: () => mockSecretService,
+  syncInstructionsBundleConfigFromFilePath: vi.fn((_agent, config) => config),
+  workspaceOperationService: () => mockWorkspaceOperationService,
+}));
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: () => ({
+    getGeneral: vi.fn(async () => ({ censorUsernameInLogs: false })),
+  }),
+}));
+
+function createApp(actor: Record<string, unknown>) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", agentRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function agentActor(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "agent",
+    agentId,
+    companyId,
+    source: "agent_key",
+    runId: "run-1",
+    ...overrides,
+  };
+}
+
+describe("POST /agents/:id/resume — budget-paused self-resume (Option C)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTelemetryClient.mockReturnValue({ track: vi.fn() });
+    mockAgentService.getById.mockResolvedValue(baseAgent);
+    mockAgentService.resume.mockImplementation(async () => ({
+      ...baseAgent,
+      status: "idle",
+      pauseReason: null,
+      pausedAt: null,
+    }));
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("lets a budget-paused agent resume itself when spend is below budget", async () => {
+    const app = createApp(agentActor());
+
+    const res = await request(app).post(`/api/agents/${agentId}/resume`).send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("idle");
+    expect(mockAgentService.resume).toHaveBeenCalledWith(agentId);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.resumed",
+        actorType: "agent",
+        actorId: agentId,
+        agentId,
+        runId: "run-1",
+        details: expect.objectContaining({
+          selfResume: true,
+          pauseReason: "budget",
+          budgetMonthlyCents: 10_000,
+          spentMonthlyCents: 2_000,
+        }),
+      }),
+    );
+  });
+
+  it("rejects self-resume when monthly spend is at or above budget", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      spentMonthlyCents: 10_000,
+    });
+    const app = createApp(agentActor());
+
+    const res = await request(app).post(`/api/agents/${agentId}/resume`).send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("monthly spend is at or above budget");
+    expect(mockAgentService.resume).not.toHaveBeenCalled();
+  });
+
+  it("rejects self-resume when the agent was manually paused (not budget)", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      pauseReason: "manual",
+    });
+    const app = createApp(agentActor());
+
+    const res = await request(app).post(`/api/agents/${agentId}/resume`).send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("budget-paused agents");
+    expect(mockAgentService.resume).not.toHaveBeenCalled();
+  });
+
+  it("rejects an agent trying to resume a peer", async () => {
+    const app = createApp(agentActor({ agentId: otherAgentId, companyId }));
+
+    const res = await request(app).post(`/api/agents/${agentId}/resume`).send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("only resume themselves");
+    expect(mockAgentService.resume).not.toHaveBeenCalled();
+  });
+
+  it("rejects self-resume across tenants", async () => {
+    const app = createApp(
+      agentActor({ companyId: "99999999-9999-4999-8999-999999999999" }),
+    );
+
+    const res = await request(app).post(`/api/agents/${agentId}/resume`).send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("cannot access another company");
+    expect(mockAgentService.resume).not.toHaveBeenCalled();
+  });
+
+  it("rejects self-resume when budget is zero (no monthly budget set)", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      budgetMonthlyCents: 0,
+      spentMonthlyCents: 0,
+    });
+    const app = createApp(agentActor());
+
+    const res = await request(app).post(`/api/agents/${agentId}/resume`).send({});
+
+    expect(res.status).toBe(403);
+    expect(mockAgentService.resume).not.toHaveBeenCalled();
+  });
+
+  it("still allows board users to resume (existing behavior)", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+    const app = createApp({
+      type: "board",
+      userId: "board-user",
+      companyIds: [companyId],
+      memberships: [
+        { companyId, status: "active", membershipRole: "admin" },
+      ],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app).post(`/api/agents/${agentId}/resume`).send({});
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.resume).toHaveBeenCalledWith(agentId);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.resumed",
+        actorType: "user",
+        actorId: "board-user",
+        details: null,
+      }),
+    );
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2075,24 +2075,69 @@ export function agentRoutes(db: Db) {
   });
 
   router.post("/agents/:id/resume", async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
-    if (!(await getAccessibleAgent(req, res, id))) {
+
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Agent not found" });
       return;
     }
+
+    const isSelfResume =
+      req.actor.type === "agent" && req.actor.agentId === id;
+
+    if (req.actor.type === "agent" && !isSelfResume) {
+      throw forbidden(
+        "Agents may only resume themselves; resuming peers requires board access",
+      );
+    }
+
+    if (isSelfResume) {
+      assertCompanyAccess(req, existing.companyId);
+      if (
+        existing.status !== "paused" ||
+        existing.pauseReason !== "budget"
+      ) {
+        throw forbidden(
+          "Self-resume is only allowed for budget-paused agents",
+        );
+      }
+      const underBudget =
+        existing.budgetMonthlyCents > 0 &&
+        existing.spentMonthlyCents < existing.budgetMonthlyCents;
+      if (!underBudget) {
+        throw forbidden(
+          "Self-resume blocked: monthly spend is at or above budget",
+        );
+      }
+    } else {
+      await assertBoardCanManageAgentsForCompany(req, existing.companyId);
+    }
+
     const agent = await svc.resume(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
       return;
     }
 
+    const actor = getActorInfo(req);
     await logActivity(db, {
       companyId: agent.companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
       action: "agent.resumed",
       entityType: "agent",
       entityId: agent.id,
+      details: isSelfResume
+        ? {
+            selfResume: true,
+            pauseReason: "budget",
+            budgetMonthlyCents: existing.budgetMonthlyCents,
+            spentMonthlyCents: existing.spentMonthlyCents,
+          }
+        : null,
     });
 
     res.json(agent);


### PR DESCRIPTION
## Summary

Extend `POST /api/agents/:id/resume` so an agent that was auto-paused on its monthly budget can resume *itself* once spend drops below budget again (e.g., calendar-month rollover, or the budget was raised). All other resume scenarios continue to require board access.

The motivation: `pause` / `resume` / `terminate` / budget-update endpoints all call `assertBoard(req)`, which rejects any `actor.type === "agent"` caller. The common operator case — "I raised the budget, now resume" — has no clean programmatic path; the current workaround is a direct `UPDATE agents ...` in psql. This PR addresses that narrow case without broadening board access to arbitrary agents.

### Authorization rules on resume

| Caller | Allowed |
|---|---|
| Board user (session or board API key) | Any agent in a company they can manage (unchanged) |
| Agent token, same agent, `paused` + `pauseReason='budget'` + `spentMonthlyCents < budgetMonthlyCents` | **New: allowed** |
| Agent token, same agent, manual/system pause, or still over budget | 403 |
| Agent token, different agent (peer) | 403 |
| Agent token, cross-company | 403 |

Self-resume activity-log entries carry `actorType: "agent"` and `details.selfResume: true` with a budget/spend snapshot. Board-initiated resumes are unchanged.

### Not in this PR

- No broader "agents can manage other agents" permission. If we later want Coordinator-style peer control without sharing a human board key, that's a separate change on `agentPermissionsSchema`.
- No code change to the existing `board_key` / CLI auth flow — it already works for every other board-only endpoint. This PR just documents it so operators stop writing to the DB directly.

## Files

- `server/src/routes/agents.ts` — guard added on the resume handler; board path refactored to share a single `svc.getById` fetch
- `server/src/__tests__/agent-self-resume-routes.test.ts` — 7 new tests covering the matrix above
- `docs/api/agents.md` — authorization rules on resume
- `docs/api/authentication.md` — new "Board API Keys (for CLI and orchestration)" section
- `docs/cli/setup-commands.md` — `paperclipai auth login/logout/whoami` reference
- `docs/guides/board-operator/managing-agents.md` — scripting example + self-resume note

## Test plan

- [x] `pnpm --filter @paperclipai/server exec vitest run agent-self-resume-routes` — 7/7 pass
- [x] `pnpm --filter @paperclipai/server exec vitest run agent-cross-tenant-authz-routes` — 5/5 pass (no regression)
- [x] `pnpm --filter @paperclipai/server exec tsc --noEmit` — error count unchanged vs. `origin/master` (66 pre-existing errors in unrelated `plugin-host-services.ts`; none from touched files)

## Related

Raised as SHA-1894 in a downstream install. Option A in that issue ("board API key path") already exists upstream and this PR documents it. Option B ("role-based `canManageAgents` permission") is deferred pending a concrete use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)