### PR TITLE
fix: resolve @-mentions from /GSTA/agents/<urlKey> markdown links

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -23,7 +23,7 @@ import {
   projects,
 } from "@paperclipai/db";
 import type { IssueRelationIssueSummary } from "@paperclipai/shared";
-import { extractAgentMentionIds, extractProjectMentionIds, isUuidLike } from "@paperclipai/shared";
+import { extractAgentMentionIds, extractProjectMentionIds, isUuidLike, deriveAgentUrlKey } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import {
   defaultIssueExecutionWorkspaceSettingsForProject,
@@ -2383,14 +2383,30 @@ export function issueService(db: Db) {
         if (normalized) tokens.add(normalized.toLowerCase());
       }
 
+      // Also extract urlKey-based mentions: [@Name](/GSTA/agents/<urlKey>) or [Name](/GSTA/agents/<urlKey>)
+      const urlKeyMentionRe = /\[[^\]]*]\(\/[^/]+\/agents\/([^)\s]+)\)/gi;
+      const mentionedUrlKeys = new Set<string>();
+      let urlKeyMatch: RegExpExecArray | null;
+      while ((urlKeyMatch = urlKeyMentionRe.exec(body)) !== null) {
+        const urlKey = urlKeyMatch[1].toLowerCase().trim();
+        if (urlKey) mentionedUrlKeys.add(urlKey);
+      }
+
       const explicitAgentMentionIds = extractAgentMentionIds(body);
-      if (tokens.size === 0 && explicitAgentMentionIds.length === 0) return [];
+      if (tokens.size === 0 && explicitAgentMentionIds.length === 0 && mentionedUrlKeys.size === 0) return [];
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));
       const resolved = new Set<string>(explicitAgentMentionIds);
       for (const agent of rows) {
         if (tokens.has(agent.name.toLowerCase())) {
           resolved.add(agent.id);
+        }
+        // Match against urlKey derived from agent name
+        if (mentionedUrlKeys.size > 0) {
+          const agentUrlKey = deriveAgentUrlKey(agent.name, agent.id);
+          if (mentionedUrlKeys.has(agentUrlKey)) {
+            resolved.add(agent.id);
+          }
         }
       }
       return [...resolved];


### PR DESCRIPTION
## Problem
Agents consistently write mentions as `[@Name](/GSTA/agents/<urlKey>)` — standard web UI links. But `findMentionedAgents()` only resolved:
1. Plain `@Name` tokens (fails on multi-word names in markdown links)
2. `agent://` URI scheme links (agents never use this format)

This resulted in **0% mention resolution** — tagged agents never got woken up (GSTA-3584).

## Fix
Adds a third resolution path in `findMentionedAgents()` that:
1. Extracts urlKeys from `/GSTA/agents/<urlKey>` markdown links via regex
2. Derives urlKeys from agent names using `deriveAgentUrlKey()`
3. Matches them to resolve agent UUIDs

## Impact
Platform-level fix — no agent instruction changes needed. All existing comments with `[@Name](/GSTA/agents/urlkey)` format will now correctly wake mentioned agents.