### PR TITLE
claude-local adapter: add retryOnTransientAuth (one-shot retry on transient claude_auth_required)

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -308,6 +308,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+  const retryOnTransientAuth = asBoolean(config.retryOnTransientAuth, true);
+  const transientAuthRetryDelayMs = Math.max(
+    0,
+    asNumber(config.transientAuthRetryDelayMs, 500),
+  );
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   const runtimeConfig = await buildClaudeRuntimeConfig({
@@ -618,7 +623,44 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   };
 
-  const initial = await runAttempt(sessionId ?? null);
+  let initial = await runAttempt(sessionId ?? null);
+
+  // Transient claude_auth_required retry: the Claude CLI can briefly surface a
+  // logged-out state (token cache miss, clock skew during a refresh, etc.) that
+  // clears on the very next invocation. One automatic retry disambiguates a
+  // transient glitch from a persistent logout. If the second attempt also
+  // reports claude_auth_required, we surface the failure unmodified — no mask.
+  if (
+    retryOnTransientAuth &&
+    !initial.proc.timedOut &&
+    (initial.proc.exitCode ?? 0) !== 0 &&
+    detectClaudeLoginRequired({
+      parsed: initial.parsed,
+      stdout: initial.proc.stdout,
+      stderr: initial.proc.stderr,
+    }).requiresLogin
+  ) {
+    const jitter = Math.floor(Math.random() * Math.max(1, Math.round(transientAuthRetryDelayMs / 2)));
+    const delayMs = transientAuthRetryDelayMs + jitter;
+    await onLog(
+      "stdout",
+      `[paperclip] Claude reported claude_auth_required; retrying once after ${delayMs}ms to distinguish a transient auth glitch from a persistent logout.\n`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    initial = await runAttempt(sessionId ?? null);
+    const stillRequiresLogin = detectClaudeLoginRequired({
+      parsed: initial.parsed,
+      stdout: initial.proc.stdout,
+      stderr: initial.proc.stderr,
+    }).requiresLogin;
+    await onLog(
+      "stdout",
+      `[paperclip] claude_auth_required retry result: ${
+        stillRequiresLogin ? "still requires login (surfacing as persistent failure)" : "recovered"
+      }.\n`,
+    );
+  }
+
   if (
     sessionId &&
     !initial.proc.timedOut &&


### PR DESCRIPTION
## Summary

Adds a single automatic retry to the `@paperclipai/adapter-claude-local` adapter when Claude CLI surfaces `claude_auth_required` on an otherwise-healthy workstation. Gated behind a new config flag `retryOnTransientAuth` (default `true`). A second consecutive `claude_auth_required` is treated as persistent and surfaced unchanged — no masking.

## Motivation

Downstream integrators (e.g. SmartHomie / PaperClipHQ) hit occasional short-lived `claude_auth_required` flaps from the Claude CLI where the very next invocation succeeds. Likely causes: token cache miss, clock skew during a token refresh, transient network hiccup during the auth handshake. Current behaviour fails the run immediately and — in our deployment — trips a circuit-breaker that masks the underlying transient signal.

Rather than adding a breaker-side retry (which would mask genuine persistent logouts), this PR disambiguates at the adapter boundary:
- **1st attempt → `claude_auth_required`** → treat as potentially transient → retry once after a jittered delay.
- **2nd attempt → `claude_auth_required`** → treat as persistent → surface unchanged, fail fast.
- **2nd attempt → success** → run proceeds normally.

## Change scope

Single file: `packages/adapters/claude-local/src/server/execute.ts`

**New config fields** (read from `config` in `execute`):
| Field | Type | Default | Purpose |
|---|---|---|---|
| `retryOnTransientAuth` | boolean | `true` | Opt out by setting `false` |
| `transientAuthRetryDelayMs` | number | `500` | Base delay; 0–50% jitter added |

**Logic** (inserted between `runAttempt(initial)` and the existing unknown-session fallback):
1. If `retryOnTransientAuth` is enabled, and the initial attempt: not timed out, non-zero exit code, `detectClaudeLoginRequired(...)` returns `requiresLogin: true` — then wait `delayMs + jitter` and re-run `runAttempt(sessionId ?? null)` once.
2. The retry re-uses the same `resumeSessionId` as the initial attempt (symmetric behaviour; sessions aren't invalidated by a transient auth glitch).
3. Emits two `onLog` lines for observability: one before the retry (declaring intent + delay) and one after (`recovered` vs `still requires login`).
4. Existing unknown-session fallback (`isClaudeUnknownSessionError`) runs against whichever attempt result is current, so resume-session recovery continues to work unchanged.

## Acceptance tests (to run against a downstream integration harness)

1. **Transient recovery**: Stub Claude CLI to return `claude_auth_required` on first invocation and a normal result on the second. Expect: run succeeds, `onLog` shows `recovered`, final `errorCode` is `null`.
2. **Persistent failure**: Stub Claude CLI to return `claude_auth_required` on both invocations. Expect: run fails, final `errorCode === \"claude_auth_required\"`, exactly 2 process spawns (no infinite retry), `onLog` shows `still requires login`.
3. **Opt-out**: With `retryOnTransientAuth: false`, a single `claude_auth_required` fails immediately with 1 spawn.
4. **Interaction with unknown-session fallback**: With a resume `sessionId` that is invalid upstream, initial attempt → `claude_auth_required` → retry still auth-required → unknown-session fallback does NOT fire (different error code). Separately: non-auth unknown-session error continues to trigger the existing fresh-session retry.
5. **No regression on happy path**: `runAttempt` returns success → no retry fires, one spawn.

## Type-check

```
pnpm --filter @paperclipai/adapter-claude-local typecheck
# passes (tsc --noEmit, no errors)
```

## Back-compat

- Default flips no existing behaviour in an observable way *unless* the adapter was previously returning `claude_auth_required`; in that case the adapter now issues one extra Claude invocation before surfacing the same error. The extra invocation is cheap and only fires on the failure path.
- Callers that want the old one-shot behaviour can set `retryOnTransientAuth: false` in the adapter config.

## Not included

- No adapter-level metrics emission (kept to `onLog` — downstream `onMeta` schema is strict and this PR doesn't want to widen it).
- No changes to `parse.ts`, `buildLoginResult`, or the UI auth banner (`paperclip/ui/src/pages/AgentDetail.tsx`) — behaviour remains identical for persistent auth-required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)