### PR TITLE
fix(heartbeat): teach reaper about out-of-process K8s adapter liveness (FAR-108)

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -358,6 +358,26 @@ export interface ServerAdapterModule {
    * rather than reading config.paperclipRuntimeSkills.
    */
   requiresMaterializedRuntimeSkills?: boolean;
+
+  /**
+   * Adapter drives execution out-of-process (Kubernetes Jobs, remote HTTP
+   * services, etc.) and therefore has no meaningful local child pid for the
+   * orphan reaper to probe. When `true`:
+   *   - The reaper skips local pid / process-group liveness checks.
+   *   - On cold startup (no staleness threshold), runs are NOT immediately
+   *     reaped; the adapter is given a chance to re-establish liveness by
+   *     refreshing `heartbeatRuns.updatedAt` via its own polling.
+   *   - When a run is ultimately reaped, the error code is
+   *     `adapter_liveness_lost` and the message makes clear that no local
+   *     pid was involved (instead of the misleading "child pid -1" string).
+   *   - No `process_lost` retry is queued (the loss has nothing to do with a
+   *     local child process disappearing).
+   *
+   * Built-in local adapters default to `false`. External adapters that run
+   * work remotely (e.g. `claude_k8s`, gateway adapters) should opt in with
+   * `true`.
+   */
+  hasOutOfProcessLiveness?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -606,6 +606,13 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     // for out-of-process adapters at startup.
     expect(run?.errorCode).not.toBe("process_lost");
     expect(run?.error ?? "").not.toContain("child pid");
+
+    // Mark the run terminal so the afterEach cleanup loop does not spin the
+    // full 100-iteration timeout waiting for it to settle.
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "failed" })
+      .where(eq(heartbeatRuns.id, runId));
   });
 
   it("reaps stale out-of-process adapter runs with adapter_liveness_lost (no process_lost retry)", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -51,13 +51,18 @@ vi.mock("@paperclipai/shared/telemetry", async () => {
   };
 });
 
+const OUT_OF_PROCESS_LIVENESS_ADAPTER_TYPE = "test_k8s_out_of_process";
+
 vi.mock("../adapters/index.ts", async () => {
   const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
   return {
     ...actual,
-    getServerAdapter: vi.fn(() => ({
+    getServerAdapter: vi.fn((adapterType?: string) => ({
       supportsLocalAgentJwt: false,
       execute: mockAdapterExecute,
+      // Used by heartbeat.ts adapterHasOutOfProcessLiveness() to identify
+      // k8s-style / remote adapters that should not be probed via local pid.
+      hasOutOfProcessLiveness: adapterType === OUT_OF_PROCESS_LIVENESS_ADAPTER_TYPE,
     })),
   };
 });
@@ -572,6 +577,98 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBeNull();
     expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  // --- FAR-108: out-of-process adapter (e.g. claude_k8s) liveness ----------
+  //
+  // These cover the reaper path for adapters that declare
+  // `hasOutOfProcessLiveness: true`. The adapter mock at the top of this file
+  // reports that flag for OUT_OF_PROCESS_LIVENESS_ADAPTER_TYPE.
+
+  it("does not reap out-of-process adapter runs on cold startup (staleThresholdMs === 0)", async () => {
+    // Even with no local pid/processGroupId (classic k8s case — run is a
+    // Kubernetes Job, not a child process), the cold-startup sweep must not
+    // kill the run. The adapter needs a window to refresh updatedAt via its
+    // own polling.
+    const { runId } = await seedRunFixture({
+      adapterType: OUT_OF_PROCESS_LIVENESS_ADAPTER_TYPE,
+      processPid: null,
+      processGroupId: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(0);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    // The misleading "child pid -1" process-loss sentinel must NOT appear
+    // for out-of-process adapters at startup.
+    expect(run?.errorCode).not.toBe("process_lost");
+    expect(run?.error ?? "").not.toContain("child pid");
+  });
+
+  it("reaps stale out-of-process adapter runs with adapter_liveness_lost (no process_lost retry)", async () => {
+    const { agentId, runId, issueId } = await seedRunFixture({
+      adapterType: OUT_OF_PROCESS_LIVENESS_ADAPTER_TYPE,
+      processPid: null,
+      processGroupId: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    // Force staleness past the threshold. The seed sets updatedAt to
+    // 2026-03-19T00:00:00Z, so 10 minutes is well beyond the 5-minute
+    // periodic-reaper window.
+    const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 10 * 60 * 1000 });
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    // Out-of-process adapters MUST NOT get the process_lost retry -- local
+    // pid disappearing has nothing to do with a remote Job dying.
+    expect(runs).toHaveLength(1);
+
+    const failedRun = runs[0];
+    expect(failedRun?.id).toBe(runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("adapter_liveness_lost");
+    expect(failedRun?.error ?? "").toContain("Adapter");
+    expect(failedRun?.error ?? "").toContain("liveness lost");
+    // Confirm the confusing local-pid wording is gone.
+    expect(failedRun?.error ?? "").not.toContain("child pid");
+    expect(failedRun?.resultJson).toMatchObject({
+      stopReason: "adapter_liveness_lost",
+    });
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
+  });
+
+  it("keeps local-child-process adapters on the process_lost path even when they share no pid", async () => {
+    // Regression guard: the new out-of-process branch must be gated strictly
+    // on the capability flag. A local adapter with no recorded pid still
+    // reaches the classic process-loss path (status failed, errorCode
+    // process_lost), not the adapter_liveness_lost path.
+    const { runId } = await seedRunFixture({
+      adapterType: "codex_local",
+      processPid: null,
+      processGroupId: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_lost");
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/services/heartbeat-stop-metadata.ts
+++ b/server/src/services/heartbeat-stop-metadata.ts
@@ -7,6 +7,7 @@ export type HeartbeatRunStopReason =
   | "budget_paused"
   | "paused"
   | "process_lost"
+  | "adapter_liveness_lost"
   | "adapter_failed";
 
 export interface HeartbeatRunTimeoutPolicy {
@@ -78,6 +79,7 @@ export function inferHeartbeatRunStopReason(input: {
   if (input.outcome === "succeeded") return "completed";
   if (input.outcome === "timed_out") return "timeout";
   if (input.outcome === "failed" && input.errorCode === "process_lost") return "process_lost";
+  if (input.outcome === "failed" && input.errorCode === "adapter_liveness_lost") return "adapter_liveness_lost";
   if (input.outcome === "cancelled") {
     const message = (input.errorMessage ?? "").toLowerCase();
     if (message.includes("budget")) return "budget_paused";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1567,11 +1567,8 @@ function adapterHasOutOfProcessLiveness(adapterType: string) {
 }
 
 function buildAdapterLivenessLostMessage(adapterType: string, staleThresholdMs: number) {
-  if (staleThresholdMs > 0) {
-    const staleSec = Math.round(staleThresholdMs / 1000);
-    return `Adapter ${adapterType} liveness lost -- no run activity for over ${staleSec}s (out-of-process adapter; local pid not applicable)`;
-  }
-  return `Adapter ${adapterType} liveness lost -- no run activity (out-of-process adapter; local pid not applicable)`;
+  const staleSec = Math.round(staleThresholdMs / 1000);
+  return `Adapter ${adapterType} liveness lost -- no run activity for over ${staleSec}s (out-of-process adapter; local pid not applicable)`;
 }
 
 // A positive liveness check means some process currently owns the PID.

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1556,6 +1556,24 @@ function isTrackedLocalChildProcessAdapter(adapterType: string) {
   return SESSIONED_LOCAL_ADAPTERS.has(adapterType);
 }
 
+// Adapters that drive execution out-of-process (Kubernetes Jobs, remote HTTP
+// services, etc.) declare `hasOutOfProcessLiveness: true`. For these, the
+// reaper has no meaningful local pid to probe, so it must skip pid/process-
+// group checks, give the adapter a chance to re-establish liveness at
+// startup, and emit a K8s-aware error code/message when it does reap.
+function adapterHasOutOfProcessLiveness(adapterType: string) {
+  const adapter = getServerAdapter(adapterType);
+  return adapter.hasOutOfProcessLiveness === true;
+}
+
+function buildAdapterLivenessLostMessage(adapterType: string, staleThresholdMs: number) {
+  if (staleThresholdMs > 0) {
+    const staleSec = Math.round(staleThresholdMs / 1000);
+    return `Adapter ${adapterType} liveness lost -- no run activity for over ${staleSec}s (out-of-process adapter; local pid not applicable)`;
+  }
+  return `Adapter ${adapterType} liveness lost -- no run activity (out-of-process adapter; local pid not applicable)`;
+}
+
 // A positive liveness check means some process currently owns the PID.
 // On Linux, PIDs can be recycled, so this is a best-effort signal rather
 // than proof that the original child is still alive.
@@ -3414,6 +3432,65 @@ export function heartbeatService(db: Db) {
       if (staleThresholdMs > 0) {
         const refTime = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
         if (now.getTime() - refTime < staleThresholdMs) continue;
+      }
+
+      // Out-of-process adapters (k8s-backed, remote HTTP, etc.) have no local
+      // pid. Take a separate path that (1) defers to adapter-driven activity
+      // at cold startup so still-running K8s Jobs survive a server restart,
+      // and (2) emits an adapter-aware error code/message when we do reap so
+      // operators don't see the confusing "child pid -1" sentinel.
+      if (adapterHasOutOfProcessLiveness(adapterType)) {
+        // Cold-startup sweep (staleThresholdMs === 0) has no timing signal
+        // and would otherwise kill every out-of-process run on every restart.
+        // Skip here; the periodic 5-minute reaper (and the adapter's own
+        // keepalive refresh of updatedAt) will catch genuinely dead runs.
+        if (staleThresholdMs <= 0) continue;
+
+        const livenessMessage = buildAdapterLivenessLostMessage(adapterType, staleThresholdMs);
+
+        let finalizedRun = await setRunStatus(run.id, "failed", {
+          error: livenessMessage,
+          errorCode: "adapter_liveness_lost",
+          finishedAt: now,
+          resultJson: mergeRunStopMetadataForAgent(
+            { adapterType, adapterConfig },
+            "failed",
+            {
+              resultJson: parseObject(run.resultJson),
+              errorCode: "adapter_liveness_lost",
+              errorMessage: livenessMessage,
+            },
+          ),
+        });
+        await setWakeupStatus(run.wakeupRequestId, "failed", {
+          finishedAt: now,
+          error: livenessMessage,
+        });
+        if (!finalizedRun) finalizedRun = await getRun(run.id);
+        if (!finalizedRun) continue;
+        finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
+
+        // No process_lost retry for out-of-process adapters: the loss has
+        // nothing to do with a local child pid disappearing, so retrying
+        // blindly is the wrong behavior.
+        await releaseIssueExecutionAndPromote(finalizedRun);
+
+        await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "error",
+          message: livenessMessage,
+          payload: {
+            adapterType,
+            staleThresholdMs,
+          },
+        });
+
+        await finalizeAgentStatus(run.agentId, "failed");
+        await startNextQueuedRunForAgent(run.agentId);
+        runningProcesses.delete(run.id);
+        reaped.push(run.id);
+        continue;
       }
 
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents can run via local adapters (child processes) or remote adapters (Kubernetes Jobs, gateway HTTP services, etc.)
> - The heartbeat reaper kills stale runs by checking local pid / process-group liveness — but K8s-style adapters have no local pid; their \"process\" is a remote Kubernetes Job
> - When the reaper finds `processPid = null` for a `claude_k8s` run it still emits the misleading `child pid -1` sentinel and a `process_lost` retry, neither of which make sense for a remote Job
> - This PR adds a `hasOutOfProcessLiveness` capability flag to `ServerAdapterModule` so K8s-style adapters can opt into a separate reaper path that (a) defers at cold startup, (b) emits a meaningful `adapter_liveness_lost` error code, and (c) skips the `process_lost` retry
> - The benefit is that long-running `claude_k8s` runs survive server restarts, operators see actionable error messages when a K8s Job genuinely disappears, and the fix is fully backward-compatible with all existing local adapters

## What Changed

- **`packages/adapter-utils/src/types.ts`** — Added `hasOutOfProcessLiveness?: boolean` to `ServerAdapterModule`. Documents semantics: skip local pid checks, defer cold-startup reap, use `adapter_liveness_lost` error code.
- **`server/src/services/heartbeat.ts`** — Added `adapterHasOutOfProcessLiveness()` helper (reads the new flag via `getServerAdapter`). In `reapOrphanedRuns`, inserted an early branch for flagged adapters that: (a) skips cold-startup sweep (`staleThresholdMs <= 0`), (b) sets run to `failed` with `errorCode: adapter_liveness_lost` and a K8s-aware message, (c) calls `releaseIssueExecutionAndPromote` without the `process_lost` retry, and (d) emits a `lifecycle` run event.
- **`server/src/services/heartbeat-stop-metadata.ts`** — Added `"adapter_liveness_lost"` to `HeartbeatRunStopReason` union and wired it into `inferHeartbeatRunStopReason`.
- **`server/src/__tests__/heartbeat-process-recovery.test.ts`** — Updated mock to accept `adapterType` and return `hasOutOfProcessLiveness: true` for `test_k8s_out_of_process`. Added three new tests:
  1. Cold-startup sweep does not reap an out-of-process run (`staleThresholdMs === 0`).
  2. Stale out-of-process run is reaped with `errorCode: adapter_liveness_lost`, no `child pid` wording, no `process_lost` retry row.
  3. Regression guard: local adapter with no pid still reaches the classic `process_lost` path (not `adapter_liveness_lost`).

## Verification

- Run existing and new heartbeat reaper tests:
  ```
  pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts
  ```
- All three new tests pass; existing tests unaffected.
- To validate end-to-end: configure a `claude_k8s` adapter with `hasOutOfProcessLiveness: true`, start a long-running run, restart the server, confirm the run is not immediately killed and that its `updatedAt` keeps refreshing.

## Risks

- **Low risk for existing local adapters.** The new code path is gated strictly on `hasOutOfProcessLiveness === true`. No built-in adapter sets this flag today; all existing behaviour is unchanged.
- **K8s adapters must opt in.** Without setting `hasOutOfProcessLiveness: true` in their `ServerAdapterModule`, `claude_k8s` and similar adapters will continue to see the old `process_lost` path. This is intentional — the fix is opt-in to avoid unintended changes.
- **Cold-startup window.** Deferring the cold-startup reap for out-of-process adapters means a truly dead K8s run (Job deleted while server was down) won't be cleaned up until the 5-minute periodic sweep. Acceptable trade-off vs. killing live Jobs on every restart.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- **Provider:** Anthropic  
- **Model:** Claude Sonnet 4.6 (`claude-sonnet-4-6`)  
- **Context window:** 200K tokens  
- **Capabilities:** Tool use, code execution, extended reasoning, multi-file editing  
- **Mode:** Paperclip heartbeat agent (Maverick) — autonomous execution with issue context

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots *(no UI changes)*
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge