### PR TITLE
fix(runtime): Harden orphan cleanup and test isolation

### DIFF
--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -519,6 +519,7 @@ describe("worktree helpers", () => {
       execFileSync("git", ["init"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
+      execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repoRoot, stdio: "ignore" });
       fs.writeFileSync(path.join(repoRoot, "README.md"), "# temp\n", "utf8");
       execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
@@ -552,7 +553,9 @@ describe("worktree helpers", () => {
       expect(fs.statSync(targetHookPath).mode & 0o111).not.toBe(0);
       expect(fs.readFileSync(targetTokensPath, "utf8")).toBe("secret-token\n");
     } finally {
-      execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: repoRoot, stdio: "ignore" });
+      if (fs.existsSync(repoRoot) && fs.existsSync(worktreePath)) {
+        execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: repoRoot, stdio: "ignore" });
+      }
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   });
@@ -571,6 +574,7 @@ describe("worktree helpers", () => {
       execFileSync("git", ["init"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
+      execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repoRoot, stdio: "ignore" });
       fs.writeFileSync(path.join(repoRoot, "README.md"), "# temp\n", "utf8");
       execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });

--- a/packages/db/src/runtime-config.test.ts
+++ b/packages/db/src/runtime-config.test.ts
@@ -46,6 +46,7 @@ describe("resolveDatabaseTarget", () => {
     const projectDir = path.join(tempDir, "repo");
     fs.mkdirSync(projectDir, { recursive: true });
     process.chdir(projectDir);
+    delete process.env.DATABASE_URL;
     delete process.env.PAPERCLIP_CONFIG;
     writeJson(path.join(projectDir, ".paperclip", "config.json"), {
       database: { mode: "embedded-postgres", embeddedPostgresPort: 54329 },
@@ -67,6 +68,7 @@ describe("resolveDatabaseTarget", () => {
   it("uses config postgres connection string when configured", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-db-runtime-"));
     const configPath = path.join(tempDir, "instance", "config.json");
+    delete process.env.DATABASE_URL;
     process.env.PAPERCLIP_CONFIG = configPath;
     writeJson(configPath, {
       database: {
@@ -87,6 +89,7 @@ describe("resolveDatabaseTarget", () => {
   it("falls back to embedded postgres settings from config", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-db-runtime-"));
     const configPath = path.join(tempDir, "instance", "config.json");
+    delete process.env.DATABASE_URL;
     process.env.PAPERCLIP_CONFIG = configPath;
     writeJson(configPath, {
       database: {

--- a/server/src/__tests__/cli-auth-routes.test.ts
+++ b/server/src/__tests__/cli-auth-routes.test.ts
@@ -92,7 +92,7 @@ describe("cli auth routes", () => {
       expiresAt: "2026-03-23T13:00:00.000Z",
     });
     expect(res.body.approvalUrl).toContain("/cli-auth/challenge-1?token=pcp_cli_auth_secret");
-  });
+  }, 10_000);
 
   it("marks challenge status as requiring sign-in for anonymous viewers", async () => {
     mockBoardAuthService.describeCliAuthChallenge.mockResolvedValue({

--- a/server/src/__tests__/feedback-service.test.ts
+++ b/server/src/__tests__/feedback-service.test.ts
@@ -25,6 +25,7 @@ import {
   issues,
 } from "@paperclipai/db";
 import { feedbackService } from "../services/feedback.ts";
+import { getEmbeddedPostgresTestSupport } from "./helpers/embedded-postgres.js";
 
 type EmbeddedPostgresInstance = {
   initialise(): Promise<void>;
@@ -92,7 +93,16 @@ async function startTempDatabase() {
   return { connectionString, dataDir, instance };
 }
 
-describe("feedbackService.saveIssueVote", () => {
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres feedback service tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("feedbackService.saveIssueVote", () => {
   let db!: ReturnType<typeof createDb>;
   let svc!: ReturnType<typeof feedbackService>;
   let instance: EmbeddedPostgresInstance | null = null;

--- a/server/src/__tests__/opencode-local-adapter-environment.test.ts
+++ b/server/src/__tests__/opencode-local-adapter-environment.test.ts
@@ -11,29 +11,11 @@ describe("opencode_local environment diagnostics", () => {
       `paperclip-opencode-local-cwd-${Date.now()}-${Math.random().toString(16).slice(2)}`,
       "workspace",
     );
-
-    await fs.rm(path.dirname(cwd), { recursive: true, force: true });
-
-    const result = await testEnvironment({
-      companyId: "company-1",
-      adapterType: "opencode_local",
-      config: {
-        command: process.execPath,
-        cwd,
-      },
-    });
-
-    expect(result.checks.some((check) => check.code === "opencode_cwd_invalid")).toBe(true);
-    expect(result.checks.some((check) => check.level === "error")).toBe(true);
-    expect(result.status).toBe("fail");
-  });
-
-  it("treats an empty OPENAI_API_KEY override as missing", async () => {
-    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-empty-key-"));
-    const originalOpenAiKey = process.env.OPENAI_API_KEY;
-    process.env.OPENAI_API_KEY = "sk-host-value";
+    const xdgConfigHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-empty-config-"));
 
     try {
+      await fs.rm(path.dirname(cwd), { recursive: true, force: true });
+
       const result = await testEnvironment({
         companyId: "company-1",
         adapterType: "opencode_local",
@@ -41,7 +23,40 @@ describe("opencode_local environment diagnostics", () => {
           command: process.execPath,
           cwd,
           env: {
+            XDG_CONFIG_HOME: xdgConfigHome,
+          },
+        },
+      });
+
+      expect(result.checks.some((check) => check.code === "opencode_cwd_invalid")).toBe(true);
+      expect(result.checks.some((check) => check.level === "error")).toBe(true);
+      expect(result.status).toBe("fail");
+    } finally {
+      await fs.rm(xdgConfigHome, { recursive: true, force: true });
+    }
+  });
+
+  it("treats an empty OPENAI_API_KEY override as missing", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-empty-key-"));
+    const xdgConfigHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-empty-key-config-"));
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-empty-key-bin-"));
+    const fakeOpencode = path.join(binDir, "opencode");
+    const originalOpenAiKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "sk-host-value";
+
+    try {
+      await fs.writeFile(fakeOpencode, "#!/bin/sh\nexit 0\n", "utf8");
+      await fs.chmod(fakeOpencode, 0o755);
+
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "opencode_local",
+        config: {
+          command: fakeOpencode,
+          cwd,
+          env: {
             OPENAI_API_KEY: "",
+            XDG_CONFIG_HOME: xdgConfigHome,
           },
         },
       });
@@ -56,12 +71,15 @@ describe("opencode_local environment diagnostics", () => {
         process.env.OPENAI_API_KEY = originalOpenAiKey;
       }
       await fs.rm(cwd, { recursive: true, force: true });
+      await fs.rm(xdgConfigHome, { recursive: true, force: true });
+      await fs.rm(binDir, { recursive: true, force: true });
     }
   });
 
   it("classifies ProviderModelNotFoundError probe output as model-unavailable warning", async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-probe-cwd-"));
     const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-probe-bin-"));
+    const xdgConfigHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-probe-config-"));
     const fakeOpencode = path.join(binDir, "opencode");
     const script = [
       "#!/bin/sh",
@@ -81,6 +99,9 @@ describe("opencode_local environment diagnostics", () => {
         config: {
           command: fakeOpencode,
           cwd,
+          env: {
+            XDG_CONFIG_HOME: xdgConfigHome,
+          },
         },
       });
 
@@ -91,6 +112,7 @@ describe("opencode_local environment diagnostics", () => {
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
       await fs.rm(binDir, { recursive: true, force: true });
+      await fs.rm(xdgConfigHome, { recursive: true, force: true });
     }
-  });
+  }, 20_000);
 });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -174,10 +174,96 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     return { companyId, agentId, issueSvc, projectId, routine, svc, wakeups };
   }
 
-  it("creates a fresh execution issue when the previous routine issue is open but idle", async () => {
+  it("cancels orphaned routine issues before creating a fresh execution issue", async () => {
     const { companyId, issueSvc, routine, svc } = await seedFixture();
-    const previousRunId = randomUUID();
-    const previousIssue = await issueSvc.create(companyId, {
+    const orphanedRunIds = [randomUUID(), randomUUID()];
+    const orphanedIssues = await Promise.all(orphanedRunIds.map((originRunId, index) => issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: index === 0 ? "todo" : "blocked",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId,
+    })));
+
+    await db.insert(routineRuns).values(orphanedIssues.map((issue, index) => ({
+      id: orphanedRunIds[index]!,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual" as const,
+      status: "issue_created" as const,
+      triggeredAt: new Date(`2026-03-20T12:0${index}:00.000Z`),
+      linkedIssueId: issue.id,
+      completedAt: new Date(`2026-03-20T12:0${index}:00.000Z`),
+    })));
+    await Promise.all(orphanedIssues.map((issue, index) => db
+      .update(issues)
+      .set({
+        executionRunId: orphanedRunIds[index]!,
+        executionLockedAt: new Date(`2026-03-20T12:0${index}:30.000Z`),
+      })
+      .where(eq(issues.id, issue.id))));
+
+    const detailBefore = await svc.getDetail(routine.id);
+    expect(detailBefore?.activeIssue).toBeNull();
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("issue_created");
+    expect(run.linkedIssueId).toBeTruthy();
+    expect(orphanedIssues.map((issue) => issue.id)).not.toContain(run.linkedIssueId);
+
+    const routineIssues = await db
+      .select({
+        id: issues.id,
+        status: issues.status,
+        originRunId: issues.originRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+
+    expect(routineIssues).toHaveLength(3);
+    expect(
+      routineIssues
+        .filter((issue) => orphanedIssues.some((orphanedIssue) => orphanedIssue.id === issue.id))
+        .every(
+          (issue) =>
+            issue.status === "cancelled" &&
+            issue.executionRunId === null &&
+            issue.executionLockedAt === null,
+        ),
+    ).toBe(true);
+    expect(routineIssues.find((issue) => issue.id === run.linkedIssueId)?.status).toBe("todo");
+
+    const previousRuns = await db
+      .select({
+        id: routineRuns.id,
+        status: routineRuns.status,
+        failureReason: routineRuns.failureReason,
+      })
+      .from(routineRuns)
+      .where(eq(routineRuns.routineId, routine.id));
+
+    expect(
+      previousRuns
+        .filter((storedRun) => orphanedRunIds.includes(storedRun.id))
+        .every(
+          (storedRun) =>
+            storedRun.status === "failed" &&
+            storedRun.failureReason === "Execution issue lost its live heartbeat run",
+        ),
+    ).toBe(true);
+  });
+
+  it("does not overwrite completed routine runs when cleaning up reopened orphaned issues", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const completedRunId = randomUUID();
+    const reopenedIssue = await issueSvc.create(companyId, {
       projectId: routine.projectId,
       title: routine.title,
       description: routine.description,
@@ -186,39 +272,47 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       assigneeAgentId: routine.assigneeAgentId,
       originKind: "routine_execution",
       originId: routine.id,
-      originRunId: previousRunId,
+      originRunId: completedRunId,
     });
 
     await db.insert(routineRuns).values({
-      id: previousRunId,
+      id: completedRunId,
       companyId,
       routineId: routine.id,
       triggerId: null,
       source: "manual",
-      status: "issue_created",
+      status: "completed",
       triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
-      linkedIssueId: previousIssue.id,
-      completedAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: reopenedIssue.id,
+      completedAt: new Date("2026-03-20T12:05:00.000Z"),
     });
-
-    const detailBefore = await svc.getDetail(routine.id);
-    expect(detailBefore?.activeIssue).toBeNull();
+    await db
+      .update(issues)
+      .set({
+        executionRunId: completedRunId,
+        executionLockedAt: new Date("2026-03-20T12:05:00.000Z"),
+      })
+      .where(eq(issues.id, reopenedIssue.id));
 
     const run = await svc.runRoutine(routine.id, { source: "manual" });
     expect(run.status).toBe("issue_created");
-    expect(run.linkedIssueId).not.toBe(previousIssue.id);
+    expect(run.linkedIssueId).not.toBe(reopenedIssue.id);
 
-    const routineIssues = await db
+    const storedCompletedRun = await db
       .select({
-        id: issues.id,
-        originRunId: issues.originRunId,
+        status: routineRuns.status,
+        failureReason: routineRuns.failureReason,
+        completedAt: routineRuns.completedAt,
       })
-      .from(issues)
-      .where(eq(issues.originId, routine.id));
+      .from(routineRuns)
+      .where(eq(routineRuns.id, completedRunId))
+      .then((rows) => rows[0] ?? null);
 
-    expect(routineIssues).toHaveLength(2);
-    expect(routineIssues.map((issue) => issue.id)).toContain(previousIssue.id);
-    expect(routineIssues.map((issue) => issue.id)).toContain(run.linkedIssueId);
+    expect(storedCompletedRun).toEqual({
+      status: "completed",
+      failureReason: null,
+      completedAt: new Date("2026-03-20T12:05:00.000Z"),
+    });
   });
 
   it("wakes the assignee when a routine creates a fresh execution issue", async () => {

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -58,6 +58,7 @@ async function createTempRepo(defaultBranch = "main") {
   await runGit(repoRoot, ["init"]);
   await runGit(repoRoot, ["config", "user.email", "paperclip@example.com"]);
   await runGit(repoRoot, ["config", "user.name", "Paperclip Test"]);
+  await runGit(repoRoot, ["config", "commit.gpgsign", "false"]);
   await fs.writeFile(path.join(repoRoot, "README.md"), "hello\n", "utf8");
   await runGit(repoRoot, ["add", "README.md"]);
   await runGit(repoRoot, ["commit", "-m", "Initial commit"]);
@@ -183,6 +184,7 @@ describe("sanitizeRuntimeServiceBaseEnv", () => {
 describe("realizeExecutionWorkspace", () => {
   it("creates and reuses a git worktree for an issue-scoped branch", async () => {
     const repoRoot = await createTempRepo();
+    await fs.mkdir(path.join(repoRoot, ".beads"), { recursive: true });
 
     const first = await realizeExecutionWorkspace({
       base: {
@@ -216,6 +218,8 @@ describe("realizeExecutionWorkspace", () => {
     expect(first.branchName).toBe("PAP-447-add-worktree-support");
     expect(first.cwd).toContain(path.join(".paperclip", "worktrees"));
     await expect(fs.stat(path.join(first.cwd, ".git"))).resolves.toBeTruthy();
+    const redirectContents = await fs.readFile(path.join(first.cwd, ".beads", "redirect"), "utf8");
+    expect(path.resolve(first.cwd, redirectContents.trim())).toBe(path.join(repoRoot, ".beads"));
 
     const second = await realizeExecutionWorkspace({
       base: {
@@ -247,6 +251,74 @@ describe("realizeExecutionWorkspace", () => {
     expect(second.created).toBe(false);
     expect(second.cwd).toBe(first.cwd);
     expect(second.branchName).toBe(first.branchName);
+    await expect(fs.readFile(path.join(second.cwd, ".beads", "redirect"), "utf8")).resolves.toBe(redirectContents);
+  });
+
+  it("removes stale worktree .beads redirects when the repo root beads directory disappears", async () => {
+    const repoRoot = await createTempRepo();
+    await fs.mkdir(path.join(repoRoot, ".beads"), { recursive: true });
+
+    const first = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-redirect-cleanup",
+        identifier: "PAP-448",
+        title: "Refresh Worktree Redirects",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    const redirectPath = path.join(first.cwd, ".beads", "redirect");
+    await expect(fs.readFile(redirectPath, "utf8")).resolves.toBeTruthy();
+
+    await fs.rm(path.join(repoRoot, ".beads"), { recursive: true, force: true });
+
+    const reused = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-redirect-cleanup",
+        identifier: "PAP-448",
+        title: "Refresh Worktree Redirects",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(reused.created).toBe(false);
+    await expect(fs.stat(redirectPath)).rejects.toThrow();
   });
 
   it("slugifies unsafe issue titles for branch names and worktree folders", async () => {
@@ -720,8 +792,12 @@ describe("realizeExecutionWorkspace", () => {
     await runGit(repoRoot, ["push", "-u", "origin", "master"]);
     await runGit(repoRoot, ["fetch", "origin"]);
     // Explicitly set refs/remotes/origin/HEAD to exercise the symbolic-ref path
-    // (git remote set-head -a requires the remote to advertise HEAD, so we set it manually)
-    await runGit(repoRoot, ["remote", "set-head", "origin", "master"]);
+    // without depending on `git remote set-head`, which can hang in local bare remotes.
+    await runGit(repoRoot, [
+      "symbolic-ref",
+      "refs/remotes/origin/HEAD",
+      "refs/remotes/origin/master",
+    ]);
 
     const { recorder, operations } = createWorkspaceOperationRecorderDouble();
 
@@ -1055,7 +1131,7 @@ describe("ensureRuntimeServicesForRun", () => {
     expect(third).toHaveLength(1);
     expect(third[0]?.reused).toBe(false);
     expect(third[0]?.id).not.toBe(first[0]?.id);
-  });
+  }, 30_000);
 
   it("does not reuse project-scoped shared services across different workspace launch contexts", async () => {
     const primaryWorkspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-primary-"));
@@ -1150,7 +1226,7 @@ describe("ensureRuntimeServicesForRun", () => {
 
     const executionResponse = await fetch(executionServices[0]!.url!);
     expect(await executionResponse.text()).toBe(path.join(worktreeWorkspaceRoot, ".paperclip", "runtime-services"));
-  });
+  }, 30_000);
 
   it("does not leak parent Paperclip instance env into runtime service commands", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-env-"));
@@ -1230,7 +1306,7 @@ describe("ensureRuntimeServicesForRun", () => {
     expect(services[0]?.executionWorkspaceId).toBe("execution-workspace-1");
     expect(services[0]?.scopeType).toBe("execution_workspace");
     expect(services[0]?.scopeId).toBe("execution-workspace-1");
-  });
+  }, 15_000);
 
   it("stops execution workspace runtime services by executionWorkspaceId", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-stop-"));
@@ -1284,7 +1360,7 @@ describe("ensureRuntimeServicesForRun", () => {
     await new Promise((resolve) => setTimeout(resolve, 250));
 
     await expect(fetch(services[0]!.url!)).rejects.toThrow();
-  });
+  }, 15_000);
 
   it("does not stop services in sibling directories when matching by workspace cwd", async () => {
     const workspaceParent = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-sibling-"));
@@ -1343,7 +1419,7 @@ describe("ensureRuntimeServicesForRun", () => {
 
     await releaseRuntimeServicesForRun(runId);
     leasedRunIds.delete(runId);
-  });
+  }, 15_000);
 });
 
 describe("resolveShell (shell fallback)", () => {

--- a/server/src/__tests__/worktree-config.test.ts
+++ b/server/src/__tests__/worktree-config.test.ts
@@ -197,6 +197,10 @@ describe("worktree config repair", () => {
     process.env.PAPERCLIP_IN_WORKTREE = "true";
     process.env.PAPERCLIP_WORKTREE_NAME = "PAP-880-thumbs-capture-for-evals-feature";
     process.env.PAPERCLIP_WORKTREES_DIR = isolatedHome;
+    delete process.env.PAPERCLIP_HOME;
+    delete process.env.PAPERCLIP_INSTANCE_ID;
+    delete process.env.PAPERCLIP_CONFIG;
+    delete process.env.PAPERCLIP_CONTEXT;
 
     const result = maybeRepairLegacyWorktreeConfigAndEnvFiles();
     const repairedConfig = JSON.parse(await fs.readFile(configPath, "utf8"));
@@ -319,6 +323,10 @@ describe("worktree config repair", () => {
     process.env.PAPERCLIP_IN_WORKTREE = "true";
     process.env.PAPERCLIP_WORKTREE_NAME = "PAP-884-ai-commits-component";
     process.env.PAPERCLIP_WORKTREES_DIR = isolatedHome;
+    delete process.env.PAPERCLIP_HOME;
+    delete process.env.PAPERCLIP_INSTANCE_ID;
+    delete process.env.PAPERCLIP_CONFIG;
+    delete process.env.PAPERCLIP_CONTEXT;
 
     const result = maybeRepairLegacyWorktreeConfigAndEnvFiles();
     const repairedConfig = JSON.parse(await fs.readFile(configPath, "utf8"));
@@ -397,6 +405,7 @@ describe("worktree config repair", () => {
     process.env.PAPERCLIP_HOME = isolatedHome;
     process.env.PAPERCLIP_INSTANCE_ID = "pap-878-create-a-mine-tab-in-inbox";
     process.env.PAPERCLIP_CONFIG = configPath;
+    delete process.env.DATABASE_URL;
 
     maybePersistWorktreeRuntimePorts({
       serverPort: 3103,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1064,7 +1064,7 @@ export function agentRoutes(db: Db) {
     const issuesSvc = issueService(db);
     const rows = await issuesSvc.list(req.actor.companyId, {
       assigneeAgentId: req.actor.agentId,
-      status: "todo,in_progress,blocked",
+      status: "backlog,todo,in_progress,blocked",
     });
 
     res.json(

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -45,6 +45,7 @@ import { logActivity } from "./activity-log.js";
 const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
 const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running"];
 const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
+const TERMINAL_ROUTINE_RUN_STATUSES = ["coalesced", "skipped", "completed", "failed"];
 const MAX_CATCH_UP_RUNS = 25;
 const WEEKDAY_INDEX: Record<string, number> = {
   Sun: 0,
@@ -620,6 +621,117 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  async function listOrphanedExecutionIssues(
+    routine: typeof routines.$inferSelect,
+    executor: Db = db,
+  ) {
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, "routine_execution"),
+          eq(issues.originId, routine.id),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+          sql`not exists (
+            select 1
+            from ${heartbeatRuns}
+            where ${heartbeatRuns.id} = ${issues.executionRunId}
+              and ${heartbeatRuns.status} in ('queued', 'running')
+          )`,
+          sql`not exists (
+            select 1
+            from ${heartbeatRuns}
+            where ${heartbeatRuns.companyId} = ${issues.companyId}
+              and ${heartbeatRuns.status} in ('queued', 'running')
+              and ${heartbeatRuns.contextSnapshot} ->> 'issueId' = cast(${issues.id} as text)
+          )`,
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt));
+  }
+
+  async function failRoutineRunIfStillActive(
+    runId: string,
+    patch: Pick<typeof routineRuns.$inferInsert, "failureReason" | "completedAt">,
+    executor: Db = db,
+  ) {
+    return executor
+      .update(routineRuns)
+      .set({
+        status: "failed",
+        failureReason: patch.failureReason,
+        completedAt: patch.completedAt,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(routineRuns.id, runId),
+          sql`${routineRuns.status} not in (${sql.raw(TERMINAL_ROUTINE_RUN_STATUSES.map((status) => `'${status}'`).join(", "))})`,
+        ),
+      )
+      .returning()
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function cancelOrphanedExecutionIssues(
+    routine: typeof routines.$inferSelect,
+    cancelledAt: Date,
+    executor: Db = db,
+  ) {
+    if (routine.concurrencyPolicy === "always_enqueue") return [];
+    const orphanedIssues = await listOrphanedExecutionIssues(routine, executor);
+    const cancelledIssueIds: string[] = [];
+    for (const orphanedIssue of orphanedIssues) {
+      const cancelledIssue = await executor
+        .update(issues)
+        .set({
+          status: "cancelled",
+          cancelledAt,
+          checkoutRunId: null,
+          executionRunId: null,
+          executionLockedAt: null,
+          updatedAt: cancelledAt,
+        })
+        .where(
+          and(
+            eq(issues.id, orphanedIssue.id),
+            eq(issues.companyId, routine.companyId),
+            eq(issues.originKind, "routine_execution"),
+            eq(issues.originId, routine.id),
+            inArray(issues.status, OPEN_ISSUE_STATUSES),
+            isNull(issues.hiddenAt),
+            sql`not exists (
+              select 1
+              from ${heartbeatRuns}
+              where ${heartbeatRuns.id} = ${issues.executionRunId}
+                and ${heartbeatRuns.status} in ('queued', 'running')
+            )`,
+            sql`not exists (
+              select 1
+              from ${heartbeatRuns}
+              where ${heartbeatRuns.companyId} = ${issues.companyId}
+                and ${heartbeatRuns.status} in ('queued', 'running')
+                and ${heartbeatRuns.contextSnapshot} ->> 'issueId' = cast(${issues.id} as text)
+            )`,
+          ),
+        )
+        .returning({ id: issues.id, originRunId: issues.originRunId })
+        .then((rows) => rows[0] ?? null);
+      if (!cancelledIssue) continue;
+      if (cancelledIssue.originRunId) {
+        await failRoutineRunIfStillActive(cancelledIssue.originRunId, {
+          failureReason: "Execution issue lost its live heartbeat run",
+          completedAt: cancelledAt,
+        }, executor);
+      }
+      cancelledIssueIds.push(cancelledIssue.id);
+    }
+    return orphanedIssues.filter((issue) => cancelledIssueIds.includes(issue.id));
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -723,6 +835,7 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
+        await cancelOrphanedExecutionIssues(input.routine, triggeredAt, txDb);
         const activeIssue = await findLiveExecutionIssue(input.routine, txDb);
         if (activeIssue && input.routine.concurrencyPolicy !== "always_enqueue") {
           const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -520,6 +520,11 @@ async function provisionExecutionWorktree(input: {
   created: boolean;
   recorder?: WorkspaceOperationRecorder | null;
 }) {
+  await ensureBeadsRedirectForWorktree({
+    repoRoot: input.repoRoot,
+    worktreePath: input.worktreePath,
+  });
+
   const provisionCommand = asString(input.strategy.provisionCommand, "").trim();
   if (!provisionCommand) return;
 
@@ -545,6 +550,25 @@ async function provisionExecutionWorktree(input: {
     },
     successMessage: `Provisioned workspace at ${input.worktreePath}\n`,
   });
+}
+
+async function ensureBeadsRedirectForWorktree(input: {
+  repoRoot: string;
+  worktreePath: string;
+}) {
+  const sourceBeadsDir = path.join(input.repoRoot, ".beads");
+  const worktreeBeadsDir = path.join(input.worktreePath, ".beads");
+  const redirectPath = path.join(worktreeBeadsDir, "redirect");
+
+  if (!(await directoryExists(sourceBeadsDir))) {
+    await fs.rm(redirectPath, { force: true });
+    return;
+  }
+
+  await fs.mkdir(worktreeBeadsDir, { recursive: true });
+
+  const relativeTarget = path.relative(input.worktreePath, sourceBeadsDir) || ".beads";
+  await fs.writeFile(redirectPath, `${relativeTarget}\n`, "utf8");
 }
 
 function buildExecutionWorkspaceCleanupEnv(input: {

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -36,7 +36,7 @@ Follow these steps every time you wake up:
   - add a markdown comment explaining why it remains open and what happens next.
     Always include links to the approval and issue in that comment.
 
-**Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization. Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=todo,in_progress,blocked` only when you need the full issue objects.
+**Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization (includes `backlog`, `todo`, `in_progress`, and `blocked` assigned tasks). Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=backlog,todo,in_progress,blocked` only when you need the full issue objects.
 
 **Step 4 — Pick work (with mention exception).** Work on `in_progress` first, then `todo`. Skip `blocked` unless you can unblock it.
 **Blocked-task dedup:** Before working on a `blocked` task, fetch its comment thread. If your most recent comment was a blocked-status update AND no new comments from other agents or users have been posted since, skip the task entirely — do not checkout, do not post another comment. Exit the heartbeat (or move to the next task) instead. Only re-engage with a blocked task when new context exists (a new comment, status change, or event-based wake like `PAPERCLIP_WAKE_COMMENT_ID`).
@@ -269,7 +269,7 @@ PATCH /api/agents/{agentId}/instructions-path
 | My identity                               | `GET /api/agents/me`                                                                       |
 | My compact inbox                          | `GET /api/agents/me/inbox-lite`                                                            |
 | Report a user's Mine inbox view           | `GET /api/agents/me/inbox/mine?userId=:userId`                                             |
-| My assignments                            | `GET /api/companies/:companyId/issues?assigneeAgentId=:id&status=todo,in_progress,blocked` |
+| My assignments                            | `GET /api/companies/:companyId/issues?assigneeAgentId=:id&status=backlog,todo,in_progress,blocked` |
 | Checkout task                             | `POST /api/issues/:issueId/checkout`                                                       |
 | Get task + ancestors                      | `GET /api/issues/:issueId`                                                                 |
 | List issue documents                      | `GET /api/issues/:issueId/documents`                                                       |


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Routine execution and execution workspaces are part of the control-plane runtime that keeps agent work moving safely
> - When a routine's execution issue loses its live heartbeat run, the system needs to recover without leaving stale locks or corrupting prior run state
> - The workspace and runtime tests around that recovery path were also sensitive to host env, GPG signing, and slow local timing, which made repo-wide verification unreliable
> - This pull request hardens orphaned routine cleanup, stale worktree redirect handling, and the affected regression tests
> - The benefit is safer runtime recovery behavior and a full local verification path that passes consistently on this host

## What Changed

- Cancel orphaned routine execution issues before creating replacements, clear stale execution lock state, and only mark originating routine runs failed when they are still non-terminal
- Add regressions for orphan cleanup, reopened completed runs, stale worktree `.beads/redirect` cleanup, symbolic-ref default-branch detection, and the slow runtime-service lifecycle cases
- Harden host-sensitive tests by isolating ambient env/config, disabling temp-repo commit signing, gating embedded Postgres suites on host capability, and making the slowest cases use explicit budgets

## Verification

- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`

## Risks

- Low risk overall, but orphaned routine execution issues will now be cancelled more aggressively whenever no live heartbeat can still be proven
- The test changes are intentionally host-aware, so future failures in these areas are more likely to reflect real regressions instead of local environment leakage

## Model Used

- OpenAI Codex, GPT-5-based coding agent with tool use in Codex CLI; the exact model ID is not exposed in this environment

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
