### PR TITLE
fix(issues): accept array form of status filter in list endpoint

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -640,8 +640,17 @@ export function issueRoutes(
       return;
     }
 
+    // Normalize ?status=X&status=Y (array form) and ?status=X,Y (comma form) to a single
+    // comma-joined string — the service expects string and calls .split(",") internally.
+    const rawStatus = req.query.status;
+    const status = Array.isArray(rawStatus)
+      ? rawStatus.filter((v): v is string => typeof v === "string").join(",")
+      : typeof rawStatus === "string"
+        ? rawStatus
+        : undefined;
+
     const result = await svc.list(companyId, {
-      status: req.query.status as string | undefined,
+      status,
       assigneeAgentId: req.query.assigneeAgentId as string | undefined,
       participantAgentId: req.query.participantAgentId as string | undefined,
       assigneeUserId,


### PR DESCRIPTION
## Problem

`GET /api/companies/:companyId/issues` returns **500** when `status` is passed as repeated query params:

```
GET /api/companies/{id}/issues?status=todo&status=in_progress
→ TypeError: filters.status.split is not a function
```

Express parses repeated params as an array (`["todo","in_progress"]`), but the service at `services/issues.ts:989` calls `filters.status.split(",")` on it, assuming a string. The route layer casts with `as string | undefined`, which is a lying cast — `req.query.status` is actually `string | string[] | ParsedQs | ParsedQs[] | undefined`.

Observed in production logs on a Paperclip instance — one in-the-wild 500, but it's a landmine for any new integration that uses the standard repeated-param form instead of the comma form.

## Fix

Normalize both query forms at the route layer before calling the service:

- `?status=todo,in_progress` (comma form) — passed through unchanged
- `?status=todo&status=in_progress` (array form) — joined with commas
- anything else (non-string, non-array) — `undefined`

The service contract (`status?: string`) is preserved, no service-level changes.

This mirrors the guard pattern already used at the feedback-traces endpoint in the same file (around line 2267):

```ts
const statusRaw = typeof req.query.status === "string" ? req.query.status : undefined;
```

## Test plan

- [ ] `GET /issues?status=todo` — existing behavior, unchanged
- [ ] `GET /issues?status=todo,in_progress` — existing behavior, unchanged
- [ ] `GET /issues?status=todo&status=in_progress` — now returns 200 with both statuses filtered (was 500)
- [ ] `GET /issues` (no status) — existing behavior, unchanged

Happy to add a route-level test if maintainers want — didn't see an existing test file for this endpoint (`issues-service.test.ts` covers the service; no route test exists for `GET /companies/:companyId/issues`). Glad to add one on request.