### PR TITLE
fix(runtime): Harden orphan cleanup and test isolation

### DIFF
--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -866,6 +866,7 @@ describe("worktree helpers", () => {
       execFileSync("git", ["init"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
+      execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repoRoot, stdio: "ignore" });
       fs.writeFileSync(path.join(repoRoot, "README.md"), "# temp\n", "utf8");
       execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
@@ -899,7 +900,9 @@ describe("worktree helpers", () => {
       expect(fs.statSync(targetHookPath).mode & 0o111).not.toBe(0);
       expect(fs.readFileSync(targetTokensPath, "utf8")).toBe("secret-token\n");
     } finally {
-      execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: repoRoot, stdio: "ignore" });
+      if (fs.existsSync(repoRoot) && fs.existsSync(worktreePath)) {
+        execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: repoRoot, stdio: "ignore" });
+      }
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   });
@@ -918,6 +921,7 @@ describe("worktree helpers", () => {
       execFileSync("git", ["init"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
+      execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repoRoot, stdio: "ignore" });
       fs.writeFileSync(path.join(repoRoot, "README.md"), "# temp\n", "utf8");
       execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
       execFileSync("git", ["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });

--- a/packages/db/src/runtime-config.test.ts
+++ b/packages/db/src/runtime-config.test.ts
@@ -46,6 +46,7 @@ describe("resolveDatabaseTarget", () => {
     const projectDir = path.join(tempDir, "repo");
     fs.mkdirSync(projectDir, { recursive: true });
     process.chdir(projectDir);
+    delete process.env.DATABASE_URL;
     delete process.env.PAPERCLIP_CONFIG;
     writeJson(path.join(projectDir, ".paperclip", "config.json"), {
       database: { mode: "embedded-postgres", embeddedPostgresPort: 54329 },
@@ -67,6 +68,7 @@ describe("resolveDatabaseTarget", () => {
   it("uses config postgres connection string when configured", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-db-runtime-"));
     const configPath = path.join(tempDir, "instance", "config.json");
+    delete process.env.DATABASE_URL;
     process.env.PAPERCLIP_CONFIG = configPath;
     writeJson(configPath, {
       database: {
@@ -87,6 +89,7 @@ describe("resolveDatabaseTarget", () => {
   it("falls back to embedded postgres settings from config", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-db-runtime-"));
     const configPath = path.join(tempDir, "instance", "config.json");
+    delete process.env.DATABASE_URL;
     process.env.PAPERCLIP_CONFIG = configPath;
     writeJson(configPath, {
       database: {

--- a/server/src/__tests__/cli-auth-routes.test.ts
+++ b/server/src/__tests__/cli-auth-routes.test.ts
@@ -107,7 +107,7 @@ describe("cli auth routes", () => {
     });
     expect(res.body.boardApiToken).toBe("pcp_board_token");
     expect(res.body.approvalUrl).toContain("/cli-auth/challenge-1?token=pcp_cli_auth_secret");
-  }, 10_000);
+  }, 15_000);
 
   it("rejects anonymous access to generic skill documents", async () => {
     const app = await createApp({ type: "none", source: "none" });

--- a/server/src/__tests__/cli-auth-routes.test.ts
+++ b/server/src/__tests__/cli-auth-routes.test.ts
@@ -107,7 +107,7 @@ describe("cli auth routes", () => {
     });
     expect(res.body.boardApiToken).toBe("pcp_board_token");
     expect(res.body.approvalUrl).toContain("/cli-auth/challenge-1?token=pcp_cli_auth_secret");
-  });
+  }, 10_000);
 
   it("rejects anonymous access to generic skill documents", async () => {
     const app = await createApp({ type: "none", source: "none" });

--- a/server/src/__tests__/feedback-service.test.ts
+++ b/server/src/__tests__/feedback-service.test.ts
@@ -25,6 +25,7 @@ import {
   issues,
 } from "@paperclipai/db";
 import { feedbackService } from "../services/feedback.ts";
+import { getEmbeddedPostgresTestSupport } from "./helpers/embedded-postgres.js";
 
 type EmbeddedPostgresInstance = {
   initialise(): Promise<void>;
@@ -96,7 +97,16 @@ async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
   await db?.$client?.end?.({ timeout: 0 });
 }
 
-describe("feedbackService.saveIssueVote", () => {
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres feedback service tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("feedbackService.saveIssueVote", () => {
   let db!: ReturnType<typeof createDb>;
   let svc!: ReturnType<typeof feedbackService>;
   let instance: EmbeddedPostgresInstance | null = null;

--- a/server/src/__tests__/opencode-local-adapter-environment.test.ts
+++ b/server/src/__tests__/opencode-local-adapter-environment.test.ts
@@ -11,29 +11,11 @@ describe("opencode_local environment diagnostics", () => {
       `paperclip-opencode-local-cwd-${Date.now()}-${Math.random().toString(16).slice(2)}`,
       "workspace",
     );
-
-    await fs.rm(path.dirname(cwd), { recursive: true, force: true });
-
-    const result = await testEnvironment({
-      companyId: "company-1",
-      adapterType: "opencode_local",
-      config: {
-        command: process.execPath,
-        cwd,
-      },
-    });
-
-    expect(result.checks.some((check) => check.code === "opencode_cwd_invalid")).toBe(true);
-    expect(result.checks.some((check) => check.level === "error")).toBe(true);
-    expect(result.status).toBe("fail");
-  });
-
-  it("treats an empty OPENAI_API_KEY override as missing", async () => {
-    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-empty-key-"));
-    const originalOpenAiKey = process.env.OPENAI_API_KEY;
-    process.env.OPENAI_API_KEY = "sk-host-value";
+    const xdgConfigHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-empty-config-"));
 
     try {
+      await fs.rm(path.dirname(cwd), { recursive: true, force: true });
+
       const result = await testEnvironment({
         companyId: "company-1",
         adapterType: "opencode_local",
@@ -41,7 +23,40 @@ describe("opencode_local environment diagnostics", () => {
           command: process.execPath,
           cwd,
           env: {
+            XDG_CONFIG_HOME: xdgConfigHome,
+          },
+        },
+      });
+
+      expect(result.checks.some((check) => check.code === "opencode_cwd_invalid")).toBe(true);
+      expect(result.checks.some((check) => check.level === "error")).toBe(true);
+      expect(result.status).toBe("fail");
+    } finally {
+      await fs.rm(xdgConfigHome, { recursive: true, force: true });
+    }
+  });
+
+  it("treats an empty OPENAI_API_KEY override as missing", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-empty-key-"));
+    const xdgConfigHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-empty-key-config-"));
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-empty-key-bin-"));
+    const fakeOpencode = path.join(binDir, "opencode");
+    const originalOpenAiKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "sk-host-value";
+
+    try {
+      await fs.writeFile(fakeOpencode, "#!/bin/sh\nexit 0\n", "utf8");
+      await fs.chmod(fakeOpencode, 0o755);
+
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "opencode_local",
+        config: {
+          command: fakeOpencode,
+          cwd,
+          env: {
             OPENAI_API_KEY: "",
+            XDG_CONFIG_HOME: xdgConfigHome,
           },
         },
       });
@@ -56,12 +71,15 @@ describe("opencode_local environment diagnostics", () => {
         process.env.OPENAI_API_KEY = originalOpenAiKey;
       }
       await fs.rm(cwd, { recursive: true, force: true });
+      await fs.rm(xdgConfigHome, { recursive: true, force: true });
+      await fs.rm(binDir, { recursive: true, force: true });
     }
   });
 
   it("classifies ProviderModelNotFoundError probe output as model-unavailable warning", async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-probe-cwd-"));
     const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-probe-bin-"));
+    const xdgConfigHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-probe-config-"));
     const fakeOpencode = path.join(binDir, "opencode");
     const script = [
       "#!/bin/sh",
@@ -81,6 +99,9 @@ describe("opencode_local environment diagnostics", () => {
         config: {
           command: fakeOpencode,
           cwd,
+          env: {
+            XDG_CONFIG_HOME: xdgConfigHome,
+          },
         },
       });
 
@@ -91,6 +112,7 @@ describe("opencode_local environment diagnostics", () => {
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
       await fs.rm(binDir, { recursive: true, force: true });
+      await fs.rm(xdgConfigHome, { recursive: true, force: true });
     }
-  });
+  }, 20_000);
 });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -174,10 +174,96 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     return { companyId, agentId, issueSvc, projectId, routine, svc, wakeups };
   }
 
-  it("creates a fresh execution issue when the previous routine issue is open but idle", async () => {
+  it("cancels orphaned routine issues before creating a fresh execution issue", async () => {
     const { companyId, issueSvc, routine, svc } = await seedFixture();
-    const previousRunId = randomUUID();
-    const previousIssue = await issueSvc.create(companyId, {
+    const orphanedRunIds = [randomUUID(), randomUUID()];
+    const orphanedIssues = await Promise.all(orphanedRunIds.map((originRunId, index) => issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: index === 0 ? "todo" : "blocked",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId,
+    })));
+
+    await db.insert(routineRuns).values(orphanedIssues.map((issue, index) => ({
+      id: orphanedRunIds[index]!,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual" as const,
+      status: "issue_created" as const,
+      triggeredAt: new Date(`2026-03-20T12:0${index}:00.000Z`),
+      linkedIssueId: issue.id,
+      completedAt: new Date(`2026-03-20T12:0${index}:00.000Z`),
+    })));
+    await Promise.all(orphanedIssues.map((issue, index) => db
+      .update(issues)
+      .set({
+        executionRunId: orphanedRunIds[index]!,
+        executionLockedAt: new Date(`2026-03-20T12:0${index}:30.000Z`),
+      })
+      .where(eq(issues.id, issue.id))));
+
+    const detailBefore = await svc.getDetail(routine.id);
+    expect(detailBefore?.activeIssue).toBeNull();
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("issue_created");
+    expect(run.linkedIssueId).toBeTruthy();
+    expect(orphanedIssues.map((issue) => issue.id)).not.toContain(run.linkedIssueId);
+
+    const routineIssues = await db
+      .select({
+        id: issues.id,
+        status: issues.status,
+        originRunId: issues.originRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+
+    expect(routineIssues).toHaveLength(3);
+    expect(
+      routineIssues
+        .filter((issue) => orphanedIssues.some((orphanedIssue) => orphanedIssue.id === issue.id))
+        .every(
+          (issue) =>
+            issue.status === "cancelled" &&
+            issue.executionRunId === null &&
+            issue.executionLockedAt === null,
+        ),
+    ).toBe(true);
+    expect(routineIssues.find((issue) => issue.id === run.linkedIssueId)?.status).toBe("todo");
+
+    const previousRuns = await db
+      .select({
+        id: routineRuns.id,
+        status: routineRuns.status,
+        failureReason: routineRuns.failureReason,
+      })
+      .from(routineRuns)
+      .where(eq(routineRuns.routineId, routine.id));
+
+    expect(
+      previousRuns
+        .filter((storedRun) => orphanedRunIds.includes(storedRun.id))
+        .every(
+          (storedRun) =>
+            storedRun.status === "failed" &&
+            storedRun.failureReason === "Execution issue lost its live heartbeat run",
+        ),
+    ).toBe(true);
+  });
+
+  it("does not overwrite completed routine runs when cleaning up reopened orphaned issues", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const completedRunId = randomUUID();
+    const reopenedIssue = await issueSvc.create(companyId, {
       projectId: routine.projectId,
       title: routine.title,
       description: routine.description,
@@ -186,39 +272,47 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       assigneeAgentId: routine.assigneeAgentId,
       originKind: "routine_execution",
       originId: routine.id,
-      originRunId: previousRunId,
+      originRunId: completedRunId,
     });
 
     await db.insert(routineRuns).values({
-      id: previousRunId,
+      id: completedRunId,
       companyId,
       routineId: routine.id,
       triggerId: null,
       source: "manual",
-      status: "issue_created",
+      status: "completed",
       triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
-      linkedIssueId: previousIssue.id,
-      completedAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: reopenedIssue.id,
+      completedAt: new Date("2026-03-20T12:05:00.000Z"),
     });
-
-    const detailBefore = await svc.getDetail(routine.id);
-    expect(detailBefore?.activeIssue).toBeNull();
+    await db
+      .update(issues)
+      .set({
+        executionRunId: completedRunId,
+        executionLockedAt: new Date("2026-03-20T12:05:00.000Z"),
+      })
+      .where(eq(issues.id, reopenedIssue.id));
 
     const run = await svc.runRoutine(routine.id, { source: "manual" });
     expect(run.status).toBe("issue_created");
-    expect(run.linkedIssueId).not.toBe(previousIssue.id);
+    expect(run.linkedIssueId).not.toBe(reopenedIssue.id);
 
-    const routineIssues = await db
+    const storedCompletedRun = await db
       .select({
-        id: issues.id,
-        originRunId: issues.originRunId,
+        status: routineRuns.status,
+        failureReason: routineRuns.failureReason,
+        completedAt: routineRuns.completedAt,
       })
-      .from(issues)
-      .where(eq(issues.originId, routine.id));
+      .from(routineRuns)
+      .where(eq(routineRuns.id, completedRunId))
+      .then((rows) => rows[0] ?? null);
 
-    expect(routineIssues).toHaveLength(2);
-    expect(routineIssues.map((issue) => issue.id)).toContain(previousIssue.id);
-    expect(routineIssues.map((issue) => issue.id)).toContain(run.linkedIssueId);
+    expect(storedCompletedRun).toEqual({
+      status: "completed",
+      failureReason: null,
+      completedAt: new Date("2026-03-20T12:05:00.000Z"),
+    });
   });
 
   it("creates draft routines without a project or default assignee", async () => {

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -185,7 +185,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
   routineTest("cancels orphaned routine issues before creating a fresh execution issue", async () => {
     const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
     const orphanedRunIds = [randomUUID(), randomUUID()];
-    const orphanedHeartbeatRunIds = [randomUUID(), randomUUID()];
+    const orphanedExecutionHeartbeatRunId = randomUUID();
     const orphanedIssues = await Promise.all(orphanedRunIds.map((originRunId, index) => issueSvc.create(companyId, {
       projectId: routine.projectId,
       title: routine.title,
@@ -209,24 +209,30 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       linkedIssueId: issue.id,
       completedAt: new Date(`2026-03-20T12:0${index}:00.000Z`),
     })));
-    await db.insert(heartbeatRuns).values(orphanedIssues.map((issue, index) => ({
-      id: orphanedHeartbeatRunIds[index]!,
+    await db.insert(heartbeatRuns).values({
+      id: orphanedExecutionHeartbeatRunId,
       companyId,
       agentId,
       invocationSource: "assignment" as const,
       triggerDetail: "system",
       status: "completed" as const,
-      contextSnapshot: { issueId: issue.id },
-      startedAt: new Date(`2026-03-20T12:0${index}:15.000Z`),
-      finishedAt: new Date(`2026-03-20T12:0${index}:20.000Z`),
-    })));
-    await Promise.all(orphanedIssues.map((issue, index) => db
+      contextSnapshot: { issueId: orphanedIssues[0]!.id },
+      startedAt: new Date("2026-03-20T12:00:15.000Z"),
+      finishedAt: new Date("2026-03-20T12:00:20.000Z"),
+    });
+    await db
       .update(issues)
       .set({
-        executionRunId: orphanedHeartbeatRunIds[index]!,
-        executionLockedAt: new Date(`2026-03-20T12:0${index}:30.000Z`),
+        executionRunId: orphanedExecutionHeartbeatRunId,
+        executionLockedAt: new Date("2026-03-20T12:00:30.000Z"),
       })
-      .where(eq(issues.id, issue.id))));
+      .where(eq(issues.id, orphanedIssues[0]!.id));
+    await db
+      .update(issues)
+      .set({
+        executionLockedAt: new Date("2026-03-20T12:01:30.000Z"),
+      })
+      .where(eq(issues.id, orphanedIssues[1]!.id));
 
     const detailBefore = await svc.getDetail(routine.id);
     expect(detailBefore?.activeIssue).toBeNull();

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -28,6 +28,14 @@ import { routineService } from "../services/routines.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+const ROUTINES_TEST_TIMEOUT_MS = 15_000;
+const ROUTINES_HOOK_TIMEOUT_MS = 20_000;
+
+const routineTest = (
+  name: Parameters<typeof it>[0],
+  fn: Parameters<typeof it>[1],
+  timeout = ROUTINES_TEST_TIMEOUT_MS,
+) => it(name, fn, timeout);
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -42,7 +50,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-routines-service-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  }, ROUTINES_HOOK_TIMEOUT_MS);
 
   afterEach(async () => {
     await db.delete(activityLog);
@@ -59,11 +67,11 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     await db.delete(agents);
     await db.delete(companies);
     await db.delete(instanceSettings);
-  });
+  }, ROUTINES_HOOK_TIMEOUT_MS);
 
   afterAll(async () => {
     await tempDb?.cleanup();
-  });
+  }, ROUTINES_HOOK_TIMEOUT_MS);
 
   async function seedFixture(opts?: {
     wakeup?: (
@@ -174,7 +182,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     return { companyId, agentId, issueSvc, projectId, routine, svc, wakeups };
   }
 
-  it("cancels orphaned routine issues before creating a fresh execution issue", async () => {
+  routineTest("cancels orphaned routine issues before creating a fresh execution issue", async () => {
     const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
     const orphanedRunIds = [randomUUID(), randomUUID()];
     const orphanedHeartbeatRunIds = [randomUUID(), randomUUID()];
@@ -272,7 +280,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     ).toBe(true);
   });
 
-  it("does not overwrite completed routine runs when cleaning up reopened orphaned issues", async () => {
+  routineTest("does not overwrite completed routine runs when cleaning up reopened orphaned issues", async () => {
     const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
     const completedRunId = randomUUID();
     const completedHeartbeatRunId = randomUUID();
@@ -339,7 +347,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     });
   });
 
-  it("creates draft routines without a project or default assignee", async () => {
+  routineTest("creates draft routines without a project or default assignee", async () => {
     const { companyId, svc } = await seedFixture();
 
     const routine = await svc.create(
@@ -364,7 +372,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routine.status).toBe("paused");
   });
 
-  it("wakes the assignee when a routine creates a fresh execution issue", async () => {
+  routineTest("wakes the assignee when a routine creates a fresh execution issue", async () => {
     const { agentId, routine, svc, wakeups } = await seedFixture();
 
     const run = await svc.runRoutine(routine.id, { source: "manual" });
@@ -387,7 +395,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     ]);
   });
 
-  it("waits for the assignee wakeup to be queued before returning the routine run", async () => {
+  routineTest("waits for the assignee wakeup to be queued before returning the routine run", async () => {
     let wakeupResolved = false;
     const { routine, svc } = await seedFixture({
       wakeup: async () => {
@@ -403,7 +411,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(wakeupResolved).toBe(true);
   });
 
-  it("coalesces only when the existing routine issue has a live execution run", async () => {
+  routineTest("coalesces only when the existing routine issue has a live execution run", async () => {
     const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
     const previousRunId = randomUUID();
     const liveHeartbeatRunId = randomUUID();
@@ -467,7 +475,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues[0]?.id).toBe(previousIssue.id);
   });
 
-  it("interpolates routine variables into the execution issue and stores resolved values", async () => {
+  routineTest("interpolates routine variables into the execution issue and stores resolved values", async () => {
     const { companyId, agentId, projectId, svc } = await seedFixture();
     const variableRoutine = await svc.create(
       companyId,
@@ -517,7 +525,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     });
   });
 
-  it("attaches the selected execution workspace to manually triggered routine issues", async () => {
+  routineTest("attaches the selected execution workspace to manually triggered routine issues", async () => {
     const { companyId, projectId, routine, svc } = await seedFixture();
     const projectWorkspaceId = randomUUID();
     const executionWorkspaceId = randomUUID();
@@ -579,7 +587,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     });
   });
 
-  it("runs draft routines with one-off agent and project overrides", async () => {
+  routineTest("runs draft routines with one-off agent and project overrides", async () => {
     const { companyId, agentId, projectId, svc } = await seedFixture();
     const draftRoutine = await svc.create(
       companyId,
@@ -622,7 +630,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     });
   });
 
-  it("rejects enabling automation for routines without a default agent", async () => {
+  routineTest("rejects enabling automation for routines without a default agent", async () => {
     const { companyId, svc } = await seedFixture();
     const draftRoutine = await svc.create(
       companyId,
@@ -646,7 +654,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     ).rejects.toThrow(/default agent required/i);
   });
 
-  it("blocks schedule triggers when required variables do not have defaults", async () => {
+  routineTest("blocks schedule triggers when required variables do not have defaults", async () => {
     const { companyId, agentId, projectId, svc } = await seedFixture();
     const variableRoutine = await svc.create(
       companyId,
@@ -678,7 +686,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     ).rejects.toThrow(/require defaults for required variables/i);
   });
 
-  it("treats malformed stored defaults as missing when validating schedule triggers", async () => {
+  routineTest("treats malformed stored defaults as missing when validating schedule triggers", async () => {
     const { companyId, agentId, projectId, svc } = await seedFixture();
     const variableRoutine = await svc.create(
       companyId,
@@ -726,7 +734,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     ).rejects.toThrow(/require defaults for required variables/i);
   });
 
-  it("serializes concurrent dispatches until the first execution issue is linked to a queued run", async () => {
+  routineTest("serializes concurrent dispatches until the first execution issue is linked to a queued run", async () => {
     const { routine, svc } = await seedFixture({
       wakeup: async (wakeupAgentId, wakeupOpts) => {
         const issueId =
@@ -774,7 +782,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues).toHaveLength(1);
   });
 
-  it("fails the run and cleans up the execution issue when wakeup queueing fails", async () => {
+  routineTest("fails the run and cleans up the execution issue when wakeup queueing fails", async () => {
     const { routine, svc } = await seedFixture({
       wakeup: async () => {
         throw new Error("queue unavailable");
@@ -795,7 +803,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues).toHaveLength(0);
   });
 
-  it("accepts standard second-precision webhook timestamps for HMAC triggers", async () => {
+  routineTest("accepts standard second-precision webhook timestamps for HMAC triggers", async () => {
     const { routine, svc } = await seedFixture();
     const { trigger, secretMaterial } = await svc.createTrigger(
       routine.id,
@@ -830,7 +838,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(run.linkedIssueId).toBeTruthy();
   });
 
-  it("accepts GitHub-style X-Hub-Signature-256 with github_hmac signing mode", async () => {
+  routineTest("accepts GitHub-style X-Hub-Signature-256 with github_hmac signing mode", async () => {
     const { routine, svc } = await seedFixture();
     const { trigger, secretMaterial } = await svc.createTrigger(
       routine.id,
@@ -857,7 +865,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(run.status).toBe("issue_created");
   });
 
-  it("rejects invalid signature for github_hmac signing mode", async () => {
+  routineTest("rejects invalid signature for github_hmac signing mode", async () => {
     const { routine, svc } = await seedFixture();
     const { trigger } = await svc.createTrigger(
       routine.id,
@@ -879,7 +887,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     ).rejects.toThrow();
   });
 
-  it("accepts any request with none signing mode", async () => {
+  routineTest("accepts any request with none signing mode", async () => {
     const { routine, svc } = await seedFixture();
     const { trigger } = await svc.createTrigger(
       routine.id,

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -175,8 +175,9 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
   }
 
   it("cancels orphaned routine issues before creating a fresh execution issue", async () => {
-    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
     const orphanedRunIds = [randomUUID(), randomUUID()];
+    const orphanedHeartbeatRunIds = [randomUUID(), randomUUID()];
     const orphanedIssues = await Promise.all(orphanedRunIds.map((originRunId, index) => issueSvc.create(companyId, {
       projectId: routine.projectId,
       title: routine.title,
@@ -200,10 +201,21 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       linkedIssueId: issue.id,
       completedAt: new Date(`2026-03-20T12:0${index}:00.000Z`),
     })));
+    await db.insert(heartbeatRuns).values(orphanedIssues.map((issue, index) => ({
+      id: orphanedHeartbeatRunIds[index]!,
+      companyId,
+      agentId,
+      invocationSource: "assignment" as const,
+      triggerDetail: "system",
+      status: "completed" as const,
+      contextSnapshot: { issueId: issue.id },
+      startedAt: new Date(`2026-03-20T12:0${index}:15.000Z`),
+      finishedAt: new Date(`2026-03-20T12:0${index}:20.000Z`),
+    })));
     await Promise.all(orphanedIssues.map((issue, index) => db
       .update(issues)
       .set({
-        executionRunId: orphanedRunIds[index]!,
+        executionRunId: orphanedHeartbeatRunIds[index]!,
         executionLockedAt: new Date(`2026-03-20T12:0${index}:30.000Z`),
       })
       .where(eq(issues.id, issue.id))));
@@ -261,8 +273,9 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
   });
 
   it("does not overwrite completed routine runs when cleaning up reopened orphaned issues", async () => {
-    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
     const completedRunId = randomUUID();
+    const completedHeartbeatRunId = randomUUID();
     const reopenedIssue = await issueSvc.create(companyId, {
       projectId: routine.projectId,
       title: routine.title,
@@ -286,10 +299,21 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       linkedIssueId: reopenedIssue.id,
       completedAt: new Date("2026-03-20T12:05:00.000Z"),
     });
+    await db.insert(heartbeatRuns).values({
+      id: completedHeartbeatRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "completed",
+      contextSnapshot: { issueId: reopenedIssue.id },
+      startedAt: new Date("2026-03-20T12:00:30.000Z"),
+      finishedAt: new Date("2026-03-20T12:05:00.000Z"),
+    });
     await db
       .update(issues)
       .set({
-        executionRunId: completedRunId,
+        executionRunId: completedHeartbeatRunId,
         executionLockedAt: new Date("2026-03-20T12:05:00.000Z"),
       })
       .where(eq(issues.id, reopenedIssue.id));

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -150,13 +150,6 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
             status: "queued",
             contextSnapshot: { ...(wakeupOpts.contextSnapshot ?? {}), issueId },
           });
-          await db
-            .update(issues)
-            .set({
-              executionRunId: queuedRunId,
-              executionLockedAt: new Date(),
-            })
-            .where(eq(issues.id, issueId));
           return { id: queuedRunId };
         },
       },
@@ -759,13 +752,6 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
           status: "queued",
           contextSnapshot: { ...(wakeupOpts.contextSnapshot ?? {}), issueId },
         });
-        await db
-          .update(issues)
-          .set({
-            executionRunId: queuedRunId,
-            executionLockedAt: new Date(),
-          })
-          .where(eq(issues.id, issueId));
         return { id: queuedRunId };
       },
     });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -71,6 +71,7 @@ async function createTempRepo(defaultBranch = "main") {
   await runGit(repoRoot, ["init"]);
   await runGit(repoRoot, ["config", "user.email", "paperclip@example.com"]);
   await runGit(repoRoot, ["config", "user.name", "Paperclip Test"]);
+  await runGit(repoRoot, ["config", "commit.gpgsign", "false"]);
   await fs.writeFile(path.join(repoRoot, "README.md"), "hello\n", "utf8");
   await runGit(repoRoot, ["add", "README.md"]);
   await runGit(repoRoot, ["commit", "-m", "Initial commit"]);
@@ -306,6 +307,7 @@ describe("ensureServerWorkspaceLinksCurrent", () => {
 describe("realizeExecutionWorkspace", () => {
   it("creates and reuses a git worktree for an issue-scoped branch", async () => {
     const repoRoot = await createTempRepo();
+    await fs.mkdir(path.join(repoRoot, ".beads"), { recursive: true });
 
     const first = await realizeExecutionWorkspace({
       base: {
@@ -339,6 +341,8 @@ describe("realizeExecutionWorkspace", () => {
     expect(first.branchName).toBe("PAP-447-add-worktree-support");
     expect(first.cwd).toContain(path.join(".paperclip", "worktrees"));
     await expect(fs.stat(path.join(first.cwd, ".git"))).resolves.toBeTruthy();
+    const redirectContents = await fs.readFile(path.join(first.cwd, ".beads", "redirect"), "utf8");
+    expect(path.resolve(first.cwd, redirectContents.trim())).toBe(path.join(repoRoot, ".beads"));
 
     const second = await realizeExecutionWorkspace({
       base: {
@@ -370,6 +374,74 @@ describe("realizeExecutionWorkspace", () => {
     expect(second.created).toBe(false);
     expect(second.cwd).toBe(first.cwd);
     expect(second.branchName).toBe(first.branchName);
+    await expect(fs.readFile(path.join(second.cwd, ".beads", "redirect"), "utf8")).resolves.toBe(redirectContents);
+  });
+
+  it("removes stale worktree .beads redirects when the repo root beads directory disappears", async () => {
+    const repoRoot = await createTempRepo();
+    await fs.mkdir(path.join(repoRoot, ".beads"), { recursive: true });
+
+    const first = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-redirect-cleanup",
+        identifier: "PAP-448",
+        title: "Refresh Worktree Redirects",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    const redirectPath = path.join(first.cwd, ".beads", "redirect");
+    await expect(fs.readFile(redirectPath, "utf8")).resolves.toBeTruthy();
+
+    await fs.rm(path.join(repoRoot, ".beads"), { recursive: true, force: true });
+
+    const reused = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-redirect-cleanup",
+        identifier: "PAP-448",
+        title: "Refresh Worktree Redirects",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(reused.created).toBe(false);
+    await expect(fs.stat(redirectPath)).rejects.toThrow();
   });
 
   it("rejects reusing an empty directory that only looks like a worktree because it sits inside the repo", async () => {
@@ -1768,8 +1840,12 @@ describe("realizeExecutionWorkspace", () => {
     await runGit(repoRoot, ["push", "-u", "origin", "master"]);
     await runGit(repoRoot, ["fetch", "origin"]);
     // Explicitly set refs/remotes/origin/HEAD to exercise the symbolic-ref path
-    // (git remote set-head -a requires the remote to advertise HEAD, so we set it manually)
-    await runGit(repoRoot, ["remote", "set-head", "origin", "master"]);
+    // without depending on `git remote set-head`, which can hang in local bare remotes.
+    await runGit(repoRoot, [
+      "symbolic-ref",
+      "refs/remotes/origin/HEAD",
+      "refs/remotes/origin/master",
+    ]);
 
     const { recorder, operations } = createWorkspaceOperationRecorderDouble();
 
@@ -2103,7 +2179,7 @@ describe("ensureRuntimeServicesForRun", () => {
     expect(third).toHaveLength(1);
     expect(third[0]?.reused).toBe(false);
     expect(third[0]?.id).not.toBe(first[0]?.id);
-  });
+  }, 30_000);
 
   it("does not reuse project-scoped shared services across different workspace launch contexts", async () => {
     const primaryWorkspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-primary-"));
@@ -2198,7 +2274,7 @@ describe("ensureRuntimeServicesForRun", () => {
 
     const executionResponse = await fetch(executionServices[0]!.url!);
     expect(await executionResponse.text()).toBe(path.join(worktreeWorkspaceRoot, ".paperclip", "runtime-services"));
-  });
+  }, 30_000);
 
   it("does not leak parent Paperclip instance env into runtime service commands", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-env-"));
@@ -2278,7 +2354,7 @@ describe("ensureRuntimeServicesForRun", () => {
     expect(services[0]?.executionWorkspaceId).toBe("execution-workspace-1");
     expect(services[0]?.scopeType).toBe("execution_workspace");
     expect(services[0]?.scopeId).toBe("execution-workspace-1");
-  });
+  }, 15_000);
 
   it("stops execution workspace runtime services by executionWorkspaceId", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-stop-"));
@@ -2332,7 +2408,7 @@ describe("ensureRuntimeServicesForRun", () => {
     await new Promise((resolve) => setTimeout(resolve, 250));
 
     await expect(fetch(services[0]!.url!)).rejects.toThrow();
-  });
+  }, 15_000);
 
   it("does not stop services in sibling directories when matching by workspace cwd", async () => {
     const workspaceParent = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-sibling-"));
@@ -2391,7 +2467,7 @@ describe("ensureRuntimeServicesForRun", () => {
 
     await releaseRuntimeServicesForRun(runId);
     leasedRunIds.delete(runId);
-  });
+  }, 15_000);
 
   it("starts only the selected workspace-controlled runtime service", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-control-start-"));

--- a/server/src/__tests__/worktree-config.test.ts
+++ b/server/src/__tests__/worktree-config.test.ts
@@ -197,6 +197,10 @@ describe("worktree config repair", () => {
     process.env.PAPERCLIP_IN_WORKTREE = "true";
     process.env.PAPERCLIP_WORKTREE_NAME = "PAP-880-thumbs-capture-for-evals-feature";
     process.env.PAPERCLIP_WORKTREES_DIR = isolatedHome;
+    delete process.env.PAPERCLIP_HOME;
+    delete process.env.PAPERCLIP_INSTANCE_ID;
+    delete process.env.PAPERCLIP_CONFIG;
+    delete process.env.PAPERCLIP_CONTEXT;
 
     const result = maybeRepairLegacyWorktreeConfigAndEnvFiles();
     const repairedConfig = JSON.parse(await fs.readFile(configPath, "utf8"));
@@ -426,6 +430,10 @@ describe("worktree config repair", () => {
     process.env.PAPERCLIP_IN_WORKTREE = "true";
     process.env.PAPERCLIP_WORKTREE_NAME = "PAP-884-ai-commits-component";
     process.env.PAPERCLIP_WORKTREES_DIR = isolatedHome;
+    delete process.env.PAPERCLIP_HOME;
+    delete process.env.PAPERCLIP_INSTANCE_ID;
+    delete process.env.PAPERCLIP_CONFIG;
+    delete process.env.PAPERCLIP_CONTEXT;
 
     const result = maybeRepairLegacyWorktreeConfigAndEnvFiles();
     const repairedConfig = JSON.parse(await fs.readFile(configPath, "utf8"));
@@ -504,6 +512,7 @@ describe("worktree config repair", () => {
     process.env.PAPERCLIP_HOME = isolatedHome;
     process.env.PAPERCLIP_INSTANCE_ID = "pap-878-create-a-mine-tab-in-inbox";
     process.env.PAPERCLIP_CONFIG = configPath;
+    delete process.env.DATABASE_URL;
 
     maybePersistWorktreeRuntimePorts({
       serverPort: 3103,

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -46,6 +46,7 @@ import { logActivity } from "./activity-log.js";
 const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
 const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running"];
 const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
+const TERMINAL_ROUTINE_RUN_STATUSES = ["coalesced", "skipped", "completed", "failed"];
 const MAX_CATCH_UP_RUNS = 25;
 const WEEKDAY_INDEX: Record<string, number> = {
   Sun: 0,
@@ -640,6 +641,117 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  async function listOrphanedExecutionIssues(
+    routine: typeof routines.$inferSelect,
+    executor: Db = db,
+  ) {
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, "routine_execution"),
+          eq(issues.originId, routine.id),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+          sql`not exists (
+            select 1
+            from ${heartbeatRuns}
+            where ${heartbeatRuns.id} = ${issues.executionRunId}
+              and ${heartbeatRuns.status} in ('queued', 'running')
+          )`,
+          sql`not exists (
+            select 1
+            from ${heartbeatRuns}
+            where ${heartbeatRuns.companyId} = ${issues.companyId}
+              and ${heartbeatRuns.status} in ('queued', 'running')
+              and ${heartbeatRuns.contextSnapshot} ->> 'issueId' = cast(${issues.id} as text)
+          )`,
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt));
+  }
+
+  async function failRoutineRunIfStillActive(
+    runId: string,
+    patch: Pick<typeof routineRuns.$inferInsert, "failureReason" | "completedAt">,
+    executor: Db = db,
+  ) {
+    return executor
+      .update(routineRuns)
+      .set({
+        status: "failed",
+        failureReason: patch.failureReason,
+        completedAt: patch.completedAt,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(routineRuns.id, runId),
+          sql`${routineRuns.status} not in (${sql.raw(TERMINAL_ROUTINE_RUN_STATUSES.map((status) => `'${status}'`).join(", "))})`,
+        ),
+      )
+      .returning()
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function cancelOrphanedExecutionIssues(
+    routine: typeof routines.$inferSelect,
+    cancelledAt: Date,
+    executor: Db = db,
+  ) {
+    if (routine.concurrencyPolicy === "always_enqueue") return [];
+    const orphanedIssues = await listOrphanedExecutionIssues(routine, executor);
+    const cancelledIssueIds: string[] = [];
+    for (const orphanedIssue of orphanedIssues) {
+      const cancelledIssue = await executor
+        .update(issues)
+        .set({
+          status: "cancelled",
+          cancelledAt,
+          checkoutRunId: null,
+          executionRunId: null,
+          executionLockedAt: null,
+          updatedAt: cancelledAt,
+        })
+        .where(
+          and(
+            eq(issues.id, orphanedIssue.id),
+            eq(issues.companyId, routine.companyId),
+            eq(issues.originKind, "routine_execution"),
+            eq(issues.originId, routine.id),
+            inArray(issues.status, OPEN_ISSUE_STATUSES),
+            isNull(issues.hiddenAt),
+            sql`not exists (
+              select 1
+              from ${heartbeatRuns}
+              where ${heartbeatRuns.id} = ${issues.executionRunId}
+                and ${heartbeatRuns.status} in ('queued', 'running')
+            )`,
+            sql`not exists (
+              select 1
+              from ${heartbeatRuns}
+              where ${heartbeatRuns.companyId} = ${issues.companyId}
+                and ${heartbeatRuns.status} in ('queued', 'running')
+                and ${heartbeatRuns.contextSnapshot} ->> 'issueId' = cast(${issues.id} as text)
+            )`,
+          ),
+        )
+        .returning({ id: issues.id, originRunId: issues.originRunId })
+        .then((rows) => rows[0] ?? null);
+      if (!cancelledIssue) continue;
+      if (cancelledIssue.originRunId) {
+        await failRoutineRunIfStillActive(cancelledIssue.originRunId, {
+          failureReason: "Execution issue lost its live heartbeat run",
+          completedAt: cancelledAt,
+        }, executor);
+      }
+      cancelledIssueIds.push(cancelledIssue.id);
+    }
+    return orphanedIssues.filter((issue) => cancelledIssueIds.includes(issue.id));
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -752,6 +864,7 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
+        await cancelOrphanedExecutionIssues(input.routine, triggeredAt, txDb);
         const activeIssue = await findLiveExecutionIssue(input.routine, txDb);
         if (activeIssue && input.routine.concurrencyPolicy !== "always_enqueue") {
           const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -898,6 +898,11 @@ async function provisionExecutionWorktree(input: {
   created: boolean;
   recorder?: WorkspaceOperationRecorder | null;
 }) {
+  await ensureBeadsRedirectForWorktree({
+    repoRoot: input.repoRoot,
+    worktreePath: input.worktreePath,
+  });
+
   const provisionCommand = asString(input.strategy.provisionCommand, "").trim();
   if (!provisionCommand) return;
   const resolvedProvisionCommand = resolveRepoManagedWorkspaceCommand(provisionCommand, input.repoRoot);
@@ -926,6 +931,25 @@ async function provisionExecutionWorktree(input: {
     },
     successMessage: `Provisioned workspace at ${input.worktreePath}\n`,
   });
+}
+
+async function ensureBeadsRedirectForWorktree(input: {
+  repoRoot: string;
+  worktreePath: string;
+}) {
+  const sourceBeadsDir = path.join(input.repoRoot, ".beads");
+  const worktreeBeadsDir = path.join(input.worktreePath, ".beads");
+  const redirectPath = path.join(worktreeBeadsDir, "redirect");
+
+  if (!(await directoryExists(sourceBeadsDir))) {
+    await fs.rm(redirectPath, { force: true });
+    return;
+  }
+
+  await fs.mkdir(worktreeBeadsDir, { recursive: true });
+
+  const relativeTarget = path.relative(input.worktreePath, sourceBeadsDir) || ".beads";
+  await fs.writeFile(redirectPath, `${relativeTarget}\n`, "utf8");
 }
 
 function buildExecutionWorkspaceCleanupEnv(input: {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Routine execution and execution workspaces are part of the runtime control plane that keeps agent work progressing safely
> - When a routine execution issue loses its live heartbeat, the system needs to recover without leaving stale execution state behind or corrupting prior routine-run history
> - The workspace and runtime regression coverage around that recovery path was also host-sensitive, which made validation noisy on slower local runs and on GitHub's embedded-Postgres runner
> - This pull request hardens orphaned routine cleanup, stale worktree redirect handling, and the affected runtime/worktree test isolation
> - The benefit is safer runtime recovery behavior and more reliable verification for the files this change actually touches

## What Changed

- Cancel orphaned routine execution issues before creating replacements, clear stale execution lock state, and only mark originating routine runs failed when they are still non-terminal
- Remove stale worktree `.beads/redirect` files when the source repo no longer has `.beads`, and keep the associated worktree regressions in place
- Fix the routines-service orphan-cleanup regressions so `issues.executionRunId` points at seeded `heartbeat_runs` rows instead of `routine_runs`
- Adjust the orphan-cleanup regression fixture to respect `issues_open_routine_execution_uq` by combining one execution-bound orphan with one lock-only orphan instead of seeding two impossible open execution issues
- Align the routines-service wakeup stubs with the real heartbeat lazy-locking behavior so queued runs carry `contextSnapshot.issueId` without stamping `executionRunId` before the run actually starts
- Widen the embedded-Postgres routines-service test and hook budgets to match slower CI runners without changing the assertions or runtime behavior
- Harden host-sensitive tests by isolating ambient env/config, disabling temp-repo commit signing, gating embedded Postgres suites on host capability, and widening the slowest route/runtime test budgets
- Rebase the change onto current `origin/master` as a clean replacement branch without the unrelated older local `master` commit that contaminated the original draft PR

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -r typecheck`
- `pnpm build`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm vitest run packages/db/src/runtime-config.test.ts server/src/__tests__/opencode-local-adapter-environment.test.ts server/src/__tests__/worktree-config.test.ts server/src/__tests__/cli-auth-routes.test.ts --testTimeout=20000`
- Attempted focused `server/src/__tests__/routines-service.test.ts` runs locally, but this host still does not produce reliable embedded-Postgres completion signal
- GitHub `verify` on run `24665709644` passed after aligning the routines wakeup harness with the lazy-locking behavior used by `heartbeatService`

## Risks

- Low risk overall, but orphaned routine execution issues will now be cancelled more aggressively whenever no live heartbeat can still be proven
- The routines-service suite now has explicit 15s test and 20s hook budgets because GitHub's runner was timing out on default Vitest limits; this trades stricter wall-clock expectations for more stable behavioral coverage
- The full-suite signal on top of current `origin/master` is currently noisy in this environment, so this draft PR intentionally separates branch-local verification from unrelated upstream failures

## Model Used

- OpenAI Codex, GPT-5-based coding agent with tool use in Codex CLI; the exact model ID is not exposed in this environment

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge