### PR TITLE
feat: show commentsPostedCount in run chip for no-op transparency

### DIFF
--- a/server/src/services/activity.ts
+++ b/server/src/services/activity.ts
@@ -364,6 +364,12 @@ export function activityService(db: Db) {
 
     runsForIssue: async (companyId: string, issueId: string) => {
       scheduleRunLivenessBackfill(companyId, issueId);
+      const commentsPostedCountSubquery = sql<number>`
+        (select count(*)::int from ${issueComments}
+         where ${issueComments.createdByRunId} = ${heartbeatRuns.id}
+           and ${issueComments.issueId} = ${issueId}
+           and ${issueComments.companyId} = ${companyId})
+      `.as("commentsPostedCount");
       return db
         .select({
           runId: heartbeatRuns.id,
@@ -382,6 +388,7 @@ export function activityService(db: Db) {
           continuationAttempt: heartbeatRuns.continuationAttempt,
           lastUsefulActionAt: heartbeatRuns.lastUsefulActionAt,
           nextAction: heartbeatRuns.nextAction,
+          commentsPostedCount: commentsPostedCountSubquery,
         })
         .from(heartbeatRuns)
         .innerJoin(

--- a/ui/src/api/activity.ts
+++ b/ui/src/api/activity.ts
@@ -20,6 +20,7 @@ export interface RunForIssue {
   continuationAttempt?: number;
   lastUsefulActionAt?: string | null;
   nextAction?: string | null;
+  commentsPostedCount?: number | null;
 }
 
 export interface IssueForRun {

--- a/ui/src/components/IssueRunLedger.tsx
+++ b/ui/src/components/IssueRunLedger.tsx
@@ -398,7 +398,7 @@ export function IssueRunLedgerContent({
                   ) : null}
                 </div>
 
-                <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+                <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-4">
                   <div className="min-w-0">
                     <span className="text-foreground">Elapsed</span>{" "}
                     {duration ?? "unknown"}
@@ -410,6 +410,10 @@ export function IssueRunLedgerContent({
                   <div className="min-w-0">
                     <span className="text-foreground">Stop</span>{" "}
                     {stopStatusLabel(run, stopReason)}
+                  </div>
+                  <div className="min-w-0">
+                    <span className="text-foreground">Comments posted</span>{" "}
+                    {run.commentsPostedCount != null ? String(run.commentsPostedCount) : "—"}
                   </div>
                 </div>
 


### PR DESCRIPTION
## Problem

When a heartbeat run exits with 0 comments posted (e.g., self-wake no-op), the run chip shows `empty_response` liveness state but gives no indication of _why_ — board users cannot distinguish:

1. **Intentional no-op**: agent correctly detected self-wake and exited (comment author == assignee guard fired)
2. **Buggy silence**: agent ran but failed silently without posting any comments

## Solution

Add a `commentsPostedCount` field to the run chip by computing a correlated subquery in `runsForIssue`:

```sql
(SELECT count(*)::int FROM issue_comments
 WHERE created_by_run_id = heartbeat_runs.id
   AND issue_id = $issueId
   AND company_id = $companyId)
```

This adds a fourth grid column to the run ledger: **"Comments posted: 0"** (or the actual count) — visible even when the count is zero.

## Changes

- `server/src/services/activity.ts` — add `commentsPostedCount` subquery to `runsForIssue`
- `ui/src/api/activity.ts` — add `commentsPostedCount?: number | null` to `RunForIssue`
- `ui/src/components/IssueRunLedger.tsx` — render count in run chip grid (4-column layout)

## No schema migration needed

`issueComments.createdByRunId` already tracks the relationship; this is a read-only query against existing data.

Closes Bug #1 from the run transparency work (part of SUH-446 upstream contributions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)