### PR TITLE
feat: model pin enforcement + parser-aware skill rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ARG USER_UID=1000
 ARG USER_GID=1000
 WORKDIR /app
 COPY --chown=node:node --from=build /app /app
-RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
+RUN npm install --global --omit=dev @anthropic-ai/claude-code@2.1.114 @openai/codex@0.121.0 opencode-ai \
   && apt-get update \
   && apt-get install -y --no-install-recommends openssh-client jq \
   && rm -rf /var/lib/apt/lists/* \

--- a/cli/src/checks/llm-check.ts
+++ b/cli/src/checks/llm-check.ts
@@ -28,7 +28,7 @@ export async function llmCheck(config: PaperclipConfig): Promise<CheckResult> {
           "content-type": "application/json",
         },
         body: JSON.stringify({
-          model: "claude-sonnet-4-5-20250929",
+          model: "claude-sonnet-4-6",
           max_tokens: 1,
           messages: [{ role: "user", content: "hi" }],
         }),

--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -517,7 +517,7 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
               "content-type": "application/json",
             },
             body: JSON.stringify({
-              model: "claude-sonnet-4-5-20250929",
+              model: "claude-sonnet-4-6",
               max_tokens: 1,
               messages: [{ role: "user", content: "hi" }],
             }),

--- a/docker/untrusted-review/Dockerfile
+++ b/docker/untrusted-review/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
 RUN ln -sf /usr/bin/fdfind /usr/local/bin/fd
 
 RUN corepack enable \
-  && npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest
+  && npm install --global --omit=dev @anthropic-ai/claude-code@2.1.114 @openai/codex@0.121.0
 
 RUN useradd --create-home --shell /bin/bash reviewer
 

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -5,7 +5,6 @@ export const models = [
   { id: "claude-opus-4-7", label: "Claude Opus 4.7" },
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
   { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-  { id: "claude-haiku-4-6", label: "Claude Haiku 4.6" },
   { id: "claude-sonnet-4-5-20250929", label: "Claude Sonnet 4.5" },
   { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
 ];

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -303,6 +303,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
   );
   const model = asString(config.model, "");
+  // BLOCKING: model MUST be a fully-versioned identifier. Empty / "latest" / "auto" / wildcard
+  // would let the underlying `claude` CLI auto-resolve to whatever Anthropic ships next, which
+  // can silently break instruction-following when a new Claude version comes online.
+  if (!model || /\b(latest|auto|\*)\b/i.test(model)) {
+    throw new Error(
+      `claude_local model_pin_required: agent ${agent.id} (${agent.name ?? "unnamed"}) has invalid model="${model}". ` +
+        `adapter_config.model MUST be a fully-versioned Anthropic model id ` +
+        `(e.g. "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"). ` +
+        `Wildcards, "latest", "auto", and empty values are forbidden — they enable silent model auto-upgrades.`,
+    );
+  }
   const effort = asString(config.effort, "");
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1074,6 +1074,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   }
 
+  // BLOCKING: model MUST be a fully-versioned identifier. openclaw-gateway has empty models[]
+  // (model resolved on the remote gateway), so empty/wildcard model would let the gateway
+  // auto-resolve to whatever upstream defaults to — a silent auto-upgrade vector. Reject early.
+  const gatewayModel = asString(ctx.config.model, "").trim();
+  if (!gatewayModel || /\b(latest|auto|\*)\b/i.test(gatewayModel)) {
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: `openclaw_gateway model_pin_required: agent ${ctx.agent.id} (${ctx.agent.name ?? "unnamed"}) has invalid model="${gatewayModel}". adapter_config.model MUST be a fully-versioned identifier; the gateway forwards this verbatim and will silently auto-resolve wildcards or "latest" to upstream's current default.`,
+      errorCode: "openclaw_gateway_model_pin_required",
+    };
+  }
+
   const timeoutSec = Math.max(0, Math.floor(asNumber(ctx.config.timeoutSec, 120)));
   const timeoutMs = timeoutSec > 0 ? timeoutSec * 1000 : 0;
   const connectTimeoutMs = timeoutMs > 0 ? Math.min(timeoutMs, 15_000) : 10_000;

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -101,6 +101,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   );
   const command = asString(config.command, "opencode");
   const model = asString(config.model, "").trim();
+  // BLOCKING: same defense as claude-local. Reject empty/wildcard/auto/latest to prevent
+  // silent provider auto-resolution. The docstring previously said "model required" but
+  // execution didn't enforce it.
+  if (!model || /\b(latest|auto|\*)\b/i.test(model)) {
+    throw new Error(
+      `opencode_local model_pin_required: agent ${agent.id} (${agent.name ?? "unnamed"}) has invalid model="${model}". ` +
+        `adapter_config.model MUST be a fully-versioned provider/model id (e.g. "anthropic/claude-sonnet-4-6"). ` +
+        `Wildcards, "latest", "auto", and empty values are forbidden.`,
+    );
+  }
   const variant = asString(config.variant, "").trim();
 
   const workspaceContext = parseObject(context.paperclipWorkspace);

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -117,6 +117,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   );
   const command = asString(config.command, "pi");
   const model = asString(config.model, "").trim();
+  // BLOCKING: same defense as claude-local. pi-local validated in test.ts but not in execute.ts;
+  // close that gap. Reject empty/wildcard/auto/latest to prevent silent provider auto-resolution.
+  if (!model || /\b(latest|auto|\*)\b/i.test(model)) {
+    throw new Error(
+      `pi_local model_pin_required: agent ${agent.id} (${agent.name ?? "unnamed"}) has invalid model="${model}". ` +
+        `adapter_config.model MUST be a fully-versioned provider/model id (e.g. "xai/grok-4"). ` +
+        `Wildcards, "latest", "auto", and empty values are forbidden.`,
+    );
+  }
   const thinking = asString(config.thinking, "").trim();
 
   // Parse model into provider and model id

--- a/scripts/audit-model-pins.ts
+++ b/scripts/audit-model-pins.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env tsx
+/**
+ * audit-model-pins.ts
+ *
+ * BLOCKING audit: scans the `agents` table for any row whose `adapter_config.model`
+ * is missing, empty, or fuzzy ("latest" / "auto" / wildcard). Such rows let the
+ * underlying provider CLI auto-resolve to whatever ships next, which can silently
+ * change agent behavior when a new model version comes online.
+ *
+ * Exit codes:
+ *   0 — all agents have fully-versioned model pins
+ *   1 — one or more agents are unpinned; details printed; ABORT any rebuild/restart
+ *   2 — could not connect to DB (config or postgres state issue)
+ *
+ * Run before: pnpm build, container rebuild, model upgrade, paperclipctl restart.
+ * Run on cron: weekly + on every paperclip server start (wire into launcher).
+ *
+ * Usage:
+ *   tsx scripts/audit-model-pins.ts
+ *   tsx scripts/audit-model-pins.ts --json    # machine-readable output
+ */
+
+import { Client } from "pg";
+
+const CONN = {
+  host: process.env.PGHOST ?? "127.0.0.1",
+  port: Number(process.env.PGPORT ?? 54329),
+  user: process.env.PGUSER ?? "paperclip",
+  password: process.env.PGPASSWORD ?? "paperclip",
+  database: process.env.PGDATABASE ?? "paperclip",
+};
+
+const FUZZY = /\b(latest|auto|\*)\b/i;
+const jsonOut = process.argv.includes("--json");
+
+type AgentRow = {
+  id: string;
+  name: string;
+  role: string;
+  adapter_type: string;
+  model: string | null;
+  status: string;
+  company: string;
+};
+
+async function main(): Promise<number> {
+  const client = new Client(CONN);
+  try {
+    await client.connect();
+  } catch (e) {
+    console.error(`[audit-model-pins] cannot connect to postgres: ${(e as Error).message}`);
+    return 2;
+  }
+
+  let bad: AgentRow[] = [];
+  let total = 0;
+
+  try {
+    const res = await client.query<AgentRow>(`
+      SELECT a.id,
+             a.name,
+             a.role,
+             a.adapter_type,
+             a.adapter_config ->> 'model' AS model,
+             a.status,
+             c.name AS company
+        FROM agents a
+   LEFT JOIN companies c ON c.id = a.company_id
+    ORDER BY c.name NULLS LAST, a.role, a.name
+    `);
+    total = res.rows.length;
+    bad = res.rows.filter((r) => {
+      const m = (r.model ?? "").trim();
+      return m === "" || FUZZY.test(m);
+    });
+  } finally {
+    await client.end();
+  }
+
+  if (jsonOut) {
+    console.log(JSON.stringify({ totalAgents: total, badPins: bad }, null, 2));
+  } else {
+    console.log(`[audit-model-pins] scanned ${total} agents`);
+    if (bad.length === 0) {
+      console.log(`[audit-model-pins] OK — all agents have fully-versioned model pins`);
+    } else {
+      console.error(`[audit-model-pins] FAIL — ${bad.length} agents have invalid pins:`);
+      for (const r of bad) {
+        console.error(
+          `  - ${r.company ?? "(no company)"} / ${r.name} (role=${r.role}, status=${r.status}, adapter=${r.adapter_type}) — model="${r.model ?? "<NULL>"}"`,
+        );
+      }
+      console.error(
+        `\n[audit-model-pins] DO NOT proceed with rebuild / restart. Pin every agent's adapter_config.model to a fully-versioned id (e.g. "claude-opus-4-7", "claude-sonnet-4-6").`,
+      );
+    }
+  }
+
+  return bad.length === 0 ? 0 : 1;
+}
+
+main().then((code) => process.exit(code)).catch((e) => {
+  console.error(`[audit-model-pins] unexpected error: ${(e as Error).stack}`);
+  process.exit(2);
+});

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -286,6 +286,19 @@ If you are asked to create or manage routines you MUST read:
 
 ## Critical Rules
 
+### Parser-critical output (BLOCKING — these break inter-agent coordination if you paraphrase)
+
+The Paperclip runtime parses agent output for routing signals. Newer Claude versions interpret instructions more literally and may shift tone or paraphrase formal markers — that breaks the parser silently and the auto-wakeup chain dies. Use these EXACT formats; do not soften, paraphrase, or substitute synonyms.
+
+1. **`@-mentions` MUST be literal `@<RoleOrName>` characters.** Required: emit the exact `@CEO`, `@CTO`, `@<AgentName>` token character-for-character in your comment body. Do NOT substitute "notify the CEO", "let the CTO know", or "the team should review" — those do NOT trigger the receiving agent's wakeup. The runtime regex-matches `@<token>` only.
+2. **Status enum strings MUST be one of**: `todo`, `in_progress`, `blocked`, `in_review`, `done`, `cancelled`, `backlog`. Do NOT substitute synonyms like "completed", "halted", "ready for review", "started". The status PATCH endpoint rejects anything else and the issue stays in its old state silently from your perspective.
+3. **Cross-issue link format MUST be Markdown link with the company-prefixed URL**: `[<TICKET-ID>](/<PREFIX>/issues/<TICKET-ID>)`. Required: emit the literal `[PAP-224](/PAP/issues/PAP-224)` form. Do NOT substitute prose like "see PAP-224" or "completed task 224" — cross-issue notification fails silently if the link is not clickable.
+4. **Status acknowledgment line at the end of every cross-issue update comment** — exactly: `Cross-issue update: @<role>, [<TICKET-ID>](/<PREFIX>/issues/<TICKET-ID>), status: <enum>`. This makes parser-side audit possible.
+
+If you find yourself wanting to "be polite" or "be more natural" in any of the above, STOP and emit the literal form. The runtime is not a human reader.
+
+### General rules
+
 - **Always checkout** before working. Never PATCH to `in_progress` manually.
 - **Never retry a 409.** The task belongs to someone else.
 - **Never look for unassigned work.**


### PR DESCRIPTION
## Summary

Defense-in-depth against silent model auto-upgrades. Triggered by an incident where an agent with no `adapter_config.model` field caused the underlying `claude` CLI to auto-resolve to a newly-shipped Claude version, which silently changed instruction-following behavior and broke the system.

## What this adds

1. **Adapter-side model validation** — `claude-local`, `openclaw-gateway`, `opencode-local`, `pi-local` throw `*_model_pin_required` at launch on empty / `latest` / `auto` / wildcard model values. Closes the existing gap where `openclaw-gateway`/`opencode-local` had no execute-path validation and `pi-local` validated only in `test.ts`.
2. **Dockerfile pins** — `Dockerfile` and `docker/untrusted-review/Dockerfile` pin `@anthropic-ai/claude-code@2.1.114` + `@openai/codex@0.121.0` (was `@latest`). Container rebuild can no longer auto-upgrade either CLI.
3. **CLI sub-services** — `cli/src/checks/llm-check.ts` and `cli/src/commands/onboard.ts` use `claude-sonnet-4-6` for the probe call (was `claude-sonnet-4-5-20250929`).
4. **`claude-local` adapter list cleanup** — removed `claude-haiku-4-6` entry (that model never existed; latest Haiku is `claude-haiku-4-5-20251001` already in the list).
5. **`paperclip` skill — parser-aware MANDATORY rules** — added a BLOCKING subsection covering literal `@<role>` mentions, status enum discipline, exact Markdown link format, and a cross-issue update acknowledgment line. Newer Claude versions paraphrase parser-dependent outputs more readily, which silently breaks inter-agent routing.
6. **`scripts/audit-model-pins.ts`** — new BLOCKING audit that scans `agents` table for any row with empty / fuzzy `adapter_config.model`. Non-zero exit on findings. Wireable into launcher pre-flight or a recurring routine.

## Why

Empty / fuzzy / `latest` model strings let the underlying provider CLI choose whatever is current. A quiet upstream release silently changes the behavior of every unpinned agent. Documenting the rule isn't enough — the adapter must refuse to launch.

## Non-goals

- Does not modify upstream Dockerfile features (USER_UID args, gosu, gh, wget, ripgrep, python3, mcp-server, openssh-client, jq all preserved — only `@latest` tags are pinned).
- Does not touch `seed.ts` (separate concern; demo seed defaults can be bumped in a follow-up if desired).

## Test plan

- [ ] Build passes: `pnpm build`
- [ ] Lint/typecheck pass: `pnpm typecheck`
- [ ] Tests pass: `pnpm test:run`
- [ ] Manually confirm a `claude_local` agent with `adapterConfig.model = ""` (or `"latest"`) is rejected at launch with `claude_local_model_pin_required`
- [ ] Manually confirm same for `openclaw-gateway`, `opencode-local`, `pi-local`
- [ ] Confirm `tsx scripts/audit-model-pins.ts` exits 0 on a clean DB and exits 1 on a seeded bad row

🤖 Generated with [Claude Code](https://claude.com/claude-code)