### PR TITLE
fix(server): share pluginLifecycleManager between dispatcher and routes

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -248,6 +248,11 @@ export async function createApp(
       },
     },
   );
+  // Back-fill the runtime-capable loader onto the lifecycle manager that
+  // was constructed before the loader existed. Without this, lifecycle
+  // calls that need runtime activation (enable/disable/upgrade/unload) fall
+  // back to a no-op loader and can't drive the plugin worker.
+  lifecycle.setLoader(loader);
   api.use(
     pluginRoutes(
       db,
@@ -256,6 +261,7 @@ export async function createApp(
       { workerManager },
       { toolDispatcher },
       { workerManager },
+      { lifecycle },
     ),
   );
   api.use(adapterRoutes());

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -37,7 +37,7 @@ import {
   PLUGIN_STATUSES,
 } from "@paperclipai/shared";
 import { pluginRegistryService } from "../services/plugin-registry.js";
-import { pluginLifecycleManager } from "../services/plugin-lifecycle.js";
+import { pluginLifecycleManager, type PluginLifecycleManager } from "../services/plugin-lifecycle.js";
 import { getPluginUiContributionMetadata, pluginLoader } from "../services/plugin-loader.js";
 import { logActivity } from "../services/activity-log.js";
 import { publishGlobalLiveEvent } from "../services/live-events.js";
@@ -246,6 +246,28 @@ export interface PluginRouteBridgeDeps {
   streamBus?: PluginStreamBus;
 }
 
+/**
+ * Optional dependencies for sharing the plugin lifecycle manager.
+ *
+ * When provided, the plugin routes reuse the caller's shared
+ * `PluginLifecycleManager` instance instead of constructing a private one.
+ * This is required for dynamic enable/disable to propagate lifecycle events
+ * to other subscribers (notably the plugin tool dispatcher) — if the routes
+ * build their own lifecycle, its `EventEmitter` is distinct from the one
+ * the dispatcher is listening on, so `plugin.enabled` events never reach
+ * the dispatcher and dynamically enabled plugins don't register their tools
+ * until the server restarts.
+ *
+ * When omitted, the routes construct a local lifecycle manager using `loader`
+ * plus any `workerManager` available from `bridgeDeps`/`webhookDeps`. This
+ * preserves backwards compatibility for callers (and tests) that haven't
+ * been updated to pass the shared instance.
+ */
+export interface PluginRouteLifecycleDeps {
+  /** The shared lifecycle manager constructed alongside the tool dispatcher. */
+  lifecycle: PluginLifecycleManager;
+}
+
 /** Request body for POST /api/plugins/tools/execute */
 interface PluginToolExecuteRequest {
   /** Fully namespaced tool name (e.g., "acme.linear:search-issues"). */
@@ -307,10 +329,11 @@ export function pluginRoutes(
   webhookDeps?: PluginRouteWebhookDeps,
   toolDeps?: PluginRouteToolDeps,
   bridgeDeps?: PluginRouteBridgeDeps,
+  lifecycleDeps?: PluginRouteLifecycleDeps,
 ) {
   const router = Router();
   const registry = pluginRegistryService(db);
-  const lifecycle = pluginLifecycleManager(db, {
+  const lifecycle = lifecycleDeps?.lifecycle ?? pluginLifecycleManager(db, {
     loader,
     workerManager: bridgeDeps?.workerManager ?? webhookDeps?.workerManager,
   });

--- a/server/src/services/plugin-lifecycle.ts
+++ b/server/src/services/plugin-lifecycle.ts
@@ -255,6 +255,28 @@ export interface PluginLifecycleManager {
     event: K,
     listener: (payload: LifecycleEventPayload<K>) => void,
   ): void;
+
+  /**
+   * Attach a runtime-capable `PluginLoader` after the manager has been
+   * constructed.
+   *
+   * The lifecycle manager needs a loader with runtime services (e.g.
+   * `loadSingle`, `unloadSingle`, `cleanupInstallArtifacts`, `upgradePlugin`)
+   * to perform runtime activation on enable/disable/upgrade/unload. Because
+   * the loader itself depends on the lifecycle manager at construction time,
+   * the two are built in a two-step handshake:
+   *
+   * 1. Construct the lifecycle manager with `workerManager` only.
+   * 2. Build the loader (passing the lifecycle manager in as a dep).
+   * 3. Call `lifecycle.setLoader(loader)` so the lifecycle manager routes
+   *    runtime calls through the same loader used elsewhere in the server.
+   *
+   * Without this handshake, two distinct lifecycle instances end up being
+   * constructed — one for the tool dispatcher (listener side) and one for
+   * the HTTP routes (emitter side) — and `plugin.enabled` events emitted by
+   * the routes never reach the dispatcher's listener.
+   */
+  setLoader(loader: PluginLoader): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -320,7 +342,7 @@ export function pluginLifecycleManager(
   }
 
   const registry = pluginRegistryService(db);
-  const pluginLoaderInstance = loaderArg ?? pluginLoader(db);
+  let pluginLoaderInstance: PluginLoader = loaderArg ?? pluginLoader(db);
   const emitter = new EventEmitter();
   emitter.setMaxListeners(100); // plugins may have many listeners; 100 is a safe upper bound
 
@@ -816,6 +838,11 @@ export function pluginLifecycleManager(
 
     once(event, listener) {
       emitter.once(event, listener);
+    },
+
+    // -- setLoader --------------------------------------------------------
+    setLoader(loader: PluginLoader): void {
+      pluginLoaderInstance = loader;
     },
   };
 }


### PR DESCRIPTION
## Summary

Fixes a bug where dynamically enabled plugins don't register their tools until a server restart.

`pluginLifecycleManager(db, ...)` constructs a fresh `EventEmitter` on every call, and prior to this change the server was calling it twice:

- `server/src/app.ts:203` — constructs the manager used by the plugin tool dispatcher (listener side).
- `server/src/routes/plugins.ts:313` — constructs a *different* manager used by the HTTP enable/disable routes (emitter side).

Because those two managers hold separate `EventEmitter` instances, `plugin.enabled` events emitted by `PATCH /api/plugins/:id/state` never reach the dispatcher's `plugin.enabled` listener. The dispatcher log `plugin enabled — registering tools { pluginId, ... }` never fires on dynamic enable, so plugin tools only become live on next server boot (which re-registers via the loader path). Disable → enable cycles on a plugin with tools are broken.

## Change

- Add `setLoader(loader)` to `PluginLifecycleManager` so a single shared instance can be back-filled with a runtime-capable `PluginLoader` after construction. The loader depends on the lifecycle manager for wiring, so the two are built in a two-step handshake and without this the dispatcher-side lifecycle would fall back to a no-op loader that doesn't support runtime activation.
- Add an optional `PluginRouteLifecycleDeps` arg to `pluginRoutes(...)`. When provided, the routes reuse the shared lifecycle. When omitted, they fall back to the existing construction path so existing callers and tests keep working.
- Wire `app.ts` to pass the shared `lifecycle` into `pluginRoutes` and to call `lifecycle.setLoader(loader)` once the loader is built.

The new dep bucket is optional to minimize the blast radius: any caller that isn't updated keeps the legacy behavior, but the in-repo call site now shares a single lifecycle manager across the dispatcher and the HTTP routes.

## Test plan

- [x] `pnpm --filter @paperclipai/server run typecheck`
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/plugin-routes-authz.test.ts src/__tests__/plugin-worker-manager.test.ts src/__tests__/plugin-telemetry-bridge.test.ts src/__tests__/plugin-dev-watcher.test.ts` — 17/17 pass
- [ ] Manual: on a running server, install a plugin that contributes agent tools, then `POST /api/plugins/:id/disable` followed by `POST /api/plugins/:id/enable`, and confirm:
  - Dispatcher logs `plugin enabled — registering tools { pluginId: "<uuid>", ... }`
  - `POST /api/plugins/tools/execute` against one of that plugin's tools succeeds without a server restart

## Context

Discovered during downstream plugin development against `@paperclipai/server@2026.416.0`. Tracked downstream as AMA-6 (also covers a separate dispatcher `pluginDbId` regression vendored locally) and AMA-10 (this specific bug). Once this lands and a fixed version ships, the downstream vendor patch can be removed and the install pinned to the fixed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)