### PR TITLE
[codex] Supplement adapter PATH with local bin dirs

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { constants as fsConstants, promises as fs, type Dirent } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type {
   AdapterSkillEntry,
@@ -737,6 +738,33 @@ export function defaultPathForPlatform() {
   return "/usr/local/bin:/opt/homebrew/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin";
 }
 
+function supplementalPathEntriesForPlatform(): string[] {
+  if (process.platform === "win32") return [];
+  const home = os.homedir();
+  return [
+    path.join(home, ".local", "bin"),
+    path.join(home, "Library", "pnpm"),
+    path.join(home, ".bun", "bin"),
+    path.join(home, "bin"),
+  ];
+}
+
+function mergePathEntries(values: string[], delimiter: string): string {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const key = process.platform === "win32" ? trimmed.toLowerCase() : trimmed;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(trimmed);
+  }
+
+  return merged.join(delimiter);
+}
+
 function windowsPathExts(env: NodeJS.ProcessEnv): string[] {
   return (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean);
 }
@@ -821,9 +849,30 @@ async function resolveSpawnTarget(
 }
 
 export function ensurePathInEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  if (typeof env.PATH === "string" && env.PATH.length > 0) return env;
-  if (typeof env.Path === "string" && env.Path.length > 0) return env;
-  return { ...env, PATH: defaultPathForPlatform() };
+  const delimiter = process.platform === "win32" ? ";" : ":";
+  const pathKey =
+    typeof env.PATH === "string"
+      ? "PATH"
+      : typeof env.Path === "string"
+        ? "Path"
+        : "PATH";
+  const currentValue =
+    pathKey === "PATH"
+      ? (typeof env.PATH === "string" ? env.PATH : "")
+      : (typeof env.Path === "string" ? env.Path : "");
+  const systemEntries = defaultPathForPlatform().split(delimiter);
+  const supplementalEntries = supplementalPathEntriesForPlatform();
+  const mergedPath = mergePathEntries(
+    [
+      ...currentValue.split(delimiter),
+      ...supplementalEntries,
+      ...systemEntries,
+    ],
+    delimiter,
+  );
+
+  if (currentValue === mergedPath) return env;
+  return { ...env, [pathKey]: mergedPath };
 }
 
 export async function ensureAbsoluteDirectory(

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -1,5 +1,7 @@
+import os from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import { buildPaperclipEnv } from "../adapters/utils.js";
+import { ensurePathInEnv } from "@paperclipai/adapter-utils/server-utils";
 
 const ORIGINAL_PAPERCLIP_API_URL = process.env.PAPERCLIP_API_URL;
 const ORIGINAL_PAPERCLIP_LISTEN_HOST = process.env.PAPERCLIP_LISTEN_HOST;
@@ -56,3 +58,16 @@ describe("buildPaperclipEnv", () => {
     expect(env.PAPERCLIP_API_URL).toBe("http://[::1]:3101");
   });
 });
+
+describe("ensurePathInEnv", () => {
+  it("supplements an existing PATH with common user-local binary directories", () => {
+    const env = ensurePathInEnv({ PATH: "/usr/bin:/bin" });
+
+    expect(env.PATH).toContain("/usr/bin");
+    expect(env.PATH).toContain(pathJoinHome(".local/bin"));
+  });
+});
+
+function pathJoinHome(relativePath: string) {
+  return `${os.homedir()}/${relativePath}`;
+}


### PR DESCRIPTION
## Summary
- Teach `ensurePathInEnv` to merge the current PATH with common user-local binary directories and platform defaults.
- Preserve existing PATH entries and key casing while de-duplicating merged entries.
- Add focused coverage for supplementing an existing PATH.

## Why
Adapters are often launched from non-interactive services where PATH is much thinner than a developer shell. In those environments, locally installed tools such as package managers or CLI wrappers may be unavailable even though they are installed in standard user-local locations.

## Compatibility
Existing PATH entries remain first and are preserved. Supplemental entries are skipped on Windows, and the platform default PATH is still used as a fallback source.

## Validation
- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `pnpm test:run server/src/__tests__/paperclip-env.test.ts`