### PR TITLE
fix: clear execution lock on reassignment

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -9,6 +9,7 @@ import {
   createDb,
   executionWorkspaces,
   goals,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -1685,5 +1686,140 @@ describeEmbeddedPostgres("issueService.findMentionedProjectIds", () => {
       titleProjectId,
       commentProjectId,
     ]);
+  });
+});
+
+describeEmbeddedPostgres("issueService.update execution lock on reassignment", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-reassign-lock-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedBaseFixture(db: ReturnType<typeof createDb>) {
+    const companyId = randomUUID();
+    const agentAId = randomUUID();
+    const agentBId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: agentAId,
+        companyId,
+        name: "AgentA",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: agentBId,
+        companyId,
+        name: "AgentB",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    // Seed a heartbeat run so FK on checkoutRunId/executionRunId is satisfied
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: agentAId,
+    });
+
+    return { companyId, agentAId, agentBId, runId };
+  }
+
+  it("clears execution lock fields when assigneeAgentId changes", async () => {
+    const { companyId, agentAId, agentBId, runId } = await seedBaseFixture(db);
+    const issueId = randomUUID();
+
+    // Create an issue assigned to agentA with a live execution lock
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Locked issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentAId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionAgentNameKey: "agenta",
+      executionLockedAt: new Date(),
+    });
+
+    // Reassign to agentB — should clear all execution lock fields
+    const updated = await svc.update(issueId, { assigneeAgentId: agentBId });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.assigneeAgentId).toBe(agentBId);
+    expect(updated!.checkoutRunId).toBeNull();
+    expect(updated!.executionRunId).toBeNull();
+    expect(updated!.executionAgentNameKey).toBeNull();
+    expect(updated!.executionLockedAt).toBeNull();
+  });
+
+  it("clears execution lock fields when issue is unassigned", async () => {
+    const { companyId, agentAId, runId } = await seedBaseFixture(db);
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Locked issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentAId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionAgentNameKey: "agenta",
+      executionLockedAt: new Date(),
+    });
+
+    // Unassign — assigneeAgentId change should still clear execution lock
+    const updated = await svc.update(issueId, { assigneeAgentId: null });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.assigneeAgentId).toBeNull();
+    expect(updated!.checkoutRunId).toBeNull();
+    expect(updated!.executionRunId).toBeNull();
+    expect(updated!.executionAgentNameKey).toBeNull();
+    expect(updated!.executionLockedAt).toBeNull();
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents; issues carry an execution lock so only one run can work on a task at a time.
> - The issue service's `update()` applies several side-effect clears: `checkoutRunId` is nulled when status leaves `in_progress`, and also when the assignee changes.
> - However, three sibling lock fields — `executionRunId`, `executionAgentNameKey`, and `executionLockedAt` — were **not** cleared on assignee change.
> - The `checkout()` WHERE clause requires `executionRunId IS NULL OR executionRunId = :newRunId`; a stale value from the previous agent's run makes this condition always false for the new assignee, so every checkout attempt silently matches 0 rows and falls through to the conflict path.
> - The new assignee receives the `issue_assigned` wake, tries to checkout, gets a permanent 409, and goes idle — with no visible error.
> - This PR clears all four execution-lock fields atomically when the assignee changes.
> - The benefit is that reassigned issues become immediately workable by the new agent without a manual `POST /release` workaround.

## What Changed

- `server/src/services/issues.ts`: in the `update()` assignee-change block, null `executionRunId`, `executionAgentNameKey`, and `executionLockedAt` alongside the existing `checkoutRunId = null`.
- `server/src/__tests__/issues-service.test.ts`: two new embedded-Postgres tests — one for agent-to-agent reassignment, one for unassignment — verifying all four lock fields are cleared.

## Verification

```
pnpm test:run -- "issues-service"
# All tests pass (850 passed, 1 skipped)
```

Repro before fix:
1. Agent A checks out issue → `executionRunId = runA`.
2. CEO reassigns to Agent B via `PATCH /api/issues/:id { assigneeAgentId: agentB }`.
3. Agent B receives `issue_assigned` wake and calls `POST /api/issues/:id/checkout`.
4. checkout SQL: `WHERE assigneeAgentId = agentB AND (executionRunId IS NULL OR executionRunId = runB)` → 0 rows (stale `runA` blocks).
5. Agent B gets 409 forever.

After fix: step 2 atomically sets `executionRunId = null`, so step 4 matches and checkout succeeds.

## Risks

Low. The only behavioral change is that reassigning an issue now also releases the execution lock. Any in-flight work by the previous agent was already interrupted by the assignee change; the stale lock was a bug, not a safety guard.

## Model Used

- Claude Sonnet 4.6 (`claude-sonnet-4-6`) via Paperclip CTO agent heartbeat
- Tool use enabled; no extended thinking

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only)
- [ ] I have updated relevant documentation to reflect my changes — no docs needed for this fix
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge