### PR TITLE
fix(agents): coerce pauseReason in updateAgent (SHA-1882)

### DIFF
--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -340,6 +340,18 @@ export function agentService(db: Db) {
       normalizedPatch.permissions = normalizeAgentPermissions(data.permissions, role);
     }
 
+    if (normalizedPatch.status === "paused" && existing.status !== "paused") {
+      if (!normalizedPatch.pauseReason) normalizedPatch.pauseReason = "manual";
+      if (!normalizedPatch.pausedAt) normalizedPatch.pausedAt = new Date();
+    } else if (
+      normalizedPatch.status &&
+      normalizedPatch.status !== "paused" &&
+      existing.status === "paused"
+    ) {
+      normalizedPatch.pauseReason = null;
+      normalizedPatch.pausedAt = null;
+    }
+
     const shouldRecordRevision = Boolean(options?.recordRevision) && hasConfigPatchFields(normalizedPatch);
     const beforeConfig = shouldRecordRevision ? buildConfigSnapshot(existing) : null;
 


### PR DESCRIPTION
## Summary
- `PATCH /agents/:id` accepts `status: "paused"` via `updateAgentSchema`, but `updateAgent()` writes it through without setting `pauseReason`/`pausedAt` — producing paused rows with `pauseReason=null`.
- Board pick (SHA-1882): soft-coerce inside `updateAgent()`.
  - On transition into `paused` with no supplied reason → default to `"manual"` and stamp `pausedAt`.
  - On transition out of `paused` → clear `pauseReason` and `pausedAt` (mirrors `resume()`).
- Explicit reasons from callers (e.g. company-portability import) still pass through unchanged.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `budgets-service`, `monthly-spend-service`, `agent-shortname-collision` suites pass
- [ ] Manual: PATCH agent with `{status:"paused"}` → verify `pause_reason="manual"`, `paused_at` set
- [ ] Manual: PATCH same agent with `{status:"idle"}` → verify `pause_reason=null`, `paused_at=null`