### PR TITLE
fix(adapter-utils): strip Claude Code OAuth/API env from spawned subprocess

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1085,11 +1085,19 @@ export async function runChildProcess(
     // These vars leak in when the Paperclip server itself is started from
     // within a Claude Code session (e.g. `npx paperclipai run` in a terminal
     // owned by Claude Code) or when cron inherits a contaminated shell env.
+    //
+    // Also strip CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY: when Claude
+    // Desktop launches the Paperclip server, it injects a baked-in OAuth token
+    // that the claude CLI prioritizes over the macOS keychain. When that token
+    // expires/rotates, subprocesses fail with 401 even though the keychain has
+    // a fresh token. Deleting these forces claude CLI to read keychain.
     const CLAUDE_CODE_NESTING_VARS = [
       "CLAUDECODE",
       "CLAUDE_CODE_ENTRYPOINT",
       "CLAUDE_CODE_SESSION",
       "CLAUDE_CODE_PARENT_SESSION",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "ANTHROPIC_API_KEY",
     ] as const;
     for (const key of CLAUDE_CODE_NESTING_VARS) {
       delete rawMerged[key];


### PR DESCRIPTION
## Problem

When the runtime spawns the `claude` CLI as a subprocess, `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` are inherited from the parent's `process.env`.

If the parent was launched by a wrapper (e.g., Claude Desktop, or any shell with a previously-cached login) that exports a stale/different-account token, the child CLI prefers that env var over the fresh keychain credentials — producing **`401 Unauthorized`** on every spawn, even after a clean `claude logout && claude login`.

The failure is silent and persistent: the keychain has the correct token, but the inherited env wins.

## Reproduction

1. Launch the Paperclip server via a wrapper that exports `CLAUDE_CODE_OAUTH_TOKEN=<stale>` (common when the wrapper was itself started by an app that stored a login).
2. Run `claude logout && claude login` as a different account → keychain is refreshed.
3. Spawn any `claude_local` adapter run → 401 loop, regardless of the keychain state.

## Fix

Strip `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` alongside the existing `CLAUDECODE` / `CLAUDE_CODE_ENTRYPOINT` / nesting vars before spawning. CLI then falls back to keychain / session auth, which is the intended behavior.

Conservative scope: deletion happens after `process.env + opts.env` merge, so an adapter that explicitly wants to force an OAuth token through `opts.env` would also be stripped. No adapter in the tree currently does that; explicit tokens should flow via config, not env.

## Validation

- Pre-fix: 100% `status=failed exitCode=1` on `claude_local` runs (401 loop on every heartbeat).
- Post-fix: `status=succeeded exitCode=0` (verified on `v2026.416.0-canary.1`, run id `02379944`).

## Note on `codex_local`

The same env-leak pattern exists for `OPENAI_API_KEY` in the `codex_local` adapter, but the fix strategy is different there — `resolveCodexBillingType` intentionally switches to API-key billing when `OPENAI_API_KEY` is present. If this becomes a real problem for Codex users, it deserves its own PR with a more nuanced config-vs-env-priority decision.

## Files

- `packages/adapter-utils/src/server-utils.ts` (+8 lines, refactors the existing strip array into a named const and adds two vars)