### PR TITLE
[codex] Add Claude local permission controls

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -23,6 +23,8 @@ Core fields:
 - promptTemplate (string, optional): run prompt template
 - maxTurnsPerRun (number, optional): max turns for one run
 - dangerouslySkipPermissions (boolean, optional, default true): pass --dangerously-skip-permissions to claude; defaults to true because Paperclip runs Claude in headless --print mode where interactive permission prompts cannot be answered
+- permissionMode (string, optional): pass --permission-mode to claude (auto|default|plan|dontAsk|bypassPermissions|acceptEdits)
+- disallowedTools (string[], optional): tool patterns to deny via --disallowed-tools (e.g. ["Bash(git push:*)", "Edit"])
 - command (string, optional): defaults to "claude"
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -308,6 +308,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+  const permissionMode = asString(config.permissionMode, "");
+  const disallowedTools = asStringArray(config.disallowedTools);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   const runtimeConfig = await buildClaudeRuntimeConfig({
@@ -437,6 +439,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const args = ["--print", "-", "--output-format", "stream-json", "--verbose"];
     if (resumeSessionId) args.push("--resume", resumeSessionId);
     if (dangerouslySkipPermissions) args.push("--dangerously-skip-permissions");
+    if (permissionMode) args.push("--permission-mode", permissionMode);
+    if (disallowedTools.length > 0) args.push("--disallowed-tools", ...disallowedTools);
     if (chrome) args.push("--chrome");
     // For Bedrock: only pass --model when the ID is a Bedrock-native identifier
     // (e.g. "us.anthropic.*" or ARN). Anthropic-style IDs like "claude-opus-4-6" are invalid

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -155,6 +155,8 @@ export async function testEnvironment(
       const chrome = asBoolean(config.chrome, false);
       const maxTurns = asNumber(config.maxTurnsPerRun, 0);
       const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+      const permissionMode = asString(config.permissionMode, "").trim();
+      const disallowedTools = asStringArray(config.disallowedTools);
       const extraArgs = (() => {
         const fromExtraArgs = asStringArray(config.extraArgs);
         if (fromExtraArgs.length > 0) return fromExtraArgs;
@@ -163,6 +165,8 @@ export async function testEnvironment(
 
       const args = ["--print", "-", "--output-format", "stream-json", "--verbose"];
       if (dangerouslySkipPermissions) args.push("--dangerously-skip-permissions");
+      if (permissionMode) args.push("--permission-mode", permissionMode);
+      if (disallowedTools.length > 0) args.push("--disallowed-tools", ...disallowedTools);
       if (chrome) args.push("--chrome");
       // For Bedrock: only pass --model when the ID is a Bedrock-native identifier.
       if (model && (!hasBedrock || isBedrockModelId(model))) {


### PR DESCRIPTION
## Summary
- Add optional `permissionMode` and `disallowedTools` config fields to the Claude local adapter.
- Pass those fields through to the Claude CLI in both normal execution and adapter environment tests.

## Why
Paperclip runs Claude in headless `--print` mode, where interactive permission prompts are not practical. Today the adapter mainly offers an all-or-nothing `dangerouslySkipPermissions` switch. These optional fields allow deployments to choose a Claude permission mode and deny specific tool patterns while preserving existing behavior by default.

## Compatibility
Existing Claude local adapter configs continue to work unchanged. The new arguments are only emitted when the corresponding config fields are provided.

## Validation
- `pnpm --filter @paperclipai/adapter-claude-local typecheck`