### PR TITLE
fix(claude-local): make fetchWithTimeout timeout env-configurable

### DIFF
--- a/packages/adapters/claude-local/src/server/quota.ts
+++ b/packages/adapters/claude-local/src/server/quota.ts
@@ -198,10 +198,18 @@ export function toPercent(utilization: number | null | undefined): number | null
   return Math.min(100, Math.round(utilization < 1 ? utilization * 100 : utilization));
 }
 
+function defaultFetchTimeoutMs(): number {
+  const raw = process.env.PAPERCLIP_CLAUDE_LOCAL_FETCH_TIMEOUT_MS;
+  if (!raw) return 8000;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 8000;
+}
+
 /** fetch with an abort-based timeout so a hanging provider api doesn't block the response indefinitely */
-export async function fetchWithTimeout(url: string, init: RequestInit, ms = 8000): Promise<Response> {
+export async function fetchWithTimeout(url: string, init: RequestInit, ms?: number): Promise<Response> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), ms);
+  const effectiveMs = ms ?? defaultFetchTimeoutMs();
+  const timer = setTimeout(() => controller.abort(), effectiveMs);
   try {
     return await fetch(url, { ...init, signal: controller.signal });
   } finally {


### PR DESCRIPTION
## Thinking Path

`fetchWithTimeout` in the claude-local adapter quota module hard-codes an 8000ms abort. That's fine on a fast local connection, but on slow links or when traffic goes through a corporate proxy the Anthropic quota endpoint can take longer than 8s to respond. The abort fires first, the call surfaces as a provider error, and the UI shows a misleading failure even though the upstream API would have answered.

The fix is to make the default overridable via env without changing the function signature, so:
- Operators can tune the timeout for their environment.
- Callers that already pass `ms` keep their explicit value.
- Bad env values (empty string, non-numeric, ≤ 0) silently fall back to the original 8s default — env misconfiguration must not disable the timeout.

Refs upstream issue #3676.

## What Changed

- `packages/adapters/claude-local/src/server/quota.ts`:
  - Added `defaultFetchTimeoutMs()` that reads `PAPERCLIP_CLAUDE_LOCAL_FETCH_TIMEOUT_MS` and returns the parsed positive number, or 8000 as fallback.
  - `fetchWithTimeout(url, init, ms?)`: `ms` is now optional; when omitted, uses the env-derived default. Caller-supplied `ms` still wins.

## Verification

- `Number.isFinite && > 0` guards against accidental disable (negative, zero, NaN, empty string all keep the safe default).
- Existing call sites pass either nothing (now → env-or-8000) or an explicit number (unchanged behaviour).
- No new dependency, no new export surface.

## Risks

- New env var must be documented; no existing deployment behaviour changes when it's unset.
- Operators who set an extremely large value can mask hung connections — same trade-off as any timeout knob; the function still aborts, just later.

## Checklist

- [x] One logical change
- [x] Defaults preserved when env is unset