### PR TITLE
[codex] 이슈 코멘트 자기 깨움 루프 차단

### DIFF
--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -104,7 +104,7 @@ function registerModuleMocks() {
   }));
 }
 
-async function createApp() {
+async function createApp(actorOverrides: Record<string, unknown> = {}) {
   const [{ errorHandler }, { issueRoutes }] = await Promise.all([
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
     vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
@@ -118,6 +118,7 @@ async function createApp() {
       companyIds: ["company-1"],
       source: "local_implicit",
       isInstanceAdmin: false,
+      ...actorOverrides,
     };
     next();
   });
@@ -251,5 +252,67 @@ describe("issue update comment wakeups", () => {
         }),
       }),
     );
+  });
+
+  it("does not self-wake on issue updates when a local implicit run comments on its own task", async () => {
+    const runId = "run-self-comment";
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+      executionRunId: runId,
+    });
+    const updated = {
+      ...existing,
+      status: "done",
+      executionRunId: null,
+      checkoutRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-3",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "wrapped",
+    });
+
+    const res = await request(await createApp({ runId }))
+      .patch(`/api/issues/${existing.id}`)
+      .send({
+        status: "done",
+        comment: "wrapped",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("does not self-wake on direct comments when a local implicit run comments on its own task", async () => {
+    const runId = "run-self-comment-direct";
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+      executionRunId: runId,
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-4",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "still working",
+    });
+
+    const res = await request(await createApp({ runId }))
+      .post(`/api/issues/${existing.id}/comments`)
+      .send({
+        body: "still working",
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -167,6 +167,22 @@ function shouldImplicitlyReopenCommentForAgent(input: {
   return true;
 }
 
+function isSelfAuthoredAssigneeComment(input: {
+  actorType: "agent" | "user";
+  actorId: string;
+  assigneeAgentId: string | null | undefined;
+  runId: string | null;
+  executionRunId: string | null | undefined;
+  previousExecutionRunId?: string | null | undefined;
+}) {
+  if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
+  if (input.actorType === "agent") {
+    return input.actorId === input.assigneeAgentId;
+  }
+  return Boolean(input.runId)
+    && (input.executionRunId === input.runId || input.previousExecutionRunId === input.runId);
+}
+
 function diffExecutionParticipants(
   previousPolicy: NormalizedExecutionPolicy | null,
   nextPolicy: NormalizedExecutionPolicy | null,
@@ -1982,8 +1998,14 @@ export function issueRoutes(
 
       if (commentBody && comment) {
         const assigneeId = issue.assigneeAgentId;
-        const actorIsAgent = actor.actorType === "agent";
-        const selfComment = actorIsAgent && actor.actorId === assigneeId;
+        const selfComment = isSelfAuthoredAssigneeComment({
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          assigneeAgentId: assigneeId,
+          runId: actor.runId,
+          executionRunId: issue.executionRunId,
+          previousExecutionRunId: existing.executionRunId,
+        });
         const skipAssigneeCommentWake = selfComment || isClosed;
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
@@ -2580,7 +2602,14 @@ export function issueRoutes(
       const wakeups = new Map<string, Parameters<typeof heartbeat.wakeup>[1]>();
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
-      const selfComment = actorIsAgent && actor.actorId === assigneeId;
+      const selfComment = isSelfAuthoredAssigneeComment({
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        assigneeAgentId: assigneeId,
+        runId: actor.runId,
+        executionRunId: currentIssue.executionRunId,
+        previousExecutionRunId: issue.executionRunId,
+      });
       const skipWake = selfComment || isClosed;
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip는 에이전트 회사의 작업을 코멘트와 wakeup으로 오케스트레이션하는 컨트롤 플레인입니다.
> - 이번 변경은 `server/src/routes/issues.ts`의 이슈 코멘트 wakeup 경로에 걸려 있습니다.
> - 로컬 implicit 실행이 자신의 이슈에 체크포인트 코멘트를 남길 때 assignee wake가 다시 큐잉되어 self-wake 루프가 생길 수 있었습니다.
> - 특히 `PATCH /api/issues/:id`와 `POST /api/issues/:id/comments`는 같은 런이 남긴 코멘트인지 구분해야 안전합니다.
> - 이 PR은 동일 runId가 남긴 self-comment를 assignee wake 대상에서 제외하는 로직을 추가하고, 그 회귀를 막는 테스트를 보강합니다.
> - 결과적으로 반복 코멘트로 같은 이슈가 즉시 다시 깨는 현상을 줄여 recurring intake/task heartbeat가 안정적으로 동작합니다.

## What Changed

- 동일 runId의 self-comment를 assignee comment wake에서 제외하는 로직을 `server/src/routes/issues.ts`에 추가했습니다.
- `PATCH /api/issues/:id` 경로에서 status 변경으로 execution lock이 비워져도 이전 `executionRunId`까지 확인하도록 처리했습니다.
- `POST /api/issues/:id/comments` 경로에도 같은 self-comment suppression 규칙을 맞췄습니다.
- `server/src/__tests__/issue-update-comment-wakeup-routes.test.ts`에 local implicit run이 자기 이슈에 코멘트할 때 self-wake가 발생하지 않는 회귀 테스트 2개를 추가했습니다.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-update-comment-wakeup-routes.test.ts`

## Risks

- 중간 정도의 리스크입니다. self-comment suppression 조건이 너무 넓으면 실제로 필요한 assignee wake까지 막을 수 있으므로 `runId`와 현재/이전 `executionRunId`가 일치하는 경우로만 제한했습니다.

> `ROADMAP.md`를 확인했고, 이번 변경은 계획된 신규 코어 기능이 아니라 좁은 범위의 버그 수정 및 회귀 테스트 추가라 중복되지 않습니다.

## Model Used

- OpenAI Codex GPT-5.4 (`gpt-5.4`), tool-enabled coding session with shell execution and targeted test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
