### PR TITLE
fix(plugin-loader): resolve symlinks in worker entrypoint path

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1891,13 +1891,23 @@ function resolveWorkerEntrypoint(
   // For local-path installs we persist the resolved package path; use it first
   if (plugin.packagePath && existsSync(plugin.packagePath)) {
     const entrypoint = path.resolve(plugin.packagePath, workerRelPath);
-    if (entrypoint.startsWith(path.resolve(plugin.packagePath)) && existsSync(entrypoint)) {
+    const resolvedPackagePath = path.resolve(plugin.packagePath);
+    // Use `dir + path.sep` so a string-prefix match cannot escape into a sibling
+    // directory (e.g. `/opt/plugins/foo` must not match `/opt/plugins/foobar/...`).
+    if (
+      (entrypoint === resolvedPackagePath ||
+        entrypoint.startsWith(resolvedPackagePath + path.sep)) &&
+      existsSync(entrypoint)
+    ) {
       // Resolve symlinks so process.argv[1] in the forked worker matches import.meta.url.
       // Re-check containment against the resolved real path to prevent a symlinked
       // entrypoint from escaping the package boundary.
       const realEntrypoint = realpathSync(entrypoint);
       const realPackagePath = realpathSync(plugin.packagePath);
-      if (realEntrypoint.startsWith(realPackagePath)) {
+      if (
+        realEntrypoint === realPackagePath ||
+        realEntrypoint.startsWith(realPackagePath + path.sep)
+      ) {
         return realEntrypoint;
       }
     }
@@ -1922,9 +1932,12 @@ function resolveWorkerEntrypoint(
   // Try in order: node_modules path, direct path
   for (const dir of [packageDir, directDir]) {
     const entrypoint = path.resolve(dir, workerRelPath);
+    const resolvedDir = path.resolve(dir);
 
-    // Security: ensure entrypoint is actually inside the directory (prevent path traversal)
-    if (!entrypoint.startsWith(path.resolve(dir))) {
+    // Security: ensure entrypoint is actually inside the directory (prevent path traversal).
+    // Use `dir + path.sep` so a string-prefix match cannot escape into a sibling directory
+    // (e.g. `/opt/plugins/foo` must not match `/opt/plugins/foobar/...`).
+    if (entrypoint !== resolvedDir && !entrypoint.startsWith(resolvedDir + path.sep)) {
       continue;
     }
 
@@ -1935,7 +1948,7 @@ function resolveWorkerEntrypoint(
       // entrypoint from escaping the package directory boundary.
       const realEntrypoint = realpathSync(entrypoint);
       const realDir = realpathSync(dir);
-      if (!realEntrypoint.startsWith(realDir)) {
+      if (realEntrypoint !== realDir && !realEntrypoint.startsWith(realDir + path.sep)) {
         continue;
       }
       return realEntrypoint;

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -24,7 +24,7 @@
  * @see PLUGIN_SPEC.md §10 — Package Contract
  * @see PLUGIN_SPEC.md §12 — Process Model
  */
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { readdir, readFile, rm, stat } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import os from "node:os";
@@ -1892,7 +1892,7 @@ function resolveWorkerEntrypoint(
   if (plugin.packagePath && existsSync(plugin.packagePath)) {
     const entrypoint = path.resolve(plugin.packagePath, workerRelPath);
     if (entrypoint.startsWith(path.resolve(plugin.packagePath)) && existsSync(entrypoint)) {
-      return entrypoint;
+      return realpathSync(entrypoint);
     }
   }
 
@@ -1922,14 +1922,16 @@ function resolveWorkerEntrypoint(
     }
 
     if (existsSync(entrypoint)) {
-      return entrypoint;
+      // Resolve symlinks so process.argv[1] in the forked worker matches import.meta.url
+      // (Node.js resolves symlinks in import.meta.url but fork() passes the path as-is)
+      return realpathSync(entrypoint);
     }
   }
 
   // Fallback: try the worker path as-is (absolute or relative to cwd)
   // ONLY if it's already an absolute path and we trust the manifest (which we've already validated)
   if (path.isAbsolute(workerRelPath) && existsSync(workerRelPath)) {
-    return workerRelPath;
+    return realpathSync(workerRelPath);
   }
 
   throw new Error(

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1892,7 +1892,14 @@ function resolveWorkerEntrypoint(
   if (plugin.packagePath && existsSync(plugin.packagePath)) {
     const entrypoint = path.resolve(plugin.packagePath, workerRelPath);
     if (entrypoint.startsWith(path.resolve(plugin.packagePath)) && existsSync(entrypoint)) {
-      return realpathSync(entrypoint);
+      // Resolve symlinks so process.argv[1] in the forked worker matches import.meta.url.
+      // Re-check containment against the resolved real path to prevent a symlinked
+      // entrypoint from escaping the package boundary.
+      const realEntrypoint = realpathSync(entrypoint);
+      const realPackagePath = realpathSync(plugin.packagePath);
+      if (realEntrypoint.startsWith(realPackagePath)) {
+        return realEntrypoint;
+      }
     }
   }
 
@@ -1923,8 +1930,15 @@ function resolveWorkerEntrypoint(
 
     if (existsSync(entrypoint)) {
       // Resolve symlinks so process.argv[1] in the forked worker matches import.meta.url
-      // (Node.js resolves symlinks in import.meta.url but fork() passes the path as-is)
-      return realpathSync(entrypoint);
+      // (Node.js resolves symlinks in import.meta.url but fork() passes the path as-is).
+      // Re-check containment against the resolved real path to prevent a symlinked
+      // entrypoint from escaping the package directory boundary.
+      const realEntrypoint = realpathSync(entrypoint);
+      const realDir = realpathSync(dir);
+      if (!realEntrypoint.startsWith(realDir)) {
+        continue;
+      }
+      return realEntrypoint;
     }
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The plugin subsystem loads first-party and third-party plugins into dedicated worker processes via `child_process.fork()`
> - Each plugin worker uses the SDK's `runWorker()` entrypoint, which guards against being imported as a library by checking whether the file was invoked as the process's main module (`thisFile === entryPath`)
> - When the Paperclip install directory is reached through a symlink (e.g. `/home/kasm-user/.paperclip` → `/user-workspace-mount/home/.paperclip`), `fork()` preserves the symlinked path in `process.argv[1]`, but Node.js resolves symlinks in `import.meta.url` — so the two don't match and the main-module check always fails
> - The result: every plugin worker loads its module, finds no match, and immediately exits with `code=0, signal=null`. All plugins appear to "fail silently" with no diagnostic.
> - This PR resolves symlinks on the entrypoint path before passing it to `fork()` so the main-module check passes in symlinked installs
> - The benefit is that Paperclip installs reliably under symlinked home directories (containers, mounted workspaces, dev environments) — which is otherwise a total-loss failure mode for the plugin system

## What Changed

- `server/src/services/plugin-loader.ts`: `resolveWorkerEntrypoint()` now applies `fs.realpathSync()` to every resolved entrypoint before returning it, so `process.argv[1]` in the forked worker matches Node's symlink-resolved `import.meta.url`.
- Containment check is re-evaluated against the resolved real paths (of both the entrypoint and its enclosing package/install directory) to prevent a symlinked worker entrypoint inside a package from escaping the package boundary — addresses Greptile P2 review feedback on the first commit.
- No API, schema, or behavior changes outside this function.

## Verification

- **Pre-fix, direct worker invocation:** `node /path/to/worker.js` on a symlinked path → exits immediately with `code=0`, no RPC host started.
- **Pre-fix, `fork()` with symlinked path:** same — worker exits `code=0`.
- **Post-fix:** worker stays alive, sends the expected `config.get` RPC during `setup()`, transitions through the activation state machine normally.
- **End-to-end:** re-enabling the affected plugins (`tomismeta.paperclip-aperture`, `paperclip-plugin-acp`, `paperclip-plugin-avp`, `paperclip-plugin-telegram`, `paperclip-plugin-hindsight`) via Settings → Plugins activates them cleanly. Before the fix, all five were stuck in `error` with identical `Worker process exited (code=0, signal=null)` logs.
- **Non-symlinked install:** unchanged — `realpathSync()` on an already-canonical path is an identity operation.

## Risks

- **Low risk overall.** The change is one file, +23/-7 lines across two commits, and only mutates the return value of a single resolver function.
- `realpathSync()` is a read-only filesystem call on a path that has already been verified to exist via `existsSync()`; it cannot introduce side effects.
- Containment re-check uses `startsWith()` on resolved absolute paths — same semantics as the pre-existing path-traversal guard, just evaluated on the canonical path.
- The absolute-path fallback branch intentionally retains the single `realpathSync()` call without an enclosing-dir check because there is no directory to validate against; the existing inline comment already documents that this branch trusts the validated manifest.
- No migration, no behavioral change for callers, no new dependencies.

## Model Used

- **Provider / model:** Anthropic Claude — Opus 4.7 (1M context)
- **Reasoning mode:** standard (no extended thinking)
- **Tool use:** file reads, edits, shell — operated within the Paperclip agent harness
- The diagnosis, fix, hardening, and this PR description were drafted by the Paperclip Web Architect agent (`claude-opus-4-7[1m]`) working under the Paperclip CEO agent, based on logs from a reproducing install; all output was reviewed by a human (@amirhmoradi) before submission.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable — no unit test added; the failure mode depends on a symlinked install and is hard to reproduce in the existing unit suite. Happy to add an integration test if reviewers want one.
- [x] If this change affects the UI, I have included before/after screenshots — N/A (server-only).
- [x] I have updated relevant documentation to reflect my changes — no user-facing docs affected; inline comments explain the non-obvious `realpathSync` + re-containment logic.
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
