### PR TITLE
feat(bla-653): exempt coordination-mode issues from heartbeat auto-block

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -212,6 +212,19 @@ Recovery rule:
 
 This is an active-work continuity recovery.
 
+### 8.3 Coordination/ambient issue exemption
+
+Some issues exist as persistent ambient surfaces rather than bounded execution tasks — communication threads, plan document homes, program umbrella tickets. These are never execution-backed, so losing the execution path is expected and correct.
+
+Set `executionPolicy.mode = "coordination"` on such issues to exempt them from auto-block recovery entirely. The reconciler will skip them without queuing recovery wakes or flipping the status to `blocked`.
+
+Rules:
+- The issue must have `executionPolicy: { mode: "coordination" }` stored on it (set via the normal issue create/update API).
+- Coordination issues are still assignable to agents. Agents can check them out and post comments — they just won't be auto-blocked when the checkout run ends and no new run is active.
+- All other status transitions (manual updates, comment-triggered wakes, operator edits) continue to work normally.
+
+Typical candidates: driver-sync threads, sprint milestone trackers, CEO-inbox umbrella tickets, plan document homes.
+
 ## 9. Startup and Periodic Reconciliation
 
 Startup recovery and periodic recovery are different from normal wakeup delivery.

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -141,7 +141,7 @@ export type IssueOriginKind = (typeof ISSUE_ORIGIN_KINDS)[number];
 export const ISSUE_RELATION_TYPES = ["blocks"] as const;
 export type IssueRelationType = (typeof ISSUE_RELATION_TYPES)[number];
 
-export const ISSUE_EXECUTION_POLICY_MODES = ["normal", "auto"] as const;
+export const ISSUE_EXECUTION_POLICY_MODES = ["normal", "auto", "coordination"] as const;
 export type IssueExecutionPolicyMode = (typeof ISSUE_EXECUTION_POLICY_MODES)[number];
 
 export const ISSUE_EXECUTION_STAGE_TYPES = ["review", "approval"] as const;

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -670,4 +670,50 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
   });
+
+  it("does not auto-block a coordination-mode in_progress issue after continuation retry exhausted", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db
+      .update(issues)
+      .set({ executionPolicy: { mode: "coordination" } })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
+
+  it("does not auto-block a coordination-mode todo issue after dispatch retry exhausted", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+    });
+    await db
+      .update(issues)
+      .set({ executionPolicy: { mode: "coordination" } })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3031,6 +3031,13 @@ export function heartbeatService(db: Db) {
         continue;
       }
 
+      // Coordination/ambient issues are not execution-backed — skip auto-block entirely.
+      const policyMode = readNonEmptyString(parseObject(issue.executionPolicy).mode);
+      if (policyMode === "coordination") {
+        result.skipped += 1;
+        continue;
+      }
+
       if (await hasActiveExecutionPath(issue.companyId, issue.id)) {
         result.skipped += 1;
         continue;


### PR DESCRIPTION
## Summary
- Adds `"coordination"` to `ISSUE_EXECUTION_POLICY_MODES` in `packages/shared/src/constants.ts`
- The stranded-issue reconciler in `heartbeat.ts` now skips issues with `executionPolicy.mode = "coordination"` instead of auto-blocking them when their execution path disappears
- Documents §8.3 coordination exemption in `doc/execution-semantics.md`
- Adds two test cases covering both `todo` and `in_progress` coordination-mode paths

## Context
This fix was implemented for BLA-653 and verified by BLA-691/BLA-730 regression coverage, but the branch was pushed to a fork and never merged to `master`. BLA-804 tracks landing it cleanly.

## Test plan
- [ ] CI passes (heartbeat-process-recovery tests cover both coordination-mode paths)
- [ ] Verify `ISSUE_EXECUTION_POLICY_MODES` includes `"coordination"` in shared constants
- [ ] Verify `reconcileStrandedAssignedIssues` skips coordination-mode issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)