### PR TITLE
SNAAA-2006: preserve external block markers in ticket health-check

### DIFF
--- a/scripts/__tests__/ticket-block-health-check.test.sh
+++ b/scripts/__tests__/ticket-block-health-check.test.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TARGET_SCRIPT="$PROJECT_ROOT/scripts/ticket-block-health-check.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_CURL="$TMP_DIR/fake-curl.sh"
+
+cat >"$FAKE_CURL" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file=""
+write_format=""
+method="GET"
+data=""
+url=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output_file="$2"
+      shift 2
+      ;;
+    -w)
+      write_format="$2"
+      shift 2
+      ;;
+    -X)
+      method="$2"
+      shift 2
+      ;;
+    -H|--max-time|--data)
+      if [[ "$1" == "--data" ]]; then
+        data="$2"
+      fi
+      shift 2
+      ;;
+    -s|-S|-sS)
+      shift
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$output_file" || -z "$url" ]]; then
+  echo "fake curl missing required arguments" >&2
+  exit 1
+fi
+
+python3 - "$FAKE_CURL_STATE" "$method" "$url" "$data" "$output_file" "$write_format" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+state_path, method, url, data, output_file, write_format = sys.argv[1:]
+state = json.loads(Path(state_path).read_text())
+parsed = urlparse(url)
+path = parsed.path
+query = parse_qs(parsed.query)
+
+issues = state["issues"]
+comments = state.setdefault("comments", {})
+patches = state.setdefault("patches", [])
+comment_counter = state.setdefault("commentCounter", 1000)
+
+body: object
+status = 200
+
+def blocked_issue_summaries():
+    limit = int(query.get("limit", ["500"])[0])
+    rows = []
+    for issue in issues.values():
+        if issue.get("status") != "blocked":
+            continue
+        rows.append({
+            "id": issue["id"],
+            "identifier": issue["identifier"],
+            "title": issue["title"],
+            "status": issue["status"],
+            "updatedAt": issue["updatedAt"],
+            "assigneeAgentId": issue.get("assigneeAgentId"),
+        })
+    return rows[:limit]
+
+if method == "GET" and path.endswith("/issues"):
+    body = blocked_issue_summaries()
+elif method == "GET" and "/comments" in path:
+    issue_id = path.split("/api/issues/", 1)[1].split("/comments", 1)[0]
+    limit = int(query.get("limit", ["5"])[0])
+    issue_comments = comments.get(issue_id, [])
+    body = list(reversed(issue_comments))[:limit]
+elif method == "GET" and "/api/issues/" in path:
+    issue_id = path.rsplit("/", 1)[-1]
+    issue = issues[issue_id]
+    body = issue
+elif method == "PATCH" and "/api/issues/" in path:
+    issue_id = path.rsplit("/", 1)[-1]
+    patch = json.loads(data or "{}")
+    issue = issues[issue_id]
+    if "status" in patch:
+      issue["status"] = patch["status"]
+    if "blockedByIssueIds" in patch:
+      next_ids = patch["blockedByIssueIds"]
+      issue["blockedBy"] = [issues[blocker_id] for blocker_id in next_ids]
+    if "comment" in patch:
+      comment_counter += 1
+      comments.setdefault(issue_id, []).append({
+          "id": f"comment-{comment_counter}",
+          "body": patch["comment"],
+      })
+    patches.append({
+        "issueId": issue_id,
+        "payload": patch,
+    })
+    state["commentCounter"] = comment_counter
+    body = issue
+else:
+    status = 404
+    body = {"error": f"Unhandled fake curl route: {method} {path}"}
+
+Path(output_file).write_text(json.dumps(body))
+Path(state_path).write_text(json.dumps(state))
+
+if write_format == "%{http_code}":
+    sys.stdout.write(str(status))
+PY
+EOF
+chmod +x "$FAKE_CURL"
+
+run_script() {
+  local state_path="$1"
+  shift
+  (
+    cd "$PROJECT_ROOT"
+    CURL_BIN="$FAKE_CURL" \
+    FAKE_CURL_STATE="$state_path" \
+    PAPERCLIP_API_URL="http://example.test" \
+    PAPERCLIP_API_KEY="test-token" \
+    PAPERCLIP_COMPANY_ID="company-1" \
+    PAPERCLIP_RUN_ID="run-1" \
+    "$@" \
+    bash "$TARGET_SCRIPT"
+  )
+}
+
+write_state() {
+  local path="$1"
+  local json="$2"
+  printf '%s' "$json" >"$path"
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "Assertion failed: $message" >&2
+    echo "Expected: $expected" >&2
+    echo "Actual:   $actual" >&2
+    exit 1
+  fi
+}
+
+test_ghost_block_auto_unblocks() {
+  local state="$TMP_DIR/ghost.json"
+  write_state "$state" '{
+    "issues": {
+      "issue-ghost": {
+        "id": "issue-ghost",
+        "identifier": "SNAAA-3000",
+        "title": "Ghost blocked ticket",
+        "status": "blocked",
+        "assigneeAgentId": "agent-1",
+        "updatedAt": "2026-04-20T07:00:00.000Z",
+        "blockedBy": []
+      }
+    },
+    "comments": { "issue-ghost": [] },
+    "patches": []
+  }'
+
+  local output
+  output="$(run_script "$state")"
+  assert_eq "actions:1" "$output" "ghost blocked ticket should be auto-unblocked"
+
+  local status patch_comment patch_count
+  status="$(jq -r '.issues["issue-ghost"].status' "$state")"
+  patch_comment="$(jq -r '.comments["issue-ghost"][0].body' "$state")"
+  patch_count="$(jq -r '.patches | length' "$state")"
+
+  assert_eq "todo" "$status" "ghost blocked ticket should move back to todo"
+  assert_eq "1" "$patch_count" "ghost blocked ticket should be patched once"
+  if [[ "$patch_comment" != *"ghost-block cleanup"* ]]; then
+    echo "Expected ghost-block cleanup comment, got: $patch_comment" >&2
+    exit 1
+  fi
+}
+
+test_external_block_stays_blocked() {
+  local state="$TMP_DIR/external.json"
+  write_state "$state" '{
+    "issues": {
+      "issue-ext": {
+        "id": "issue-ext",
+        "identifier": "SNAAA-3001",
+        "title": "External blocker",
+        "status": "blocked",
+        "assigneeAgentId": "agent-1",
+        "updatedAt": "2026-04-20T07:00:00.000Z",
+        "blockedBy": []
+      }
+    },
+    "comments": {
+      "issue-ext": [
+        { "id": "comment-1", "body": "EXTERNAL BLOCK: waiting on vendor" }
+      ]
+    },
+    "patches": []
+  }'
+
+  local output
+  output="$(run_script "$state")"
+  assert_eq "clean" "$output" "external blocks should not be auto-unblocked"
+  assert_eq "0" "$(jq -r '.patches | length' "$state")" "external block should not be patched"
+  assert_eq "blocked" "$(jq -r '.issues["issue-ext"].status' "$state")" "external block should remain blocked"
+}
+
+test_stale_blocker_auto_unblocks() {
+  local state="$TMP_DIR/stale.json"
+  write_state "$state" '{
+    "issues": {
+      "issue-stale": {
+        "id": "issue-stale",
+        "identifier": "SNAAA-3002",
+        "title": "Resolved blockers",
+        "status": "blocked",
+        "assigneeAgentId": "agent-1",
+        "updatedAt": "2026-04-20T07:00:00.000Z",
+        "blockedBy": [
+          { "id": "blocker-done", "identifier": "SNAAA-10", "status": "done" },
+          { "id": "blocker-cancelled", "identifier": "SNAAA-11", "status": "cancelled" }
+        ]
+      }
+    },
+    "comments": { "issue-stale": [] },
+    "patches": []
+  }'
+
+  local output
+  output="$(run_script "$state")"
+  assert_eq "actions:1" "$output" "done/cancelled blockers should auto-unblock"
+  assert_eq "todo" "$(jq -r '.issues["issue-stale"].status' "$state")" "stale blockers should clear blocked status"
+  if [[ "$(jq -r '.comments["issue-stale"][0].body' "$state")" != *"SNAAA-10, SNAAA-11"* ]]; then
+    echo "Expected stale blocker comment to include blocker identifiers" >&2
+    exit 1
+  fi
+}
+
+test_partial_blocker_is_untouched() {
+  local state="$TMP_DIR/partial.json"
+  write_state "$state" '{
+    "issues": {
+      "issue-partial": {
+        "id": "issue-partial",
+        "identifier": "SNAAA-3003",
+        "title": "Partially blocked",
+        "status": "blocked",
+        "assigneeAgentId": "agent-1",
+        "updatedAt": "2026-04-20T07:00:00.000Z",
+        "blockedBy": [
+          { "id": "blocker-active", "identifier": "SNAAA-12", "status": "in_progress" },
+          { "id": "blocker-done", "identifier": "SNAAA-13", "status": "done" }
+        ]
+      }
+    },
+    "comments": { "issue-partial": [] },
+    "patches": []
+  }'
+
+  local output
+  output="$(run_script "$state")"
+  assert_eq "clean" "$output" "partial blockers should be logged only"
+  assert_eq "0" "$(jq -r '.patches | length' "$state")" "partial blocker should not be patched"
+  assert_eq "blocked" "$(jq -r '.issues["issue-partial"].status' "$state")" "partial blocker should stay blocked"
+}
+
+test_repeated_run_is_not_spammy() {
+  local state="$TMP_DIR/repeat.json"
+  write_state "$state" '{
+    "issues": {
+      "issue-repeat": {
+        "id": "issue-repeat",
+        "identifier": "SNAAA-3004",
+        "title": "Repeat ghost block",
+        "status": "blocked",
+        "assigneeAgentId": "agent-1",
+        "updatedAt": "2026-04-20T07:00:00.000Z",
+        "blockedBy": []
+      }
+    },
+    "comments": { "issue-repeat": [] },
+    "patches": []
+  }'
+
+  assert_eq "actions:1" "$(run_script "$state")" "first run should auto-unblock"
+  assert_eq "clean" "$(run_script "$state")" "second run should do nothing"
+  assert_eq "1" "$(jq -r '.comments["issue-repeat"] | length' "$state")" "second run should not add a duplicate comment"
+}
+
+test_dry_run_skips_patch() {
+  local state="$TMP_DIR/dry-run.json"
+  write_state "$state" '{
+    "issues": {
+      "issue-dry": {
+        "id": "issue-dry",
+        "identifier": "SNAAA-3005",
+        "title": "Dry-run ghost block",
+        "status": "blocked",
+        "assigneeAgentId": "agent-1",
+        "updatedAt": "2026-04-20T07:00:00.000Z",
+        "blockedBy": []
+      }
+    },
+    "comments": { "issue-dry": [] },
+    "patches": []
+  }'
+
+  local output
+  output="$(run_script "$state" env DRY_RUN=true)"
+  assert_eq "actions:1" "$output" "dry run should still report planned action"
+  assert_eq "0" "$(jq -r '.patches | length' "$state")" "dry run should not patch the issue"
+  assert_eq "blocked" "$(jq -r '.issues["issue-dry"].status' "$state")" "dry run should leave issue blocked"
+}
+
+test_ghost_block_auto_unblocks
+test_external_block_stays_blocked
+test_stale_blocker_auto_unblocks
+test_partial_blocker_is_untouched
+test_repeated_run_is_not_spammy
+test_dry_run_skips_patch
+
+echo "ticket-block-health-check tests passed"

--- a/scripts/__tests__/ticket-block-health-check.test.sh
+++ b/scripts/__tests__/ticket-block-health-check.test.sh
@@ -111,8 +111,18 @@ if method == "GET" and path.endswith("/issues"):
 elif method == "GET" and "/comments" in path:
     issue_id = path.split("/api/issues/", 1)[1].split("/comments", 1)[0]
     limit = int(query.get("limit", ["5"])[0])
-    issue_comments = comments.get(issue_id, [])
-    body = list(reversed(issue_comments))[:limit]
+    order = query.get("order", ["desc"])[0]
+    after = query.get("after", [None])[0]
+    issue_comments = list(comments.get(issue_id, []))
+    if order == "desc":
+        issue_comments.reverse()
+    if after:
+        after_index = next((index for index, comment in enumerate(issue_comments) if comment.get("id") == after), None)
+        if after_index is None:
+            issue_comments = []
+        else:
+            issue_comments = issue_comments[after_index + 1 :]
+    body = issue_comments[:limit]
 elif method == "GET" and "/api/issues/" in path:
     issue_id = path.rsplit("/", 1)[-1]
     issue = issues[issue_id]
@@ -249,6 +259,41 @@ test_external_block_stays_blocked() {
   assert_eq "blocked" "$(jq -r '.issues["issue-ext"].status' "$state")" "external block should remain blocked"
 }
 
+test_external_block_older_than_first_page_stays_blocked() {
+  local state="$TMP_DIR/external-paginated.json"
+  write_state "$state" '{
+    "issues": {
+      "issue-ext-paginated": {
+        "id": "issue-ext-paginated",
+        "identifier": "SNAAA-3006",
+        "title": "Older external blocker marker",
+        "status": "blocked",
+        "assigneeAgentId": "agent-1",
+        "updatedAt": "2026-04-20T07:00:00.000Z",
+        "blockedBy": []
+      }
+    },
+    "comments": {
+      "issue-ext-paginated": [
+        { "id": "comment-1", "body": "EXTERNAL BLOCK: waiting on board decision" },
+        { "id": "comment-2", "body": "follow-up 1" },
+        { "id": "comment-3", "body": "follow-up 2" },
+        { "id": "comment-4", "body": "follow-up 3" },
+        { "id": "comment-5", "body": "follow-up 4" },
+        { "id": "comment-6", "body": "follow-up 5" },
+        { "id": "comment-7", "body": "follow-up 6" }
+      ]
+    },
+    "patches": []
+  }'
+
+  local output
+  output="$(run_script "$state")"
+  assert_eq "clean" "$output" "older external block markers must remain durable across comment pages"
+  assert_eq "0" "$(jq -r '.patches | length' "$state")" "paginated external block should not be patched"
+  assert_eq "blocked" "$(jq -r '.issues["issue-ext-paginated"].status' "$state")" "paginated external block should remain blocked"
+}
+
 test_stale_blocker_auto_unblocks() {
   local state="$TMP_DIR/stale.json"
   write_state "$state" '{
@@ -358,6 +403,7 @@ test_dry_run_skips_patch() {
 
 test_ghost_block_auto_unblocks
 test_external_block_stays_blocked
+test_external_block_older_than_first_page_stays_blocked
 test_stale_blocker_auto_unblocks
 test_partial_blocker_is_untouched
 test_repeated_run_is_not_spammy

--- a/scripts/ticket-block-health-check.sh
+++ b/scripts/ticket-block-health-check.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+readonly SCRIPT_NAME="ticket-block-health-check"
+readonly SCRIPT_SOURCE="scripts/ticket-block-health-check.sh"
+readonly CURL_BIN="${CURL_BIN:-curl}"
+readonly JQ_BIN="${JQ_BIN:-jq}"
+readonly PYTHON_BIN="${PYTHON_BIN:-python3}"
+readonly PAPERCLIP_API_URL="${PAPERCLIP_API_URL:-}"
+readonly PAPERCLIP_COMPANY_ID="${PAPERCLIP_COMPANY_ID:-}"
+readonly PAPERCLIP_API_KEY="${PAPERCLIP_API_KEY:-}"
+readonly PAPERCLIP_RUN_ID="${PAPERCLIP_RUN_ID:-ticket-block-health-check-local}"
+readonly BLOCKED_LIMIT="${BLOCKED_LIMIT:-500}"
+readonly COMMENT_SCAN_LIMIT="${COMMENT_SCAN_LIMIT:-5}"
+readonly STALE_PARTIAL_DAYS="${STALE_PARTIAL_DAYS:-7}"
+readonly CURL_MAX_TIME_SEC="${CURL_MAX_TIME_SEC:-20}"
+readonly DRY_RUN="${DRY_RUN:-false}"
+readonly GHOST_COMMENT_PREFIX="Auto-unblocked: no active blocker (ghost-block cleanup)."
+readonly STALE_COMMENT_PREFIX="Auto-unblocked: all blockers"
+readonly COMMENT_SOURCE_SUFFIX="Source: ${SCRIPT_SOURCE}"
+
+API_RESPONSE_BODY=""
+API_RESPONSE_CODE=""
+declare -a ACTION_IDS=()
+declare -a HEALTH_ISSUES=()
+
+log() {
+  local level="$1"
+  shift
+  printf '[%s] %s\n' "$SCRIPT_NAME:$level" "$*" >&2
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    log error "Required command missing: $command_name"
+    exit 1
+  fi
+}
+
+require_env() {
+  local var_name="$1"
+  if [[ -z "${!var_name:-}" ]]; then
+    log error "Required environment variable missing: $var_name"
+    exit 1
+  fi
+}
+
+is_truthy() {
+  local normalized
+  normalized="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$normalized" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+paperclip_request() {
+  local method="$1"
+  local path="$2"
+  local data="${3-}"
+  local tmp
+  tmp="$(mktemp)"
+
+  local -a curl_args=(
+    --max-time "$CURL_MAX_TIME_SEC"
+    -sS
+    -o "$tmp"
+    -w "%{http_code}"
+    -X "$method"
+    -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+    -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID"
+  )
+
+  if [[ -n "$data" ]]; then
+    curl_args+=(-H "Content-Type: application/json" --data "$data")
+  fi
+
+  API_RESPONSE_CODE="$("$CURL_BIN" "${curl_args[@]}" "${PAPERCLIP_API_URL}${path}")"
+  API_RESPONSE_BODY="$(cat "$tmp")"
+  rm -f "$tmp"
+
+  if [[ ! "$API_RESPONSE_CODE" =~ ^2 ]]; then
+    log error "API ${method} ${path} failed with HTTP ${API_RESPONSE_CODE}: ${API_RESPONSE_BODY}"
+    return 1
+  fi
+}
+
+paperclip_api_read() {
+  paperclip_request GET "$1"
+}
+
+paperclip_api_write() {
+  local method="$1"
+  local path="$2"
+  local data="$3"
+  paperclip_request "$method" "$path" "$data"
+}
+
+record_health_issue() {
+  local identifier="$1"
+  local message="$2"
+  HEALTH_ISSUES+=("$identifier")
+  log warn "${identifier}: ${message}"
+}
+
+get_all_blocked_tickets() {
+  paperclip_api_read "/api/companies/${PAPERCLIP_COMPANY_ID}/issues?status=blocked&limit=${BLOCKED_LIMIT}"
+  local count
+  count="$("$JQ_BIN" 'length' <<<"$API_RESPONSE_BODY")"
+  if [[ "$count" -eq "$BLOCKED_LIMIT" ]]; then
+    log warn "Blocked issue list hit limit=${BLOCKED_LIMIT}; rerun with a higher BLOCKED_LIMIT if needed."
+  fi
+  printf '%s\n' "$API_RESPONSE_BODY"
+}
+
+issue_has_external_block_comment() {
+  local issue_id="$1"
+  paperclip_api_read "/api/issues/${issue_id}/comments?limit=${COMMENT_SCAN_LIMIT}"
+  "$JQ_BIN" -e 'any(.[]?; (.body // "") | contains("EXTERNAL BLOCK:"))' <<<"$API_RESPONSE_BODY" >/dev/null
+}
+
+issue_is_stale_partial_block() {
+  local updated_at="$1"
+  local threshold_days="$2"
+  "$PYTHON_BIN" - "$updated_at" "$threshold_days" <<'PY'
+from datetime import datetime, timezone
+import sys
+
+updated_at = sys.argv[1]
+threshold_days = int(sys.argv[2])
+
+normalized = updated_at.replace("Z", "+00:00")
+updated = datetime.fromisoformat(normalized)
+now = datetime.now(timezone.utc)
+delta_days = (now - updated.astimezone(timezone.utc)).days
+print("true" if delta_days >= threshold_days else "false")
+PY
+}
+
+build_stale_comment() {
+  local blockers_csv="$1"
+  printf '%s (%s) are done/cancelled. %s' "$STALE_COMMENT_PREFIX" "$blockers_csv" "$COMMENT_SOURCE_SUFFIX"
+}
+
+auto_unblock_issue() {
+  local issue_json="$1"
+  local comment_body="$2"
+
+  local issue_id issue_identifier
+  issue_id="$("$JQ_BIN" -r '.id' <<<"$issue_json")"
+  issue_identifier="$("$JQ_BIN" -r '.identifier // .id' <<<"$issue_json")"
+
+  if is_truthy "$DRY_RUN"; then
+    ACTION_IDS+=("$issue_identifier")
+    log info "[dry-run] would auto-unblock ${issue_identifier}"
+    return 0
+  fi
+
+  local payload
+  # shellcheck disable=SC2016
+  payload="$("$JQ_BIN" -nc --arg status "todo" --arg comment "$comment_body" '{status: $status, blockedByIssueIds: [], comment: $comment}')"
+  paperclip_api_write PATCH "/api/issues/${issue_id}" "$payload"
+  ACTION_IDS+=("$issue_identifier")
+  log info "Auto-unblocked ${issue_identifier}"
+}
+
+handle_issue() {
+  local issue_summary="$1"
+  local issue_id
+  issue_id="$("$JQ_BIN" -r '.id' <<<"$issue_summary")"
+
+  paperclip_api_read "/api/issues/${issue_id}"
+  local issue_detail="$API_RESPONSE_BODY"
+
+  local issue_identifier blocked_count
+  issue_identifier="$("$JQ_BIN" -r '.identifier // .id' <<<"$issue_detail")"
+  blocked_count="$("$JQ_BIN" '(.blockedBy // []) | length' <<<"$issue_detail")"
+
+  if [[ "$blocked_count" -eq 0 ]]; then
+    if issue_has_external_block_comment "$issue_id"; then
+      log info "${issue_identifier}: blocked with EXTERNAL BLOCK comment, leaving untouched"
+      return 0
+    fi
+    auto_unblock_issue "$issue_detail" "${GHOST_COMMENT_PREFIX} ${COMMENT_SOURCE_SUFFIX}"
+    return 0
+  fi
+
+  local blocker_summary_json
+  # shellcheck disable=SC2016
+  blocker_summary_json="$("$JQ_BIN" -c '
+    (.blockedBy // []) as $blockers
+    | {
+        blockers: $blockers,
+        identifiers: ($blockers | map(.identifier // .id)),
+        activeIdentifiers: ($blockers | map(select((.status // "") != "done" and (.status // "") != "cancelled") | (.identifier // .id)))
+      }
+  ' <<<"$issue_detail")"
+
+  local blocker_identifiers_csv active_identifiers_csv active_count
+  blocker_identifiers_csv="$("$JQ_BIN" -r '.identifiers | join(", ")' <<<"$blocker_summary_json")"
+  active_identifiers_csv="$("$JQ_BIN" -r '.activeIdentifiers | join(", ")' <<<"$blocker_summary_json")"
+  active_count="$("$JQ_BIN" '.activeIdentifiers | length' <<<"$blocker_summary_json")"
+
+  if [[ "$active_count" -eq 0 ]]; then
+    auto_unblock_issue "$issue_detail" "$(build_stale_comment "$blocker_identifiers_csv")"
+    return 0
+  fi
+
+  log info "${issue_identifier}: still blocked by active blockers (${active_identifiers_csv})"
+  local is_stale
+  is_stale="$(issue_is_stale_partial_block "$("$JQ_BIN" -r '.updatedAt' <<<"$issue_detail")" "$STALE_PARTIAL_DAYS")"
+  if [[ "$is_stale" == "true" ]]; then
+    record_health_issue "$issue_identifier" "still blocked by active blockers (${active_identifiers_csv}) for >= ${STALE_PARTIAL_DAYS} days"
+  fi
+}
+
+main() {
+  cd "$PROJECT_ROOT"
+
+  require_command "$CURL_BIN"
+  require_command "$JQ_BIN"
+  require_command "$PYTHON_BIN"
+  require_env PAPERCLIP_API_URL
+  require_env PAPERCLIP_COMPANY_ID
+  require_env PAPERCLIP_API_KEY
+
+  local blocked_issues_json
+  blocked_issues_json="$(get_all_blocked_tickets)"
+  local blocked_count
+  blocked_count="$("$JQ_BIN" 'length' <<<"$blocked_issues_json")"
+  log info "Inspecting ${blocked_count} blocked issues"
+
+  if [[ "$blocked_count" -eq 0 ]]; then
+    echo "clean"
+    return 0
+  fi
+
+  while IFS= read -r issue_summary; do
+    [[ -n "$issue_summary" ]] || continue
+    handle_issue "$issue_summary"
+  done < <("$JQ_BIN" -c '.[]' <<<"$blocked_issues_json")
+
+  if [[ "${#HEALTH_ISSUES[@]}" -gt 0 ]]; then
+    log warn "Potentially stale blocked issues: ${HEALTH_ISSUES[*]}"
+  fi
+
+  if [[ "${#ACTION_IDS[@]}" -gt 0 ]]; then
+    log info "Auto-unblocked issues this run: ${ACTION_IDS[*]}"
+    echo "actions:${#ACTION_IDS[@]}"
+    return 0
+  fi
+
+  if [[ "${#HEALTH_ISSUES[@]}" -gt 0 ]]; then
+    echo "issues:${#HEALTH_ISSUES[@]}"
+    return 0
+  fi
+
+  echo "clean"
+}
+
+main "$@"

--- a/scripts/ticket-block-health-check.sh
+++ b/scripts/ticket-block-health-check.sh
@@ -119,8 +119,33 @@ get_all_blocked_tickets() {
 
 issue_has_external_block_comment() {
   local issue_id="$1"
-  paperclip_api_read "/api/issues/${issue_id}/comments?limit=${COMMENT_SCAN_LIMIT}"
-  "$JQ_BIN" -e 'any(.[]?; (.body // "") | contains("EXTERNAL BLOCK:"))' <<<"$API_RESPONSE_BODY" >/dev/null
+  local after=""
+
+  while true; do
+    local path="/api/issues/${issue_id}/comments?limit=${COMMENT_SCAN_LIMIT}&order=asc"
+    if [[ -n "$after" ]]; then
+      path="${path}&after=${after}"
+    fi
+
+    paperclip_api_read "$path"
+
+    if "$JQ_BIN" -e 'any(.[]?; (.body // "") | contains("EXTERNAL BLOCK:"))' <<<"$API_RESPONSE_BODY" >/dev/null; then
+      return 0
+    fi
+
+    local page_count last_comment_id
+    page_count="$("$JQ_BIN" 'length' <<<"$API_RESPONSE_BODY")"
+    if [[ "$page_count" -eq 0 || "$page_count" -lt "$COMMENT_SCAN_LIMIT" ]]; then
+      return 1
+    fi
+
+    last_comment_id="$("$JQ_BIN" -r '.[-1].id // empty' <<<"$API_RESPONSE_BODY")"
+    if [[ -z "$last_comment_id" ]]; then
+      return 1
+    fi
+
+    after="$last_comment_id"
+  done
 }
 
 issue_is_stale_partial_block() {


### PR DESCRIPTION
## What
- paginate issue comment scans in `ticket-block-health-check.sh` until an `EXTERNAL BLOCK:` marker is found or history is exhausted
- keep the existing per-page limit while making the external-block guard durable across older comments
- add a regression test covering an `EXTERNAL BLOCK:` comment that is older than the first comment page

## Why
The previous implementation only checked the latest five comments, which could wrongly auto-unblock legitimately externally blocked tickets after enough follow-up comments.

## Validation
- `bash scripts/__tests__/ticket-block-health-check.test.sh`
- `shellcheck scripts/ticket-block-health-check.sh scripts/__tests__/ticket-block-health-check.test.sh`
- `pnpm typecheck`