### PR TITLE
SUP-630 clear stale execution ownership on reassignment

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -425,6 +425,184 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.checkoutRunId).toBeNull();
   });
 
+  it("cancels a stale queued issue_assigned run after the issue is reassigned", async () => {
+    const { companyId, issueId, runId, wakeupRequestId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+    });
+    const otherAgentId = randomUUID();
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId,
+      name: "OtherCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db
+      .update(issues)
+      .set({
+        status: "todo",
+        assigneeAgentId: otherAgentId,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      })
+      .where(eq(issues.id, issueId));
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    await heartbeat.resumeQueuedRuns();
+
+    const queuedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(queuedRun?.status).toBe("cancelled");
+    expect(queuedRun?.error).toContain("reassigned");
+    expect(issue?.assigneeAgentId).toBe(otherAgentId);
+    expect(issue?.executionRunId).toBeNull();
+    expect(wakeup?.status).toBe("cancelled");
+  });
+
+  it("does not restamp a stale queued issue_assigned run when waking the new assignee", async () => {
+    const { companyId, issueId, runId: staleRunId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+    });
+    const otherAgentId = randomUUID();
+    const blockerWakeupRequestId = randomUUID();
+    const blockerRunId = randomUUID();
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId,
+      name: "OtherCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: blockerWakeupRequestId,
+      companyId,
+      agentId: otherAgentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: {},
+      status: "claimed",
+      runId: blockerRunId,
+      claimedAt: new Date("2026-03-19T00:03:00.000Z"),
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: blockerRunId,
+      companyId,
+      agentId: otherAgentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId: blockerWakeupRequestId,
+      contextSnapshot: { taskKey: "other-task" },
+      startedAt: new Date("2026-03-19T00:03:00.000Z"),
+      updatedAt: new Date("2026-03-19T00:03:00.000Z"),
+    });
+
+    await db
+      .update(issues)
+      .set({
+        status: "todo",
+        assigneeAgentId: otherAgentId,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      })
+      .where(eq(issues.id, issueId));
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+      })
+      .where(eq(heartbeatRuns.id, staleRunId));
+
+    const promotedRun = await heartbeat.wakeup(otherAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "update" },
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+
+    expect(promotedRun).toEqual(expect.objectContaining({
+      agentId: otherAgentId,
+      status: "queued",
+    }));
+    expect(promotedRun?.id).not.toBe(staleRunId);
+
+    const issueAfterWake = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    const deferredWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, otherAgentId))
+      .then((rows) => rows.find((row) => row.status === "deferred_issue_execution") ?? null);
+
+    expect(issueAfterWake?.assigneeAgentId).toBe(otherAgentId);
+    expect(issueAfterWake?.executionRunId).toBe(promotedRun?.id ?? null);
+    expect(deferredWake).toBeNull();
+
+    await heartbeat.resumeQueuedRuns();
+
+    const staleRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, staleRunId))
+      .then((rows) => rows[0] ?? null);
+    const issueAfterResume = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(staleRun?.status).toBe("cancelled");
+    expect(staleRun?.error).toContain("reassigned");
+    expect(issueAfterResume?.executionRunId).toBe(promotedRun?.id ?? null);
+  });
+
   it("clears the detached warning when the run reports activity again", async () => {
     const { runId } = await seedRunFixture({
       includeIssue: false,

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1,12 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { spawn, type ChildProcess } from "node:child_process";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   agents,
   agentRuntimeState,
   agentWakeupRequests,
   companies,
+  companySkills,
   createDb,
   heartbeatRunEvents,
   heartbeatRuns,
@@ -52,12 +53,14 @@ function spawnAliveProcess() {
 
 describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   let db!: ReturnType<typeof createDb>;
+  let raceDb!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
   const childProcesses = new Set<ChildProcess>();
 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-recovery-");
     db = createDb(tempDb.connectionString);
+    raceDb = createDb(tempDb.connectionString);
   }, 20_000);
 
   afterEach(async () => {
@@ -73,6 +76,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(agentWakeupRequests);
     await db.delete(agentRuntimeState);
     await db.delete(agents);
+    await db.delete(companySkills);
     await db.delete(companies);
   });
 
@@ -319,6 +323,106 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.assigneeAgentId).toBe(otherAgentId);
     expect(issue?.executionRunId).toBeNull();
     expect(wakeup?.status).toBe("cancelled");
+  });
+
+  it("does not restamp stale execution ownership when reassignment races the queued claim", async () => {
+    const { companyId, issueId, runId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+    });
+    const otherAgentId = randomUUID();
+    const heartbeat = heartbeatService(db);
+    const lockKey = Number.parseInt(runId.replaceAll("-", "").slice(0, 8), 16);
+    const triggerName = `test_claim_sleep_${runId.replaceAll("-", "_")}`;
+    const functionName = `${triggerName}_fn`;
+
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId,
+      name: "OtherCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    await db.execute(sql.raw(`
+      CREATE OR REPLACE FUNCTION ${functionName}()
+      RETURNS trigger AS $$
+      BEGIN
+        IF OLD.id = '${runId}'::uuid AND OLD.status = 'queued' AND NEW.status = 'running' THEN
+          PERFORM pg_advisory_lock(${lockKey});
+          PERFORM pg_sleep(0.4);
+          PERFORM pg_advisory_unlock(${lockKey});
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `));
+    await db.execute(sql.raw(`
+      CREATE TRIGGER ${triggerName}
+      BEFORE UPDATE ON heartbeat_runs
+      FOR EACH ROW
+      EXECUTE FUNCTION ${functionName}();
+    `));
+
+    async function waitForClaimWindow() {
+      for (let attempt = 0; attempt < 40; attempt += 1) {
+        const rows = await raceDb.execute(sql<{ acquired: boolean }>`SELECT pg_try_advisory_lock(${lockKey}) AS acquired`);
+        const acquired = rows[0]?.acquired === true;
+        if (!acquired) return;
+        await raceDb.execute(sql`SELECT pg_advisory_unlock(${lockKey})`);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      throw new Error("Timed out waiting for the queued-claim race window");
+    }
+
+    try {
+      const resumePromise = heartbeat.resumeQueuedRuns();
+      await waitForClaimWindow();
+
+      const reassignPromise = raceDb
+        .update(issues)
+        .set({
+          status: "todo",
+          assigneeAgentId: otherAgentId,
+          checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+        })
+        .where(eq(issues.id, issueId));
+
+      await Promise.all([resumePromise, reassignPromise]);
+    } finally {
+      await db.execute(sql.raw(`DROP TRIGGER IF EXISTS ${triggerName} ON heartbeat_runs`));
+      await db.execute(sql.raw(`DROP FUNCTION IF EXISTS ${functionName}()`));
+    }
+
+    const queuedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(queuedRun?.status).toBe("running");
+    expect(issue?.assigneeAgentId).toBe(otherAgentId);
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   agents,
+  agentRuntimeState,
   agentWakeupRequests,
   companies,
   createDb,
@@ -70,6 +71,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -253,6 +255,70 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBeNull();
     expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it("cancels a stale queued issue_assigned run after the issue is reassigned", async () => {
+    const { companyId, issueId, runId, wakeupRequestId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+    });
+    const otherAgentId = randomUUID();
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId,
+      name: "OtherCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db
+      .update(issues)
+      .set({
+        status: "todo",
+        assigneeAgentId: otherAgentId,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      })
+      .where(eq(issues.id, issueId));
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    await heartbeat.resumeQueuedRuns();
+
+    const queuedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(queuedRun?.status).toBe("cancelled");
+    expect(queuedRun?.error).toContain("reassigned");
+    expect(issue?.assigneeAgentId).toBe(otherAgentId);
+    expect(issue?.executionRunId).toBeNull();
+    expect(wakeup?.status).toBe("cancelled");
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -280,6 +280,45 @@ describe("issue comment reopen routes", () => {
     );
   });
 
+  it("wakes the newly assigned agent after reassignment even when stale execution metadata exists", async () => {
+    const previousAssigneeId = "22222222-2222-4222-8222-222222222222";
+    const nextAssigneeId = "33333333-3333-4333-8333-333333333333";
+    const issue = {
+      ...makeIssue("todo"),
+      assigneeAgentId: previousAssigneeId,
+      executionRunId: "run-stale",
+      executionAgentNameKey: "previousagent",
+    };
+
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      assigneeAgentId: nextAssigneeId,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ assigneeAgentId: nextAssigneeId });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      nextAssigneeId,
+      expect.objectContaining({
+        reason: "issue_assigned",
+        payload: expect.objectContaining({
+          issueId: "11111111-1111-4111-8111-111111111111",
+          mutation: "update",
+        }),
+      }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(previousAssigneeId, expect.anything());
+  });
+
   it("writes decision ids into executionState and inserts the decision inside the transaction", async () => {
     const policy = await normalizePolicy({
       stages: [

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -8,6 +8,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -66,6 +67,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -328,6 +330,102 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
         identifier: "PAP-1064",
       }),
     );
+  });
+
+  it("clears stale execution ownership on reassignment so the new assignee can check out", async () => {
+    const companyId = randomUUID();
+    const previousAgentId = randomUUID();
+    const nextAgentId = randomUUID();
+    const issueId = randomUUID();
+    const staleRunId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: previousAgentId,
+        companyId,
+        name: "PreviousAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: nextAgentId,
+        companyId,
+        name: "NextAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId: previousAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-19T13:00:00.000Z"),
+      },
+      {
+        id: checkoutRunId,
+        companyId,
+        agentId: nextAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-19T13:05:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Reassigned issue with stale execution ownership",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: previousAgentId,
+      executionRunId: staleRunId,
+      executionAgentNameKey: "previousagent",
+      executionLockedAt: new Date("2026-04-19T13:00:00.000Z"),
+    });
+
+    const reassigned = await svc.update(issueId, { assigneeAgentId: nextAgentId });
+
+    expect(reassigned).toEqual(expect.objectContaining({
+      assigneeAgentId: nextAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    }));
+
+    const checkedOut = await svc.checkout(issueId, nextAgentId, ["todo"], checkoutRunId);
+
+    expect(checkedOut).toEqual(expect.objectContaining({
+      id: issueId,
+      assigneeAgentId: nextAgentId,
+      status: "in_progress",
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+    }));
   });
 
   it("returns null instead of throwing for malformed non-uuid issue refs", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -750,6 +750,276 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       "2026-03-26T10:00:00.000Z",
     );
   });
+
+  it("allows checkout when executionRunId points to a queued run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const queuedRunId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: queuedRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      contextSnapshot: { issueId },
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: checkoutRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-06T16:05:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Queued execution lock",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: queuedRunId,
+    });
+
+    const checkedOut = await svc.checkout(issueId, agentId, ["todo"], checkoutRunId);
+
+    expect(checkedOut).toEqual(expect.objectContaining({
+      id: issueId,
+      status: "in_progress",
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+    }));
+  });
+
+  it("allows null-run checkout when executionRunId points to a queued run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const queuedRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: queuedRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      contextSnapshot: { issueId },
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Queued execution lock without actor run",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: queuedRunId,
+    });
+
+    const checkedOut = await svc.checkout(issueId, agentId, ["todo"], null);
+
+    expect(checkedOut).toEqual(expect.objectContaining({
+      id: issueId,
+      status: "in_progress",
+      checkoutRunId: null,
+      executionRunId: null,
+    }));
+  });
+
+  it("still rejects checkout when executionRunId points to a running run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runningRunId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runningRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-06T16:00:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Running execution lock",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runningRunId,
+    });
+
+    await expect(svc.checkout(issueId, agentId, ["todo"], checkoutRunId)).rejects.toMatchObject({
+      message: "Issue checkout conflict",
+    });
+  });
+
+  it("clears stale execution ownership on reassignment so the new assignee can check out", async () => {
+    const companyId = randomUUID();
+    const previousAgentId = randomUUID();
+    const nextAgentId = randomUUID();
+    const issueId = randomUUID();
+    const staleRunId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: previousAgentId,
+        companyId,
+        name: "PreviousAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: nextAgentId,
+        companyId,
+        name: "NextAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId: previousAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-19T13:00:00.000Z"),
+      },
+      {
+        id: checkoutRunId,
+        companyId,
+        agentId: nextAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-19T13:05:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Reassigned issue with stale execution ownership",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: previousAgentId,
+      executionRunId: staleRunId,
+      executionAgentNameKey: "previousagent",
+      executionLockedAt: new Date("2026-04-19T13:00:00.000Z"),
+    });
+
+    const reassigned = await svc.update(issueId, { assigneeAgentId: nextAgentId });
+
+    expect(reassigned).toEqual(expect.objectContaining({
+      assigneeAgentId: nextAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    }));
+
+    const checkedOut = await svc.checkout(issueId, nextAgentId, ["todo"], checkoutRunId);
+
+    expect(checkedOut).toEqual(expect.objectContaining({
+      id: issueId,
+      assigneeAgentId: nextAgentId,
+      status: "in_progress",
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+    }));
+  });
 });
 
 describeEmbeddedPostgres("issueService.create workspace inheritance", () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2199,26 +2199,52 @@ export function heartbeatService(db: Db) {
     return Number(count ?? 0);
   }
 
-  async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect) {
+  async function claimQueuedRun(
+    run: typeof heartbeatRuns.$inferSelect,
+    opts?: { startNextQueuedRunOnCancel?: boolean },
+  ) {
     if (run.status !== "queued") return run;
+    const startNextQueuedRunOnCancel = opts?.startNextQueuedRunOnCancel ?? true;
     const agent = await getAgent(run.agentId);
     if (!agent) {
-      await cancelRunInternal(run.id, "Cancelled because the agent no longer exists");
+      await cancelRunInternal(run.id, "Cancelled because the agent no longer exists", {
+        startNextQueuedRun: startNextQueuedRunOnCancel,
+      });
       return null;
     }
     if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
-      await cancelRunInternal(run.id, "Cancelled because the agent is not invokable");
+      await cancelRunInternal(run.id, "Cancelled because the agent is not invokable", {
+        startNextQueuedRun: startNextQueuedRunOnCancel,
+      });
       return null;
     }
 
     const context = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(context.issueId);
     const budgetBlock = await budgets.getInvocationBlock(run.companyId, run.agentId, {
-      issueId: readNonEmptyString(context.issueId),
+      issueId,
       projectId: readNonEmptyString(context.projectId),
     });
     if (budgetBlock) {
-      await cancelRunInternal(run.id, budgetBlock.reason);
+      await cancelRunInternal(run.id, budgetBlock.reason, {
+        startNextQueuedRun: startNextQueuedRunOnCancel,
+      });
       return null;
+    }
+
+    if (issueId && readNonEmptyString(context.wakeReason) === "issue_assigned") {
+      const issue = await db
+        .select({ assigneeAgentId: issues.assigneeAgentId })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .then((rows) => rows[0] ?? null);
+
+      if (issue?.assigneeAgentId !== run.agentId) {
+        await cancelRunInternal(run.id, "Cancelled because the issue was reassigned before this wake ran", {
+          startNextQueuedRun: startNextQueuedRunOnCancel,
+        });
+        return null;
+      }
     }
 
     const claimedAt = new Date();
@@ -2254,8 +2280,7 @@ export function heartbeatService(db: Db) {
 
     // Fix A (lazy locking): stamp executionRunId now that the run is actually running,
     // not at queue time. Guard is idempotent — safe if called more than once.
-    const claimedIssueId = readNonEmptyString(parseObject(claimed.contextSnapshot).issueId);
-    if (claimedIssueId) {
+    if (issueId) {
       const claimedAgent = await getAgent(claimed.agentId);
       await db
         .update(issues)
@@ -2267,7 +2292,7 @@ export function heartbeatService(db: Db) {
         })
         .where(
           and(
-            eq(issues.id, claimedIssueId),
+            eq(issues.id, issueId),
             eq(issues.companyId, claimed.companyId),
             or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
           ),
@@ -2519,7 +2544,9 @@ export function heartbeatService(db: Db) {
 
       const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
       for (const queuedRun of queuedRuns) {
-        const claimed = await claimQueuedRun(queuedRun);
+        const claimed = await claimQueuedRun(queuedRun, {
+          startNextQueuedRunOnCancel: false,
+        });
         if (claimed) claimedRuns.push(claimed);
       }
       if (claimedRuns.length === 0) return [];
@@ -4235,7 +4262,11 @@ export function heartbeatService(db: Db) {
     return wakeupIds.length;
   }
 
-  async function cancelRunInternal(runId: string, reason = "Cancelled by control plane") {
+  async function cancelRunInternal(
+    runId: string,
+    reason = "Cancelled by control plane",
+    opts?: { startNextQueuedRun?: boolean },
+  ) {
     const run = await getRun(runId);
     if (!run) throw notFound("Heartbeat run not found");
     if (run.status !== "running" && run.status !== "queued") return run;
@@ -4274,7 +4305,9 @@ export function heartbeatService(db: Db) {
 
     runningProcesses.delete(run.id);
     await finalizeAgentStatus(run.agentId, "cancelled");
-    await startNextQueuedRunForAgent(run.agentId);
+    if (opts?.startNextQueuedRun ?? true) {
+      await startNextQueuedRunForAgent(run.agentId);
+    }
     return cancelled;
   }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2221,6 +2221,7 @@ export function heartbeatService(db: Db) {
 
     const context = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(context.issueId);
+    const wakeReason = readNonEmptyString(context.wakeReason);
     const budgetBlock = await budgets.getInvocationBlock(run.companyId, run.agentId, {
       issueId,
       projectId: readNonEmptyString(context.projectId),
@@ -2232,33 +2233,87 @@ export function heartbeatService(db: Db) {
       return null;
     }
 
-    if (issueId && readNonEmptyString(context.wakeReason) === "issue_assigned") {
-      const issue = await db
-        .select({ assigneeAgentId: issues.assigneeAgentId })
-        .from(issues)
-        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
-        .then((rows) => rows[0] ?? null);
+    class CancelQueuedRunError extends Error {}
 
-      if (issue?.assigneeAgentId !== run.agentId) {
-        await cancelRunInternal(run.id, "Cancelled because the issue was reassigned before this wake ran", {
+    let claimed: typeof heartbeatRuns.$inferSelect | null = null;
+
+    try {
+      claimed = await db.transaction(async (tx) => {
+        if (issueId && wakeReason === "issue_assigned") {
+          await tx.execute(
+            sql`select id from issues where company_id = ${run.companyId} and id = ${issueId} for update`,
+          );
+
+          const issue = await tx
+            .select({ assigneeAgentId: issues.assigneeAgentId })
+            .from(issues)
+            .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+            .then((rows) => rows[0] ?? null);
+
+          if (!issue) {
+            throw new CancelQueuedRunError("Cancelled because the issue no longer exists");
+          }
+          if (issue.assigneeAgentId !== run.agentId) {
+            throw new CancelQueuedRunError("Cancelled because the issue was reassigned before this wake ran");
+          }
+        }
+
+        const claimedAt = new Date();
+        const nextClaimed = await tx
+          .update(heartbeatRuns)
+          .set({
+            status: "running",
+            startedAt: run.startedAt ?? claimedAt,
+            updatedAt: claimedAt,
+          })
+          .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!nextClaimed) return null;
+
+        // Fix A (lazy locking): stamp executionRunId now that the run is actually running,
+        // not at queue time. Keep issue_assigned claims assignee-safe in the same transaction.
+        if (issueId) {
+          const issueStampWhere = [
+            eq(issues.id, issueId),
+            eq(issues.companyId, nextClaimed.companyId),
+            or(isNull(issues.executionRunId), eq(issues.executionRunId, nextClaimed.id)),
+          ];
+          if (wakeReason === "issue_assigned") {
+            issueStampWhere.push(eq(issues.assigneeAgentId, nextClaimed.agentId));
+          }
+
+          const stampedIssue = await tx
+            .update(issues)
+            .set({
+              executionRunId: nextClaimed.id,
+              executionAgentNameKey: normalizeAgentNameKey(agent.name),
+              executionLockedAt: claimedAt,
+              updatedAt: claimedAt,
+            })
+            .where(and(...issueStampWhere))
+            .returning({ id: issues.id })
+            .then((rows) => rows[0] ?? null);
+
+          if (!stampedIssue && wakeReason === "issue_assigned") {
+            throw new CancelQueuedRunError("Cancelled because the issue was reassigned before this wake ran");
+          }
+        }
+
+        return nextClaimed;
+      });
+    } catch (error) {
+      if (error instanceof CancelQueuedRunError) {
+        await cancelRunInternal(run.id, error.message, {
           startNextQueuedRun: startNextQueuedRunOnCancel,
         });
         return null;
       }
+      throw error;
     }
-
-    const claimedAt = new Date();
-    const claimed = await db
-      .update(heartbeatRuns)
-      .set({
-        status: "running",
-        startedAt: run.startedAt ?? claimedAt,
-        updatedAt: claimedAt,
-      })
-      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
-      .returning()
-      .then((rows) => rows[0] ?? null);
     if (!claimed) return null;
+
+    const claimedAt = claimed.startedAt ?? new Date();
 
     publishLiveEvent({
       companyId: claimed.companyId,
@@ -2277,27 +2332,6 @@ export function heartbeatService(db: Db) {
     });
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
-
-    // Fix A (lazy locking): stamp executionRunId now that the run is actually running,
-    // not at queue time. Guard is idempotent — safe if called more than once.
-    if (issueId) {
-      const claimedAgent = await getAgent(claimed.agentId);
-      await db
-        .update(issues)
-        .set({
-          executionRunId: claimed.id,
-          executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
-          executionLockedAt: claimedAt,
-          updatedAt: claimedAt,
-        })
-        .where(
-          and(
-            eq(issues.id, issueId),
-            eq(issues.companyId, claimed.companyId),
-            or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
-          ),
-        );
-    }
 
     return claimed;
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -386,6 +386,14 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
+function isStaleIssueAssignedRunForAssignee(
+  run: { agentId: string; contextSnapshot: unknown },
+  assigneeAgentId: string | null | undefined,
+) {
+  return readNonEmptyString(parseObject(run.contextSnapshot).wakeReason) === "issue_assigned" &&
+    assigneeAgentId !== run.agentId;
+}
+
 function normalizeLedgerBillingType(value: unknown): BillingType {
   const raw = readNonEmptyString(value);
   switch (raw) {
@@ -2239,22 +2247,66 @@ export function heartbeatService(db: Db) {
 
     try {
       claimed = await db.transaction(async (tx) => {
-        if (issueId && wakeReason === "issue_assigned") {
+        let issue:
+          | {
+              id: string;
+              status: string;
+              assigneeAgentId: string | null;
+              checkoutRunId: string | null;
+              executionRunId: string | null;
+            }
+          | null = null;
+        let currentExecutionRun: { id: string; status: string } | null = null;
+
+        if (issueId) {
           await tx.execute(
             sql`select id from issues where company_id = ${run.companyId} and id = ${issueId} for update`,
           );
 
-          const issue = await tx
-            .select({ assigneeAgentId: issues.assigneeAgentId })
+          issue = await tx
+            .select({
+              id: issues.id,
+              status: issues.status,
+              assigneeAgentId: issues.assigneeAgentId,
+              checkoutRunId: issues.checkoutRunId,
+              executionRunId: issues.executionRunId,
+            })
             .from(issues)
             .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
             .then((rows) => rows[0] ?? null);
 
-          if (!issue) {
+          if (wakeReason === "issue_assigned" && !issue) {
             throw new CancelQueuedRunError("Cancelled because the issue no longer exists");
           }
-          if (issue.assigneeAgentId !== run.agentId) {
+
+          currentExecutionRun = issue?.executionRunId
+            ? await tx
+                .select({
+                  id: heartbeatRuns.id,
+                  status: heartbeatRuns.status,
+                })
+                .from(heartbeatRuns)
+                .where(eq(heartbeatRuns.id, issue.executionRunId))
+                .then((rows) => rows[0] ?? null)
+            : null;
+
+          if (issue && isStaleIssueAssignedRunForAssignee(run, issue.assigneeAgentId)) {
             throw new CancelQueuedRunError("Cancelled because the issue was reassigned before this wake ran");
+          }
+
+          if (currentExecutionRun && currentExecutionRun.id !== run.id) {
+            throw new CancelQueuedRunError("Cancelled because the issue is already owned by another execution run");
+          }
+
+          if (
+            issue &&
+            issue.executionRunId == null &&
+            issue.status === "in_progress" &&
+            issue.checkoutRunId == null
+          ) {
+            throw new CancelQueuedRunError(
+              "Cancelled because the issue execution lock was cleared before this queued run was claimed",
+            );
           }
         }
 
@@ -3823,6 +3875,7 @@ export function heartbeatService(db: Db) {
           .select({
             id: issues.id,
             companyId: issues.companyId,
+            assigneeAgentId: issues.assigneeAgentId,
             executionRunId: issues.executionRunId,
             executionAgentNameKey: issues.executionAgentNameKey,
           })
@@ -3859,6 +3912,10 @@ export function heartbeatService(db: Db) {
           activeExecutionRun = null;
         }
 
+        if (activeExecutionRun && isStaleIssueAssignedRunForAssignee(activeExecutionRun, issue.assigneeAgentId)) {
+          activeExecutionRun = null;
+        }
+
         if (!activeExecutionRun && issue.executionRunId) {
           await tx
             .update(issues)
@@ -3886,8 +3943,7 @@ export function heartbeatService(db: Db) {
               sql`case when ${heartbeatRuns.status} = 'running' then 0 else 1 end`,
               asc(heartbeatRuns.createdAt),
             )
-            .limit(1)
-            .then((rows) => rows[0] ?? null);
+            .then((rows) => rows.find((candidate) => !isStaleIssueAssignedRunForAssignee(candidate, issue.assigneeAgentId)) ?? null);
 
           if (legacyRun) {
             activeExecutionRun = legacyRun;


### PR DESCRIPTION
## Summary
- cancel queued `issue_assigned` heartbeat runs when the issue has already been reassigned before the wake is claimed
- avoid recursive queue promotion while `resumeQueuedRuns()` is cancelling stale queued work
- add regressions covering reassignment checkout recovery, stale queued wake cancellation, and wake routing to the newly assigned agent

## Linked tickets
- SUP-630
- SUP-130
- SUP-131
- SUP-627

## Why this stayed separate
`SUP-131` addressed queued-run checkout locking broadly. This PR keeps `SUP-630` scoped to reassignment fallout: clearing stale execution ownership, cancelling stale reassignment wakes, and targeting the new assignee. The only borrowed `SUP-131` behavior here is the minimal queue-resume cancellation guard needed to prevent recursive `startNextQueuedRunForAgent()` when a stale queued run is cancelled during resume.

## Verification
- `pnpm test:run server/src/__tests__/issues-service.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts server/src/__tests__/issue-comment-reopen-routes.test.ts`
- `pnpm exec tsc --noEmit` from `server/` still fails on pre-existing `@paperclipai/plugin-sdk` / plugin typing errors outside this slice
