### PR TITLE
fix(ui): treat blocked issues as inactive in run chat surface

### DIFF
--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -149,6 +149,7 @@ function AgentRunCard({
           transcript={transcript}
           hasOutput={hasOutput}
           companyId={companyId}
+          issueStatus={issue?.status ?? null}
         />
       </div>
     </div>

--- a/ui/src/components/LiveRunWidget.tsx
+++ b/ui/src/components/LiveRunWidget.tsx
@@ -13,6 +13,7 @@ import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
 interface LiveRunWidgetProps {
   issueId: string;
   companyId?: string | null;
+  issueStatus?: string | null;
 }
 
 function toIsoString(value: string | Date | null | undefined): string | null {
@@ -24,7 +25,7 @@ function isRunActive(status: string): boolean {
   return status === "queued" || status === "running";
 }
 
-export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
+export function LiveRunWidget({ issueId, companyId, issueStatus }: LiveRunWidgetProps) {
   const queryClient = useQueryClient();
   const [cancellingRunIds, setCancellingRunIds] = useState(new Set<string>());
 
@@ -147,6 +148,7 @@ export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
                   transcript={transcript}
                   hasOutput={hasOutputForRun(run.id)}
                   companyId={companyId}
+                  issueStatus={issueStatus}
                 />
               </div>
             </section>

--- a/ui/src/components/RunChatSurface.tsx
+++ b/ui/src/components/RunChatSurface.tsx
@@ -13,6 +13,7 @@ interface RunChatSurfaceProps {
   transcript: TranscriptEntry[];
   hasOutput: boolean;
   companyId?: string | null;
+  issueStatus?: string | null;
 }
 
 export function RunChatSurface({
@@ -20,8 +21,9 @@ export function RunChatSurface({
   transcript,
   hasOutput,
   companyId,
+  issueStatus,
 }: RunChatSurfaceProps) {
-  const active = isRunActive(run);
+  const active = isRunActive(run) && issueStatus !== "blocked";
   const liveRuns = active ? [run] : [];
   const linkedRuns = useMemo<IssueChatLinkedRun[]>(
     () =>


### PR DESCRIPTION
## Thinking Path

`RunChatSurface` decides whether the chat is \"live\" purely from the run status (`queued`/`running`). When the parent issue is `blocked`, the run is functionally suspended — but the chat surface still presents itself as live, with the composer enabled and the empty state saying \"Waiting for run output…\".

Conceptually, a blocked issue means \"don't act\". The surface should reflect that immediately, even if a stale `queued` row hasn't yet been reaped.

This requires the issue's status to be visible at the surface level, so I added an optional `issueStatus` prop and threaded it through the two existing call sites. The prop is optional, so any other consumer keeps the previous behaviour.

Refs upstream issue #3820.

## What Changed

- `ui/src/components/RunChatSurface.tsx`: added optional `issueStatus?: string | null`. Active calculation now `isRunActive(run) && issueStatus !== \"blocked\"`.
- `ui/src/components/LiveRunWidget.tsx`: forwarded a new optional `issueStatus` prop into the surface.
- `ui/src/components/ActiveAgentsPanel.tsx`: passes `issueStatus={issue?.status ?? null}` to the surface (it already loads the issue per card).

## Verification

- Default behaviour preserved: when callers don't pass `issueStatus`, the predicate `issueStatus !== \"blocked\"` is `true` and the active branch runs exactly as before.
- LiveRunWidget receives the prop optionally — issue pages that already have the status can pass it; ones that don't are unaffected.
- ActiveAgentsPanel resolves the issue from its existing query map; if the issue isn't loaded yet, the prop is `null` and the surface stays in its previous behaviour.

## Risks

- Pure additive prop, no required call-site changes, no schema or API impact.
- Visible behaviour change only kicks in when the prop is explicitly passed and the issue is `blocked`.

## Checklist

- [x] One logical change
- [x] Backwards-compatible prop addition