### PR TITLE
fix(openclaw-gateway): remove paperclip property from agent params (regression of #606)

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1123,7 +1123,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
   const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
 
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
@@ -1132,7 +1131,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  delete agentParams.paperclip;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {


### PR DESCRIPTION
## Summary

The OpenClaw Gateway's `agent` method has strict parameter validation and rejects unknown root-level properties. Every gateway-based agent wake currently fails with:

```
[openclaw-gateway] request failed: invalid agent params: at root: unexpected property 'paperclip'
```

This was originally fixed in 6c9e639a ("fix: remove paperclip property from OpenClaw Gateway agent params", closing #606 — thank you @caiqinghua).

Commit 91e040a6 ("Batch inline comment wake payloads") reintroduced the line `agentParams.paperclip = paperclipPayload;` in `execute.ts`, silently regressing the fix. The regression is on current `master` and reproduces on every wake event.

## Fix

- Remove the `agentParams.paperclip = paperclipPayload;` line (the original fix).
- Also `delete agentParams.paperclip` defensively, so a stale `paperclip` field coming in through `payloadTemplate` / adapter config can't reintroduce the same failure through configuration.
- The paperclip metadata (run/agent/company IDs, workspace info, wake context) is still delivered to the remote agent via the wake text in the `message` field (`buildWakeText`), so no operational information is lost. This matches the rationale in the original fix PR.

## Reproduction

1. Configure any agent with the `openclaw_gateway` adapter.
2. Trigger a wake (e.g. assign an issue to the agent).
3. Observe in server logs:

```
[openclaw-gateway] outbound payload (redacted): {"message":"Paperclip wake event ...","sessionKey":"paperclip:issue:...","idempotencyKey":"...","paperclip":{...}, ...}
[openclaw-gateway] request failed: invalid agent params: at root: unexpected property 'paperclip'
```

After this patch the `paperclip` key is no longer present at the root of the outbound payload and the gateway accepts the request.

## Test plan

- [x] `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck`
- [x] Manual repro: wake an agent in local dev with the openclaw_gateway adapter pointing at a local gateway; with this patch the request is accepted instead of rejected.

Re-fixes #606.