### PR TITLE
AJL-548: suppress umbrella comment wakes and surface idle umbrella state

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -53,7 +53,8 @@
               "guides/board-operator/approvals",
               "guides/board-operator/costs-and-budgets",
               "guides/board-operator/activity-log",
-              "guides/board-operator/importing-and-exporting"
+              "guides/board-operator/importing-and-exporting",
+              "guides/board-operator/umbrella-wake-suppression"
             ]
           },
           {

--- a/docs/guides/board-operator/umbrella-wake-suppression.md
+++ b/docs/guides/board-operator/umbrella-wake-suppression.md
@@ -1,0 +1,78 @@
+---
+title: Umbrella Wake Suppression
+summary: Why Paperclip suppresses comment wakes on idle umbrella issues, and what you should do when you see the banner
+---
+
+Paperclip treats certain in-progress issues as **umbrellas** — issues whose work is done by their children, not by their own assignee. Examples: matrix / documentation issues, multi-phase refactors, roll-ups, or coordinator tickets that exist to tie several executable tasks together.
+
+When every child of an umbrella is `done` or `cancelled`, the umbrella is **idle**: there is no open executable child, so further comment-triggered heartbeats on the umbrella will only produce summary / digest output, not forward progress. Paperclip detects this state and **suppresses comment wakes** on the umbrella until an operator acts.
+
+## What "idle umbrella" means
+
+An issue is classified as `umbrella_idle_no_child` when all of the following hold:
+
+- it has at least one child issue, AND
+- every child is in a terminal state (`done` or `cancelled`), AND
+- the umbrella itself is still `in_progress` or `in_review`
+
+Issues with no children at all are **leaves** — they execute normally and wakes are never suppressed. Issues that still have at least one child in `todo`, `in_progress`, `blocked`, or `in_review` have an **open executable child** — wakes also execute normally for those.
+
+## Why wakes are suppressed
+
+The suppression rule is the result of a concrete incident class we hit on the AJL board (see [AJL-407](/AJL/issues/AJL-407), [AJL-444](/AJL/issues/AJL-444), [AJL-446](/AJL/issues/AJL-446)). The loop looked like this:
+
+1. Someone (operator or another agent) posts a comment on an umbrella issue that is still marked `in_progress`.
+2. The umbrella has no open executable child — only done/cancelled children or doc-only children.
+3. The comment wake starts a normal heartbeat run.
+4. The run succeeds but can only emit summary / matrix / distillation output — there is nothing executable to do.
+5. The umbrella stays `in_progress` because no one closed it.
+6. The next manual comment repeats the cycle.
+
+This is a **board-state / event-routing loop**, not a stuck process. The code is doing exactly what the topology asks of it. The fix is upstream: stop waking the umbrella when there is nothing executable underneath, and prompt the operator to close or reclassify the issue instead.
+
+## Where you see it
+
+### Issue detail page
+
+When you open an umbrella issue that is currently idle-no-child, a yellow banner appears near the top of the detail page:
+
+> **Umbrella idle — no open executable child**
+>
+> All N children are done or cancelled. Comment wakes on this issue are suppressed. Close it, move to review, or open a new child to resume supervision.
+
+The banner only appears while the issue is in a non-terminal status. Once you close the umbrella or open a new executable child, the banner disappears and normal wake behavior resumes.
+
+### Dashboard
+
+The dashboard shows an **Idle Umbrellas** callout at the top of the board when the current company has one or more idle umbrellas. The callout lists up to ten idle umbrellas with their identifier, title, child count, and current status, so the operator can triage them in one pass.
+
+## What to do when you see it
+
+You have three valid moves:
+
+1. **Close the umbrella.** If the work it was tracking is genuinely done, set the umbrella to `done`. This is the most common case for matrix / documentation roll-up issues after their deliverable is current.
+2. **Move it to review.** If the umbrella needs a final sign-off before closing, set it to `in_review` and assign the reviewer. `in_review` is still detected as idle until children are re-opened, so the banner stays up to remind the reviewer.
+3. **Open a new child.** If the umbrella still has meaningful work ahead, create a new executable child. Once a child exists in `todo` / `in_progress` / `blocked`, the umbrella returns to `has_open_executable_child` and wakes resume normally.
+
+What you should **not** do:
+
+- Ignore the banner and keep posting comments. Paperclip will keep suppressing those wakes — you will not get progress, you will just build up digest runs that cost budget.
+- Reopen a completed child just to silence the banner. Reopening without real work to do puts the board right back into the loop we are trying to prevent.
+
+## Related doctrine
+
+- Matrix / documentation issues should not remain `in_progress` after their deliverable is current and no open child remains.
+- Supervisory / coordinator agents (for example Boss Baby) should be used for routing and gatekeeping — not as terminal sinks for repeated digest generation on converged umbrellas.
+- If you find yourself repeatedly commenting on the same umbrella to poke it forward, that is the signal to reclassify or close it instead of escalating.
+
+## Technical reference
+
+The classifier lives in `server/src/services/issues.ts` as `classifyUmbrellaWakeState`. Its output shape is one of:
+
+- `leaf` — no children, normal execution
+- `has_open_executable_child` — at least one open child, normal wake
+- `umbrella_idle_no_child` — children exist but all are terminal, wake is suppressed
+
+The UI reads the same classifier via `GET /api/issues/:id/umbrella-state`. The dashboard list is served by `GET /api/companies/:companyId/idle-umbrellas` and returns only `in_progress` / `in_review` umbrellas in that state.
+
+The suppression itself runs server-side in the comment / mention wake emission path before a heartbeat is ever queued — so you will see the banner instead of a stuck run.

--- a/packages/db/src/migrations/0058_ajl_551_result_class.sql
+++ b/packages/db/src/migrations/0058_ajl_551_result_class.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "heartbeat_runs" ADD COLUMN "result_class" text;--> statement-breakpoint

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1776309613598,
       "tag": "0057_tidy_join_requests",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1776206400000,
+      "tag": "0058_ajl_551_result_class",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/heartbeat_runs.ts
+++ b/packages/db/src/schema/heartbeat_runs.ts
@@ -42,6 +42,7 @@ export const heartbeatRuns = pgTable(
     issueCommentSatisfiedByCommentId: uuid("issue_comment_satisfied_by_comment_id"),
     issueCommentRetryQueuedAt: timestamp("issue_comment_retry_queued_at", { withTimezone: true }),
     contextSnapshot: jsonb("context_snapshot").$type<Record<string, unknown>>(),
+    resultClass: text("result_class"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  getSupervisorySummaryOnlyStreakForUmbrella: vi.fn().mockResolvedValue({ streak: 0, inspected: 0 }),
   detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
 }));
 

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -12,6 +12,7 @@ const mockIssueService = vi.hoisted(() => ({
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
+  classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -10,6 +10,7 @@ const mockIssueService = vi.hoisted(() => ({
   findMentionedAgents: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
+  classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
 }));
 
 const mockAccessService = vi.hoisted(() => ({

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -11,6 +11,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
 }));
 
 const mockAccessService = vi.hoisted(() => ({

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -11,6 +11,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  getSupervisorySummaryOnlyStreakForUmbrella: vi.fn().mockResolvedValue({ streak: 0, inspected: 0 }),
   detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
 }));
 

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -14,6 +14,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
   findMentionedAgents: vi.fn(async () => []),
 }));
 

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -14,6 +14,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  getSupervisorySummaryOnlyStreakForUmbrella: vi.fn().mockResolvedValue({ streak: 0, inspected: 0 }),
   detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
   findMentionedAgents: vi.fn(async () => []),
 }));

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   update: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
+  classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
   findMentionedAgents: vi.fn(async () => []),
 }));
 

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  getSupervisorySummaryOnlyStreakForUmbrella: vi.fn().mockResolvedValue({ streak: 0, inspected: 0 }),
   detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
 }));
 

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -12,6 +12,7 @@ const mockIssueService = vi.hoisted(() => ({
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
+  classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({

--- a/server/src/__tests__/issue-telemetry-routes.test.ts
+++ b/server/src/__tests__/issue-telemetry-routes.test.ts
@@ -6,6 +6,7 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
   listWakeableBlockedDependents: vi.fn(),
   update: vi.fn(),
 }));

--- a/server/src/__tests__/issue-telemetry-routes.test.ts
+++ b/server/src/__tests__/issue-telemetry-routes.test.ts
@@ -6,6 +6,7 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  getSupervisorySummaryOnlyStreakForUmbrella: vi.fn().mockResolvedValue({ streak: 0, inspected: 0 }),
   detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
   listWakeableBlockedDependents: vi.fn(),
   update: vi.fn(),

--- a/server/src/__tests__/issue-telemetry-routes.test.ts
+++ b/server/src/__tests__/issue-telemetry-routes.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
+  classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
   listWakeableBlockedDependents: vi.fn(),
   update: vi.fn(),
 }));

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -12,6 +12,7 @@ const mockIssueService = vi.hoisted(() => ({
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
+  classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({
@@ -250,6 +251,70 @@ describe("issue update comment wakeups", () => {
           source: "issue.comment",
         }),
       }),
+    );
+  });
+
+  // AJL-548 — umbrella wake suppression via PATCH /issues/:id comment path.
+  it("AJL-548: suppresses comment wake when the target is an idle umbrella", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    const updated = { ...existing };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-suppress",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "bump",
+    });
+    mockIssueService.classifyUmbrellaWakeState.mockResolvedValue({
+      kind: "umbrella_idle_no_child",
+      totalChildren: 3,
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ comment: "bump" });
+
+    expect(res.status).toBe(200);
+    // Classifier was consulted, wakeup was NOT dispatched.
+    expect(mockIssueService.classifyUmbrellaWakeState).toHaveBeenCalledWith(existing.id);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("AJL-548: still wakes when the umbrella has an open executable child", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    const updated = { ...existing };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-allow",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "keep going",
+    });
+    mockIssueService.classifyUmbrellaWakeState.mockResolvedValue({
+      kind: "has_open_executable_child",
+      totalChildren: 2,
+      openExecutableChildCount: 1,
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ comment: "keep going" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({ reason: "issue_commented" }),
     );
   });
 });

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  getSupervisorySummaryOnlyStreakForUmbrella: vi.fn().mockResolvedValue({ streak: 0, inspected: 0 }),
   detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
 }));
 
@@ -317,5 +318,77 @@ describe("issue update comment wakeups", () => {
       ASSIGNEE_AGENT_ID,
       expect.objectContaining({ reason: "issue_commented" }),
     );
+  });
+
+  it("AJL-551: suppresses wake on has_open_executable_child when last 2 runs were supervisory_summary_only", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    const updated = { ...existing };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-streak-suppress",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "ping",
+    });
+    mockIssueService.classifyUmbrellaWakeState.mockResolvedValue({
+      kind: "has_open_executable_child",
+      totalChildren: 2,
+      openExecutableChildCount: 1,
+    });
+    mockIssueService.getSupervisorySummaryOnlyStreakForUmbrella.mockResolvedValue({
+      streak: 2,
+      inspected: 2,
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ comment: "ping" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.getSupervisorySummaryOnlyStreakForUmbrella).toHaveBeenCalledWith(
+      existing.id,
+      5,
+    );
+    // Even with an open executable child, the 2-run supervisory streak
+    // force-suppresses the comment-derived wake (AJL-551).
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("AJL-551: still wakes when has_open_executable_child and streak is below threshold", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    const updated = { ...existing };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-streak-allow",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "ping",
+    });
+    mockIssueService.classifyUmbrellaWakeState.mockResolvedValue({
+      kind: "has_open_executable_child",
+      totalChildren: 2,
+      openExecutableChildCount: 1,
+    });
+    mockIssueService.getSupervisorySummaryOnlyStreakForUmbrella.mockResolvedValue({
+      streak: 1,
+      inspected: 3,
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ comment: "ping" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/src/__tests__/issue-workspace-command-authz.test.ts
+++ b/server/src/__tests__/issue-workspace-command-authz.test.ts
@@ -14,6 +14,7 @@ const mockIssueService = vi.hoisted(() => ({
   getRelationSummaries: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  getSupervisorySummaryOnlyStreakForUmbrella: vi.fn().mockResolvedValue({ streak: 0, inspected: 0 }),
   detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
   listWakeableBlockedDependents: vi.fn(),
   update: vi.fn(),

--- a/server/src/__tests__/issue-workspace-command-authz.test.ts
+++ b/server/src/__tests__/issue-workspace-command-authz.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   getRelationSummaries: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
+  classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
   listWakeableBlockedDependents: vi.fn(),
   update: vi.fn(),
 }));

--- a/server/src/__tests__/issue-workspace-command-authz.test.ts
+++ b/server/src/__tests__/issue-workspace-command-authz.test.ts
@@ -14,6 +14,7 @@ const mockIssueService = vi.hoisted(() => ({
   getRelationSummaries: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   classifyUmbrellaWakeState: vi.fn().mockResolvedValue({ kind: "leaf", totalChildren: 0 }),
+  detectSameOwnerParentChildOverlap: vi.fn().mockResolvedValue({ kind: "no_overlap", reason: "no_parent" }),
   listWakeableBlockedDependents: vi.fn(),
   update: vi.fn(),
 }));

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1573,3 +1573,118 @@ describeEmbeddedPostgres("issueService.findMentionedProjectIds", () => {
     ]);
   });
 });
+
+// AJL-548 — umbrella wake suppression classifier.
+describeEmbeddedPostgres("issueService.classifyUmbrellaWakeState", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-service-umbrella-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedIssue(companyId: string, overrides: Partial<typeof issues.$inferInsert> = {}) {
+    const id = overrides.id ?? randomUUID();
+    await db.insert(issues).values({
+      id,
+      companyId,
+      title: "Issue",
+      status: "todo",
+      priority: "medium",
+      ...overrides,
+    });
+    return id;
+  }
+
+  it("returns leaf when the issue has no children", async () => {
+    const companyId = await seedCompany();
+    const leaf = await seedIssue(companyId, { status: "in_progress" });
+
+    const state = await svc.classifyUmbrellaWakeState(leaf);
+    expect(state).toEqual({ kind: "leaf", totalChildren: 0 });
+  });
+
+  it("returns umbrella_idle_no_child when all children are done/cancelled", async () => {
+    const companyId = await seedCompany();
+    const umbrella = await seedIssue(companyId, { status: "in_progress" });
+    await seedIssue(companyId, { status: "done", parentId: umbrella });
+    await seedIssue(companyId, { status: "cancelled", parentId: umbrella });
+
+    const state = await svc.classifyUmbrellaWakeState(umbrella);
+    expect(state.kind).toBe("umbrella_idle_no_child");
+    if (state.kind === "umbrella_idle_no_child") {
+      expect(state.totalChildren).toBe(2);
+    }
+  });
+
+  it("returns has_open_executable_child when at least one child is todo/in_progress/blocked/in_review", async () => {
+    const companyId = await seedCompany();
+    const umbrella = await seedIssue(companyId, { status: "in_progress" });
+    await seedIssue(companyId, { status: "done", parentId: umbrella });
+    await seedIssue(companyId, { status: "in_progress", parentId: umbrella });
+
+    const state = await svc.classifyUmbrellaWakeState(umbrella);
+    expect(state.kind).toBe("has_open_executable_child");
+    if (state.kind === "has_open_executable_child") {
+      expect(state.totalChildren).toBe(2);
+      expect(state.openExecutableChildCount).toBe(1);
+    }
+  });
+
+  it("treats blocked and in_review children as open executable children", async () => {
+    const companyId = await seedCompany();
+
+    const umbrellaA = await seedIssue(companyId, { status: "in_progress" });
+    await seedIssue(companyId, { status: "blocked", parentId: umbrellaA });
+    const stateA = await svc.classifyUmbrellaWakeState(umbrellaA);
+    expect(stateA.kind).toBe("has_open_executable_child");
+
+    const umbrellaB = await seedIssue(companyId, { status: "in_progress" });
+    await seedIssue(companyId, { status: "in_review", parentId: umbrellaB });
+    const stateB = await svc.classifyUmbrellaWakeState(umbrellaB);
+    expect(stateB.kind).toBe("has_open_executable_child");
+  });
+
+  it("treats backlog children as idle for suppression purposes", async () => {
+    // Backlog children are not yet active work — they shouldn't prevent suppression
+    // because the umbrella isn't supervising anything runnable.
+    const companyId = await seedCompany();
+    const umbrella = await seedIssue(companyId, { status: "in_progress" });
+    await seedIssue(companyId, { status: "done", parentId: umbrella });
+    await seedIssue(companyId, { status: "backlog", parentId: umbrella });
+
+    const state = await svc.classifyUmbrellaWakeState(umbrella);
+    expect(state.kind).toBe("umbrella_idle_no_child");
+  });
+
+  it("returns leaf for an unknown issue id (defensive default)", async () => {
+    const state = await svc.classifyUmbrellaWakeState(randomUUID());
+    expect(state).toEqual({ kind: "leaf", totalChildren: 0 });
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -8,6 +8,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -1933,5 +1934,374 @@ describeEmbeddedPostgres("issueService.detectSameOwnerParentChildOverlap", () =>
     if (result.kind === "no_overlap") {
       expect(result.reason).toBe("child_not_found");
     }
+  });
+});
+
+// AJL-551 — heartbeat run result classifier.
+describeEmbeddedPostgres("issueService.classifyHeartbeatRunResult", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-service-resultclass-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(heartbeatRuns);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompanyAndAgent() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "SysOps",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  async function seedIssue(
+    companyId: string,
+    overrides: Partial<typeof issues.$inferInsert> = {},
+  ) {
+    const id = overrides.id ?? randomUUID();
+    await db.insert(issues).values({
+      id,
+      companyId,
+      title: "Issue",
+      status: "in_progress",
+      priority: "medium",
+      ...overrides,
+    });
+    return id;
+  }
+
+  async function seedRun(
+    companyId: string,
+    agentId: string,
+    issueId: string | null,
+    overrides: Partial<typeof heartbeatRuns.$inferInsert> = {},
+  ) {
+    const id = overrides.id ?? randomUUID();
+    const startedAt = overrides.startedAt ?? new Date(Date.now() - 60_000);
+    const finishedAt = overrides.finishedAt ?? new Date();
+    await db.insert(heartbeatRuns).values({
+      id,
+      companyId,
+      agentId,
+      status: overrides.status ?? "running",
+      startedAt,
+      finishedAt,
+      contextSnapshot: issueId ? { issueId } : {},
+      ...overrides,
+    });
+    return id;
+  }
+
+  it("returns supervisory_summary_only when issueId is missing", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const runId = await seedRun(companyId, agentId, null);
+    const result = await svc.classifyHeartbeatRunResult({
+      issueId: null,
+      runStartedAt: new Date(Date.now() - 60_000),
+      runFinishedAt: new Date(),
+      runId,
+    });
+    expect(result.kind).toBe("supervisory_summary_only");
+  });
+
+  it("returns executable_progress when a new subtask is created in the run window", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const umbrellaId = await seedIssue(companyId, { status: "in_progress" });
+    // Umbrella already existed before the window.
+    await db
+      .update(issues)
+      .set({ updatedAt: new Date(Date.now() - 120_000) })
+      .where(eq(issues.id, umbrellaId));
+    const runStartedAt = new Date(Date.now() - 60_000);
+    // New child created inside the window.
+    await seedIssue(companyId, { parentId: umbrellaId, status: "todo" });
+    const runId = await seedRun(companyId, agentId, umbrellaId, {
+      startedAt: runStartedAt,
+      finishedAt: new Date(),
+    });
+
+    const result = await svc.classifyHeartbeatRunResult({
+      issueId: umbrellaId,
+      runStartedAt,
+      runFinishedAt: new Date(),
+      runId,
+    });
+    expect(result.kind).toBe("executable_progress");
+    expect(result.signals.childSubtasksCreatedInWindow).toBe(1);
+  });
+
+  it("returns executable_progress when an existing child is touched in the run window", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const umbrellaId = await seedIssue(companyId, { status: "in_progress" });
+    const childId = await seedIssue(companyId, { parentId: umbrellaId, status: "todo" });
+    // Backdate both issues to before the window.
+    const before = new Date(Date.now() - 120_000);
+    await db.update(issues).set({ createdAt: before, updatedAt: before }).where(eq(issues.id, umbrellaId));
+    await db.update(issues).set({ createdAt: before, updatedAt: before }).where(eq(issues.id, childId));
+    const runStartedAt = new Date(Date.now() - 60_000);
+    // Touch the child inside the window.
+    await db.update(issues).set({ status: "in_progress", updatedAt: new Date() }).where(eq(issues.id, childId));
+    const runId = await seedRun(companyId, agentId, umbrellaId, {
+      startedAt: runStartedAt,
+      finishedAt: new Date(),
+    });
+
+    const result = await svc.classifyHeartbeatRunResult({
+      issueId: umbrellaId,
+      runStartedAt,
+      runFinishedAt: new Date(),
+      runId,
+    });
+    expect(result.kind).toBe("executable_progress");
+    expect(result.signals.childSubtasksTouchedInWindow).toBe(1);
+    expect(result.signals.childSubtasksCreatedInWindow).toBe(0);
+  });
+
+  it("returns bounded_handoff when the issue transitions to blocked during the run", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = await seedIssue(companyId, { status: "in_progress" });
+    const before = new Date(Date.now() - 120_000);
+    await db.update(issues).set({ createdAt: before, updatedAt: before }).where(eq(issues.id, issueId));
+    const runStartedAt = new Date(Date.now() - 60_000);
+    await db.update(issues).set({ status: "blocked", updatedAt: new Date() }).where(eq(issues.id, issueId));
+    const runId = await seedRun(companyId, agentId, issueId, {
+      startedAt: runStartedAt,
+      finishedAt: new Date(),
+    });
+
+    const result = await svc.classifyHeartbeatRunResult({
+      issueId,
+      runStartedAt,
+      runFinishedAt: new Date(),
+      runId,
+    });
+    expect(result.kind).toBe("bounded_handoff");
+    expect(result.signals.currentIssueStatus).toBe("blocked");
+  });
+
+  it("returns review_gate when the issue transitions to in_review during the run", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = await seedIssue(companyId, { status: "in_progress" });
+    const before = new Date(Date.now() - 120_000);
+    await db.update(issues).set({ createdAt: before, updatedAt: before }).where(eq(issues.id, issueId));
+    const runStartedAt = new Date(Date.now() - 60_000);
+    await db.update(issues).set({ status: "in_review", updatedAt: new Date() }).where(eq(issues.id, issueId));
+    const runId = await seedRun(companyId, agentId, issueId, {
+      startedAt: runStartedAt,
+      finishedAt: new Date(),
+    });
+
+    const result = await svc.classifyHeartbeatRunResult({
+      issueId,
+      runStartedAt,
+      runFinishedAt: new Date(),
+      runId,
+    });
+    expect(result.kind).toBe("review_gate");
+  });
+
+  it("returns supervisory_summary_only when only comments were posted with no issue/child delta", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const umbrellaId = await seedIssue(companyId, { status: "in_progress" });
+    const childId = await seedIssue(companyId, { parentId: umbrellaId, status: "in_progress" });
+    // Backdate both to before the window so updatedAt doesn't leak into it.
+    const before = new Date(Date.now() - 120_000);
+    await db.update(issues).set({ createdAt: before, updatedAt: before }).where(eq(issues.id, umbrellaId));
+    await db.update(issues).set({ createdAt: before, updatedAt: before }).where(eq(issues.id, childId));
+    const runStartedAt = new Date(Date.now() - 60_000);
+    const runId = await seedRun(companyId, agentId, umbrellaId, {
+      startedAt: runStartedAt,
+      finishedAt: new Date(),
+    });
+    // Posting comments alone should not count as progress.
+    await db.insert(issueComments).values({
+      id: randomUUID(),
+      companyId,
+      issueId: umbrellaId,
+      authorAgentId: agentId,
+      createdByRunId: runId,
+      body: "supervisory ping",
+    });
+
+    const result = await svc.classifyHeartbeatRunResult({
+      issueId: umbrellaId,
+      runStartedAt,
+      runFinishedAt: new Date(),
+      runId,
+    });
+    expect(result.kind).toBe("supervisory_summary_only");
+    expect(result.signals.commentsAuthoredByRun).toBe(1);
+    expect(result.signals.childSubtasksCreatedInWindow).toBe(0);
+    expect(result.signals.childSubtasksTouchedInWindow).toBe(0);
+  });
+});
+
+// AJL-551 — supervisory-summary-only streak lookup for last-2-runs gate.
+describeEmbeddedPostgres("issueService.getSupervisorySummaryOnlyStreakForUmbrella", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-service-streak-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(heartbeatRuns);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedBaseRow() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "SysOps",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    const umbrellaId = randomUUID();
+    await db.insert(issues).values({
+      id: umbrellaId,
+      companyId,
+      title: "Umbrella",
+      status: "in_progress",
+      priority: "medium",
+    });
+    return { companyId, agentId, umbrellaId };
+  }
+
+  async function insertRun(
+    companyId: string,
+    agentId: string,
+    umbrellaId: string,
+    resultClass: string | null,
+    finishedAt: Date,
+  ) {
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      status: resultClass ? "succeeded" : "running",
+      startedAt: new Date(finishedAt.getTime() - 30_000),
+      finishedAt,
+      contextSnapshot: { issueId: umbrellaId },
+      resultClass,
+    });
+  }
+
+  it("returns 0 when there are no finished runs on the umbrella", async () => {
+    const { umbrellaId } = await seedBaseRow();
+    const result = await svc.getSupervisorySummaryOnlyStreakForUmbrella(umbrellaId);
+    expect(result).toEqual({ streak: 0, inspected: 0 });
+  });
+
+  it("counts 2 when the last 2 runs were supervisory_summary_only", async () => {
+    const { companyId, agentId, umbrellaId } = await seedBaseRow();
+    const now = Date.now();
+    await insertRun(companyId, agentId, umbrellaId, "executable_progress", new Date(now - 180_000));
+    await insertRun(companyId, agentId, umbrellaId, "supervisory_summary_only", new Date(now - 120_000));
+    await insertRun(companyId, agentId, umbrellaId, "supervisory_summary_only", new Date(now - 60_000));
+
+    const result = await svc.getSupervisorySummaryOnlyStreakForUmbrella(umbrellaId);
+    expect(result.streak).toBe(2);
+    expect(result.inspected).toBe(3);
+  });
+
+  it("breaks the streak at the first non-supervisory run (most recent win)", async () => {
+    const { companyId, agentId, umbrellaId } = await seedBaseRow();
+    const now = Date.now();
+    await insertRun(companyId, agentId, umbrellaId, "supervisory_summary_only", new Date(now - 180_000));
+    await insertRun(companyId, agentId, umbrellaId, "supervisory_summary_only", new Date(now - 120_000));
+    // Most recent run produced real progress — streak must reset to 0.
+    await insertRun(companyId, agentId, umbrellaId, "executable_progress", new Date(now - 60_000));
+
+    const result = await svc.getSupervisorySummaryOnlyStreakForUmbrella(umbrellaId);
+    expect(result.streak).toBe(0);
+  });
+
+  it("ignores runs that have not been classified yet (null resultClass)", async () => {
+    const { companyId, agentId, umbrellaId } = await seedBaseRow();
+    const now = Date.now();
+    await insertRun(companyId, agentId, umbrellaId, null, new Date(now - 30_000));
+    await insertRun(companyId, agentId, umbrellaId, "supervisory_summary_only", new Date(now - 90_000));
+    await insertRun(companyId, agentId, umbrellaId, "supervisory_summary_only", new Date(now - 150_000));
+
+    const result = await svc.getSupervisorySummaryOnlyStreakForUmbrella(umbrellaId);
+    expect(result.streak).toBe(2);
+    expect(result.inspected).toBe(2);
+  });
+
+  it("ignores runs whose contextSnapshot issueId does not match the umbrella", async () => {
+    const { companyId, agentId, umbrellaId } = await seedBaseRow();
+    const otherUmbrellaId = randomUUID();
+    await db.insert(issues).values({
+      id: otherUmbrellaId,
+      companyId,
+      title: "Other umbrella",
+      status: "in_progress",
+      priority: "medium",
+    });
+    const now = Date.now();
+    await insertRun(companyId, agentId, otherUmbrellaId, "supervisory_summary_only", new Date(now - 30_000));
+    await insertRun(companyId, agentId, otherUmbrellaId, "supervisory_summary_only", new Date(now - 60_000));
+    // The target umbrella has a single executable_progress run.
+    await insertRun(companyId, agentId, umbrellaId, "executable_progress", new Date(now - 90_000));
+
+    const result = await svc.getSupervisorySummaryOnlyStreakForUmbrella(umbrellaId);
+    expect(result.streak).toBe(0);
+    expect(result.inspected).toBe(1);
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1688,3 +1688,250 @@ describeEmbeddedPostgres("issueService.classifyUmbrellaWakeState", () => {
     expect(state).toEqual({ kind: "leaf", totalChildren: 0 });
   });
 });
+
+// AJL-550 — same-owner parent+child overlap detector.
+describeEmbeddedPostgres("issueService.detectSameOwnerParentChildOverlap", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-service-overlap-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedAgent(companyId: string, id: string = randomUUID()) {
+    await db.insert(agents).values({
+      id,
+      companyId,
+      name: `Agent-${id.slice(0, 8)}`,
+      role: "engineer",
+      status: "paused",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return id;
+  }
+
+  async function seedIssue(companyId: string, overrides: Partial<typeof issues.$inferInsert> = {}) {
+    const id = overrides.id ?? randomUUID();
+    await db.insert(issues).values({
+      id,
+      companyId,
+      title: "Issue",
+      status: "todo",
+      priority: "medium",
+      ...overrides,
+    });
+    return id;
+  }
+
+  it("detects overlap when same-owner parent+child are in_progress with no open grandchildren", async () => {
+    const companyId = await seedCompany();
+    const ownerAgentId = await seedAgent(companyId);
+    const parent = await seedIssue(companyId, {
+      status: "in_progress",
+      assigneeAgentId: ownerAgentId,
+    });
+    const child = await seedIssue(companyId, {
+      status: "in_progress",
+      parentId: parent,
+      assigneeAgentId: ownerAgentId,
+    });
+    // grandchild is closed → doesn't rescue the overlap
+    await seedIssue(companyId, { status: "done", parentId: child });
+
+    const result = await svc.detectSameOwnerParentChildOverlap(child);
+    expect(result.kind).toBe("same_owner_parent_child_idle_grandchildren");
+    if (result.kind === "same_owner_parent_child_idle_grandchildren") {
+      expect(result.parentId).toBe(parent);
+      expect(result.childId).toBe(child);
+      expect(result.ownerAgentId).toBe(ownerAgentId);
+      expect(result.ownerUserId).toBeNull();
+      expect(result.totalGrandchildren).toBe(1);
+    }
+  });
+
+  it("detects overlap with no grandchildren at all", async () => {
+    const companyId = await seedCompany();
+    const ownerAgentId = await seedAgent(companyId);
+    const parent = await seedIssue(companyId, {
+      status: "in_progress",
+      assigneeAgentId: ownerAgentId,
+    });
+    const child = await seedIssue(companyId, {
+      status: "in_progress",
+      parentId: parent,
+      assigneeAgentId: ownerAgentId,
+    });
+
+    const result = await svc.detectSameOwnerParentChildOverlap(child);
+    expect(result.kind).toBe("same_owner_parent_child_idle_grandchildren");
+  });
+
+  it("does not flag overlap when the child has an open grandchild (executable work)", async () => {
+    const companyId = await seedCompany();
+    const ownerAgentId = await seedAgent(companyId);
+    const parent = await seedIssue(companyId, {
+      status: "in_progress",
+      assigneeAgentId: ownerAgentId,
+    });
+    const child = await seedIssue(companyId, {
+      status: "in_progress",
+      parentId: parent,
+      assigneeAgentId: ownerAgentId,
+    });
+    await seedIssue(companyId, { status: "in_progress", parentId: child });
+
+    const result = await svc.detectSameOwnerParentChildOverlap(child);
+    expect(result.kind).toBe("no_overlap");
+    if (result.kind === "no_overlap") {
+      expect(result.reason).toBe("child_has_open_grandchildren");
+    }
+  });
+
+  it("treats blocked and in_review grandchildren as open (no overlap)", async () => {
+    const companyId = await seedCompany();
+    const ownerAgentId = await seedAgent(companyId);
+    const parent = await seedIssue(companyId, {
+      status: "in_progress",
+      assigneeAgentId: ownerAgentId,
+    });
+    const child = await seedIssue(companyId, {
+      status: "in_progress",
+      parentId: parent,
+      assigneeAgentId: ownerAgentId,
+    });
+    await seedIssue(companyId, { status: "blocked", parentId: child });
+    await seedIssue(companyId, { status: "in_review", parentId: child });
+
+    const result = await svc.detectSameOwnerParentChildOverlap(child);
+    expect(result.kind).toBe("no_overlap");
+    if (result.kind === "no_overlap") {
+      expect(result.reason).toBe("child_has_open_grandchildren");
+    }
+  });
+
+  it("does not flag overlap when assignees differ (different_owners)", async () => {
+    const companyId = await seedCompany();
+    const parent = await seedIssue(companyId, {
+      status: "in_progress",
+      assigneeAgentId: await seedAgent(companyId),
+    });
+    const child = await seedIssue(companyId, {
+      status: "in_progress",
+      parentId: parent,
+      assigneeAgentId: await seedAgent(companyId),
+    });
+
+    const result = await svc.detectSameOwnerParentChildOverlap(child);
+    expect(result.kind).toBe("no_overlap");
+    if (result.kind === "no_overlap") {
+      expect(result.reason).toBe("different_owners");
+    }
+  });
+
+  it("matches overlap on shared assigneeUserId (human supervisor)", async () => {
+    const companyId = await seedCompany();
+    const ownerUserId = `user-${randomUUID()}`;
+    const parent = await seedIssue(companyId, {
+      status: "in_progress",
+      assigneeUserId: ownerUserId,
+    });
+    const child = await seedIssue(companyId, {
+      status: "in_progress",
+      parentId: parent,
+      assigneeUserId: ownerUserId,
+    });
+
+    const result = await svc.detectSameOwnerParentChildOverlap(child);
+    expect(result.kind).toBe("same_owner_parent_child_idle_grandchildren");
+    if (result.kind === "same_owner_parent_child_idle_grandchildren") {
+      expect(result.ownerAgentId).toBeNull();
+      expect(result.ownerUserId).toBe(ownerUserId);
+    }
+  });
+
+  it("does not flag overlap when parent or child is not in_progress", async () => {
+    const companyId = await seedCompany();
+    const ownerAgentId = await seedAgent(companyId);
+
+    const parentTodo = await seedIssue(companyId, {
+      status: "todo",
+      assigneeAgentId: ownerAgentId,
+    });
+    const childA = await seedIssue(companyId, {
+      status: "in_progress",
+      parentId: parentTodo,
+      assigneeAgentId: ownerAgentId,
+    });
+    const resultA = await svc.detectSameOwnerParentChildOverlap(childA);
+    expect(resultA.kind).toBe("no_overlap");
+    if (resultA.kind === "no_overlap") {
+      expect(resultA.reason).toBe("parent_not_in_progress");
+    }
+
+    const parentOk = await seedIssue(companyId, {
+      status: "in_progress",
+      assigneeAgentId: ownerAgentId,
+    });
+    const childB = await seedIssue(companyId, {
+      status: "todo",
+      parentId: parentOk,
+      assigneeAgentId: ownerAgentId,
+    });
+    const resultB = await svc.detectSameOwnerParentChildOverlap(childB);
+    expect(resultB.kind).toBe("no_overlap");
+    if (resultB.kind === "no_overlap") {
+      expect(resultB.reason).toBe("child_not_in_progress");
+    }
+  });
+
+  it("returns no_overlap for an issue with no parent", async () => {
+    const companyId = await seedCompany();
+    const leaf = await seedIssue(companyId, {
+      status: "in_progress",
+      assigneeAgentId: await seedAgent(companyId),
+    });
+    const result = await svc.detectSameOwnerParentChildOverlap(leaf);
+    expect(result.kind).toBe("no_overlap");
+    if (result.kind === "no_overlap") {
+      expect(result.reason).toBe("no_parent");
+    }
+  });
+
+  it("returns no_overlap for an unknown issue id (defensive default)", async () => {
+    const result = await svc.detectSameOwnerParentChildOverlap(randomUUID());
+    expect(result.kind).toBe("no_overlap");
+    if (result.kind === "no_overlap") {
+      expect(result.reason).toBe("child_not_found");
+    }
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1690,6 +1690,111 @@ describeEmbeddedPostgres("issueService.classifyUmbrellaWakeState", () => {
   });
 });
 
+// AJL-552 — list idle umbrellas for dashboard surface.
+describeEmbeddedPostgres("issueService.listIdleUmbrellasForCompany", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-service-idle-umbrellas-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedIssue(companyId: string, overrides: Partial<typeof issues.$inferInsert> = {}) {
+    const id = overrides.id ?? randomUUID();
+    await db.insert(issues).values({
+      id,
+      companyId,
+      title: "Issue",
+      status: "todo",
+      priority: "medium",
+      ...overrides,
+    });
+    return id;
+  }
+
+  it("returns only in_progress/in_review parents whose children are all terminal", async () => {
+    const companyId = await seedCompany();
+
+    // Idle umbrella — in_progress with only done/cancelled children → should surface.
+    const idleA = await seedIssue(companyId, { status: "in_progress", title: "Idle A" });
+    await seedIssue(companyId, { status: "done", parentId: idleA });
+    await seedIssue(companyId, { status: "cancelled", parentId: idleA });
+
+    // Idle in_review — also surfaces.
+    const idleB = await seedIssue(companyId, { status: "in_review", title: "Idle B" });
+    await seedIssue(companyId, { status: "done", parentId: idleB });
+
+    // Active umbrella — has at least one open executable child → skipped.
+    const activeUmbrella = await seedIssue(companyId, { status: "in_progress", title: "Active" });
+    await seedIssue(companyId, { status: "done", parentId: activeUmbrella });
+    await seedIssue(companyId, { status: "in_progress", parentId: activeUmbrella });
+
+    // Leaf issue — no children → skipped.
+    await seedIssue(companyId, { status: "in_progress", title: "Leaf" });
+
+    // Closed umbrella — status done, not a candidate → skipped.
+    const closedUmbrella = await seedIssue(companyId, { status: "done", title: "Closed" });
+    await seedIssue(companyId, { status: "done", parentId: closedUmbrella });
+
+    const idle = await svc.listIdleUmbrellasForCompany(companyId);
+    const titles = idle.map((row) => row.title).sort();
+    expect(titles).toEqual(["Idle A", "Idle B"]);
+
+    const idleARow = idle.find((row) => row.title === "Idle A");
+    expect(idleARow?.totalChildren).toBe(2);
+  });
+
+  it("scopes results to the requested company", async () => {
+    const companyA = await seedCompany();
+    const companyB = await seedCompany();
+
+    const idleA = await seedIssue(companyA, { status: "in_progress", title: "A idle" });
+    await seedIssue(companyA, { status: "done", parentId: idleA });
+
+    const idleB = await seedIssue(companyB, { status: "in_progress", title: "B idle" });
+    await seedIssue(companyB, { status: "done", parentId: idleB });
+
+    const resultA = await svc.listIdleUmbrellasForCompany(companyA);
+    expect(resultA.map((row) => row.title)).toEqual(["A idle"]);
+
+    const resultB = await svc.listIdleUmbrellasForCompany(companyB);
+    expect(resultB.map((row) => row.title)).toEqual(["B idle"]);
+  });
+
+  it("returns empty array when the company has no idle umbrellas", async () => {
+    const companyId = await seedCompany();
+    await seedIssue(companyId, { status: "in_progress", title: "Leaf only" });
+    const result = await svc.listIdleUmbrellasForCompany(companyId);
+    expect(result).toEqual([]);
+  });
+});
+
 // AJL-550 — same-owner parent+child overlap detector.
 describeEmbeddedPostgres("issueService.detectSameOwnerParentChildOverlap", () => {
   let db!: ReturnType<typeof createDb>;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2021,6 +2021,7 @@ export function issueRoutes(
 
       // AJL-548 — suppress comment-derived wakes on idle umbrella issues.
       const umbrellaCache = new Map<string, Awaited<ReturnType<typeof svc.classifyUmbrellaWakeState>>>();
+      const streakCache = new Map<string, Awaited<ReturnType<typeof svc.getSupervisorySummaryOnlyStreakForUmbrella>>>();
       for (const { agentId, wakeup } of wakeups.values()) {
         const wakeReason = readWakeReason(wakeup);
         if (wakeReason && COMMENT_DERIVED_WAKE_REASONS.has(wakeReason)) {
@@ -2046,6 +2047,42 @@ export function issueRoutes(
               "wake.suppressed reason=umbrella_idle_no_child",
             );
             continue;
+          }
+          // AJL-551 — reinforce phase-1: if classifier says there is an open
+          // executable child but the last 2 heartbeat runs on this umbrella
+          // were supervisory_summary_only, force-suppress this wake too. This
+          // is the pre-loop topology from AJL-407 / AJL-444 / AJL-446 where
+          // the umbrella keeps churning supervisory summaries without any
+          // real child delta.
+          if (state && state.kind === "has_open_executable_child") {
+            let streakInfo = streakCache.get(targetIssueId);
+            if (!streakInfo) {
+              try {
+                streakInfo = await svc.getSupervisorySummaryOnlyStreakForUmbrella(targetIssueId, 5);
+                streakCache.set(targetIssueId, streakInfo);
+              } catch (err) {
+                logger.warn(
+                  { err, issueId: targetIssueId },
+                  "supervisory-summary streak lookup failed",
+                );
+              }
+            }
+            if (streakInfo && streakInfo.streak >= 2) {
+              logger.info(
+                {
+                  issueId: targetIssueId,
+                  agentId,
+                  wakeReason,
+                  totalChildren: state.totalChildren,
+                  openExecutableChildCount: state.openExecutableChildCount,
+                  supervisorySummaryOnlyStreak: streakInfo.streak,
+                  runsInspected: streakInfo.inspected,
+                  source: "routes.issues.update",
+                },
+                "wake.suppressed reason=supervisory_summary_only_streak",
+              );
+              continue;
+            }
           }
         }
         heartbeat
@@ -2613,6 +2650,7 @@ export function issueRoutes(
 
       // AJL-548 — suppress comment-derived wakes on idle umbrella issues.
       const umbrellaCache = new Map<string, Awaited<ReturnType<typeof svc.classifyUmbrellaWakeState>>>();
+      const streakCache = new Map<string, Awaited<ReturnType<typeof svc.getSupervisorySummaryOnlyStreakForUmbrella>>>();
       for (const [agentId, wakeup] of wakeups.entries()) {
         const wakeReason = readWakeReason(wakeup);
         if (wakeReason && COMMENT_DERIVED_WAKE_REASONS.has(wakeReason)) {
@@ -2638,6 +2676,37 @@ export function issueRoutes(
               "wake.suppressed reason=umbrella_idle_no_child",
             );
             continue;
+          }
+          // AJL-551 — last-2-runs reinforcement on has_open_executable_child.
+          if (state && state.kind === "has_open_executable_child") {
+            let streakInfo = streakCache.get(targetIssueId);
+            if (!streakInfo) {
+              try {
+                streakInfo = await svc.getSupervisorySummaryOnlyStreakForUmbrella(targetIssueId, 5);
+                streakCache.set(targetIssueId, streakInfo);
+              } catch (err) {
+                logger.warn(
+                  { err, issueId: targetIssueId },
+                  "supervisory-summary streak lookup failed",
+                );
+              }
+            }
+            if (streakInfo && streakInfo.streak >= 2) {
+              logger.info(
+                {
+                  issueId: targetIssueId,
+                  agentId,
+                  wakeReason,
+                  totalChildren: state.totalChildren,
+                  openExecutableChildCount: state.openExecutableChildCount,
+                  supervisorySummaryOnlyStreak: streakInfo.streak,
+                  runsInspected: streakInfo.inspected,
+                  source: "routes.issues.comment",
+                },
+                "wake.suppressed reason=supervisory_summary_only_streak",
+              );
+              continue;
+            }
           }
         }
         heartbeat

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -99,6 +99,39 @@ function readWakeTargetIssueId(wakeup: unknown, fallback: string): string {
   return fallback;
 }
 
+// AJL-550 — non-blocking same-owner parent+child overlap detector.
+// Fires a structured warn log when the pre-loop topology from AJL-444 → AJL-446
+// is detected on a child issue: both parent and child assigned to the same
+// supervisory owner, both in_progress, child has zero open grandchildren.
+// Fire-and-forget by contract: never rejects the mutation, never throws.
+function runOverlapDetector(
+  svc: ReturnType<typeof issueService>,
+  childIssueId: string,
+  source: string,
+): void {
+  try {
+    void Promise.resolve(svc.detectSameOwnerParentChildOverlap(childIssueId))
+      .then((overlap) => {
+        if (overlap && overlap.kind === "same_owner_parent_child_idle_grandchildren") {
+          logger.warn(
+            {
+              issueId: overlap.childId,
+              parentId: overlap.parentId,
+              ownerAgentId: overlap.ownerAgentId,
+              ownerUserId: overlap.ownerUserId,
+              totalGrandchildren: overlap.totalGrandchildren,
+              source,
+            },
+            "overlap.detected kind=same_owner_parent_child_idle_grandchildren",
+          );
+        }
+      })
+      .catch((err) => logger.warn({ err, issueId: childIssueId, source }, "overlap detector failed"));
+  } catch (err) {
+    logger.warn({ err, issueId: childIssueId, source }, "overlap detector failed synchronously");
+  }
+}
+
 type ParsedExecutionState = NonNullable<ReturnType<typeof parseIssueExecutionState>>;
 type NormalizedExecutionPolicy = NonNullable<ReturnType<typeof normalizeIssueExecutionPolicy>>;
 type ActivityIssueRelationSummary = {
@@ -1397,6 +1430,9 @@ export function issueRoutes(
       requestedByActorId: actor.actorId,
     });
 
+    // AJL-550 — overlap detector (non-blocking).
+    runOverlapDetector(svc, issue.id, "routes.issues.create");
+
     res.status(201).json(issue);
   });
 
@@ -2016,6 +2052,9 @@ export function issueRoutes(
           .wakeup(agentId, wakeup)
           .catch((err) => logger.warn({ err, issueId: issue.id, agentId }, "failed to wake agent on issue update"));
       }
+
+      // AJL-550 — overlap detector (non-blocking).
+      runOverlapDetector(svc, issue.id, "routes.issues.update");
     })();
 
     res.json({ ...issueResponse, comment });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -71,6 +71,34 @@ const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
 
+// AJL-548 — wake reasons that originate from a comment/mention event and
+// are eligible for umbrella-idle suppression. Structural signals (assignment,
+// status change, child completion, execution review, etc.) are never
+// suppressed because they carry real board-state deltas.
+const COMMENT_DERIVED_WAKE_REASONS = new Set<string>([
+  "issue_commented",
+  "issue_comment_mentioned",
+  "issue_reopened_via_comment",
+]);
+
+function readWakeReason(wakeup: unknown): string | null {
+  if (!wakeup || typeof wakeup !== "object") return null;
+  const snapshot = (wakeup as Record<string, unknown>).contextSnapshot;
+  if (!snapshot || typeof snapshot !== "object") return null;
+  const reason = (snapshot as Record<string, unknown>).wakeReason;
+  return typeof reason === "string" && reason.length > 0 ? reason : null;
+}
+
+function readWakeTargetIssueId(wakeup: unknown, fallback: string): string {
+  if (!wakeup || typeof wakeup !== "object") return fallback;
+  const payload = (wakeup as Record<string, unknown>).payload;
+  if (payload && typeof payload === "object") {
+    const pid = (payload as Record<string, unknown>).issueId;
+    if (typeof pid === "string" && pid.length > 0) return pid;
+  }
+  return fallback;
+}
+
 type ParsedExecutionState = NonNullable<ReturnType<typeof parseIssueExecutionState>>;
 type NormalizedExecutionPolicy = NonNullable<ReturnType<typeof normalizeIssueExecutionPolicy>>;
 type ActivityIssueRelationSummary = {
@@ -1955,7 +1983,35 @@ export function issueRoutes(
         }
       }
 
+      // AJL-548 — suppress comment-derived wakes on idle umbrella issues.
+      const umbrellaCache = new Map<string, Awaited<ReturnType<typeof svc.classifyUmbrellaWakeState>>>();
       for (const { agentId, wakeup } of wakeups.values()) {
+        const wakeReason = readWakeReason(wakeup);
+        if (wakeReason && COMMENT_DERIVED_WAKE_REASONS.has(wakeReason)) {
+          const targetIssueId = readWakeTargetIssueId(wakeup, issue.id);
+          let state = umbrellaCache.get(targetIssueId);
+          if (!state) {
+            try {
+              state = await svc.classifyUmbrellaWakeState(targetIssueId);
+              umbrellaCache.set(targetIssueId, state);
+            } catch (err) {
+              logger.warn({ err, issueId: targetIssueId }, "umbrella wake classifier failed");
+            }
+          }
+          if (state && state.kind === "umbrella_idle_no_child") {
+            logger.info(
+              {
+                issueId: targetIssueId,
+                agentId,
+                wakeReason,
+                totalChildren: state.totalChildren,
+                source: "routes.issues.update",
+              },
+              "wake.suppressed reason=umbrella_idle_no_child",
+            );
+            continue;
+          }
+        }
         heartbeat
           .wakeup(agentId, wakeup)
           .catch((err) => logger.warn({ err, issueId: issue.id, agentId }, "failed to wake agent on issue update"));
@@ -2516,7 +2572,35 @@ export function issueRoutes(
         });
       }
 
+      // AJL-548 — suppress comment-derived wakes on idle umbrella issues.
+      const umbrellaCache = new Map<string, Awaited<ReturnType<typeof svc.classifyUmbrellaWakeState>>>();
       for (const [agentId, wakeup] of wakeups.entries()) {
+        const wakeReason = readWakeReason(wakeup);
+        if (wakeReason && COMMENT_DERIVED_WAKE_REASONS.has(wakeReason)) {
+          const targetIssueId = readWakeTargetIssueId(wakeup, currentIssue.id);
+          let state = umbrellaCache.get(targetIssueId);
+          if (!state) {
+            try {
+              state = await svc.classifyUmbrellaWakeState(targetIssueId);
+              umbrellaCache.set(targetIssueId, state);
+            } catch (err) {
+              logger.warn({ err, issueId: targetIssueId }, "umbrella wake classifier failed");
+            }
+          }
+          if (state && state.kind === "umbrella_idle_no_child") {
+            logger.info(
+              {
+                issueId: targetIssueId,
+                agentId,
+                wakeReason,
+                totalChildren: state.totalChildren,
+                source: "routes.issues.comment",
+              },
+              "wake.suppressed reason=umbrella_idle_no_child",
+            );
+            continue;
+          }
+        }
         heartbeat
           .wakeup(agentId, wakeup)
           .catch((err) => logger.warn({ err, issueId: currentIssue.id, agentId }, "failed to wake agent on issue comment"));

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -816,6 +816,25 @@ export function issueRoutes(
     });
   });
 
+  router.get("/issues/:id/umbrella-state", async (req, res) => {
+    const id = req.params.id as string;
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    const state = await svc.classifyUmbrellaWakeState(issue.id);
+    res.json({ issueId: issue.id, ...state });
+  });
+
+  router.get("/companies/:companyId/idle-umbrellas", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const rows = await svc.listIdleUmbrellasForCompany(companyId);
+    res.json(rows);
+  });
+
   router.get("/issues/:id/heartbeat-context", async (req, res) => {
     const id = req.params.id as string;
     const issue = await svc.getById(id);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -94,6 +94,14 @@ const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
 const ACTIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running"] as const;
+// AJL-551 — terminal statuses for a heartbeat run. resultClass is computed
+// once when a run first enters one of these statuses.
+const HEARTBEAT_RUN_TERMINAL_STATUSES = new Set([
+  "succeeded",
+  "failed",
+  "cancelled",
+  "timed_out",
+]);
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
@@ -2153,6 +2161,43 @@ export function heartbeatService(db: Db) {
           finishedAt: updated.finishedAt ? new Date(updated.finishedAt).toISOString() : null,
         },
       });
+    }
+
+    // AJL-551 — compute and persist resultClass on terminal transitions.
+    if (updated && HEARTBEAT_RUN_TERMINAL_STATUSES.has(updated.status) && updated.resultClass == null) {
+      try {
+        const context = parseObject(updated.contextSnapshot);
+        const issueId = readNonEmptyString(context.issueId);
+        const finishedAt = updated.finishedAt ?? new Date();
+        const startedAt = updated.startedAt ?? updated.createdAt ?? finishedAt;
+        const classification = await issuesSvc.classifyHeartbeatRunResult({
+          issueId,
+          runStartedAt: startedAt,
+          runFinishedAt: finishedAt,
+          runId: updated.id,
+        });
+        const patched = await db
+          .update(heartbeatRuns)
+          .set({ resultClass: classification.kind, updatedAt: new Date() })
+          .where(eq(heartbeatRuns.id, updated.id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        logger.info(
+          {
+            runId: updated.id,
+            agentId: updated.agentId,
+            issueId: issueId ?? null,
+            runStatus: updated.status,
+            resultClass: classification.kind,
+            signals: classification.signals,
+            source: "services.heartbeat.setRunStatus",
+          },
+          "heartbeat.run.result_classified",
+        );
+        if (patched) return patched;
+      } catch (err) {
+        logger.warn({ err, runId: updated.id }, "failed to classify heartbeat run result (AJL-551)");
+      }
     }
 
     return updated;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1465,6 +1465,100 @@ export function issueService(db: Db) {
       return { kind: "umbrella_idle_no_child" as const, totalChildren: children.length };
     },
 
+    /**
+     * AJL-550 — same-owner parent+child overlap detector.
+     *
+     * Detects the exact pre-loop topology from AJL-444 → AJL-446:
+     *  - child and its parent are both assigned to the same supervisory owner
+     *    (same agentId OR same userId, whichever is set)
+     *  - both are in_progress
+     *  - the child has zero open grandchildren
+     *    (open = status in {todo, in_progress, blocked, in_review})
+     *
+     * Returns either `no_overlap` with a structured reason, or
+     * `same_owner_parent_child_idle_grandchildren` with ownership identifiers
+     * suitable for a structured warn log.
+     *
+     * Non-blocking: callers fire-and-forget and emit a log on match.
+     */
+    detectSameOwnerParentChildOverlap: async (childIssueId: string) => {
+      const child = await db
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          parentId: issues.parentId,
+          status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+        })
+        .from(issues)
+        .where(eq(issues.id, childIssueId))
+        .then((rows) => rows[0] ?? null);
+      if (!child) {
+        return { kind: "no_overlap" as const, reason: "child_not_found" as const };
+      }
+      if (!child.parentId) {
+        return { kind: "no_overlap" as const, reason: "no_parent" as const };
+      }
+      if (child.status !== "in_progress") {
+        return { kind: "no_overlap" as const, reason: "child_not_in_progress" as const };
+      }
+
+      const parent = await db
+        .select({
+          id: issues.id,
+          status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, child.companyId), eq(issues.id, child.parentId)))
+        .then((rows) => rows[0] ?? null);
+      if (!parent) {
+        return { kind: "no_overlap" as const, reason: "parent_not_found" as const };
+      }
+      if (parent.status !== "in_progress") {
+        return { kind: "no_overlap" as const, reason: "parent_not_in_progress" as const };
+      }
+
+      const agentMatch =
+        parent.assigneeAgentId !== null &&
+        child.assigneeAgentId !== null &&
+        parent.assigneeAgentId === child.assigneeAgentId;
+      const userMatch =
+        parent.assigneeUserId !== null &&
+        child.assigneeUserId !== null &&
+        parent.assigneeUserId === child.assigneeUserId;
+      if (!agentMatch && !userMatch) {
+        return { kind: "no_overlap" as const, reason: "different_owners" as const };
+      }
+
+      const grandchildren = await db
+        .select({ id: issues.id, status: issues.status })
+        .from(issues)
+        .where(and(eq(issues.companyId, child.companyId), eq(issues.parentId, child.id)));
+
+      const openExecutableStatuses = new Set(["todo", "in_progress", "blocked", "in_review"]);
+      const openGrandchildCount = grandchildren.filter((g) => openExecutableStatuses.has(g.status)).length;
+      if (openGrandchildCount > 0) {
+        return {
+          kind: "no_overlap" as const,
+          reason: "child_has_open_grandchildren" as const,
+          totalGrandchildren: grandchildren.length,
+          openGrandchildCount,
+        };
+      }
+
+      return {
+        kind: "same_owner_parent_child_idle_grandchildren" as const,
+        parentId: parent.id,
+        childId: child.id,
+        ownerAgentId: agentMatch ? parent.assigneeAgentId : null,
+        ownerUserId: userMatch ? parent.assigneeUserId : null,
+        totalGrandchildren: grandchildren.length,
+      };
+    },
+
     create: async (
       companyId: string,
       data: IssueCreateInput,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1466,6 +1466,196 @@ export function issueService(db: Db) {
     },
 
     /**
+     * AJL-551 — heartbeat run result classifier.
+     *
+     * Computes a `resultClass` value for a finished heartbeat run by inspecting
+     * issue/run deltas inside the run's execution window. Supports four values:
+     *
+     *  - executable_progress         real forward motion: the issue's status
+     *                                moved to done/cancelled/in_progress, a new
+     *                                subtask was created, or a pre-existing
+     *                                child's status was touched during the run
+     *  - bounded_handoff             the run explicitly handed the issue off:
+     *                                status moved to `blocked` during the run
+     *  - review_gate                 the run closed a review cycle: status
+     *                                moved to `in_review` during the run
+     *  - supervisory_summary_only    the run only produced comments / logs with
+     *                                no issue or child delta — the exact shape
+     *                                of the AJL-444 → AJL-446 loop family
+     *
+     * The window is [runStartedAt, runFinishedAt]. We use the issue's
+     * updatedAt as a proxy for "mutated during this run" because every
+     * status/assignee/description write bumps updatedAt and the run is the
+     * only actor on that issue for the window (`agentId` + row lock on
+     * current issues service).
+     *
+     * If `issueId` is null (non-issue-anchored run), we can't compute issue
+     * deltas, so we return `supervisory_summary_only` with an empty signals
+     * block.
+     */
+    classifyHeartbeatRunResult: async (input: {
+      issueId: string | null | undefined;
+      runStartedAt: Date | null | undefined;
+      runFinishedAt: Date | null | undefined;
+      runId: string;
+    }) => {
+      const baseSignals = {
+        issueMutatedInWindow: false,
+        currentIssueStatus: null as string | null,
+        childSubtasksCreatedInWindow: 0,
+        childSubtasksTouchedInWindow: 0,
+        commentsAuthoredByRun: 0,
+        windowStart: input.runStartedAt ? new Date(input.runStartedAt).toISOString() : null,
+        windowEnd: input.runFinishedAt ? new Date(input.runFinishedAt).toISOString() : null,
+      } as const;
+
+      if (!input.issueId) {
+        return { kind: "supervisory_summary_only" as const, signals: baseSignals };
+      }
+      if (!input.runStartedAt || !input.runFinishedAt) {
+        return { kind: "supervisory_summary_only" as const, signals: baseSignals };
+      }
+
+      const windowStart = new Date(input.runStartedAt);
+      const windowEnd = new Date(input.runFinishedAt);
+
+      const issueRow = await db
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          status: issues.status,
+          updatedAt: issues.updatedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, input.issueId))
+        .then((rows) => rows[0] ?? null);
+      if (!issueRow) {
+        return { kind: "supervisory_summary_only" as const, signals: baseSignals };
+      }
+
+      const issueUpdatedAt = issueRow.updatedAt ? new Date(issueRow.updatedAt) : null;
+      const issueMutatedInWindow =
+        !!issueUpdatedAt && issueUpdatedAt.getTime() >= windowStart.getTime();
+
+      const childRows = await db
+        .select({
+          id: issues.id,
+          createdAt: issues.createdAt,
+          updatedAt: issues.updatedAt,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, issueRow.companyId), eq(issues.parentId, input.issueId)));
+
+      let childSubtasksCreatedInWindow = 0;
+      let childSubtasksTouchedInWindow = 0;
+      for (const child of childRows) {
+        const createdAt = child.createdAt ? new Date(child.createdAt) : null;
+        const updatedAt = child.updatedAt ? new Date(child.updatedAt) : null;
+        const createdInWindow =
+          !!createdAt && createdAt.getTime() >= windowStart.getTime();
+        const touchedInWindow =
+          !!updatedAt && updatedAt.getTime() >= windowStart.getTime();
+        if (createdInWindow) {
+          childSubtasksCreatedInWindow += 1;
+        } else if (touchedInWindow) {
+          childSubtasksTouchedInWindow += 1;
+        }
+      }
+
+      const commentsAuthoredByRun = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(issueComments)
+        .where(
+          and(
+            eq(issueComments.issueId, input.issueId),
+            eq(issueComments.createdByRunId, input.runId),
+          ),
+        )
+        .then((rows) => Number(rows[0]?.count ?? 0));
+
+      const signals = {
+        issueMutatedInWindow,
+        currentIssueStatus: issueRow.status ?? null,
+        childSubtasksCreatedInWindow,
+        childSubtasksTouchedInWindow,
+        commentsAuthoredByRun,
+        windowStart: windowStart.toISOString(),
+        windowEnd: windowEnd.toISOString(),
+      };
+
+      // review_gate dominates: in_review is the handoff-for-review shape.
+      if (issueMutatedInWindow && issueRow.status === "in_review") {
+        return { kind: "review_gate" as const, signals };
+      }
+      // bounded_handoff: explicit blocked transition.
+      if (issueMutatedInWindow && issueRow.status === "blocked") {
+        return { kind: "bounded_handoff" as const, signals };
+      }
+      // executable_progress: any real child/task delta or terminal progress on
+      // the owning issue.
+      if (
+        childSubtasksCreatedInWindow > 0 ||
+        childSubtasksTouchedInWindow > 0 ||
+        (issueMutatedInWindow && (issueRow.status === "done" || issueRow.status === "cancelled" || issueRow.status === "in_progress"))
+      ) {
+        return { kind: "executable_progress" as const, signals };
+      }
+      return { kind: "supervisory_summary_only" as const, signals };
+    },
+
+    /**
+     * AJL-551 — phase-1 reinforcement: count the tail streak of heartbeat
+     * runs on this umbrella issue whose `resultClass` is
+     * `supervisory_summary_only`. Runs are identified by
+     * `contextSnapshot->>issueId = umbrellaIssueId`, scoped to the umbrella's
+     * own company, and considered in reverse chronological order of their
+     * finalized `finishedAt` (with `createdAt` as the tiebreak for races).
+     *
+     * Only runs that have finished (non-null `resultClass`) are counted.
+     * The first finished run whose resultClass is NOT
+     * `supervisory_summary_only` breaks the streak.
+     */
+    getSupervisorySummaryOnlyStreakForUmbrella: async (
+      umbrellaIssueId: string,
+      limit = 5,
+    ) => {
+      const umbrella = await db
+        .select({ id: issues.id, companyId: issues.companyId })
+        .from(issues)
+        .where(eq(issues.id, umbrellaIssueId))
+        .then((rows) => rows[0] ?? null);
+      if (!umbrella) return { streak: 0, inspected: 0 };
+
+      const rows = await db
+        .select({
+          id: heartbeatRuns.id,
+          resultClass: heartbeatRuns.resultClass,
+          finishedAt: heartbeatRuns.finishedAt,
+          createdAt: heartbeatRuns.createdAt,
+        })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, umbrella.companyId),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${umbrellaIssueId}`,
+            sql`${heartbeatRuns.resultClass} IS NOT NULL`,
+          ),
+        )
+        .orderBy(desc(heartbeatRuns.finishedAt), desc(heartbeatRuns.createdAt))
+        .limit(Math.max(1, Math.min(50, limit)));
+
+      let streak = 0;
+      for (const row of rows) {
+        if (row.resultClass === "supervisory_summary_only") {
+          streak += 1;
+        } else {
+          break;
+        }
+      }
+      return { streak, inspected: rows.length };
+    },
+
+    /**
      * AJL-550 — same-owner parent+child overlap detector.
      *
      * Detects the exact pre-loop topology from AJL-444 → AJL-446:

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1421,6 +1421,50 @@ export function issueService(db: Db) {
       };
     },
 
+    /**
+     * AJL-548 — umbrella-wake suppression classifier.
+     *
+     * Classifies an issue's child topology to decide whether a heartbeat wake
+     * triggered by a comment / mention on that issue should actually run, or
+     * be suppressed because the umbrella is idle with no executable child.
+     *
+     * Returns one of:
+     *  - leaf: no children at all → normal execution (unchanged)
+     *  - has_open_executable_child: ≥1 child is todo|in_progress|blocked|in_review → normal wake
+     *  - umbrella_idle_no_child: has children but all are done|cancelled → suppress wake
+     */
+    classifyUmbrellaWakeState: async (issueId: string) => {
+      const issueRow = await db
+        .select({ id: issues.id, companyId: issues.companyId })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      if (!issueRow) {
+        return { kind: "leaf" as const, totalChildren: 0 };
+      }
+
+      const children = await db
+        .select({ id: issues.id, status: issues.status })
+        .from(issues)
+        .where(and(eq(issues.companyId, issueRow.companyId), eq(issues.parentId, issueId)));
+
+      if (children.length === 0) {
+        return { kind: "leaf" as const, totalChildren: 0 };
+      }
+
+      const openExecutableStatuses = new Set(["todo", "in_progress", "blocked", "in_review"]);
+      const openCount = children.filter((c) => openExecutableStatuses.has(c.status)).length;
+      if (openCount > 0) {
+        return {
+          kind: "has_open_executable_child" as const,
+          totalChildren: children.length,
+          openExecutableChildCount: openCount,
+        };
+      }
+
+      return { kind: "umbrella_idle_no_child" as const, totalChildren: children.length };
+    },
+
     create: async (
       companyId: string,
       data: IssueCreateInput,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1466,6 +1466,78 @@ export function issueService(db: Db) {
     },
 
     /**
+     * AJL-552 — list umbrella issues for a company that are currently
+     * in an `umbrella_idle_no_child` state: still in_progress / in_review,
+     * but every child is done or cancelled. These are candidates for the
+     * board-hygiene "close or move to review" recommendation.
+     *
+     * Returns a compact summary for the dashboard surface. Limited to
+     * `in_progress` and `in_review` parents so we do not recommend closing
+     * already-closed umbrellas.
+     */
+    listIdleUmbrellasForCompany: async (companyId: string) => {
+      const parentRows = await db
+        .select({
+          id: issues.id,
+          identifier: issues.identifier,
+          title: issues.title,
+          status: issues.status,
+          priority: issues.priority,
+          assigneeAgentId: issues.assigneeAgentId,
+          updatedAt: issues.updatedAt,
+        })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            inArray(issues.status, ["in_progress", "in_review"]),
+            isNull(issues.hiddenAt),
+          ),
+        );
+
+      if (parentRows.length === 0) return [] as const;
+
+      const parentIds = parentRows.map((p) => p.id);
+      const childRows = await db
+        .select({ parentId: issues.parentId, status: issues.status })
+        .from(issues)
+        .where(
+          and(eq(issues.companyId, companyId), inArray(issues.parentId, parentIds)),
+        );
+
+      const openExecutableStatuses = new Set(["todo", "in_progress", "blocked", "in_review"]);
+      const totalByParent = new Map<string, number>();
+      const openByParent = new Map<string, number>();
+      for (const c of childRows) {
+        if (!c.parentId) continue;
+        totalByParent.set(c.parentId, (totalByParent.get(c.parentId) ?? 0) + 1);
+        if (openExecutableStatuses.has(c.status)) {
+          openByParent.set(c.parentId, (openByParent.get(c.parentId) ?? 0) + 1);
+        }
+      }
+
+      const idle = parentRows
+        .filter((p) => {
+          const total = totalByParent.get(p.id) ?? 0;
+          const open = openByParent.get(p.id) ?? 0;
+          return total > 0 && open === 0;
+        })
+        .map((p) => ({
+          id: p.id,
+          identifier: p.identifier,
+          title: p.title,
+          status: p.status,
+          priority: p.priority,
+          assigneeAgentId: p.assigneeAgentId,
+          updatedAt: p.updatedAt,
+          totalChildren: totalByParent.get(p.id) ?? 0,
+        }));
+
+      idle.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      return idle;
+    },
+
+    /**
      * AJL-551 — heartbeat run result classifier.
      *
      * Computes a `resultClass` value for a finished heartbeat run by inspecting

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -18,6 +18,29 @@ export type IssueUpdateResponse = Issue & {
   comment?: IssueComment | null;
 };
 
+export type IssueUmbrellaWakeStateKind =
+  | "leaf"
+  | "has_open_executable_child"
+  | "umbrella_idle_no_child";
+
+export type IssueUmbrellaState = {
+  issueId: string;
+  kind: IssueUmbrellaWakeStateKind;
+  totalChildren: number;
+  openExecutableChildCount?: number;
+};
+
+export type IdleUmbrellaIssue = {
+  id: string;
+  identifier: string;
+  title: string;
+  status: Issue["status"];
+  priority: Issue["priority"];
+  assigneeAgentId: string | null;
+  updatedAt: string;
+  totalChildren: number;
+};
+
 export const issuesApi = {
   list: (
     companyId: string,
@@ -65,6 +88,10 @@ export const issuesApi = {
     api.post<IssueLabel>(`/companies/${companyId}/labels`, data),
   deleteLabel: (id: string) => api.delete<IssueLabel>(`/labels/${id}`),
   get: (id: string) => api.get<Issue>(`/issues/${id}`),
+  getUmbrellaState: (id: string) =>
+    api.get<IssueUmbrellaState>(`/issues/${id}/umbrella-state`),
+  listIdleUmbrellas: (companyId: string) =>
+    api.get<IdleUmbrellaIssue[]>(`/companies/${companyId}/idle-umbrellas`),
   markRead: (id: string) => api.post<{ id: string; lastReadAt: Date }>(`/issues/${id}/read`, {}),
   markUnread: (id: string) => api.delete<{ id: string; removed: boolean }>(`/issues/${id}/read`),
   archiveFromInbox: (id: string) =>

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -55,6 +55,8 @@ export const queryKeys = {
     liveRuns: (issueId: string) => ["issues", "live-runs", issueId] as const,
     activeRun: (issueId: string) => ["issues", "active-run", issueId] as const,
     workProducts: (issueId: string) => ["issues", "work-products", issueId] as const,
+    umbrellaState: (issueId: string) => ["issues", "umbrella-state", issueId] as const,
+    idleUmbrellas: (companyId: string) => ["issues", companyId, "idle-umbrellas"] as const,
   },
   routines: {
     list: (companyId: string) => ["routines", companyId] as const,

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -21,7 +21,7 @@ import { ActivityRow } from "../components/ActivityRow";
 import { Identity } from "../components/Identity";
 import { timeAgo } from "../lib/timeAgo";
 import { cn, formatCents } from "../lib/utils";
-import { Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard, PauseCircle } from "lucide-react";
+import { AlertTriangle, Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard, PauseCircle } from "lucide-react";
 import { ActiveAgentsPanel } from "../components/ActiveAgentsPanel";
 import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRateChart } from "../components/ActivityCharts";
 import { PageSkeleton } from "../components/PageSkeleton";
@@ -94,6 +94,15 @@ export function Dashboard() {
     () => buildCompanyUserProfileMap(companyMembers?.users),
     [companyMembers?.users],
   );
+
+  // AJL-552 — board-hygiene surface: idle umbrellas where all children are
+  // done or cancelled, so comment wakes are suppressed. Recommend close or move
+  // to review.
+  const { data: idleUmbrellas } = useQuery({
+    queryKey: queryKeys.issues.idleUmbrellas(selectedCompanyId!),
+    queryFn: () => issuesApi.listIdleUmbrellas(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
 
   const recentIssues = issues ? getRecentIssues(issues) : [];
   const recentActivity = useMemo(() => (activity ?? []).slice(0, 10), [activity]);
@@ -312,6 +321,51 @@ export function Dashboard() {
               <SuccessRateChart runs={runs ?? []} />
             </ChartCard>
           </div>
+
+          {idleUmbrellas && idleUmbrellas.length > 0 && (
+            <div
+              data-testid="dashboard-idle-umbrellas"
+              className="rounded-xl border border-amber-300 bg-amber-50 p-4 dark:border-amber-500/30 dark:bg-amber-950/30"
+            >
+              <div className="flex items-start gap-2.5">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
+                    {idleUmbrellas.length} idle umbrella{idleUmbrellas.length === 1 ? "" : "s"} — close or move to review
+                  </p>
+                  <p className="text-xs text-amber-800/90 dark:text-amber-200/80">
+                    These issues are still in progress but every child is done or cancelled. Comment wakes are suppressed until an operator acts.{" "}
+                    <Link
+                      to="/docs/guides/board-operator/umbrella-wake-suppression"
+                      className="underline underline-offset-2 hover:opacity-80"
+                    >
+                      Why this doctrine exists
+                    </Link>
+                  </p>
+                </div>
+              </div>
+              <ul className="mt-3 divide-y divide-amber-200 border-t border-amber-200 dark:divide-amber-500/20 dark:border-amber-500/20">
+                {idleUmbrellas.slice(0, 10).map((u) => (
+                  <li key={u.id} className="py-2">
+                    <Link
+                      to={`/issues/${u.identifier ?? u.id}`}
+                      className="flex items-center gap-2 text-sm no-underline text-inherit hover:opacity-80"
+                    >
+                      <span className="text-xs font-mono text-amber-900/80 dark:text-amber-200/80 shrink-0">
+                        {u.identifier ?? u.id.slice(0, 8)}
+                      </span>
+                      <span className="truncate flex-1 text-amber-900 dark:text-amber-100">
+                        {u.title}
+                      </span>
+                      <span className="text-xs text-amber-800/70 dark:text-amber-200/60 shrink-0">
+                        {u.totalChildren} child{u.totalChildren === 1 ? "" : "ren"} · {u.status}
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           <PluginSlotOutlet
             slotTypes={["dashboardWidget"]}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -95,6 +95,7 @@ import {
   MoreHorizontal,
   MoreVertical,
   Paperclip,
+  PauseCircle,
   Plus,
   Repeat,
   SlidersHorizontal,
@@ -983,6 +984,19 @@ export function IssueDetail() {
     enabled: !!resolvedCompanyId && !!issue?.id,
     placeholderData: keepPreviousDataForSameQueryTail<Issue[]>(issue?.id ?? "pending"),
   });
+
+  // AJL-552 — umbrella wake suppression state. Loaded only for non-terminal
+  // issues, since done/cancelled umbrellas can't be waked anyway.
+  const umbrellaStateEnabled =
+    !!issue?.id &&
+    issue.status !== "done" &&
+    issue.status !== "cancelled";
+  const { data: umbrellaState } = useQuery({
+    queryKey: issue?.id ? queryKeys.issues.umbrellaState(issue.id) : ["issues", "umbrella-state", "pending"],
+    queryFn: () => issuesApi.getUmbrellaState(issue!.id),
+    enabled: umbrellaStateEnabled,
+  });
+  const isUmbrellaIdleNoChild = umbrellaState?.kind === "umbrella_idle_no_child";
 
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
@@ -2198,6 +2212,31 @@ export function IssueDetail() {
         <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
           <EyeOff className="h-4 w-4 shrink-0" />
           This issue is hidden
+        </div>
+      )}
+
+      {isUmbrellaIdleNoChild && (
+        <div
+          data-testid="umbrella-idle-banner"
+          className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-500/30 dark:bg-amber-950/40 dark:text-amber-100"
+        >
+          <PauseCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="font-medium">
+              Umbrella idle — no open executable child
+            </p>
+            <p className="text-xs text-amber-800/90 dark:text-amber-200/80">
+              All {umbrellaState?.totalChildren ?? 0} children are done or cancelled. Comment
+              wakes on this issue are suppressed. Close it, move to review, or open a new child
+              to resume supervision.{" "}
+              <Link
+                to="/docs/guides/board-operator/umbrella-wake-suppression"
+                className="underline underline-offset-2 hover:opacity-80"
+              >
+                Why?
+              </Link>
+            </p>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, so wake routing and board truth directly affect execution quality and operator trust.
> - The impacted subsystem is issue wake policy plus the board surfaces operators use to understand why an issue did or did not wake.
> - AJL-548 narrowed a specific control-plane failure: comment activity on umbrella issues could trigger wasteful wakes even when no executable child lane existed.
> - That failure also lacked a clear surfaced state, so operators could not quickly distinguish healthy idle umbrellas from stuck or silently suppressed execution.
> - This pull request adds a tighter heartbeat / issue-update suppression policy for idle umbrella issues, detects same-owner parent-child overlap, records the resulting suppression class in telemetry, and surfaces the idle umbrella state in the UI/docs.
> - The goal is to reduce false-positive wakes, preserve bounded execution lanes, and make the board explain the suppression outcome instead of hiding it.
> - The benefit is lower orchestration noise, fewer wasted agent cycles, and clearer operator readback when an umbrella is intentionally idle.

## What Changed

- Suppressed comment-derived wakes on idle umbrella issues so non-executable parent chatter does not wake agents unnecessarily.
- Added same-owner parent/child overlap detection to the heartbeat / issues service wake policy.
- Added `resultClass` plus last-two-run suppression handling to heartbeat telemetry and route/service tests.
- Added the supporting DB migration/schema update for the new heartbeat run classification field.
- Added targeted server tests covering comment wake suppression, issue update wake behavior, and issues-service policy behavior.
- Surfaced the `umbrella_idle_no_child` state in the dashboard and issue detail UI.
- Added board-operator documentation for umbrella wake suppression and refreshed docs metadata.

## Verification

- Git-level verification completed:
  - rebased cleanly onto current `upstream/master`
  - `git rev-list --left-right --count upstream/master...HEAD` -> `0 4`
  - `git diff --stat upstream/master...HEAD` confirms the expected 20-file AJL-548/AJL-552 stack
- Runtime verification not completed in this clone because dependencies are not installed (`node_modules` missing; `tsx` unavailable), so the following are still the intended follow-up commands:
  - `npx pnpm install`
  - `npx pnpm --filter @paperclipai/db check:migrations`
  - `npx pnpm test:run -- server/src/__tests__/issues-service.test.ts`
  - `npx pnpm --filter @paperclipai/ui typecheck`
- UI proof for phase 4 remains the screenshot artifacts attached on AJL-552 / AJL-557.

## Risks

- Wake-policy changes can under-wake issues if the suppression contract is too aggressive, especially around edge cases where parent and child ownership differs only transiently.
- The migration numbering changed during rebase (`0058_ajl_551_result_class.sql`) to preserve upstream journal order; reviewers should confirm this aligns with current migration sequencing expectations.
- UI/readback copy could drift from backend classification semantics if future suppression classes are added without updating the surfaced state.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex runtime on Hermes / Lisa lane using `gpt-5.4` with tool use, terminal access, browser/API inspection, and delegated subagent support.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
