### PR TITLE
fix(db): use calendar months for monthly backup retention

### DIFF
--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -111,7 +111,9 @@ function pruneOldBackups(backupDir: string, retention: BackupRetentionPolicy, fi
   const now = Date.now();
   const dailyCutoff = now - Math.max(1, retention.dailyDays) * 24 * 60 * 60 * 1000;
   const weeklyCutoff = now - Math.max(1, retention.weeklyWeeks) * 7 * 24 * 60 * 60 * 1000;
-  const monthlyCutoff = now - Math.max(1, retention.monthlyMonths) * 30 * 24 * 60 * 60 * 1000;
+  const monthlyCutoffDate = new Date(now);
+  monthlyCutoffDate.setMonth(monthlyCutoffDate.getMonth() - Math.max(1, retention.monthlyMonths));
+  const monthlyCutoff = monthlyCutoffDate.getTime();
 
   type BackupEntry = { name: string; fullPath: string; mtimeMs: number };
   const entries: BackupEntry[] = [];


### PR DESCRIPTION
## Thinking Path

`pruneOldBackups` computes the monthly cutoff as `now - monthlyMonths * 30 * 24h`. Since real months are 28–31 days long, this drifts: every year a backup configured to retain N months actually retains slightly less than N calendar months. After 12 months the drift is ~5 days, which can cause the prune step to delete a monthly backup that the user expected to still be present.

The fix is to compute the cutoff with calendar arithmetic (`Date#setMonth`) instead of a fixed millisecond offset. Daily/weekly cutoffs remain second-based since their units are well-defined.

Refs upstream issue #3713.

## What Changed

- `packages/db/src/backup-lib.ts`: monthly cutoff now uses `new Date(now); setMonth(getMonth() - n)` so the boundary lands on the same calendar day N months ago.

## Verification

- Walked through `setMonth` semantics for edge cases:
  - Mar 31 → setMonth(-1) → Feb 28/29 (clamped, expected behaviour and still produces a valid cutoff in the past).
  - Jan 1 → setMonth(-1) → year boundary handled by Date.
- Daily and weekly windows are unchanged.

## Risks

- Behaviour change: a backup that was about to be pruned by the 30-day approximation may now survive until the equivalent calendar day passes. Effect is at most a few extra days of retention; no data loss.
- No new dependencies, no migration.

## Checklist

- [x] One logical change
- [x] No schema or migration impact