### PR TITLE
fix: return blockedByIssueIds on issue readback

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -146,6 +146,11 @@ Use it for:
 - explicit waiting relationships
 - automatic wakeups when all blockers resolve
 
+Readback contract:
+
+- issue read routes return `blockedByIssueIds` as the stored blocker id set
+- issue read routes also return `blockedBy` and `blocks` relation summaries so callers can render the dependency graph without extra joins
+
 If a parent is truly waiting on a child, model that with blockers. Do not rely on the parent/child relationship alone.
 
 ## 7. Consistent Execution Path Rules

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -180,6 +180,7 @@ export interface Issue {
   projectWorkspaceId: string | null;
   goalId: string | null;
   parentId: string | null;
+  blockedByIssueIds?: string[];
   ancestors?: IssueAncestor[];
   title: string;
   description: string | null;

--- a/server/src/__tests__/issue-blocker-readback-routes.test.ts
+++ b/server/src/__tests__/issue-blocker-readback-routes.test.ts
@@ -1,0 +1,201 @@
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  companies,
+  createDb,
+  heartbeatRuns,
+  instanceSettings,
+  issueComments,
+  issueInboxArchives,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function ensureIssueRelationsTable(db: ReturnType<typeof createDb>) {
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS "issue_relations" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "company_id" uuid NOT NULL,
+      "issue_id" uuid NOT NULL,
+      "related_issue_id" uuid NOT NULL,
+      "type" text NOT NULL,
+      "created_by_agent_id" uuid,
+      "created_by_user_id" text,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "updated_at" timestamptz NOT NULL DEFAULT now()
+    );
+  `));
+}
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue blocker route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue blocker readback routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-blockers-routes-");
+    db = createDb(tempDb.connectionString);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp() {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "local-board",
+        companyIds: [],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedCompanyAndBlockers() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const blockerA = randomUUID();
+    const blockerB = randomUUID();
+    const blockerC = randomUUID();
+    await db.insert(issues).values([
+      { id: blockerA, companyId, title: "Blocker A", status: "todo", priority: "high" },
+      { id: blockerB, companyId, title: "Blocker B", status: "todo", priority: "high" },
+      { id: blockerC, companyId, title: "Blocker C", status: "todo", priority: "high" },
+    ]);
+
+    return { companyId, blockerA, blockerB, blockerC };
+  }
+
+  it("returns blockedByIssueIds, blockedBy, and blocks across create and patch readback", async () => {
+    const app = createApp();
+    const { companyId, blockerA, blockerB, blockerC } = await seedCompanyAndBlockers();
+
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "Dependent issue",
+        status: "blocked",
+        priority: "medium",
+        blockedByIssueIds: [blockerA],
+      });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.blockedByIssueIds).toEqual([blockerA]);
+    expect(createRes.body.blockedBy).toEqual([
+      expect.objectContaining({ id: blockerA, title: "Blocker A" }),
+    ]);
+    expect(createRes.body.blocks).toEqual([]);
+
+    const dependentId = createRes.body.id as string;
+
+    const createReadback = await request(app).get(`/api/issues/${dependentId}`);
+    expect(createReadback.status).toBe(200);
+    expect(createReadback.body.blockedByIssueIds).toEqual([blockerA]);
+    expect(createReadback.body.blockedBy).toEqual([
+      expect.objectContaining({ id: blockerA, title: "Blocker A" }),
+    ]);
+
+    const blockerAReadback = await request(app).get(`/api/issues/${blockerA}`);
+    expect(blockerAReadback.status).toBe(200);
+    expect(blockerAReadback.body.blocks).toEqual([
+      expect.objectContaining({ id: dependentId, title: "Dependent issue" }),
+    ]);
+
+    const addRes = await request(app)
+      .patch(`/api/issues/${dependentId}`)
+      .send({ blockedByIssueIds: [blockerA, blockerB] });
+
+    expect(addRes.status).toBe(200);
+    expect(addRes.body.blockedByIssueIds).toEqual([blockerA, blockerB]);
+    expect(addRes.body.blockedBy).toEqual([
+      expect.objectContaining({ id: blockerA, title: "Blocker A" }),
+      expect.objectContaining({ id: blockerB, title: "Blocker B" }),
+    ]);
+
+    const addReadback = await request(app).get(`/api/issues/${dependentId}`);
+    expect(addReadback.status).toBe(200);
+    expect(addReadback.body.blockedByIssueIds).toEqual([blockerA, blockerB]);
+
+    const replaceRes = await request(app)
+      .patch(`/api/issues/${dependentId}`)
+      .send({ blockedByIssueIds: [blockerB, blockerC] });
+
+    expect(replaceRes.status).toBe(200);
+    expect(replaceRes.body.blockedByIssueIds).toEqual([blockerB, blockerC]);
+    expect(replaceRes.body.blockedBy).toEqual([
+      expect.objectContaining({ id: blockerB, title: "Blocker B" }),
+      expect.objectContaining({ id: blockerC, title: "Blocker C" }),
+    ]);
+
+    const replaceReadback = await request(app).get(`/api/issues/${dependentId}`);
+    expect(replaceReadback.status).toBe(200);
+    expect(replaceReadback.body.blockedByIssueIds).toEqual([blockerB, blockerC]);
+
+    const blockerCReadback = await request(app).get(`/api/issues/${blockerC}`);
+    expect(blockerCReadback.status).toBe(200);
+    expect(blockerCReadback.body.blocks).toEqual([
+      expect.objectContaining({ id: dependentId, title: "Dependent issue" }),
+    ]);
+
+    const clearRes = await request(app)
+      .patch(`/api/issues/${dependentId}`)
+      .send({ blockedByIssueIds: [] });
+
+    expect(clearRes.status).toBe(200);
+    expect(clearRes.body.blockedByIssueIds).toEqual([]);
+    expect(clearRes.body.blockedBy).toEqual([]);
+
+    const clearReadback = await request(app).get(`/api/issues/${dependentId}`);
+    expect(clearReadback.status).toBe(200);
+    expect(clearReadback.body.blockedByIssueIds).toEqual([]);
+    expect(clearReadback.body.blockedBy).toEqual([]);
+
+    const blockerBReadback = await request(app).get(`/api/issues/${blockerB}`);
+    expect(blockerBReadback.status).toBe(200);
+    expect(blockerBReadback.body.blocks).toEqual([]);
+  });
+});

--- a/server/src/__tests__/issue-blocker-readback-routes.test.ts
+++ b/server/src/__tests__/issue-blocker-readback-routes.test.ts
@@ -198,4 +198,22 @@ describeEmbeddedPostgres("issue blocker readback routes", () => {
     expect(blockerBReadback.status).toBe(200);
     expect(blockerBReadback.body.blocks).toEqual([]);
   });
+
+  it("returns empty blocker fields on create when blockedByIssueIds is omitted", async () => {
+    const app = createApp();
+    const { companyId } = await seedCompanyAndBlockers();
+
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "Standalone issue",
+        status: "todo",
+        priority: "medium",
+      });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.blockedByIssueIds).toEqual([]);
+    expect(createRes.body.blockedBy).toEqual([]);
+    expect(createRes.body.blocks).toEqual([]);
+  });
 });

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -235,7 +235,36 @@ describe("issue goal context routes", () => {
     );
 
     expect(res.status).toBe(200);
+    expect(res.body.issue.blockedByIssueIds).toEqual(["55555555-5555-4555-8555-555555555555"]);
     expect(res.body.issue.blockedBy).toEqual([
+      expect.objectContaining({
+        id: "55555555-5555-4555-8555-555555555555",
+        identifier: "PAP-580",
+      }),
+    ]);
+  });
+
+  it("surfaces blockedByIssueIds on GET /issues/:id", async () => {
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [
+        {
+          id: "55555555-5555-4555-8555-555555555555",
+          identifier: "PAP-580",
+          title: "Finish wakeup plumbing",
+          status: "done",
+          priority: "medium",
+          assigneeAgentId: null,
+          assigneeUserId: null,
+        },
+      ],
+      blocks: [],
+    });
+
+    const res = await request(await createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111");
+
+    expect(res.status).toBe(200);
+    expect(res.body.blockedByIssueIds).toEqual(["55555555-5555-4555-8555-555555555555"]);
+    expect(res.body.blockedBy).toEqual([
       expect.objectContaining({
         id: "55555555-5555-4555-8555-555555555555",
         identifier: "PAP-580",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -282,6 +282,24 @@ function buildExecutionStageWakeup(input: {
   return null;
 }
 
+function withBlockedByRelations<T extends object, TBlockedBy extends { id: string }, TBlocks extends { id: string }>(
+  issue: T,
+  relations: {
+    blockedBy: TBlockedBy[];
+    blocks: TBlocks[];
+  },
+): T & {
+  blockedByIssueIds: string[];
+  blockedBy: TBlockedBy[];
+  blocks: TBlocks[];
+} {
+  return {
+    ...issue,
+    blockedByIssueIds: relations.blockedBy.map((relation) => relation.id),
+    blockedBy: relations.blockedBy,
+    blocks: relations.blocks,
+  };
+}
 export function issueRoutes(
   db: Db,
   storage: StorageService,
@@ -741,11 +759,9 @@ export function issueRoutes(
       : null;
     const workProducts = await workProductsSvc.listForIssue(issue.id);
     res.json({
-      ...issue,
+      ...withBlockedByRelations(issue, relations),
       goalId: goal?.id ?? issue.goalId,
       ancestors,
-      blockedBy: relations.blockedBy,
-      blocks: relations.blocks,
       ...documentPayload,
       project: project ?? null,
       goal: goal ?? null,
@@ -790,6 +806,7 @@ export function issueRoutes(
         projectId: issue.projectId,
         goalId: goal?.id ?? issue.goalId,
         parentId: issue.parentId,
+        blockedByIssueIds: relations.blockedBy.map((relation) => relation.id),
         blockedBy: relations.blockedBy,
         blocks: relations.blocks,
         assigneeAgentId: issue.assigneeAgentId,
@@ -1369,6 +1386,12 @@ export function issueRoutes(
       requestedByActorId: actor.actorId,
     });
 
+    if (Array.isArray(req.body.blockedByIssueIds)) {
+      const relations = await svc.getRelationSummaries(issue.id);
+      res.status(201).json(withBlockedByRelations(issue, relations));
+      return;
+    }
+
     res.status(201).json(issue);
   });
 
@@ -1582,15 +1605,11 @@ export function issueRoutes(
       res.status(404).json({ error: "Issue not found" });
       return;
     }
-    let issueResponse: typeof issue & { blockedBy?: unknown; blocks?: unknown } = issue;
+    let issueResponse: typeof issue & { blockedBy?: unknown; blocks?: unknown; blockedByIssueIds?: string[] } = issue;
     let updatedRelations: Awaited<ReturnType<typeof svc.getRelationSummaries>> | null = null;
     if (issue && Array.isArray(req.body.blockedByIssueIds)) {
       updatedRelations = await svc.getRelationSummaries(issue.id);
-      issueResponse = {
-        ...issue,
-        blockedBy: updatedRelations.blockedBy,
-        blocks: updatedRelations.blocks,
-      };
+      issueResponse = withBlockedByRelations(issue, updatedRelations);
     }
     await routinesSvc.syncRunStatusForIssue(issue.id);
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -300,6 +300,7 @@ function withBlockedByRelations<T extends object, TBlockedBy extends { id: strin
     blocks: relations.blocks,
   };
 }
+
 export function issueRoutes(
   db: Db,
   storage: StorageService,
@@ -1386,13 +1387,8 @@ export function issueRoutes(
       requestedByActorId: actor.actorId,
     });
 
-    if (Array.isArray(req.body.blockedByIssueIds)) {
-      const relations = await svc.getRelationSummaries(issue.id);
-      res.status(201).json(withBlockedByRelations(issue, relations));
-      return;
-    }
-
-    res.status(201).json(issue);
+    const relations = await svc.getRelationSummaries(issue.id);
+    res.status(201).json(withBlockedByRelations(issue, relations));
   });
 
   router.patch("/issues/:id", validate(updateIssueRouteSchema), async (req, res) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip models issue execution state, routing, and dependency edges so agents and operators can rely on first-class issue metadata instead of comment-only coordination.
> - Issue dependency handling lives in the issue routes and issue service layer, where create, patch, and readback endpoints need to expose the same blocker contract.
> - [SUP-831](/SUP/issues/SUP-831) exists because PATCH `/api/issues/:issueId` accepted blocker updates but immediate readback did not expose `blockedByIssueIds`, which made dependency graphs look stale.
> - The initial fix restored `blockedByIssueIds` on issue readback, but review found one remaining API inconsistency: create responses only included blocker fields when the request body explicitly sent blockers.
> - This pull request makes the blocker response contract uniform across create and read paths, adds regression coverage for omitted-blocker creates, and documents the readback semantics.
> - The benefit is that callers can trust a stable issue shape with `blockedByIssueIds`, `blockedBy`, and `blocks` on readback without conditional response handling.

## What Changed

- Return blocker metadata from issue readback routes by attaching `blockedByIssueIds`, `blockedBy`, and `blocks` to `GET /api/issues/:id`, heartbeat context, and blocker-updating `PATCH /api/issues/:id` responses.
- Normalize the `POST /api/companies/:companyId/issues` response so newly created issues always include blocker fields, even when `blockedByIssueIds` is omitted and the values are empty.
- Add route regression coverage for create/add/replace/clear blocker flows plus the empty-blocker create case, and keep the existing service-level blocker tests green.
- Document the blocker readback contract in `doc/execution-semantics.md`.

## Verification

- `pnpm test:run server/src/__tests__/issues-goal-context-routes.test.ts server/src/__tests__/issue-blocker-readback-routes.test.ts server/src/__tests__/issues-service.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low risk. The change is backend-only and does not alter relation persistence, schema shape, or dependency wake logic.
- API consumers that were previously branching on missing blocker keys from create responses will now receive empty arrays instead, which is the intended contract normalization.

## Model Used

- OpenAI GPT-5.4 via Codex local adapter, high reasoning effort, with repository-aware shell/tool execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
