### PR TITLE
fix(server): recover stuck heartbeat runs (GEA-857)

### DIFF
--- a/server/scripts/reap-stuck-runs.ts
+++ b/server/scripts/reap-stuck-runs.ts
@@ -1,0 +1,202 @@
+// One-shot hotfix script for GEA-857 — recovers heartbeat runs stuck in
+// `running` status with no liveness signal. Sets them to `failed` and releases
+// the issue execution lock so the scheduler can pick them up again.
+//
+// THE 30-MINUTE THRESHOLD IS DELIBERATELY BLUNT and only suitable for a one-off
+// manual intervention. Do NOT reuse this number as a generic watchdog default —
+// the structural fix in `heartbeatService.reapOrphanedRuns` uses a per-agent,
+// interval-aware timeout (`max(agent.heartbeatIntervalSec * 2, 600s)`).
+//
+// Usage:
+//   pnpm --filter @paperclipai/server tsx scripts/reap-stuck-runs.ts \
+//     [--apply] [--threshold-minutes 30] [--config /path/to/config.json]
+//
+// Default mode: dry-run (prints affected runs without changing the DB).
+// Pass `--apply` to perform the writes.
+
+import { and, eq, isNull, lt, sql } from "drizzle-orm";
+import {
+  agentWakeupRequests,
+  agents,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import { loadConfig } from "../src/config.js";
+
+type Db = ReturnType<typeof createDb>;
+type StuckRunRow = {
+  runId: string;
+  companyId: string;
+  agentId: string;
+  agentName: string | null;
+  startedAt: Date | null;
+  errorCode: string | null;
+  wakeupRequestId: string | null;
+  contextSnapshot: Record<string, unknown> | null;
+};
+
+const HOTFIX_ERROR_MESSAGE = "stuck-run recovery (manual hotfix GEA-857)";
+const HOTFIX_ERROR_CODE = "process_stuck_hotfix";
+
+function readArg(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index === -1) return null;
+  return process.argv[index + 1] ?? null;
+}
+
+function hasFlag(flag: string): boolean {
+  return process.argv.includes(flag);
+}
+
+function resolveDatabaseUrl(): string {
+  if (process.env.PAPERCLIP_CONFIG === undefined) {
+    const overrideConfig = readArg("--config");
+    if (overrideConfig) process.env.PAPERCLIP_CONFIG = overrideConfig;
+  }
+  const config = loadConfig();
+  if (config.databaseUrl) return config.databaseUrl;
+  if (config.databaseMode === "embedded-postgres") {
+    return `postgres://paperclip:paperclip@127.0.0.1:${config.embeddedPostgresPort}/paperclip`;
+  }
+  throw new Error("Could not resolve database URL: set DATABASE_URL or configure database in config.json");
+}
+
+async function findStuckRuns(db: Db, threshold: Date): Promise<StuckRunRow[]> {
+  const rows = await db
+    .select({
+      runId: heartbeatRuns.id,
+      companyId: heartbeatRuns.companyId,
+      agentId: heartbeatRuns.agentId,
+      agentName: agents.name,
+      startedAt: heartbeatRuns.startedAt,
+      errorCode: heartbeatRuns.errorCode,
+      wakeupRequestId: heartbeatRuns.wakeupRequestId,
+      contextSnapshot: heartbeatRuns.contextSnapshot,
+    })
+    .from(heartbeatRuns)
+    .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+    .where(
+      and(
+        eq(heartbeatRuns.status, "running"),
+        isNull(heartbeatRuns.finishedAt),
+        lt(heartbeatRuns.startedAt, threshold),
+      ),
+    );
+  return rows;
+}
+
+async function reapRun(db: Db, run: StuckRunRow, now: Date): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx
+      .update(heartbeatRuns)
+      .set({
+        status: "failed",
+        error: HOTFIX_ERROR_MESSAGE,
+        errorCode: HOTFIX_ERROR_CODE,
+        finishedAt: now,
+        updatedAt: now,
+      })
+      .where(and(eq(heartbeatRuns.id, run.runId), eq(heartbeatRuns.status, "running")));
+
+    if (run.wakeupRequestId) {
+      await tx
+        .update(agentWakeupRequests)
+        .set({
+          status: "failed",
+          finishedAt: now,
+          error: HOTFIX_ERROR_MESSAGE,
+          updatedAt: now,
+        })
+        .where(eq(agentWakeupRequests.id, run.wakeupRequestId));
+    }
+
+    // Release the issue execution lock for any issue holding this run.
+    // Mirrors `releaseIssueExecutionAndPromote` minus deferred-wakeup promotion;
+    // the next scheduler tick will pick up deferred wakeups normally.
+    const contextIssueId =
+      typeof run.contextSnapshot === "object" &&
+      run.contextSnapshot !== null &&
+      typeof (run.contextSnapshot as Record<string, unknown>).issueId === "string"
+        ? ((run.contextSnapshot as Record<string, unknown>).issueId as string)
+        : null;
+
+    await tx
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(issues.companyId, run.companyId),
+          eq(issues.executionRunId, run.runId),
+          contextIssueId ? eq(issues.id, contextIssueId) : sql`true`,
+        ),
+      );
+  });
+}
+
+async function main() {
+  const apply = hasFlag("--apply");
+  const thresholdMinutesArg = readArg("--threshold-minutes");
+  const thresholdMinutes = thresholdMinutesArg ? Number(thresholdMinutesArg) : 30;
+  if (!Number.isFinite(thresholdMinutes) || thresholdMinutes <= 0) {
+    throw new Error(`Invalid --threshold-minutes: ${thresholdMinutesArg}`);
+  }
+
+  const dbUrl = resolveDatabaseUrl();
+  const db = createDb(dbUrl);
+  const closableDb = db as typeof db & {
+    $client?: { end?: (options?: { timeout?: number }) => Promise<void> };
+  };
+
+  try {
+    const now = new Date();
+    const threshold = new Date(now.getTime() - thresholdMinutes * 60_000);
+
+    process.stdout.write(
+      `[reap-stuck-runs] mode=${apply ? "APPLY" : "dry-run"} threshold=${thresholdMinutes}m ` +
+        `(runs started before ${threshold.toISOString()})\n`,
+    );
+
+    const stuck = await findStuckRuns(db, threshold);
+    process.stdout.write(`[reap-stuck-runs] found ${stuck.length} stuck run(s)\n`);
+    for (const run of stuck) {
+      process.stdout.write(
+        `  - run=${run.runId} agent=${run.agentName ?? run.agentId} ` +
+          `startedAt=${run.startedAt?.toISOString() ?? "null"} ` +
+          `errorCode=${run.errorCode ?? "null"}\n`,
+      );
+    }
+
+    if (!apply) {
+      process.stdout.write("[reap-stuck-runs] dry-run only — pass --apply to write changes\n");
+      return;
+    }
+
+    let reaped = 0;
+    let failed = 0;
+    for (const run of stuck) {
+      try {
+        await reapRun(db, run, now);
+        reaped += 1;
+        process.stdout.write(`[reap-stuck-runs] reaped ${run.runId}\n`);
+      } catch (err) {
+        failed += 1;
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[reap-stuck-runs] FAILED to reap ${run.runId}: ${msg}\n`);
+      }
+    }
+    process.stdout.write(`[reap-stuck-runs] done — reaped=${reaped} failed=${failed}\n`);
+  } finally {
+    await closableDb.$client?.end?.({ timeout: 5 }).catch(() => undefined);
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/server/scripts/reap-stuck-runs.ts
+++ b/server/scripts/reap-stuck-runs.ts
@@ -1,11 +1,15 @@
 // One-shot hotfix script for GEA-857 — recovers heartbeat runs stuck in
-// `running` status with no liveness signal. Sets them to `failed` and releases
-// the issue execution lock so the scheduler can pick them up again.
+// `running` status with no liveness signal. Delegates the actual reap to
+// `heartbeatService.reapOrphanedRuns({ staleThresholdMs })`, which is the
+// same primitive the periodic sweeper uses (and which calls
+// `releaseIssueExecutionAndPromote` so any deferred wakeups waiting on the
+// stuck run's execution lock get promoted instead of stranded).
 //
 // THE 30-MINUTE THRESHOLD IS DELIBERATELY BLUNT and only suitable for a one-off
 // manual intervention. Do NOT reuse this number as a generic watchdog default —
 // the structural fix in `heartbeatService.reapOrphanedRuns` uses a per-agent,
-// interval-aware timeout (`max(agent.heartbeatIntervalSec * 2, 600s)`).
+// interval-aware timeout (`max(agent.heartbeatIntervalSec * 2, 600s)`) for
+// `process_detached` runs.
 //
 // Usage:
 //   pnpm --filter @paperclipai/server tsx scripts/reap-stuck-runs.ts \
@@ -14,30 +18,24 @@
 // Default mode: dry-run (prints affected runs without changing the DB).
 // Pass `--apply` to perform the writes.
 
-import { and, eq, isNull, lt, sql } from "drizzle-orm";
+import { and, eq, isNull, lt } from "drizzle-orm";
 import {
-  agentWakeupRequests,
   agents,
   createDb,
   heartbeatRuns,
-  issues,
 } from "@paperclipai/db";
 import { loadConfig } from "../src/config.js";
+import { heartbeatService } from "../src/services/heartbeat.js";
 
 type Db = ReturnType<typeof createDb>;
 type StuckRunRow = {
   runId: string;
-  companyId: string;
   agentId: string;
   agentName: string | null;
   startedAt: Date | null;
+  updatedAt: Date | null;
   errorCode: string | null;
-  wakeupRequestId: string | null;
-  contextSnapshot: Record<string, unknown> | null;
 };
-
-const HOTFIX_ERROR_MESSAGE = "stuck-run recovery (manual hotfix GEA-857)";
-const HOTFIX_ERROR_CODE = "process_stuck_hotfix";
 
 function readArg(flag: string): string | null {
   const index = process.argv.indexOf(flag);
@@ -66,13 +64,11 @@ async function findStuckRuns(db: Db, threshold: Date): Promise<StuckRunRow[]> {
   const rows = await db
     .select({
       runId: heartbeatRuns.id,
-      companyId: heartbeatRuns.companyId,
       agentId: heartbeatRuns.agentId,
       agentName: agents.name,
       startedAt: heartbeatRuns.startedAt,
+      updatedAt: heartbeatRuns.updatedAt,
       errorCode: heartbeatRuns.errorCode,
-      wakeupRequestId: heartbeatRuns.wakeupRequestId,
-      contextSnapshot: heartbeatRuns.contextSnapshot,
     })
     .from(heartbeatRuns)
     .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
@@ -80,63 +76,10 @@ async function findStuckRuns(db: Db, threshold: Date): Promise<StuckRunRow[]> {
       and(
         eq(heartbeatRuns.status, "running"),
         isNull(heartbeatRuns.finishedAt),
-        lt(heartbeatRuns.startedAt, threshold),
+        lt(heartbeatRuns.updatedAt, threshold),
       ),
     );
   return rows;
-}
-
-async function reapRun(db: Db, run: StuckRunRow, now: Date): Promise<void> {
-  await db.transaction(async (tx) => {
-    await tx
-      .update(heartbeatRuns)
-      .set({
-        status: "failed",
-        error: HOTFIX_ERROR_MESSAGE,
-        errorCode: HOTFIX_ERROR_CODE,
-        finishedAt: now,
-        updatedAt: now,
-      })
-      .where(and(eq(heartbeatRuns.id, run.runId), eq(heartbeatRuns.status, "running")));
-
-    if (run.wakeupRequestId) {
-      await tx
-        .update(agentWakeupRequests)
-        .set({
-          status: "failed",
-          finishedAt: now,
-          error: HOTFIX_ERROR_MESSAGE,
-          updatedAt: now,
-        })
-        .where(eq(agentWakeupRequests.id, run.wakeupRequestId));
-    }
-
-    // Release the issue execution lock for any issue holding this run.
-    // Mirrors `releaseIssueExecutionAndPromote` minus deferred-wakeup promotion;
-    // the next scheduler tick will pick up deferred wakeups normally.
-    const contextIssueId =
-      typeof run.contextSnapshot === "object" &&
-      run.contextSnapshot !== null &&
-      typeof (run.contextSnapshot as Record<string, unknown>).issueId === "string"
-        ? ((run.contextSnapshot as Record<string, unknown>).issueId as string)
-        : null;
-
-    await tx
-      .update(issues)
-      .set({
-        executionRunId: null,
-        executionAgentNameKey: null,
-        executionLockedAt: null,
-        updatedAt: now,
-      })
-      .where(
-        and(
-          eq(issues.companyId, run.companyId),
-          eq(issues.executionRunId, run.runId),
-          contextIssueId ? eq(issues.id, contextIssueId) : sql`true`,
-        ),
-      );
-  });
 }
 
 async function main() {
@@ -155,19 +98,21 @@ async function main() {
 
   try {
     const now = new Date();
-    const threshold = new Date(now.getTime() - thresholdMinutes * 60_000);
+    const thresholdMs = thresholdMinutes * 60_000;
+    const threshold = new Date(now.getTime() - thresholdMs);
 
     process.stdout.write(
       `[reap-stuck-runs] mode=${apply ? "APPLY" : "dry-run"} threshold=${thresholdMinutes}m ` +
-        `(runs started before ${threshold.toISOString()})\n`,
+        `(runs whose updatedAt is older than ${threshold.toISOString()})\n`,
     );
 
     const stuck = await findStuckRuns(db, threshold);
-    process.stdout.write(`[reap-stuck-runs] found ${stuck.length} stuck run(s)\n`);
+    process.stdout.write(`[reap-stuck-runs] preview: ${stuck.length} candidate run(s)\n`);
     for (const run of stuck) {
       process.stdout.write(
         `  - run=${run.runId} agent=${run.agentName ?? run.agentId} ` +
           `startedAt=${run.startedAt?.toISOString() ?? "null"} ` +
+          `updatedAt=${run.updatedAt?.toISOString() ?? "null"} ` +
           `errorCode=${run.errorCode ?? "null"}\n`,
       );
     }
@@ -177,20 +122,15 @@ async function main() {
       return;
     }
 
-    let reaped = 0;
-    let failed = 0;
-    for (const run of stuck) {
-      try {
-        await reapRun(db, run, now);
-        reaped += 1;
-        process.stdout.write(`[reap-stuck-runs] reaped ${run.runId}\n`);
-      } catch (err) {
-        failed += 1;
-        const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(`[reap-stuck-runs] FAILED to reap ${run.runId}: ${msg}\n`);
-      }
-    }
-    process.stdout.write(`[reap-stuck-runs] done — reaped=${reaped} failed=${failed}\n`);
+    // Delegate to the canonical primitive. It applies its own per-error-code
+    // logic (process_detached → max(intervalSec*2, 600s); process_lost path
+    // for runs with no detached marker) AND calls releaseIssueExecutionAndPromote
+    // so deferred wakeups don't get stranded.
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: thresholdMs });
+    process.stdout.write(
+      `[reap-stuck-runs] done — reaped=${result.reaped} runIds=${JSON.stringify(result.runIds)}\n`,
+    );
   } finally {
     await closableDb.$client?.end?.({ timeout: 5 }).catch(() => undefined);
   }

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -568,6 +568,74 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.executionRunId).toBeNull();
   });
 
+  it("does NOT reap a process_detached run while still under the threshold", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    // intervalSec=60 → threshold = max(120s, 600s) = 600s. Use 5 minutes
+    // staleness — well under the 600s floor, so no reap.
+    const stalenessMs = 5 * 60 * 1000;
+    const runUpdatedAt = new Date(Date.now() - stalenessMs);
+
+    const { runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      runErrorCode: "process_detached",
+      runError: `Lost in-memory process handle, but child pid ${child.pid} is still alive`,
+      runUpdatedAt,
+      agentRuntimeConfig: { heartbeat: { intervalSec: 60 } },
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+
+    expect(result.reaped).toBe(0);
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    expect(run?.errorCode).toBe("process_detached");
+  });
+
+  it("scales the stuck-detached threshold to 2x interval when interval > 300s", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    // intervalSec=400 → threshold = max(800s, 600s) = 800s. The 600s floor must
+    // NOT clamp here. Stage staleness at 700s: above the floor but below 2x
+    // interval, so the run must remain.
+    const stalenessMs = 700 * 1000;
+    const runUpdatedAt = new Date(Date.now() - stalenessMs);
+
+    const { runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      runErrorCode: "process_detached",
+      runError: `Lost in-memory process handle, but child pid ${child.pid} is still alive`,
+      runUpdatedAt,
+      agentRuntimeConfig: { heartbeat: { intervalSec: 400 } },
+    });
+
+    const heartbeat = heartbeatService(db);
+
+    // Below 2x interval — no reap.
+    const firstResult = await heartbeat.reapOrphanedRuns();
+    expect(firstResult.reaped).toBe(0);
+    let run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    expect(run?.errorCode).toBe("process_detached");
+
+    // Now age the run further so it crosses 2x interval (900s > 800s) — reap.
+    await db
+      .update(heartbeatRuns)
+      .set({ updatedAt: new Date(Date.now() - 900 * 1000) })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const secondResult = await heartbeat.reapOrphanedRuns();
+    expect(secondResult.reaped).toBe(1);
+    run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_stuck");
+  });
+
   it("clears the detached warning when the run reports activity again", async () => {
     const { runId } = await seedRunFixture({
       includeIssue: false,

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -226,6 +226,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     includeIssue?: boolean;
     runErrorCode?: string | null;
     runError?: string | null;
+    runUpdatedAt?: Date;
+    agentRuntimeConfig?: Record<string, unknown>;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -250,7 +252,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       status: input?.agentStatus ?? "paused",
       adapterType: input?.adapterType ?? "codex_local",
       adapterConfig: {},
-      runtimeConfig: {},
+      runtimeConfig: input?.agentRuntimeConfig ?? {},
       permissions: {},
     });
 
@@ -282,7 +284,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       errorCode: input?.runErrorCode ?? null,
       error: input?.runError ?? null,
       startedAt: now,
-      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      updatedAt: input?.runUpdatedAt ?? new Date("2026-03-19T00:00:00.000Z"),
     });
 
     if (input?.includeIssue !== false) {
@@ -516,6 +518,54 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBeNull();
     expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it("reaps a process_detached run after 2x agent interval without activity", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    // Use a small interval (60s) so the threshold is the 600s floor.
+    // Set updatedAt 20 minutes in the past relative to "now" — well over the
+    // 600s/10min floor but well under any plausible clock skew.
+    const stalenessMs = 20 * 60 * 1000;
+    const runUpdatedAt = new Date(Date.now() - stalenessMs);
+
+    const { agentId, runId, issueId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      runErrorCode: "process_detached",
+      runError: `Lost in-memory process handle, but child pid ${child.pid} is still alive`,
+      runUpdatedAt,
+      agentRuntimeConfig: { heartbeat: { intervalSec: 60 } },
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    // Stuck-detached runs must NOT be retried (the pid is suspect under PID
+    // recycling; a retry would not address the root cause).
+    expect(runs).toHaveLength(1);
+
+    const failedRun = runs[0];
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_stuck");
+    expect(failedRun?.error).toContain("stuck");
+    expect(failedRun?.finishedAt).not.toBeNull();
+
+    // The issue execution lock must be released so future runs can claim it.
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2765,6 +2765,12 @@ export function heartbeatService(db: Db) {
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
+      // When a detached run shows no liveness signal (no `reportRunActivity` call,
+      // which would bump `updatedAt` and clear the detached errorCode) for longer
+      // than `max(agent.heartbeatIntervalSec * 2, 600s)`, treat it as stuck and
+      // reap even if the recorded pid is still "alive" — under PID recycling that
+      // pid likely belongs to an unrelated process now (GEA-857).
+      let stuckDetachedReason: { thresholdMs: number; staleMs: number } | null = null;
       if (processPidAlive) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
@@ -2783,12 +2789,21 @@ export function heartbeatService(db: Db) {
               },
             });
           }
+          continue;
         }
-        continue;
+        const detachedAgent = await getAgent(run.agentId);
+        const intervalSec = detachedAgent ? parseHeartbeatPolicy(detachedAgent).intervalSec : 0;
+        const detachedStuckMs = Math.max(intervalSec * 2 * 1000, 600_000);
+        const detachedRefMs = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
+        const detachedStaleMs = now.getTime() - detachedRefMs;
+        if (detachedStaleMs < detachedStuckMs) continue;
+        stuckDetachedReason = { thresholdMs: detachedStuckMs, staleMs: detachedStaleMs };
+        // Fall through to reap, but do NOT call terminateHeartbeatRunProcess —
+        // the recorded pid may belong to an unrelated process (PID recycling).
       }
 
       let descendantOnlyCleanup = false;
-      if (processGroupAlive) {
+      if (!stuckDetachedReason && processGroupAlive) {
         descendantOnlyCleanup = true;
         await terminateHeartbeatRunProcess({
           pid: run.processPid,
@@ -2796,12 +2811,20 @@ export function heartbeatService(db: Db) {
         });
       }
 
-      const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
-      const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const shouldRetry =
+        !stuckDetachedReason &&
+        tracksLocalChild &&
+        (!!run.processPid || !!run.processGroupId) &&
+        (run.processLossRetryCount ?? 0) < 1;
+      const baseMessage = stuckDetachedReason
+        ? `Detached worker showed no activity for ${Math.round(stuckDetachedReason.staleMs / 1000)}s ` +
+          `(threshold ${Math.round(stuckDetachedReason.thresholdMs / 1000)}s); ` +
+          `reaping as stuck. pid ${run.processPid} may belong to an unrelated process (PID recycling).`
+        : buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
 
       let finalizedRun = await setRunStatus(run.id, "failed", {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
-        errorCode: "process_lost",
+        errorCode: stuckDetachedReason ? "process_stuck" : "process_lost",
         finishedAt: now,
       });
       await setWakeupStatus(run.wakeupRequestId, "failed", {
@@ -2833,6 +2856,13 @@ export function heartbeatService(db: Db) {
           ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
           ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
           ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
+          ...(stuckDetachedReason
+            ? {
+                stuckDetached: true,
+                staleMs: stuckDetachedReason.staleMs,
+                thresholdMs: stuckDetachedReason.thresholdMs,
+              }
+            : {}),
         },
       });
 


### PR DESCRIPTION
## Summary

Recovers heartbeat runs stuck in `running` status due to PID-recycling masking the `process_detached → reap` path. Two-part fix:

**1. One-shot hotfix script** (`server/scripts/reap-stuck-runs.ts`)
Manual escape hatch for the production runs already stuck. Dry-run by default; pass `--apply` to write. Marks `running` rows older than `--threshold-minutes` (default 30) as `failed`, fails their wakeup_request, and clears `issues.executionRunId` so the scheduler can pick the work up again.

The 30-minute threshold is intentionally blunt and only suitable for one-off intervention — the structural fix uses a per-agent, interval-aware timeout. Header comment makes this explicit.

**2. Structural fix** (`server/src/services/heartbeat.ts` → `reapOrphanedRuns`)
When a `process_detached` run shows no liveness signal (no `reportRunActivity` call — the only path that bumps `updated_at` and clears the detached state) for longer than `max(agent.heartbeatIntervalSec * 2, 600s)`, reap it as `process_stuck`.

Stuck-detached runs are deliberately:
- **NOT retried** — the recorded pid is suspect under recycling; retry won't address the root cause
- **NOT subject to `terminateHeartbeatRunProcess`** — the pid may belong to an unrelated process

## Why this happened (Sam's run, 64h+ stuck)

`reapOrphanedRuns` checks `isProcessAlive(run.processPid)`. Under Linux PID recycling that eventually succeeds against an unrelated process, so the run is repeatedly marked `process_detached` instead of failed. Without a liveness signal, it never escapes that state.

## Test plan

- [x] New test: `reaps a process_detached run after 2x agent interval without activity`
- [x] All 12 heartbeat-process-recovery tests pass
- [x] `pnpm --filter @paperclipai/server typecheck` clean
- [ ] Run hotfix script in production with `--apply` if any stuck runs remain
- [ ] Monitor `process_stuck` errorCode in heartbeat_runs after rollout

## Notes

- Metrics counter for `process_stuck` reaps was scoped out — the server has no `prom-client`/`/metrics` infrastructure to attach to. Logs already capture `reapedCount`/`runIds` via `logger.warn("reaped orphaned heartbeat runs", ...)`. Worth a follow-up issue for proper observability.

GEA-857