### PR TITLE
Fix company import label portability

### DIFF
--- a/cli/src/__tests__/company.test.ts
+++ b/cli/src/__tests__/company.test.ts
@@ -224,6 +224,7 @@ describe("renderCompanyImportPreview", () => {
             metadata: null,
           },
         ],
+        labels: [],
         issues: [
           {
             slug: "kickoff",
@@ -239,6 +240,7 @@ describe("renderCompanyImportPreview", () => {
             legacyRecurrence: null,
             status: null,
             priority: null,
+            labelSlugs: [],
             labelIds: [],
             billingCode: null,
             executionWorkspaceSettings: null,
@@ -439,6 +441,7 @@ describe("import selection catalog", () => {
             metadata: null,
           },
         ],
+        labels: [],
         issues: [
           {
             slug: "kickoff",
@@ -454,6 +457,7 @@ describe("import selection catalog", () => {
             legacyRecurrence: null,
             status: null,
             priority: null,
+            labelSlugs: [],
             labelIds: [],
             billingCode: null,
             executionWorkspaceSettings: null,
@@ -581,6 +585,7 @@ describe("default adapter overrides", () => {
         ],
         skills: [],
         projects: [],
+        labels: [],
         issues: [],
         envInputs: [],
       },

--- a/docs/guides/board-operator/importing-and-exporting.md
+++ b/docs/guides/board-operator/importing-and-exporting.md
@@ -27,7 +27,7 @@ my-company/
 - **COMPANY.md** defines company name, description, and metadata.
 - **AGENT.md** files contain agent identity, role, and instructions.
 - **SKILL.md** files are compatible with the Agent Skills ecosystem.
-- **.paperclip.yaml** holds Paperclip-specific config (adapter types, env inputs, budgets) as an optional sidecar.
+- **.paperclip.yaml** holds Paperclip-specific config (adapter types, env inputs, budgets, task labels) as an optional sidecar.
 
 ## Exporting a Company
 
@@ -68,6 +68,7 @@ paperclipai company export abc123 --out ./skills-only --include skills --skills 
 - Agent names, roles, reporting structure, and instructions
 - Project definitions and workspace config
 - Task/issue descriptions (when included)
+- Task labels as portable label definitions plus task-level label slugs
 - Skill packages (as references or vendored content)
 - Adapter type and env input declarations in `.paperclip.yaml`
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -373,6 +373,7 @@ export type {
   CompanyPortabilityIssueRoutineTriggerManifestEntry,
   CompanyPortabilityIssueRoutineManifestEntry,
   CompanyPortabilityIssueManifestEntry,
+  CompanyPortabilityLabelManifestEntry,
   CompanyPortabilityManifest,
   CompanyPortabilityExportResult,
   CompanyPortabilityExportPreviewFile,

--- a/packages/shared/src/types/company-portability.ts
+++ b/packages/shared/src/types/company-portability.ts
@@ -93,6 +93,13 @@ export interface CompanyPortabilityIssueRoutineManifestEntry {
   triggers: CompanyPortabilityIssueRoutineTriggerManifestEntry[];
 }
 
+export interface CompanyPortabilityLabelManifestEntry {
+  slug: string;
+  name: string;
+  color: string;
+  sourceId: string | null;
+}
+
 export interface CompanyPortabilityIssueManifestEntry {
   slug: string;
   identifier: string | null;
@@ -107,6 +114,11 @@ export interface CompanyPortabilityIssueManifestEntry {
   legacyRecurrence: Record<string, unknown> | null;
   status: string | null;
   priority: string | null;
+  labelSlugs: string[];
+  /**
+   * @deprecated Raw label ids are source-company scoped and are only retained
+   * for backwards compatibility with packages exported before labelSlugs.
+   */
   labelIds: string[];
   billingCode: string | null;
   executionWorkspaceSettings: Record<string, unknown> | null;
@@ -163,6 +175,7 @@ export interface CompanyPortabilityManifest {
   agents: CompanyPortabilityAgentManifestEntry[];
   skills: CompanyPortabilitySkillManifestEntry[];
   projects: CompanyPortabilityProjectManifestEntry[];
+  labels: CompanyPortabilityLabelManifestEntry[];
   issues: CompanyPortabilityIssueManifestEntry[];
   envInputs: CompanyPortabilityEnvInput[];
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -214,6 +214,7 @@ export type {
   CompanyPortabilityIssueRoutineTriggerManifestEntry,
   CompanyPortabilityIssueRoutineManifestEntry,
   CompanyPortabilityIssueManifestEntry,
+  CompanyPortabilityLabelManifestEntry,
   CompanyPortabilityManifest,
   CompanyPortabilityExportResult,
   CompanyPortabilityExportPreviewFile,

--- a/packages/shared/src/validators/company-portability.ts
+++ b/packages/shared/src/validators/company-portability.ts
@@ -129,6 +129,13 @@ export const portabilityIssueRoutineManifestEntrySchema = z.object({
   triggers: z.array(portabilityIssueRoutineTriggerManifestEntrySchema).default([]),
 });
 
+export const portabilityLabelManifestEntrySchema = z.object({
+  slug: z.string().min(1),
+  name: z.string().min(1),
+  color: z.string().min(1),
+  sourceId: z.string().min(1).nullable().default(null),
+});
+
 export const portabilityIssueManifestEntrySchema = z.object({
   slug: z.string().min(1),
   identifier: z.string().min(1).nullable(),
@@ -143,6 +150,7 @@ export const portabilityIssueManifestEntrySchema = z.object({
   legacyRecurrence: z.record(z.unknown()).nullable(),
   status: z.string().nullable(),
   priority: z.string().nullable(),
+  labelSlugs: z.array(z.string().min(1)).default([]),
   labelIds: z.array(z.string().min(1)).default([]),
   billingCode: z.string().nullable(),
   executionWorkspaceSettings: z.record(z.unknown()).nullable(),
@@ -171,6 +179,7 @@ export const portabilityManifestSchema = z.object({
   agents: z.array(portabilityAgentManifestEntrySchema),
   skills: z.array(portabilitySkillManifestEntrySchema).default([]),
   projects: z.array(portabilityProjectManifestEntrySchema).default([]),
+  labels: z.array(portabilityLabelManifestEntrySchema).default([]),
   issues: z.array(portabilityIssueManifestEntrySchema).default([]),
   envInputs: z.array(portabilityEnvInputSchema).default([]),
 });

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -37,6 +37,8 @@ const issueSvc = {
   list: vi.fn(),
   getById: vi.fn(),
   getByIdentifier: vi.fn(),
+  listLabels: vi.fn(),
+  createLabel: vi.fn(),
   create: vi.fn(),
 };
 
@@ -225,6 +227,15 @@ describe("company portability", () => {
     issueSvc.list.mockResolvedValue([]);
     issueSvc.getById.mockResolvedValue(null);
     issueSvc.getByIdentifier.mockResolvedValue(null);
+    issueSvc.listLabels.mockResolvedValue([]);
+    issueSvc.createLabel.mockImplementation(async (companyId: string, data: { name: string; color: string }) => ({
+      id: `imported-${data.name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+      companyId,
+      name: data.name,
+      color: data.color,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
     routineSvc.list.mockResolvedValue([]);
     routineSvc.getDetail.mockImplementation(async (id: string) => {
       const rows = await routineSvc.list();
@@ -2307,8 +2318,26 @@ describe("company portability", () => {
     expect(materializedFiles["AGENTS.md"]).not.toContain('name: "ClaudeCoder"');
   });
 
-  it("preserves issue labelIds through export and import round-trip", async () => {
+  it("preserves issue labels through portable slugs during export and import", async () => {
     const portability = companyPortabilityService({} as any);
+    const sourceLabels = [
+      {
+        id: "label-a",
+        companyId: "company-1",
+        name: "Customer",
+        color: "#ef4444",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "label-b",
+        companyId: "company-1",
+        name: "Launch",
+        color: "#22c55e",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
 
     projectSvc.list.mockResolvedValue([
       {
@@ -2340,15 +2369,24 @@ describe("company portability", () => {
         assigneeAdapterOverrides: null,
       },
     ]);
+    issueSvc.listLabels.mockImplementation(async (companyId: string) => (
+      companyId === "company-1" ? sourceLabels : []
+    ));
 
     const exported = await portability.exportBundle("company-1", {
       include: { company: true, agents: false, projects: true, issues: true },
     });
 
     const extension = asTextFile(exported.files[".paperclip.yaml"]);
-    expect(extension).toContain("labelIds:");
-    expect(extension).toContain("label-a");
-    expect(extension).toContain("label-b");
+    expect(extension).toContain("labels:");
+    expect(extension).toContain("labelSlugs:");
+    expect(extension).toContain("customer");
+    expect(extension).toContain("launch");
+    expect(extension).not.toContain("labelIds:");
+    expect(exported.manifest.labels).toEqual([
+      expect.objectContaining({ slug: "customer", name: "Customer", color: "#ef4444", sourceId: "label-a" }),
+      expect.objectContaining({ slug: "launch", name: "Launch", color: "#22c55e", sourceId: "label-b" }),
+    ]);
 
     companySvc.create.mockResolvedValue({ id: "company-imported", name: "Imported" });
     accessSvc.ensureMembership.mockResolvedValue(undefined);
@@ -2368,8 +2406,69 @@ describe("company portability", () => {
     expect(issueSvc.create).toHaveBeenCalledWith(
       "company-imported",
       expect.objectContaining({
-        labelIds: ["label-a", "label-b"],
+        labelIds: ["imported-customer", "imported-launch"],
       }),
+    );
+    expect(issueSvc.createLabel).toHaveBeenCalledWith("company-imported", {
+      name: "Customer",
+      color: "#ef4444",
+    });
+    expect(issueSvc.createLabel).toHaveBeenCalledWith("company-imported", {
+      name: "Launch",
+      color: "#22c55e",
+    });
+  });
+
+  it("skips legacy raw labelIds when no portable label definitions exist", async () => {
+    const portability = companyPortabilityService({} as any);
+    companySvc.create.mockResolvedValue({ id: "company-imported", name: "Imported" });
+    accessSvc.ensureMembership.mockResolvedValue(undefined);
+    agentSvc.list.mockResolvedValue([]);
+    projectSvc.list.mockResolvedValue([]);
+    issueSvc.create.mockResolvedValue({ id: "issue-imported", title: "Labelled task" });
+
+    const result = await portability.importBundle({
+      source: {
+        type: "inline",
+        rootPath: "paperclip",
+        files: {
+          "COMPANY.md": [
+            "---",
+            'name: "Paperclip"',
+            'schema: "agentcompanies/v1"',
+            "---",
+            "",
+          ].join("\n"),
+          "tasks/labelled-task/TASK.md": [
+            "---",
+            'name: "Labelled task"',
+            "---",
+            "",
+            "Has labels",
+          ].join("\n"),
+          ".paperclip.yaml": [
+            'schema: "paperclip/v1"',
+            "tasks:",
+            "  labelled-task:",
+            "    labelIds:",
+            '      - "source-label-a"',
+          ].join("\n"),
+        },
+      },
+      include: { company: true, agents: false, projects: false, issues: true },
+      target: { mode: "new_company", newCompanyName: "Imported" },
+      agents: "all",
+      collisionStrategy: "rename",
+    }, "user-1");
+
+    expect(issueSvc.create).toHaveBeenCalledWith(
+      "company-imported",
+      expect.objectContaining({
+        labelIds: [],
+      }),
+    );
+    expect(result.warnings).toContain(
+      "Task labelled-task references labels source-label-a, but they were not available in the target company and were skipped.",
     );
   });
 

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -24,6 +24,7 @@ import type {
   CompanyPortabilityIssueRoutineManifestEntry,
   CompanyPortabilityIssueRoutineTriggerManifestEntry,
   CompanyPortabilityIssueManifestEntry,
+  CompanyPortabilityLabelManifestEntry,
   CompanyPortabilitySidebarOrder,
   CompanyPortabilitySkillManifestEntry,
   CompanySkill,
@@ -121,6 +122,7 @@ const DEFAULT_INCLUDE: CompanyPortabilityInclude = {
 };
 
 const DEFAULT_COLLISION_STRATEGY: CompanyPortabilityCollisionStrategy = "rename";
+const DEFAULT_LABEL_COLOR = "#64748b";
 const IMPORT_FORBIDDEN_ADAPTER_TYPES = new Set(["process", "http"]);
 const execFileAsync = promisify(execFile);
 let bundledSkillsCommitPromise: Promise<string | null> | null = null;
@@ -496,6 +498,7 @@ type PaperclipExtensionDoc = {
   company?: Record<string, unknown> | null;
   agents?: Record<string, Record<string, unknown>> | null;
   projects?: Record<string, Record<string, unknown>> | null;
+  labels?: Record<string, Record<string, unknown>> | null;
   tasks?: Record<string, Record<string, unknown>> | null;
   routines?: Record<string, Record<string, unknown>> | null;
 };
@@ -1470,6 +1473,64 @@ function normalizePortableSlugList(value: unknown) {
   return normalized;
 }
 
+function normalizePortableLabelExtension(
+  slug: string,
+  value: unknown,
+): CompanyPortabilityLabelManifestEntry | null {
+  const safeSlug = normalizeAgentUrlKey(slug) ?? slug.trim();
+  if (!safeSlug) return null;
+  const extension = isPlainRecord(value) ? value : {};
+  const name = asString(extension.name) ?? slug;
+  return {
+    slug: safeSlug,
+    name,
+    color: asString(extension.color) ?? DEFAULT_LABEL_COLOR,
+    sourceId: asString(extension.sourceId),
+  };
+}
+
+function resolvePortableIssueLabelIds(
+  issue: Pick<CompanyPortabilityIssueManifestEntry, "slug" | "labelSlugs" | "labelIds">,
+  importedLabelIdBySlug: Map<string, string>,
+  importedLabelIdBySourceId: Map<string, string>,
+  warnings: string[],
+) {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const missing: string[] = [];
+  const addLabelId = (labelId: string | undefined) => {
+    if (!labelId || seen.has(labelId)) return;
+    seen.add(labelId);
+    out.push(labelId);
+  };
+
+  for (const labelSlug of issue.labelSlugs ?? []) {
+    const labelId = importedLabelIdBySlug.get(labelSlug);
+    if (labelId) {
+      addLabelId(labelId);
+    } else {
+      missing.push(labelSlug);
+    }
+  }
+
+  for (const sourceLabelId of issue.labelIds ?? []) {
+    const labelId = importedLabelIdBySourceId.get(sourceLabelId);
+    if (labelId) {
+      addLabelId(labelId);
+    } else if ((issue.labelSlugs ?? []).length === 0) {
+      missing.push(sourceLabelId);
+    }
+  }
+
+  if (missing.length > 0) {
+    const preview = missing.slice(0, 4).join(", ");
+    const remainder = missing.length > 4 ? ` and ${missing.length - 4} more` : "";
+    warnings.push(`Task ${issue.slug} references labels ${preview}${remainder}, but they were not available in the target company and were skipped.`);
+  }
+
+  return out;
+}
+
 function normalizePortableSidebarOrder(value: unknown): CompanyPortabilitySidebarOrder | null {
   if (!isPlainRecord(value)) return null;
   const sidebar = {
@@ -2370,6 +2431,7 @@ function buildManifestFromPackageFiles(
   const paperclipSidebar = normalizePortableSidebarOrder(paperclipExtension.sidebar);
   const paperclipAgents = isPlainRecord(paperclipExtension.agents) ? paperclipExtension.agents : {};
   const paperclipProjects = isPlainRecord(paperclipExtension.projects) ? paperclipExtension.projects : {};
+  const paperclipLabels = isPlainRecord(paperclipExtension.labels) ? paperclipExtension.labels : {};
   const paperclipTasks = isPlainRecord(paperclipExtension.tasks) ? paperclipExtension.tasks : {};
   const paperclipRoutines = isPlainRecord(paperclipExtension.routines) ? paperclipExtension.routines : {};
   const companyName =
@@ -2412,7 +2474,7 @@ function buildManifestFromPackageFiles(
   const skillPaths = Array.from(new Set([...referencedSkillPaths, ...discoveredSkillPaths])).sort();
 
   const manifest: CompanyPortabilityManifest = {
-    schemaVersion: 5,
+    schemaVersion: 6,
     generatedAt: new Date().toISOString(),
     source: opts?.sourceLabel ?? null,
     includes: {
@@ -2449,11 +2511,19 @@ function buildManifestFromPackageFiles(
     agents: [],
     skills: [],
     projects: [],
+    labels: [],
     issues: [],
     envInputs: [],
   };
 
   const warnings: string[] = [];
+  const usedLabelSlugs = new Set<string>();
+  for (const [rawSlug, rawExtension] of Object.entries(paperclipLabels).sort(([left], [right]) => left.localeCompare(right))) {
+    const label = normalizePortableLabelExtension(rawSlug, rawExtension);
+    if (!label) continue;
+    label.slug = uniqueSlug(label.slug, usedLabelSlugs);
+    manifest.labels.push(label);
+  }
   if (manifest.company?.logoPath && !normalizedFiles[manifest.company.logoPath]) {
     warnings.push(`Referenced company logo file is missing from package: ${manifest.company.logoPath}`);
   }
@@ -2671,6 +2741,8 @@ function buildManifestFromPackageFiles(
       legacyRecurrence,
       status: asString(extension.status) ?? asString(routineExtensionRaw.status),
       priority: asString(extension.priority) ?? asString(routineExtensionRaw.priority),
+      labelSlugs: normalizePortableSlugList(extension.labelSlugs)
+        .map((entry) => normalizeAgentUrlKey(entry) ?? entry),
       labelIds: Array.isArray(extension.labelIds)
         ? extension.labelIds.filter((entry): entry is string => typeof entry === "string")
         : [],
@@ -3190,8 +3262,36 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     const paperclipAgentsOut: Record<string, Record<string, unknown>> = {};
     const paperclipProjectsOut: Record<string, Record<string, unknown>> = {};
     const paperclipTasksOut: Record<string, Record<string, unknown>> = {};
+    const paperclipLabelsOut: Record<string, Record<string, unknown>> = {};
     const unportableTaskWorkspaceRefs = new Map<string, { workspaceId: string; taskSlugs: string[] }>();
     const paperclipRoutinesOut: Record<string, Record<string, unknown>> = {};
+
+    const labelSlugById = new Map<string, string>();
+    if (include.issues) {
+      const referencedLabelIds = new Set(
+        selectedIssueRows.flatMap((issue) => issue.labelIds ?? []),
+      );
+      if (referencedLabelIds.size > 0) {
+        const labelRows = await issuesSvc.listLabels(companyId);
+        const usedLabelSlugs = new Set<string>();
+        for (const label of labelRows
+          .filter((entry) => referencedLabelIds.has(entry.id))
+          .sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id))) {
+          const slug = uniqueSlug(toSafeSlug(label.name, "label"), usedLabelSlugs);
+          labelSlugById.set(label.id, slug);
+          paperclipLabelsOut[slug] = {
+            name: label.name,
+            color: label.color,
+            sourceId: label.id,
+          };
+        }
+        for (const labelId of referencedLabelIds) {
+          if (!labelSlugById.has(labelId)) {
+            warnings.push(`Issue label ${labelId} was omitted from export because the label record was not found.`);
+          }
+        }
+      }
+    }
 
     const skillByReference = new Map<string, typeof companySkillRows[number]>();
     for (const skill of companySkillRows) {
@@ -3396,7 +3496,9 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
         identifier: issue.identifier,
         status: issue.status,
         priority: issue.priority,
-        labelIds: issue.labelIds ?? undefined,
+        labelSlugs: (issue.labelIds ?? [])
+          .map((labelId) => labelSlugById.get(labelId))
+          .filter((labelSlug): labelSlug is string => Boolean(labelSlug)),
         billingCode: issue.billingCode ?? null,
         projectWorkspaceKey: projectWorkspaceKey ?? undefined,
         executionWorkspaceSettings: issue.executionWorkspaceSettings ?? undefined,
@@ -3474,6 +3576,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
         sidebar: stripEmptyValues(sidebarOrder),
         agents: Object.keys(paperclipAgents).length > 0 ? paperclipAgents : undefined,
         projects: Object.keys(paperclipProjects).length > 0 ? paperclipProjects : undefined,
+        labels: Object.keys(paperclipLabelsOut).length > 0 ? paperclipLabelsOut : undefined,
         tasks: Object.keys(paperclipTasks).length > 0 ? paperclipTasks : undefined,
         routines: Object.keys(paperclipRoutines).length > 0 ? paperclipRoutines : undefined,
       },
@@ -4097,6 +4200,31 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     for (const existing of existingProjects) {
       existingProjectSlugToId.set(existing.urlKey, existing.id);
     }
+    const importedLabelIdBySlug = new Map<string, string>();
+    const importedLabelIdBySourceId = new Map<string, string>();
+    const sourceLabelDefinitions = sourceManifest.labels ?? [];
+    const legacyIssueLabelIds = new Set(sourceManifest.issues.flatMap((issue) => issue.labelIds ?? []));
+    if (include.issues && (sourceLabelDefinitions.length > 0 || legacyIssueLabelIds.size > 0)) {
+      const existingLabels = await issues.listLabels(targetCompany.id);
+      for (const existingLabel of existingLabels) {
+        importedLabelIdBySourceId.set(existingLabel.id, existingLabel.id);
+      }
+      const labelByName = new Map(existingLabels.map((label) => [label.name, label]));
+      for (const manifestLabel of sourceLabelDefinitions) {
+        let targetLabel = labelByName.get(manifestLabel.name);
+        if (!targetLabel) {
+          targetLabel = await issues.createLabel(targetCompany.id, {
+            name: manifestLabel.name,
+            color: manifestLabel.color || DEFAULT_LABEL_COLOR,
+          });
+          labelByName.set(targetLabel.name, targetLabel);
+        }
+        importedLabelIdBySlug.set(manifestLabel.slug, targetLabel.id);
+        if (manifestLabel.sourceId) {
+          importedLabelIdBySourceId.set(manifestLabel.sourceId, targetLabel.id);
+        }
+      }
+    }
 
     const importedSkills = include.skills || include.agents
       ? await companySkills.importPackageFiles(targetCompany.id, pickTextFiles(plan.source.files), {
@@ -4494,6 +4622,12 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           warnings.push(`Task ${manifestIssue.slug} was downgraded to todo because its assignee could not be imported as assignable work.`);
           issueStatus = "todo";
         }
+        const labelIds = resolvePortableIssueLabelIds(
+          manifestIssue,
+          importedLabelIdBySlug,
+          importedLabelIdBySourceId,
+          warnings,
+        );
         await issues.create(targetCompany.id, {
           projectId,
           projectWorkspaceId,
@@ -4507,7 +4641,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           billingCode: manifestIssue.billingCode,
           assigneeAdapterOverrides: manifestIssue.assigneeAdapterOverrides,
           executionWorkspaceSettings: manifestIssue.executionWorkspaceSettings,
-          labelIds: manifestIssue.labelIds ?? [],
+          labelIds,
         });
       }
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agent companies through company-scoped agents, projects, issues, and reusable company packages.
> - The company import/export subsystem should let operators move or duplicate a company package into a different company boundary.
> - Issue labels are company-scoped database records, so raw label ids from the source company are not portable across imports.
> - Export currently writes task `labelIds` directly, and import passes those ids to issue creation, which can fail with `One or more labels are invalid for this company` when importing into a new company.
> - This pull request makes labels portable by exporting label definitions and task-level label slugs, then resolving or creating target-company labels on import.
> - The benefit is that company packages with labelled tasks can round-trip into new companies without leaking source-company ids or failing validation.

## What Changed

- Added portable label entries to the company portability manifest and validator.
- Export labels used by selected issues into `.paperclip.yaml` as label definitions.
- Export task label references as `labelSlugs` instead of raw source-company `labelIds`.
- Import portable labels by reusing target labels with the same name or creating them when absent.
- Keep legacy raw `labelIds` safe: preserve them only when they already exist in the target company, otherwise skip them with a warning instead of passing invalid ids into issue creation.
- Updated portability tests, CLI test fixtures, and import/export docs.

## Verification

- `pnpm test:run cli/src/__tests__/company.test.ts server/src/__tests__/company-portability.test.ts server/src/__tests__/company-portability-routes.test.ts`
- `pnpm typecheck`

No UI surface changed; screenshots are not applicable.

## Risks

- Low-to-moderate compatibility risk: this adds `labels` and `labelSlugs` to the portable manifest while retaining `labelIds` as legacy-compatible input.
- Existing packages with only raw `labelIds` cannot preserve labels when imported into a different company unless matching label ids already exist in the target; those labels are now skipped with a warning instead of failing the import.
- Existing target labels are matched by exact name; if a package expects a same-name label with a different color, the existing target label is reused.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 coding agent with tool use and local command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
