### PR TITLE
PAP-1627: route sidebar Memories link through company prefix

### DIFF
--- a/ui/src/lib/company-routes.test.ts
+++ b/ui/src/lib/company-routes.test.ts
@@ -20,4 +20,10 @@ describe("company routes", () => {
       "/execution-workspaces/workspace-123",
     );
   });
+
+  it("treats memories as a company board route", () => {
+    expect(isBoardPathWithoutPrefix("/memories")).toBe(true);
+    expect(extractCompanyPrefixFromPath("/memories")).toBeNull();
+    expect(applyCompanyPrefix("/memories", "PAP")).toBe("/PAP/memories");
+  });
 });

--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -9,6 +9,7 @@ const BOARD_ROUTE_ROOTS = new Set([
   "workspaces",
   "execution-workspaces",
   "issues",
+  "memories",
   "routines",
   "goals",
   "approvals",


### PR DESCRIPTION
## Summary

- Sidebar's Memories link was resolving to `/memories` instead of `/:companyPrefix/memories`.
- Root cause: `memories` was missing from `BOARD_ROUTE_ROOTS` in `ui/src/lib/company-routes.ts`, so `applyCompanyPrefix` treated `/memories` as already having a company prefix and skipped the rewrite.
- Fix: add `memories` to `BOARD_ROUTE_ROOTS` plus a regression test.

Fixes PAP-1627.

## Test plan

- [x] `pnpm vitest run ui/src/lib/company-routes.test.ts` (3 tests pass, including the new `/memories` regression)
- [ ] Manual: confirm sidebar Memories link navigates to `/PAP/memories` for an active company

🤖 Generated with [Claude Code](https://claude.com/claude-code)