### PR TITLE
fix: reconcile issue execution ownership

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -392,6 +392,114 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     return { companyId, agentId, runId, wakeupRequestId, issueId };
   }
 
+  it("does not stamp execution metadata from another agent's queued mention wake when checkout is absent", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const wakingAgentId = randomUUID();
+    const issueId = randomUUID();
+    const staleRunId = randomUUID();
+    const staleWakeupRequestId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "Release Engineer",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: wakingAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Mention wake should not mint ownership",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: staleWakeupRequestId,
+      companyId,
+      agentId: wakingAgentId,
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "issue_comment_mentioned",
+      payload: { issueId },
+      status: "queued",
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: staleRunId,
+      companyId,
+      agentId: wakingAgentId,
+      invocationSource: "on_demand",
+      triggerDetail: "manual",
+      status: "queued",
+      wakeupRequestId: staleWakeupRequestId,
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_comment_mentioned",
+      },
+      updatedAt: new Date("2026-04-19T17:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.wakeup(wakingAgentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "issue_comment_mentioned",
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_comment_mentioned",
+      },
+    });
+
+    const issue = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+    });
+  });
+
   it("keeps a local run active when the recorded pid is still alive", async () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -500,6 +500,100 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  it("does not stamp execution metadata from the assignee's own queued mention wake when checkout is absent", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const issueId = randomUUID();
+    const staleRunId = randomUUID();
+    const staleWakeupRequestId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "Release Engineer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Same-assignee mention wake should not mint ownership",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: staleWakeupRequestId,
+      companyId,
+      agentId: assigneeAgentId,
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "issue_comment_mentioned",
+      payload: { issueId },
+      status: "queued",
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: staleRunId,
+      companyId,
+      agentId: assigneeAgentId,
+      invocationSource: "on_demand",
+      triggerDetail: "manual",
+      status: "queued",
+      wakeupRequestId: staleWakeupRequestId,
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_comment_mentioned",
+      },
+      updatedAt: new Date("2026-04-19T17:05:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.wakeup(assigneeAgentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "issue_comment_mentioned",
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_comment_mentioned",
+      },
+    });
+
+    const issue = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+    });
+  });
+
   it("keeps a local run active when the recorded pid is still alive", async () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -656,6 +656,205 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     });
   });
 
+  it("replaces a live wrong-issue execution reference with the checked-out issue run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const checkoutRunId = randomUUID();
+    const wrongIssueRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Release Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: checkoutRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        wakeupRequestId: randomUUID(),
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-19T17:00:00.000Z"),
+        updatedAt: new Date("2026-04-19T17:00:00.000Z"),
+      },
+      {
+        id: wrongIssueRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        wakeupRequestId: randomUUID(),
+        contextSnapshot: { issueId: randomUUID() },
+        startedAt: new Date("2026-04-19T17:01:00.000Z"),
+        updatedAt: new Date("2026-04-19T17:01:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: 1069,
+      identifier: "PAP-1069",
+      title: "Wrong issue execution pointer",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId,
+      executionRunId: wrongIssueRunId,
+      executionAgentNameKey: null,
+      createdByUserId: "user-1",
+    });
+
+    const detail = await svc.getById("PAP-1069");
+    const [listed] = await svc.list(companyId, { identifier: "PAP-1069" });
+    const persisted = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(detail).toEqual(expect.objectContaining({
+      id: issueId,
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+      executionAgentNameKey: "release engineer",
+    }));
+    expect(listed).toEqual(expect.objectContaining({
+      id: issueId,
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+      executionAgentNameKey: "release engineer",
+    }));
+    expect(persisted).toEqual({
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+      executionAgentNameKey: "release engineer",
+    });
+  });
+
+  it("preserves a live retry run when it still belongs to the checked-out issue", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const checkoutRunId = randomUUID();
+    const retryRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Release Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: checkoutRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "failed",
+        wakeupRequestId: randomUUID(),
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-19T17:00:00.000Z"),
+        updatedAt: new Date("2026-04-19T17:00:00.000Z"),
+      },
+      {
+        id: retryRunId,
+        companyId,
+        agentId,
+        invocationSource: "issue.continuation_recovery",
+        triggerDetail: "system",
+        status: "running",
+        wakeupRequestId: randomUUID(),
+        retryOfRunId: checkoutRunId,
+        contextSnapshot: { issueId, retryReason: "issue_continuation_needed" },
+        startedAt: new Date("2026-04-19T17:01:00.000Z"),
+        updatedAt: new Date("2026-04-19T17:01:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: 1070,
+      identifier: "PAP-1070",
+      title: "Continuation retry keeps execution ownership",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId,
+      executionRunId: retryRunId,
+      executionAgentNameKey: null,
+      createdByUserId: "user-1",
+    });
+
+    const detail = await svc.getById("PAP-1070");
+    const [listed] = await svc.list(companyId, { identifier: "PAP-1070" });
+    const persisted = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(detail).toEqual(expect.objectContaining({
+      id: issueId,
+      checkoutRunId,
+      executionRunId: retryRunId,
+      executionAgentNameKey: "release engineer",
+    }));
+    expect(listed).toEqual(expect.objectContaining({
+      id: issueId,
+      checkoutRunId,
+      executionRunId: retryRunId,
+      executionAgentNameKey: "release engineer",
+    }));
+    expect(persisted).toEqual({
+      checkoutRunId,
+      executionRunId: retryRunId,
+      executionAgentNameKey: "release engineer",
+    });
+  });
+
   it("filters issues by execution workspace id", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -8,6 +8,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -379,6 +380,91 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
   it("returns null instead of throwing for malformed non-uuid issue refs", async () => {
     await expect(svc.getById("not-a-uuid")).resolves.toBeNull();
   });
+
+  it("reconciles stale execution metadata consistently across detail and list reads", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const staleRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Release Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: staleRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId: randomUUID(),
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-19T17:00:00.000Z"),
+      updatedAt: new Date("2026-04-19T17:00:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: 1065,
+      identifier: "PAP-1065",
+      title: "Stale execution metadata",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: staleRunId,
+      executionAgentNameKey: "release-engineer",
+      createdByUserId: "user-1",
+    });
+
+    const detail = await svc.getById("PAP-1065");
+    const [listed] = await svc.list(companyId, { identifier: "PAP-1065" });
+    const persisted = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(detail).toEqual(expect.objectContaining({
+      id: issueId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+    }));
+    expect(listed).toEqual(expect.objectContaining({
+      id: issueId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+    }));
+    expect(persisted).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+    });
+  });
+
   it("filters issues by execution workspace id", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -471,6 +471,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     const activeIssueId = randomUUID();
     const siblingIssueId = randomUUID();
     const checkoutRunId = randomUUID();
+    const unrelatedRunId = randomUUID();
 
     await db.insert(companies).values({
       id: companyId,
@@ -504,6 +505,19 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       updatedAt: new Date("2026-04-19T17:00:00.000Z"),
     });
 
+    await db.insert(heartbeatRuns).values({
+      id: unrelatedRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId: randomUUID(),
+      contextSnapshot: { issueId: randomUUID() },
+      startedAt: new Date("2026-04-19T17:01:00.000Z"),
+      updatedAt: new Date("2026-04-19T17:01:00.000Z"),
+    });
+
     await db.insert(issues).values([
       {
         id: activeIssueId,
@@ -525,6 +539,8 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
         status: "blocked",
         priority: "medium",
         assigneeAgentId: agentId,
+        executionRunId: unrelatedRunId,
+        executionAgentNameKey: "release engineer",
         createdByUserId: "user-1",
       },
     ]);
@@ -554,6 +570,90 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       executionRunId: null,
       executionAgentNameKey: null,
     }));
+  });
+
+  it("backfills a live execution tuple from checkoutRunId when execution fields are missing", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Staff Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: checkoutRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId: randomUUID(),
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-19T17:00:00.000Z"),
+      updatedAt: new Date("2026-04-19T17:00:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: 1068,
+      identifier: "PAP-1068",
+      title: "Missing execution tuple",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      createdByUserId: "user-1",
+    });
+
+    const detail = await svc.getById("PAP-1068");
+    const [listed] = await svc.list(companyId, { identifier: "PAP-1068" });
+    const persisted = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(detail).toEqual(expect.objectContaining({
+      id: issueId,
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+      executionAgentNameKey: "staff engineer",
+    }));
+    expect(listed).toEqual(expect.objectContaining({
+      id: issueId,
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+      executionAgentNameKey: "staff engineer",
+    }));
+    expect(persisted).toEqual({
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+      executionAgentNameKey: "staff engineer",
+    });
   });
 
   it("filters issues by execution workspace id", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -96,6 +96,8 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -465,6 +465,97 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     });
   });
 
+  it("surfaces a coherent active execution owner on the checked-out issue only", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const activeIssueId = randomUUID();
+    const siblingIssueId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Release Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: checkoutRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId: randomUUID(),
+      contextSnapshot: { issueId: activeIssueId },
+      startedAt: new Date("2026-04-19T17:00:00.000Z"),
+      updatedAt: new Date("2026-04-19T17:00:00.000Z"),
+    });
+
+    await db.insert(issues).values([
+      {
+        id: activeIssueId,
+        companyId,
+        issueNumber: 1066,
+        identifier: "PAP-1066",
+        title: "Active execution ownership",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        createdByUserId: "user-1",
+      },
+      {
+        id: siblingIssueId,
+        companyId,
+        issueNumber: 1067,
+        identifier: "PAP-1067",
+        title: "Blocked sibling",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        createdByUserId: "user-1",
+      },
+    ]);
+
+    await svc.checkout(activeIssueId, agentId, ["todo"], checkoutRunId);
+
+    const detail = await svc.getById("PAP-1066");
+    const listed = await svc.list(companyId, {});
+    const activeListed = listed.find((issue) => issue.id === activeIssueId);
+    const siblingListed = listed.find((issue) => issue.id === siblingIssueId);
+
+    expect(detail).toEqual(expect.objectContaining({
+      id: activeIssueId,
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+      executionAgentNameKey: "release engineer",
+    }));
+    expect(activeListed).toEqual(expect.objectContaining({
+      id: activeIssueId,
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+      executionAgentNameKey: "release engineer",
+    }));
+    expect(siblingListed).toEqual(expect.objectContaining({
+      id: siblingIssueId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+    }));
+  });
+
   it("filters issues by execution workspace id", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5,6 +5,7 @@ import { sql } from "drizzle-orm";
 import {
   activityLog,
   agents,
+  agentWakeupRequests,
   companies,
   createDb,
   executionWorkspaces,
@@ -42,6 +43,33 @@ async function ensureIssueRelationsTable(db: ReturnType<typeof createDb>) {
       "updated_at" timestamptz NOT NULL DEFAULT now()
     );
   `));
+}
+
+async function insertHeartbeatRunsWithWakeups(
+  db: ReturnType<typeof createDb>,
+  runs: typeof heartbeatRuns.$inferInsert | Array<typeof heartbeatRuns.$inferInsert>,
+) {
+  const runList = Array.isArray(runs) ? runs : [runs];
+  const wakeupRows = runList.map((run) => ({
+    id: run.wakeupRequestId as string,
+    companyId: run.companyId,
+    agentId: run.agentId,
+    source: run.invocationSource === "assignment" ? "assignment" : "automation",
+    triggerDetail: run.triggerDetail ?? "system",
+    reason: "issue_assigned",
+    payload: (
+      typeof run.contextSnapshot === "object"
+      && run.contextSnapshot
+      && "issueId" in run.contextSnapshot
+      && typeof run.contextSnapshot.issueId === "string"
+    )
+      ? { issueId: run.contextSnapshot.issueId }
+      : {},
+    status: "queued",
+  }));
+
+  await db.insert(agentWakeupRequests).values(wakeupRows);
+  await db.insert(heartbeatRuns).values(runList);
 }
 
 if (!embeddedPostgresSupport.supported) {
@@ -406,7 +434,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       permissions: {},
     });
 
-    await db.insert(heartbeatRuns).values({
+    await insertHeartbeatRunsWithWakeups(db, {
       id: staleRunId,
       companyId,
       agentId,
@@ -492,7 +520,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       permissions: {},
     });
 
-    await db.insert(heartbeatRuns).values({
+    await insertHeartbeatRunsWithWakeups(db, {
       id: checkoutRunId,
       companyId,
       agentId,
@@ -505,7 +533,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       updatedAt: new Date("2026-04-19T17:00:00.000Z"),
     });
 
-    await db.insert(heartbeatRuns).values({
+    await insertHeartbeatRunsWithWakeups(db, {
       id: unrelatedRunId,
       companyId,
       agentId,
@@ -597,7 +625,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       permissions: {},
     });
 
-    await db.insert(heartbeatRuns).values({
+    await insertHeartbeatRunsWithWakeups(db, {
       id: checkoutRunId,
       companyId,
       agentId,
@@ -682,7 +710,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       permissions: {},
     });
 
-    await db.insert(heartbeatRuns).values([
+    await insertHeartbeatRunsWithWakeups(db, [
       {
         id: checkoutRunId,
         companyId,
@@ -781,7 +809,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       permissions: {},
     });
 
-    await db.insert(heartbeatRuns).values([
+    await insertHeartbeatRunsWithWakeups(db, [
       {
         id: checkoutRunId,
         companyId,
@@ -882,7 +910,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       permissions: {},
     });
 
-    await db.insert(heartbeatRuns).values([
+    await insertHeartbeatRunsWithWakeups(db, [
       {
         id: checkoutRunId,
         companyId,

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -855,6 +855,155 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     });
   });
 
+  it("does not let a stale repair overwrite newer execution ownership", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const checkoutRunId = randomUUID();
+    const staleExecutionRunId = randomUUID();
+    const newerExecutionRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Release Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: checkoutRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        wakeupRequestId: randomUUID(),
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-19T17:00:00.000Z"),
+        updatedAt: new Date("2026-04-19T17:00:00.000Z"),
+      },
+      {
+        id: staleExecutionRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        wakeupRequestId: randomUUID(),
+        contextSnapshot: { issueId: randomUUID() },
+        startedAt: new Date("2026-04-19T16:59:00.000Z"),
+        updatedAt: new Date("2026-04-19T16:59:00.000Z"),
+      },
+      {
+        id: newerExecutionRunId,
+        companyId,
+        agentId,
+        invocationSource: "issue.continuation_recovery",
+        triggerDetail: "system",
+        status: "running",
+        wakeupRequestId: randomUUID(),
+        retryOfRunId: checkoutRunId,
+        contextSnapshot: { issueId, retryReason: "issue_continuation_needed" },
+        startedAt: new Date("2026-04-19T17:01:00.000Z"),
+        updatedAt: new Date("2026-04-19T17:01:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: 1071,
+      identifier: "PAP-1071",
+      title: "Concurrent repair does not clobber newer execution owner",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId,
+      executionRunId: staleExecutionRunId,
+      executionAgentNameKey: null,
+      createdByUserId: "user-1",
+    });
+
+    let injectedConcurrentUpdate = false;
+    const proxiedDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop !== "update") {
+          return Reflect.get(target, prop, receiver);
+        }
+        return (table: unknown) => {
+          const builder = target.update(table as never) as {
+            set: (values: Record<string, unknown>) => { where: (condition: unknown) => Promise<unknown> };
+          };
+          return {
+            ...builder,
+            set: (values: Record<string, unknown>) => {
+              const setBuilder = builder.set(values);
+              return {
+                ...setBuilder,
+                where: async (condition: unknown) => {
+                  if (
+                    !injectedConcurrentUpdate &&
+                    table === issues &&
+                    values.executionRunId === checkoutRunId &&
+                    values.executionAgentNameKey === "release engineer"
+                  ) {
+                    injectedConcurrentUpdate = true;
+                    await db
+                      .update(issues)
+                      .set({
+                        executionRunId: newerExecutionRunId,
+                        executionAgentNameKey: "release engineer",
+                      })
+                      .where(eq(issues.id, issueId));
+                  }
+                  return setBuilder.where(condition);
+                },
+              };
+            },
+          };
+        };
+      },
+    });
+
+    const proxiedSvc = issueService(proxiedDb as typeof db);
+    const detail = await proxiedSvc.getById("PAP-1071");
+    const persisted = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(injectedConcurrentUpdate).toBe(true);
+    expect(detail).toEqual(expect.objectContaining({
+      id: issueId,
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+      executionAgentNameKey: "release engineer",
+    }));
+    expect(persisted).toEqual({
+      checkoutRunId,
+      executionRunId: newerExecutionRunId,
+      executionAgentNameKey: "release engineer",
+    });
+  });
+
   it("filters issues by execution workspace id", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2676,6 +2676,7 @@ export function heartbeatService(db: Db) {
           and(
             eq(issues.id, claimedIssueId),
             eq(issues.companyId, claimed.companyId),
+            eq(issues.status, "in_progress"),
             eq(issues.assigneeAgentId, claimed.agentId),
             eq(issues.checkoutRunId, claimed.id),
             or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2377,12 +2377,12 @@ export function heartbeatService(db: Db) {
       await tx
         .update(issues)
         .set({
-          executionRunId: queuedRun.id,
-          executionAgentNameKey: normalizeAgentNameKey(agent.name),
-          executionLockedAt: now,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
           updatedAt: now,
         })
-        .where(eq(issues.id, issue.id));
+        .where(and(eq(issues.id, issue.id), eq(issues.executionRunId, run.id)));
 
       await tx
         .update(heartbeatRuns)
@@ -2550,9 +2550,9 @@ export function heartbeatService(db: Db) {
         await tx
           .update(issues)
           .set({
-            executionRunId: retryRun.id,
-            executionAgentNameKey: normalizeAgentNameKey(agent.name),
-            executionLockedAt: now,
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
             updatedAt: now,
           })
           .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
@@ -2676,6 +2676,7 @@ export function heartbeatService(db: Db) {
           and(
             eq(issues.id, claimedIssueId),
             eq(issues.companyId, claimed.companyId),
+            eq(issues.assigneeAgentId, claimed.agentId),
             or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
           ),
         );
@@ -4395,12 +4396,12 @@ export function heartbeatService(db: Db) {
         await tx
           .update(issues)
           .set({
-            executionRunId: newRun.id,
-            executionAgentNameKey: normalizeAgentNameKey(deferredAgent.name),
-            executionLockedAt: now,
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
             updatedAt: now,
           })
-          .where(eq(issues.id, issue.id));
+          .where(and(eq(issues.id, issue.id), eq(issues.executionRunId, run.id)));
 
         return {
           run: newRun,
@@ -4545,6 +4546,7 @@ export function heartbeatService(db: Db) {
           .select({
             id: issues.id,
             companyId: issues.companyId,
+            assigneeAgentId: issues.assigneeAgentId,
             executionRunId: issues.executionRunId,
             executionAgentNameKey: issues.executionAgentNameKey,
           })
@@ -4594,39 +4596,28 @@ export function heartbeatService(db: Db) {
         }
 
         if (!activeExecutionRun) {
-          const legacyRun = await tx
-            .select()
-            .from(heartbeatRuns)
-            .where(
-              and(
-                eq(heartbeatRuns.companyId, issue.companyId),
-                inArray(heartbeatRuns.status, ["queued", "running"]),
-                sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
-              ),
-            )
-            .orderBy(
-              sql`case when ${heartbeatRuns.status} = 'running' then 0 else 1 end`,
-              asc(heartbeatRuns.createdAt),
-            )
-            .limit(1)
-            .then((rows) => rows[0] ?? null);
+          const legacyRun = issue.assigneeAgentId
+            ? await tx
+              .select()
+              .from(heartbeatRuns)
+              .where(
+                and(
+                  eq(heartbeatRuns.companyId, issue.companyId),
+                  eq(heartbeatRuns.agentId, issue.assigneeAgentId),
+                  inArray(heartbeatRuns.status, ["queued", "running"]),
+                  sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
+                ),
+              )
+              .orderBy(
+                sql`case when ${heartbeatRuns.status} = 'running' then 0 else 1 end`,
+                asc(heartbeatRuns.createdAt),
+              )
+              .limit(1)
+              .then((rows) => rows[0] ?? null)
+            : null;
 
           if (legacyRun) {
             activeExecutionRun = legacyRun;
-            const legacyAgent = await tx
-              .select({ name: agents.name })
-              .from(agents)
-              .where(eq(agents.id, legacyRun.agentId))
-              .then((rows) => rows[0] ?? null);
-            await tx
-              .update(issues)
-              .set({
-                executionRunId: legacyRun.id,
-                executionAgentNameKey: normalizeAgentNameKey(legacyAgent?.name),
-                executionLockedAt: new Date(),
-                updatedAt: new Date(),
-              })
-              .where(eq(issues.id, issue.id));
           }
         }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2677,6 +2677,7 @@ export function heartbeatService(db: Db) {
             eq(issues.id, claimedIssueId),
             eq(issues.companyId, claimed.companyId),
             eq(issues.assigneeAgentId, claimed.agentId),
+            eq(issues.checkoutRunId, claimed.id),
             or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
           ),
         );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2550,9 +2550,9 @@ export function heartbeatService(db: Db) {
         await tx
           .update(issues)
           .set({
-            executionRunId: null,
-            executionAgentNameKey: null,
-            executionLockedAt: null,
+            executionRunId: retryRun.id,
+            executionAgentNameKey: normalizeAgentNameKey(agent.name),
+            executionLockedAt: now,
             updatedAt: now,
           })
           .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -646,7 +646,7 @@ async function reconcileExecutionStateForIssues(
           executionAgentNameKey: executionState.executionAgentNameKey,
           updatedAt: now,
         })
-        .where(and(eq(issues.id, issueId), eq(issues.checkoutRunId, executionState.executionRunId)));
+        .where(eq(issues.id, issueId));
     }
   }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -134,6 +134,12 @@ function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
 const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "failed", "cancelled", "timed_out"]);
 const ISSUE_LIST_DESCRIPTION_MAX_CHARS = 1200;
 
+function normalizeAgentNameKey(value: string | null | undefined) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
 function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, "\\$&");
 }
@@ -511,19 +517,20 @@ async function reconcileExecutionStateForIssues(
       .map((row) => row.executionRunId)
       .filter((id): id is string => id != null),
   )];
-  const runRows: Array<{ id: string; status: string }> = runIds.length === 0
+  const runRows: Array<{ id: string; status: string; agentId: string }> = runIds.length === 0
     ? []
     : await dbOrTx
-      .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+      .select({ id: heartbeatRuns.id, status: heartbeatRuns.status, agentId: heartbeatRuns.agentId })
       .from(heartbeatRuns)
       .where(inArray(heartbeatRuns.id, runIds));
-  const runMap = new Map<string, { id: string; status: string }>(
-    runRows.map((row: { id: string; status: string }) => [row.id, row]),
+  const runMap = new Map<string, { id: string; status: string; agentId: string }>(
+    runRows.map((row: { id: string; status: string; agentId: string }) => [row.id, row]),
   );
 
   const staleWithoutCheckoutIds: string[] = [];
   const staleRunIssueIds: string[] = [];
   const staleRunIds: string[] = [];
+  const missingExecutionAgentNameByIssueId = new Map<string, string>();
 
   const normalizedRows = issueRows.map((row) => {
     if (!row.executionRunId) {
@@ -536,6 +543,9 @@ async function reconcileExecutionStateForIssues(
       || !activeRun
       || !ACTIVE_RUN_STATUSES.includes(activeRun.status);
     if (!shouldClear) {
+      if (!row.executionAgentNameKey && activeRun) {
+        missingExecutionAgentNameByIssueId.set(row.id, activeRun.agentId);
+      }
       return row;
     }
 
@@ -583,7 +593,46 @@ async function reconcileExecutionStateForIssues(
       ));
   }
 
-  return normalizedRows;
+  const backfilledExecutionAgentNameKeys = new Map<string, string>();
+  if (missingExecutionAgentNameByIssueId.size > 0) {
+    const agentRows = await dbOrTx
+      .select({ id: agents.id, name: agents.name })
+      .from(agents)
+      .where(inArray(agents.id, [...new Set(missingExecutionAgentNameByIssueId.values())]));
+    const agentNameKeyById = new Map(
+      agentRows.map((row: { id: string; name: string }) => [row.id, normalizeAgentNameKey(row.name)]),
+    );
+    for (const [issueId, agentId] of missingExecutionAgentNameByIssueId.entries()) {
+      const executionAgentNameKey = agentNameKeyById.get(agentId);
+      if (executionAgentNameKey) {
+        backfilledExecutionAgentNameKeys.set(issueId, executionAgentNameKey);
+      }
+    }
+  }
+
+  if (backfilledExecutionAgentNameKeys.size > 0) {
+    const now = new Date();
+    for (const [issueId, executionAgentNameKey] of backfilledExecutionAgentNameKeys.entries()) {
+      await dbOrTx
+        .update(issues)
+        .set({
+          executionAgentNameKey,
+          updatedAt: now,
+        })
+        .where(and(eq(issues.id, issueId), isNull(issues.executionAgentNameKey)));
+    }
+  }
+
+  return normalizedRows.map((row) => {
+    const executionAgentNameKey = backfilledExecutionAgentNameKeys.get(row.id);
+    if (!executionAgentNameKey) {
+      return row;
+    }
+    return {
+      ...row,
+      executionAgentNameKey,
+    };
+  });
 }
 
 async function activeRunMapForIssues(
@@ -715,6 +764,7 @@ export function issueService(db: Db) {
       .select({
         id: agents.id,
         companyId: agents.companyId,
+        name: agents.name,
         status: agents.status,
       })
       .from(agents)
@@ -731,6 +781,7 @@ export function issueService(db: Db) {
     if (assignee.status === "terminated") {
       throw conflict("Cannot assign work to terminated agents");
     }
+    return assignee;
   }
 
   async function assertAssignableUser(companyId: string, userId: string) {
@@ -1879,7 +1930,8 @@ export function issueService(db: Db) {
         .where(eq(issues.id, id))
         .then((rows) => rows[0] ?? null);
       if (!issueCompany) throw notFound("Issue not found");
-      await assertAssignableAgent(issueCompany.companyId, agentId);
+      const assignee = await assertAssignableAgent(issueCompany.companyId, agentId);
+      const executionAgentNameKey = checkoutRunId ? normalizeAgentNameKey(assignee.name) : null;
 
       const now = new Date();
 
@@ -1945,6 +1997,7 @@ export function issueService(db: Db) {
           assigneeUserId: null,
           checkoutRunId,
           executionRunId: checkoutRunId,
+          executionAgentNameKey,
           status: "in_progress",
           startedAt: now,
           updatedAt: now,
@@ -1991,6 +2044,7 @@ export function issueService(db: Db) {
           .set({
             checkoutRunId,
             executionRunId: checkoutRunId,
+            executionAgentNameKey,
             updatedAt: new Date(),
           })
           .where(

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -499,6 +499,20 @@ async function withIssueLabels(dbOrTx: any, rows: IssueRow[]): Promise<IssueWith
 
 const ACTIVE_RUN_STATUSES = ["queued", "running"];
 
+function runOwnsIssueExecution(
+  row: Pick<IssueWithLabels, "id" | "status" | "assigneeAgentId" | "checkoutRunId">,
+  run: { status: string; agentId: string; issueId: string | null } | null,
+) {
+  return (
+    row.status === "in_progress"
+    && row.checkoutRunId != null
+    && run != null
+    && ACTIVE_RUN_STATUSES.includes(run.status)
+    && run.agentId === row.assigneeAgentId
+    && run.issueId === row.id
+  );
+}
+
 async function reconcileExecutionStateForIssues(
   dbOrTx: any,
   issueRows: IssueWithLabels[],
@@ -545,14 +559,26 @@ async function reconcileExecutionStateForIssues(
     }
 
     const activeCheckoutRun = row.checkoutRunId ? runMap.get(row.checkoutRunId) : null;
-    const hasMatchingActiveCheckout =
-      Boolean(row.checkoutRunId)
-      && Boolean(activeCheckoutRun)
-      && activeCheckoutRun?.agentId === row.assigneeAgentId
-      && activeCheckoutRun?.issueId === row.id;
+    const activeExecutionRun = row.executionRunId ? runMap.get(row.executionRunId) : null;
+    const hasMatchingActiveExecution = runOwnsIssueExecution(row, activeExecutionRun ?? null);
+    if (hasMatchingActiveExecution && row.executionRunId && activeExecutionRun) {
+      const executionAgentNameKey = row.executionAgentNameKey ?? normalizeAgentNameKey(activeExecutionRun.agentName);
+      if (row.executionAgentNameKey !== executionAgentNameKey) {
+        backfilledExecutionStateByIssueId.set(row.id, {
+          executionRunId: row.executionRunId,
+          executionAgentNameKey,
+        });
+      }
+      return {
+        ...row,
+        executionRunId: row.executionRunId,
+        executionAgentNameKey,
+      };
+    }
+
+    const hasMatchingActiveCheckout = runOwnsIssueExecution(row, activeCheckoutRun ?? null);
     if (hasMatchingActiveCheckout && row.checkoutRunId && activeCheckoutRun) {
-      const executionAgentNameKey =
-        row.executionAgentNameKey ?? normalizeAgentNameKey(activeCheckoutRun.agentName);
+      const executionAgentNameKey = row.executionAgentNameKey ?? normalizeAgentNameKey(activeCheckoutRun.agentName);
       if (row.executionRunId !== row.checkoutRunId || row.executionAgentNameKey !== executionAgentNameKey) {
         backfilledExecutionStateByIssueId.set(row.id, {
           executionRunId: row.checkoutRunId,
@@ -564,18 +590,6 @@ async function reconcileExecutionStateForIssues(
         executionRunId: row.checkoutRunId,
         executionAgentNameKey,
       };
-    }
-
-    const activeExecutionRun = row.executionRunId ? runMap.get(row.executionRunId) : null;
-    const shouldClear =
-      row.checkoutRunId == null
-      || row.executionRunId !== row.checkoutRunId
-      || !activeExecutionRun
-      || activeExecutionRun.agentId !== row.assigneeAgentId
-      || activeExecutionRun.issueId !== row.id
-      || !ACTIVE_RUN_STATUSES.includes(activeExecutionRun.status);
-    if (!shouldClear) {
-      return row;
     }
 
     if (row.checkoutRunId == null || !row.executionRunId) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -507,49 +507,78 @@ async function reconcileExecutionStateForIssues(
     return issueRows;
   }
 
-  const rowsWithExecution = issueRows.filter((row) => row.executionRunId != null);
-  if (rowsWithExecution.length === 0) {
+  const rowsWithExecutionState = issueRows.filter((row) => row.executionRunId != null || row.checkoutRunId != null);
+  if (rowsWithExecutionState.length === 0) {
     return issueRows;
   }
 
   const runIds = [...new Set(
-    rowsWithExecution
-      .map((row) => row.executionRunId)
+    rowsWithExecutionState
+      .flatMap((row) => [row.executionRunId, row.checkoutRunId])
       .filter((id): id is string => id != null),
   )];
-  const runRows: Array<{ id: string; status: string; agentId: string }> = runIds.length === 0
+  const runRows: Array<{ id: string; status: string; agentId: string; agentName: string | null; issueId: string | null }> = runIds.length === 0
     ? []
     : await dbOrTx
-      .select({ id: heartbeatRuns.id, status: heartbeatRuns.status, agentId: heartbeatRuns.agentId })
+      .select({
+        id: heartbeatRuns.id,
+        status: heartbeatRuns.status,
+        agentId: heartbeatRuns.agentId,
+        agentName: agents.name,
+        issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`,
+      })
       .from(heartbeatRuns)
+      .leftJoin(agents, eq(agents.id, heartbeatRuns.agentId))
       .where(inArray(heartbeatRuns.id, runIds));
-  const runMap = new Map<string, { id: string; status: string; agentId: string }>(
-    runRows.map((row: { id: string; status: string; agentId: string }) => [row.id, row]),
+  const runMap = new Map<string, { id: string; status: string; agentId: string; agentName: string | null; issueId: string | null }>(
+    runRows.map((row: { id: string; status: string; agentId: string; agentName: string | null; issueId: string | null }) => [row.id, row]),
   );
 
   const staleWithoutCheckoutIds: string[] = [];
   const staleRunIssueIds: string[] = [];
   const staleRunIds: string[] = [];
-  const missingExecutionAgentNameByIssueId = new Map<string, string>();
+  const backfilledExecutionStateByIssueId = new Map<string, { executionRunId: string; executionAgentNameKey: string | null }>();
 
   const normalizedRows = issueRows.map((row) => {
-    if (!row.executionRunId) {
+    if (!row.executionRunId && !row.checkoutRunId) {
       return row;
     }
 
-    const activeRun = runMap.get(row.executionRunId);
+    const activeCheckoutRun = row.checkoutRunId ? runMap.get(row.checkoutRunId) : null;
+    const hasMatchingActiveCheckout =
+      Boolean(row.checkoutRunId)
+      && Boolean(activeCheckoutRun)
+      && activeCheckoutRun?.agentId === row.assigneeAgentId
+      && activeCheckoutRun?.issueId === row.id;
+    if (hasMatchingActiveCheckout && row.checkoutRunId && activeCheckoutRun) {
+      const executionAgentNameKey =
+        row.executionAgentNameKey ?? normalizeAgentNameKey(activeCheckoutRun.agentName);
+      if (row.executionRunId !== row.checkoutRunId || row.executionAgentNameKey !== executionAgentNameKey) {
+        backfilledExecutionStateByIssueId.set(row.id, {
+          executionRunId: row.checkoutRunId,
+          executionAgentNameKey,
+        });
+      }
+      return {
+        ...row,
+        executionRunId: row.checkoutRunId,
+        executionAgentNameKey,
+      };
+    }
+
+    const activeExecutionRun = row.executionRunId ? runMap.get(row.executionRunId) : null;
     const shouldClear =
       row.checkoutRunId == null
-      || !activeRun
-      || !ACTIVE_RUN_STATUSES.includes(activeRun.status);
+      || row.executionRunId !== row.checkoutRunId
+      || !activeExecutionRun
+      || activeExecutionRun.agentId !== row.assigneeAgentId
+      || activeExecutionRun.issueId !== row.id
+      || !ACTIVE_RUN_STATUSES.includes(activeExecutionRun.status);
     if (!shouldClear) {
-      if (!row.executionAgentNameKey && activeRun) {
-        missingExecutionAgentNameByIssueId.set(row.id, activeRun.agentId);
-      }
       return row;
     }
 
-    if (row.checkoutRunId == null) {
+    if (row.checkoutRunId == null || !row.executionRunId) {
       staleWithoutCheckoutIds.push(row.id);
     } else {
       staleRunIssueIds.push(row.id);
@@ -593,44 +622,29 @@ async function reconcileExecutionStateForIssues(
       ));
   }
 
-  const backfilledExecutionAgentNameKeys = new Map<string, string>();
-  if (missingExecutionAgentNameByIssueId.size > 0) {
-    const agentRows = await dbOrTx
-      .select({ id: agents.id, name: agents.name })
-      .from(agents)
-      .where(inArray(agents.id, [...new Set(missingExecutionAgentNameByIssueId.values())]));
-    const agentNameKeyById = new Map(
-      agentRows.map((row: { id: string; name: string }) => [row.id, normalizeAgentNameKey(row.name)]),
-    );
-    for (const [issueId, agentId] of missingExecutionAgentNameByIssueId.entries()) {
-      const executionAgentNameKey = agentNameKeyById.get(agentId);
-      if (executionAgentNameKey) {
-        backfilledExecutionAgentNameKeys.set(issueId, executionAgentNameKey);
-      }
-    }
-  }
-
-  if (backfilledExecutionAgentNameKeys.size > 0) {
+  if (backfilledExecutionStateByIssueId.size > 0) {
     const now = new Date();
-    for (const [issueId, executionAgentNameKey] of backfilledExecutionAgentNameKeys.entries()) {
+    for (const [issueId, executionState] of backfilledExecutionStateByIssueId.entries()) {
       await dbOrTx
         .update(issues)
         .set({
-          executionAgentNameKey,
+          executionRunId: executionState.executionRunId,
+          executionAgentNameKey: executionState.executionAgentNameKey,
           updatedAt: now,
         })
-        .where(and(eq(issues.id, issueId), isNull(issues.executionAgentNameKey)));
+        .where(and(eq(issues.id, issueId), eq(issues.checkoutRunId, executionState.executionRunId)));
     }
   }
 
   return normalizedRows.map((row) => {
-    const executionAgentNameKey = backfilledExecutionAgentNameKeys.get(row.id);
-    if (!executionAgentNameKey) {
+    const executionState = backfilledExecutionStateByIssueId.get(row.id);
+    if (!executionState) {
       return row;
     }
     return {
       ...row,
-      executionAgentNameKey,
+      executionRunId: executionState.executionRunId,
+      executionAgentNameKey: executionState.executionAgentNameKey,
     };
   });
 }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -140,6 +140,10 @@ function normalizeAgentNameKey(value: string | null | undefined) {
   return normalized.length > 0 ? normalized : null;
 }
 
+function nullableEq<T>(column: any, value: T | null) {
+  return value == null ? isNull(column) : eq(column, value);
+}
+
 function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, "\\$&");
 }
@@ -551,7 +555,13 @@ async function reconcileExecutionStateForIssues(
   const staleWithoutCheckoutIds: string[] = [];
   const staleRunIssueIds: string[] = [];
   const staleRunIds: string[] = [];
-  const backfilledExecutionStateByIssueId = new Map<string, { executionRunId: string; executionAgentNameKey: string | null }>();
+  const backfilledExecutionStateByIssueId = new Map<string, {
+    executionRunId: string;
+    executionAgentNameKey: string | null;
+    originalCheckoutRunId: string | null;
+    originalExecutionRunId: string | null;
+    originalExecutionAgentNameKey: string | null;
+  }>();
 
   const normalizedRows = issueRows.map((row) => {
     if (!row.executionRunId && !row.checkoutRunId) {
@@ -567,6 +577,9 @@ async function reconcileExecutionStateForIssues(
         backfilledExecutionStateByIssueId.set(row.id, {
           executionRunId: row.executionRunId,
           executionAgentNameKey,
+          originalCheckoutRunId: row.checkoutRunId,
+          originalExecutionRunId: row.executionRunId,
+          originalExecutionAgentNameKey: row.executionAgentNameKey,
         });
       }
       return {
@@ -583,6 +596,9 @@ async function reconcileExecutionStateForIssues(
         backfilledExecutionStateByIssueId.set(row.id, {
           executionRunId: row.checkoutRunId,
           executionAgentNameKey,
+          originalCheckoutRunId: row.checkoutRunId,
+          originalExecutionRunId: row.executionRunId,
+          originalExecutionAgentNameKey: row.executionAgentNameKey,
         });
       }
       return {
@@ -646,7 +662,12 @@ async function reconcileExecutionStateForIssues(
           executionAgentNameKey: executionState.executionAgentNameKey,
           updatedAt: now,
         })
-        .where(eq(issues.id, issueId));
+        .where(and(
+          eq(issues.id, issueId),
+          nullableEq(issues.checkoutRunId, executionState.originalCheckoutRunId),
+          nullableEq(issues.executionRunId, executionState.originalExecutionRunId),
+          nullableEq(issues.executionAgentNameKey, executionState.originalExecutionAgentNameKey),
+        ));
     }
   }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -493,6 +493,99 @@ async function withIssueLabels(dbOrTx: any, rows: IssueRow[]): Promise<IssueWith
 
 const ACTIVE_RUN_STATUSES = ["queued", "running"];
 
+async function reconcileExecutionStateForIssues(
+  dbOrTx: any,
+  issueRows: IssueWithLabels[],
+): Promise<IssueWithLabels[]> {
+  if (issueRows.length === 0) {
+    return issueRows;
+  }
+
+  const rowsWithExecution = issueRows.filter((row) => row.executionRunId != null);
+  if (rowsWithExecution.length === 0) {
+    return issueRows;
+  }
+
+  const runIds = [...new Set(
+    rowsWithExecution
+      .map((row) => row.executionRunId)
+      .filter((id): id is string => id != null),
+  )];
+  const runRows: Array<{ id: string; status: string }> = runIds.length === 0
+    ? []
+    : await dbOrTx
+      .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(inArray(heartbeatRuns.id, runIds));
+  const runMap = new Map<string, { id: string; status: string }>(
+    runRows.map((row: { id: string; status: string }) => [row.id, row]),
+  );
+
+  const staleWithoutCheckoutIds: string[] = [];
+  const staleRunIssueIds: string[] = [];
+  const staleRunIds: string[] = [];
+
+  const normalizedRows = issueRows.map((row) => {
+    if (!row.executionRunId) {
+      return row;
+    }
+
+    const activeRun = runMap.get(row.executionRunId);
+    const shouldClear =
+      row.checkoutRunId == null
+      || !activeRun
+      || !ACTIVE_RUN_STATUSES.includes(activeRun.status);
+    if (!shouldClear) {
+      return row;
+    }
+
+    if (row.checkoutRunId == null) {
+      staleWithoutCheckoutIds.push(row.id);
+    } else {
+      staleRunIssueIds.push(row.id);
+      staleRunIds.push(row.executionRunId);
+    }
+
+    return {
+      ...row,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    };
+  });
+
+  const now = new Date();
+
+  if (staleWithoutCheckoutIds.length > 0) {
+    await dbOrTx
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: now,
+      })
+      .where(and(inArray(issues.id, staleWithoutCheckoutIds), isNull(issues.checkoutRunId)));
+  }
+
+  if (staleRunIssueIds.length > 0) {
+    await dbOrTx
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: now,
+      })
+      .where(and(
+        inArray(issues.id, staleRunIssueIds),
+        inArray(issues.executionRunId, [...new Set(staleRunIds)]),
+      ));
+  }
+
+  return normalizedRows;
+}
+
 async function activeRunMapForIssues(
   dbOrTx: any,
   issueRows: IssueWithLabels[],
@@ -594,7 +687,8 @@ export function issueService(db: Db) {
       .then((rows) => rows[0] ?? null);
     if (!row) return null;
     const [enriched] = await withIssueLabels(db, [row]);
-    return enriched;
+    const [reconciled] = await reconcileExecutionStateForIssues(db, [enriched]);
+    return reconciled;
   }
 
   async function getIssueByIdentifier(identifier: string) {
@@ -605,7 +699,8 @@ export function issueService(db: Db) {
       .then((rows) => rows[0] ?? null);
     if (!row) return null;
     const [enriched] = await withIssueLabels(db, [row]);
-    return enriched;
+    const [reconciled] = await reconcileExecutionStateForIssues(db, [enriched]);
+    return reconciled;
   }
 
   function redactIssueComment<T extends { body: string }>(comment: T, censorUsernameInLogs: boolean): T {
@@ -1062,8 +1157,9 @@ export function issueService(db: Db) {
         );
       const rows = limit === undefined ? await baseQuery : await baseQuery.limit(limit);
       const withLabels = await withIssueLabels(db, rows);
-      const runMap = await activeRunMapForIssues(db, withLabels);
-      const withRuns = withActiveRuns(withLabels, runMap);
+      const reconciled = await reconcileExecutionStateForIssues(db, withLabels);
+      const runMap = await activeRunMapForIssues(db, reconciled);
+      const withRuns = withActiveRuns(reconciled, runMap);
       if (withRuns.length === 0) {
         return withRuns;
       }
@@ -1797,11 +1893,24 @@ export function issueService(db: Db) {
           sql`select id from issues where id = ${id} for update`,
         );
         const preCheckRow = await tx
-          .select({ executionRunId: issues.executionRunId })
+          .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
           .from(issues)
           .where(eq(issues.id, id))
           .then((rows) => rows[0] ?? null);
         if (!preCheckRow?.executionRunId) return;
+        if (!preCheckRow.checkoutRunId) {
+          await tx
+            .update(issues)
+            .set({ executionRunId: null, executionAgentNameKey: null, executionLockedAt: null, updatedAt: now })
+            .where(
+              and(
+                eq(issues.id, id),
+                isNull(issues.checkoutRunId),
+                eq(issues.executionRunId, preCheckRow.executionRunId),
+              ),
+            );
+          return;
+        }
         const lockRun = await tx
           .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
           .from(heartbeatRuns)


### PR DESCRIPTION
## Summary
- stop heartbeat retry and promotion paths from minting issue execution ownership before a real checkout exists
- reconcile stale execution metadata on issue detail/list reads and clear orphaned state during checkout
- add regressions for stale execution redaction and mention-wake ownership leakage

## Verification
- `corepack pnpm -C /Users/ftimoshek/Documents/projects/paperclip exec vitest run server/src/__tests__/issues-service.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts` (tests skipped on this host because embedded Postgres failed to initialize)
- `corepack pnpm -C /Users/ftimoshek/Documents/projects/paperclip --filter @paperclipai/server exec tsc -p tsconfig.json --noEmit` (fails in pre-existing plugin-sdk workspace paths; no remaining errors from `server/src/services/heartbeat.ts` or `server/src/services/issues.ts`)

## Notes
- local install updated `pnpm-lock.yaml` due existing lock/config drift; that file is intentionally not included in this PR