### PR TITLE
chore(ui): remove deprecated baseUrl from ui/tsconfig.json

### DIFF
--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -11,7 +11,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "lexical": ["./node_modules/lexical/index.d.ts"]


### PR DESCRIPTION
## Thinking Path

- TypeScript editor integration surfaces the warning `Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0` on `ui/tsconfig.json`.
- TS 5+ resolves `paths` relative to the `tsconfig.json` file when `baseUrl` is absent.
- The existing `paths` entries already use `./` prefixes (`./src/*`, `./node_modules/lexical/index.d.ts`), so removing `baseUrl: "."` is a no-op at runtime.
- Clearing the warning now avoids the cliff when TypeScript 7 ships.

## What Changed

- Removed `"baseUrl": "."` from `ui/tsconfig.json`.

## Verification

- `pnpm --filter @paperclipai/ui typecheck` passes unchanged.
- `@/...` and `lexical` imports continue to resolve identically (same prefixes work with or without `baseUrl` because they start with `./`).

## Risks

- None expected. `baseUrl` was only used for path-mapping resolution, and every entry in `paths` is already relative.

## Checklist

- [x] Ran `pnpm typecheck` locally — passes
- [x] No runtime behavior change
- [x] Single-file, single-line cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)