### PR TITLE
fix(heartbeat): persist task-session before finalizing run (SHA-1903)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ tests/release-smoke/test-results/
 tests/release-smoke/playwright-report/
 .superset/
 .claude/worktrees/
+
+# SharpAPI workspace-local
+.mcp.json
+webhook-listener/

--- a/docs/adapters/http.md
+++ b/docs/adapters/http.md
@@ -49,3 +49,12 @@ The webhook receives a JSON payload with:
 ```
 
 The external agent uses `PAPERCLIP_API_URL` and an API key to call back to Paperclip.
+
+## Heartbeat Interval
+
+For persistent HTTP-adapter agents, `runtimeConfig.heartbeat.intervalSec` is a liveness probe only — the adapter's webhook handles real-time work delivery (assignments, comments, mentions) via push. Timer wakes that arrive while the queue is empty are no-op roundtrips.
+
+New HTTP-adapter agents therefore default to `intervalSec: 1200` (20 minutes) instead of the 300s default used for `claude_local`/`codex_local`. This is still frequent enough to catch liveness drift (a dead channel MCP, a crashed `claude+` that tmux missed) while avoiding the ~90 unnecessary wakes/24h that 300s produces for a well-plumbed channel agent.
+
+Agents that genuinely benefit from a shorter cadence can override via `PATCH /agents/{id}` with an explicit `runtimeConfig.heartbeat.intervalSec`.
+

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -64,6 +64,7 @@
               "guides/agent-developer/writing-a-skill",
               "guides/agent-developer/task-workflow",
               "guides/agent-developer/comments-and-communication",
+              "guides/agent-developer/channel-driven-agents",
               "guides/agent-developer/handling-approvals",
               "guides/agent-developer/cost-reporting"
             ]

--- a/docs/guides/agent-developer/channel-driven-agents.md
+++ b/docs/guides/agent-developer/channel-driven-agents.md
@@ -1,0 +1,163 @@
+---
+title: Channel-Driven Agents
+summary: How to run a persistent claude+ agent with live message push instead of spawn-per-heartbeat
+---
+
+Paperclip's default agent model spawns a fresh `claude --print` subprocess per heartbeat. For agents that need low-latency response — customer support chat, real-time monitoring, long-running context — you can instead run a **persistent `claude+` inside tmux** and use an MCP channel plugin to push work into the running session.
+
+This is how SharpAPI runs its Nova (email/SEO), Sentinel (integrity), and Maya (customer support) agents.
+
+## Architecture
+
+```
+Paperclip server
+    │  POST /heartbeat  (assignment, @-mention, timer)
+    ▼
+Agent LXC :8201  ◄── paperclip-channel.ts (bun MCP plugin, child of claude+)
+    │  MCP notification: notifications/claude/channel
+    ▼
+claude+ in tmux  ◄── long-running session, picks up and acts
+    │
+    ├─► paperclip_update MCP tool → issue comment / status
+    └─► paperclip_checkout / etc.
+
+Agent LXC :8200  ◄── paperclip-listener.py (standalone external liveness probe)
+    │  GET /health
+    ▼
+  { tmux ✓, claude ✓, paperclip-channel ✓, jsonl_age: 12s }
+```
+
+Heartbeats go to `:8201` (channel MCP). `:8200` is a separate external-monitoring probe you can optionally cron against.
+
+## Setup
+
+### 1. systemd unit — `/etc/systemd/system/claude-channels.service`
+
+```ini
+[Unit]
+Description=Claude Code Channels (<Agent name>)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+User=root
+WorkingDirectory=/<agent>-workspace
+ExecStart=/usr/bin/tmux new-session -d -s claude-channels /usr/local/bin/claude-channels.sh
+ExecStop=/usr/bin/tmux kill-session -t claude-channels
+RemainAfterExit=yes
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### 2. Launch script — `/usr/local/bin/claude-channels.sh`
+
+```bash
+#!/bin/bash
+export PATH="/root/.local/bin:/root/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export HOME="/root"
+export IS_SANDBOX=1
+export LANG="en_US.UTF-8"
+export TERM="xterm-256color"
+
+source /root/.claude/channels/telegram/.env 2>/dev/null
+source /etc/default/paperclip 2>/dev/null
+
+cd /<agent>-workspace
+
+# Idempotent tmux guard — systemd restart won't duplicate sessions
+if [ -z "$TMUX" ]; then
+  if tmux has-session -t claude-channels 2>/dev/null; then
+    echo "claude-channels session already exists; tmux kill-session -t claude-channels to force restart"
+    exit 0
+  fi
+  exec tmux new-session -d -s claude-channels "$0"
+fi
+
+# Auto-dismiss dev-channels dialog if it appears
+# (hasDevChannels is in-memory only in claude+, reappears on every start)
+(
+  for i in {1..30}; do
+    sleep 1
+    if tmux capture-pane -t claude-channels:0 -p 2>/dev/null | grep -q "Enter to confirm"; then
+      tmux send-keys -t claude-channels:0 "1" C-m
+      break
+    fi
+  done
+) &
+
+exec claude+ --channels \
+  plugin:telegram@claude-plugins-official \
+  --dangerously-load-development-channels \
+  server:paperclip
+  # add server:crisp server:approval etc. as needed
+```
+
+### 3. tmux config — `/root/.tmux.conf`
+
+```
+set -g allow-passthrough on
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",*256col*:Tc"
+set-option -g window-size largest
+set -g aggressive-resize on
+set -g history-limit 50000
+```
+
+`window-size largest` is critical — without it tmux clamps the session to the smallest attached client, which ruins readability when you SSH in from a narrow pane.
+
+### 4. Paperclip agent config
+
+```bash
+curl -X PATCH "$PAPERCLIP_API_URL/agents/$AGENT_ID" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "adapterConfig": { "url": "http://<lxc-ip>:8201/heartbeat" },
+    "runtimeConfig": { "heartbeat": { "enabled": true, "intervalSec": 300 } }
+  }'
+```
+
+**The field is `intervalSec`, not `intervalSeconds`.** The wrong name saves silently but the scheduler reads `intervalSec` and nothing fires.
+
+### 5. AGENTS.md — mention guidance
+
+Channel-driven agents get woken on `issue_comment_mentioned` and `issue_reopened_via_comment` independently. If your agent is both the assignee AND someone @-mentions a different agent on the same issue, the assignee gets a wake too. Include this rule in AGENTS.md:
+
+> **When you receive an @-mention directed at another agent** (you were woken as assignee or watcher): stay silent. Don't post a "this isn't for me" comment — the mentioned agent already has its own wake. Over-commenting creates noise.
+
+### 6. External liveness probe (optional but recommended)
+
+`/opt/paperclip-listener/listener.py` on port 8200 — a tiny Python HTTP server that checks:
+
+- `tmux has-session -t claude-channels`
+- `pgrep -f 'claude.*--channels'`
+- `pgrep -f 'paperclip-channel.ts'`
+- Most recent `~/.claude/projects/*/*.jsonl` mtime (hang detection, default 30min threshold)
+
+Run it with `python3 -u` (unbuffered) under systemd so logs reach the journal.
+
+## Gotchas
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Heartbeats succeed but @-mentions never reach claude+ | adapter URL pointed at `:8200` (Python listener) instead of `:8201` (channel MCP) | PATCH `adapterConfig.url` → `:8201` |
+| Scheduled heartbeats never fire, `lastHeartbeatAt` frozen | Wrong field name `intervalSeconds` | Use `intervalSec` |
+| Restart requires manual `1 Enter` keystroke | `--dangerously-load-development-channels` dialog re-prompts on every run, not persisted | Auto-dismiss sidecar in launch script |
+| `●` `⎿` `✻` glyphs render as `_` | TERM=linux from systemd inherits minimal terminfo | `export TERM="xterm-256color"` + tmux `default-terminal` |
+| Tmux pane clamped to narrow width after SSH reconnect | tmux default is smallest-client sizing | `set-option -g window-size largest` |
+| Two claude+ processes, one zombie, `:8201` port collision | Service restarted without killing the old claude+'s children | Kill-all before restart: `pkill -9 -f "claude --channels\|paperclip-channel\|crisp-channel\|approval-channel"` then `systemctl restart` |
+| Python listener comment spam ("HTTP POST http://...") | HTTP adapter's summary leaks as issue comment | Fixed upstream in `server/src/adapters/http/execute.ts` (`summary: null`) |
+
+## Verifying a new agent
+
+Once configured, a 3-step smoke test covers the full pipeline:
+
+1. **Liveness**: `curl http://<lxc-ip>:8201/health` → `200 {"status":"ok","channel":true}`
+2. **Direct assignment**: create an issue assigned to the agent, verify response within ~30s
+3. **@-mention routing**: comment `@<AgentName> …` on an issue, verify wake + response
+
+For the assignee/watcher silence rule, file an issue assigned to your new agent that asks *them* to @-mention another agent (e.g. `@Nova what date is today?`) and verify the two-hop round-trip completes cleanly without extra noise comments.

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -28,6 +28,7 @@ import {
   describeClaudeFailure,
   detectClaudeLoginRequired,
   isClaudeMaxTurnsResult,
+  isClaudeRateLimitError,
   isClaudeUnknownSessionError,
 } from "./parse.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
@@ -543,12 +544,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
 
     if (!parsed) {
+      const combinedOutput = `${proc.stdout}\n${proc.stderr}`;
+      const looksRateLimited = /you(?:'ve| have) hit your limit|rate limit|quota exceeded|usage limit|too many requests/i.test(combinedOutput);
       return {
         exitCode: proc.exitCode,
         signal: proc.signal,
         timedOut: false,
         errorMessage: parseFallbackErrorMessage(proc),
-        errorCode: loginMeta.requiresLogin ? "claude_auth_required" : null,
+        errorCode: loginMeta.requiresLogin
+          ? "claude_auth_required"
+          : looksRateLimited
+            ? "rate_limited"
+            : null,
         errorMeta,
         resultJson: {
           stdout: proc.stdout,
@@ -592,7 +599,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         (proc.exitCode ?? 0) === 0
           ? null
           : describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`,
-      errorCode: loginMeta.requiresLogin ? "claude_auth_required" : null,
+      errorCode: loginMeta.requiresLogin
+        ? "claude_auth_required"
+        : isClaudeRateLimitError(parsed)
+          ? "rate_limited"
+          : null,
       errorMeta,
       usage,
       sessionId: resolvedSessionId,

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -6,6 +6,7 @@ export {
   parseClaudeStreamJson,
   describeClaudeFailure,
   isClaudeMaxTurnsResult,
+  isClaudeRateLimitError,
   isClaudeUnknownSessionError,
 } from "./parse.js";
 export {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -167,6 +167,24 @@ export function isClaudeMaxTurnsResult(parsed: Record<string, unknown> | null | 
   return /max(?:imum)?\s+turns?/i.test(resultText);
 }
 
+const CLAUDE_RATE_LIMIT_RE =
+  /you(?:'ve| have) hit your limit|rate limit|quota exceeded|usage limit|too many requests|resets \d{1,2}(?:am|pm)/i;
+
+/**
+ * Detect whether a Claude result represents a transient rate-limit / quota error.
+ * Returns true when the output text or error messages match known rate-limit patterns.
+ */
+export function isClaudeRateLimitError(parsed: Record<string, unknown> | null | undefined): boolean {
+  if (!parsed) return false;
+
+  const resultText = asString(parsed.result, "").trim();
+  const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
+    .map((msg) => msg.trim())
+    .filter(Boolean);
+
+  return allMessages.some((msg) => CLAUDE_RATE_LIMIT_RE.test(msg));
+}
+
 export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): boolean {
   const resultText = asString(parsed.result, "").trim();
   const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]

--- a/packages/db/src/schema/routines.ts
+++ b/packages/db/src/schema/routines.ts
@@ -32,6 +32,7 @@ export const routines = pgTable(
     status: text("status").notNull().default("active"),
     concurrencyPolicy: text("concurrency_policy").notNull().default("coalesce_if_active"),
     catchUpPolicy: text("catch_up_policy").notNull().default("skip_missed"),
+    skipIssueCreation: boolean("skip_issue_creation").notNull().default(false),
     variables: jsonb("variables").$type<RoutineVariable[]>().notNull().default([]),
     createdByAgentId: uuid("created_by_agent_id").references(() => agents.id, { onDelete: "set null" }),
     createdByUserId: text("created_by_user_id"),

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import {
-  addIssueCommentSchema,
   checkoutIssueSchema,
   createApprovalSchema,
   createIssueSchema,
@@ -105,7 +104,10 @@ const checkoutIssueToolSchema = z.object({
 
 const addCommentToolSchema = z.object({
   issueId: issueIdSchema,
-}).merge(addIssueCommentSchema);
+  body: z.string().min(1).describe("Comment body (markdown)"),
+  reopen: z.boolean().optional(),
+  interrupt: z.boolean().optional(),
+});
 
 const approvalDecisionSchema = z.object({
   approvalId: approvalIdSchema,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -295,6 +295,8 @@ export type {
   CostByAgentModel,
   CostWindowSpendRow,
   CostByProject,
+  IssueCostSummary,
+  IssueCostContributor,
   FinanceEvent,
   FinanceSummary,
   FinanceByBiller,

--- a/packages/shared/src/types/cost.ts
+++ b/packages/shared/src/types/cost.ts
@@ -111,3 +111,22 @@ export interface CostByProject {
   cachedInputTokens: number;
   outputTokens: number;
 }
+
+export interface IssueCostContributor {
+  agentId: string;
+  agentName: string | null;
+  costCents: number;
+  runs: number;
+}
+
+/** aggregated cost for a single issue with per-agent breakdown */
+export interface IssueCostSummary {
+  issueId: string;
+  identifier: string | null;
+  totalCostCents: number;
+  runs: number;
+  totalInputTokens: number;
+  totalCachedInputTokens: number;
+  totalOutputTokens: number;
+  topContributors: IssueCostContributor[];
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -154,7 +154,7 @@ export type {
   RoutineExecutionIssueOrigin,
   RoutineListItem,
 } from "./routine.js";
-export type { CostEvent, CostSummary, CostByAgent, CostByProviderModel, CostByBiller, CostByAgentModel, CostWindowSpendRow, CostByProject } from "./cost.js";
+export type { CostEvent, CostSummary, CostByAgent, CostByProviderModel, CostByBiller, CostByAgentModel, CostWindowSpendRow, CostByProject, IssueCostSummary, IssueCostContributor } from "./cost.js";
 export type { FinanceEvent, FinanceSummary, FinanceByBiller, FinanceByKind } from "./finance.js";
 export type {
   AgentWakeupResponse,

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -163,11 +163,22 @@ export const checkoutIssueSchema = z.object({
 
 export type CheckoutIssue = z.infer<typeof checkoutIssueSchema>;
 
-export const addIssueCommentSchema = z.object({
-  body: z.string().min(1),
-  reopen: z.boolean().optional(),
-  interrupt: z.boolean().optional(),
-});
+export const addIssueCommentSchema = z.preprocess(
+  (val: unknown) => {
+    // Accept `comment` as alias for `body` — agents often conflate the
+    // PATCH /issues/:id field name (`comment`) with this POST endpoint.
+    if (val && typeof val === "object" && "comment" in val && !("body" in val)) {
+      const { comment, ...rest } = val as Record<string, unknown>;
+      return { body: comment, ...rest };
+    }
+    return val;
+  },
+  z.object({
+    body: z.string().min(1),
+    reopen: z.boolean().optional(),
+    interrupt: z.boolean().optional(),
+  }),
+);
 
 export type AddIssueComment = z.infer<typeof addIssueCommentSchema>;
 

--- a/paperclip-channel/paperclip-channel.ts
+++ b/paperclip-channel/paperclip-channel.ts
@@ -7,6 +7,14 @@
  * → Claude does the work → calls paperclip_update tool to report back.
  *
  * Runs alongside Telegram channel in the same session.
+ *
+ * Cost tracking (SHA-1865):
+ *   claude+ writes a session JSONL at ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
+ *   with per-assistant-message `message.usage`. On each /heartbeat POST we record
+ *   the current tail offset of the most recent JSONL; when claude+ calls a
+ *   paperclip_* tool with a known run_id we read the delta, aggregate usage by
+ *   model, price it, and POST a cost-event so HTTP-adapter agents show up in
+ *   Paperclip's spend dashboards like claude_local agents do.
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -15,9 +23,12 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { open } from "fs/promises";
+import { homedir } from "os";
+import path from "path";
 
 // Load /etc/default/paperclip if env vars are missing
-import { existsSync, readFileSync } from "fs";
 const envFile = "/etc/default/paperclip";
 if (existsSync(envFile)) {
   for (const line of readFileSync(envFile, "utf-8").split("\n")) {
@@ -52,6 +63,165 @@ async function paperclipFetch(
   });
   return res.json();
 }
+
+// --- Cost tracking ----------------------------------------------------------
+// Anthropic USD pricing per million tokens. Prefix match so dated model IDs
+// (claude-opus-4-7-20260101) still resolve.
+type Pricing = { input: number; output: number; cacheRead: number; cacheWrite: number };
+const PRICING: Record<string, Pricing> = {
+  "claude-opus-4": { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+  "claude-sonnet-4": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  "claude-haiku-4": { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 },
+};
+function priceFor(model: string): Pricing {
+  for (const [key, value] of Object.entries(PRICING)) {
+    if (model.startsWith(key)) return value;
+  }
+  if (model.includes("opus")) return PRICING["claude-opus-4"];
+  if (model.includes("haiku")) return PRICING["claude-haiku-4"];
+  return PRICING["claude-sonnet-4"];
+}
+
+const CLAUDE_PROJECTS_DIR = path.join(homedir(), ".claude", "projects");
+function currentSessionJsonl(): string | null {
+  const encoded = process.cwd().replace(/\//g, "-");
+  const dir = path.join(CLAUDE_PROJECTS_DIR, encoded);
+  if (!existsSync(dir)) return null;
+  let best: { path: string; mtime: number } | null = null;
+  try {
+    for (const name of readdirSync(dir)) {
+      if (!name.endsWith(".jsonl")) continue;
+      const full = path.join(dir, name);
+      try {
+        const st = statSync(full);
+        if (!best || st.mtimeMs > best.mtime) best = { path: full, mtime: st.mtimeMs };
+      } catch {}
+    }
+  } catch {}
+  return best?.path ?? null;
+}
+
+type PendingRun = {
+  runId: string;
+  taskId: string;
+  jsonlPath: string | null;
+  offset: number;
+  startedAt: number;
+  flushed: boolean;
+};
+const pendingRuns = new Map<string, PendingRun>();
+
+function snapshotOffset(jsonlPath: string | null): number {
+  if (!jsonlPath) return 0;
+  try { return statSync(jsonlPath).size; } catch { return 0; }
+}
+
+async function flushUsageForRun(runId: string, opts: { final?: boolean } = {}) {
+  if (!runId) return;
+  const pending = pendingRuns.get(runId);
+  if (!pending || pending.flushed) return;
+
+  const jsonlPath = pending.jsonlPath;
+  if (!jsonlPath || !existsSync(jsonlPath)) return;
+
+  let size = 0;
+  try { size = statSync(jsonlPath).size; } catch { return; }
+  let start = pending.offset;
+  if (size < start) start = 0;
+  if (size <= start) return;
+
+  let content: string;
+  try {
+    const fh = await open(jsonlPath, "r");
+    try {
+      const buf = Buffer.alloc(size - start);
+      await fh.read(buf, 0, buf.length, start);
+      content = buf.toString("utf8");
+    } finally {
+      await fh.close();
+    }
+  } catch {
+    return;
+  }
+
+  type Totals = { input: number; cacheWrite: number; cacheRead: number; output: number };
+  const perModel = new Map<string, Totals>();
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+    let parsed: any;
+    try { parsed = JSON.parse(line); } catch { continue; }
+    if (parsed.type !== "assistant") continue;
+    const msg = parsed.message;
+    if (!msg?.usage || !msg?.model) continue;
+    const u = msg.usage;
+    const t = perModel.get(msg.model) ?? { input: 0, cacheWrite: 0, cacheRead: 0, output: 0 };
+    t.input += u.input_tokens || 0;
+    t.cacheWrite += u.cache_creation_input_tokens || 0;
+    t.cacheRead += u.cache_read_input_tokens || 0;
+    t.output += u.output_tokens || 0;
+    perModel.set(msg.model, t);
+  }
+
+  pending.offset = size;
+  if (opts.final) {
+    pending.flushed = true;
+    pendingRuns.delete(runId);
+  }
+
+  if (perModel.size === 0) return;
+
+  const occurredAt = new Date().toISOString();
+  for (const [model, t] of perModel) {
+    const price = priceFor(model);
+    const costUsd =
+      (t.input * price.input +
+        t.cacheWrite * price.cacheWrite +
+        t.cacheRead * price.cacheRead +
+        t.output * price.output) / 1_000_000;
+    const costCents = Math.max(0, Math.round(costUsd * 100));
+    const body: Record<string, unknown> = {
+      agentId: AGENT_ID,
+      heartbeatRunId: pending.runId,
+      provider: "anthropic",
+      biller: "anthropic",
+      billingType: "metered_api",
+      model,
+      inputTokens: t.input,
+      cachedInputTokens: t.cacheRead + t.cacheWrite,
+      outputTokens: t.output,
+      costCents,
+      occurredAt,
+    };
+    if (pending.taskId) body.issueId = pending.taskId;
+    try {
+      await paperclipFetch("POST", `/companies/${COMPANY_ID}/cost-events`, body);
+    } catch (err) {
+      console.error(`[paperclip-channel] cost-event POST failed: ${(err as Error).message}`);
+    }
+  }
+}
+
+function flushFromToolCall(toolName: string, args: Record<string, string>) {
+  const runId = args?.run_id;
+  if (!runId) return;
+  const final =
+    toolName === "paperclip_update" &&
+    ["done", "blocked", "in_review"].includes(args?.status);
+  flushUsageForRun(runId, { final }).catch((err) =>
+    console.error(`[paperclip-channel] flush failed: ${err?.message ?? err}`)
+  );
+}
+
+// Best-effort cleanup of runs whose terminal paperclip_update never arrived.
+setInterval(() => {
+  const cutoffMs = 30 * 60_000;
+  const now = Date.now();
+  for (const [runId, p] of pendingRuns) {
+    if (now - p.startedAt > cutoffMs) {
+      flushUsageForRun(runId, { final: true }).catch(() => {});
+    }
+  }
+}, 5 * 60_000);
 
 // --- MCP Server with channel capability -------------------------------------
 const mcp = new Server(
@@ -174,22 +344,23 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
 }));
 
 mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
-  const args = req.params.arguments as Record<string, string>;
+  const args = (req.params.arguments || {}) as Record<string, string>;
+  let response: unknown;
 
   switch (req.params.name) {
     case "paperclip_inbox": {
-      const data = await paperclipFetch("GET", `/agents/me/inbox-lite`);
-      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      response = await paperclipFetch("GET", `/agents/me/inbox-lite`);
+      break;
     }
 
     case "paperclip_checkout": {
-      const data = await paperclipFetch(
+      response = await paperclipFetch(
         "POST",
         `/issues/${args.issue_id}/checkout`,
         { agentId: AGENT_ID, expectedStatuses: ["todo", "backlog", "blocked"] },
         { "X-Paperclip-Run-Id": args.run_id }
       );
-      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      break;
     }
 
     case "paperclip_update": {
@@ -197,20 +368,20 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         status: args.status,
         comment: args.comment,
       };
-      const data = await paperclipFetch("PATCH", `/issues/${args.issue_id}`, body, {
+      response = await paperclipFetch("PATCH", `/issues/${args.issue_id}`, body, {
         "X-Paperclip-Run-Id": args.run_id,
       });
-      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      break;
     }
 
     case "paperclip_comment": {
-      const data = await paperclipFetch(
+      response = await paperclipFetch(
         "POST",
         `/issues/${args.issue_id}/comments`,
         { body: args.body },
         args.run_id ? { "X-Paperclip-Run-Id": args.run_id } : {}
       );
-      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      break;
     }
 
     case "paperclip_create_issue": {
@@ -224,17 +395,20 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       if (args.label_ids) {
         try { body.labelIds = JSON.parse(args.label_ids); } catch {}
       }
-      const data = await paperclipFetch(
+      response = await paperclipFetch(
         "POST",
         `/companies/${COMPANY_ID}/issues`,
         body
       );
-      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      break;
     }
 
     default:
       throw new Error(`Unknown tool: ${req.params.name}`);
   }
+
+  flushFromToolCall(req.params.name, args);
+  return { content: [{ type: "text", text: JSON.stringify(response, null, 2) }] };
 });
 
 // --- Connect to Claude Code over stdio --------------------------------------
@@ -259,6 +433,19 @@ Bun.serve({
       const runId = (body.runId || "") as string;
       const wakeReason = context.wakeReason || "manual";
       const commentId = context.wakeCommentId || "";
+
+      // Snapshot the current JSONL tail so cost-tracking can diff on flush.
+      if (runId) {
+        const jsonlPath = currentSessionJsonl();
+        pendingRuns.set(runId, {
+          runId,
+          taskId,
+          jsonlPath,
+          offset: snapshotOffset(jsonlPath),
+          startedAt: Date.now(),
+          flushed: false,
+        });
+      }
 
       // Build the task description for Claude
       let taskInfo = `Heartbeat received. Wake reason: ${wakeReason}.`;

--- a/paperclip-channel/paperclip-channel.ts
+++ b/paperclip-channel/paperclip-channel.ts
@@ -1,0 +1,322 @@
+#!/usr/bin/env bun
+/**
+ * Paperclip Channel Plugin for Claude Code
+ *
+ * Pushes Paperclip heartbeat tasks into a running Claude Code session.
+ * Paperclip sends POST /heartbeat → this channel pushes it as a <channel> event
+ * → Claude does the work → calls paperclip_update tool to report back.
+ *
+ * Runs alongside Telegram channel in the same session.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+// Load /etc/default/paperclip if env vars are missing
+import { existsSync, readFileSync } from "fs";
+const envFile = "/etc/default/paperclip";
+if (existsSync(envFile)) {
+  for (const line of readFileSync(envFile, "utf-8").split("\n")) {
+    const match = line.match(/^([A-Z_]+)=(.*)$/);
+    if (match && !process.env[match[1]]?.trim()) {
+      process.env[match[1]] = match[2];
+    }
+  }
+}
+
+const PORT = parseInt(process.env.PAPERCLIP_LISTENER_PORT || "8201");
+const API_URL = process.env.PAPERCLIP_API_URL || "http://192.168.4.151:3100/api";
+const API_KEY = process.env.PAPERCLIP_API_KEY || "";
+const AGENT_ID = process.env.PAPERCLIP_AGENT_ID || "";
+const COMPANY_ID = process.env.PAPERCLIP_COMPANY_ID || "";
+
+// --- Paperclip API helper ---------------------------------------------------
+async function paperclipFetch(
+  method: string,
+  path: string,
+  body?: Record<string, unknown>,
+  headers?: Record<string, string>
+): Promise<unknown> {
+  const res = await fetch(`${API_URL}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return res.json();
+}
+
+// --- MCP Server with channel capability -------------------------------------
+const mcp = new Server(
+  { name: "paperclip", version: "1.0.0" },
+  {
+    capabilities: {
+      experimental: { "claude/channel": {} },
+      tools: {},
+    },
+    instructions: `Paperclip heartbeat tasks arrive as <channel source="paperclip" run_id="..." task_id="..." wake_reason="...">.
+
+When you receive a heartbeat:
+1. Read the task description in the channel event
+2. If task_id is set, use the paperclip_checkout tool to claim it
+3. Do the actual work described in the task
+4. Use the paperclip_update tool to update the task status and add a comment
+5. If no task is assigned, use paperclip_inbox to check for assignments
+
+Always include the run_id from the channel event when updating tasks.
+
+For routine execution tasks: post your results as a comment using paperclip_comment, but do NOT mark the issue as done. Leave it in_progress so the next routine fire reuses the same issue.
+
+If wake_reason is "message_approved", read the message_text from the meta and send it via crisp_reply, then post a confirmation comment.
+
+Available tools:
+- paperclip_inbox: Check your assigned tasks
+- paperclip_checkout: Claim a task before working on it
+- paperclip_update: Update task status and add a comment
+- paperclip_comment: Add a comment without changing status
+- paperclip_create_issue: Create a new issue for problems you discover. Always set assignee_agent_id to the Coordinator (4f525e83-7b23-47c2-884f-71b6bff440bd) for triage unless you are creating a message approval for yourself.`,
+  }
+);
+
+// --- Tools ------------------------------------------------------------------
+mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "paperclip_inbox",
+      description:
+        "Check your Paperclip inbox for assigned tasks. Returns compact list of todo/in_progress/blocked issues.",
+      inputSchema: { type: "object", properties: {}, required: [] },
+    },
+    {
+      name: "paperclip_checkout",
+      description:
+        "Claim a task before working on it. Must be called before doing any work. Returns 409 if another agent owns it.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          issue_id: { type: "string", description: "The issue UUID to checkout" },
+          run_id: { type: "string", description: "The heartbeat run_id from the channel event" },
+        },
+        required: ["issue_id", "run_id"],
+      },
+    },
+    {
+      name: "paperclip_update",
+      description:
+        "Update a task's status and add a comment. Use after completing or getting blocked on work.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          issue_id: { type: "string", description: "The issue UUID to update" },
+          run_id: { type: "string", description: "The heartbeat run_id" },
+          status: {
+            type: "string",
+            enum: ["in_progress", "in_review", "done", "blocked"],
+            description: "New status",
+          },
+          comment: { type: "string", description: "Markdown comment describing what was done" },
+        },
+        required: ["issue_id", "run_id", "status", "comment"],
+      },
+    },
+    {
+      name: "paperclip_comment",
+      description: "Add a comment to a task without changing its status.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          issue_id: { type: "string", description: "The issue UUID" },
+          run_id: { type: "string", description: "The heartbeat run_id" },
+          body: { type: "string", description: "Markdown comment" },
+        },
+        required: ["issue_id", "body"],
+      },
+    },
+    {
+      name: "paperclip_create_issue",
+      description:
+        "Create a new Paperclip issue for problems you discover during work.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          title: { type: "string", description: "Issue title" },
+          description: { type: "string", description: "Markdown description" },
+          priority: {
+            type: "string",
+            enum: ["critical", "high", "medium", "low"],
+            description: "Priority level",
+          },
+          status: {
+            type: "string",
+            enum: ["backlog", "todo", "in_progress", "in_review"],
+            description: "Initial status (default: todo)",
+          },
+          label_ids: {
+            type: "string",
+            description: "JSON array of label UUIDs to attach, e.g. '[\"uuid1\"]'",
+          },
+          assignee_agent_id: {
+            type: "string",
+            description: "Agent UUID to assign the issue to",
+          },
+        },
+        required: ["title", "description"],
+      },
+    },
+  ],
+}));
+
+mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const args = req.params.arguments as Record<string, string>;
+
+  switch (req.params.name) {
+    case "paperclip_inbox": {
+      const data = await paperclipFetch("GET", `/agents/me/inbox-lite`);
+      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    }
+
+    case "paperclip_checkout": {
+      const data = await paperclipFetch(
+        "POST",
+        `/issues/${args.issue_id}/checkout`,
+        { agentId: AGENT_ID, expectedStatuses: ["todo", "backlog", "blocked"] },
+        { "X-Paperclip-Run-Id": args.run_id }
+      );
+      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    }
+
+    case "paperclip_update": {
+      const body: Record<string, unknown> = {
+        status: args.status,
+        comment: args.comment,
+      };
+      const data = await paperclipFetch("PATCH", `/issues/${args.issue_id}`, body, {
+        "X-Paperclip-Run-Id": args.run_id,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    }
+
+    case "paperclip_comment": {
+      const data = await paperclipFetch(
+        "POST",
+        `/issues/${args.issue_id}/comments`,
+        { body: args.body },
+        args.run_id ? { "X-Paperclip-Run-Id": args.run_id } : {}
+      );
+      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    }
+
+    case "paperclip_create_issue": {
+      const body: Record<string, unknown> = {
+        title: args.title,
+        description: args.description,
+        priority: args.priority || "high",
+        status: args.status || "todo",
+      };
+      if (args.assignee_agent_id) body.assigneeAgentId = args.assignee_agent_id;
+      if (args.label_ids) {
+        try { body.labelIds = JSON.parse(args.label_ids); } catch {}
+      }
+      const data = await paperclipFetch(
+        "POST",
+        `/companies/${COMPANY_ID}/issues`,
+        body
+      );
+      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${req.params.name}`);
+  }
+});
+
+// --- Connect to Claude Code over stdio --------------------------------------
+await mcp.connect(new StdioServerTransport());
+
+// --- HTTP listener for Paperclip heartbeat webhooks -------------------------
+Bun.serve({
+  port: PORT,
+  hostname: "0.0.0.0",
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (req.method === "GET" && url.pathname === "/health") {
+      return Response.json({ status: "ok", agentId: AGENT_ID, channel: true });
+    }
+
+    if (req.method === "POST" && url.pathname === "/heartbeat") {
+      const body = await req.json() as Record<string, unknown>;
+      const context = (body.context || {}) as Record<string, string>;
+
+      const taskId = context.taskId || "";
+      const runId = (body.runId || "") as string;
+      const wakeReason = context.wakeReason || "manual";
+      const commentId = context.wakeCommentId || "";
+
+      // Build the task description for Claude
+      let taskInfo = `Heartbeat received. Wake reason: ${wakeReason}.`;
+      if (taskId) {
+        // Fetch the actual task details
+        try {
+          const issue = (await paperclipFetch("GET", `/issues/${taskId}`)) as Record<string, unknown>;
+          taskInfo = `Task: ${(issue as any).identifier || taskId}\nTitle: ${(issue as any).title}\nStatus: ${(issue as any).status}\n\nDescription:\n${(issue as any).description || "No description"}`;
+        } catch {
+          taskInfo = `Task ${taskId} assigned but could not fetch details.`;
+        }
+      }
+
+      // If triggered by a comment mention, fetch the comment
+      if (commentId && taskId) {
+        try {
+          const comment = (await paperclipFetch("GET", `/issues/${taskId}/comments/${commentId}`)) as Record<string, unknown>;
+          taskInfo += `\n\n---\n\n**You were @-mentioned in this comment:**\n${(comment as any).body || ""}`;
+        } catch {
+          // Try fetching recent comments as fallback
+          try {
+            const comments = (await paperclipFetch("GET", `/issues/${taskId}/comments?order=desc&limit=3`)) as any[];
+            if (comments?.length) {
+              taskInfo += `\n\n---\n\n**Recent comments:**`;
+              for (const c of comments.slice(0, 3)) {
+                taskInfo += `\n\n> ${c.body?.slice(0, 500) || ""}`;
+              }
+            }
+          } catch {}
+        }
+      }
+
+      // Append approved message text for message_approved wakes
+      const messageText = context.messageText || "";
+      if (wakeReason === "message_approved" && messageText) {
+        taskInfo += `\n\n---\n\n**Approved message text to send:**\n${messageText}`;
+      }
+
+      // Push into the running Claude session
+      await mcp.notification({
+        method: "notifications/claude/channel",
+        params: {
+          content: taskInfo,
+          meta: {
+            run_id: runId,
+            task_id: taskId,
+            wake_reason: wakeReason,
+            ...(commentId ? { comment_id: commentId } : {}),
+            ...(messageText ? { message_text: messageText } : {}),
+          },
+        },
+      });
+
+      return Response.json({ status: "accepted", runId });
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+});
+
+console.error(`[paperclip-channel] listening on 0.0.0.0:${PORT}`);

--- a/paperclip-channel/paperclip-mcp.ts
+++ b/paperclip-channel/paperclip-mcp.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env bun
+/**
+ * Paperclip MCP Server for claude_local agents
+ *
+ * Provides Paperclip API tools (inbox, checkout, update, comment, create_issue)
+ * over stdio MCP. No HTTP heartbeat listener — that's for VM/channel agents.
+ *
+ * Environment variables (set by the claude_local adapter during heartbeat runs):
+ *   PAPERCLIP_API_URL    — Paperclip API base URL
+ *   PAPERCLIP_API_KEY    — Agent or run JWT
+ *   PAPERCLIP_AGENT_ID   — This agent's UUID
+ *   PAPERCLIP_COMPANY_ID — Company UUID
+ *   PAPERCLIP_RUN_ID     — Current heartbeat run ID
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const API_URL = process.env.PAPERCLIP_API_URL || "http://192.168.4.151:3100/api";
+const API_KEY = process.env.PAPERCLIP_API_KEY || "";
+const AGENT_ID = process.env.PAPERCLIP_AGENT_ID || "";
+const COMPANY_ID = process.env.PAPERCLIP_COMPANY_ID || "";
+const RUN_ID = process.env.PAPERCLIP_RUN_ID || "";
+
+async function paperclipFetch(
+  method: string,
+  path: string,
+  body?: Record<string, unknown>,
+  headers?: Record<string, string>,
+): Promise<unknown> {
+  const res = await fetch(`${API_URL}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return res.json();
+}
+
+const mcp = new Server(
+  { name: "paperclip", version: "1.0.0" },
+  {
+    capabilities: { tools: {} },
+    instructions: `Paperclip API tools for managing tasks and issues.
+
+Available tools:
+- paperclip_inbox: Check your assigned tasks
+- paperclip_checkout: Claim a task before working on it
+- paperclip_update: Update task status and add a comment
+- paperclip_comment: Add a comment without changing status
+- paperclip_create_issue: Create a new issue. Always assign to Coordinator (4f525e83-7b23-47c2-884f-71b6bff440bd) for triage unless creating a message approval for yourself.`,
+  },
+);
+
+mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "paperclip_inbox",
+      description: "Check your Paperclip inbox for assigned tasks.",
+      inputSchema: { type: "object", properties: {}, required: [] },
+    },
+    {
+      name: "paperclip_checkout",
+      description: "Claim a task before working on it. Returns 409 if another agent owns it.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          issue_id: { type: "string", description: "The issue UUID to checkout" },
+        },
+        required: ["issue_id"],
+      },
+    },
+    {
+      name: "paperclip_update",
+      description: "Update a task's status and add a comment.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          issue_id: { type: "string", description: "The issue UUID to update" },
+          status: {
+            type: "string",
+            enum: ["in_progress", "in_review", "done", "blocked"],
+            description: "New status",
+          },
+          comment: { type: "string", description: "Markdown comment describing what was done" },
+        },
+        required: ["issue_id", "status", "comment"],
+      },
+    },
+    {
+      name: "paperclip_comment",
+      description: "Add a comment to a task without changing its status.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          issue_id: { type: "string", description: "The issue UUID" },
+          body: { type: "string", description: "Markdown comment" },
+        },
+        required: ["issue_id", "body"],
+      },
+    },
+    {
+      name: "paperclip_create_issue",
+      description: "Create a new Paperclip issue for problems you discover during work.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          title: { type: "string", description: "Issue title" },
+          description: { type: "string", description: "Markdown description" },
+          priority: {
+            type: "string",
+            enum: ["critical", "high", "medium", "low"],
+            description: "Priority level",
+          },
+          status: {
+            type: "string",
+            enum: ["backlog", "todo", "in_progress", "in_review"],
+            description: "Initial status (default: todo)",
+          },
+          label_ids: {
+            type: "string",
+            description: "JSON array of label UUIDs, e.g. '[\"uuid1\"]'",
+          },
+          assignee_agent_id: {
+            type: "string",
+            description: "Agent UUID to assign the issue to",
+          },
+        },
+        required: ["title", "description"],
+      },
+    },
+  ],
+}));
+
+mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const args = req.params.arguments as Record<string, string>;
+  const runId = RUN_ID;
+
+  switch (req.params.name) {
+    case "paperclip_inbox": {
+      const data = await paperclipFetch("GET", `/agents/me/inbox-lite`);
+      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    }
+
+    case "paperclip_checkout": {
+      const data = await paperclipFetch(
+        "POST",
+        `/issues/${args.issue_id}/checkout`,
+        { agentId: AGENT_ID, expectedStatuses: ["todo", "backlog", "blocked"] },
+        runId ? { "X-Paperclip-Run-Id": runId } : {},
+      );
+      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    }
+
+    case "paperclip_update": {
+      const data = await paperclipFetch(
+        "PATCH",
+        `/issues/${args.issue_id}`,
+        { status: args.status, comment: args.comment },
+        runId ? { "X-Paperclip-Run-Id": runId } : {},
+      );
+      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    }
+
+    case "paperclip_comment": {
+      const data = await paperclipFetch(
+        "POST",
+        `/issues/${args.issue_id}/comments`,
+        { body: args.body },
+        runId ? { "X-Paperclip-Run-Id": runId } : {},
+      );
+      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    }
+
+    case "paperclip_create_issue": {
+      const body: Record<string, unknown> = {
+        title: args.title,
+        description: args.description,
+        priority: args.priority || "high",
+        status: args.status || "todo",
+      };
+      if (args.assignee_agent_id) body.assigneeAgentId = args.assignee_agent_id;
+      if (args.label_ids) {
+        try { body.labelIds = JSON.parse(args.label_ids); } catch {}
+      }
+      const data = await paperclipFetch("POST", `/companies/${COMPANY_ID}/issues`, body);
+      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${req.params.name}`);
+  }
+});
+
+await mcp.connect(new StdioServerTransport());

--- a/server/src/__tests__/budgets-service.test.ts
+++ b/server/src/__tests__/budgets-service.test.ts
@@ -151,6 +151,161 @@ describe("budgetService", () => {
     });
   });
 
+  it("fires onAutoPaused with scope and details when a hard incident is newly created", async () => {
+    const policy = {
+      id: "policy-1",
+      companyId: "company-1",
+      scopeType: "agent",
+      scopeId: "agent-1",
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      amount: 100,
+      warnPercent: 80,
+      hardStopEnabled: true,
+      notifyEnabled: false,
+      isActive: true,
+    };
+
+    const dbStub = createDbStub([
+      [policy],
+      [{ total: 200 }],
+      [],
+      [{
+        companyId: "company-1",
+        name: "Budget Agent",
+        status: "running",
+        pauseReason: null,
+      }],
+    ]);
+
+    dbStub.queueInsert([{
+      id: "approval-1",
+      companyId: "company-1",
+      status: "pending",
+    }]);
+    dbStub.queueInsert([{
+      id: "incident-42",
+      companyId: "company-1",
+      policyId: "policy-1",
+      approvalId: "approval-1",
+    }]);
+    dbStub.queueUpdate([]);
+
+    const cancelWorkForScope = vi.fn().mockResolvedValue(undefined);
+    const onAutoPaused = vi.fn().mockResolvedValue(undefined);
+
+    const service = budgetService(dbStub.db as any, { cancelWorkForScope, onAutoPaused });
+    await service.evaluateCostEvent({
+      companyId: "company-1",
+      agentId: "agent-1",
+      projectId: null,
+    } as any);
+
+    expect(onAutoPaused).toHaveBeenCalledTimes(1);
+    expect(onAutoPaused).toHaveBeenCalledWith(
+      { companyId: "company-1", scopeType: "agent", scopeId: "agent-1" },
+      expect.objectContaining({
+        policyId: "policy-1",
+        scopeName: "Budget Agent",
+        metric: "billed_cents",
+        windowKind: "calendar_month_utc",
+        amountLimit: 100,
+        amountObserved: 200,
+        incidentId: "incident-42",
+      }),
+    );
+  });
+
+  it("does not re-fire onAutoPaused when a hard incident already exists for the same window", async () => {
+    const policy = {
+      id: "policy-1",
+      companyId: "company-1",
+      scopeType: "agent",
+      scopeId: "agent-1",
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      amount: 100,
+      warnPercent: 80,
+      hardStopEnabled: true,
+      notifyEnabled: false,
+      isActive: true,
+    };
+
+    // existing open hard incident → createIncidentIfNeeded returns created=false
+    const dbStub = createDbStub([
+      [policy],
+      [{ total: 200 }],
+      [{
+        id: "incident-existing",
+        companyId: "company-1",
+        policyId: "policy-1",
+        thresholdType: "hard",
+        status: "open",
+        approvalId: "approval-existing",
+      }],
+    ]);
+    dbStub.queueUpdate([]);
+
+    const cancelWorkForScope = vi.fn().mockResolvedValue(undefined);
+    const onAutoPaused = vi.fn().mockResolvedValue(undefined);
+
+    const service = budgetService(dbStub.db as any, { cancelWorkForScope, onAutoPaused });
+    await service.evaluateCostEvent({
+      companyId: "company-1",
+      agentId: "agent-1",
+      projectId: null,
+    } as any);
+
+    expect(onAutoPaused).not.toHaveBeenCalled();
+  });
+
+  it("swallows onAutoPaused errors without breaking budget enforcement", async () => {
+    const policy = {
+      id: "policy-1",
+      companyId: "company-1",
+      scopeType: "agent",
+      scopeId: "agent-1",
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      amount: 100,
+      warnPercent: 80,
+      hardStopEnabled: true,
+      notifyEnabled: false,
+      isActive: true,
+    };
+
+    const dbStub = createDbStub([
+      [policy],
+      [{ total: 200 }],
+      [],
+      [{
+        companyId: "company-1",
+        name: "Budget Agent",
+        status: "running",
+        pauseReason: null,
+      }],
+    ]);
+
+    dbStub.queueInsert([{ id: "approval-1", companyId: "company-1", status: "pending" }]);
+    dbStub.queueInsert([{ id: "incident-1", companyId: "company-1", policyId: "policy-1", approvalId: "approval-1" }]);
+    dbStub.queueUpdate([]);
+
+    const cancelWorkForScope = vi.fn().mockResolvedValue(undefined);
+    const onAutoPaused = vi.fn().mockRejectedValue(new Error("telegram down"));
+
+    const service = budgetService(dbStub.db as any, { cancelWorkForScope, onAutoPaused });
+    await expect(
+      service.evaluateCostEvent({ companyId: "company-1", agentId: "agent-1", projectId: null } as any),
+    ).resolves.not.toThrow();
+
+    expect(onAutoPaused).toHaveBeenCalledTimes(1);
+    expect(cancelWorkForScope).toHaveBeenCalled();
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "budget.auto_pause_alert_failed" }),
+    );
+  });
+
   it("blocks new work when an agent hard-stop remains exceeded even if the agent is not paused yet", async () => {
     const agentPolicy = {
       id: "policy-agent-1",

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -59,6 +59,7 @@ const mockCostService = vi.hoisted(() => ({
   byBiller: vi.fn().mockResolvedValue([]),
   windowSpend: vi.fn().mockResolvedValue([]),
   byProject: vi.fn().mockResolvedValue([]),
+  listEvents: vi.fn().mockResolvedValue([]),
 }));
 const mockFinanceService = vi.hoisted(() => ({
   createEvent: vi.fn(),
@@ -196,6 +197,43 @@ describe("cost routes", () => {
   it("accepts valid finance event list limits", async () => {
     const { parseCostLimit } = await loadCostParsers();
     expect(parseCostLimit({ limit: "25" })).toBe(25);
+  });
+
+  it("returns cost-events list with default limit", async () => {
+    mockCostService.listEvents.mockResolvedValueOnce([
+      { id: "event-1", companyId: "company-1", agentId: "agent-1", costCents: 150 },
+    ]);
+    const app = await createApp();
+    const res = await request(app).get("/api/companies/company-1/cost-events");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      costEvents: [
+        { id: "event-1", companyId: "company-1", agentId: "agent-1", costCents: 150 },
+      ],
+    });
+    expect(mockCostService.listEvents).toHaveBeenCalledWith("company-1", {
+      range: undefined,
+      agentId: undefined,
+      limit: 100,
+    });
+  });
+
+  it("passes agentId, since, and limit through to listEvents", async () => {
+    mockCostService.listEvents.mockResolvedValueOnce([]);
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/cost-events")
+      .query({
+        agentId: "agent-42",
+        since: "2026-04-01T00:00:00.000Z",
+        limit: "25",
+      });
+    expect(res.status).toBe(200);
+    expect(mockCostService.listEvents).toHaveBeenCalledWith("company-1", {
+      range: { from: new Date("2026-04-01T00:00:00.000Z") },
+      agentId: "agent-42",
+      limit: 25,
+    });
   });
 
   it("rejects company budget updates for board users outside the company", async () => {

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -89,11 +89,16 @@ function registerModuleMocks() {
     companyService: () => mockCompanyService,
     agentService: () => mockAgentService,
     heartbeatService: () => mockHeartbeatService,
+    issueService: () => ({ create: vi.fn() }),
     logActivity: mockLogActivity,
   }));
 
   vi.doMock("../services/quota-windows.js", () => ({
     fetchAllQuotaWindows: mockFetchAllQuotaWindows,
+  }));
+
+  vi.doMock("../services/budget-auto-pause-alert.js", () => ({
+    buildBudgetAutoPauseIssueHook: () => async () => {},
   }));
 }
 
@@ -138,6 +143,7 @@ beforeEach(() => {
   vi.resetModules();
   vi.doUnmock("../services/index.js");
   vi.doUnmock("../services/quota-windows.js");
+  vi.doUnmock("../services/budget-auto-pause-alert.js");
   vi.doUnmock("../routes/costs.js");
   vi.doUnmock("../middleware/index.js");
   registerModuleMocks();

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { afterAll, afterEach, beforeAll } from "vitest";
 import { randomUUID } from "node:crypto";
-import { createDb, companies, agents, costEvents, financeEvents, projects } from "@paperclipai/db";
+import { createDb, companies, agents, costEvents, financeEvents, issues, projects } from "@paperclipai/db";
 import { costService } from "../services/costs.ts";
 import { financeService } from "../services/finance.ts";
 import {
@@ -432,5 +432,165 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     expect(summary.estimatedDebitCents).toBe(2_000_000_000);
     expect(byKindRow?.debitCents).toBe(4_000_000_000);
     expect(byKindRow?.netCents).toBe(4_000_000_000);
+  });
+
+  it("aggregates per-issue cost with per-agent topContributors and distinct run count", async () => {
+    const companyId = randomUUID();
+    const agentA = randomUUID();
+    const agentB = randomUUID();
+    const issueId = randomUUID();
+    const otherIssueId = randomUUID();
+    const runA1 = randomUUID();
+    const runA2 = randomUUID();
+    const runB1 = randomUUID();
+    const runOther = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: agentA,
+        companyId,
+        name: "Platform",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: agentB,
+        companyId,
+        name: "QA",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: issueId,
+        companyId,
+        identifier: "T-1897",
+        title: "Cost drill-down",
+        status: "in_progress",
+        priority: "low",
+      },
+      {
+        id: otherIssueId,
+        companyId,
+        identifier: "T-1898",
+        title: "Other",
+        status: "todo",
+        priority: "low",
+      },
+    ]);
+
+    await db.insert(costEvents).values([
+      // agentA, two distinct runs on target issue
+      {
+        companyId, agentId: agentA, issueId,
+        provider: "anthropic", biller: "anthropic", billingType: "metered_api",
+        model: "claude-opus-4-7",
+        inputTokens: 100, cachedInputTokens: 40, outputTokens: 500, costCents: 3_000,
+        heartbeatRunId: runA1,
+        occurredAt: new Date("2026-04-15T10:00:00.000Z"),
+      },
+      // two rows sharing the same run — should count as one run, summed cost
+      {
+        companyId, agentId: agentA, issueId,
+        provider: "anthropic", biller: "anthropic", billingType: "metered_api",
+        model: "claude-opus-4-7",
+        inputTokens: 50, cachedInputTokens: 10, outputTokens: 200, costCents: 1_200,
+        heartbeatRunId: runA2,
+        occurredAt: new Date("2026-04-15T11:00:00.000Z"),
+      },
+      {
+        companyId, agentId: agentA, issueId,
+        provider: "anthropic", biller: "anthropic", billingType: "metered_api",
+        model: "claude-opus-4-7",
+        inputTokens: 20, cachedInputTokens: 0, outputTokens: 80, costCents: 800,
+        heartbeatRunId: runA2,
+        occurredAt: new Date("2026-04-15T11:30:00.000Z"),
+      },
+      // agentB, one run on target issue
+      {
+        companyId, agentId: agentB, issueId,
+        provider: "anthropic", biller: "anthropic", billingType: "metered_api",
+        model: "claude-sonnet-4-6",
+        inputTokens: 300, cachedInputTokens: 0, outputTokens: 600, costCents: 600,
+        heartbeatRunId: runB1,
+        occurredAt: new Date("2026-04-15T12:00:00.000Z"),
+      },
+      // unrelated issue — must be excluded
+      {
+        companyId, agentId: agentA, issueId: otherIssueId,
+        provider: "anthropic", biller: "anthropic", billingType: "metered_api",
+        model: "claude-opus-4-7",
+        inputTokens: 9999, cachedInputTokens: 0, outputTokens: 9999, costCents: 99_999,
+        heartbeatRunId: runOther,
+        occurredAt: new Date("2026-04-15T13:00:00.000Z"),
+      },
+    ]);
+
+    const summary = await costs.byIssue(companyId, issueId);
+
+    expect(summary.issueId).toBe(issueId);
+    expect(summary.identifier).toBe("T-1897");
+    expect(summary.totalCostCents).toBe(3_000 + 1_200 + 800 + 600);
+    expect(summary.runs).toBe(3); // runA1, runA2, runB1
+    expect(summary.totalInputTokens).toBe(100 + 50 + 20 + 300);
+    expect(summary.totalCachedInputTokens).toBe(40 + 10);
+    expect(summary.totalOutputTokens).toBe(500 + 200 + 80 + 600);
+
+    expect(summary.topContributors).toHaveLength(2);
+    const [top, second] = summary.topContributors;
+    expect(top.agentId).toBe(agentA);
+    expect(top.agentName).toBe("Platform");
+    expect(top.costCents).toBe(3_000 + 1_200 + 800);
+    expect(top.runs).toBe(2);
+    expect(second.agentId).toBe(agentB);
+    expect(second.agentName).toBe("QA");
+    expect(second.costCents).toBe(600);
+    expect(second.runs).toBe(1);
+  });
+
+  it("throws notFound when issue does not belong to company", async () => {
+    const companyId = randomUUID();
+    const otherCompanyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: `A${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: otherCompanyId,
+        name: "Other",
+        issuePrefix: `B${otherCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: otherCompanyId,
+      identifier: "OTH-1",
+      title: "wrong tenant",
+      status: "todo",
+      priority: "low",
+    });
+
+    await expect(costs.byIssue(companyId, issueId)).rejects.toThrow(/not found/i);
   });
 });

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -639,12 +639,35 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
-  it("blocks stranded in-progress work after the continuation retry was already used", async () => {
-    const { issueId } = await seedStrandedIssueFixture({
+  it("blocks stranded in-progress work once the continuation retry cap is reached", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "failed",
       retryReason: "issue_continuation_needed",
     });
+    // Seed two additional prior continuation-retry runs so the cap (3) is hit.
+    for (let i = 0; i < 2; i += 1) {
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+        },
+        startedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:00:00.000Z`),
+        finishedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:05:00.000Z`),
+        updatedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:05:00.000Z`),
+        errorCode: "process_lost",
+        error: "run failed before issue advanced",
+      });
+    }
+
     const heartbeat = heartbeatService(db);
 
     const result = await heartbeat.reconcileStrandedAssignedIssues();
@@ -657,8 +680,59 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
     expect(comments).toHaveLength(1);
-    expect(comments[0]?.body).toContain("retried continuation");
+    expect(comments[0]?.body).toContain("Auto-blocked after 3 continuation retries");
+    expect(comments[0]?.body).toContain("Retry history:");
     expect(comments[0]?.body).toContain("Latest retry failure: `process_lost` - run failed before issue advanced.");
+  });
+
+  it("resets the continuation retry counter once the assignee posts a comment", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    // Seed three prior continuation retries (above the cap) — but fenced off by
+    // a subsequent assignee comment, so they should not count.
+    for (let i = 0; i < 3; i += 1) {
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+        },
+        startedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:00:00.000Z`),
+        finishedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:05:00.000Z`),
+        updatedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:05:00.000Z`),
+        errorCode: "process_lost",
+        error: "run failed before issue advanced",
+      });
+    }
+    await db.insert(issueComments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      authorAgentId: agentId,
+      body: "progress update from assignee",
+      createdAt: new Date("2026-03-18T23:00:00.000Z"),
+      updatedAt: new Date("2026-03-18T23:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
   });
 
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -308,6 +308,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     runStatus: "failed" | "timed_out" | "cancelled" | "succeeded";
     retryReason?: "assignment_recovery" | "issue_continuation_needed" | null;
     assignToUser?: boolean;
+    runErrorCode?: string | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -370,7 +371,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       startedAt: now,
       finishedAt: new Date("2026-03-19T00:05:00.000Z"),
       updatedAt: new Date("2026-03-19T00:05:00.000Z"),
-      errorCode: input.runStatus === "succeeded" ? null : "process_lost",
+      errorCode: input.runStatus === "succeeded" ? null : (input.runErrorCode ?? "process_lost"),
       error: input.runStatus === "succeeded" ? null : "run failed before issue advanced",
     });
 
@@ -491,12 +492,32 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
   });
 
-  it("does not queue a second retry after the first process-loss retry was already used", async () => {
-    const { agentId, runId, issueId } = await seedRunFixture({
+  it("auto-blocks the issue and stops retrying after MAX_SAME_ERROR_RETRIES consecutive process_lost failures (SHA-1891)", async () => {
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
       agentStatus: "running",
       processPid: 999_999_999,
-      processLossRetryCount: 1,
     });
+    // Seed 4 prior failed `process_lost` runs for the same (agent, issue) pair
+    // so that after the current running run is finalized as failed, the
+    // consecutive-failure counter hits MAX_SAME_ERROR_RETRIES (5) and the
+    // backoff schedule is exhausted — triggering auto-block instead of retry.
+    for (let i = 0; i < 4; i += 1) {
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: { issueId },
+        startedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:00:00.000Z`),
+        finishedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:05:00.000Z`),
+        updatedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:05:00.000Z`),
+        errorCode: "process_lost",
+        error: "prior process_lost failure",
+      });
+    }
+
     const heartbeat = heartbeatService(db);
 
     const result = await heartbeat.reapOrphanedRuns();
@@ -507,16 +528,22 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .select()
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.agentId, agentId));
-    expect(runs).toHaveLength(1);
-    expect(runs[0]?.status).toBe("failed");
+    // 4 prior failed + 1 just-finalized = 5. No retry queued.
+    expect(runs).toHaveLength(5);
+    expect(runs.every((row) => row.status === "failed")).toBe(true);
 
     const issue = await db
       .select()
       .from(issues)
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
     expect(issue?.executionRunId).toBeNull();
-    expect(issue?.checkoutRunId).toBe(runId);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("Auto-blocked after 5 consecutive `process_lost` failures");
+    expect(comments[0]?.body).toContain("exponential backoff exhausted");
 
     // After exhausted process_lost retries, agent should be idle (not error)
     // because process_lost is a transient infrastructure issue, not a persistent agent failure
@@ -526,6 +553,156 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(agents.id, agentId))
       .then((rows) => rows[0] ?? null);
     expect(agent?.status).toBe("idle");
+  });
+
+  it("defers the retry (no immediate queued run) on the 2nd consecutive process_lost failure (SHA-1891 backoff)", async () => {
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: 999_999_999,
+    });
+    // Seed 1 prior failed process_lost run → current finalization brings the
+    // counter to 2, which maps to a 30s deferred retry. The retry is scheduled
+    // via setTimeout; no new heartbeatRuns row should exist immediately.
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-03-18T00:00:00.000Z"),
+      finishedAt: new Date("2026-03-18T00:05:00.000Z"),
+      updatedAt: new Date("2026-03-18T00:05:00.000Z"),
+      errorCode: "process_lost",
+      error: "prior process_lost failure",
+    });
+
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    // Only the 1 prior + 1 just-finalized — no immediate retry row because
+    // the retry is deferred behind a 30s timer.
+    expect(runs).toHaveLength(2);
+    expect(runs.every((row) => row.status === "failed")).toBe(true);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    // Issue not blocked yet — backoff schedule still has room.
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("does not count a different errorCode toward the process_lost retry counter (SHA-1891)", async () => {
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: 999_999_999,
+    });
+    // Seed 4 prior failed runs with a DIFFERENT errorCode — these must not
+    // accumulate against the current process_lost run.
+    for (let i = 0; i < 4; i += 1) {
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: { issueId },
+        startedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:00:00.000Z`),
+        finishedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:05:00.000Z`),
+        updatedAt: new Date(`2026-03-18T${String(i).padStart(2, "0")}:05:00.000Z`),
+        errorCode: "claude_auth_required",
+        error: "prior transient failure",
+      });
+    }
+
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    // Counter should be 1 (only the current process_lost), so an immediate
+    // retry is queued — 4 prior + 1 finalized + 1 retry = 6 total rows.
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(6);
+    expect(runs.filter((row) => row.status === "queued")).toHaveLength(1);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("resets the process_lost counter when a succeeded run exists for the same (agent, issue) pair (SHA-1891)", async () => {
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: 999_999_999,
+    });
+    // 3 prior failures → 1 success → then current failure.
+    for (let i = 0; i < 3; i += 1) {
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: { issueId },
+        startedAt: new Date(`2026-03-17T${String(i).padStart(2, "0")}:00:00.000Z`),
+        finishedAt: new Date(`2026-03-17T${String(i).padStart(2, "0")}:05:00.000Z`),
+        updatedAt: new Date(`2026-03-17T${String(i).padStart(2, "0")}:05:00.000Z`),
+        errorCode: "process_lost",
+        error: "prior process_lost failure",
+      });
+    }
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-03-18T00:00:00.000Z"),
+      finishedAt: new Date("2026-03-18T00:05:00.000Z"),
+      updatedAt: new Date("2026-03-18T00:05:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    // Counter resets to 1 after the success — immediate retry queued.
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.filter((row) => row.status === "queued")).toHaveLength(1);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
   });
 
   it("clears the detached warning when the run reports activity again", async () => {
@@ -610,6 +787,23 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("retried dispatch");
     expect(comments[0]?.body).toContain("Latest retry failure: `process_lost` - run failed before issue advanced.");
+  });
+
+  it("does not escalate assigned todo work when the latest retry failed with claude_auth_required (transient)", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+      runErrorCode: "claude_auth_required",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
   });
 
   it("re-enqueues continuation for stranded in-progress work with no active run", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -493,6 +493,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   it("does not queue a second retry after the first process-loss retry was already used", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "running",
       processPid: 999_999_999,
       processLossRetryCount: 1,
     });
@@ -516,6 +517,15 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBeNull();
     expect(issue?.checkoutRunId).toBe(runId);
+
+    // After exhausted process_lost retries, agent should be idle (not error)
+    // because process_lost is a transient infrastructure issue, not a persistent agent failure
+    const agent = await db
+      .select()
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(agent?.status).toBe("idle");
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -929,6 +929,99 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.status).toBe("in_progress");
   });
 
+  it("skips escalation while a deferred_agent_pause with a future resumeAt is active", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    // Seed three prior continuation retries so the cap would otherwise fire.
+    for (let i = 0; i < 2; i += 1) {
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+        },
+        startedAt: new Date(`2026-03-19T${String(i).padStart(2, "0")}:00:00.000Z`),
+        finishedAt: new Date(`2026-03-19T${String(i).padStart(2, "0")}:05:00.000Z`),
+        updatedAt: new Date(`2026-03-19T${String(i).padStart(2, "0")}:05:00.000Z`),
+        errorCode: "process_lost",
+        error: "run failed before issue advanced",
+      });
+    }
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.deferIssueExecution({
+      companyId,
+      issueId,
+      agentId,
+      resumeAt: new Date(Date.now() + 240_000),
+      reason: "ScheduleWakeup 240s",
+    });
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("escalates stranded work once a deferred_agent_pause resumeAt is past the grace window", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    for (let i = 0; i < 2; i += 1) {
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+        },
+        startedAt: new Date(`2026-03-20T${String(i).padStart(2, "0")}:00:00.000Z`),
+        finishedAt: new Date(`2026-03-20T${String(i).padStart(2, "0")}:05:00.000Z`),
+        updatedAt: new Date(`2026-03-20T${String(i).padStart(2, "0")}:05:00.000Z`),
+        errorCode: "process_lost",
+        error: "run failed before issue advanced",
+      });
+    }
+
+    const heartbeat = heartbeatService(db);
+    // resumeAt already past, beyond the 60s grace window.
+    await heartbeat.deferIssueExecution({
+      companyId,
+      issueId,
+      agentId,
+      resumeAt: new Date(Date.now() - 120_000),
+      reason: "ScheduleWakeup that never woke",
+    });
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+  });
+
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {
     const { issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -779,4 +779,48 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(run.source).toBe("webhook");
     expect(run.status).toBe("issue_created");
   });
+
+  // SHA-1845: dispatch previously recomputed trigger.nextRunAt from
+  // triggeredAt=now() and wrote it on every run path. Under a slow-transaction
+  // race with tickScheduledTriggers, the stale dispatch write could clobber the
+  // scheduler's freshly-claimed value — leaving nextRunAt pinned in the past
+  // and stalling the routine. Manual/webhook fires also shouldn't perturb the
+  // cron schedule. Regression: after any dispatch, the trigger's nextRunAt
+  // must equal whatever value the scheduler / CRUD path last wrote.
+  it("dispatch does not overwrite trigger nextRunAt (SHA-1845)", async () => {
+    const { routine, svc } = await seedFixture();
+    const { trigger } = await svc.createTrigger(
+      routine.id,
+      {
+        kind: "schedule",
+        label: "every thirty",
+        cronExpression: "*/30 * * * *",
+        timezone: "America/New_York",
+      },
+      {},
+    );
+
+    // Simulate tickScheduledTriggers having just claimed a future slot.
+    const claimedNextRunAt = new Date("2030-06-01T12:30:00.000Z");
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: claimedNextRunAt })
+      .where(eq(routineTriggers.id, trigger.id));
+
+    const run = await svc.runRoutine(routine.id, {
+      source: "manual",
+      triggerId: trigger.id,
+    });
+    expect(run.status).toBe("issue_created");
+
+    const afterManual = await db
+      .select({ nextRunAt: routineTriggers.nextRunAt, lastFiredAt: routineTriggers.lastFiredAt })
+      .from(routineTriggers)
+      .where(eq(routineTriggers.id, trigger.id))
+      .then((rows) => rows[0]!);
+
+    // Scheduler's claim must survive a manual fire; lastFiredAt still advances.
+    expect(afterManual.nextRunAt?.toISOString()).toBe(claimedNextRunAt.toISOString());
+    expect(afterManual.lastFiredAt).not.toBeNull();
+  });
 });

--- a/server/src/adapters/http/execute.ts
+++ b/server/src/adapters/http/execute.ts
@@ -34,7 +34,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       exitCode: 0,
       signal: null,
       timedOut: false,
-      summary: `HTTP ${method} ${url}`,
+      summary: null,
     };
   } finally {
     if (timer) clearTimeout(timer);

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -39,13 +39,15 @@ export function errorHandler(
   _next: NextFunction,
 ) {
   if (err instanceof HttpError) {
-    if (err.status >= 500) {
+    if (err.status >= 400) {
       attachErrorContext(
         req,
         res,
         { message: err.message, stack: err.stack, name: err.name, details: err.details },
-        err,
+        err.status >= 500 ? err : undefined,
       );
+    }
+    if (err.status >= 500) {
       const tc = getTelemetryClient();
       if (tc) trackErrorHandlerCrash(tc, { errorCode: err.name });
     }

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -505,7 +505,16 @@ export function agentRoutes(db: Db) {
     };
   }
 
-  function normalizeNewAgentRuntimeConfig(runtimeConfig: unknown): Record<string, unknown> {
+  // For persistent HTTP-adapter agents the webhook push delivers real work in
+  // real time, so the periodic timer only needs to act as a liveness probe. A
+  // 20-minute default keeps drift detection in range while cutting no-op wakes
+  // to ~a third of the 300s default used for claude_local and friends.
+  const HTTP_ADAPTER_DEFAULT_INTERVAL_SEC = 1200;
+
+  function normalizeNewAgentRuntimeConfig(
+    runtimeConfig: unknown,
+    adapterType?: string | null,
+  ): Record<string, unknown> {
     const parsedRuntimeConfig = asRecord(runtimeConfig);
     const normalizedRuntimeConfig = parsedRuntimeConfig ? { ...parsedRuntimeConfig } : {};
     const parsedHeartbeat = asRecord(normalizedRuntimeConfig.heartbeat);
@@ -513,6 +522,10 @@ export function agentRoutes(db: Db) {
 
     if (parseBooleanLike(heartbeat.enabled) == null) {
       heartbeat.enabled = false;
+    }
+
+    if (adapterType === "http" && parseNumberLike(heartbeat.intervalSec) == null) {
+      heartbeat.intervalSec = HTTP_ADAPTER_DEFAULT_INTERVAL_SEC;
     }
 
     normalizedRuntimeConfig.heartbeat = heartbeat;
@@ -1404,7 +1417,7 @@ export function agentRoutes(db: Db) {
     const normalizedHireInput = {
       ...hireInput,
       adapterConfig: normalizedAdapterConfig,
-      runtimeConfig: normalizeNewAgentRuntimeConfig(hireInput.runtimeConfig),
+      runtimeConfig: normalizeNewAgentRuntimeConfig(hireInput.runtimeConfig, hireInput.adapterType),
     };
 
     const company = await db
@@ -1571,7 +1584,7 @@ export function agentRoutes(db: Db) {
     const createdAgent = await svc.create(companyId, {
       ...createInput,
       adapterConfig: normalizedAdapterConfig,
-      runtimeConfig: normalizeNewAgentRuntimeConfig(createInput.runtimeConfig),
+      runtimeConfig: normalizeNewAgentRuntimeConfig(createInput.runtimeConfig, createInput.adapterType),
       status: "idle",
       spentMonthlyCents: 0,
       lastHeartbeatAt: null,

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -15,8 +15,10 @@ import {
   companyService,
   agentService,
   heartbeatService,
+  issueService,
   logActivity,
 } from "../services/index.js";
+import { buildBudgetAutoPauseIssueHook } from "../services/budget-auto-pause-alert.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import { fetchAllQuotaWindows } from "../services/quota-windows.js";
 import { badRequest } from "../errors.js";
@@ -44,8 +46,10 @@ export function parseCostLimit(query: Record<string, unknown>) {
 export function costRoutes(db: Db) {
   const router = Router();
   const heartbeat = heartbeatService(db);
+  const issues = issueService(db);
   const budgetHooks = {
     cancelWorkForScope: heartbeat.cancelBudgetScopeWork,
+    onAutoPaused: buildBudgetAutoPauseIssueHook(db, issues),
   };
   const costs = costService(db, budgetHooks);
   const finance = financeService(db);

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -82,6 +82,20 @@ export function costRoutes(db: Db) {
     res.status(201).json(event);
   });
 
+  router.get("/companies/:companyId/cost-events", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const query = { ...req.query } as Record<string, unknown>;
+    // accept `since` as alias for `from` so callers can say ?since=...
+    if (query.since && !query.from) query.from = query.since;
+    const range = parseCostDateRange(query);
+    const limit = parseCostLimit(req.query);
+    const agentIdRaw = Array.isArray(req.query.agentId) ? req.query.agentId[0] : req.query.agentId;
+    const agentId = typeof agentIdRaw === "string" && agentIdRaw.length > 0 ? agentIdRaw : undefined;
+    const rows = await costs.listEvents(companyId, { range, agentId, limit });
+    res.json({ costEvents: rows });
+  });
+
   router.post("/companies/:companyId/finance-events", validate(createFinanceEventSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -599,6 +599,18 @@ export function issueRoutes(
     });
   });
 
+  // Company-scoped shim: agents often construct /companies/:companyId/issues/:id/...
+  // by pattern-matching from the list/create endpoint. Rewrite to canonical /issues/:id/...
+  // before route matching. The regex requires an issue ID segment after /issues/ so it
+  // does not interfere with GET/POST /companies/:companyId/issues (list & create).
+  router.use((req, _res, next) => {
+    const match = req.url.match(/^\/companies\/[^/]+\/issues\/([^/?]+)(\/[^?]*)?(\?.*)?$/);
+    if (match) {
+      req.url = `/issues/${match[1]}${match[2] || ""}${match[3] || ""}`;
+    }
+    next();
+  });
+
   router.get("/companies/:companyId/issues", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -150,6 +150,13 @@ function isClosedIssueStatus(status: string | null | undefined): status is "done
   return status === "done" || status === "cancelled";
 }
 
+// SharpAPI fork: QA gate for close-to-done transitions.
+// Issues labeled with any of these can only be closed by an agent whose role === "qa".
+// Engineers must set status to "in_review" and @-mention QA for verification.
+// Refactor/docs-labeled issues are exempt and may self-close.
+const QA_GATED_LABEL_NAMES = new Set(["bug", "customer-report", "feature", "integrity-monitored"]);
+const QA_GATE_ENFORCER_ROLE = "qa";
+
 function shouldImplicitlyReopenCommentForAgent(input: {
   issueStatus: string | null | undefined;
   assigneeAgentId: string | null | undefined;
@@ -1514,6 +1521,33 @@ export function issueRoutes(
     if (assigneeWillChange && !transition.workflowControlledAssignment) {
       if (!isAgentReturningIssueToCreator) {
         await assertCanAssignTasks(req, existing.companyId);
+      }
+    }
+
+    // SharpAPI QA Gate: block non-QA agents from closing gated issues to `done`.
+    // Users/board actors bypass this gate (they can still close directly).
+    if (
+      updateFields.status === "done" &&
+      existing.status !== "done" &&
+      actor.actorType === "agent" &&
+      actor.agentId
+    ) {
+      const gatedLabels = ((existing as { labels?: Array<{ name: string }> }).labels ?? []).filter(
+        (l) => QA_GATED_LABEL_NAMES.has(l.name),
+      );
+      if (gatedLabels.length > 0) {
+        const actorAgent = await agentsSvc.getById(actor.agentId);
+        if (actorAgent?.role !== QA_GATE_ENFORCER_ROLE) {
+          res.status(403).json({
+            error: `QA gate: issues labeled ${gatedLabels.map((l) => l.name).join(", ")} can only be closed to 'done' by an agent with role='${QA_GATE_ENFORCER_ROLE}'. Set status to 'in_review' and @-mention QA for verification.`,
+            qaGate: {
+              gatedLabels: gatedLabels.map((l) => l.name),
+              requiredRole: QA_GATE_ENFORCER_ROLE,
+              actorRole: actorAgent?.role ?? null,
+            },
+          });
+          return;
+        }
       }
     }
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1524,6 +1524,36 @@ export function issueRoutes(
       }
     }
 
+    // SharpAPI QA Auto-Handoff: when a non-QA agent sets a gated issue to
+    // `in_review`, automatically reassign to QA so the standard assignment
+    // wakeup fires. Closes the loop where engineers forget to @-mention QA.
+    // Skipped if the actor explicitly set an assignee in the same patch.
+    if (
+      updateFields.status === "in_review" &&
+      existing.status !== "in_review" &&
+      actor.actorType === "agent" &&
+      actor.agentId &&
+      updateFields.assigneeAgentId === undefined
+    ) {
+      const gatedLabels = ((existing as { labels?: Array<{ name: string }> }).labels ?? []).filter(
+        (l) => QA_GATED_LABEL_NAMES.has(l.name),
+      );
+      if (gatedLabels.length > 0) {
+        const actorAgent = await agentsSvc.getById(actor.agentId);
+        if (actorAgent?.role !== QA_GATE_ENFORCER_ROLE) {
+          const allAgents = await agentsSvc.list(existing.companyId);
+          const qaAgent = allAgents.find((a) => a.role === QA_GATE_ENFORCER_ROLE);
+          if (qaAgent && qaAgent.id !== existing.assigneeAgentId) {
+            updateFields.assigneeAgentId = qaAgent.id;
+            logger.info(
+              { issueId: existing.id, identifier: existing.identifier, qaAgentId: qaAgent.id, actorAgentId: actor.agentId },
+              "QA auto-handoff: reassigning gated issue to QA on in_review",
+            );
+          }
+        }
+      }
+    }
+
     // SharpAPI QA Gate: block non-QA agents from closing gated issues to `done`.
     // Users/board actors bypass this gate (they can still close directly).
     if (

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -47,7 +47,7 @@ import {
 } from "../services/index.js";
 import { logger } from "../middleware/logger.js";
 import { conflict, forbidden, HttpError, notFound, unauthorized } from "../errors.js";
-import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import {
   assertNoAgentHostWorkspaceCommandMutation,
   collectIssueWorkspaceCommandPaths,
@@ -2113,6 +2113,137 @@ export function issueRoutes(
     });
 
     res.json(released);
+  });
+
+  // ── Merge approval actions ──────────────────────────────────────────
+  router.post("/issues/:id/approve-merge", async (req, res) => {
+    const id = req.params.id as string;
+    assertBoard(req);
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    if (issue.status !== "in_review") {
+      res.status(409).json({ error: "Issue must be in_review to approve merge" });
+      return;
+    }
+    if (!issue.assigneeAgentId) {
+      res.status(409).json({ error: "Issue has no assigned agent" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    const note = typeof req.body.decisionNote === "string" ? req.body.decisionNote.trim() : "";
+    const body = note ? `Merge approved. ${note}` : "Merge approved.";
+
+    const comment = await svc.addComment(id, body, {
+      userId: actor.actorType === "user" ? actor.actorId : undefined,
+      runId: null,
+    });
+
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: null,
+      runId: null,
+      action: "issue.merge_approved",
+      entityType: "issue",
+      entityId: id,
+      details: { identifier: issue.identifier, commentId: comment.id },
+    });
+
+    heartbeat
+      .wakeup(issue.assigneeAgentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "merge_approved",
+        payload: { issueId: id, commentId: comment.id },
+        requestedByActorType: actor.actorType,
+        requestedByActorId: actor.actorId,
+        contextSnapshot: {
+          issueId: id,
+          taskId: id,
+          commentId: comment.id,
+          wakeReason: "merge_approved",
+          source: "issue.merge_approved",
+        },
+      })
+      .catch((err) =>
+        logger.warn({ err, issueId: id }, "failed to wake agent on merge approval"),
+      );
+
+    res.json({ issue, comment });
+  });
+
+  router.post("/issues/:id/request-changes", async (req, res) => {
+    const id = req.params.id as string;
+    assertBoard(req);
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    if (issue.status !== "in_review") {
+      res.status(409).json({ error: "Issue must be in_review to request changes" });
+      return;
+    }
+    if (!issue.assigneeAgentId) {
+      res.status(409).json({ error: "Issue has no assigned agent" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    const note = typeof req.body.decisionNote === "string" ? req.body.decisionNote.trim() : "";
+    const body = note ? `Changes requested. ${note}` : "Changes requested.";
+
+    const updated = await svc.update(id, { status: "in_progress" });
+    if (!updated) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+
+    const comment = await svc.addComment(id, body, {
+      userId: actor.actorType === "user" ? actor.actorId : undefined,
+      runId: null,
+    });
+
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: null,
+      runId: null,
+      action: "issue.changes_requested",
+      entityType: "issue",
+      entityId: id,
+      details: { identifier: issue.identifier, commentId: comment.id },
+    });
+
+    heartbeat
+      .wakeup(issue.assigneeAgentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "changes_requested",
+        payload: { issueId: id, commentId: comment.id },
+        requestedByActorType: actor.actorType,
+        requestedByActorId: actor.actorId,
+        contextSnapshot: {
+          issueId: id,
+          taskId: id,
+          commentId: comment.id,
+          wakeReason: "changes_requested",
+          source: "issue.changes_requested",
+        },
+      })
+      .catch((err) =>
+        logger.warn({ err, issueId: id }, "failed to wake agent on changes requested"),
+      );
+
+    res.json({ issue: updated, comment });
   });
 
   router.get("/issues/:id/comments", async (req, res) => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -32,6 +32,7 @@ import { validate } from "../middleware/validate.js";
 import {
   accessService,
   agentService,
+  costService,
   executionWorkspaceService,
   feedbackService,
   goalService,
@@ -308,6 +309,7 @@ export function issueRoutes(
   const access = accessService(db);
   const heartbeat = heartbeatService(db);
   const feedback = feedbackService(db);
+  const costs = costService(db);
   const instanceSettings = instanceSettingsService(db);
   const agentsSvc = agentService(db);
   const projectsSvc = projectService(db);
@@ -772,6 +774,18 @@ export function issueRoutes(
       currentExecutionWorkspace,
       workProducts,
     });
+  });
+
+  router.get("/issues/:id/cost-summary", async (req, res) => {
+    const id = req.params.id as string;
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    const summary = await costs.byIssue(issue.companyId, issue.id);
+    res.json(summary);
   });
 
   router.get("/issues/:id/heartbeat-context", async (req, res) => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2154,6 +2154,84 @@ export function issueRoutes(
     res.json(updated);
   });
 
+  router.post("/issues/:id/defer-execution", async (req, res) => {
+    const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
+
+    const rawResumeAt = typeof req.body?.resumeAt === "string" ? req.body.resumeAt : null;
+    const rawResumeInSec = Number.isFinite(req.body?.resumeInSeconds)
+      ? Number(req.body.resumeInSeconds)
+      : null;
+    let resumeAt: Date | null = null;
+    if (rawResumeAt) {
+      const parsed = new Date(rawResumeAt);
+      if (!Number.isNaN(parsed.getTime())) resumeAt = parsed;
+    } else if (rawResumeInSec && rawResumeInSec > 0) {
+      resumeAt = new Date(Date.now() + rawResumeInSec * 1000);
+    }
+    if (!resumeAt) {
+      res.status(400).json({ error: "resumeAt (ISO string) or resumeInSeconds (>0) is required" });
+      return;
+    }
+    if (resumeAt.getTime() <= Date.now() - 1000) {
+      res.status(400).json({ error: "resumeAt must be in the future" });
+      return;
+    }
+    const MAX_DEFER_MS = 60 * 60 * 1000;
+    if (resumeAt.getTime() > Date.now() + MAX_DEFER_MS) {
+      res.status(400).json({ error: "resumeAt too far in the future (max 1h)" });
+      return;
+    }
+
+    const reason = typeof req.body?.reason === "string" && req.body.reason.trim().length > 0
+      ? req.body.reason.trim().slice(0, 500)
+      : null;
+
+    // Must be executed by the agent that holds the checkout run for this issue.
+    if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;
+    const actorRunId = requireAgentRunId(req, res);
+    if (req.actor.type === "agent" && !actorRunId) return;
+    if (req.actor.type !== "agent" || !req.actor.agentId) {
+      res.status(403).json({ error: "Only the assigned agent can defer issue execution" });
+      return;
+    }
+
+    const row = await heartbeat.deferIssueExecution({
+      companyId: existing.companyId,
+      issueId: existing.id,
+      agentId: req.actor.agentId,
+      resumeAt,
+      reason,
+      requestedByActorType: "agent",
+      requestedByActorId: req.actor.agentId,
+    });
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: existing.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "issue.execution_deferred",
+      entityType: "issue",
+      entityId: existing.id,
+      details: {
+        identifier: existing.identifier,
+        resumeAt: resumeAt.toISOString(),
+        reason,
+        wakeupRequestId: row.id,
+      },
+    });
+
+    res.json({ wakeupRequestId: row.id, resumeAt: resumeAt.toISOString(), reason });
+  });
+
   router.post("/issues/:id/release", async (req, res) => {
     const id = req.params.id as string;
     const existing = await svc.getById(id);

--- a/server/src/services/budget-auto-pause-alert.ts
+++ b/server/src/services/budget-auto-pause-alert.ts
@@ -1,0 +1,63 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { labels } from "@paperclipai/db";
+import type {
+  BudgetAutoPauseDetails,
+  BudgetEnforcementScope,
+} from "./budgets.js";
+import type { issueService } from "./issues.js";
+
+type IssueService = ReturnType<typeof issueService>;
+
+const ALERT_LABEL_NAME = "infra-alert";
+
+function formatDollars(cents: number) {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatUtilization(observedCents: number, limitCents: number) {
+  if (limitCents <= 0) return "n/a";
+  const pct = (observedCents / limitCents) * 100;
+  return `${pct.toFixed(1)}%`;
+}
+
+export function buildBudgetAutoPauseIssueHook(db: Db, issues: IssueService) {
+  return async function onAutoPaused(
+    scope: BudgetEnforcementScope,
+    details: BudgetAutoPauseDetails,
+  ) {
+    const labelRow = await db
+      .select({ id: labels.id })
+      .from(labels)
+      .where(and(eq(labels.companyId, scope.companyId), eq(labels.name, ALERT_LABEL_NAME)))
+      .then((rows) => rows[0] ?? null);
+
+    const title = `Budget auto-pause: ${scope.scopeType} "${details.scopeName}"`;
+    const body = [
+      `**Auto-pause triggered** — ${scope.scopeType} **${details.scopeName}** has been paused because its ${details.windowKind} budget was exceeded.`,
+      "",
+      "| Field | Value |",
+      "| --- | --- |",
+      `| Scope | \`${scope.scopeType}\` \`${scope.scopeId}\` |`,
+      `| Pause reason | \`budget\` |`,
+      `| Metric | \`${details.metric}\` |`,
+      `| Window | \`${details.windowKind}\` |`,
+      `| Budget limit | ${formatDollars(details.amountLimit)} |`,
+      `| Observed spend | ${formatDollars(details.amountObserved)} |`,
+      `| Utilization | ${formatUtilization(details.amountObserved, details.amountLimit)} |`,
+      `| Incident | \`${details.incidentId}\` |`,
+      `| Policy | \`${details.policyId}\` |`,
+      "",
+      "Resume by either raising the budget or resolving the incident via the budget approvals flow.",
+    ].join("\n");
+
+    await issues.create(scope.companyId, {
+      title,
+      description: body,
+      priority: "critical",
+      status: "todo",
+      originKind: "manual",
+      labelIds: labelRow ? [labelRow.id] : [],
+    });
+  };
+}

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -40,8 +40,22 @@ export type BudgetEnforcementScope = {
   scopeId: string;
 };
 
+export type BudgetAutoPauseDetails = {
+  policyId: string;
+  scopeName: string;
+  metric: BudgetMetric;
+  windowKind: BudgetWindowKind;
+  amountLimit: number;
+  amountObserved: number;
+  incidentId: string;
+};
+
 export type BudgetServiceHooks = {
   cancelWorkForScope?: (scope: BudgetEnforcementScope) => Promise<void>;
+  onAutoPaused?: (
+    scope: BudgetEnforcementScope,
+    details: BudgetAutoPauseDetails,
+  ) => Promise<void>;
 };
 
 function currentUtcMonthWindow(now = new Date()) {
@@ -350,7 +364,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
     policy: PolicyRow,
     thresholdType: BudgetThresholdType,
     amountObserved: number,
-  ) {
+  ): Promise<{ incident: IncidentRow; created: boolean; scopeName: string } | null> {
     const { start, end } = resolveWindow(policy.windowKind as BudgetWindowKind);
     const existing = await db
       .select()
@@ -364,12 +378,14 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         ),
       )
       .then((rows) => rows[0] ?? null);
-    if (existing) return existing;
+    if (existing) return { incident: existing, created: false, scopeName: "" };
 
     const scope = await resolveScopeRecord(db, policy.scopeType as BudgetScopeType, policy.scopeId);
+    const scopeName = normalizeScopeName(policy.scopeType as BudgetScopeType, scope.name);
+
     const payload = buildApprovalPayload({
       policy,
-      scopeName: normalizeScopeName(policy.scopeType as BudgetScopeType, scope.name),
+      scopeName,
       thresholdType,
       amountObserved,
       windowStart: start,
@@ -391,7 +407,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         .then((rows) => rows[0] ?? null)
       : null;
 
-    return db
+    const inserted = await db
       .insert(budgetIncidents)
       .values({
         companyId: policy.companyId,
@@ -410,6 +426,9 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
       })
       .returning()
       .then((rows) => rows[0] ?? null);
+
+    if (!inserted) return null;
+    return { incident: inserted, created: true, scopeName };
   }
 
   async function resolveOpenSoftIncidents(policyId: string) {
@@ -600,6 +619,9 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
             await resolveOpenSoftIncidents(row.id);
             await createIncidentIfNeeded(row, "hard", observedAmount);
             await pauseAndCancelScopeForBudget(row);
+            // No onAutoPaused here: this path is reached when the board lowers
+            // a budget below current spend. The actor already knows; alerting
+            // would be noise and violates the "manual pauses don't alert" rule.
           }
         }
       } else {
@@ -669,15 +691,15 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         const softThreshold = Math.ceil((policy.amount * policy.warnPercent) / 100);
 
         if (policy.notifyEnabled && observedAmount >= softThreshold) {
-          const softIncident = await createIncidentIfNeeded(policy, "soft", observedAmount);
-          if (softIncident) {
+          const softResult = await createIncidentIfNeeded(policy, "soft", observedAmount);
+          if (softResult) {
             await logActivity(db, {
               companyId: policy.companyId,
               actorType: "system",
               actorId: "budget_service",
               action: "budget.soft_threshold_crossed",
               entityType: "budget_incident",
-              entityId: softIncident.id,
+              entityId: softResult.incident.id,
               details: {
                 scopeType: policy.scopeType,
                 scopeId: policy.scopeId,
@@ -690,24 +712,60 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
 
         if (policy.hardStopEnabled && observedAmount >= policy.amount) {
           await resolveOpenSoftIncidents(policy.id);
-          const hardIncident = await createIncidentIfNeeded(policy, "hard", observedAmount);
+          const hardResult = await createIncidentIfNeeded(policy, "hard", observedAmount);
           await pauseAndCancelScopeForBudget(policy);
-          if (hardIncident) {
+          if (hardResult) {
             await logActivity(db, {
               companyId: policy.companyId,
               actorType: "system",
               actorId: "budget_service",
               action: "budget.hard_threshold_crossed",
               entityType: "budget_incident",
-              entityId: hardIncident.id,
+              entityId: hardResult.incident.id,
               details: {
                 scopeType: policy.scopeType,
                 scopeId: policy.scopeId,
                 amountObserved: observedAmount,
                 amountLimit: policy.amount,
-                approvalId: hardIncident.approvalId ?? null,
+                approvalId: hardResult.incident.approvalId ?? null,
               },
             });
+
+            // Fire onAutoPaused ONLY on newly-created hard incidents so
+            // resume/re-cross doesn't re-alert (idempotent via incident keying).
+            if (hardResult.created && hooks.onAutoPaused) {
+              try {
+                await hooks.onAutoPaused(
+                  {
+                    companyId: policy.companyId,
+                    scopeType: policy.scopeType as BudgetScopeType,
+                    scopeId: policy.scopeId,
+                  },
+                  {
+                    policyId: policy.id,
+                    scopeName: hardResult.scopeName,
+                    metric: policy.metric as BudgetMetric,
+                    windowKind: policy.windowKind as BudgetWindowKind,
+                    amountLimit: policy.amount,
+                    amountObserved: observedAmount,
+                    incidentId: hardResult.incident.id,
+                  },
+                );
+              } catch (err) {
+                // Never let an alert-delivery failure break budget enforcement.
+                await logActivity(db, {
+                  companyId: policy.companyId,
+                  actorType: "system",
+                  actorId: "budget_service",
+                  action: "budget.auto_pause_alert_failed",
+                  entityType: "budget_incident",
+                  entityId: hardResult.incident.id,
+                  details: {
+                    error: err instanceof Error ? err.message : String(err),
+                  },
+                });
+              }
+            }
           }
         }
       }

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -315,6 +315,23 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         .orderBy(costEvents.provider, costEvents.biller, costEvents.billingType, costEvents.model);
     },
 
+    listEvents: async (
+      companyId: string,
+      opts: { range?: CostDateRange; agentId?: string; limit?: number } = {},
+    ) => {
+      const conditions: ReturnType<typeof eq>[] = [eq(costEvents.companyId, companyId)];
+      if (opts.agentId) conditions.push(eq(costEvents.agentId, opts.agentId));
+      if (opts.range?.from) conditions.push(gte(costEvents.occurredAt, opts.range.from));
+      if (opts.range?.to) conditions.push(lte(costEvents.occurredAt, opts.range.to));
+
+      return db
+        .select()
+        .from(costEvents)
+        .where(and(...conditions))
+        .orderBy(desc(costEvents.occurredAt), desc(costEvents.createdAt))
+        .limit(opts.limit ?? 100);
+    },
+
     byProject: async (companyId: string, range?: CostDateRange) => {
       const issueIdAsText = sql<string>`${issues.id}::text`;
       const runProjectLinks = db

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -381,5 +381,69 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         .groupBy(effectiveProjectId, projects.name)
         .orderBy(desc(costCentsExpr));
     },
+
+    /**
+     * Cost rollup for a single issue: totals + per-agent breakdown.
+     * Uses cost_events.issue_id directly (populated by heartbeat runs and
+     * paperclip-channel telemetry post-SHA-1865). Pre-SHA-1865 attribution
+     * is partial — acceptable for a board-level drill-down tool.
+     */
+    byIssue: async (companyId: string, issueId: string) => {
+      const issue = await db
+        .select({ id: issues.id, identifier: issues.identifier })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, companyId)))
+        .then((rows) => rows[0] ?? null);
+
+      if (!issue) throw notFound("Issue not found");
+
+      const conditions = [
+        eq(costEvents.companyId, companyId),
+        eq(costEvents.issueId, issueId),
+      ];
+
+      const costCentsExpr = sumAsNumber(costEvents.costCents);
+      const runsExpr = sql<number>`count(distinct ${costEvents.heartbeatRunId})::int`;
+
+      const [totalsRow] = await db
+        .select({
+          totalCostCents: costCentsExpr,
+          runs: runsExpr,
+          totalInputTokens: sumAsNumber(costEvents.inputTokens),
+          totalCachedInputTokens: sumAsNumber(costEvents.cachedInputTokens),
+          totalOutputTokens: sumAsNumber(costEvents.outputTokens),
+        })
+        .from(costEvents)
+        .where(and(...conditions));
+
+      const contributors = await db
+        .select({
+          agentId: costEvents.agentId,
+          agentName: agents.name,
+          costCents: costCentsExpr,
+          runs: runsExpr,
+        })
+        .from(costEvents)
+        .leftJoin(agents, eq(costEvents.agentId, agents.id))
+        .where(and(...conditions))
+        .groupBy(costEvents.agentId, agents.name)
+        .orderBy(desc(costCentsExpr));
+
+      return {
+        issueId: issue.id,
+        identifier: issue.identifier,
+        totalCostCents: Number(totalsRow?.totalCostCents ?? 0),
+        runs: Number(totalsRow?.runs ?? 0),
+        totalInputTokens: Number(totalsRow?.totalInputTokens ?? 0),
+        totalCachedInputTokens: Number(totalsRow?.totalCachedInputTokens ?? 0),
+        totalOutputTokens: Number(totalsRow?.totalOutputTokens ?? 0),
+        topContributors: contributors.map((row) => ({
+          agentId: row.agentId,
+          agentName: row.agentName,
+          costCents: Number(row.costCents),
+          runs: Number(row.runs),
+        })),
+      };
+    },
   };
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1522,6 +1522,7 @@ export function heartbeatService(db: Db) {
   const executionWorkspacesSvc = executionWorkspaceService(db);
   const workspaceOperationsSvc = workspaceOperationService(db);
   const activeRunExecutions = new Set<string>();
+  const pendingTransientRetryTimers = new Set<ReturnType<typeof setTimeout>>();
   const budgetHooks = {
     cancelWorkForScope: cancelBudgetScopeWork,
   };
@@ -2608,6 +2609,302 @@ export function heartbeatService(db: Db) {
     return queued;
   }
 
+  async function enqueueTransientErrorRetry(
+    run: typeof heartbeatRuns.$inferSelect,
+    agent: typeof agents.$inferSelect,
+    nextRetryCount: number,
+  ) {
+    const contextSnapshot = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
+    const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
+    const originalWakeReason = readNonEmptyString(contextSnapshot.wakeReason);
+    const now = new Date();
+    const retryContextSnapshot = {
+      ...contextSnapshot,
+      retryOfRunId: run.id,
+      wakeReason: "transient_error_retry",
+      retryReason: "transient_error_retry",
+      transientRetryCount: nextRetryCount,
+      ...(originalWakeReason && !contextSnapshot.originalWakeReason
+        ? { originalWakeReason }
+        : {}),
+    };
+
+    const queued = await db.transaction(async (tx) => {
+      const wakeupRequest = await tx
+        .insert(agentWakeupRequests)
+        .values({
+          companyId: run.companyId,
+          agentId: run.agentId,
+          source: "automation",
+          triggerDetail: "system",
+          reason: "transient_error_retry",
+          payload: {
+            ...(issueId ? { issueId } : {}),
+            retryOfRunId: run.id,
+            transientRetryCount: nextRetryCount,
+          },
+          status: "queued",
+          requestedByActorType: "system",
+          requestedByActorId: null,
+          updatedAt: now,
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const retryRun = await tx
+        .insert(heartbeatRuns)
+        .values({
+          companyId: run.companyId,
+          agentId: run.agentId,
+          invocationSource: "automation",
+          triggerDetail: "system",
+          status: "queued",
+          wakeupRequestId: wakeupRequest.id,
+          contextSnapshot: retryContextSnapshot,
+          sessionIdBefore: sessionBefore,
+          retryOfRunId: run.id,
+          updatedAt: now,
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      await tx
+        .update(agentWakeupRequests)
+        .set({
+          runId: retryRun.id,
+          updatedAt: now,
+        })
+        .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+
+      if (issueId) {
+        await tx
+          .update(issues)
+          .set({
+            executionRunId: retryRun.id,
+            executionAgentNameKey: normalizeAgentNameKey(agent.name),
+            executionLockedAt: now,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(issues.id, issueId),
+              eq(issues.companyId, run.companyId),
+              isNull(issues.executionRunId),
+            ),
+          );
+      }
+
+      return retryRun;
+    });
+
+    publishLiveEvent({
+      companyId: queued.companyId,
+      type: "heartbeat.run.queued",
+      payload: {
+        runId: queued.id,
+        agentId: queued.agentId,
+        invocationSource: queued.invocationSource,
+        triggerDetail: queued.triggerDetail,
+        wakeupRequestId: queued.wakeupRequestId,
+      },
+    });
+
+    await appendRunEvent(queued, 1, {
+      eventType: "lifecycle",
+      stream: "system",
+      level: "warn",
+      message: `Queued automatic retry after transient error (consecutive failure #${nextRetryCount} for this agent-issue-errorCode)`,
+      payload: {
+        retryOfRunId: run.id,
+        transientRetryCount: nextRetryCount,
+        errorCode: run.errorCode,
+      },
+    });
+
+    return queued;
+  }
+
+  // Count consecutive failed runs with matching `errorCode` for the same
+  // (agent, issueId) pair since the most recent successful run for that pair.
+  // A success naturally resets the counter by advancing the lower bound.
+  async function countConsecutiveSameErrorCodeFailures(
+    companyId: string,
+    agentId: string,
+    issueId: string | null,
+    errorCode: string,
+  ): Promise<{ count: number; runIds: string[] }> {
+    const issueFilter = issueId
+      ? sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`
+      : sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' IS NULL`;
+
+    const lastSuccess = await db
+      .select({ createdAt: heartbeatRuns.createdAt })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.status, "succeeded"),
+          issueFilter,
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    const runs = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.status, "failed"),
+          eq(heartbeatRuns.errorCode, errorCode),
+          issueFilter,
+          lastSuccess ? gt(heartbeatRuns.createdAt, lastSuccess.createdAt) : sql`true`,
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.createdAt));
+
+    return { count: runs.length, runIds: runs.map((r) => r.id) };
+  }
+
+  function backoffDelayForFailureCount(failureCount: number): number | null {
+    if (failureCount < 1) return null;
+    if (failureCount > RETRY_BACKOFF_SCHEDULE_MS.length) return null;
+    return RETRY_BACKOFF_SCHEDULE_MS[failureCount - 1];
+  }
+
+  async function blockIssueForRetryExhaustion(
+    run: typeof heartbeatRuns.$inferSelect,
+    errorCode: string,
+    failureCount: number,
+    runIds: string[],
+  ) {
+    const contextSnapshot = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    if (!issueId) return false;
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!issue) return false;
+    if (issue.status === "blocked" || issue.status === "done" || issue.status === "cancelled") {
+      return false;
+    }
+
+    const retryHistory = runIds.slice(0, MAX_SAME_ERROR_RETRIES).join(", ");
+    const comment =
+      `Auto-blocked after ${failureCount} consecutive \`${errorCode}\` failures on this agent-issue pair — ` +
+      `exponential backoff exhausted, needs human review. Retry history: ${retryHistory}.`;
+
+    const previousStatus = issue.status;
+    const updated = await issuesSvc.update(issue.id, { status: "blocked" });
+    if (!updated) return false;
+
+    await issuesSvc.addComment(issue.id, comment, {});
+
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: null,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        identifier: issue.identifier,
+        status: "blocked",
+        previousStatus,
+        source: "heartbeat.retry_backoff_exhausted",
+        errorCode,
+        consecutiveFailures: failureCount,
+        retryRunIds: runIds.slice(0, MAX_SAME_ERROR_RETRIES),
+      },
+    });
+
+    return true;
+  }
+
+  // Schedule an auto-retry for a run that finalized with a retryable errorCode,
+  // using the exponential backoff schedule. Returns the outcome so callers can
+  // log appropriately. Retries are scoped per (agent, issue, errorCode) so
+  // different error codes don't accumulate together and a success for the same
+  // pair resets the counter.
+  async function maybeScheduleBackoffRetryOrBlock(
+    run: typeof heartbeatRuns.$inferSelect,
+    agent: typeof agents.$inferSelect,
+    errorCode: string,
+    kind: "process_lost" | "transient",
+  ): Promise<{
+    outcome: "retry_immediate" | "retry_deferred" | "blocked" | "skipped";
+    runId: string | null;
+    delayMs: number;
+    failureCount: number;
+  }> {
+    const contextSnapshot = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const { count, runIds } = await countConsecutiveSameErrorCodeFailures(
+      run.companyId,
+      run.agentId,
+      issueId,
+      errorCode,
+    );
+
+    const delayMs = backoffDelayForFailureCount(count);
+    if (delayMs === null) {
+      await blockIssueForRetryExhaustion(run, errorCode, count, runIds);
+      return { outcome: "blocked", runId: null, delayMs: 0, failureCount: count };
+    }
+
+    if (delayMs === 0) {
+      const queued = kind === "process_lost"
+        ? await enqueueProcessLossRetry(run, agent, new Date())
+        : await enqueueTransientErrorRetry(run, agent, count);
+      return {
+        outcome: "retry_immediate",
+        runId: queued?.id ?? null,
+        delayMs: 0,
+        failureCount: count,
+      };
+    }
+
+    scheduleBackoffRetry(run, agent, kind, count, delayMs);
+    return { outcome: "retry_deferred", runId: null, delayMs, failureCount: count };
+  }
+
+  function scheduleBackoffRetry(
+    run: typeof heartbeatRuns.$inferSelect,
+    agent: typeof agents.$inferSelect,
+    kind: "process_lost" | "transient",
+    failureCount: number,
+    delayMs: number,
+  ) {
+    const handle = setTimeout(() => {
+      pendingTransientRetryTimers.delete(handle);
+      const enqueueFn = kind === "process_lost"
+        ? () => enqueueProcessLossRetry(run, agent, new Date())
+        : () => enqueueTransientErrorRetry(run, agent, failureCount);
+      enqueueFn().catch((err) => {
+        logger.error(
+          { err, runId: run.id, agentId: agent.id, failureCount, kind },
+          "failed to enqueue backoff retry",
+        );
+      });
+    }, delayMs);
+    if (typeof handle === "object" && handle && typeof (handle as { unref?: () => void }).unref === "function") {
+      (handle as { unref: () => void }).unref();
+    }
+    pendingTransientRetryTimers.add(handle);
+  }
+
   function parseHeartbeatPolicy(agent: typeof agents.$inferSelect) {
     const runtimeConfig = parseObject(agent.runtimeConfig);
     const heartbeat = parseObject(runtimeConfig.heartbeat);
@@ -2818,49 +3115,73 @@ export function heartbeatService(db: Db) {
         });
       }
 
-      const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
+      const eligibleForRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId);
       const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
 
       let finalizedRun = await setRunStatus(run.id, "failed", {
-        error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+        error: baseMessage,
         errorCode: "process_lost",
         finishedAt: now,
       });
       await setWakeupStatus(run.wakeupRequestId, "failed", {
         finishedAt: now,
-        error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+        error: baseMessage,
       });
       if (!finalizedRun) finalizedRun = await getRun(run.id);
       if (!finalizedRun) continue;
 
-      let retriedRun: typeof heartbeatRuns.$inferSelect | null = null;
-      if (shouldRetry) {
+      let retryResult:
+        | Awaited<ReturnType<typeof maybeScheduleBackoffRetryOrBlock>>
+        | null = null;
+      if (eligibleForRetry) {
         const agent = await getAgent(run.agentId);
         if (agent) {
-          retriedRun = await enqueueProcessLossRetry(finalizedRun, agent, now);
+          retryResult = await maybeScheduleBackoffRetryOrBlock(
+            finalizedRun,
+            agent,
+            "process_lost",
+            "process_lost",
+          );
         }
-      } else {
+      }
+
+      if (!retryResult || retryResult.outcome === "blocked" || retryResult.outcome === "skipped") {
         await releaseIssueExecutionAndPromote(finalizedRun);
       }
+
+      const retryMessage = (() => {
+        if (!retryResult) return baseMessage;
+        switch (retryResult.outcome) {
+          case "retry_immediate":
+            return `${baseMessage}; queued retry ${retryResult.runId ?? ""}`.trim();
+          case "retry_deferred":
+            return `${baseMessage}; scheduled retry in ${Math.round(retryResult.delayMs / 1000)}s (consecutive failure #${retryResult.failureCount})`;
+          case "blocked":
+            return `${baseMessage}; auto-blocked issue after ${retryResult.failureCount} consecutive process_lost failures`;
+          default:
+            return baseMessage;
+        }
+      })();
 
       await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
         eventType: "lifecycle",
         stream: "system",
         level: "error",
-        message: shouldRetry
-          ? `${baseMessage}; queued retry ${retriedRun?.id ?? ""}`.trim()
-          : baseMessage,
+        message: retryMessage,
         payload: {
           ...(run.processPid ? { processPid: run.processPid } : {}),
           ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
           ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
-          ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
+          ...(retryResult?.runId ? { retryRunId: retryResult.runId } : {}),
+          ...(retryResult ? { retryOutcome: retryResult.outcome, retryFailureCount: retryResult.failureCount } : {}),
         },
       });
 
       // When process_lost retries are exhausted, the agent itself is fine —
       // it was a transient child process death. Reset to idle, not error.
-      const processLostRetriesExhausted = tracksLocalChild && !!run.processPid && !shouldRetry;
+      const retriedOrDeferred =
+        retryResult?.outcome === "retry_immediate" || retryResult?.outcome === "retry_deferred";
+      const processLostRetriesExhausted = tracksLocalChild && !!run.processPid && !retriedOrDeferred;
       await finalizeAgentStatus(run.agentId, processLostRetriesExhausted ? "cancelled" : "failed");
       await startNextQueuedRunForAgent(run.agentId);
       runningProcesses.delete(run.id);
@@ -3020,10 +3341,29 @@ export function heartbeatService(db: Db) {
     return queued;
   }
 
-  // Error codes that represent transient failures (e.g. subscription quota).
-  // When the latest recovery run failed with one of these, we skip escalation
-  // to `blocked` and let the normal heartbeat cycle retry after the window resets.
-  const TRANSIENT_ERROR_CODES = new Set(["rate_limited", "timeout"]);
+  // Error codes that represent transient failures (e.g. subscription quota,
+  // OAuth refresh hiccup). When the latest recovery run failed with one of
+  // these, we skip escalation to `blocked` and let the normal heartbeat cycle
+  // retry after the window resets.
+  const TRANSIENT_ERROR_CODES = new Set(["rate_limited", "timeout", "claude_auth_required"]);
+
+  // Error codes produced by the adapter execution path that should trigger an
+  // in-process auto-retry when the run finalizes with them. These are transient
+  // failures (e.g. an OAuth token rotation race) where a fresh attempt often
+  // succeeds. `process_lost` has its own retry path in `reapOrphanedRuns` and
+  // is intentionally not listed here. Retries for both are gated by the
+  // exponential backoff helper so sustained failures don't burn spend in a
+  // tight loop. See SHA-1868, SHA-1891.
+  const AUTO_RETRY_ERROR_CODES = new Set(["claude_auth_required"]);
+
+  // Exponential backoff schedule for consecutive same-`errorCode` failures
+  // scoped to a single (agent, issue) pair. The N-th consecutive failure
+  // schedules retry #N with delay `RETRY_BACKOFF_SCHEDULE_MS[N-1]`. Once the
+  // count exceeds the schedule length we stop retrying and auto-block the
+  // issue for human review (SHA-1866-style). A successful run for the same
+  // (agent, issue) pair naturally resets the counter (query-bound). See SHA-1891.
+  const RETRY_BACKOFF_SCHEDULE_MS = [0, 30_000, 120_000, 480_000];
+  const MAX_SAME_ERROR_RETRIES = RETRY_BACKOFF_SCHEDULE_MS.length + 1;
 
   async function escalateStrandedAssignedIssue(input: {
     issue: typeof issues.$inferSelect;
@@ -4155,6 +4495,19 @@ export function heartbeatService(db: Db) {
         }
         await finalizeIssueCommentPolicy(finalizedRun, agent);
         await releaseIssueExecutionAndPromote(finalizedRun);
+
+        if (
+          outcome === "failed" &&
+          adapterResult.errorCode &&
+          AUTO_RETRY_ERROR_CODES.has(adapterResult.errorCode)
+        ) {
+          await maybeScheduleBackoffRetryOrBlock(
+            finalizedRun,
+            agent,
+            adapterResult.errorCode,
+            "transient",
+          );
+        }
       }
 
       if (finalizedRun) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2980,6 +2980,11 @@ export function heartbeatService(db: Db) {
     return queued;
   }
 
+  // Error codes that represent transient failures (e.g. subscription quota).
+  // When the latest recovery run failed with one of these, we skip escalation
+  // to `blocked` and let the normal heartbeat cycle retry after the window resets.
+  const TRANSIENT_ERROR_CODES = new Set(["rate_limited", "timeout"]);
+
   async function escalateStrandedAssignedIssue(input: {
     issue: typeof issues.$inferSelect;
     previousStatus: "todo" | "in_progress";
@@ -2989,6 +2994,13 @@ export function heartbeatService(db: Db) {
     > | null;
     comment: string;
   }) {
+    // Don't escalate when the failure is transient — the issue will be
+    // picked up again on the next heartbeat cycle after the rate-limit /
+    // timeout window resets.
+    if (input.latestRun?.errorCode && TRANSIENT_ERROR_CODES.has(input.latestRun.errorCode)) {
+      return null;
+    }
+
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
     });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2906,6 +2906,46 @@ export function heartbeatService(db: Db) {
       .then((rows) => rows[0] ?? null);
   }
 
+  // Cap how many `issue_continuation_needed` wakes may fire for a single issue
+  // before we escalate to `blocked` for human review. The counter resets when
+  // the assignee posts a comment (treated as proof of progress). See SHA-1866.
+  const MAX_CONTINUATION_RETRIES = 3;
+
+  async function countContinuationRetriesSinceLastAssigneeComment(
+    companyId: string,
+    issueId: string,
+    assigneeAgentId: string,
+  ): Promise<{ count: number; runIds: string[] }> {
+    const lastComment = await db
+      .select({ createdAt: issueComments.createdAt })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, companyId),
+          eq(issueComments.issueId, issueId),
+          eq(issueComments.authorAgentId, assigneeAgentId),
+        ),
+      )
+      .orderBy(desc(issueComments.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    const runs = await db
+      .select({ id: heartbeatRuns.id, createdAt: heartbeatRuns.createdAt })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+          sql`${heartbeatRuns.contextSnapshot} ->> 'retryReason' = 'issue_continuation_needed'`,
+          lastComment ? gt(heartbeatRuns.createdAt, lastComment.createdAt) : sql`true`,
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.createdAt));
+
+    return { count: runs.length, runIds: runs.map((r) => r.id) };
+  }
+
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
     const [run, deferredWake] = await Promise.all([
       db
@@ -3120,16 +3160,22 @@ export function heartbeatService(db: Db) {
         continue;
       }
 
-      if (latestRetryReason === "issue_continuation_needed") {
+      const continuation = await countContinuationRetriesSinceLastAssigneeComment(
+        issue.companyId,
+        issue.id,
+        agentId,
+      );
+
+      if (continuation.count >= MAX_CONTINUATION_RETRIES) {
         const failureSummary = summarizeRunFailureForIssueComment(latestRun);
+        const retryHistory = continuation.runIds.slice(0, MAX_CONTINUATION_RETRIES).join(", ");
         const updated = await escalateStrandedAssignedIssue({
           issue,
           previousStatus: "in_progress",
           latestRun,
           comment:
-            "Paperclip automatically retried continuation for this assigned `in_progress` issue after its live " +
-            `execution disappeared, but it still has no live execution path.${failureSummary ?? ""} ` +
-            "Moving it to `blocked` so it is visible for intervention.",
+            `Auto-blocked after ${continuation.count} continuation retries without agent comment progress — ` +
+            `needs human review.${failureSummary ?? ""} Retry history: ${retryHistory}.`,
         });
         if (updated) {
           result.escalated += 1;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2836,7 +2836,10 @@ export function heartbeatService(db: Db) {
         },
       });
 
-      await finalizeAgentStatus(run.agentId, "failed");
+      // When process_lost retries are exhausted, the agent itself is fine —
+      // it was a transient child process death. Reset to idle, not error.
+      const processLostRetriesExhausted = tracksLocalChild && !!run.processPid && !shouldRetry;
+      await finalizeAgentStatus(run.agentId, processLostRetriesExhausted ? "cancelled" : "failed");
       await startNextQueuedRunForAgent(run.agentId);
       runningProcesses.delete(run.id);
       reaped.push(run.id);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -971,11 +971,23 @@ function deriveTaskKey(
  * The synthetic key is only used when:
  * - No explicit task/issue key exists in the context
  * - The wake source is "timer" (scheduled heartbeat)
+ *
+ * Routine-dispatched wakes (source === "routine.dispatch") also use a
+ * stable task key so that successive fires of the same routine reuse the
+ * same Claude session instead of starting fresh each time.
  */
 export function deriveTaskKeyWithHeartbeatFallback(
   contextSnapshot: Record<string, unknown> | null | undefined,
   payload: Record<string, unknown> | null | undefined,
 ) {
+  const source = readNonEmptyString(contextSnapshot?.source);
+  if (source === "routine.dispatch") {
+    // Routine-dispatched wakes create a new issue per fire, but the agent
+    // should reuse its session across fires.  Use the heartbeat task key
+    // so all routine fires share the same session slot.
+    return HEARTBEAT_TASK_KEY;
+  }
+
   const explicit = deriveTaskKey(contextSnapshot, payload);
   if (explicit) return explicit;
 
@@ -997,6 +1009,12 @@ export function shouldResetTaskSessionForWake(
     wakeReason === "execution_approval_requested" ||
     wakeReason === "execution_changes_requested"
   ) {
+    // Routine-dispatched wakes create a fresh issue per fire but should
+    // reuse the existing session so agents accumulate context across runs.
+    if (wakeReason === "issue_assigned") {
+      const source = readNonEmptyString(contextSnapshot?.source);
+      if (source === "routine.dispatch") return false;
+    }
     return true;
   }
   return false;
@@ -1027,7 +1045,11 @@ function describeSessionResetReason(
   if (contextSnapshot?.forceFreshSession === true) return "forceFreshSession was requested";
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
-  if (wakeReason === "issue_assigned") return "wake reason is issue_assigned";
+  if (wakeReason === "issue_assigned") {
+    const source = readNonEmptyString(contextSnapshot?.source);
+    if (source === "routine.dispatch") return null;
+    return "wake reason is issue_assigned";
+  }
   if (wakeReason === "execution_review_requested") return "wake reason is execution_review_requested";
   if (wakeReason === "execution_approval_requested") return "wake reason is execution_approval_requested";
   if (wakeReason === "execution_changes_requested") return "wake reason is execution_changes_requested";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3267,8 +3267,13 @@ export function heartbeatService(db: Db) {
     return { count: runs.length, runIds: runs.map((r) => r.id) };
   }
 
+  // Grace window after an agent-initiated pause's resumeAt before the reconciler
+  // stops treating the pause as an active execution path. Covers scheduler drift
+  // between the agent's ScheduleWakeup fire and the next heartbeat cycle.
+  const AGENT_PAUSE_GRACE_MS = 60_000;
+
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
-    const [run, deferredWake] = await Promise.all([
+    const [run, deferredWake, agentPause] = await Promise.all([
       db
         .select({ id: heartbeatRuns.id })
         .from(heartbeatRuns)
@@ -3293,9 +3298,22 @@ export function heartbeatService(db: Db) {
         )
         .limit(1)
         .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: agentWakeupRequests.id })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.status, "deferred_agent_pause"),
+            sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+            sql`(${agentWakeupRequests.payload} ->> 'resumeAt')::timestamptz + make_interval(secs => ${AGENT_PAUSE_GRACE_MS / 1000}) > now()`,
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
     ]);
 
-    return Boolean(run || deferredWake);
+    return Boolean(run || deferredWake || agentPause);
   }
 
   async function enqueueStrandedIssueRecovery(input: {
@@ -3409,6 +3427,42 @@ export function heartbeatService(db: Db) {
     });
 
     return updated;
+  }
+
+  // Agent-initiated pause for an issue currently under execution. Records a
+  // `deferred_agent_pause` wakeup so the reconciler can distinguish an
+  // intentional ScheduleWakeup-style pause from a process-lost run. See
+  // SHA-1873.
+  async function deferIssueExecution(input: {
+    companyId: string;
+    issueId: string;
+    agentId: string;
+    resumeAt: Date;
+    reason?: string | null;
+    requestedByActorType?: "user" | "agent" | "system" | null;
+    requestedByActorId?: string | null;
+  }) {
+    const now = new Date();
+    const [row] = await db
+      .insert(agentWakeupRequests)
+      .values({
+        companyId: input.companyId,
+        agentId: input.agentId,
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_execution_deferred_by_agent",
+        payload: {
+          issueId: input.issueId,
+          resumeAt: input.resumeAt.toISOString(),
+          ...(input.reason ? { deferReason: input.reason } : {}),
+        },
+        status: "deferred_agent_pause",
+        requestedByActorType: input.requestedByActorType ?? null,
+        requestedByActorId: input.requestedByActorId ?? null,
+        requestedAt: now,
+      })
+      .returning();
+    return row;
   }
 
   async function reconcileStrandedAssignedIssues() {
@@ -5760,6 +5814,8 @@ export function heartbeatService(db: Db) {
     resumeQueuedRuns,
 
     reconcileStrandedAssignedIssues,
+
+    deferIssueExecution,
 
     tickTimers: async (now = new Date()) => {
       const allAgents = await db.select().from(agents);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4485,6 +4485,31 @@ export function heartbeatService(db: Db) {
         adapterResult.summary ?? null,
       );
 
+      // Persist the task-session BEFORE finalizing the run. releaseIssueExecutionAndPromote
+      // (called from the finalized-run block below) may immediately queue a next wake, and
+      // that wake's resolveSessionBeforeForWakeup reads agent_task_sessions. If we finalized
+      // first, a wake fired between setRunStatus and upsertTaskSession would miss the fresh
+      // session and start a new one. See SHA-1903.
+      if (taskKey) {
+        if (adapterResult.clearSession || (!nextSessionState.params && !nextSessionState.displayId)) {
+          await clearTaskSessions(agent.companyId, agent.id, {
+            taskKey,
+            adapterType: agent.adapterType,
+          });
+        } else {
+          await upsertTaskSession({
+            companyId: agent.companyId,
+            agentId: agent.id,
+            adapterType: agent.adapterType,
+            taskKey,
+            sessionParamsJson: nextSessionState.params,
+            sessionDisplayId: nextSessionState.displayId,
+            lastRunId: run.id,
+            lastError: outcome === "succeeded" ? null : (adapterResult.errorMessage ?? "run_failed"),
+          });
+        }
+      }
+
       await setRunStatus(run.id, status, {
         finishedAt: new Date(),
         error:
@@ -4568,25 +4593,6 @@ export function heartbeatService(db: Db) {
         await updateRuntimeState(agent, finalizedRun, adapterResult, {
           legacySessionId: nextSessionState.legacySessionId,
         }, normalizedUsage);
-        if (taskKey) {
-          if (adapterResult.clearSession || (!nextSessionState.params && !nextSessionState.displayId)) {
-            await clearTaskSessions(agent.companyId, agent.id, {
-              taskKey,
-              adapterType: agent.adapterType,
-            });
-          } else {
-            await upsertTaskSession({
-              companyId: agent.companyId,
-              agentId: agent.id,
-              adapterType: agent.adapterType,
-              taskKey,
-              sessionParamsJson: nextSessionState.params,
-              sessionDisplayId: nextSessionState.displayId,
-              lastRunId: finalizedRun.id,
-              lastError: outcome === "succeeded" ? null : (adapterResult.errorMessage ?? "run_failed"),
-            });
-          }
-        }
       }
       await finalizeAgentStatus(agent.id, outcome);
     } catch (err) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2092,15 +2092,20 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        // postgres@3.4.8 can't bind Date in sql template literals (throws
+        // "The \"string\" argument must be of type string... Received an instance of Date").
+        // Serialize to ISO string — Postgres accepts it for timestamptz columns.
+        const anchorCreatedAt =
+          anchor.createdAt instanceof Date ? anchor.createdAt.toISOString() : anchor.createdAt;
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1777,6 +1777,22 @@ export function issueService(db: Db) {
       }),
 
     checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
+      // Validate checkoutRunId references an existing heartbeat_run before attempting
+      // to write it as a foreign key. A stale/reaped runId would cause the issues
+      // table update to fail with FK constraint violation ("issues_checkout_run_id_heartbeat_runs_id_fk"),
+      // putting agents with an orphaned runId into a retry loop.
+      if (checkoutRunId) {
+        const runExists = await db
+          .select({ id: heartbeatRuns.id })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, checkoutRunId))
+          .limit(1)
+          .then((rows) => rows.length > 0);
+        if (!runExists) {
+          throw conflict("Checkout run no longer exists; agent should request a fresh heartbeat");
+        }
+      }
+
       const issueCompany = await db
         .select({ companyId: issues.companyId })
         .from(issues)

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -750,6 +750,35 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
         ? nextCronTickInTimeZone(input.trigger.cronExpression, input.trigger.timezone, triggeredAt)
         : undefined;
 
+      // Skip issue creation — fire heartbeat directly
+      if (input.routine.skipIssueCreation) {
+        await heartbeat.wakeup(input.routine.assigneeAgentId!, {
+          source: "timer",
+          triggerDetail: "system",
+          reason: "routine_heartbeat",
+          payload: { routineId: input.routine.id, routineTitle: input.routine.title },
+          requestedByActorType: "system",
+          contextSnapshot: {
+            source: "routine.dispatch",
+            wakeReason: "routine_heartbeat",
+            routineId: input.routine.id,
+            routineTitle: input.routine.title,
+          },
+        });
+        const updated = await finalizeRun(createdRun.id, {
+          status: "completed",
+          completedAt: new Date(),
+        }, txDb);
+        await updateRoutineTouchedState({
+          routineId: input.routine.id,
+          triggerId: input.trigger?.id ?? null,
+          triggeredAt,
+          status: "completed",
+          nextRunAt,
+        }, txDb);
+        return updated ?? createdRun;
+      }
+
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
         const activeIssue = await findLiveExecutionIssue(input.routine, txDb);

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -746,9 +746,11 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
         })
         .returning();
 
-      const nextRunAt = input.trigger?.kind === "schedule" && input.trigger.cronExpression && input.trigger.timezone
-        ? nextCronTickInTimeZone(input.trigger.cronExpression, input.trigger.timezone, triggeredAt)
-        : undefined;
+      // nextRunAt is owned by tickScheduledTriggers (scheduled fires) and
+      // createTrigger/updateTrigger (CRUD). Dispatch must not write it —
+      // doing so can overwrite the scheduler's freshly-claimed value with a
+      // stale computation (race from slow transactions or enqueue_missed_with_cap)
+      // and can corrupt the cron schedule on manual/webhook fires.
 
       // Skip issue creation — fire heartbeat directly
       if (input.routine.skipIssueCreation) {
@@ -774,7 +776,6 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
           triggerId: input.trigger?.id ?? null,
           triggeredAt,
           status: "completed",
-          nextRunAt,
         }, txDb);
         return updated ?? createdRun;
       }
@@ -796,7 +797,6 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
             triggeredAt,
             status,
             issueId: activeIssue.id,
-            nextRunAt,
           }, txDb);
           return updated ?? createdRun;
         }
@@ -845,7 +845,6 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
             triggeredAt,
             status,
             issueId: existingIssue.id,
-            nextRunAt,
           }, txDb);
           return updated ?? createdRun;
         }
@@ -870,7 +869,6 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
           triggeredAt,
           status: "issue_created",
           issueId: createdIssue.id,
-          nextRunAt,
         }, txDb);
         return updated ?? createdRun;
       } catch (error) {
@@ -888,7 +886,6 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
           triggerId: input.trigger?.id ?? null,
           triggeredAt,
           status: "failed",
-          nextRunAt,
         }, txDb);
         return failed ?? createdRun;
       }

--- a/ui/src/api/costs.ts
+++ b/ui/src/api/costs.ts
@@ -10,6 +10,7 @@ import type {
   FinanceByBiller,
   FinanceByKind,
   FinanceEvent,
+  IssueCostSummary,
   ProviderQuotaResult,
 } from "@paperclipai/shared";
 import { api } from "./client";
@@ -47,6 +48,10 @@ export const costsApi = {
     api.get<CostWindowSpendRow[]>(`/companies/${companyId}/costs/window-spend`),
   quotaWindows: (companyId: string) =>
     api.get<ProviderQuotaResult[]>(`/companies/${companyId}/costs/quota-windows`),
+  issueSummary: (companyId: string, issueIdOrIdentifier: string) =>
+    api.get<IssueCostSummary>(
+      `/companies/${companyId}/issues/${issueIdOrIdentifier}/cost-summary`,
+    ),
 };
 
 function dateParamsWithLimit(from?: string, to?: string, limit?: number): string {

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -166,4 +166,14 @@ export const issuesApi = {
   updateWorkProduct: (id: string, data: Record<string, unknown>) =>
     api.patch<IssueWorkProduct>(`/work-products/${id}`, data),
   deleteWorkProduct: (id: string) => api.delete<IssueWorkProduct>(`/work-products/${id}`),
+  approveMerge: (id: string, decisionNote?: string) =>
+    api.post<{ issue: Issue; comment: IssueComment }>(
+      `/issues/${id}/approve-merge`,
+      { decisionNote },
+    ),
+  requestChanges: (id: string, decisionNote?: string) =>
+    api.post<{ issue: Issue; comment: IssueComment }>(
+      `/issues/${id}/request-changes`,
+      { decisionNote },
+    ),
 };

--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -18,6 +18,12 @@ function isRunActive(run: LiveRunForIssue): boolean {
   return run.status === "queued" || run.status === "running";
 }
 
+// SharpAPI dashboard: only show currently-running runs (plus finished-filler).
+// Queued runs are hidden — they're just "about to start" and clutter the panel.
+function isRunVisibleOnDashboard(run: LiveRunForIssue): boolean {
+  return run.status !== "queued";
+}
+
 interface ActiveAgentsPanelProps {
   companyId: string;
 }
@@ -28,7 +34,10 @@ export function ActiveAgentsPanel({ companyId }: ActiveAgentsPanelProps) {
     queryFn: () => heartbeatsApi.liveRunsForCompany(companyId, MIN_DASHBOARD_RUNS),
   });
 
-  const runs = liveRuns ?? [];
+  const runs = useMemo(
+    () => (liveRuns ?? []).filter(isRunVisibleOnDashboard),
+    [liveRuns],
+  );
   const { data: issues } = useQuery({
     queryKey: [...queryKeys.issues.list(companyId), "with-routine-executions"],
     queryFn: () => issuesApi.list(companyId, { includeRoutineExecutions: true }),

--- a/ui/src/components/IssueCostStrip.tsx
+++ b/ui/src/components/IssueCostStrip.tsx
@@ -1,0 +1,81 @@
+import { useQuery } from "@tanstack/react-query";
+import type { IssueCostSummary } from "@paperclipai/shared";
+import { DollarSign } from "lucide-react";
+import { costsApi } from "../api/costs";
+import { queryKeys } from "../lib/queryKeys";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function formatUsd(cents: number): string {
+  const usd = cents / 100;
+  if (usd < 0.01) return "$0.00";
+  if (usd < 10) return `$${usd.toFixed(2)}`;
+  return `$${usd.toFixed(0)}`;
+}
+
+interface IssueCostStripProps {
+  companyId: string;
+  issueId: string;
+  /** Identifier (e.g. SHA-1897) when available; fallback to raw UUID. */
+  issueIdentifier?: string | null;
+}
+
+export function IssueCostStrip({ companyId, issueId, issueIdentifier }: IssueCostStripProps) {
+  const key = issueIdentifier ?? issueId;
+  const { data, isLoading, isError } = useQuery<IssueCostSummary>({
+    queryKey: queryKeys.issues.costSummary(companyId, key),
+    queryFn: () => costsApi.issueSummary(companyId, key),
+    staleTime: 30_000,
+  });
+
+  if (isError) return null;
+  if (isLoading && !data) {
+    return (
+      <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+        <DollarSign className="h-3.5 w-3.5" />
+        <Skeleton className="h-3 w-40" />
+      </div>
+    );
+  }
+  if (!data || data.totalCostCents === 0) return null;
+
+  const agentCount = data.topContributors.length;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-1.5 text-[11px] text-muted-foreground hover:text-foreground transition-colors rounded-md px-1.5 py-0.5 -mx-1.5 hover:bg-muted/60"
+          title="Click for per-agent breakdown"
+        >
+          <DollarSign className="h-3.5 w-3.5" />
+          <span className="font-medium text-foreground">{formatUsd(data.totalCostCents)}</span>
+          <span>·</span>
+          <span>{data.runs} {data.runs === 1 ? "run" : "runs"}</span>
+          <span>·</span>
+          <span>{agentCount} {agentCount === 1 ? "agent" : "agents"}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-72 p-0">
+        <div className="px-3 py-2 border-b">
+          <div className="text-xs font-medium">Cost breakdown</div>
+          <div className="text-[11px] text-muted-foreground">
+            {formatUsd(data.totalCostCents)} across {data.runs} {data.runs === 1 ? "run" : "runs"}
+          </div>
+        </div>
+        <ul className="max-h-80 overflow-auto divide-y">
+          {data.topContributors.map((c) => (
+            <li key={c.agentId} className="flex items-center gap-2 px-3 py-1.5 text-xs">
+              <span className="truncate flex-1">{c.agentName ?? "(unknown agent)"}</span>
+              <span className="tabular-nums text-muted-foreground">{c.runs}×</span>
+              <span className="tabular-nums font-medium w-14 text-right">
+                {formatUsd(c.costCents)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   DollarSign,
   History,
   Search,
+  ShieldCheck,
   SquarePen,
   Network,
   Boxes,
@@ -19,6 +20,7 @@ import { SidebarProjects } from "./SidebarProjects";
 import { SidebarAgents } from "./SidebarAgents";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
+import { approvalsApi } from "../api/approvals";
 import { heartbeatsApi } from "../api/heartbeats";
 import { queryKeys } from "../lib/queryKeys";
 import { useInboxBadge } from "../hooks/useInboxBadge";
@@ -38,6 +40,13 @@ export function Sidebar() {
     refetchInterval: 10_000,
   });
   const liveRunCount = liveRuns?.length ?? 0;
+  const { data: pendingApprovals } = useQuery({
+    queryKey: queryKeys.approvals.list(selectedCompanyId!, "pending"),
+    queryFn: () => approvalsApi.list(selectedCompanyId!, "pending"),
+    enabled: !!selectedCompanyId,
+    refetchInterval: 30_000,
+  });
+  const pendingApprovalCount = pendingApprovals?.length ?? 0;
 
   function openSearch() {
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true }));
@@ -100,6 +109,13 @@ export function Sidebar() {
           <SidebarNavItem to="/issues" label="Issues" icon={CircleDot} />
           <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
           <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+          <SidebarNavItem
+            to="/approvals/pending"
+            label="Approvals"
+            icon={ShieldCheck}
+            badge={pendingApprovalCount > 0 ? pendingApprovalCount : undefined}
+            badgeTone={pendingApprovalCount > 0 ? "danger" : "default"}
+          />
         </SidebarSection>
 
         <SidebarProjects />

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -25,6 +25,7 @@ import { useInboxBadge } from "../hooks/useInboxBadge";
 import { Button } from "@/components/ui/button";
 import { PluginSlotOutlet } from "@/plugins/slots";
 import { SidebarCompanyMenu } from "./SidebarCompanyMenu";
+import { PluginLauncherOutlet } from "@/plugins/launchers";
 
 export function Sidebar() {
   const { openNewIssue } = useDialog();
@@ -87,6 +88,11 @@ export function Sidebar() {
             className="flex flex-col gap-0.5"
             itemClassName="text-[13px] font-medium"
             missingBehavior="placeholder"
+          />
+          <PluginLauncherOutlet
+            placementZones={["sidebar"]}
+            context={pluginContext}
+            className="flex flex-col gap-0.5"
           />
         </div>
 

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -385,7 +385,7 @@ async function hydrateVisibleIssueComment(
   }
 }
 
-const ISSUE_TOAST_ACTIONS = new Set(["issue.created", "issue.updated", "issue.comment_added"]);
+const ISSUE_TOAST_ACTIONS = new Set(["issue.created", "issue.updated", "issue.comment_added", "issue.merge_approved", "issue.changes_requested"]);
 const AGENT_TOAST_STATUSES = new Set(["error"]);
 const RUN_TOAST_STATUSES = new Set(["failed", "timed_out", "cancelled"]);
 
@@ -443,12 +443,33 @@ function buildActivityToast(
     };
   }
 
+  if (action === "issue.merge_approved") {
+    return {
+      title: `Merge approved on ${issue.ref}`,
+      body: issue.title ? truncate(issue.title, 96) : undefined,
+      tone: "success",
+      action: { label: `View ${issue.ref}`, href: issue.href },
+      dedupeKey: `activity:${action}:${entityId}`,
+    };
+  }
+
+  if (action === "issue.changes_requested") {
+    return {
+      title: `Changes requested on ${issue.ref}`,
+      body: issue.title ? truncate(issue.title, 96) : undefined,
+      tone: "warn",
+      action: { label: `View ${issue.ref}`, href: issue.href },
+      dedupeKey: `activity:${action}:${entityId}`,
+    };
+  }
+
   if (action === "issue.updated") {
     if (readString(details?.source) === "comment") {
       // Comment-driven updates emit a paired comment event; show one combined toast on the comment event.
       return null;
     }
     const changeDesc = describeIssueUpdate(details);
+    const isReviewReady = details?.status === "in_review";
     const body = changeDesc
       ? issue.title
         ? `${truncate(issue.title, 64)} - ${changeDesc}`
@@ -457,9 +478,9 @@ function buildActivityToast(
         ? truncate(issue.title, 96)
         : issue.label;
     return {
-      title: `${actor} updated ${issue.ref}`,
+      title: isReviewReady ? `${issue.ref} ready for review` : `${actor} updated ${issue.ref}`,
       body: truncate(body, 100),
-      tone: "info",
+      tone: isReviewReady ? "warn" : "info",
       action: { label: `View ${issue.ref}`, href: issue.href },
       dedupeKey: `activity:${action}:${entityId}`,
     };

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -55,6 +55,8 @@ export const queryKeys = {
     liveRuns: (issueId: string) => ["issues", "live-runs", issueId] as const,
     activeRun: (issueId: string) => ["issues", "active-run", issueId] as const,
     workProducts: (issueId: string) => ["issues", "work-products", issueId] as const,
+    costSummary: (companyId: string, issueIdOrIdentifier: string) =>
+      ["issues", "cost-summary", companyId, issueIdOrIdentifier] as const,
   },
   routines: {
     list: (companyId: string) => ["routines", companyId] as const,

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1320,7 +1320,8 @@ export function IssueDetail() {
   const approveMerge = useMutation({
     mutationFn: () => issuesApi.approveMerge(issueId!),
     onSuccess: () => {
-      invalidateIssue();
+      invalidateIssueDetail();
+      invalidateIssueRunState();
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.comments(issueId!) });
     },
   });
@@ -1328,7 +1329,8 @@ export function IssueDetail() {
   const requestChanges = useMutation({
     mutationFn: () => issuesApi.requestChanges(issueId!),
     onSuccess: () => {
-      invalidateIssue();
+      invalidateIssueDetail();
+      invalidateIssueRunState();
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.comments(issueId!) });
     },
   });

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1317,6 +1317,22 @@ export function IssueDetail() {
     },
   });
 
+  const approveMerge = useMutation({
+    mutationFn: () => issuesApi.approveMerge(issueId!),
+    onSuccess: () => {
+      invalidateIssue();
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.comments(issueId!) });
+    },
+  });
+
+  const requestChanges = useMutation({
+    mutationFn: () => issuesApi.requestChanges(issueId!),
+    onSuccess: () => {
+      invalidateIssue();
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.comments(issueId!) });
+    },
+  });
+
   const addComment = useMutation({
     mutationFn: ({ body, reopen, interrupt }: { body: string; reopen?: boolean; interrupt?: boolean }) =>
       issuesApi.addComment(issueId!, body, reopen, interrupt),
@@ -2336,6 +2352,28 @@ export function IssueDetail() {
             </Popover>
           </div>
         </div>
+
+        {issue.status === "in_review" && issue.assigneeAgentId && (
+          <div className="flex items-center gap-2 rounded-lg border border-violet-300 dark:border-violet-700/40 bg-violet-50 dark:bg-violet-900/20 px-3 py-2">
+            <span className="text-sm text-violet-800 dark:text-violet-200 mr-auto">Ready for review</span>
+            <Button
+              size="sm"
+              className="bg-green-700 hover:bg-green-600 text-white"
+              onClick={() => approveMerge.mutate()}
+              disabled={approveMerge.isPending || requestChanges.isPending}
+            >
+              {approveMerge.isPending ? "Approving\u2026" : "Approve Merge"}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => requestChanges.mutate()}
+              disabled={approveMerge.isPending || requestChanges.isPending}
+            >
+              {requestChanges.isPending ? "Sending\u2026" : "Request Changes"}
+            </Button>
+          </div>
+        )}
 
         <InlineEditor
           value={issue.title}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -63,6 +63,7 @@ import { IssueDocumentsSection } from "../components/IssueDocumentsSection";
 import { IssuesList } from "../components/IssuesList";
 import { IssueProperties } from "../components/IssueProperties";
 import { IssueWorkspaceCard } from "../components/IssueWorkspaceCard";
+import { IssueCostStrip } from "../components/IssueCostStrip";
 import type { MentionOption } from "../components/MarkdownEditor";
 import { ImageGalleryModal } from "../components/ImageGalleryModal";
 import { ScrollToBottom } from "../components/ScrollToBottom";
@@ -2382,6 +2383,12 @@ export function IssueDetail() {
           onSave={(title) => updateIssue.mutateAsync({ title })}
           as="h2"
           className="text-xl font-bold"
+        />
+
+        <IssueCostStrip
+          companyId={issue.companyId}
+          issueId={issue.id}
+          issueIdentifier={issue.identifier ?? null}
         />
 
         <InlineEditor


### PR DESCRIPTION
## Summary

- Race: `setRunStatus` wrote `session_id_after` (and `finishedAt`) before `upsertTaskSession` persisted the new session. A next wake that fired in between — e.g. a deferred promotion from `releaseIssueExecutionAndPromote`, which is invoked from the finalized-run block — would read `agent_task_sessions`, see no fresh row, and start a new session.
- Fix: move the `upsertTaskSession` / `clearTaskSessions` call for the success path to **before** `setRunStatus`, so any observer of the finalized run also sees the persisted task-session.

## Repro evidence

QA, 2026-04-18 16:14→16:17. Prior run finished at 16:17:22.348 with `session_id_after=da147a4a…`. Next wake's `created_at=16:17:22.388` (40ms later). Next run's `session_id_before` was NULL — the fresh session was not picked up.

Rescues an estimated 1–3 lost sessions per day and closes a genuinely unsafe ordering.

## Test plan

- [x] Typecheck passes (`bunx tsc --noEmit`)
- [x] `heartbeat-workspace-session.test.ts` passes (35/35)
- [ ] Post-merge: watch `session_id_before IS NULL` when `session_id_after` was set on the prior run — should trend to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)