### PR TITLE
fix(issues): inherit projectId on workspace inheritance + heal legacy rows (fixes #3459)

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1855,9 +1855,27 @@ export function heartbeatService(db: Db) {
           .where(and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)))
           .then((rows) => rows[0] ?? null)
       : null;
-    const issueProjectId = issueProjectRef?.projectId ?? null;
+    let issueProjectId = issueProjectRef?.projectId ?? null;
     const preferredProjectWorkspaceId =
       issueProjectRef?.projectWorkspaceId ?? contextProjectWorkspaceId ?? null;
+    // Heal issues created with projectWorkspaceId set but projectId null (the create-time
+    // bug fixed in services/issues.ts). Without this, resolveWorkspaceForRun falls back to
+    // agent_home for legacy rows even after the create-time fix ships.
+    if (!issueProjectId && preferredProjectWorkspaceId) {
+      const workspaceProjectRow = await db
+        .select({ projectId: projectWorkspaces.projectId })
+        .from(projectWorkspaces)
+        .where(
+          and(
+            eq(projectWorkspaces.id, preferredProjectWorkspaceId),
+            eq(projectWorkspaces.companyId, agent.companyId),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      if (workspaceProjectRow?.projectId) {
+        issueProjectId = workspaceProjectRow.projectId;
+      }
+    }
     const resolvedProjectId = issueProjectId ?? contextProjectId;
     const useProjectWorkspace = opts?.useProjectWorkspace !== false;
     const workspaceProjectId = useProjectWorkspace ? resolvedProjectId : null;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1451,7 +1451,7 @@ export function issueService(db: Db) {
       }
       return db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
-        const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
+        let projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
         let projectWorkspaceId = issueData.projectWorkspaceId ?? null;
         let executionWorkspaceId = issueData.executionWorkspaceId ?? null;
         let executionWorkspacePreference = issueData.executionWorkspacePreference ?? null;
@@ -1466,6 +1466,10 @@ export function issueService(db: Db) {
           const workspaceSource = await getWorkspaceInheritanceIssue(tx, companyId, workspaceInheritanceIssueId);
           if (projectWorkspaceId == null && workspaceSource.projectWorkspaceId) {
             projectWorkspaceId = workspaceSource.projectWorkspaceId;
+          }
+          if (issueData.projectId == null && workspaceSource.projectId) {
+            issueData.projectId = workspaceSource.projectId;
+            projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
           }
           if (
             isolatedWorkspacesEnabled &&


### PR DESCRIPTION
## Summary

Fixes #3459.

Sub-issues (and sibling follow-ups via `inheritExecutionWorkspaceFromIssueId`) created without an explicit `projectId` currently inherit `projectWorkspaceId` from the workspace source but not `projectId`. The partial-inheritance leaves rows with `projectWorkspaceId` set but `projectId = null`, and `resolveWorkspaceForRun` then falls back to `agent_home` because its project-workspace enumeration keys off `projectId`. In practice, the `git_worktree` strategy spawns in the agent-home directory and fails with `fatal: not a git repository`.

Same failure mode, two triggers — both covered here because `workspaceInheritanceIssueId = inheritExecutionWorkspaceFromIssueId ?? issueData.parentId ?? null` (see `server/src/services/issues.ts`, line 1460):

- Sub-issue via `parentId`
- Sibling follow-up via `inheritExecutionWorkspaceFromIssueId`

Reproduction table and independent repro on `v2026.416.0` are in [my comment on #3459](https://github.com/paperclipai/paperclip/issues/3459#issuecomment-4274033668).

## Changes

### 1. `server/src/services/issues.ts` — create-time inheritance

Inside the `workspaceInheritanceIssueId` block, inherit `projectId` alongside `projectWorkspaceId` and recompute `projectGoalId` from the newly resolved project. `projectGoalId` becomes `let` so the recomputation is possible.

```ts
if (projectWorkspaceId == null && workspaceSource.projectWorkspaceId) {
  projectWorkspaceId = workspaceSource.projectWorkspaceId;
}
if (issueData.projectId == null && workspaceSource.projectId) {
  issueData.projectId = workspaceSource.projectId;
  projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
}
```

The subsequent `values` spread (`...issueData`) picks up the healed `projectId`, and `resolveIssueGoalId({ projectId: issueData.projectId, ..., projectGoalId, ... })` picks up the recomputed goal.

### 2. `server/src/services/heartbeat.ts` — defensive companion: heal legacy rows

`resolveWorkspaceForRun` now looks up `projectId` from `projectWorkspaces` when an issue row has `projectWorkspaceId` set but `projectId = null`. This heals legacy rows created before the create-time fix ships, so teams do not have to re-create stuck tickets after upgrading. Scoped to `companyId` and only triggered when `issueProjectId` is null, so happy-path behaviour is unchanged.

```ts
let issueProjectId = issueProjectRef?.projectId ?? null;
const preferredProjectWorkspaceId =
  issueProjectRef?.projectWorkspaceId ?? contextProjectWorkspaceId ?? null;
if (!issueProjectId && preferredProjectWorkspaceId) {
  const workspaceProjectRow = await db
    .select({ projectId: projectWorkspaces.projectId })
    .from(projectWorkspaces)
    .where(
      and(
        eq(projectWorkspaces.id, preferredProjectWorkspaceId),
        eq(projectWorkspaces.companyId, agent.companyId),
      ),
    )
    .then((rows) => rows[0] ?? null);
  if (workspaceProjectRow?.projectId) {
    issueProjectId = workspaceProjectRow.projectId;
  }
}
const resolvedProjectId = issueProjectId ?? contextProjectId;
```

Happy to split the heartbeat heal into its own PR if you prefer to keep this one scoped to the create-time fix — just let me know.

## Test plan

Manual repro (same setup used to produce the original bug report):

- [ ] Create a parent issue with `projectId = P` and `projectWorkspaceId = W`.
- [ ] As an agent, call `POST /api/companies/:companyId/issues` with `inheritExecutionWorkspaceFromIssueId = parentId` and **no** explicit `projectId`. Expect the new issue's `projectId = P` (previously `null`).
- [ ] Same call with `parentId = parentId` instead of `inheritExecutionWorkspaceFromIssueId`. Expect the new issue's `projectId = P`.
- [ ] Insert a row directly with `projectId = null, projectWorkspaceId = W`, then wake an agent on it. Expect `resolveWorkspaceForRun` to resolve to the project workspace (source `project_primary`), not `agent_home`.

Automated regression test sketch is in the [issue comment](https://github.com/paperclipai/paperclip/issues/3459#issuecomment-4274033668) (covers both triggers + the heartbeat heal). Happy to add it to this PR once you confirm which test file you want it in — `server/src/__tests__/issues-service.test.ts` already uses embedded Postgres and looks like the natural home.

## Notes

- No changes to the `isolatedWorkspaces` experimental path.
- No schema changes.
- Happy-path behaviour for issues created with an explicit `projectId` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)