### PR TITLE
fix(ui): harden IssueChatThread against malformed transcript parts (DAT-2042)

### DIFF
--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -156,19 +156,24 @@ function findCoTSegmentIndex(
   messageParts: ReadonlyArray<{ type: string }>,
   cotParts: ReadonlyArray<{ type: string }>,
 ): number {
-  if (cotParts.length === 0) return -1;
-  const firstPart = cotParts[0];
-  let segIdx = -1;
-  let inCoT = false;
-  for (const part of messageParts) {
-    if (part.type === "reasoning" || part.type === "tool-call") {
-      if (!inCoT) { segIdx++; inCoT = true; }
-      if (part === firstPart) return segIdx;
-    } else {
-      inCoT = false;
+  try {
+    if (!Array.isArray(messageParts) || !Array.isArray(cotParts) || cotParts.length === 0) return -1;
+    const firstPart = cotParts[0];
+    let segIdx = -1;
+    let inCoT = false;
+    for (const part of messageParts) {
+      const type = (part as { type?: unknown } | null)?.type;
+      if (type === "reasoning" || type === "tool-call") {
+        if (!inCoT) { segIdx++; inCoT = true; }
+        if (part === firstPart) return segIdx;
+      } else {
+        inCoT = false;
+      }
     }
+    return -1;
+  } catch {
+    return -1;
   }
-  return -1;
 }
 
 function useLiveElapsed(startMs: number | null | undefined, active: boolean): string | null {
@@ -310,17 +315,31 @@ function fallbackAuthorLabel(message: ThreadMessage) {
   return "System";
 }
 
+const FALLBACK_TOOL_BODY_MAX = 400;
+
+function truncateForFallback(value: string): string {
+  if (value.length <= FALLBACK_TOOL_BODY_MAX) return value;
+  return `${value.slice(0, FALLBACK_TOOL_BODY_MAX)}\n\n… truncated (${value.length - FALLBACK_TOOL_BODY_MAX} more chars). Open the raw run for full detail.`;
+}
+
 function fallbackTextParts(message: ThreadMessage) {
   const contentLines: string[] = [];
-  for (const part of message.content) {
+  const parts = Array.isArray(message.content) ? message.content : [];
+  for (const part of parts) {
+    if (!part || typeof part !== "object") continue;
     if (part.type === "text" || part.type === "reasoning") {
-      if (part.text.trim().length > 0) contentLines.push(part.text);
+      const text = typeof part.text === "string" ? part.text : "";
+      if (text.trim().length > 0) contentLines.push(text);
       continue;
     }
     if (part.type === "tool-call") {
-      const lines = [`Tool: ${part.toolName}`];
-      if (part.argsText?.trim()) lines.push(`Args:\n${part.argsText}`);
-      if (typeof part.result === "string" && part.result.trim()) lines.push(`Result:\n${part.result}`);
+      const toolName = typeof part.toolName === "string" && part.toolName.length > 0 ? part.toolName : "tool";
+      const lines = [`_Fallback render — open raw run for full detail._`, `**Tool:** ${toolName}`];
+      const argsText = typeof part.argsText === "string" ? part.argsText : "";
+      if (argsText.trim()) lines.push(`Args:\n\n\`\`\`\n${truncateForFallback(argsText)}\n\`\`\``);
+      if (typeof part.result === "string" && part.result.trim()) {
+        lines.push(`Result:\n\n\`\`\`\n${truncateForFallback(part.result)}\n\`\`\``);
+      }
       contentLines.push(lines.join("\n\n"));
     }
   }
@@ -597,12 +616,16 @@ function IssueChatChainOfThought({
   );
 
   const allReasoningText = cotParts
-    .filter((p): p is { type: "reasoning"; text: string } => p.type === "reasoning" && !!p.text)
+    .filter((p): p is { type: "reasoning"; text: string } => p.type === "reasoning" && typeof p.text === "string" && p.text.length > 0)
     .map((p) => p.text)
     .join("\n");
-  const toolParts = cotParts.filter(
-    (p): p is ToolCallMessagePart => p.type === "tool-call",
-  );
+  const toolParts = cotParts
+    .filter((p): p is ToolCallMessagePart => p.type === "tool-call")
+    .map((p): ToolCallMessagePart => ({
+      ...p,
+      toolName: typeof p.toolName === "string" && p.toolName.length > 0 ? p.toolName : "tool",
+      argsText: typeof p.argsText === "string" ? p.argsText : "",
+    }));
 
   const hasActiveTool = toolParts.some((t) => t.result === undefined);
   const isActive = isMessageRunning && hasActiveTool;

--- a/ui/src/lib/issue-chat-messages.test.ts
+++ b/ui/src/lib/issue-chat-messages.test.ts
@@ -614,4 +614,19 @@ describe("stabilizeThreadMessages", () => {
 
     expect(secondStable.messages).toBe(firstStable.messages);
   });
+
+  it("does not throw when a message contains a non-serializable value", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const message = {
+      id: "comment-bad",
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "hello" }],
+      createdAt: new Date("2026-04-06T12:00:00.000Z"),
+      metadata: { custom: { circular } },
+    };
+    expect(() =>
+      stabilizeThreadMessages([message as never], [], new Map()),
+    ).not.toThrow();
+  });
 });

--- a/ui/src/lib/issue-chat-messages.ts
+++ b/ui/src/lib/issue-chat-messages.ts
@@ -95,7 +95,16 @@ function toTimestamp(value: Date | string | null | undefined) {
 }
 
 function fingerprintThreadMessage(message: ThreadMessage) {
-  return JSON.stringify(message);
+  try {
+    return JSON.stringify(message);
+  } catch {
+    const partsLength = Array.isArray(message.content) ? message.content.length : 0;
+    const createdAt = message.createdAt instanceof Date
+      ? message.createdAt.getTime()
+      : message.createdAt ?? "";
+    const status = message.status?.type ?? "";
+    return `fallback:${message.id}:${message.role}:${partsLength}:${createdAt}:${status}`;
+  }
 }
 
 export function stabilizeThreadMessages(


### PR DESCRIPTION
## Summary

Prevent `IssueChatErrorBoundary` from falling through to the raw tool-call dump renderer when a run transcript contains non-serializable values or malformed parts. Board has been seeing inline `Tool: Bash ...` dumps in issue threads whenever the normal Chain-of-Thought renderer crashed — this fix stops hitting the boundary on valid data and polishes the fallback for the rare case where it still fires.

- `fingerprintThreadMessage` (`ui/src/lib/issue-chat-messages.ts`): wrapped `JSON.stringify` in try/catch with an id+role+length+createdAt+status fallback fingerprint so circular refs / BigInts / non-serializable tool payloads can't throw inside the `useMemo` that trips the error boundary.
- `findCoTSegmentIndex` (`ui/src/components/IssueChatThread.tsx`): wrapped in try/catch and tolerant of non-array inputs or parts without a string `type`.
- `IssueChatChainOfThought` tool parts: normalize `toolName` to `"tool"` when missing/non-string and `argsText` to `""` when non-string, so downstream `displayToolName` / `humanizeLabel` calls can't throw on malformed transcript data.
- `fallbackTextParts`: defensive against non-array `content` and non-string `text`/`argsText`/`result`. Adds a per-block `_Fallback render — open raw run for full detail._` marker and truncates tool args/result to 400 chars with a trailing `… truncated` note so the fallback card is much less noisy if it ever fires again.
- Adds a regression test that `stabilizeThreadMessages` does not throw on a message containing a circular reference.

The error boundary is intentionally not suppressed — it's still the safety net. The goal is to stop hitting it on valid run data and, when it does fire, keep the noise bounded.

## Test plan

- [x] `pnpm --filter @paperclipai/ui typecheck`
- [x] `pnpm --filter @paperclipai/ui build`
- [x] `npx vitest run ui/src/lib/issue-chat-messages.test.ts` — 14/14 passing, including the new circular-ref regression test.
- [ ] Manual: open a long CEO-run issue in the UI and confirm the normal Chain-of-Thought fold is shown instead of the amber fallback card, with no console errors. (Defer to reviewer; my workspace only has read access, no live UI.)

Tracks [DAT-2042](/DAT/issues/DAT-2042). Parent: [DAT-2041](/DAT/issues/DAT-2041).