### PR TITLE
fix: fire issue_assigned wake for backlog-status issues

### DIFF
--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+
+function makeHeartbeat() {
+  const wakeup = vi.fn().mockResolvedValue(null);
+  return { heartbeat: { wakeup }, wakeup };
+}
+
+describe("queueIssueAssignmentWakeup", () => {
+  it("fires wake when issue is todo and has assignee", async () => {
+    const { heartbeat, wakeup } = makeHeartbeat();
+    await queueIssueAssignmentWakeup({
+      heartbeat,
+      issue: { id: "issue-1", assigneeAgentId: "agent-1", status: "todo" },
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "issue.create",
+    });
+    expect(wakeup).toHaveBeenCalledOnce();
+  });
+
+  it("fires wake for backlog issues with assignee (default status at creation)", async () => {
+    // Root cause of Bug #2: createIssueSchema defaults status to "backlog".
+    // When an issue is created with an assigneeAgentId but no explicit status,
+    // it gets status="backlog". The old guard `status === "backlog" → return`
+    // silently blocked the wake, leaving the assignee unnotified.
+    const { heartbeat, wakeup } = makeHeartbeat();
+    await queueIssueAssignmentWakeup({
+      heartbeat,
+      issue: { id: "issue-2", assigneeAgentId: "agent-2", status: "backlog" },
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "issue.create",
+    });
+    expect(wakeup).toHaveBeenCalledOnce();
+  });
+
+  it("skips wake when there is no assignee", async () => {
+    const { heartbeat, wakeup } = makeHeartbeat();
+    await queueIssueAssignmentWakeup({
+      heartbeat,
+      issue: { id: "issue-3", assigneeAgentId: null, status: "todo" },
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "issue.create",
+    });
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -9,6 +9,7 @@ import {
   createDb,
   executionWorkspaces,
   goals,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -1685,5 +1686,140 @@ describeEmbeddedPostgres("issueService.findMentionedProjectIds", () => {
       titleProjectId,
       commentProjectId,
     ]);
+  });
+});
+
+describeEmbeddedPostgres("issueService.update execution lock on reassignment", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-reassign-lock-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedBaseFixture(db: ReturnType<typeof createDb>) {
+    const companyId = randomUUID();
+    const agentAId = randomUUID();
+    const agentBId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: agentAId,
+        companyId,
+        name: "AgentA",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: agentBId,
+        companyId,
+        name: "AgentB",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    // Seed a heartbeat run so FK on checkoutRunId/executionRunId is satisfied
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: agentAId,
+    });
+
+    return { companyId, agentAId, agentBId, runId };
+  }
+
+  it("clears execution lock fields when assigneeAgentId changes", async () => {
+    const { companyId, agentAId, agentBId, runId } = await seedBaseFixture(db);
+    const issueId = randomUUID();
+
+    // Create an issue assigned to agentA with a live execution lock
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Locked issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentAId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionAgentNameKey: "agenta",
+      executionLockedAt: new Date(),
+    });
+
+    // Reassign to agentB — should clear all execution lock fields
+    const updated = await svc.update(issueId, { assigneeAgentId: agentBId });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.assigneeAgentId).toBe(agentBId);
+    expect(updated!.checkoutRunId).toBeNull();
+    expect(updated!.executionRunId).toBeNull();
+    expect(updated!.executionAgentNameKey).toBeNull();
+    expect(updated!.executionLockedAt).toBeNull();
+  });
+
+  it("clears execution lock fields when issue is unassigned", async () => {
+    const { companyId, agentAId, runId } = await seedBaseFixture(db);
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Locked issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentAId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionAgentNameKey: "agenta",
+      executionLockedAt: new Date(),
+    });
+
+    // Unassign — assigneeAgentId change should still clear execution lock
+    const updated = await svc.update(issueId, { assigneeAgentId: null });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.assigneeAgentId).toBeNull();
+    expect(updated!.checkoutRunId).toBeNull();
+    expect(updated!.executionRunId).toBeNull();
+    expect(updated!.executionAgentNameKey).toBeNull();
+    expect(updated!.executionLockedAt).toBeNull();
   });
 });

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -28,7 +28,7 @@ export function queueIssueAssignmentWakeup(input: {
   requestedByActorId?: string | null;
   rethrowOnError?: boolean;
 }) {
-  if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return;
+  if (!input.issue.assigneeAgentId) return;
 
   return input.heartbeat
     .wakeup(input.issue.assigneeAgentId, {


### PR DESCRIPTION
## Problem

`createIssueSchema` defaults `status` to `"backlog"` when not supplied by the caller (line 47 of `packages/shared/src/validators/issue.ts`).

The old guard in `queueIssueAssignmentWakeup`:

```ts
if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return;
```

silently blocked the wake for **any issue created with an assignee but no explicit status** — leaving assignees unnotified until their next scheduled heartbeat.

Observed failure: creating a subtask for a Designer agent (e.g. `POST /api/companies/{id}/issues` with `assigneeAgentId` but no `status`) → issue stored as `backlog` → wake skipped → agent stays idle indefinitely.

## Fix

Remove `input.issue.status === "backlog"` from the early-return guard.

**Rationale:** The backlog guard exists to suppress timer-driven wakes for idle backlog items. For *assignment-triggered* wakes the agent should always be notified and decide for itself whether to pick up the work. Issues without an assignee are already covered by the `!assigneeAgentId` guard, so there is no regression risk.

## Tests

New file `server/src/__tests__/issue-assignment-wakeup.test.ts` covers:

- `todo` issue with assignee → wake fires ✅
- `backlog` issue with assignee (the previously broken case) → wake fires ✅
- no assignee → wake skipped ✅