### PR TITLE
fix(agents): add PATCH /agents/me self-update route

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1919,7 +1919,16 @@ export function agentRoutes(db: Db) {
     res.json(result.bundle);
   });
 
-  router.patch("/agents/:id", validate(updateAgentSchema), async (req, res) => {
+  router.patch("/agents/me", (req, res, next) => {
+    if (req.actor.type !== "agent" || !req.actor.agentId) {
+      res.status(401).json({ error: "Agent authentication required" });
+      return;
+    }
+    req.params.id = req.actor.agentId;
+    next();
+  }, validate(updateAgentSchema), (req, res) => updateAgentHandler(req, res));
+
+  const updateAgentHandler = async (req: Request, res: Response) => {
     const id = req.params.id as string;
     const existing = await svc.getById(id);
     if (!existing) {
@@ -2046,7 +2055,9 @@ export function agentRoutes(db: Db) {
     });
 
     res.json(agent);
-  });
+  };
+
+  router.patch("/agents/:id", validate(updateAgentSchema), (req, res) => updateAgentHandler(req, res));
 
   router.post("/agents/:id/pause", async (req, res) => {
     assertBoard(req);


### PR DESCRIPTION
## Thinking Path

The server exposes `GET /agents/me` so an agent can fetch its own profile using only its bearer token. The corresponding `PATCH /agents/me` is missing — to update its own record an agent has to know its own UUID and hit `PATCH /agents/:id`. Agents authenticated by token don't always have that ID handy (it's never returned to them in some flows), so the only options today are either an extra round-trip to `/agents/me` or pass the ID through every adapter manually.

The fix is to register `PATCH /agents/me` as a thin pre-handler that resolves the actor's `agentId` and forwards to the existing handler logic (extracted into a shared function so both routes share validation and behaviour).

Refs upstream issue #3831.

## What Changed

- `server/src/routes/agents.ts`:
  - Added `router.patch(\"/agents/me\", ...)` with a guard that 401s for non-agent callers, sets `req.params.id` from `req.actor.agentId`, then runs the same `validate` middleware and shared handler.
  - Extracted the existing `PATCH /agents/:id` body into `updateAgentHandler(req, res)` and re-registered the `:id` route to call it.

## Verification

- The shared handler keeps the existing `validate(updateAgentSchema)` chain on both routes.
- The `/me` guard returns 401 with a clear message when called by a non-agent actor (e.g. user session, board admin) — matches the auth model used by the existing `GET /agents/me`.
- No behaviour change for `PATCH /agents/:id`; same handler, same middleware, same status codes.

## Risks

- New endpoint surface only — existing routes untouched.
- Handler is now shared between two routes; any future change must keep both call sites in mind. Function name (`updateAgentHandler`) is unambiguous.

## Checklist

- [x] One logical change
- [x] Auth guard on the new endpoint