### PR TITLE
fix(company-skills): atomic upsert with bundled-skill guard

### DIFF
--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { companySkills } from "@paperclipai/db";
 import { readPaperclipSkillSyncPreference } from "@paperclipai/adapter-utils/server-utils";
@@ -2298,22 +2298,12 @@ export function companySkillService(db: Db) {
   async function upsertImportedSkills(companyId: string, imported: ImportedSkill[]): Promise<CompanySkill[]> {
     const out: CompanySkill[] = [];
     for (const skill of imported) {
-      const existing = await getByKey(companyId, skill.key);
-      const existingMeta = existing ? getSkillMeta(existing) : {};
       const incomingMeta = skill.metadata && isPlainRecord(skill.metadata) ? skill.metadata : {};
       const incomingOwner = asString(incomingMeta.owner);
       const incomingRepo = asString(incomingMeta.repo);
       const incomingKind = asString(incomingMeta.sourceKind);
-      if (
-        existing
-        && existingMeta.sourceKind === "paperclip_bundled"
-        && incomingKind === "github"
-        && incomingOwner === "paperclipai"
-        && incomingRepo === "paperclip"
-      ) {
-        out.push(existing);
-        continue;
-      }
+      const skipBundledOverwrite =
+        incomingKind === "github" && incomingOwner === "paperclipai" && incomingRepo === "paperclip";
 
       const metadata = {
         ...(skill.metadata ?? {}),
@@ -2335,20 +2325,35 @@ export function companySkillService(db: Db) {
         metadata,
         updatedAt: new Date(),
       };
-      const row = existing
-        ? await db
-          .update(companySkills)
-          .set(values)
-          .where(eq(companySkills.id, existing.id))
-          .returning()
-          .then((rows) => rows[0] ?? null)
-        : await db
-          .insert(companySkills)
-          .values(values)
-          .returning()
-          .then((rows) => rows[0] ?? null);
-      if (!row) throw notFound("Failed to persist company skill");
-      out.push(toCompanySkill(row));
+
+      const setOnConflict: Partial<typeof values> = { ...values };
+      delete (setOnConflict as Record<string, unknown>).companyId;
+      delete (setOnConflict as Record<string, unknown>).key;
+
+      const upsertWhere = skipBundledOverwrite
+        ? sql`coalesce(${companySkills.metadata} ->> 'sourceKind', '') <> 'paperclip_bundled'`
+        : undefined;
+
+      const row = await db
+        .insert(companySkills)
+        .values(values)
+        .onConflictDoUpdate({
+          target: [companySkills.companyId, companySkills.key],
+          set: setOnConflict,
+          setWhere: upsertWhere,
+        })
+        .returning()
+        .then((rows) => rows[0] ?? null);
+
+      if (row) {
+        out.push(toCompanySkill(row));
+        continue;
+      }
+
+      // setWhere blocked the update — re-fetch the existing row to return.
+      const existing = await getByKey(companyId, skill.key);
+      if (!existing) throw notFound("Failed to persist company skill");
+      out.push(existing);
     }
     return out;
   }


### PR DESCRIPTION
## Thinking Path

`upsertImportedSkills` does `getByKey` → branch → `INSERT or UPDATE` for each imported skill. That's a textbook check-then-act race:
- Two concurrent imports for the same `(companyId, key)` both see \"no row\".
- Both run the INSERT branch.
- The second one trips the unique constraint and the import aborts mid-way through the list.

The same function also has a guard that prevents overwriting `paperclip_bundled` skills with the upstream `paperclipai/paperclip` github mirror copy. That guard runs on the read snapshot, so under contention it can also be bypassed (read says \"not bundled\" but a concurrent insert just made it bundled).

The fix is to collapse SELECT-then-INSERT/UPDATE into a single atomic upsert, and express the bundled guard as a SQL predicate that runs inside the same transaction.

Refs upstream issue #3845.

## What Changed

- `server/src/services/company-skills.ts`:
  - Single `db.insert(companySkills).values(...).onConflictDoUpdate({...})` per skill.
  - Conflict target: `(companyId, key)` (matches the existing unique index).
  - For incoming bundled-mirror payloads, the upsert carries `setWhere: coalesce(metadata->>'sourceKind','') <> 'paperclip_bundled'` so the UPDATE only runs when the existing row is *not* the bundled skill.
  - When `setWhere` blocks the update *and* the INSERT no-ops (conflict path), re-fetch by key and return the existing row.
  - Added `sql` to the drizzle-orm import for the predicate.

## Verification

- Walked through both branches:
  - Non-bundled-mirror import: behaves as a plain conditional upsert; identical end state to the original code.
  - Bundled-mirror import on top of a `paperclip_bundled` row: `setWhere` blocks the update, returning row is null, fallback `getByKey` returns the bundled row — same protection as the previous in-process check, now race-safe.
  - Bundled-mirror import on top of a non-bundled row: `setWhere` evaluates true; the row is overwritten as expected.
- Concurrent-import scenario: both inserts hit the conflict, only one update wins, neither raises a constraint violation.

## Risks

- New SQL predicate runs once per imported skill; no measurable cost change because we removed the prior SELECT.
- `companyId` / `key` are excluded from the `set` payload to avoid changing the conflict target, matching standard upsert practice.

## Checklist

- [x] One logical change
- [x] No schema changes