### PR TITLE
fix: respect agent cooldown in stranded issue reconciliation

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2595,6 +2595,7 @@ export function heartbeatService(db: Db) {
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      cooldownSec: Math.max(0, asNumber(heartbeat.cooldownSec, 0)),
     };
   }
 
@@ -2868,6 +2869,7 @@ export function heartbeatService(db: Db) {
         error: heartbeatRuns.error,
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
+        finishedAt: heartbeatRuns.finishedAt,
       })
       .from(heartbeatRuns)
       .where(
@@ -3039,6 +3041,17 @@ export function heartbeatService(db: Db) {
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
       const latestContext = parseObject(latestRun?.contextSnapshot);
       const latestRetryReason = readNonEmptyString(latestContext.retryReason);
+
+      // If the agent recently completed a run and is within its cooldown window,
+      // don't treat the issue as stranded — the agent is cooling down, not stuck.
+      const policy = parseHeartbeatPolicy(agent);
+      if (policy.cooldownSec > 0 && latestRun?.finishedAt) {
+        const cooldownEndMs = new Date(latestRun.finishedAt).getTime() + policy.cooldownSec * 1000;
+        if (Date.now() < cooldownEndMs) {
+          result.skipped += 1;
+          continue;
+        }
+      }
 
       if (issue.status === "todo") {
         if (!latestRun || latestRun.status === "succeeded") {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The heartbeat scheduler runs every 30s, checking for assigned issues with no active execution path via `reconcileStrandedAssignedIssues()`
> - When no live execution exists, it treats the issue as "stranded" and either retries or escalates to `blocked`
> - But agents have a `cooldownSec` config that creates a deliberate pause between runs — the reconciliation doesn't respect this
> - This causes a relentless blocked→unblock→blocked loop for any agent with cooldownSec > 0
> - This PR adds a cooldown grace check so reconciliation skips issues whose latest run finished within the cooldown window
> - The benefit is eliminating false-positive stranding while preserving legitimate recovery for genuinely stuck agents

## What Changed

- **`parseHeartbeatPolicy()`** — now extracts `cooldownSec` from `agent.runtimeConfig.heartbeat` (was stored but ignored)
- **`getLatestIssueRun()`** — now returns `finishedAt` timestamp (needed for recency check)
- **`reconcileStrandedAssignedIssues()`** — adds cooldown grace guard: if latest run finished within the agent's cooldown window, skip the issue instead of escalating
- The cooldown applies to **all terminal run statuses** (succeeded and failed). This is intentional: retrying a failing agent every 30s burns tokens without progress, so cooldown acts as a natural backoff.

## Verification

- All 11 existing `heartbeat-process-recovery` tests pass (no regressions)
- 2 new tests added:
  - "skips reconciliation when the agent is within its cooldown window after a recent run" — sets `cooldownSec: 300` and `finishedAt: now`, asserts no escalation
  - "allows reconciliation after the cooldown window has expired" — sets `cooldownSec: 10` and `finishedAt: 5 minutes ago`, asserts recovery proceeds
- Running in production (our instance) for 30+ minutes with confirmed results — issues that previously flipped to `blocked` every 30s now remain stable during cooldown

## Risks

- **Low risk.** The guard is purely additive — `cooldownSec: 0` (the default) skips the check entirely, preserving existing behavior exactly.
- Agents with cooldown configured will have a slightly longer window before genuine stranding is detected. For a 300s cooldown, this means up to 5 minutes delay before a genuinely stuck agent's issue is escalated. This is acceptable and preferable to the current false-positive loop.
- The failed-run cooldown behavior differs from pre-PR: a freshly-failed issue will be skipped during cooldown. This is intentional (prevents token-burning retry loops) and documented in the code comment.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Claude Opus 4.7 (`claude-opus-4-7`) via Claude Code CLI. Extended thinking enabled. 200K context window. Tool use enabled (file read/write, bash execution, web search).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge