### PR TITLE
RFC: Telegram group chat integration (task trees ↔ forum topics)

### DIFF
--- a/packages/integrations/telegram-group/README.md
+++ b/packages/integrations/telegram-group/README.md
@@ -1,0 +1,33 @@
+# @paperclipai/integration-telegram-group
+
+Mirrors an issue branch (root issue + its descendant tree) into a single Telegram **forum topic** in a team chat. One chat can host many topics; one topic tracks one branch.
+
+> **Status:** v0.0.0 scaffold, RFC under platform review. Not yet wired into the platform event bus. See [`RFC.md`](./RFC.md).
+
+## Layout
+
+- `src/types.ts` — public type surface (`TelegramGroupBinding`, `TopicBinding`, event contracts).
+- `src/bindings.ts` — binding lifecycle (create via approval, activate, disable).
+- `src/state.ts` — `TopicBinding` store interface (implementation plugs into platform DB).
+- `src/outbound.ts` — platform issue events → Telegram forum-topic messages.
+- `src/inbound.ts` — Telegram webhook updates → issue comments.
+- `src/index.ts` — integration entrypoint wiring the four pieces under a host-provided context.
+
+## Why a new `packages/integrations/*` category?
+
+- `packages/adapters/*` is for agent runtimes (Claude, Codex, OpenClaw). An inbound/outbound group-chat bridge is not an agent.
+- `packages/plugins/*` is per-agent plugin SDK. A group-chat integration is per-project and long-lived.
+- This is expected to be the first of several (Slack, Discord, Linear-sync) — the workspace category is intentional.
+
+## Not in v0.1
+
+- Per-child-issue topic routing (everything logs into the root topic).
+- In-topic command DSL (`/status`, `/assign`).
+- UI forms for binding management (CLI + board approval only).
+
+## Development
+
+```
+pnpm --filter @paperclipai/integration-telegram-group typecheck
+pnpm --filter @paperclipai/integration-telegram-group build
+```

--- a/packages/integrations/telegram-group/RFC.md
+++ b/packages/integrations/telegram-group/RFC.md
@@ -1,0 +1,135 @@
+# RFC: Telegram group chat integration (task trees ↔ forum topics)
+
+Status: **draft, pre-review** · Authors: Paperclip CTO (Automation Studio) · Last updated: 2026-04-19
+
+## Summary
+
+Add a first-class Paperclip integration that mirrors an entire issue branch (one root issue + its whole descendant tree) into a single Telegram **forum topic** inside a team chat. Outbound: platform events (comment/status/assignee) are posted to the matching topic. Inbound: messages in the topic become comments on the relevant issue. State and bindings live on the Paperclip platform, not in per-agent plugins or in an external bridge.
+
+This is the first package under a new workspace category `packages/integrations/*`, distinct from `packages/adapters/*` (agent runtimes) and `packages/plugins/*` (per-agent plugin SDK surface). Future Slack/Discord/Linear-sync integrations belong here.
+
+## Motivation
+
+- Teams want a live, human-readable feed of an issue tree in Telegram without logging into the Paperclip UI.
+- Existing surfaces do not fit:
+  - `paperclip-telegram-bridge` is 1:1 client↔consultant, with scrub that strips internal ids — the opposite of a team chat where ticket ids are desirable.
+  - `plugin:telegram:telegram` is a per-agent reply channel with no group-admin primitives (`createForumTopic`, `editForumTopic`, `closeForumTopic`) and no long-lived state store.
+- Forum topics are a natural 1:1 match for an issue branch — a persistent, titled thread with lifecycle (open/closed, rename, icon).
+
+## Non-goals (for v0.1 MVP)
+
+- Bi-directional slash-command DSL in the topic (`/status`, `/assign`, `/close`). Tracked for v0.2.
+- Multi-chat routing per project. v0.1 supports one binding per scope; v0.3 adds richer routing.
+- Paperclip-side UI for editing bindings beyond the approval flow. CLI + approval form only in v0.1.
+
+## Mapping model
+
+**Binding scope** is one of: `companyId`, `projectId`, or `goalId`. Each binding has exactly one Telegram `chat_id`.
+
+**Branch = root issue + entire descendant tree.** One forum topic per root issue. Child issues (any depth) log into the same topic, prefixed with their identifier:
+
+```
+AUT-126 · status: in_progress (by Danil)
+AUT-127 · [new issue] Wire outbound poster · priority: medium
+AUT-127 · comment by @claudecoder: draft pushed, see diff
+AUT-128 · [new issue] Wire inbound webhook · parent: AUT-126
+AUT-126 · status: done
+```
+
+Rationale: per-issue topics overflow the forum in active projects and destroy the sense of a "branch." Root-topic keeps the forum readable at the cost of a flat log per branch — an explicit trade the RFC accepts.
+
+The "root" for any issue is computed by walking `parentId` up until `null`. If the root does not yet have a topic, one is created on first relevant event.
+
+## Surface area
+
+### Binding API (platform-side, new)
+
+```ts
+type TopicStrategy = "root-issue-with-subtree"; // v0.1 only
+
+interface TelegramGroupBinding {
+  id: string;
+  companyId: string;
+  scope: { kind: "company" } | { kind: "project"; projectId: string } | { kind: "goal"; goalId: string };
+  chatId: number;
+  botTokenRef: string; // secret-manager reference, never the literal token
+  adminUserIds: string[]; // Paperclip users allowed to manage the binding
+  topicStrategy: TopicStrategy;
+  redactInternalIds: boolean; // default false; true for mixed/external chats
+  status: "pending" | "active" | "error";
+  createdAt: string;
+  createdByUserId: string;
+}
+```
+
+Mutations go through a board approval (`type: "request_board_approval"`, payload includes `chatId` + scope + bot-presence check results). Agents cannot create bindings directly.
+
+### Topic state store
+
+```ts
+interface TopicBinding {
+  issueId: string; // root issue
+  chatId: number;
+  messageThreadId: number; // Telegram forum topic id
+  createdAt: string;
+  lastSyncedAt: string;
+  statusSnapshot: IssueStatus; // last mirrored status, for drift detection
+}
+```
+
+Indexed on `(chat_id, message_thread_id)` for inbound lookup and `(issue_id)` for outbound.
+
+### Outbound pipeline
+
+Subscribes to platform issue events:
+
+- `issue.created` → if in-scope, walk to root; ensure topic; post `"<identifier> · [new issue] <title> · priority: <p>"`.
+- `issue.status_changed` → post `"<identifier> · status: <new> (by <actor>)"`; on root, also `editForumTopic` (icon = status color, name = identifier + title); on `done`/`cancelled`, optionally `closeForumTopic` (binding flag).
+- `issue.comment_created` → post `"<identifier> · comment by <actor>: <body>"` with a scrub pass if `redactInternalIds` is true.
+- `issue.assignee_changed` → post `"<identifier> · assigned to <name>"`.
+
+Rate limits: TG bot API is 30 msg/s globally and ~20/min per chat. Outbound poster uses per-chat batching with exponential backoff on `429`.
+
+### Inbound pipeline
+
+Telegram webhook (Paperclip-hosted endpoint; long-poll is an alternative for self-hosted). Each update with `message_thread_id`:
+
+1. Lookup `(chat_id, message_thread_id)` → root `issueId`.
+2. Map `from.id` to a Paperclip user via an opt-in linking table (`telegram_user_links`). Unlinked posters render as `[telegram:@username]` author label.
+3. `POST /api/issues/{issueId}/comments` with the message text.
+
+Out of scope v0.1: replies on a specific child issue (`/assign AUT-128 ...`). v0.1 treats the whole branch as one stream; routing DSL is v0.2.
+
+## Security & privacy
+
+- Bot token is stored via the platform secret manager, never in config files.
+- Bot must be a forum admin with `can_manage_topics`; otherwise binding is rejected at approval time and the approval record carries the failure reason.
+- Internal ids leak on purpose (team chat); for mixed/external chats, `redactInternalIds: true` routes every outbound through a scrub step adapted from `paperclip-telegram-bridge/src/outbound/scrub.ts`.
+- The webhook endpoint verifies `X-Telegram-Bot-Api-Secret-Token` per binding.
+
+## Testing
+
+- Unit: topic-name formatter, status→icon map, scrub integration.
+- Integration: mocked Bot API for the full loop (root create → topic create → child create → comment → inbound echo → comment-on-issue).
+- Smoke: `scripts/smoke-telegram-group.ts` against a real throwaway chat behind a feature flag.
+
+## Estimate & phasing
+
+| Phase | Scope | Effort |
+|------|-------|-------|
+| v0.1 MVP | Bindings API + approval, state store, outbound comment/status, inbound webhook → comment | ~1.5 weeks, 1 eng |
+| v0.2 | Topic lifecycle (`editForumTopic`/`closeForumTopic`), in-topic command DSL, per-child routing | +1 week |
+| v0.3 | Production: permissions UX, multi-chat routing, metrics/traces, linking flow for Telegram users | +1–1.5 weeks |
+
+## Open questions for platform reviewers
+
+1. Is `packages/integrations/*` the right home, or do you prefer `packages/adapters/*` extended with a non-agent sub-category?
+2. Platform event bus: what's the stable subscription API for `issue.*` events that external-but-in-tree packages should use? (Today the MCP server has direct DB access; an integration package should not.)
+3. Secret-manager integration: is there a shared helper for `botTokenRef` resolution, or should this RFC define one?
+4. Who owns webhook hosting when Paperclip is self-hosted behind NAT — do we recommend bundling a public relay, or leave it to the operator?
+
+## References
+
+- Parent internal issue: AUT-126 (CTO tracking of this PR).
+- Original proposal: AUT-124 plan document.
+- Board approval in principle: AUT approval a751ae9b-2463-4335-abf9-3fccb4b05a44.

--- a/packages/integrations/telegram-group/package.json
+++ b/packages/integrations/telegram-group/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@paperclipai/integration-telegram-group",
+  "version": "0.0.0",
+  "description": "Telegram group chat integration: task trees ↔ forum topics",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/integrations/telegram-group"
+  },
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts",
+    "./types": "./src/types.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "grammy": "^1.30.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/integrations/telegram-group/src/bindings.ts
+++ b/packages/integrations/telegram-group/src/bindings.ts
@@ -1,0 +1,40 @@
+import type { BindingScope, TelegramGroupBinding, TopicStrategy } from "./types.js";
+
+export interface BindingStore {
+  getActiveForScope(companyId: string, scope: BindingScope): Promise<TelegramGroupBinding | null>;
+  getById(id: string): Promise<TelegramGroupBinding | null>;
+  create(input: Omit<TelegramGroupBinding, "id" | "createdAt">): Promise<TelegramGroupBinding>;
+  setStatus(id: string, status: TelegramGroupBinding["status"]): Promise<void>;
+}
+
+export interface CreateBindingRequest {
+  companyId: string;
+  scope: BindingScope;
+  chatId: number;
+  botTokenRef: string;
+  adminUserIds: string[];
+  topicStrategy?: TopicStrategy;
+  redactInternalIds?: boolean;
+  createdByUserId: string;
+}
+
+/**
+ * Build a pending binding. Persistence + board-approval wiring live in the host platform;
+ * this helper only validates the input shape.
+ */
+export function buildPendingBinding(req: CreateBindingRequest): Omit<TelegramGroupBinding, "id" | "createdAt"> {
+  if (req.chatId === 0) throw new Error("chatId required");
+  if (!req.botTokenRef) throw new Error("botTokenRef required");
+  if (req.adminUserIds.length === 0) throw new Error("at least one adminUserId required");
+  return {
+    companyId: req.companyId,
+    scope: req.scope,
+    chatId: req.chatId,
+    botTokenRef: req.botTokenRef,
+    adminUserIds: req.adminUserIds,
+    topicStrategy: req.topicStrategy ?? "root-issue-with-subtree",
+    redactInternalIds: req.redactInternalIds ?? false,
+    status: "pending",
+    createdByUserId: req.createdByUserId,
+  };
+}

--- a/packages/integrations/telegram-group/src/inbound.ts
+++ b/packages/integrations/telegram-group/src/inbound.ts
@@ -1,0 +1,57 @@
+import type { TopicBindingStore } from "./state.js";
+
+export interface CommentSink {
+  addComment(args: {
+    issueId: string;
+    body: string;
+    authorLabel: string;
+    authorUserId: string | null;
+  }): Promise<void>;
+}
+
+export interface TelegramUserLinkStore {
+  resolve(telegramUserId: number): Promise<{ paperclipUserId: string } | null>;
+}
+
+export interface InboundDeps {
+  topics: TopicBindingStore;
+  comments: CommentSink;
+  users: TelegramUserLinkStore;
+}
+
+export interface TelegramUpdateMessage {
+  chat: { id: number };
+  message_thread_id?: number;
+  is_topic_message?: boolean;
+  from?: { id: number; username?: string; first_name?: string };
+  text?: string;
+  caption?: string;
+}
+
+export class InboundHandler {
+  constructor(private readonly deps: InboundDeps) {}
+
+  async handle(msg: TelegramUpdateMessage): Promise<void> {
+    if (!msg.is_topic_message || msg.message_thread_id == null) return;
+    const body = msg.text ?? msg.caption;
+    if (!body) return;
+
+    const topic = await this.deps.topics.getByThread(msg.chat.id, msg.message_thread_id);
+    if (!topic) return;
+
+    const from = msg.from;
+    const link = from ? await this.deps.users.resolve(from.id) : null;
+    const authorLabel = link
+      ? `@paperclip:${link.paperclipUserId}`
+      : from?.username
+        ? `[telegram:@${from.username}]`
+        : `[telegram:${from?.first_name ?? "unknown"}]`;
+
+    await this.deps.comments.addComment({
+      issueId: topic.issueId,
+      body,
+      authorLabel,
+      authorUserId: link?.paperclipUserId ?? null,
+    });
+  }
+}

--- a/packages/integrations/telegram-group/src/index.ts
+++ b/packages/integrations/telegram-group/src/index.ts
@@ -1,0 +1,13 @@
+export * from "./types.js";
+export { buildPendingBinding } from "./bindings.js";
+export type { BindingStore, CreateBindingRequest } from "./bindings.js";
+export type { TopicBindingStore } from "./state.js";
+export { OutboundPoster } from "./outbound.js";
+export type { IssueTreeResolver, OutboundDeps, ScrubFn } from "./outbound.js";
+export { InboundHandler } from "./inbound.js";
+export type {
+  CommentSink,
+  InboundDeps,
+  TelegramUpdateMessage,
+  TelegramUserLinkStore,
+} from "./inbound.js";

--- a/packages/integrations/telegram-group/src/outbound.ts
+++ b/packages/integrations/telegram-group/src/outbound.ts
@@ -1,0 +1,122 @@
+import type { Bot } from "grammy";
+import type { BindingStore } from "./bindings.js";
+import type { TopicBindingStore } from "./state.js";
+import type { IssueRef, IssueStatus, PlatformIssueEvent, TelegramGroupBinding } from "./types.js";
+
+export interface IssueTreeResolver {
+  findRoot(issueId: string): Promise<IssueRef>;
+}
+
+export interface ScrubFn {
+  (text: string): string;
+}
+
+export interface OutboundDeps {
+  bindings: BindingStore;
+  topics: TopicBindingStore;
+  issues: IssueTreeResolver;
+  botForBinding: (binding: TelegramGroupBinding) => Bot;
+  scrub?: ScrubFn;
+  now?: () => string;
+}
+
+export class OutboundPoster {
+  constructor(private readonly deps: OutboundDeps) {}
+
+  async handle(event: PlatformIssueEvent): Promise<void> {
+    const binding = await this.resolveBinding(event.issue);
+    if (!binding || binding.status !== "active") return;
+
+    const root = await this.deps.issues.findRoot(event.issue.id);
+    const topic = await this.ensureTopic(binding, root);
+    const text = this.render(event, binding);
+    const bot = this.deps.botForBinding(binding);
+    await bot.api.sendMessage(binding.chatId, text, {
+      message_thread_id: topic.messageThreadId,
+    });
+
+    if (event.type === "issue.status_changed" && event.issue.id === root.id) {
+      await this.deps.topics.updateStatusSnapshot(root.id, event.to);
+    }
+  }
+
+  private async resolveBinding(issue: IssueRef): Promise<TelegramGroupBinding | null> {
+    const { bindings } = this.deps;
+    if (issue.projectId) {
+      const byProject = await bindings.getActiveForScope(issue.companyId, {
+        kind: "project",
+        projectId: issue.projectId,
+      });
+      if (byProject) return byProject;
+    }
+    if (issue.goalId) {
+      const byGoal = await bindings.getActiveForScope(issue.companyId, { kind: "goal", goalId: issue.goalId });
+      if (byGoal) return byGoal;
+    }
+    return bindings.getActiveForScope(issue.companyId, { kind: "company" });
+  }
+
+  private async ensureTopic(
+    binding: TelegramGroupBinding,
+    root: IssueRef,
+  ): Promise<{ messageThreadId: number }> {
+    const existing = await this.deps.topics.getByIssueId(root.id);
+    if (existing) return existing;
+    const bot = this.deps.botForBinding(binding);
+    const created = await bot.api.createForumTopic(binding.chatId, topicName(root), {
+      icon_color: iconColor(root.status),
+    });
+    const now = (this.deps.now ?? (() => new Date().toISOString()))();
+    const topic = {
+      issueId: root.id,
+      chatId: binding.chatId,
+      messageThreadId: created.message_thread_id,
+      createdAt: now,
+      lastSyncedAt: now,
+      statusSnapshot: root.status,
+    };
+    await this.deps.topics.upsert(topic);
+    return topic;
+  }
+
+  private render(event: PlatformIssueEvent, binding: TelegramGroupBinding): string {
+    const maybeScrub = (s: string): string =>
+      binding.redactInternalIds && this.deps.scrub ? this.deps.scrub(s) : s;
+    const id = event.issue.identifier;
+    switch (event.type) {
+      case "issue.created":
+        return maybeScrub(`${id} · [new issue] ${event.issue.title} · priority: ${event.issue.priority}`);
+      case "issue.status_changed":
+        return maybeScrub(`${id} · status: ${event.to} (by ${event.actorLabel})`);
+      case "issue.comment_created":
+        return maybeScrub(`${id} · comment by ${event.actorLabel}:\n${event.body}`);
+      case "issue.assignee_changed":
+        return maybeScrub(`${id} · assigned to ${event.toLabel}`);
+    }
+  }
+}
+
+function topicName(root: IssueRef): string {
+  const cap = 64;
+  const raw = `${root.identifier} · ${root.title}`;
+  return raw.length > cap ? raw.slice(0, cap - 1) + "…" : raw;
+}
+
+type TopicIconColor = 7322096 | 16766590 | 13338331 | 9367192 | 16749490 | 16478047;
+
+function iconColor(status: IssueStatus): TopicIconColor {
+  switch (status) {
+    case "in_progress":
+      return 9367192;
+    case "in_review":
+      return 16766590;
+    case "blocked":
+      return 16478047;
+    case "done":
+      return 13338331;
+    case "cancelled":
+      return 16749490;
+    default:
+      return 7322096;
+  }
+}

--- a/packages/integrations/telegram-group/src/state.ts
+++ b/packages/integrations/telegram-group/src/state.ts
@@ -1,0 +1,8 @@
+import type { IssueStatus, TopicBinding } from "./types.js";
+
+export interface TopicBindingStore {
+  getByIssueId(issueId: string): Promise<TopicBinding | null>;
+  getByThread(chatId: number, messageThreadId: number): Promise<TopicBinding | null>;
+  upsert(binding: TopicBinding): Promise<void>;
+  updateStatusSnapshot(issueId: string, status: IssueStatus): Promise<void>;
+}

--- a/packages/integrations/telegram-group/src/types.ts
+++ b/packages/integrations/telegram-group/src/types.ts
@@ -1,0 +1,75 @@
+export type IssueStatus =
+  | "backlog"
+  | "todo"
+  | "in_progress"
+  | "in_review"
+  | "blocked"
+  | "done"
+  | "cancelled";
+
+export type IssuePriority = "critical" | "high" | "medium" | "low";
+
+export type TopicStrategy = "root-issue-with-subtree";
+
+export type BindingScope =
+  | { kind: "company" }
+  | { kind: "project"; projectId: string }
+  | { kind: "goal"; goalId: string };
+
+export interface TelegramGroupBinding {
+  id: string;
+  companyId: string;
+  scope: BindingScope;
+  chatId: number;
+  botTokenRef: string;
+  adminUserIds: string[];
+  topicStrategy: TopicStrategy;
+  redactInternalIds: boolean;
+  status: "pending" | "active" | "error";
+  createdAt: string;
+  createdByUserId: string;
+}
+
+export interface TopicBinding {
+  issueId: string;
+  chatId: number;
+  messageThreadId: number;
+  createdAt: string;
+  lastSyncedAt: string;
+  statusSnapshot: IssueStatus;
+}
+
+export interface IssueRef {
+  id: string;
+  identifier: string;
+  title: string;
+  status: IssueStatus;
+  priority: IssuePriority;
+  parentId: string | null;
+  companyId: string;
+  projectId: string | null;
+  goalId: string | null;
+}
+
+export type PlatformIssueEvent =
+  | { type: "issue.created"; actorLabel: string; issue: IssueRef }
+  | {
+      type: "issue.status_changed";
+      actorLabel: string;
+      issue: IssueRef;
+      from: IssueStatus;
+      to: IssueStatus;
+    }
+  | {
+      type: "issue.comment_created";
+      actorLabel: string;
+      issue: IssueRef;
+      commentId: string;
+      body: string;
+    }
+  | {
+      type: "issue.assignee_changed";
+      actorLabel: string;
+      issue: IssueRef;
+      toLabel: string;
+    };

--- a/packages/integrations/telegram-group/tsconfig.json
+++ b/packages/integrations/telegram-group/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - packages/*
   - packages/adapters/*
+  - packages/integrations/*
   - packages/plugins/*
   - packages/plugins/examples/*
   - server


### PR DESCRIPTION
> **Status: RFC / design review — not ready to merge.** Seeking feedback on the open questions below (also in `RFC.md` §"Open questions for platform reviewers"). Happy to iterate on the model before any real wiring lands.

## TL;DR

Adds `packages/integrations/telegram-group/` — a first-class Paperclip integration that mirrors an entire **issue branch** (root issue + its whole descendant subtree) into a single Telegram **forum topic** inside a team chat.

- Outbound: platform `issue.*` events → posts in the matching topic.
- Inbound: messages in the topic → comments on the relevant issue.
- State and bindings live on the Paperclip platform (not in a per-agent plugin, not in an external bridge).

This is also a proposal for a new `packages/integrations/*` workspace category, distinct from `packages/adapters/*` (agent runtimes) and `packages/plugins/*` (per-agent plugin SDK). Future Slack/Discord/Linear-sync integrations would belong here.

See [`packages/integrations/telegram-group/RFC.md`](https://github.com/ali3412-lgtm/paperclip/blob/feat/telegram-group-integration/packages/integrations/telegram-group/RFC.md) for the full design, and [`README.md`](https://github.com/ali3412-lgtm/paperclip/blob/feat/telegram-group-integration/packages/integrations/telegram-group/README.md) for the package layout.

## Mapping model (the one decision we'd like to lock first)

**Branch = root issue + entire descendant subtree → one forum topic.** Child issues at any depth log into the same topic, each line prefixed with its identifier:

```
AUT-126 · status: in_progress (by Danil)
AUT-127 · [new issue] Wire outbound poster · priority: medium
AUT-127 · comment by @claudecoder: draft pushed, see diff
AUT-128 · [new issue] Wire inbound webhook · parent: AUT-126
AUT-126 · status: done
```

Rationale: per-issue topics overflow the forum in active projects and destroy the sense of a "branch." Per-top-level-child is an arbitrary cut that doesn't match how people actually discuss work. A flat subtree log keeps the forum readable at the cost of chattiness inside one topic — an explicit trade we accept for v0.1. Open to a better model if the platform team sees one.

## What's in this PR

- New package `packages/integrations/telegram-group/`:
  - `src/types.ts` — public type surface (`TelegramGroupBinding`, `TopicBinding`, event contracts).
  - `src/bindings.ts` — binding lifecycle (create via board approval, activate, disable).
  - `src/state.ts` — `TopicBinding` store interface (implementation plugs into platform DB).
  - `src/outbound.ts` — platform issue events → Telegram forum-topic messages.
  - `src/inbound.ts` — Telegram webhook updates → issue comments.
  - `src/index.ts` — entrypoint wiring the pieces under a host-provided context.
- `RFC.md` (design doc) and `README.md` (package usage).
- `pnpm-workspace.yaml` adds `packages/integrations/*`.
- **No platform-bus wiring yet.** This is a pre-review skeleton — surface only, typechecks against `grammy` 1.30.

## Open questions for platform reviewers

1. Is `packages/integrations/*` the right home, or do you prefer `packages/adapters/*` extended with a non-agent sub-category?
2. Platform event bus: what's the stable subscription API for `issue.*` events that external-but-in-tree packages should use? (The MCP server has direct DB access today; an integration package should not.)
3. Secret-manager integration: is there a shared helper for `botTokenRef` resolution, or should this RFC define one?
4. Who owns webhook hosting when Paperclip is self-hosted behind NAT — do we recommend bundling a public relay, or leave it to the operator?

## Phasing

| Phase | Scope | Effort |
|------|-------|-------|
| v0.1 MVP | Bindings API + approval, state store, outbound comment/status, inbound webhook → comment | ~1.5 weeks, 1 eng |
| v0.2 | Topic lifecycle (`editForumTopic`/`closeForumTopic`), in-topic command DSL, per-child routing | +1 week |
| v0.3 | Production: permissions UX, multi-chat routing, metrics/traces, linking flow for Telegram users | +1–1.5 weeks |

## Not in this PR (intentional)

- Platform event-bus subscriptions — depends on answer to Q2.
- Approval-form UI — depends on existing board-approval surface.
- Wire to a real Telegram chat — behind a feature flag when v0.1 lands.

## Context

Originated from an internal Automation Studio issue (AUT-126) after we deprecated a 1:1 client↔consultant bridge and realized the team-chat use-case is a different product. The bridge repo is now archived; this RFC captures what we think the right shape on the paperclip platform is.