### PR TITLE
fix(heartbeat): promote deferred wake when executionRunId pre-cleared by Fix-B

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -3,9 +3,11 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
+  agentRuntimeState,
   agents,
   agentWakeupRequests,
   companies,
+  companySkills,
   createDb,
   heartbeatRunEvents,
   heartbeatRuns,
@@ -138,7 +140,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
     await db.delete(agents);
+    await db.delete(companySkills);
     await db.delete(companies);
   });
 
@@ -169,6 +173,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     includeIssue?: boolean;
     runErrorCode?: string | null;
     runError?: string | null;
+    startedAt?: Date;
+    updatedAt?: Date;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -224,8 +230,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       processLossRetryCount: input?.processLossRetryCount ?? 0,
       errorCode: input?.runErrorCode ?? null,
       error: input?.runError ?? null,
-      startedAt: now,
-      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      startedAt: input?.startedAt ?? now,
+      updatedAt: input?.updatedAt ?? new Date("2026-03-19T00:00:00.000Z"),
     });
 
     if (input?.includeIssue !== false) {
@@ -306,6 +312,27 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.checkoutRunId).toBe(runId);
   });
 
+  it("uses startedAt instead of updatedAt for stale orphaned run detection", async () => {
+    const nowMs = Date.now();
+    const { runId } = await seedRunFixture({
+      adapterType: "hermes_local",
+      includeIssue: false,
+      processPid: null,
+      startedAt: new Date(nowMs - 60 * 60 * 1000),
+      updatedAt: new Date(nowMs - 10 * 1000),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 30 * 60 * 1000 });
+
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_lost");
+  });
+
   it.skipIf(process.platform === "win32")("reaps orphaned descendant process groups when the parent pid is already gone", async () => {
     const orphan = await spawnOrphanedProcessGroup();
     cleanupPids.add(orphan.descendantPid);
@@ -370,6 +397,68 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBeNull();
     expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it("promotes a deferred wake when executionRunId was pre-cleared by Fix-B (TBG-198 regression)", async () => {
+    // Regression for the race in releaseIssueExecutionAndPromote:
+    // Fix-B clears executionRunId synchronously during a PATCH reassign, so by the time
+    // releaseIssueExecutionAndPromote runs, the primary lookup (WHERE executionRunId = run.id)
+    // finds nothing and exits — leaving any concurrently-created deferred wake orphaned.
+    // The fix adds a fallback lookup via contextSnapshot.issueId.
+    const { companyId, issueId } = await seedRunFixture({
+      processPid: 999_999_999, // dead pid → will be reaped
+      processLossRetryCount: 1, // retry already exhausted → goes straight to releaseIssueExecutionAndPromote
+    });
+
+    // Simulate Fix-B: clear executionRunId on the issue (as PATCH does on reassign).
+    await db
+      .update(issues)
+      .set({ executionRunId: null, executionAgentNameKey: null })
+      .where(eq(issues.id, issueId));
+
+    // Create a second QA agent and a deferred wake for it, as enqueueWakeup would have.
+    const qaAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: qaAgentId,
+      companyId,
+      name: "QAInspector",
+      role: "qa",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const deferredWakeId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: deferredWakeId,
+      companyId,
+      agentId: qaAgentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_execution_deferred",
+      payload: { issueId, mutation: "update" },
+      status: "deferred_issue_execution",
+    });
+
+    // Reaping the orphaned run triggers releaseIssueExecutionAndPromote.
+    // Without the fix, the deferred wake would stay deferred forever.
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+
+    const deferredWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, deferredWakeId))
+      .then((rows) => rows[0] ?? null);
+
+    // The deferred wake must have been promoted out of deferred_issue_execution.
+    // startNextQueuedRunForAgent may immediately claim it (queued → claimed),
+    // so accept any status that is not deferred_issue_execution.
+    expect(deferredWake?.status).not.toBe("deferred_issue_execution");
+    expect(["queued", "claimed", "running", "failed"]).toContain(deferredWake?.status);
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -90,6 +90,7 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "gemini_local",
   "opencode_local",
   "pi_local",
+  "hermes_local",
 ]);
 
 type RuntimeConfigSecretResolver = Pick<
@@ -2462,11 +2463,13 @@ export function heartbeatService(db: Db) {
     const reaped: string[] = [];
 
     for (const { run, adapterType } of activeRuns) {
+      logger.warn({ runId: run.id, adapterType, processPid: run.processPid, rpSize: runningProcesses.size, areSize: activeRunExecutions.size, staleMs: staleThresholdMs }, "[reaper-debug] considering orphan");
       if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
 
       // Apply staleness threshold to avoid false positives
       if (staleThresholdMs > 0) {
-        const refTime = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
+        const stalenessAnchor = run.startedAt ?? run.processStartedAt ?? run.createdAt;
+        const refTime = new Date(stalenessAnchor).getTime();
         if (now.getTime() - refTime < staleThresholdMs) continue;
       }
 
@@ -3637,7 +3640,7 @@ export function heartbeatService(db: Db) {
         sql`select id from issues where company_id = ${run.companyId} and execution_run_id = ${run.id} for update`,
       );
 
-      const issue = await tx
+      let issue: { id: string; companyId: string } | null = await tx
         .select({
           id: issues.id,
           companyId: issues.companyId,
@@ -3646,7 +3649,44 @@ export function heartbeatService(db: Db) {
         .where(and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)))
         .then((rows) => rows[0] ?? null);
 
-      if (!issue) return;
+      if (!issue) {
+        // Race fix: Fix-B (svc.update on PATCH reassign / status-change) clears
+        // executionRunId synchronously before this release runs, so the primary lookup
+        // above finds nothing.  However, enqueueWakeup's async transaction may run
+        // concurrently: it sees executionRunId = null, re-stamps it to our run via the
+        // legacy-run path (run still "running" at that point), and inserts a
+        // deferred_issue_execution wake — all before its own transaction commits.
+        // If releaseIssueExecutionAndPromote exits here, that deferred wake is orphaned
+        // until the next timer fires (~70 min).
+        //
+        // Fix: lock the issue by contextSnapshot.issueId and promote any deferred wakes
+        // whose payload references it, as long as no *other* run now owns the lock.
+        const runCtx = run.contextSnapshot as Record<string, unknown> | null;
+        const ctxIssueId = typeof runCtx?.issueId === "string" ? runCtx.issueId : null;
+        if (!ctxIssueId) return null;
+
+        await tx.execute(
+          sql`select id from issues where id = ${ctxIssueId} and company_id = ${run.companyId} for update`,
+        );
+        const candidate = await tx
+          .select({
+            id: issues.id,
+            companyId: issues.companyId,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(and(eq(issues.id, ctxIssueId), eq(issues.companyId, run.companyId)))
+          .then((rows) => rows[0] ?? null);
+
+        if (
+          !candidate ||
+          (candidate.executionRunId !== null && candidate.executionRunId !== run.id)
+        ) {
+          // Issue not found, or a different run now owns the execution lock — skip.
+          return null;
+        }
+        issue = { id: candidate.id, companyId: candidate.companyId };
+      }
 
       await tx
         .update(issues)


### PR DESCRIPTION
## Summary

Fixes a race in `releaseIssueExecutionAndPromote` that orphaned deferred assignment wakes for up to 70 minutes after a handoff-by-PATCH.

**Root cause.** When an agent does a PATCH-reassign, Fix-B (`issues.ts`) synchronously clears `executionRunId` on the issue. `releaseIssueExecutionAndPromote` then runs after the previous run terminates, but its primary lookup `WHERE executionRunId = run.id` finds nothing and returns early. Any `deferred_issue_execution` wake that `enqueueWakeup`'s concurrent transaction inserted for the new assignee is left dangling until the next timer tick (~70 min).

**Fix.** If the primary lookup finds nothing, fall back to `contextSnapshot.issueId`, lock that issue row, verify no *other* run owns the lock, and promote any deferred wakes whose payload references it — idempotently feeding the same `update + promoteDeferred` path.

Also in this PR:
- Adds `hermes_local` to `SESSIONED_LOCAL_ADAPTERS`.
- Switches stale-run anchor from `updatedAt` to `startedAt ?? processStartedAt ?? createdAt` so orphan detection is not defeated by unrelated `updatedAt` bumps (e.g. from Fix-B).
- Cleanup-fix in `heartbeat-process-recovery.test.ts` afterEach (companySkills cleanup ordering).
- Adds a debug `[reaper-debug]` warn log — intentional observability for this release; can be demoted to debug-level once the pattern is stable.

## Test plan

- [x] `npx vitest run server/src/__tests__/heartbeat-process-recovery.test.ts` — 8/8 pass (2.36s), includes:
  - Regression test: `promotes a deferred wake when executionRunId was pre-cleared by Fix-B (TBG-198 regression)`
  - Staleness anchor test: `uses startedAt instead of updatedAt for stale orphaned run detection`
- [x] Independent Tech-QA pass (private tracker: TBG-218)
- [x] Deployed to a live Paperclip instance; observed `[reaper-debug]` firing and deferred-wake promotion on real handoffs

## Notes for review

The `[reaper-debug]` log is intentionally left at `warn` for this release — happy to demote to `debug` or remove if reviewers prefer a quieter log surface.

🤖 Submitted on behalf of the TBGAuto Paperclip fleet.