### PR TITLE
fix(server-utils): prefer PAPERCLIP_PUBLIC_URL when PAPERCLIP_API_URL unset

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { describe, expect, it } from "vitest";
-import { runChildProcess } from "./server-utils.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildPaperclipEnv, runChildProcess } from "./server-utils.js";
 
 function isPidAlive(pid: number) {
   try {
@@ -84,5 +84,63 @@ describe("runChildProcess", () => {
     expect(Number.isInteger(descendantPid) && descendantPid > 0).toBe(true);
 
     expect(await waitForPidExit(descendantPid!, 2_000)).toBe(true);
+  });
+});
+
+describe("buildPaperclipEnv PAPERCLIP_API_URL resolution", () => {
+  const keys = [
+    "PAPERCLIP_API_URL",
+    "PAPERCLIP_PUBLIC_URL",
+    "PAPERCLIP_LISTEN_HOST",
+    "PAPERCLIP_LISTEN_PORT",
+    "HOST",
+    "PORT",
+  ] as const;
+  const saved: Partial<Record<(typeof keys)[number], string>> = {};
+
+  beforeEach(() => {
+    for (const k of keys) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  const AGENT = { id: "a-1", companyId: "co-1" };
+
+  it("prefers PAPERCLIP_API_URL when explicitly set", () => {
+    process.env.PAPERCLIP_API_URL = "http://internal-api.example:9000";
+    process.env.PAPERCLIP_PUBLIC_URL = "https://public.example";
+    expect(buildPaperclipEnv(AGENT).PAPERCLIP_API_URL).toBe(
+      "http://internal-api.example:9000",
+    );
+  });
+
+  it("falls back to PAPERCLIP_PUBLIC_URL when PAPERCLIP_API_URL is unset", () => {
+    // Setting only PAPERCLIP_PUBLIC_URL is the common operator case — an
+    // externally-reachable HTTPS URL that agents + adapters should use to
+    // call back to Paperclip. Previously buildPaperclipEnv ignored this
+    // variable and fell through to the loopback default, which leaked
+    // `http://127.0.0.1:<port>` into envelope bodies and (in paths that
+    // sit behind a WAF) tripped SSRF detection rules.
+    process.env.PAPERCLIP_PUBLIC_URL = "https://public.example";
+    expect(buildPaperclipEnv(AGENT).PAPERCLIP_API_URL).toBe("https://public.example");
+  });
+
+  it("falls back to the runtime host:port loopback URL when neither is set", () => {
+    process.env.PAPERCLIP_LISTEN_PORT = "3100";
+    expect(buildPaperclipEnv(AGENT).PAPERCLIP_API_URL).toBe("http://localhost:3100");
+  });
+
+  it("ignores empty-string values and continues the fallback chain", () => {
+    process.env.PAPERCLIP_API_URL = "";
+    process.env.PAPERCLIP_PUBLIC_URL = "https://public.example";
+    expect(buildPaperclipEnv(AGENT).PAPERCLIP_API_URL).toBe("https://public.example");
   });
 });

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -550,9 +550,30 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
   );
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
-  const apiUrl = process.env.PAPERCLIP_API_URL ?? `http://${runtimeHost}:${runtimePort}`;
+  // Resolution order for `PAPERCLIP_API_URL` consumed by agents/adapters:
+  //   1. `PAPERCLIP_API_URL`   — explicit override (e.g. an internal-only URL
+  //       that differs from the public one).
+  //   2. `PAPERCLIP_PUBLIC_URL` — the operator's publicly-advertised URL,
+  //       which config.ts already consumes for auth callbacks. Preferring
+  //       it over the loopback default keeps outbound invoke envelopes
+  //       from leaking `http://127.0.0.1:<port>` into bodies that leave
+  //       the host — a leak that breaks any reverse-proxy or WAF path
+  //       fronting the receiving service.
+  //   3. Runtime host:port loopback fallback for pure-local dev when
+  //      neither is set.
+  const explicitApiUrl = readNonEmptyEnv("PAPERCLIP_API_URL");
+  const publicUrl = readNonEmptyEnv("PAPERCLIP_PUBLIC_URL");
+  const apiUrl =
+    explicitApiUrl ?? publicUrl ?? `http://${runtimeHost}:${runtimePort}`;
   vars.PAPERCLIP_API_URL = apiUrl;
   return vars;
+}
+
+function readNonEmptyEnv(name: string): string | null {
+  const v = process.env[name];
+  if (typeof v !== "string") return null;
+  const trimmed = v.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 export function defaultPathForPlatform() {

--- a/packages/adapter-utils/vitest.config.ts
+++ b/packages/adapter-utils/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildPaperclipEnv } from "../adapters/utils.js";
 
 const ORIGINAL_PAPERCLIP_API_URL = process.env.PAPERCLIP_API_URL;
+const ORIGINAL_PAPERCLIP_PUBLIC_URL = process.env.PAPERCLIP_PUBLIC_URL;
 const ORIGINAL_PAPERCLIP_LISTEN_HOST = process.env.PAPERCLIP_LISTEN_HOST;
 const ORIGINAL_PAPERCLIP_LISTEN_PORT = process.env.PAPERCLIP_LISTEN_PORT;
 const ORIGINAL_HOST = process.env.HOST;
@@ -10,6 +11,9 @@ const ORIGINAL_PORT = process.env.PORT;
 afterEach(() => {
   if (ORIGINAL_PAPERCLIP_API_URL === undefined) delete process.env.PAPERCLIP_API_URL;
   else process.env.PAPERCLIP_API_URL = ORIGINAL_PAPERCLIP_API_URL;
+
+  if (ORIGINAL_PAPERCLIP_PUBLIC_URL === undefined) delete process.env.PAPERCLIP_PUBLIC_URL;
+  else process.env.PAPERCLIP_PUBLIC_URL = ORIGINAL_PAPERCLIP_PUBLIC_URL;
 
   if (ORIGINAL_PAPERCLIP_LISTEN_HOST === undefined) delete process.env.PAPERCLIP_LISTEN_HOST;
   else process.env.PAPERCLIP_LISTEN_HOST = ORIGINAL_PAPERCLIP_LISTEN_HOST;
@@ -54,5 +58,25 @@ describe("buildPaperclipEnv", () => {
     const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
 
     expect(env.PAPERCLIP_API_URL).toBe("http://[::1]:3101");
+  });
+
+  it("falls back to PAPERCLIP_PUBLIC_URL when PAPERCLIP_API_URL is not set", () => {
+    delete process.env.PAPERCLIP_API_URL;
+    process.env.PAPERCLIP_PUBLIC_URL = "https://paperclip.example.com";
+    process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+    process.env.PAPERCLIP_LISTEN_PORT = "3101";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("https://paperclip.example.com");
+  });
+
+  it("prefers PAPERCLIP_API_URL over PAPERCLIP_PUBLIC_URL when both are set", () => {
+    process.env.PAPERCLIP_API_URL = "http://internal-api.example:9000";
+    process.env.PAPERCLIP_PUBLIC_URL = "https://paperclip.example.com";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://internal-api.example:9000");
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -555,7 +555,15 @@ export async function startServer(): Promise<StartedServer> {
   process.env.PAPERCLIP_LISTEN_HOST = runtimeListenHost;
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
   if (!process.env.PAPERCLIP_API_URL) {
-    process.env.PAPERCLIP_API_URL = `http://${runtimeApiHost}:${listenPort}`;
+    // Prefer the operator-supplied public URL when present — it's the URL
+    // the operator already advertises for auth callbacks, and it's what
+    // agents + adapters should call back to. The loopback fallback stays
+    // as a convenience for pure local dev when neither var is set.
+    const publicUrl = process.env.PAPERCLIP_PUBLIC_URL?.trim();
+    process.env.PAPERCLIP_API_URL =
+      publicUrl && publicUrl.length > 0
+        ? publicUrl
+        : `http://${runtimeApiHost}:${listenPort}`;
   }
   
   setupLiveEventsWebSocketServer(server, db as any, {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     projects: [
+      "packages/adapter-utils",
       "packages/db",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Each wake hands the agent a `PAPERCLIP_API_URL` env var (built by `buildPaperclipEnv` in `@paperclipai/adapter-utils`) that the agent uses to call back to Paperclip — checkout, comments, status updates.
> - Paperclip also has a `PAPERCLIP_PUBLIC_URL` env var that `config.ts` already consumes for auth callbacks and for the `allowedHostnames` gate, so operators running non-local deployments typically set this to their public HTTPS URL.
> - But `buildPaperclipEnv`'s resolution chain was `PAPERCLIP_API_URL → http://localhost:<port>` — `PAPERCLIP_PUBLIC_URL` was never consulted. An operator who set only `PAPERCLIP_PUBLIC_URL` got agents pointed at `http://127.0.0.1:<port>` regardless.
> - Worse than a bare misconfiguration: that loopback URL then flows into outbound HTTP bodies the agent produces. Any reverse proxy / WAF fronting the receiving service treats the loopback string in a body as an SSRF-shaped signal — we hit this end-to-end during an integration smoke (AWS ALB returned HTML 403 on a valid request purely because the body contained a `127.0.0.1:<port>` URL).
> - This pull request closes the resolution gap by inserting `PAPERCLIP_PUBLIC_URL` between the explicit override and the loopback fallback, in both `buildPaperclipEnv` and the server's boot-time `process.env.PAPERCLIP_API_URL` seeding.
> - The benefit: operators who already advertise a public URL get the behavior they'd reasonably expect, agents don't leak loopback URLs into outbound request bodies, and deployments with a WAF/reverse-proxy stop failing on loopback-pattern detection. No behavior change for deployments that set `PAPERCLIP_API_URL` explicitly or pure-local dev that sets neither.

## What Changed

- **`packages/adapter-utils/src/server-utils.ts`** — `buildPaperclipEnv` resolves `PAPERCLIP_API_URL` via `PAPERCLIP_API_URL → PAPERCLIP_PUBLIC_URL → loopback fallback`. Empty-string values are treated as unset so a stray `PAPERCLIP_API_URL=""` doesn't short-circuit the chain. New `readNonEmptyEnv` helper keeps the precedence logic readable.
- **`server/src/index.ts`** — when the server pre-populates `process.env.PAPERCLIP_API_URL` at boot, it seeds from `PAPERCLIP_PUBLIC_URL` (if set) before defaulting to the loopback URL. Same precedence as `buildPaperclipEnv`, applied earlier in the lifecycle.
- **`packages/adapter-utils/src/server-utils.test.ts`** — 4 new regression tests pinning each branch of the new resolution chain: explicit wins, PUBLIC fallback when explicit is unset, loopback when neither is set, empty-string treated as unset.
- **`packages/adapter-utils/vitest.config.ts`** (new) — per-package vitest config so the package can be added to the root runner.
- **`vitest.config.ts`** — adds `packages/adapter-utils` to the root projects list. The package had an existing `server-utils.test.ts` with `runChildProcess` tests + a `billing.test.ts` (5 tests total) that weren't running in CI because the project wasn't in the root vitest projects list.
- **`server/src/__tests__/paperclip-env.test.ts`** — 2 new regression tests exercising the same behavior through the server's re-export of `buildPaperclipEnv`. Also extends the `afterEach` cleanup to restore `PAPERCLIP_PUBLIC_URL` alongside the other env vars it already manages.

Net test delta: **+6 new tests**, **+5 previously-unrun tests now running in CI**.

## Verification

```
# Affected surfaces (fast)
pnpm exec vitest run packages/adapter-utils server/src/__tests__/paperclip-env.test.ts
#  → 14 passed (9 adapter-utils + 5 server)

# Full monorepo
pnpm exec vitest run
#  → 1578 passed, 1 skipped, 0 failed
#    (existing flaky heartbeat-comment-wake-batching timing test
#     passes on most runs; its flake predates and is unrelated to
#     this change)

# Typecheck
cd packages/adapter-utils && pnpm exec tsc --noEmit    # clean
cd server && pnpm exec tsc --noEmit                    # clean
```

Manual scenario that motivated the PR (reproducible in any environment with a WAF/ALB in front of an outbound call):

1. Run the server with `PAPERCLIP_PUBLIC_URL=https://paperclip.example.com` set and `PAPERCLIP_API_URL` **not** set.
2. Trigger a heartbeat for an adapter that includes `PAPERCLIP_API_URL` in an outbound JSON body (e.g. any webhook-style integration).
3. **Before this PR:** the body contained `http://127.0.0.1:<listenPort>`; a WAF/ALB in the outbound path returned HTML 403.
4. **After this PR:** the body contains `https://paperclip.example.com`; the request passes.

## Risks

**Low risk.**

- Behavior is **unchanged** for the two common configurations:
  - Deployments that set `PAPERCLIP_API_URL` explicitly — still takes top precedence.
  - Pure-local dev that sets neither — still falls through to the loopback URL.
- The only behavioral change: deployments that set `PAPERCLIP_PUBLIC_URL` and expected it to be honored by `buildPaperclipEnv` now get that behavior. If any operator was relying on the previous loopback behavior while also setting `PAPERCLIP_PUBLIC_URL`, they need to add `PAPERCLIP_API_URL=http://localhost:<port>` explicitly — an unlikely combination, but worth noting.
- Wiring `packages/adapter-utils` into the root vitest runner surfaces 5 existing tests that weren't being run before. All 5 currently pass — the change just removes a silent coverage gap.

## Model Used

- Claude Opus 4.7 (1M context), via Claude Code. Extended thinking / tool use enabled. All design decisions, test cases, and the motivating end-to-end scenario were validated during an integration smoke before drafting this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — **N/A (no UI impact)**
- [x] I have updated relevant documentation to reflect my changes — the change is small enough that inline comments are the appropriate doc surface; no public docs reference `buildPaperclipEnv` directly
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge