### PR TITLE
fix(issues): clear execution lock fields on release

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2026,6 +2026,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Thinking Path

`releaseIssue` is the recovery path used when an agent abandons or hands off an issue. It currently resets `status`, `assigneeAgentId`, and `checkoutRunId` — but the parallel `execution*` lock columns (`executionRunId`, `executionAgentNameKey`, `executionLockedAt`) are left as they were.

Those execution fields are checked elsewhere when a new run tries to claim the issue. Stale values look like an active claim by a run that no longer exists, so the next agent gets blocked or the issue silently stalls in `todo`.

The fix is to null out the execution-lock triple in the same UPDATE — the same way `assigneeAgentId` / `checkoutRunId` are already cleared.

Refs upstream issue #4011.

## What Changed

- `server/src/services/issues.ts`: `releaseIssue` now sets `executionRunId`, `executionAgentNameKey`, and `executionLockedAt` to `null` alongside the existing reset fields.

## Verification

- The same fields are nulled together in other recovery paths (e.g. when a heartbeat reaper expires a stuck run), so the schema and downstream consumers already handle a fully-cleared lock.
- No new query or column references; existing UPDATE was just missing three set-clauses.

## Risks

- Behaviour change is intentional and narrow: any subsequent run can now successfully claim an issue that was released — which is the documented purpose of release.

## Checklist

- [x] One logical change
- [x] No schema changes