### PR TITLE
fix(heartbeat): emit agent.run.* activity events on status transitions

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2125,6 +2125,24 @@ export function heartbeatService(db: Db) {
       .then((rows) => rows[0]);
   }
 
+  function mapRunStatusToPluginEvent(
+    status: string,
+  ): "agent.run.started" | "agent.run.finished" | "agent.run.failed" | "agent.run.cancelled" | null {
+    switch (status) {
+      case "running":
+        return "agent.run.started";
+      case "succeeded":
+        return "agent.run.finished";
+      case "failed":
+      case "timed_out":
+        return "agent.run.failed";
+      case "cancelled":
+        return "agent.run.cancelled";
+      default:
+        return null;
+    }
+  }
+
   async function setRunStatus(
     runId: string,
     status: string,
@@ -2153,6 +2171,30 @@ export function heartbeatService(db: Db) {
           finishedAt: updated.finishedAt ? new Date(updated.finishedAt).toISOString() : null,
         },
       });
+
+      const pluginEventAction = mapRunStatusToPluginEvent(updated.status);
+      if (pluginEventAction) {
+        await logActivity(db, {
+          companyId: updated.companyId,
+          actorType: "agent",
+          actorId: updated.agentId,
+          agentId: updated.agentId,
+          runId: updated.id,
+          action: pluginEventAction,
+          entityType: "agent",
+          entityId: updated.agentId,
+          details: {
+            runId: updated.id,
+            status: updated.status,
+            invocationSource: updated.invocationSource,
+            triggerDetail: updated.triggerDetail,
+            error: updated.error ?? null,
+            errorCode: updated.errorCode ?? null,
+            startedAt: updated.startedAt ? new Date(updated.startedAt).toISOString() : null,
+            finishedAt: updated.finishedAt ? new Date(updated.finishedAt).toISOString() : null,
+          },
+        });
+      }
     }
 
     return updated;


### PR DESCRIPTION
## Thinking Path

Plugins subscribe to `agent.run.started`, `agent.run.finished`, `agent.run.failed`, and `agent.run.cancelled` to react to run lifecycle changes. Today, `setRunStatus` publishes the in-process event-bus notification but doesn't write a corresponding `activity` row. Any plugin or audit consumer that hydrates from the activity stream — instead of subscribing to the in-process bus — never sees those transitions.

The fix is to map the status string to a single canonical plugin event name and `logActivity` it from the same code path that handles the in-process publish, so both surfaces stay consistent.

Refs upstream issue #3789.

## What Changed

- `server/src/services/heartbeat.ts`: added `mapRunStatusToPluginEvent` mapping `running → agent.run.started`, `succeeded → agent.run.finished`, `failed`/`timed_out → agent.run.failed`, `cancelled → agent.run.cancelled`. Returns `null` for `queued` (no event needed).
- `setRunStatus` calls `logActivity` after the in-process publish when the mapping returns a non-null event, with the same details payload (status, source, error, timing).

## Verification

- `mapRunStatusToPluginEvent` returns `null` for all non-mapped statuses, so the activity write is skipped — no spurious rows for transient states.
- The in-process publish path is unchanged, so existing in-process subscribers continue to receive events at the same time as before.
- Activity write happens after the DB update has succeeded, so we never log an event for a status change that didn't persist.

## Risks

- New activity rows on every run lifecycle transition. Volume scales with run throughput; acceptable since it matches the documented plugin event surface.
- No schema changes.

## Checklist

- [x] One logical change
- [x] No new dependencies