### PR TITLE
feat(plugins): emit agent.run.* lifecycle events per PLUGIN_SPEC §16

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2125,6 +2125,53 @@ export function heartbeatService(db: Db) {
       .then((rows) => rows[0]);
   }
 
+  async function emitRunLifecyclePluginEvent(
+    run: typeof heartbeatRuns.$inferSelect,
+  ): Promise<void> {
+    const actionByStatus: Record<string, string> = {
+      running: "agent.run.started",
+      succeeded: "agent.run.finished",
+      failed: "agent.run.failed",
+      cancelled: "agent.run.cancelled",
+    };
+    const action = actionByStatus[run.status];
+    if (!action) return;
+    const details: Record<string, unknown> = {
+      agentId: run.agentId,
+      runId: run.id,
+    };
+    const context = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(context.issueId);
+    if (issueId && action === "agent.run.started") {
+      const issue = await db
+        .select({ title: issues.title, description: issues.description })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      if (issue) {
+        details.issueTitle = issue.title;
+        details.issueDescription = issue.description;
+      }
+    }
+    if (action === "agent.run.finished" || action === "agent.run.failed") {
+      const resultJson = run.resultJson ?? null;
+      const stdoutExcerpt = run.stdoutExcerpt ?? null;
+      if (stdoutExcerpt) details.output = stdoutExcerpt;
+      if (resultJson) details.result = typeof resultJson === "string" ? resultJson : JSON.stringify(resultJson);
+    }
+    await logActivity(db, {
+      companyId: run.companyId,
+      actorType: "system",
+      actorId: "heartbeat",
+      agentId: run.agentId,
+      runId: run.id,
+      action,
+      entityType: "heartbeat_run",
+      entityId: run.id,
+      details,
+    });
+  }
+
   async function setRunStatus(
     runId: string,
     status: string,
@@ -2153,6 +2200,7 @@ export function heartbeatService(db: Db) {
           finishedAt: updated.finishedAt ? new Date(updated.finishedAt).toISOString() : null,
         },
       });
+      await emitRunLifecyclePluginEvent(updated);
     }
 
     return updated;
@@ -2656,6 +2704,7 @@ export function heartbeatService(db: Db) {
         finishedAt: claimed.finishedAt ? new Date(claimed.finishedAt).toISOString() : null,
       },
     });
+    await emitRunLifecyclePluginEvent(claimed);
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip's plugin system publishes a typed event bus via the plugin SDK.
> - `PLUGIN_SPEC.md` §16 names `agent.run.started`, `agent.run.finished`, `agent.run.failed`, and `agent.run.cancelled` in the minimum event set that **the host must emit**.
> - `PLUGIN_EVENT_TYPES` in `@paperclipai/shared` declares the types and the plugin SDK README republishes the contract to plugin authors.
> - The event-bus bridge added in 30e29144 forwards to plugins via `logActivity` when `input.action` matches a PLUGIN_EVENT_TYPE.
> - But nothing in the server ever calls `logActivity({ action: "agent.run.started" | ".finished" | ".failed" | ".cancelled" })`, so plugins subscribing per spec see nothing.
> - Concrete impact: `@vectorize-io/hindsight-paperclip` subscribes to `agent.run.started` (for recall) and `agent.run.finished` (for retain) per the published contract, and currently goes silent on a stock Paperclip install — no auto-recall, no auto-retain. Any future run-lifecycle-aware plugin hits the same wall.
> - This PR closes the spec-vs-code gap by emitting those four events from the two places where run state transitions already happen.
> - The benefit is that the documented plugin event contract matches the implementation — third-party plugins start working as their authors intend with zero additional plumbing.

## What Changed

- Added a private `emitRunLifecyclePluginEvent(run)` helper in `server/src/services/heartbeat.ts` that:
  - maps `run.status` (`running` / `succeeded` / `failed` / `cancelled`) to the corresponding plugin-event action,
  - looks up the linked issue's `title` + `description` for the `agent.run.started` payload (matching the shape Hindsight and similar consumers expect), and
  - pulls `result_json` + `stdout_excerpt` into the `agent.run.finished` / `agent.run.failed` payload so consumers get the run output for retain, summarization, etc.
- Called it from two insertion points that close the run-status transition graph:
  - `setRunStatus()` — covers `succeeded`, `failed`, `cancelled`, and the retry path that re-enters `status=running`.
  - `claimQueuedRun()` — covers the queued → running transition that bypasses `setRunStatus` with an inline update.
- No new plumbing: reuses the existing `logActivity` → `PluginEventBus` bridge that was wired in 30e29144.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — passes.
- Local end-to-end smoke on v2026.416.0 against `@vectorize-io/hindsight-paperclip@0.2.1`:
  - Before patch: no `agent.run.*` events fire; plugin logs nothing after runs complete; no memories retained.
  - After patch: plugin logs `[plugin] Retained run output to memory` with a `paperclip::{companyId}::{agentId}` bank, and Hindsight's `/v1/default/banks/{bank}/operations` shows a retain op queued with `items_count=1`.
- No new dependencies.
- No migrations.

## Risks

- Low/medium. The emitter only fires on run-status transitions that are already being written to the DB and published to `publishLiveEvent`. Adding a fourth side-effect (`logActivity` with a plugin event action) shouldn't change run ordering or create new transactional hazards.
- `logActivity` writes an `activity_log` row per transition, so activity-log volume grows by 2 rows per run (start + finish). If existing installations have very high run throughput, operators may want to monitor `activity_log` table size.
- Plugins that subscribe to `agent.run.*` will start receiving traffic they didn't receive before. For the Hindsight plugin specifically this is correct behavior per its README; for any other plugin that subscribed "optimistically", behavior may change.
- No test harness exists for plugin-event emission in the current suite — happy to add one if the maintainers have a preferred pattern (mock `PluginEventBus`, assert call count per run transition?).

## Model Used

- Claude Opus 4.7 (1M context), Anthropic. Tool-using agent workflow via Claude Code CLI (claude.ai/code).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass (`typecheck`)
- [ ] I have added or updated tests where applicable (no existing plugin-event test pattern; willing to add one on request)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-side only)
- [x] I have updated relevant documentation to reflect my changes (spec was already correct; this aligns the code to the spec)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge