### PR TITLE
fix(inbox): exclude done issues from inbox badge count

### DIFF
--- a/ui/src/hooks/useInboxBadge.ts
+++ b/ui/src/hooks/useInboxBadge.ts
@@ -20,7 +20,7 @@ import {
   READ_ITEMS_KEY,
 } from "../lib/inbox";
 
-const INBOX_ISSUE_STATUSES = "backlog,todo,in_progress,in_review,blocked,done";
+const INBOX_ISSUE_STATUSES = "backlog,todo,in_progress,in_review,blocked";
 const INBOX_BADGE_HEARTBEAT_RUN_LIMIT = 200;
 
 export function useDismissedInboxAlerts() {


### PR DESCRIPTION
## Thinking Path

The inbox badge fetches issues with statuses `backlog,todo,in_progress,in_review,blocked,done`. Including `done` means every completed-but-not-archived issue keeps inflating the unread count, even though the badge is supposed to surface work that still needs attention.

The intended semantics are \"things still on your plate\". Finished work should not count toward the badge — the user already finished it.

The fix is a one-token change to the status list. Other inbox surfaces (the inbox tab itself, dashboard) load their own queries with their own status sets, so they're unaffected.

Refs upstream issue #3919.

## What Changed

- `ui/src/hooks/useInboxBadge.ts`: removed `done` from `INBOX_ISSUE_STATUSES`.

## Verification

- The badge count is computed from this query result via `computeInboxBadgeData`, which already filters by archive/dismissal. Removing `done` only narrows the set going in.
- The inbox view itself uses different queries and continues to display done issues; the change is scoped to the badge count.

## Risks

- Visible-to-user behaviour change: badge counts may decrease for users with many finished-but-not-archived issues. This is the intended correction.

## Checklist

- [x] One logical change
- [x] Touches only the badge query