### PR TITLE
chore(github): add issue templates and enforce issue-link check on PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,207 @@
+name: Bug Report
+description: Report something in Paperclip that is not working correctly.
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The more detail you provide, the faster it can be fixed.
+
+        > **⚠️ Privacy notice:** Several fields below accept logs, config, or transcript output that may contain **personally identifiable information (PII)** — usernames in file paths, API keys, tokens, company names, agent output, or task content. Before pasting:
+        > 1. Review for sensitive data
+        > 2. Redact usernames, paths, API keys, tokens (e.g. replace `/Users/yourname/` with `/Users/REDACTED/`)
+        > 3. For heavy output, consider running it through an anonymizer such as **[presidio-anonymizer](https://microsoft.github.io/presidio/)** (open-source, local-only) or **[scrub](https://github.com/dssg/scrub)**
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-submission checklist
+      description: Please confirm each of these before filing.
+      options:
+        - label: I have searched existing open and closed issues and this is not a duplicate.
+          required: true
+        - label: I am on the latest released version of Paperclip (or can reproduce on `master`).
+          required: true
+        - label: I have confirmed the error originates in Paperclip itself — not in my agent adapter, API provider, or local configuration. See `AGENTS.md` → "For AI Agents Filing Issues" if you are an AI agent.
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Paperclip version
+      description: "Run `paperclip --version`, or check the version field in the repo's `package.json`."
+      placeholder: "e.g. 1.24.0, or commit SHA if on master"
+    validations:
+      required: true
+
+  - type: input
+    id: node_version
+    attributes:
+      label: Node.js version
+      description: "Run `node --version`."
+      placeholder: "e.g. v20.11.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux (Ubuntu / Debian)
+        - Linux (Fedora / RHEL)
+        - Linux (Arch)
+        - Linux (other)
+        - WSL
+        - Other (please describe in additional context)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: Installation method
+      options:
+        - npm / pnpm global install
+        - Docker
+        - Built from source (pnpm dev / pnpm build)
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: adapters
+    attributes:
+      label: Agent adapter(s) involved
+      description: Select all that apply. If unsure, leave unchecked and describe in additional context.
+      options:
+        - label: Claude Code
+        - label: Codex
+        - label: Cursor
+        - label: Droid
+        - label: Hermes
+        - label: Custom / external plugin adapter
+        - label: Not adapter-specific (core bug)
+
+  - type: dropdown
+    id: database
+    attributes:
+      label: Database mode
+      options:
+        - Embedded PGlite (default — `DATABASE_URL` unset)
+        - External Postgres
+        - Not database-related
+    validations:
+      required: true
+
+  - type: dropdown
+    id: access_context
+    attributes:
+      label: Access context
+      description: Whose credentials were being used when the bug occurred?
+      options:
+        - Board (human operator)
+        - Agent (bearer API key via `agent_api_keys`)
+        - Both
+        - Unclear / not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly. Be specific about which Paperclip command, endpoint, or UI action was involved.
+      placeholder: |
+        When I call POST /api/companies with ..., the server responds with 500 and logs ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: Describe the behavior you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps so someone else can reproduce this. Start from a clean install where possible.
+      placeholder: |
+        1. `pnpm install && pnpm dev`
+        2. `curl http://localhost:3100/api/health` → 200 OK
+        3. `curl -X POST http://localhost:3100/api/companies -d '{"name":"foo"}'` → 500
+        4. Error appears in server log at ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error output / logs
+      description: |
+        Paste relevant stack traces, console output, or log lines. This will be rendered as code.
+
+        **⚠️ PII warning:** Server logs often contain file paths with your username (e.g. `/Users/yourname/...`). Redact before pasting.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant config (if applicable)
+      description: |
+        If the bug is config-related, paste the relevant snippet.
+
+        **⚠️ PII warning:** Paperclip config may contain API keys, encrypted-secrets paths, company names, or tokens. **Remove all secrets before pasting.**
+      render: json
+    validations:
+      required: false
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: How often does this happen?
+      options:
+        - Every time (100% reproducible)
+        - Most of the time
+        - Sometimes / intermittent
+        - Only happened once
+    validations:
+      required: true
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      description: How much does this affect your use of Paperclip?
+      options:
+        - Blocker — cannot use Paperclip at all
+        - Major — core feature is broken, no workaround
+        - Moderate — feature is broken but I have a workaround
+        - Minor — cosmetic or edge case
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, related issues, adapter plugin details, or anything else.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: pii_confirmed
+    attributes:
+      label: Privacy checklist
+      description: Please confirm you've reviewed your submission for sensitive data.
+      options:
+        - label: I have reviewed all pasted output for PII (usernames, file paths, API keys, tokens, company names) and redacted where necessary.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord — questions & support
+    url: https://discord.gg/m4HZY7xNG3
+    about: For setup help, general questions, and conversation — not bug reports.
+  - name: GitHub Discussions
+    url: https://github.com/paperclipai/paperclip/discussions
+    about: For ideas, RFCs, and open-ended discussion.

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,0 +1,46 @@
+name: Documentation Issue
+description: Report incorrect, missing, or unclear documentation.
+labels: ["documentation", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help improve the docs. Point us at what's wrong, missing, or confusing.
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Issue type
+      options:
+        - Incorrect information
+        - Missing documentation
+        - Unclear or confusing
+        - Outdated (no longer matches behavior)
+        - Typo or formatting
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Where is the issue?
+      description: File path, URL, or section name.
+      placeholder: "e.g. README.md#installation, doc/DEVELOPING.md, docs/plugins.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What's wrong?
+      description: Describe the documentation issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: If you know what the correct information should be, include it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,93 @@
+name: Enhancement Proposal
+description: Propose an improvement to an existing Paperclip feature.
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        An enhancement improves something that already exists — better output, broader edge-case handling, clearer UX, performance. It does not add new commands, endpoints, or concepts. If you are proposing something new, use the **Feature Request** template instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I have confirmed this improves existing behavior — it does not add a new command, endpoint, or concept.
+          required: true
+        - label: I have searched existing open and closed issues and this has not already been proposed.
+          required: true
+
+  - type: input
+    id: what_is_improved
+    attributes:
+      label: What existing behavior does this improve?
+      description: Name the specific command, endpoint, UI view, or behavior being enhanced.
+      placeholder: "e.g. /api/companies response shape, board task list sorting, adapter startup log output"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: subsystem
+    attributes:
+      label: Subsystem affected
+      options:
+        - server/ — REST API & orchestration services
+        - ui/ — React + Vite board UI
+        - packages/db — Drizzle schema, migrations
+        - packages/shared — types, constants, validators, API paths
+        - packages/adapters — agent adapter implementations
+        - packages/plugins — plugin system
+        - Cross-cutting (multiple of the above)
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current behavior
+      description: Describe exactly how it works today. Include example output or a screenshot if helpful.
+      placeholder: |
+        Currently, when I call ..., the response is ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_behavior
+    attributes:
+      label: Proposed behavior
+      description: Describe exactly how it should work after the enhancement. Include example output.
+      placeholder: |
+        After this enhancement, the response would be ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: Reason and benefit
+      description: |
+        Why is the current behavior a problem, and what is the concrete benefit of the proposed behavior?
+
+        Vague answers like "it would be better" or "more user-friendly" are not enough.
+    validations:
+      required: true
+
+  - type: textarea
+    id: breaking_changes
+    attributes:
+      label: Breaking changes
+      description: |
+        Does this change any behavior, response shape, or output format that users or agents might rely on?
+        If yes, describe exactly what changes and how backward compatibility is maintained.
+        Write "None" only if you are certain.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Screenshots, related issues, or anything else.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,102 @@
+name: Feature Request
+description: Propose a new capability for Paperclip.
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to propose a feature. Please read `CONTRIBUTING.md` before opening — bigger changes should be discussed in Discord `#dev` first.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I have searched existing open and closed issues and Discussions — this has not been proposed before.
+          required: true
+        - label: This feature belongs in Paperclip core, not in a plugin, skill, or external adapter.
+          required: true
+        - label: I have read `AGENTS.md` §3 (Repo Map) and know which subsystem this would affect.
+          required: true
+
+  - type: input
+    id: feature_name
+    attributes:
+      label: Feature name
+      description: A short, concrete name for what you're proposing.
+      placeholder: "e.g. Per-company budget overrides, Cross-company task templates"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: subsystem
+    attributes:
+      label: Subsystem affected
+      description: Which part of the codebase would this primarily live in?
+      options:
+        - server/ — REST API & orchestration services
+        - ui/ — React + Vite board UI
+        - packages/db — Drizzle schema, migrations
+        - packages/shared — types, constants, validators, API paths
+        - packages/adapters — agent adapter implementations
+        - packages/plugins — plugin system
+        - Cross-cutting (multiple of the above)
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem_statement
+    attributes:
+      label: Problem
+      description: Describe the concrete problem this solves. Focus on the problem, not the solution yet.
+      placeholder: |
+        Today, when [specific situation], the user cannot [specific thing], which causes [specific negative outcome].
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to see added. Be specific about commands, endpoints, UI, and behavior.
+      placeholder: |
+        Add ... so that ...
+        Example usage: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider? Why did you reject them?
+    validations:
+      required: true
+
+  - type: textarea
+    id: invariants
+    attributes:
+      label: Impact on Paperclip invariants
+      description: |
+        `AGENTS.md` §5 lists the control-plane invariants that must be preserved:
+        - Single-assignee task model
+        - Atomic issue checkout semantics
+        - Approval gates for governed actions
+        - Budget hard-stop auto-pause behavior
+        - Activity logging for mutating actions
+        - Company-scoping of all domain entities
+
+        Does this feature affect any of them? How is compliance preserved? Write "None" if not applicable.
+      placeholder: |
+        This feature touches activity logging — any mutations made by the new endpoint must write to the activity log. Other invariants unaffected.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, prior art from other tools, related Discussions, or anything else that helps explain the proposal.
+    validations:
+      required: false

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,0 +1,42 @@
+name: Auto-label new issues
+
+# Security review: this workflow only reads context.issue.number, context.repo.owner,
+# and context.repo.repo via actions/github-script. No untrusted user input
+# (issue title, body, comments, head_ref, etc.) is interpolated into shell commands.
+# No run: steps at all — all logic runs inside github-script's JS sandbox.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  add-triage-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // Ensure the label exists before applying it. Self-healing on first run.
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'needs-triage',
+                color: 'fbca04',
+                description: 'Newly filed, not yet reviewed by a maintainer',
+              });
+            } catch (e) {
+              // 422 = label already exists — safe no-op.
+              if (e.status !== 422) throw e;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['needs-triage'],
+            });

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -48,9 +48,12 @@ jobs:
             // The "edited" event fires on both title and body edits, so without
             // this check a contributor editing the title while the body still
             // lacks a closing reference would accumulate a new bot comment each
-            // time. The check still fails unconditionally when the link is
-            // missing — only the comment is skipped on repeats.
-            const { data: comments } = await github.rest.issues.listComments({
+            // time. Uses github.paginate so the check scans every page of
+            // comments, not just the first 100 — otherwise on high-traffic PRs
+            // the original bot comment could fall outside the fetched page and
+            // duplicates would reappear. The check still fails unconditionally
+            // when the link is missing — only the comment is skipped on repeats.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -1,14 +1,22 @@
 name: Require Issue Link
 
-# Security review: the PR body (github.event.pull_request.body) is untrusted input
-# and is handled via the safe env-var pattern — bound to $PR_BODY, then matched with
-# grep. Never interpolated directly into the shell command string. The github-script
-# step constructs its comment body with template literals over context values only
-# (owner, repo, PR number) — none from untrusted sources.
+# Security review:
+# - Uses pull_request_target so fork PRs receive a write-scoped GITHUB_TOKEN and the
+#   comment step actually posts instead of silently 403-ing. Safe here because
+#   neither step checks out PR-supplied code — the scan reads $PR_BODY from an env
+#   var, and the github-script step only calls the REST API with trusted context
+#   values (owner, repo, PR number). No untrusted content is executed or written.
+# - The PR body (github.event.pull_request.body) is untrusted and is handled via
+#   the safe env-var pattern: bound to $PR_BODY, then matched with grep. Never
+#   interpolated directly into the shell command string.
+# - "synchronize" is intentionally omitted from the trigger types to avoid posting
+#   duplicate "missing issue link" comments on every push. Adding a Closes/Fixes/
+#   Resolves reference happens by editing the PR body, which fires "edited", so
+#   the check still runs when contributors add the reference after opening.
 
 on:
-  pull_request:
-    types: [opened, edited, reopened, synchronize]
+  pull_request_target:
+    types: [opened, edited, reopened]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -1,0 +1,58 @@
+name: Require Issue Link
+
+# Security review: the PR body (github.event.pull_request.body) is untrusted input
+# and is handled via the safe env-var pattern — bound to $PR_BODY, then matched with
+# grep. Never interpolated directly into the shell command string. The github-script
+# step constructs its comment body with template literals over context values only
+# (owner, repo, PR number) — none from untrusted sources.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-issue-link:
+    name: Issue link required
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Scan PR body for closing reference
+        id: check
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if printf '%s' "$PR_BODY" | grep -qiE '(closes|fixes|resolves)\s+#[0-9]+'; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment and fail if missing
+        if: steps.check.outputs.found == 'false'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                '## Missing issue link',
+                '',
+                'This PR does not reference an issue. Every PR should link to an open issue using a closing keyword in the PR body:',
+                '',
+                '```',
+                'Closes #123',
+                '```',
+                '',
+                `If no issue exists yet, please [open one first](${repoUrl}/issues/new/choose) and update this PR body to reference it.`,
+                '',
+                'This is a soft check — if your PR genuinely has no associated issue (e.g. a trivial typo fix or maintainer-only tooling change), add a short note in the PR body explaining why and ask a maintainer to override this check.',
+              ].join('\n'),
+            });
+            core.setFailed('PR body must contain a closing issue reference (e.g. "Closes #123").');

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -44,23 +44,42 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            await github.rest.issues.createComment({
+            // Dedup guard: only post the comment if one isn't already present.
+            // The "edited" event fires on both title and body edits, so without
+            // this check a contributor editing the title while the body still
+            // lacks a closing reference would accumulate a new bot comment each
+            // time. The check still fails unconditionally when the link is
+            // missing — only the comment is skipped on repeats.
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: [
-                '## Missing issue link',
-                '',
-                'This PR does not reference an issue. Every PR should link to an open issue using a closing keyword in the PR body:',
-                '',
-                '```',
-                'Closes #123',
-                '```',
-                '',
-                `If no issue exists yet, please [open one first](${repoUrl}/issues/new/choose) and update this PR body to reference it.`,
-                '',
-                'This is a soft check — if your PR genuinely has no associated issue (e.g. a trivial typo fix or maintainer-only tooling change), add a short note in the PR body explaining why and ask a maintainer to override this check.',
-              ].join('\n'),
+              per_page: 100,
             });
+            const alreadyCommented = comments.some(
+              c => c.user && c.user.type === 'Bot' && typeof c.body === 'string' && c.body.startsWith('## Missing issue link')
+            );
+
+            if (!alreadyCommented) {
+              const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: [
+                  '## Missing issue link',
+                  '',
+                  'This PR does not reference an issue. Every PR should link to an open issue using a closing keyword in the PR body:',
+                  '',
+                  '```',
+                  'Closes #123',
+                  '```',
+                  '',
+                  `If no issue exists yet, please [open one first](${repoUrl}/issues/new/choose) and update this PR body to reference it.`,
+                  '',
+                  'This is a soft check — if your PR genuinely has no associated issue (e.g. a trivial typo fix or maintainer-only tooling change), add a short note in the PR body explaining why and ask a maintainer to override this check.',
+                ].join('\n'),
+              });
+            }
+
             core.setFailed('PR body must contain a closing issue reference (e.g. "Closes #123").');

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if printf '%s' "$PR_BODY" | grep -qiE '(closes|fixes|resolves)\s+#[0-9]+'; then
+          if printf '%s' "$PR_BODY" | grep -qiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+'; then
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,27 @@ When creating a pull request (via `gh pr create` or any other method), you **mus
 - **Model Used** — the AI model that produced or assisted with the change (provider, exact model ID, context window, capabilities). Write "None — human-authored" if no AI was used.
 - **Checklist** — all items checked
 
-## 11. Definition of Done
+## 11. For AI Agents Filing Issues
+
+If you are an AI agent and you have encountered an error while using Paperclip, read this before filing an issue.
+
+**Before filing, verify all three:**
+
+1. The error originates in Paperclip's own source code — not in your API provider, your configuration, your `CLAUDE.md`, or your agent's own logic.
+2. You can reproduce the error on a clean install with the latest Paperclip version.
+3. No existing open or closed issue already describes this — search first.
+
+**Common false positives — do NOT file issues for:**
+
+- API quota, rate limit, or 429 errors from Anthropic, OpenAI, or any other model provider
+- Authentication failures caused by expired, missing, or malformed API keys
+- Errors originating in your own agent code, `CLAUDE.md` configuration, or local toolchain
+- Network timeouts on your host machine
+- Errors coming from an external adapter plugin — file those upstream in the plugin's own repository
+
+If in doubt, raise the error with your human operator or ask in Discord `#help` before filing an issue. All issues must use one of the templates at `.github/ISSUE_TEMPLATE/` — blank issues are disabled.
+
+## 12. Definition of Done
 
 A change is done when all are true:
 
@@ -174,7 +194,7 @@ A change is done when all are true:
 4. Docs updated when behavior or commands change
 5. PR description follows the [PR template](.github/PULL_REQUEST_TEMPLATE.md) with all sections filled in (including Model Used)
 
-## 11. Fork-Specific: HenkDz/paperclip
+## 13. Fork-Specific: HenkDz/paperclip
 
 This is a fork of `paperclipai/paperclip` with QoL patches and an **external-only** Hermes adapter story on branch `feat/externalize-hermes-adapter` ([tree](https://github.com/HenkDz/paperclip/tree/feat/externalize-hermes-adapter)).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thanks for wanting to contribute!
 
 We really appreciate both small fixes and thoughtful larger changes.
 
+> **Filing an issue?** Please use one of the [issue templates](./.github/ISSUE_TEMPLATE). Blank issues are disabled. For questions or general discussion, please use [Discord](https://discord.gg/m4HZY7xNG3) or [GitHub Discussions](https://github.com/paperclipai/paperclip/discussions) instead of filing an issue.
+
 ## Two Paths to Get Your Pull Request Accepted
 
 ### Path 1: Small, Focused Changes (Fastest way to get merged)


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and the GitHub tracker is the entry point for anyone — humans *or* agents — reporting problems or proposing work
> - But the repo has no issue templates today, so new issues arrive with no environment data, no reproduction steps, and a meaningful fraction are filed by users' own AI agents reacting to their provider-side errors (API quota, auth, external adapter plugin failures) rather than actual Paperclip bugs
> - New PRs also sometimes arrive without a linked issue, which makes triage harder — the existing PR template already has a `closes #` line but nothing nudges contributors when it is empty
> - So this PR closes the intake gap: four YAML issue templates (bug / feature / enhancement / docs) with required environment fields and PII warnings; `config.yml` disabling blank issues and pinning Discord + Discussions; a small workflow that tags every new issue with `needs-triage`; a soft PR-body check for `Closes/Fixes/Resolves #NNN`; and an `AGENTS.md` subsection teaching AI agents to deflect their own false-positive filings
> - The benefit is that the backlog (currently ~1,100 open issues and ~1,500 open PRs) becomes cheaper to triage going forward, agent-filed noise is either gated at intake or dissuaded upstream, and PRs consistently reference their issue so review can start from context instead of reconstruction

## What Changed

**New files under `.github/ISSUE_TEMPLATE/`:**
- `bug_report.yml` — required fields for Paperclip version, Node, OS, install method, adapter(s), DB mode (PGlite / external Postgres), access context (board / agent). Frequency + impact dropdowns. PII warnings on every paste field plus a mandatory privacy checkbox
- `feature_request.yml` — pre-submission checklist, subsystem picker (server / ui / packages/db / packages/shared / packages/adapters / packages/plugins / cross-cutting), impact-on-invariants field referencing `AGENTS.md` §5
- `enhancement.yml` — for improvements to existing behaviour (before/after, breaking-change check)
- `docs_issue.yml` — lightweight, 4 fields
- `config.yml` — `blank_issues_enabled: false` and pinned contact links to Discord and GitHub Discussions

**New files under `.github/workflows/`:**
- `auto-label-issues.yml` — applies `needs-triage` to every new issue. Self-healing: creates the label on first run if it doesn't exist (it currently doesn't). SHA-pinned `actions/github-script@3a2844b7...` (v9.0.0). No shell interpolation of untrusted input — all logic in the github-script JS sandbox
- `require-issue-link.yml` — scans PR body for `Closes/Fixes/Resolves #NNN`; if missing, posts a comment and fails the check. **Soft check** — contributors can add a rationale line in the PR body for genuinely issue-less PRs. Untrusted input (`github.event.pull_request.body`) is bound to `$PR_BODY` via `env:` and scanned with `grep`, never interpolated directly into the shell command (follows [the documented safe pattern](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/)). Uses `pull_request_target` and only `[opened, edited, reopened]` trigger types — see "Changes from Greptile review" below

**Modified files:**
- `AGENTS.md` — adds new §11 *"For AI Agents Filing Issues"* listing common false positives (API quota / rate limit, auth failures in user's own config, external plugin errors) that agents should not file against Paperclip. Also fixes an existing duplicate-§11 numbering bug (both "Definition of Done" and "Fork-Specific: HenkDz/paperclip" were §11) by renumbering them to §12 and §13 respectively
- `CONTRIBUTING.md` — one-line pointer at the top of the file directing question-askers to Discord/Discussions and bug-filers to the template chooser

**Deliberately NOT touched:**
- `.github/PULL_REQUEST_TEMPLATE.md` — already rich (Thinking Path, Model Used, full checklist), would be a regression to weaken it
- All existing workflows (`docker.yml`, `e2e.yml`, `pr.yml`, `refresh-lockfile.yml`, `release.yml`, `release-smoke.yml`) — no interaction, the two new workflows run alongside
- `CODEOWNERS`

## How the issue templates work (and the concrete benefits for Paperclip)

**Mechanically, YAML issue forms ≠ markdown templates.** GitHub renders `.yml` templates as typed UI forms, not a textarea pre-filled with boilerplate. The submit button stays *disabled* until every field marked `required: true` has content. This is the key mechanism: it converts "please include these details" (a polite request that lazy filers and AI agents ignore) into "you cannot submit without these details" (a hard gate enforced by the GitHub UI, before anything reaches your tracker).

**`blank_issues_enabled: false`** closes the bypass route. GitHub normally shows an "Open a blank issue" button underneath the template chooser — that button is where most of the unstructured agent noise currently slips through. With the config, every issue must pick one of the four templates; there is no blank path.

**Concrete downstream effects for the paperclip tracker:**

- **Reproducibility data arrives by default.** A bug report cannot be filed without the Paperclip version, Node version, OS, install method, adapter(s), DB mode, and access context. No more "what version are you on?" / "which adapter?" ping-pong — the fields are there because the submit is blocked without them.
- **Agent-filed noise is largely self-gated.** The common pattern today is an AI agent auto-filing on any unhandled exception from its own provider or local config. Between required environment fields (which agent auto-filers tend to leave blank) and the `AGENTS.md` §11 addition listing common false positives (API quota, auth, external plugin errors), those filings either arrive with enough context to see they're not Paperclip's problem (→ quick close with a link to `AGENTS.md` §11) or they don't arrive at all.
- **Auto-applied labels take the first triage step off the maintainer's plate.** Every bug lands with `bug` + `needs-triage`, every feature with `enhancement` + `needs-triage`, every docs issue with `documentation` + `needs-triage`. Combined with the subsystem picker in feature/enhancement templates, `issues?q=label:needs-triage+label:bug` or an equivalent subsystem filter gives you a tight queue instead of the full backlog.
- **PII protection.** Every paste field (logs, config, state) carries an explicit warning about PII, with suggested anonymisers. The mandatory privacy checkbox at the bottom of the bug report forces the filer to confirm they've redacted before submission. Given that Paperclip state routinely contains agent transcripts, company names, encrypted-secrets paths, and tokens, this protects both the filer and the tracker's public history.
- **Paperclip-specific framing, not generic boilerplate.** The feature/enhancement templates reference `AGENTS.md` §5 directly (company scoping, atomic issue checkout, approval gates, budget hard-stop, activity logging) and force the filer to answer "does this affect any of them?" That single field tends to surface scope-creep and invariant-conflict issues *before* a maintainer has to read the body and work it out.
- **`needs-triage` as a queue marker, not decoration.** Once merged, `issues?q=label:needs-triage` becomes a clean "inbox" view — separate from the ~1,100 historic backlog. Every issue reviewed and classified (or closed) leaves that queue, so triage work has a concrete end state rather than being open-ended. The filter is the forcing function that makes triage feel finite.

## Changes from Greptile review (commit c8588061)

Greptile's initial review flagged two P1 issues in `require-issue-link.yml`, both fixed:

1. **Duplicate bot comments under `synchronize`** — every pushed commit on a link-less PR was posting a fresh identical "Missing issue link" comment. Dropped `synchronize` from the trigger list. Adding a `Closes/Fixes/Resolves` reference happens by editing the PR body, which fires `edited`, so the check still runs when the reference is added after opening — no dedup loop needed.
2. **Fork PRs got read-only `GITHUB_TOKEN` under `pull_request`** — the comment step would silently 403 for every external contributor, meaning they never saw the helpful message. Switched to `pull_request_target`. Safe here because neither step checks out PR-supplied code: the grep step reads `$PR_BODY` from an env var, and the github-script step only calls the REST API with trusted context values (owner, repo, PR number).

## Verification

**Local checks (all green on this branch against current `upstream/master`):**

- `python3 -c "import yaml; yaml.safe_load(...)"` on all 7 new YAML files — all parse
- `pnpm -r typecheck` — exit 0
- `pnpm build` — exit 0
- `pnpm test:run` — has 40 failing tests. I verified these are **pre-existing** by stashing this branch's changes and running the same failing test files against clean `upstream/master` — they fail identically there (`TypeError: localStorage.clear is not a function` in `ui/src/pages/Routines.test.tsx` and `ui/src/pages/InviteLanding.test.tsx`, which are test-environment setup issues unrelated to this PR's `.github/` + markdown-only diff). Flagging here so CI noise doesn't obscure the actual signal

**Post-merge reviewer checks:**

- **Issue templates:** navigate to `github.com/paperclipai/paperclip/issues/new/choose`. Expect four template cards + two contact links. Expect **no** "Open a blank issue" option. Click into each — required fields should block submission when empty
- **`auto-label-issues.yml`:** open a fresh test issue after merge. Expect a `needs-triage` label to appear (the workflow creates the label on its first run if it doesn't exist). Subsequent issues reuse the same label
- **`require-issue-link.yml`:** this PR itself demonstrates the happy path — the body contains `Closes #4188`, so the check will pass. To verify the negative path, temporarily remove that line, observe the workflow post its comment and fail, then restore it. After merge, future PRs without a closing reference will surface the comment automatically
- **Existing `pr.yml` CI** (policy / verify / e2e jobs) stays green — none of those jobs touch `.github/` content

## Risks

- **Label creation side-effect**: the `auto-label-issues` workflow creates the `needs-triage` label on first run. Colour chosen: `fbca04` (yellow). If that colour clashes with something existing, the label still creates; only the visual clashes. Easy to adjust post-merge
- **`require-issue-link.yml` on in-flight PRs**: will run on currently-open PRs when they're next edited/reopened and comment on any without `Closes/Fixes/Resolves #NNN`. Because `synchronize` is intentionally excluded, a push alone does not retrigger the check — only an opened/edited/reopened event will. The check is *soft* (contributors can override by adding a one-line rationale in the PR body)
- **AGENTS.md numbering**: the renumber of §11 → §13 for the HenkDz fork section is incidental to fixing a pre-existing duplicate-§11 bug. If you'd rather leave the duplicate and only have my new section appended at the end, happy to re-arrange
- **Tone calibration**: the PII warnings and pre-submission checklists are modelled on `gsd-build/get-shit-done`'s templates but dialled softer (no "unchecked boxes are an immediate close" language, no auto-close behaviour). Happy to dial further up or down — this PR is the starting point, not the destination
- **Explicitly deferred to future separate PRs**: stale bot (would use a 42-day / 14-day window with exempt labels), approval-label gates (`approved-feature` etc.), multi-typed PR template chooser, draft-PR auto-close. Mentioning only so you know what's *not* being proposed here

## Model Used

**Claude Opus 4.7 (1M context)** — provider Anthropic, exact model ID `claude-opus-4-7[1m]`, 1,000,000-token context window, extended thinking mode with tool use. Used for: research (reading `gsd-build/get-shit-done/.github` as reference, studying this repo's `AGENTS.md` §5 invariants and existing PR template), drafting all 9 files, writing the tracking issue body, authoring this PR description, and applying the Greptile-flagged fixes in commit `c8588061`. All code reviewed and approved by a human (@Omee11) before pushing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass (typecheck + build green; pre-existing UI test failures in `Routines.test.tsx` / `InviteLanding.test.tsx` are unrelated — verified against clean `upstream/master`, see Verification)
- [x] I have added or updated tests where applicable (N/A — `.github/` + markdown only; no runtime code changed)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — no UI changes)
- [x] I have updated relevant documentation to reflect my changes (`AGENTS.md` §11 + `CONTRIBUTING.md` pointer)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #4188