### PR TITLE
fix(issues): alias nested routes to flat handlers (#3993)

### DIFF
--- a/server/src/__tests__/issue-nested-alias-routes.test.ts
+++ b/server/src/__tests__/issue-nested-alias-routes.test.ts
@@ -1,0 +1,188 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  getRelationSummaries: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+  listComments: vi.fn(),
+  markRead: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(async () => true),
+    hasPermission: vi.fn(async () => true),
+  }),
+  agentService: () => ({
+    getById: vi.fn(async () => null),
+    resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({
+      ambiguous: false,
+      agent: { id: raw },
+    })),
+  }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({
+      vote: null,
+      consentEnabledNow: false,
+      sharingEnabled: false,
+    })),
+  }),
+  goalService: () => ({
+    getById: vi.fn(async () => null),
+    getDefaultCompanyGoal: vi.fn(async () => null),
+  }),
+  heartbeatService: () => mockHeartbeatService,
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    })),
+    listCompanyIds: vi.fn(async () => ["company-1"]),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+}));
+
+async function createApp() {
+  const [{ errorHandler }, { issueRoutes }] = await Promise.all([
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    companyId: "company-1",
+    status: "todo",
+    priority: "medium",
+    projectId: null,
+    goalId: null,
+    parentId: null,
+    assigneeAgentId: null,
+    assigneeUserId: "local-board",
+    createdByUserId: "local-board",
+    identifier: "PAP-999",
+    title: "Alias test",
+    executionPolicy: null,
+    executionState: null,
+    hiddenAt: null,
+    ...overrides,
+  };
+}
+
+describe("nested-route aliases for flat issue routes", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+  });
+
+  it("PATCH /companies/:companyId/issues/:id routes to the flat PATCH handler", async () => {
+    const existing = makeIssue();
+    const updated = makeIssue({ title: "Renamed" });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+
+    const res = await request(await createApp())
+      .patch(`/api/companies/company-1/issues/${existing.id}`)
+      .send({ title: "Renamed" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledTimes(1);
+    expect(res.body.title).toBe("Renamed");
+  });
+
+  it("POST /companies/:companyId/issues/:id/comments routes to the flat comment handler", async () => {
+    const existing = makeIssue();
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-alias-1",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "hello via nested",
+    });
+
+    const res = await request(await createApp())
+      .post(`/api/companies/company-1/issues/${existing.id}/comments`)
+      .send({ body: "hello via nested" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledTimes(1);
+    expect(res.body.body).toBe("hello via nested");
+  });
+
+  it("POST /companies/:companyId/issues/:id/read routes to the flat handler", async () => {
+    const existing = makeIssue();
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.markRead.mockResolvedValue({
+      issueId: existing.id,
+      userId: "local-board",
+      lastReadAt: new Date("2026-04-19T00:00:00Z"),
+    });
+
+    const res = await request(await createApp()).post(
+      `/api/companies/company-1/issues/${existing.id}/read`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.markRead).toHaveBeenCalledTimes(1);
+  });
+
+  it("flat PATCH /issues/:id still works (no regression)", async () => {
+    const existing = makeIssue();
+    const updated = makeIssue({ title: "Still flat" });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ title: "Still flat" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe("Still flat");
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -585,6 +585,27 @@ export function issueRoutes(
     }
   });
 
+  // Alias: accept /companies/:companyId/issues/:issueId/* and route to the flat
+  // /issues/:issueId/* handlers below. Fixes #3993: agents over-generalize from
+  // the nested create endpoint and 404 on modify/comment paths.
+  router.use((req, _res, next) => {
+    const queryIdx = req.url.indexOf("?");
+    const pathname = queryIdx === -1 ? req.url : req.url.slice(0, queryIdx);
+    const query = queryIdx === -1 ? "" : req.url.slice(queryIdx);
+
+    const match = pathname.match(/^\/companies\/[^/]+\/issues\/([^/]+)(\/.*)?$/);
+    if (!match) return next();
+
+    const [, issueId, subpath = ""] = match;
+
+    // POST /companies/:companyId/issues/:issueId/attachments has a native
+    // nested handler (no flat equivalent for create). Let it through unchanged.
+    if (subpath === "/attachments" && req.method === "POST") return next();
+
+    req.url = `/issues/${issueId}${subpath}${query}`;
+    next();
+  });
+
   // Common malformed path when companyId is empty in "/api/companies/{companyId}/issues".
   router.get("/issues", (_req, res) => {
     res.status(400).json({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -585,9 +585,9 @@ export function issueRoutes(
     }
   });
 
-  // Alias: accept /companies/:companyId/issues/:issueId/* and route to the flat
-  // /issues/:issueId/* handlers below. Fixes #3993: agents over-generalize from
-  // the nested create endpoint and 404 on modify/comment paths.
+  // Accept /companies/:companyId/issues/:issueId/* as aliases for the flat
+  // /issues/:issueId/* handlers. The URL's companyId is advisory — authz
+  // stays actor-based inside each handler.
   router.use((req, _res, next) => {
     const queryIdx = req.url.indexOf("?");
     const pathname = queryIdx === -1 ? req.url : req.url.slice(0, queryIdx);
@@ -598,8 +598,9 @@ export function issueRoutes(
 
     const [, issueId, subpath = ""] = match;
 
-    // POST /companies/:companyId/issues/:issueId/attachments has a native
-    // nested handler (no flat equivalent for create). Let it through unchanged.
+    // Bypass paths that have a native nested handler with no flat equivalent.
+    // Today only POST /.../attachments qualifies; extend this list if more
+    // nested-only endpoints are added.
     if (subpath === "/attachments" && req.method === "POST") return next();
 
     req.url = `/issues/${issueId}${subpath}${query}`;

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -719,6 +719,12 @@ Terminal states: `done`, `cancelled`
 
 ### Issues (Tasks)
 
+**Route shape — when to use `/api/companies/:companyId/...` vs `/api/issues/:issueId/...`:**
+
+- **List and create** are company-scoped: `GET` / `POST /api/companies/:companyId/issues`. Attachment create is also company-scoped.
+- **All other per-issue operations are flat**: `GET` / `PATCH` / `DELETE /api/issues/:issueId`, and every sub-resource (`/comments`, `/checkout`, `/approvals`, `/documents`, `/read`, etc.).
+- The flat shape is preferred. Nested aliases also work for per-issue operations — e.g. `POST /api/companies/:companyId/issues/:issueId/comments` routes to the flat handler — so agents that over-generalize from the create endpoint won't 404. The URL `:companyId` is advisory on aliased routes; authorization comes from the caller's actor context, not the URL.
+
 | Method | Path                               | Description                                                                              |
 | ------ | ---------------------------------- | ---------------------------------------------------------------------------------------- |
 | GET    | `/api/companies/:companyId/issues` | List issues, sorted by priority. Filters: `?status=`, `?assigneeAgentId=`, `?assigneeUserId=`, `?projectId=`, `?labelId=`, `?q=` (full-text search across title, identifier, description, comments) |


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents talk to the Paperclip control plane via REST — issues, comments, checkouts, documents, approvals, etc.
> - Issue routes have a long-standing asymmetry: **list + create + attachment-create** are nested under `/api/companies/:companyId/issues`, but **every other per-issue operation** is flat under `/api/issues/:issueId`
> - Agents that read the skill's API reference see the nested create endpoint and over-generalize, constructing `POST /api/companies/:cid/issues/:id/comments` or `PATCH /api/companies/:cid/issues/:id` and getting consistent 404s — burning tokens on retry loops
> - This PR makes the nested shape work as an alias for per-issue operations via a single URL-rewrite middleware, so over-generalization stops costing money and time
> - The benefit is agent ergonomics: both shapes route to the same handlers with the same authz, flat remains canonical, and future issue sub-resources only need to be registered once

## What Changed

- `server/src/routes/issues.ts` — new rewrite middleware at the top of the issue router. Matches `/companies/:companyId/issues/:issueId/*`, rewrites `req.url` to `/issues/:issueId/*`, and calls `next()` so the existing flat handlers match. One explicit bypass: `POST /companies/:companyId/issues/:issueId/attachments` has a native nested handler (no flat equivalent), so that request passes through unchanged.
- `server/src/__tests__/issue-nested-alias-routes.test.ts` — new focused test file: 4 cases covering PATCH, POST comments, POST read via nested shape, plus a flat-PATCH regression check.
- `skills/paperclip/references/api-reference.md` — route-shape callout above the Issues table explaining flat is canonical, nested aliases work for per-issue ops, and URL `:companyId` on aliased routes is advisory.

Deliberately minimal: no duplicate route registrations, no changes to existing handlers, no new routes.

## Verification

**Unit tests:**
```
cd server
pnpm vitest run src/__tests__/issue-nested-alias-routes.test.ts   # 4 pass
pnpm vitest run 'src/__tests__/issue-' 'src/__tests__/issues-'     # 130 pass (19 files), no regressions
```

**Live smoke test** against a running Paperclip instance (my YPO EN deployment, which runs off this branch):
```bash
ID=<real-issue-id>; COMP=<company-id>
# All three previously 404'd; now return 200:
curl -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" $API/companies/$COMP/issues/$ID            # 200
curl -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" $API/companies/$COMP/issues/$ID/comments   # 200
curl -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" -X POST -H 'Content-Type: application/json' -d '{"body":"alias smoke"}' $API/companies/$COMP/issues/$ID/comments   # 201

# Flat shape still works:
curl -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" $API/issues/$ID   # 200
```

## Risks

- **Low risk.** Change is additive: adds one middleware, zero handlers modified, zero behavior change on flat routes.
- **Authz semantics:** The `:companyId` in aliased URLs is advisory — flat handlers enforce company access via the actor context, not the URL segment. This matches how the flat routes already work and doesn't widen the authz model. Documented in the api-reference callout.
- **Attachment surface:** Only `POST /attachments` is bypassed (native nested handler). Other methods on `/.../attachments` (PUT/DELETE/PATCH) don't have routes at either shape — attachment mutation is keyed by `attachmentId` via `/api/attachments/:id`. So aliased calls like `DELETE /companies/:cid/issues/:iid/attachments/:aid` 404 after rewrite, same as they did before this PR (they 404'd at the nested shape too). No regression. Addresses Greptile's attachment comment.
- **Observability:** Logging middleware mounted upstream of this router will log the original (nested) URL, while handlers execute as flat. Acceptable for this change; worth noting if a follow-up wants to standardize log URLs.

## Model Used

Claude Opus 4.7, 1M-context variant (`claude-opus-4-7[1m]`) via Claude Code. No extended thinking mode. Tool use for codebase exploration, test authoring, and the live smoke-test against my Paperclip instance.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #3993.