### PR TITLE
[codex] Prefer configured cwd when heartbeat workspace is unavailable

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2262,6 +2262,41 @@ export function heartbeatService(db: Db) {
       }
     }
 
+    const agentConfig = parseObject(agent.adapterConfig);
+    const configuredAgentCwd = readNonEmptyString(agentConfig.cwd);
+    if (configuredAgentCwd) {
+      const configuredAgentCwdExists = await fs
+        .stat(configuredAgentCwd)
+        .then((stats) => stats.isDirectory())
+        .catch(() => false);
+      if (configuredAgentCwdExists) {
+        const warnings: string[] = [];
+        if (sessionCwd) {
+          warnings.push(
+            `Saved session workspace "${sessionCwd}" is not available. Using configured agent cwd "${configuredAgentCwd}" for this run.`,
+          );
+        } else if (resolvedProjectId) {
+          warnings.push(
+            `No project workspace directory is currently available for this issue. Using configured agent cwd "${configuredAgentCwd}" for this run.`,
+          );
+        } else {
+          warnings.push(
+            `No project or prior session workspace was available. Using configured agent cwd "${configuredAgentCwd}" for this run.`,
+          );
+        }
+        return {
+          cwd: configuredAgentCwd,
+          source: "project_primary" as const,
+          projectId: resolvedProjectId,
+          workspaceId: null,
+          repoUrl: null,
+          repoRef: null,
+          workspaceHints,
+          warnings,
+        };
+      }
+    }
+
     const cwd = resolveDefaultAgentWorkspaceDir(agent.id);
     await fs.mkdir(cwd, { recursive: true });
     const warnings: string[] = [];
@@ -2272,6 +2307,10 @@ export function heartbeatService(db: Db) {
     } else if (resolvedProjectId) {
       warnings.push(
         `No project workspace directory is currently available for this issue. Using fallback workspace "${cwd}" for this run.`,
+      );
+    } else if (configuredAgentCwd) {
+      warnings.push(
+        `Configured agent cwd "${configuredAgentCwd}" is not available. Using fallback workspace "${cwd}" for this run.`,
       );
     } else {
       warnings.push(


### PR DESCRIPTION
## Summary
- When a heartbeat cannot use the issue project workspace or saved session cwd, try the agent adapter config `cwd` before falling back to the generated agent-home workspace.
- Preserve the existing final fallback behavior and add warnings that explain which workspace was unavailable and which cwd is being used.

## Why
If an agent has an explicit configured cwd, that directory is usually a better recovery target than an empty generated fallback workspace. This makes heartbeat recovery less surprising when project/session workspace metadata is missing or temporarily unavailable.

## Compatibility
This only changes behavior when no project/session workspace is available and the configured agent cwd exists on disk. If that configured cwd is missing, Paperclip still uses the existing generated fallback workspace path.

## Validation
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm test:run server/src/__tests__/heartbeat-workspace-session.test.ts`