### PR TITLE
fix: resolve mobile black screen on iPhone/Samsung browsers

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -42,7 +42,22 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div id="app-loader" style="display:flex;align-items:center;justify-content:center;height:100vh;height:100dvh">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="animation:spin 1s linear infinite;opacity:0.4">
+          <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+        </svg>
+        <style>@keyframes spin{to{transform:rotate(360deg)}}</style>
+      </div>
+    </div>
+    <noscript>
+      <div style="display:flex;align-items:center;justify-content:center;min-height:100vh;padding:2rem;font-family:system-ui,sans-serif;color:#a1a1aa;text-align:center">
+        <div>
+          <h1 style="font-size:1.25rem;font-weight:600;color:#fafafa;margin-bottom:0.5rem">Paperclip</h1>
+          <p>JavaScript is required to use this application.</p>
+        </div>
+      </div>
+    </noscript>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -125,7 +125,14 @@
   body {
     @apply bg-background text-foreground antialiased;
     height: 100%;
-    overflow: hidden;
+  }
+  #root {
+    height: 100%;
+  }
+  @media (min-width: 768px) {
+    body {
+      overflow: hidden;
+    }
   }
   h1,
   h2,

--- a/ui/src/plugins/launchers.tsx
+++ b/ui/src/plugins/launchers.tsx
@@ -211,7 +211,7 @@ function launcherShellBoundsStyle(bounds: PluginLauncherBounds | null): CSSPrope
     case "wide":
       return { width: "min(64rem, calc(100vw - 2rem))" };
     case "full":
-      return { width: "calc(100vw - 2rem)", height: "calc(100vh - 2rem)" };
+      return { width: "calc(100vw - 2rem)", height: "calc(100dvh - 2rem)" };
     case "inline":
       return { width: "min(24rem, calc(100vw - 2rem))" };
     case "default":
@@ -525,7 +525,7 @@ function LauncherModalShell({
     ? "fixed right-0 top-0 h-full max-w-[min(44rem,100vw)] overflow-hidden border-l border-border bg-background shadow-2xl"
     : shellType === "openPopover"
       ? "fixed overflow-hidden rounded-xl border border-border bg-background shadow-2xl"
-      : "fixed left-1/2 top-1/2 max-h-[calc(100vh-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl border border-border bg-background shadow-2xl";
+      : "fixed left-1/2 top-1/2 max-h-[calc(100dvh-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl border border-border bg-background shadow-2xl";
 
   return (
     <>
@@ -576,7 +576,7 @@ function LauncherModalShell({
         <div
           className={cn(
             "overflow-auto p-4",
-            shellType === "openDrawer" ? "h-[calc(100%-3.5rem)]" : "max-h-[calc(100vh-7rem)]",
+            shellType === "openDrawer" ? "h-[calc(100%-3.5rem)]" : "max-h-[calc(100dvh-7rem)]",
           )}
         >
           <LauncherRenderContent instance={instance} renderEnvironment={renderEnvironment} />


### PR DESCRIPTION
## Summary

Fixes the black screen issue on mobile browsers (iPhone Safari, Samsung Internet) reported in AI-50.

**Root cause:** `body { overflow: hidden }` blocks scrolling on mobile, combined with dark-mode default background (`oklch(0.145 0 0)`), no loading indicator during 4.6MB JS bundle load, and `100vh` miscalculating viewport height on mobile browsers with dynamic address bars.

### Changes (3 files)

- **`ui/index.html`** — Added CSS-only loading spinner + `<noscript>` fallback message so users see feedback during JS load
- **`ui/src/index.css`** — Moved `body overflow:hidden` inside `@media (min-width: 768px)` (desktop only) + added `#root { height: 100% }`
- **`ui/src/plugins/launchers.tsx`** — Changed `100vh` → `100dvh` in 3 places for correct mobile dynamic viewport height

## Test plan

- [ ] Open site on iPhone Safari — should show spinner then load normally
- [ ] Open site on Samsung Internet — same behavior
- [ ] Verify desktop layout unchanged (overflow still hidden on ≥768px)
- [ ] Verify dialog/launcher heights adapt to mobile address bar

Co-Authored-By: Paperclip <noreply@paperclip.ing>