### PR TITLE
fix(server): forward pluginDbId when registering plugin tools

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1812,7 +1812,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,16 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin's unique identifier (pluginKey)
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - Optional DB UUID of the plugin. When omitted, the
+   *   registry falls back to `pluginId` as the dbId, which breaks
+   *   `workerManager` lookups that are keyed by DB UUID.
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +433,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Plugins extend agents with additional tools via the plugin tool dispatcher
> - On a fresh plugin load, the dispatcher was registering each tool's `dbId` as the plugin's string `pluginKey` instead of the DB UUID
> - Agent tool execution then failed with `502 worker for plugin "<key>" is not running` because `workerManager` is keyed by the DB UUID — so the lookup always missed even though the worker was healthy
> - This PR forwards the DB UUID through `registerPluginTools(...)` to the registry so the registered tools carry the right `pluginDbId`
> - The benefit is that any plugin with declared tools becomes callable immediately on load, without a manual re-registration step

## What Changed

- `server/src/services/plugin-tool-dispatcher.ts`: `PluginToolDispatcher.registerPluginTools` (both the interface and the implementation) now accepts an optional `pluginDbId?: string` and forwards it to `registry.registerPlugin(pluginId, manifest, pluginDbId)`.
- `server/src/services/plugin-loader.ts`: the existing call site at the agent-tool registration step now passes the plugin's DB UUID (`pluginId`) as the third argument.

The parameter is optional to preserve call-site compatibility for any external tests or callers that omit it; the registry already falls back to `dbId = pluginId` when no UUID is provided, so behavior for callers that don't pass one is unchanged.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — green (no output errors).
- `pnpm --filter @paperclipai/server exec vitest run --root .` — 933 passed, 7 failed. The 7 failures are all in `server/src/__tests__/workspace-runtime.test.ts` and `server/src/__tests__/worktree-config.test.ts` (worktree provisioning / port rebalancing). They reproduce on pristine `master` with this PR's changes stashed, so they are pre-existing on my environment and unrelated to this change.
- Manual reproduction of the bug + fix against `@paperclipai/server@2026.416.0`:
  - Before: `POST /api/plugins/tools/execute` returned `502 — worker for plugin "<key>" is not running` for healthy plugin workers. Dispatcher logs showed the tool registration happening but with the wrong `pluginDbId`.
  - After: `DEBUG: executing tool via plugin worker {pluginDbId:"<uuid>", ...}` followed by `DEBUG: tool execution completed`. End-to-end plugin tool round-trip succeeds.
- Downstream AMA-5 (Telegram plugin) round-trip, which was blocked on this, succeeded with the same change applied as a userland patch.

## Risks

- **Low risk.** Adds an optional parameter in the public `PluginToolDispatcher` interface; existing callers that omit it continue to work. Behavior only changes for call sites that now forward the DB UUID (currently only the one in `plugin-loader.ts`).
- The change surfaces the same `pluginDbId` the dispatcher's own `handlePluginEnabled` / `registerFromDb` path was already using, so we aren't introducing a new concept — we're plugging the one path that was dropping it.
- No migration, no schema change, no wire-protocol change.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (`claude-opus-4-7`)
- Context window: 1M
- Capabilities used: tool use (local filesystem + shell), no extended reasoning mode

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (bug fix only)
- [x] I have run tests locally and they pass (with the pre-existing failures called out explicitly above)
- [ ] I have added or updated tests where applicable — there are currently no tests covering `PluginToolDispatcher.registerPluginTools` or this plugin-loader call site. Happy to add a targeted regression test if reviewers prefer; wanted to keep the initial diff minimal per the "small, focused changes" path in CONTRIBUTING.
- [x] If this change affects the UI, I have included before/after screenshots — N/A (server-only).
- [x] I have updated relevant documentation to reflect my changes — the dispatcher interface's JSDoc now documents the new param and why it matters.
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
