### PR TITLE
fix(heartbeat): skip phantom recovery when routine execution is in-flight (DLD-3430)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -926,4 +926,89 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
   });
+
+  it("skips recovery enqueue when a recent queued/run heartbeat_run exists for the same issue (DLD-3430 phantom wake guard)", async () => {
+    // When a routine execution handler is in-flight for an issue, the watchdog must NOT
+    // enqueue a recovery wakeup. The routine sets executionRunId AFTER the run completes,
+    // so the hasActiveExecutionPath check passes (no active run found) — but the agent
+    // is already working on the issue via the in-flight run.
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const failedRunId = randomUUID();
+    const inFlightRunId = randomUUID();
+    const now = new Date("2026-03-19T00:00:00.000Z");
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Ceo",
+      role: "ceo",
+      status: "idle",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    // The failed run that would normally trigger recovery
+    await db.insert(heartbeatRuns).values({
+      id: failedRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      contextSnapshot: { issueId, wakeReason: "issue_assignment_recovery" },
+      startedAt: now,
+      finishedAt: new Date("2026-03-19T00:05:00.000Z"),
+      errorCode: "process_lost",
+      error: "run failed before issue advanced",
+    });
+
+    // A RECENT in-flight run for the same issue (e.g. routine execution handler picked it up)
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
+    await db.insert(heartbeatRuns).values({
+      id: inFlightRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId, wakeReason: "routine_execution" },
+      startedAt: fiveMinAgo,
+      createdAt: fiveMinAgo,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Paperclip Daily Self-improvement",
+      status: "todo",
+      assigneeAgentId: agentId,
+      identifier: `${issuePrefix}-3430`,
+      issueNumber: 3430,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Must NOT enqueue recovery — the in-flight run handles the issue
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+
+    // Verify no extra run was created for recovery
+    const allRuns = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.companyId, companyId));
+    expect(allRuns).toHaveLength(2); // only the two we inserted
+  });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, gte, inArray, isNull, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -3696,6 +3696,29 @@ export function heartbeatService(db: Db) {
       }
 
       if (await hasActiveExecutionPath(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      // Guard: skip if there's a recent queued/running heartbeat_run for this issue.
+      // Without this, the watchdog enqueues a recovery wakeup for an issue whose routine
+      // execution handler has already started a follow-up run — but hasn't yet set
+      // executionRunId (it gets set after the run completes). The phantom recovery wake
+      // fires while the agent is already in-flight (DLD-3430 cascade).
+      const recentActiveRunCutoff = new Date(Date.now() - 30 * 60 * 1000);
+      const [recentActiveRun] = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, issue.companyId),
+            inArray(heartbeatRuns.status, ["queued", "running"]),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
+            gte(heartbeatRuns.createdAt, recentActiveRunCutoff),
+          ),
+        )
+        .limit(1);
+      if (recentActiveRun) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Summary
DLD-3430: CEO received 4+ consecutive phantom wakes for a routine execution issue.

**Root cause:** `reconcileStrandedAssignedIssues` calls `hasActiveExecutionPath` which checks for active heartbeat_runs. But routine execution handlers set `executionRunId` on the issue AFTER the run completes. When the handler picks up an issue and starts a follow-up run, the watchdog checks before `executionRunId` is set — finds no active run — and enqueues a phantom recovery wakeup while the agent is already in-flight.

**Fix:** After the `hasActiveExecutionPath` check, query `heartbeat_runs` for a queued/running run created in the last 30 minutes for the same issue. If found, skip the recovery enqueue. This prevents the phantom wake cascade described in DLD-3433.

**Files changed:**
- `server/src/services/heartbeat.ts`: +26 lines (gte import + active run guard in `reconcileStrandedAssignedIssues`)
- `server/src/__tests__/heartbeat-process-recovery.test.ts`: +82 lines (new test case)

**Tests:** 17/17 pass including the new DLD-3430 scenario test.

Closes DLD-3433