### PR TITLE
fix: pass pluginDbId through tool dispatcher to fix 502 on tool execution

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1812,7 +1812,12 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        // Pass pluginId (DB UUID) as the 3rd arg so tool entries store the
+        // correct `pluginDbId` — without it, `workerManager.isRunning()`
+        // lookups in the dispatcher fail and every plugin tool call 502s
+        // with "worker for plugin is not running". See dispatcher's
+        // registerPluginTools jsdoc.
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,17 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin's npm package key (e.g. `paperclip-plugin-discord`)
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - The plugin's DB UUID. REQUIRED when the caller wants
+   *   `workerManager.isRunning()` lookups to succeed on tool dispatch, because
+   *   workers are registered by DB UUID. Omit only when the DB UUID equals the
+   *   `pluginId` (e.g. during `initialize()` when the registry seeds itself).
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +434,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Summary

Fixes #4094 — plugin tool dispatch returns 502 ("worker for plugin is not running") because `registerPluginTools` drops the `pluginDbId` argument between `plugin-loader` and the dispatcher wrapper. Three-edit fix across two files.

## Root cause (short version)

`server/src/services/plugin-tool-dispatcher.ts:429` accepts only 2 args. `server/src/services/plugin-loader.ts:1815` passes only 2. The registry at `server/src/services/plugin-tool-registry.ts:299` already accepts an optional 3rd `pluginDbId` and falls back to the npm key — so tools get registered with the wrong id, and `workerManager.isRunning(tool.pluginDbId)` later fails because workers are keyed by DB UUID.

Full trace is in the linked issue.

## Changes

1. `server/src/services/plugin-tool-dispatcher.ts` — add `pluginDbId?: string` to the interface declaration and implementation, forward it to `registry.registerPlugin(pluginId, manifest, pluginDbId)`.
2. `server/src/services/plugin-loader.ts` — pass `pluginId` (the DB UUID already bound in scope) as the third arg.

No changes to `plugin-tool-registry.ts` — its `registerPlugin` signature already accepts the optional param. Registry's own `initialize()` path already calls with all 3 args and is unaffected.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:run` — 1568 passed, 1 skipped (no new tests added; existing suite does not cover `plugin-tool-registry`/`plugin-tool-dispatcher`)
- [x] Deployed against a 3-company authenticated-mode install running v2026.416.0 with `paperclip-plugin-discord@0.7.3`. Before: every `escalate_to_human` call returned 502. After: returns 200 with real `escalationId` and posts correctly to the company's Discord channel across all three tenants.

## Notes

Happy to add a focused test at `server/src/__tests__/plugin-tool-dispatcher.test.ts` that mocks a worker-manager and asserts `isRunning` is called with the DB UUID — let me know if that's wanted before merge.
