### PR TITLE
fix(server): skip git worktrees for fallback workspaces

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -372,6 +372,46 @@ describe("realizeExecutionWorkspace", () => {
     expect(second.branchName).toBe(first.branchName);
   });
 
+  it("falls back to the resolved workspace when git worktree strategy is requested for a non-git cwd", async () => {
+    const fallbackCwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fallback-workspace-"));
+
+    const realized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: fallbackCwd,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-4020",
+        title: "Projectless issues fail instantly",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Claude Code",
+        companyId: "company-1",
+      },
+    });
+
+    expect(realized.strategy).toBe("project_primary");
+    expect(realized.cwd).toBe(fallbackCwd);
+    expect(realized.created).toBe(false);
+    expect(realized.branchName).toBeNull();
+    expect(realized.worktreePath).toBeNull();
+    expect(realized.warnings).toEqual([
+      `Workspace strategy requested git worktree, but base cwd "${fallbackCwd}" is not a git checkout. Using the resolved workspace directly for this run.`,
+    ]);
+  });
+
   it("rejects reusing an empty directory that only looks like a worktree because it sits inside the repo", async () => {
     const repoRoot = await createTempRepo();
     const branchName = "PAP-447-add-worktree-support";

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -998,6 +998,20 @@ export async function realizeExecutionWorkspace(input: {
     };
   }
 
+  if (!await isGitCheckout(input.base.baseCwd)) {
+    return {
+      ...input.base,
+      strategy: "project_primary",
+      cwd: input.base.baseCwd,
+      branchName: null,
+      worktreePath: null,
+      warnings: [
+        `Workspace strategy requested git worktree, but base cwd "${input.base.baseCwd}" is not a git checkout. Using the resolved workspace directly for this run.`,
+      ],
+      created: false,
+    };
+  }
+
   const repoRoot = await resolveGitOwnerRepoRoot(input.base.baseCwd);
   const branchTemplate = asString(rawStrategy.branchTemplate, "{{issue.identifier}}-{{slug}}");
   const renderedBranch = renderWorkspaceTemplate(branchTemplate, {


### PR DESCRIPTION
## Summary
- skip git worktree creation when the resolved workspace cwd is not a git checkout
- keep the existing fallback workspace instead of letting `git rev-parse` fail immediately
- add a regression test for non-git fallback workspaces

## Why this matters
Company-level or otherwise fallback-backed runs can already resolve to a usable local workspace, but `realizeExecutionWorkspace` still assumes every `git_worktree` run starts from a checkout. That turns a recoverable fallback into an immediate `fatal: not a git repository` failure.

This keeps the current fallback behavior intact and only disables the worktree path when the resolved cwd is not actually a git repo.

Closes #4020
