### PR TITLE
fix(error-handler): translate PostgresError P0403 status-guard to HTTP 422

### DIFF
--- a/server/src/__tests__/error-handler.test.ts
+++ b/server/src/__tests__/error-handler.test.ts
@@ -50,4 +50,36 @@ describe("errorHandler", () => {
     expect(res.err).toBe(err);
     expect(res.__errorContext?.error?.message).toBe("db exploded");
   });
+
+  it("returns 422 with status_transition_blocked for P0403 postgres guard errors", () => {
+    const req = makeReq();
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+    const err = Object.assign(new Error("Status transition blocked: in_progress -> done is not allowed. Use paperclip.bypass_status_guard to override."), {
+      code: "P0403",
+    });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "status_transition_blocked",
+      message: "Status transition blocked: in_progress -> done is not allowed. Use paperclip.bypass_status_guard to override.",
+      allowedNextStatuses: ["in_review", "blocked", "cancelled"],
+    });
+  });
+
+  it("returns 500 for P0403 errors that do not start with 'Status transition blocked:'", () => {
+    const req = makeReq();
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+    const err = Object.assign(new Error("Some other P0403 message"), {
+      code: "P0403",
+    });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
+  });
 });

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -61,6 +61,23 @@ export function errorHandler(
     return;
   }
 
+  // postgres.js raises with err.code === 'P0403' for the status-transition guard.
+  // Translate to 422 so clients receive an actionable error instead of an opaque 500.
+  if (
+    err &&
+    typeof err === "object" &&
+    (err as any).code === "P0403" &&
+    typeof (err as any).message === "string" &&
+    (err as any).message.startsWith("Status transition blocked:")
+  ) {
+    res.status(422).json({
+      error: "status_transition_blocked",
+      message: (err as any).message,
+      allowedNextStatuses: ["in_review", "blocked", "cancelled"],
+    });
+    return;
+  }
+
   const rootError = err instanceof Error ? err : new Error(String(err));
   attachErrorContext(
     req,

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -149,6 +149,7 @@ Practical rules:
 - If you are waiting on another ticket, use `blocked`, not `in_progress`, and set `blockedByIssueIds` instead of relying on `parentId` or a free-text comment alone.
 - If a human asks to review or take the task back, usually reassign to that user and set `in_review`.
 - `parentId` is structural only. It does not mean the parent or child is blocked unless `blockedByIssueIds` says so explicitly.
+- Direct transitions to `done` from `in_progress`, `todo`, `blocked`, or `cancelled` are rejected at the DB (`Status transition blocked: X -> done is not allowed`). Always pass through `in_review` first unless the execution policy or an emergency `paperclip.bypass_status_guard` is in effect. The server returns HTTP 422 with `error: status_transition_blocked` for these cases.
 
 **Step 9 — Delegate if needed.** Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. When a follow-up issue needs to stay on the same code change but is not a true child task, set `inheritExecutionWorkspaceFromIssueId` to the source issue. Set `billingCode` for cross-team work.
 


### PR DESCRIPTION
## Problem

When the DB status-transition guard fires (e.g. `PATCH status=done` from `in_progress`), postgres.js raises an error with `err.code === 'P0403'` and a message beginning `Status transition blocked:`. The Express `errorHandler` did not recognise this and fell through to the generic 500 branch, returning an opaque `{"error":"Internal server error"}` to the client. The actionable reason only appeared in `server.log`.

Observed baseline: ~460 guard-block events in server.log; ~80% are `in_progress -> done`. Agents could not distinguish this from a real crash and had to resort to workarounds.

## Changes

### `server/src/middleware/error-handler.ts`
- Added a branch before the generic 500 catch-all that detects `err.code === 'P0403'` + `err.message.startsWith('Status transition blocked:')` and returns **HTTP 422** with:
  ```json
  {
    "error": "status_transition_blocked",
    "message": "<original DB message, including bypass_status_guard hint>",
    "allowedNextStatuses": ["in_review", "blocked", "cancelled"]
  }
  ```
- Leaves the `bypass_status_guard` hint from the DB message intact in the response.
- Does not attach `__errorContext` or call `trackErrorHandlerCrash` (this is not a crash).

### `server/src/__tests__/error-handler.test.ts`
- Added two regression tests:
  - `P0403` with `Status transition blocked:` prefix → 422 + `status_transition_blocked`
  - `P0403` without the recognised prefix → still falls through to 500 (guard is narrow)

### `skills/paperclip/SKILL.md`
- Added a Practical Rule under the Status Quick Guide documenting the `in_review` requirement and the HTTP 422 response shape, so agents stop attempting direct `done` transitions.

## References

- Root cause analysis: AKS-1257
- Baseline measurement: ~460 P0403 guard events (snapshot 2026-04-20), ~80% `in_progress -> done`
- Success metric: post-deploy, opaque 500s for this class drop to zero; clients receive 422 with actionable body