### PR TITLE
fix: normalize board assignee handoffs

### DIFF
--- a/server/src/__tests__/issue-assignee-patch.test.ts
+++ b/server/src/__tests__/issue-assignee-patch.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { normalizeExclusiveAssigneePatch } from "../services/issue-assignee-patch.js";
+
+describe("normalizeExclusiveAssigneePatch", () => {
+  it("clears a user assignee when an agent-only handoff is requested", () => {
+    expect(normalizeExclusiveAssigneePatch({ assigneeAgentId: "agent-1" })).toEqual({
+      assigneeAgentId: "agent-1",
+      assigneeUserId: null,
+    });
+  });
+
+  it("clears an agent assignee when a user-only handoff is requested", () => {
+    expect(normalizeExclusiveAssigneePatch({ assigneeUserId: "user-1" })).toEqual({
+      assigneeAgentId: null,
+      assigneeUserId: "user-1",
+    });
+  });
+
+  it("preserves explicit dual-field payloads for downstream validation", () => {
+    expect(
+      normalizeExclusiveAssigneePatch({
+        assigneeAgentId: "agent-1",
+        assigneeUserId: "user-1",
+      }),
+    ).toEqual({
+      assigneeAgentId: "agent-1",
+      assigneeUserId: "user-1",
+    });
+  });
+});

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -207,6 +207,105 @@ describe("issue update comment wakeups", () => {
     );
   });
 
+  it("normalizes board handoffs into a single agent assignee when moving backlog work into todo", async () => {
+    const existing = makeIssue({ status: "backlog" });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...existing,
+      ...patch,
+      status: "todo",
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+    }));
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({
+        status: "todo",
+        assigneeAgentId: ASSIGNEE_AGENT_ID,
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      existing.id,
+      expect.objectContaining({
+        status: "todo",
+        assigneeAgentId: ASSIGNEE_AGENT_ID,
+        assigneeUserId: null,
+        actorAgentId: null,
+        actorUserId: "local-board",
+      }),
+    );
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({
+        source: "assignment",
+        reason: "issue_assigned",
+        payload: expect.objectContaining({
+          issueId: existing.id,
+          mutation: "update",
+        }),
+      }),
+    );
+  });
+
+  it("wakes the existing agent when backlog work becomes todo without a lane change", async () => {
+    const existing = makeIssue({
+      status: "backlog",
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+    });
+    const updated = { ...existing, status: "todo" };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ status: "todo" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({
+        source: "automation",
+        reason: "issue_status_changed",
+        payload: expect.objectContaining({
+          issueId: existing.id,
+          mutation: "update",
+        }),
+      }),
+    );
+  });
+
+  it("keeps repeated todo resyncs idempotent once the agent lane is already set", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+    });
+    const updated = { ...existing };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({
+        status: "todo",
+        assigneeAgentId: ASSIGNEE_AGENT_ID,
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      existing.id,
+      expect.objectContaining({
+        assigneeAgentId: ASSIGNEE_AGENT_ID,
+        assigneeUserId: null,
+      }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
   it("wakes the assignee on comment-only issue updates", async () => {
     const existing = makeIssue({
       assigneeAgentId: ASSIGNEE_AGENT_ID,

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -218,7 +218,7 @@ describe("issue update comment wakeups", () => {
       assigneeUserId: null,
     }));
 
-    const res = await request(createApp())
+    const res = await request(await createApp())
       .patch(`/api/issues/${existing.id}`)
       .send({
         status: "todo",
@@ -260,7 +260,7 @@ describe("issue update comment wakeups", () => {
     mockIssueService.getById.mockResolvedValue(existing);
     mockIssueService.update.mockResolvedValue(updated);
 
-    const res = await request(createApp())
+    const res = await request(await createApp())
       .patch(`/api/issues/${existing.id}`)
       .send({ status: "todo" });
 
@@ -288,7 +288,7 @@ describe("issue update comment wakeups", () => {
     mockIssueService.getById.mockResolvedValue(existing);
     mockIssueService.update.mockResolvedValue(updated);
 
-    const res = await request(createApp())
+    const res = await request(await createApp())
       .patch(`/api/issues/${existing.id}`)
       .send({
         status: "todo",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -60,6 +60,7 @@ import {
   SVG_CONTENT_TYPE,
 } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+import { normalizeExclusiveAssigneePatch } from "../services/issue-assignee-patch.js";
 import {
   applyIssueExecutionPolicyTransition,
   normalizeIssueExecutionPolicy,
@@ -1330,14 +1331,15 @@ export function issueRoutes(
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (req.body.assigneeAgentId || req.body.assigneeUserId) {
+    const createBody = normalizeExclusiveAssigneePatch(req.body);
+    if (createBody.assigneeAgentId || createBody.assigneeUserId) {
       await assertCanAssignTasks(req, companyId);
     }
 
     const actor = getActorInfo(req);
-    const executionPolicy = normalizeIssueExecutionPolicy(req.body.executionPolicy);
+    const executionPolicy = normalizeIssueExecutionPolicy(createBody.executionPolicy);
     const issue = await svc.create(companyId, {
-      ...req.body,
+      ...createBody,
       executionPolicy,
       createdByAgentId: actor.agentId,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
@@ -1393,13 +1395,14 @@ export function issueRoutes(
       Array.isArray(req.body.blockedByIssueIds)
         ? await svc.getRelationSummaries(existing.id)
         : null;
+    const requestBody = normalizeExclusiveAssigneePatch(req.body);
     const {
       comment: commentBody,
       reopen: reopenRequested,
       interrupt: interruptRequested,
       hiddenAt: hiddenAtRaw,
       ...updateFields
-    } = req.body;
+    } = requestBody;
     const requestedAssigneeAgentId =
       normalizedAssigneeAgentId === undefined ? existing.assigneeAgentId : normalizedAssigneeAgentId;
     const effectiveReopenRequested =
@@ -1456,8 +1459,8 @@ export function issueRoutes(
     if (commentBody && effectiveReopenRequested && isClosed && updateFields.status === undefined) {
       updateFields.status = "todo";
     }
-    if (req.body.executionPolicy !== undefined) {
-      updateFields.executionPolicy = normalizeIssueExecutionPolicy(req.body.executionPolicy);
+    if (requestBody.executionPolicy !== undefined) {
+      updateFields.executionPolicy = normalizeIssueExecutionPolicy(requestBody.executionPolicy);
     }
     const previousExecutionPolicy = normalizeIssueExecutionPolicy(existing.executionPolicy ?? null);
     const nextExecutionPolicy =
@@ -1474,8 +1477,7 @@ export function issueRoutes(
       requestedStatus: typeof updateFields.status === "string" ? updateFields.status : undefined,
       requestedAssigneePatch: {
         assigneeAgentId: normalizedAssigneeAgentId,
-        assigneeUserId:
-          req.body.assigneeUserId === undefined ? undefined : (req.body.assigneeUserId as string | null),
+        assigneeUserId: requestBody.assigneeUserId === undefined ? undefined : (requestBody.assigneeUserId as string | null),
       },
       actor: {
         agentId: actor.agentId ?? null,
@@ -1563,8 +1565,7 @@ export function issueRoutes(
             companyId: existing.companyId,
             assigneePatch: {
               assigneeAgentId: normalizedAssigneeAgentId === undefined ? "__omitted__" : normalizedAssigneeAgentId,
-              assigneeUserId:
-                req.body.assigneeUserId === undefined ? "__omitted__" : req.body.assigneeUserId,
+              assigneeUserId: requestBody.assigneeUserId === undefined ? "__omitted__" : requestBody.assigneeUserId,
             },
             currentAssignee: {
               assigneeAgentId: existing.assigneeAgentId,

--- a/server/src/services/issue-assignee-patch.ts
+++ b/server/src/services/issue-assignee-patch.ts
@@ -1,0 +1,14 @@
+type AssigneePatch = {
+  assigneeAgentId?: string | null;
+  assigneeUserId?: string | null;
+};
+
+export function normalizeExclusiveAssigneePatch<T extends AssigneePatch>(patch: T): T {
+  if (patch.assigneeAgentId !== undefined && patch.assigneeAgentId !== null && patch.assigneeUserId === undefined) {
+    return { ...patch, assigneeUserId: null };
+  }
+  if (patch.assigneeUserId !== undefined && patch.assigneeUserId !== null && patch.assigneeAgentId === undefined) {
+    return { ...patch, assigneeAgentId: null };
+  }
+  return patch;
+}


### PR DESCRIPTION
## Summary
- normalize board-originated assignee handoffs so an `assigneeAgentId` patch also clears any stale board `assigneeUserId`
- preserve the expected wake contract for `backlog -> todo` moves by ensuring the update path emits a single agent assignment lane
- add focused regression coverage for board handoffs, backlog-to-todo wake behavior, and idempotent todo resyncs

## Testing
- `pnpm test:run server/src/__tests__/issue-update-comment-wakeup-routes.test.ts server/src/__tests__/issue-execution-policy.test.ts`
- `pnpm test:run server/src/__tests__/issue-assignee-patch.test.ts server/src/__tests__/issues-checkout-wakeup.test.ts`

## Risks
- this hardens the backend mutation contract, but production GitHub board trigger wiring still depends on [SUP-174](https://app.paperclip.dev/SUP/issues/SUP-174)
