### PR TITLE
[codex] fix inbox badge crash on company switch

### DIFF
--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -457,6 +457,34 @@ describe("inbox helpers", () => {
     expect(result.approvals).toBe(0);
   });
 
+  it("ignores transient null inbox entities during badge computation", () => {
+    const result = computeInboxBadgeData({
+      approvals: [
+        null as unknown as Approval,
+        { ...makeApproval("pending"), requestedByUserId: "user-1" },
+      ],
+      joinRequests: [null as unknown as JoinRequest, makeJoinRequest("join-1")],
+      dashboard,
+      heartbeatRuns: [
+        null as unknown as HeartbeatRun,
+        makeRun("run-1", "failed", "2026-03-11T00:00:00.000Z"),
+      ],
+      mineIssues: [null as unknown as Issue, makeIssue("1", true)],
+      dismissedAlerts: new Set<string>(),
+      dismissedAtByKey: new Map(),
+      currentUserId: "user-1",
+    });
+
+    expect(result).toEqual({
+      inbox: 4,
+      approvals: 1,
+      failedRuns: 1,
+      joinRequests: 1,
+      mineIssues: 1,
+      alerts: 1,
+    });
+  });
+
   it("does not count company-wide alerts in the personal inbox badge", () => {
     const result = computeInboxBadgeData({
       approvals: [],

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -132,6 +132,10 @@ export interface InboxWorkspaceGroupingOptions {
   defaultProjectWorkspaceIdByProjectId?: ReadonlyMap<string, string>;
 }
 
+function isPresent<T>(value: T | null | undefined): value is T {
+  return value != null;
+}
+
 const defaultInboxFilterPreferences: InboxFilterPreferences = {
   allCategoryFilter: "everything",
   allApprovalFilter: "all",
@@ -651,7 +655,7 @@ export function getInboxKeyboardSelectionIndex(
 }
 
 export function getLatestFailedRunsByAgent(runs: HeartbeatRun[]): HeartbeatRun[] {
-  const sorted = [...runs].sort(
+  const sorted = runs.filter(isPresent).sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
   );
   const latestByAgent = new Map<string, HeartbeatRun>();
@@ -688,11 +692,11 @@ export function sortIssuesByMostRecentActivity(a: Issue, b: Issue): number {
 }
 
 export function getRecentTouchedIssues(issues: Issue[]): Issue[] {
-  return [...issues].sort(sortIssuesByMostRecentActivity).slice(0, RECENT_ISSUES_LIMIT);
+  return issues.filter(isPresent).sort(sortIssuesByMostRecentActivity).slice(0, RECENT_ISSUES_LIMIT);
 }
 
 export function getUnreadTouchedIssues(issues: Issue[]): Issue[] {
-  return issues.filter((issue) => issue.isUnreadForMe);
+  return issues.filter(isPresent).filter((issue) => issue.isUnreadForMe);
 }
 
 export function getApprovalsForTab(
@@ -701,7 +705,7 @@ export function getApprovalsForTab(
   filter: InboxApprovalFilter,
   currentUserId?: string | null,
 ): Approval[] {
-  const sortedApprovals = [...approvals].sort(
+  const sortedApprovals = approvals.filter(isPresent).sort(
     (a, b) => normalizeTimestamp(b.updatedAt) - normalizeTimestamp(a.updatedAt),
   );
 
@@ -742,22 +746,22 @@ export function getInboxWorkItems({
   joinRequests?: JoinRequest[];
 }): InboxWorkItem[] {
   return [
-    ...issues.map((issue) => ({
+    ...issues.filter(isPresent).map((issue) => ({
       kind: "issue" as const,
       timestamp: issueLastActivityTimestamp(issue),
       issue,
     })),
-    ...approvals.map((approval) => ({
+    ...approvals.filter(isPresent).map((approval) => ({
       kind: "approval" as const,
       timestamp: approvalActivityTimestamp(approval),
       approval,
     })),
-    ...failedRuns.map((run) => ({
+    ...failedRuns.filter(isPresent).map((run) => ({
       kind: "failed_run" as const,
       timestamp: normalizeTimestamp(run.createdAt),
       run,
     })),
-    ...joinRequests.map((joinRequest) => ({
+    ...joinRequests.filter(isPresent).map((joinRequest) => ({
       kind: "join_request" as const,
       timestamp: normalizeTimestamp(joinRequest.createdAt),
       joinRequest,
@@ -1028,7 +1032,7 @@ export function computeInboxBadgeData({
   dismissedAtByKey: ReadonlyMap<string, number>;
   currentUserId?: string | null;
 }): InboxBadgeData {
-  const actionableApprovals = approvals.filter(
+  const actionableApprovals = approvals.filter(isPresent).filter(
     (approval) =>
       !!currentUserId &&
       (approval.requestedByUserId === currentUserId || approval.decidedByUserId === currentUserId) &&
@@ -1038,10 +1042,10 @@ export function computeInboxBadgeData({
   const failedRuns = getLatestFailedRunsByAgent(heartbeatRuns).filter(
     (run) => !isInboxEntityDismissed(dismissedAtByKey, `run:${run.id}`, run.createdAt),
   ).length;
-  const visibleJoinRequests = joinRequests.filter(
+  const visibleJoinRequests = joinRequests.filter(isPresent).filter(
     (jr) => !isInboxEntityDismissed(dismissedAtByKey, `join:${jr.id}`, jr.updatedAt ?? jr.createdAt),
   ).length;
-  const visibleMineIssues = mineIssues.filter((issue) => issue.isUnreadForMe).length;
+  const visibleMineIssues = mineIssues.filter(isPresent).filter((issue) => issue.isUnreadForMe).length;
   const agentErrorCount = dashboard?.agents.error ?? 0;
   const monthBudgetCents = dashboard?.costs.monthBudgetCents ?? 0;
   const monthUtilizationPercent = dashboard?.costs.monthUtilizationPercent ?? 0;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The board UI depends on company-scoped sidebar and inbox badge state staying stable while the selected company changes.
> - The inbox badge helper currently assumes every approval, join request, run, and issue entry is always non-null.
> - During a company switch, that assumption can break transiently and crash the sidebar with `Cannot read properties of null (reading 'requestedByUserId')` from `computeInboxBadgeData`.
> - This pull request hardens the inbox helper layer so transient null entities are ignored instead of crashing the UI, and adds a regression test for that switch path.
> - The benefit is that operators can switch between companies without taking down the sidebar or inbox badge computation.

## What Changed

- Added a small `isPresent` guard in `ui/src/lib/inbox.ts` and applied it across inbox badge, touched-issue, failed-run, approval, and work-item helper paths that were previously assuming non-null entries.
- Added a regression test in `ui/src/lib/inbox.test.ts` covering transient null approvals, join requests, runs, and issues during badge computation.
- Kept the fix intentionally narrow to the shared inbox helper layer so existing callers benefit without changing API contracts.

## Verification

- `pnpm vitest run ui/src/lib/inbox.test.ts`
- `pnpm --filter @paperclipai/ui typecheck`
- Manual local verification on April 20, 2026: restarted Paperclip dev, opened the app in a browser, created two disposable companies, switched between them repeatedly via the company rail, and confirmed there were no page errors, no severe console errors, and no `requestedByUserId` crash.

## Risks

- Low risk: this is a defensive UI-only fix in helper functions that already operate on query results.
- The main behavioral change is that nullish transient entities are now ignored in inbox computations instead of throwing; if a deeper data-shape issue exists elsewhere, it may now fail soft in this path rather than crash hard.
- No schema, API, or persistence changes are included.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent in Codex desktop with tool use (shell, git, GitHub CLI, and browser automation for local verification).
- Exact model ID, context window size, and reasoning mode are not exposed by this harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
