### PR TITLE
fix(openclaw-gateway): drop 'paperclip' agentParams + regression test

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1132,7 +1132,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -414,12 +414,6 @@ describe("heartbeat comment wake batching", () => {
       }, 90_000);
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          commentIds: [comment2.id, comment3.id],
-          latestCommentId: comment3.id,
-        },
-      });
       expect(String(secondPayload.message ?? "")).toContain("Second comment");
       expect(String(secondPayload.message ?? "")).toContain("Third comment");
       expect(String(secondPayload.message ?? "")).not.toContain("First comment");
@@ -594,20 +588,6 @@ describe("heartbeat comment wake batching", () => {
       });
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_commented",
-          commentIds: [comment2.id],
-          latestCommentId: comment2.id,
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Reopen after deferred comment",
-            status: "in_progress",
-            priority: "medium",
-          },
-        },
-      });
       expect(String(secondPayload.message ?? "")).toContain("Please handle this follow-up after you finish");
     } finally {
       gateway.releaseFirstWait();
@@ -680,20 +660,6 @@ describe("heartbeat comment wake batching", () => {
       expect(firstRun).not.toBeNull();
       await waitFor(() => gateway.getAgentPayloads().length === 1);
       const firstPayload = gateway.getAgentPayloads()[0] ?? {};
-      expect(firstPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_assigned",
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Require a comment",
-            status: "in_progress",
-            priority: "medium",
-          },
-          checkedOutByHarness: true,
-          commentIds: [],
-        },
-      });
       expect(String(firstPayload.message ?? "")).toContain("## Paperclip Wake Payload");
       expect(String(firstPayload.message ?? "")).toContain("Do not switch to another issue until you have handled this wake.");
       expect(String(firstPayload.message ?? "")).toContain("- checkout: already claimed by the harness for this run");

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -502,12 +502,6 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
-      expect(payload?.paperclip).toMatchObject({
-        wake: {
-          latestCommentId: "comment-2",
-          commentIds: ["comment-1", "comment-2"],
-        },
-      });
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
     } finally {

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -515,6 +515,38 @@ describe("openclaw gateway adapter execute", () => {
     expect(result.errorCode).toBe("openclaw_gateway_url_missing");
   });
 
+  it("does not attach a 'paperclip' root property to agent params (regression guard for #3923)", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext(
+          {
+            url: gateway.url,
+            payloadTemplate: { message: "wake now" },
+            waitTimeoutMs: 2000,
+          },
+          {
+            context: {
+              taskId: "task-123",
+              issueId: "issue-123",
+              wakeReason: "issue_assigned",
+              issueIds: ["issue-123"],
+              paperclipWake: { reason: "issue_assigned" },
+            },
+          },
+        ),
+      );
+
+      expect(result.exitCode).toBe(0);
+      const payload = gateway.getAgentPayload();
+      expect(payload).toBeTruthy();
+      expect(payload).not.toHaveProperty("paperclip");
+    } finally {
+      await gateway.close();
+    }
+  });
+
   it("returns adapter-managed runtime services from gateway result meta", async () => {
     const gateway = await createMockGatewayServer({
       waitPayload: {


### PR DESCRIPTION
## Summary
- Re-applies the 1-line fix from #626 that commit 91e040a6 regressed (restoring PAPERCLIPAI/paperclip master to a working openclaw-gateway heartbeat).
- Drops the now-obsolete positive assertions on `payload.paperclip` in `heartbeat-comment-wake-batching.test.ts` (the metadata is no longer attached at the root — coverage is preserved via `payload.message` assertions).
- **Adds a negative test** in `openclaw-gateway-adapter.test.ts` so any future re-introduction of `agentParams.paperclip` fails CI.

Fixes #3923.

## Background
`packages/adapters/openclaw-gateway/src/server/execute.ts` assigned `agentParams.paperclip = paperclipPayload` at the root. OpenClaw Gateway's `agent` RPC validates params with `additionalProperties: false`, so every heartbeat failed with:

```
Error: invalid agent params: at root: unexpected property 'paperclip'
```

PR #626 removed that assignment in March; commit 91e040a6 ("Batch inline comment wake payloads") re-added it on 2026-03-28 without a failing test to catch it. The paperclip metadata is already encoded inside `agentParams.message` via `wakeText`, so removing the root-level property is lossless.

## Why the negative test matters
PR #626's original test coverage relied on **positive** assertions (`payload?.paperclip` had some expected shape). When the fix landed, those assertions were dropped cleanly because the property no longer existed — but no **negative** assertion was left behind, so the regression shipped without CI noticing.

The new test explicitly asserts:
```ts
expect(payload).not.toHaveProperty("paperclip");
```

I verified this catches the regression by temporarily re-adding `agentParams.paperclip = paperclipPayload;` locally — the new test fails with the expected diff while the other 7 tests continue to pass. After reverting, all 8 tests pass.

## Test plan
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/openclaw-gateway-adapter.test.ts` — 8 passed
- [x] Negative proof: re-inject `agentParams.paperclip = paperclipPayload;` → only the new test fails; revert → 8/8 pass
- [ ] CI on full suite (running on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)