### PR TITLE
fix(issues): wake parent agent when a child becomes blocked

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1927,29 +1927,34 @@ export function issueRoutes(
         }
       }
 
+      const PARENT_WAKE_STATUSES = ["done", "cancelled", "blocked"] as const;
       const becameTerminal =
-        !["done", "cancelled"].includes(existing.status) && ["done", "cancelled"].includes(issue.status);
+        !PARENT_WAKE_STATUSES.includes(existing.status as typeof PARENT_WAKE_STATUSES[number])
+        && PARENT_WAKE_STATUSES.includes(issue.status as typeof PARENT_WAKE_STATUSES[number]);
       if (becameTerminal && issue.parentId) {
         const parent = await svc.getWakeableParentAfterChildCompletion(issue.parentId);
         if (parent) {
+          const wakeReason = issue.status === "blocked" ? "issue_child_blocked" : "issue_children_completed";
           addWakeup(parent.assigneeAgentId, {
             source: "automation",
             triggerDetail: "system",
-            reason: "issue_children_completed",
+            reason: wakeReason,
             payload: {
               issueId: parent.id,
               completedChildIssueId: issue.id,
               childIssueIds: parent.childIssueIds,
+              childStatus: issue.status,
             },
             requestedByActorType: actor.actorType,
             requestedByActorId: actor.actorId,
             contextSnapshot: {
               issueId: parent.id,
               taskId: parent.id,
-              wakeReason: "issue_children_completed",
-              source: "issue.children_completed",
+              wakeReason,
+              source: issue.status === "blocked" ? "issue.child_blocked" : "issue.children_completed",
               completedChildIssueId: issue.id,
               childIssueIds: parent.childIssueIds,
+              childStatus: issue.status,
             },
           });
         }


### PR DESCRIPTION
## Thinking Path

When a child issue reaches a terminal state, the parent's assignee gets a wakeup so it can replan. Today \"terminal\" means `done` or `cancelled` only. If a child transitions to `blocked`, the parent is never woken — the parent agent has no way to know progress on its sub-task has stalled until the next manual touch.

`blocked` is functionally a stop signal for the child's branch of work; the parent typically needs to either unblock it, reassign, or abandon. Treating it as a wake trigger lets the parent react immediately, which matches how `done` and `cancelled` are handled.

To keep the wake informative, distinguish the cause: `issue_child_blocked` vs `issue_children_completed`, and surface the child's status in the payload/contextSnapshot so the wake recipient can branch on it.

Refs upstream issue #3822.

## What Changed

- `server/src/routes/issues.ts`: introduced `PARENT_WAKE_STATUSES = [done, cancelled, blocked]`; `becameTerminal` now uses that set.
- Branched `wakeReason` and `source` strings on `issue.status === \"blocked\"`.
- Added `childStatus` to both `payload` and `contextSnapshot`.

## Verification

- The `done`/`cancelled` paths produce the same `reason` and `source` strings as before — backwards-compatible for existing wake handlers.
- The new `blocked` path uses unique strings (`issue_child_blocked` / `issue.child_blocked`) so any consumer that special-cased the old reasons keeps working unchanged.

## Risks

- Parent agents will now wake on `blocked` transitions they previously ignored. Volume should be small (only direct children of an assigned parent).
- Wake handlers that key off `reason` see a new value. They should default to a generic re-plan if unknown — verified the existing handlers in this repo do exactly that.

## Checklist

- [x] One logical change
- [x] Backwards-compatible payload (extra fields only)