### PR TITLE
fix(cursor-local): probe cursor-agent before agent; refresh fallback model IDs

### DIFF
--- a/packages/adapters/cursor-local/src/index.ts
+++ b/packages/adapters/cursor-local/src/index.ts
@@ -4,6 +4,8 @@ export const DEFAULT_CURSOR_LOCAL_MODEL = "auto";
 
 const CURSOR_FALLBACK_MODEL_IDS = [
   "auto",
+  "composer-2",
+  "composer-2-fast",
   "composer-1.5",
   "composer-1",
   "gpt-5.3-codex-low",
@@ -29,6 +31,8 @@ const CURSOR_FALLBACK_MODEL_IDS = [
   "gpt-5.2-high",
   "gpt-5.1-high",
   "gpt-5.1-codex-mini",
+  "opus-4.7",
+  "opus-4.7-thinking",
   "opus-4.6-thinking",
   "opus-4.6",
   "opus-4.5",
@@ -40,6 +44,8 @@ const CURSOR_FALLBACK_MODEL_IDS = [
   "gemini-3.1-pro",
   "gemini-3-pro",
   "gemini-3-flash",
+  "gemini-2.5-flash",
+  "grok-4-20-thinking",
   "grok",
   "kimi-k2.5",
 ];
@@ -66,7 +72,7 @@ Core fields:
 - promptTemplate (string, optional): run prompt template
 - model (string, optional): Cursor model id (for example auto or gpt-5.3-codex)
 - mode (string, optional): Cursor execution mode passed as --mode (plan|ask). Leave unset for normal autonomous runs.
-- command (string, optional): defaults to "agent"
+- command (string, optional): defaults to auto-detecting "cursor-agent" then "agent" on PATH
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables
 

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -28,6 +28,7 @@ import { DEFAULT_CURSOR_LOCAL_MODEL } from "../index.js";
 import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
 import { normalizeCursorStreamLine } from "../shared/stream.js";
 import { hasCursorTrustBypassArg } from "../shared/trust.js";
+import { resolveCursorDefaultCommand } from "../shared/command.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -166,7 +167,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     config.promptTemplate,
     "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
   );
-  const command = asString(config.command, "agent");
+  const configuredCommand = asString(config.command, "").trim();
   const model = asString(config.model, DEFAULT_CURSOR_LOCAL_MODEL).trim();
   const mode = normalizeMode(asString(config.mode, ""));
 
@@ -277,6 +278,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   );
   const billingType = resolveCursorBillingType(effectiveEnv);
   const runtimeEnv = ensurePathInEnv(effectiveEnv);
+  const command = configuredCommand || await resolveCursorDefaultCommand(cwd, runtimeEnv);
   await ensureCommandResolvable(command, cwd, runtimeEnv);
   const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
   const loggedEnv = buildInvocationEnvForLogs(env, {

--- a/packages/adapters/cursor-local/src/server/test.ts
+++ b/packages/adapters/cursor-local/src/server/test.ts
@@ -18,6 +18,7 @@ import path from "node:path";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "../index.js";
 import { parseCursorJsonl } from "./parse.js";
 import { hasCursorTrustBypassArg } from "../shared/trust.js";
+import { resolveCursorDefaultCommand } from "../shared/command.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -38,9 +39,9 @@ function firstNonEmptyLine(text: string): string {
   );
 }
 
-function commandLooksLike(command: string, expected: string): boolean {
+function commandLooksLike(command: string, ...expected: string[]): boolean {
   const base = path.basename(command).toLowerCase();
-  return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
+  return expected.some((e) => base === e || base === `${e}.cmd` || base === `${e}.exe`);
 }
 
 function summarizeProbeDetail(stdout: string, stderr: string, parsedError: string | null): string | null {
@@ -94,7 +95,7 @@ export async function testEnvironment(
 ): Promise<AdapterEnvironmentTestResult> {
   const checks: AdapterEnvironmentCheck[] = [];
   const config = parseObject(ctx.config);
-  const command = asString(config.command, "agent");
+  const configuredCommand = asString(config.command, "").trim();
   const cwd = asString(config.cwd, process.cwd());
 
   try {
@@ -119,6 +120,7 @@ export async function testEnvironment(
     if (typeof value === "string") env[key] = value;
   }
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const command = configuredCommand || await resolveCursorDefaultCommand(cwd, runtimeEnv);
   try {
     await ensureCommandResolvable(command, cwd, runtimeEnv);
     checks.push({
@@ -170,13 +172,13 @@ export async function testEnvironment(
   const canRunProbe =
     checks.every((check) => check.code !== "cursor_cwd_invalid" && check.code !== "cursor_command_unresolvable");
   if (canRunProbe) {
-    if (!commandLooksLike(command, "agent")) {
+    if (!commandLooksLike(command, "agent", "cursor-agent")) {
       checks.push({
         code: "cursor_hello_probe_skipped_custom_command",
         level: "info",
-        message: "Skipped hello probe because command is not `agent`.",
+        message: "Skipped hello probe because command is not `agent` or `cursor-agent`.",
         detail: command,
-        hint: "Use the `agent` CLI command to run the automatic installation and auth probe.",
+        hint: "Use the `agent` or `cursor-agent` CLI command to run the automatic installation and auth probe.",
       });
     } else {
       const model = asString(config.model, DEFAULT_CURSOR_LOCAL_MODEL).trim();

--- a/packages/adapters/cursor-local/src/shared/command.ts
+++ b/packages/adapters/cursor-local/src/shared/command.ts
@@ -1,0 +1,28 @@
+import { ensureCommandResolvable } from "@paperclipai/adapter-utils/server-utils";
+
+/**
+ * Resolve which Cursor CLI binary is available on PATH.
+ *
+ * Cursor ships as `cursor-agent` on most platforms. Some older installs expose
+ * only `agent`. We probe in preference order and return the first resolvable
+ * name so that neither spelling silently disappears from the Paperclip adapter
+ * list.
+ *
+ * If neither candidate resolves we return `"cursor-agent"` and let the
+ * downstream `ensureCommandResolvable` call produce the real error with full
+ * context (PATH, cwd, remediation hint).
+ */
+export async function resolveCursorDefaultCommand(
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
+  for (const candidate of ["cursor-agent", "agent"]) {
+    try {
+      await ensureCommandResolvable(candidate, cwd, env);
+      return candidate;
+    } catch {
+      // not on PATH — try next
+    }
+  }
+  return "cursor-agent";
+}


### PR DESCRIPTION
## Problem

Two independent regressions that both surface as _Cursor / Composer adapters disappearing from the Paperclip UI_:

### 1 — Wrong default CLI binary name

The adapter hard-coded `command` default to `"agent"`. On Windows, macOS, and most modern Linux installs the Cursor CLI ships as `cursor-agent` (not `agent`). When `ensureCommandResolvable` cannot find `agent` on PATH the adapter silently drops out of the `/api/agents` list.

### 2 — Stale `CURSOR_FALLBACK_MODEL_IDS`

The static model list in `src/index.ts` was missing several models released since the last refresh, causing _model not available_ errors for operators on current Cursor versions.

## Changes

| File | Change |
|------|--------|
| `src/shared/command.ts` | New `resolveCursorDefaultCommand(cwd, env)` — probes `cursor-agent` then `agent`; returns `cursor-agent` if neither found so the downstream error is actionable |
| `src/server/execute.ts` | Replace hard-coded `asString(config.command, "agent")` with auto-resolved default via the helper |
| `src/server/test.ts` | Same default replacement; expand `commandLooksLike` to accept both `agent` and `cursor-agent`; update skip-probe message |
| `src/index.ts` | Add `composer-2`, `composer-2-fast`, `opus-4.7`, `opus-4.7-thinking`, `gemini-2.5-flash`, `grok-4-20-thinking` in family order |

## Backward compatibility

- Operators who **explicitly set `command: agent`** in their adapter config are unaffected (configured value always wins).
- Operators who previously relied on the `agent` default on a host where `cursor-agent` is on PATH will now resolve automatically without any config change.

## Test plan

- [ ] `tsc` passes (verified locally — zero type errors)
- [ ] On a host with `cursor-agent` on PATH: adapter appears in `/api/agents`, hello probe passes
- [ ] On a host with only `agent` on PATH: same result
- [ ] On a host with neither binary: adapter shows `cursor_command_unresolvable` error (not a silent disappearance)
- [ ] New model IDs appear in Paperclip model picker without restart
