### PR TITLE
[codex] Harden issue and routine lifecycle cleanup

### DIFF
--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -252,4 +252,35 @@ describe("issue update comment wakeups", () => {
       }),
     );
   });
+
+  it("does not wake the assignee when closing an issue with an audit comment", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    const updated = {
+      ...existing,
+      status: "done",
+      completedAt: new Date(),
+    };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-3",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "closing with final audit context",
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({
+        status: "done",
+        comment: "closing with final audit context",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -221,6 +221,63 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues.map((issue) => issue.id)).toContain(run.linkedIssueId);
   });
 
+  it("clears stale execution locks before creating a fresh routine issue", async () => {
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const staleExecutionRunId = randomUUID();
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "todo",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: staleExecutionRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      contextSnapshot: { issueId: previousIssue.id },
+      startedAt: new Date("2026-03-20T12:01:00.000Z"),
+      finishedAt: new Date("2026-03-20T12:02:00.000Z"),
+    });
+    await db
+      .update(issues)
+      .set({
+        executionRunId: staleExecutionRunId,
+        executionLockedAt: new Date("2026-03-20T12:01:00.000Z"),
+      })
+      .where(eq(issues.id, previousIssue.id));
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("issue_created");
+    expect(run.linkedIssueId).not.toBe(previousIssue.id);
+
+    const [unlockedPreviousIssue] = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, previousIssue.id));
+
+    expect(unlockedPreviousIssue?.executionRunId).toBeNull();
+  });
+
   it("creates draft routines without a project or default assignee", async () => {
     const { companyId, svc } = await seedFixture();
 

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1965,6 +1965,37 @@ describe("realizeExecutionWorkspace", () => {
     });
   });
 
+  it("archives non-runtime-owned local workspaces without expecting the directory to be removed", async () => {
+    const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-shared-workspace-"));
+    await fs.writeFile(path.join(workspacePath, "README.md"), "shared checkout\n", "utf8");
+
+    const cleanup = await cleanupExecutionWorkspaceArtifacts({
+      workspace: {
+        id: "execution-workspace-1",
+        cwd: workspacePath,
+        providerType: "local_fs",
+        providerRef: null,
+        branchName: null,
+        repoUrl: null,
+        baseRef: null,
+        projectId: "project-1",
+        projectWorkspaceId: "workspace-1",
+        sourceIssueId: "issue-1",
+        metadata: {
+          createdByRuntime: false,
+        },
+      },
+      projectWorkspace: {
+        cwd: workspacePath,
+        cleanupCommand: null,
+      },
+    });
+
+    expect(cleanup.cleaned).toBe(true);
+    expect(cleanup.warnings).toEqual([]);
+    await expect(fs.stat(workspacePath)).resolves.toBeTruthy();
+  });
+
   it("records teardown and cleanup operations when a recorder is provided", async () => {
     const repoRoot = await createTempRepo();
     const { recorder, operations } = createWorkspaceOperationRecorderDouble();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1759,6 +1759,8 @@ export function issueRoutes(
       previous.status !== undefined &&
       issue.status === "todo";
     const reopenFromStatus = reopened ? existing.status : null;
+    const closedByThisUpdate =
+      !isClosed && previous.status !== undefined && isClosedIssueStatus(issue.status);
     await logActivity(db, {
       companyId: issue.companyId,
       actorType: actor.actorType,
@@ -1984,7 +1986,7 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+        const skipAssigneeCommentWake = selfComment || isClosed || closedByThisUpdate;
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -656,6 +656,29 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  async function clearStaleExecutionLocksForRoutine(routine: typeof routines.$inferSelect, executor: Db = db) {
+    await executor.execute(sql`
+      update ${issues}
+      set
+        execution_run_id = null,
+        execution_agent_name_key = null,
+        execution_locked_at = null,
+        updated_at = now()
+      where ${issues.companyId} = ${routine.companyId}
+        and ${issues.originKind} = 'routine_execution'
+        and ${issues.originId} = ${routine.id}
+        and ${issues.hiddenAt} is null
+        and ${issues.executionRunId} is not null
+        and ${issues.status} in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked')
+        and not exists (
+          select 1
+          from ${heartbeatRuns}
+          where ${heartbeatRuns.id} = ${issues.executionRunId}
+            and ${heartbeatRuns.status} in ('queued', 'running')
+        )
+    `);
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -745,6 +768,7 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
     const title = interpolateRoutineTemplate(input.routine.title, allVariables) ?? input.routine.title;
     const description = interpolateRoutineTemplate(input.routine.description, allVariables);
     const triggerPayload = mergeRoutineRunPayload(input.payload, { ...automaticVariables, ...resolvedVariables });
+    await clearStaleExecutionLocksForRoutine(input.routine);
     const run = await db.transaction(async (tx) => {
       const txDb = tx as unknown as Db;
       await tx.execute(

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1452,8 +1452,12 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     }
   }
 
+  const expectsPathRemoval =
+    input.workspace.providerType === "git_worktree" ||
+    (input.workspace.providerType === "local_fs" && createdByRuntime);
   const cleaned =
     !workspacePath ||
+    !expectsPathRemoval ||
     !(await directoryExists(workspacePath));
 
   return {


### PR DESCRIPTION
## Summary

This PR hardens two routine/issue lifecycle edges that can make local Paperclip instances look like agents are looping or getting stuck:

- skips assignee wakeups when an issue update closes the issue with an audit comment, so a "mark done + note" operation does not immediately re-wake/reopen work
- treats non-runtime-owned local shared workspaces as successfully archived without expecting Paperclip to remove the real project checkout
- clears stale routine issue execution locks before routine dispatch, so an old open issue whose run is no longer queued/running cannot trip `issues_open_routine_execution_uq` and fail the next scheduled run

## Why

These cases showed up while cleaning up a local Paperclip instance after several days of paused agents. The root causes were small lifecycle mismatches: closing comments were still considered wake-worthy, shared local project checkouts were expected to disappear during cleanup, and stale `executionRunId` values could remain attached to old routine issues after the underlying heartbeat run had finished.

## Validation

- `pnpm test:run server/src/__tests__/issue-update-comment-wakeup-routes.test.ts server/src/__tests__/issue-comment-reopen-routes.test.ts server/src/__tests__/heartbeat-comment-wake-batching.test.ts server/src/__tests__/workspace-runtime.test.ts server/src/__tests__/routines-service.test.ts server/src/__tests__/routines-e2e.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
