### PR TITLE
feat(routines): pre-flight assignee-status check before issue emit (AKS-1350)

### DIFF
--- a/packages/db/src/migrations/0060_routine_execution_assignee_guard.sql
+++ b/packages/db/src/migrations/0060_routine_execution_assignee_guard.sql
@@ -1,0 +1,6 @@
+-- Guard: routine_execution issues must have an assignee.
+-- NOT VALID skips backfill validation on pre-existing orphan rows (AKS-1350 scan found 14);
+-- future inserts must satisfy the constraint. Run VALIDATE CONSTRAINT after cleanup.
+--> statement-breakpoint
+ALTER TABLE "issues" ADD CONSTRAINT "issues_routine_execution_requires_assignee"
+  CHECK (origin_kind != 'routine_execution' OR assignee_agent_id IS NOT NULL) NOT VALID;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1776542246000,
       "tag": "0059_plugin_database_namespaces",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1745193600000,
+      "tag": "0060_routine_execution_assignee_guard",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -1,5 +1,5 @@
 import { createHmac, randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
@@ -943,9 +943,12 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
 
     it("skips issue creation when assignee agent no longer exists in DB (null-record guard)", async () => {
       const { agentId, routine, svc } = await seedFixture();
-      // Force-delete the agent row to simulate deletion between dispatch start and issue creation.
-      // The routine FK to agents has no onDelete so this requires bypassing normal deletion guards.
+      // routines.assigneeAgentId has a RESTRICT FK to agents, blocking normal deletion.
+      // Disable FK triggers on routines to simulate an orphaned assigneeAgentId (defense-in-depth
+      // guard for any future code path that bypasses application-level constraints).
+      await db.execute(sql`ALTER TABLE routines DISABLE TRIGGER ALL`);
       await db.delete(agents).where(eq(agents.id, agentId));
+      await db.execute(sql`ALTER TABLE routines ENABLE TRIGGER ALL`);
       const run = await svc.runRoutine(routine.id, { source: "manual" });
       expect(run.status).toBe("assignee_not_found");
       expect(run.linkedIssueId).toBeNull();

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -940,5 +940,20 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       expect(resumedRun.status).toBe("issue_created");
       expect(resumedRun.linkedIssueId).toBeTruthy();
     });
+
+    it("skips issue creation when assignee agent no longer exists in DB (null-record guard)", async () => {
+      const { agentId, routine, svc } = await seedFixture();
+      // Force-delete the agent row to simulate deletion between dispatch start and issue creation.
+      // The routine FK to agents has no onDelete so this requires bypassing normal deletion guards.
+      await db.delete(agents).where(eq(agents.id, agentId));
+      const run = await svc.runRoutine(routine.id, { source: "manual" });
+      expect(run.status).toBe("assignee_not_found");
+      expect(run.linkedIssueId).toBeNull();
+      const routineIssues = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(eq(issues.originId, routine.id));
+      expect(routineIssues).toHaveLength(0);
+    });
   });
 });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -944,11 +944,13 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     it("skips issue creation when assignee agent no longer exists in DB (null-record guard)", async () => {
       const { agentId, routine, svc } = await seedFixture();
       // routines.assigneeAgentId has a RESTRICT FK to agents, blocking normal deletion.
-      // Disable FK triggers on routines to simulate an orphaned assigneeAgentId (defense-in-depth
-      // guard for any future code path that bypasses application-level constraints).
-      await db.execute(sql`ALTER TABLE routines DISABLE TRIGGER ALL`);
-      await db.delete(agents).where(eq(agents.id, agentId));
-      await db.execute(sql`ALTER TABLE routines ENABLE TRIGGER ALL`);
+      // Wrap in a transaction so ALTER TABLE DISABLE TRIGGER and DELETE share one connection
+      // (pool connections are not sticky across separate execute/delete calls).
+      await db.transaction(async (tx) => {
+        await tx.execute(sql`ALTER TABLE routines DISABLE TRIGGER ALL`);
+        await tx.delete(agents).where(eq(agents.id, agentId));
+        await tx.execute(sql`ALTER TABLE routines ENABLE TRIGGER ALL`);
+      });
       const run = await svc.runRoutine(routine.id, { source: "manual" });
       expect(run.status).toBe("assignee_not_found");
       expect(run.linkedIssueId).toBeNull();

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -863,4 +863,82 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(run.source).toBe("webhook");
     expect(run.status).toBe("issue_created");
   });
+
+  describe("pre-flight assignee-status check (AKS-1350)", () => {
+    it("creates issue when assignee status is idle", async () => {
+      const { agentId, routine, svc } = await seedFixture();
+      await db.update(agents).set({ status: "idle" }).where(eq(agents.id, agentId));
+      const run = await svc.runRoutine(routine.id, { source: "manual" });
+      expect(run.status).toBe("issue_created");
+      expect(run.linkedIssueId).toBeTruthy();
+    });
+
+    it("creates issue when assignee status is running", async () => {
+      const { agentId, routine, svc } = await seedFixture();
+      await db.update(agents).set({ status: "running" }).where(eq(agents.id, agentId));
+      const run = await svc.runRoutine(routine.id, { source: "manual" });
+      expect(run.status).toBe("issue_created");
+      expect(run.linkedIssueId).toBeTruthy();
+    });
+
+    it("skips issue creation and emits log when assignee is paused with pauseReason=manual", async () => {
+      const { agentId, routine, svc } = await seedFixture();
+      await db.update(agents)
+        .set({ status: "paused", pauseReason: "manual", pausedAt: new Date() })
+        .where(eq(agents.id, agentId));
+      const run = await svc.runRoutine(routine.id, { source: "manual" });
+      expect(run.status).toBe("assignee_paused");
+      expect(run.linkedIssueId).toBeNull();
+      const routineIssues = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(eq(issues.originId, routine.id));
+      expect(routineIssues).toHaveLength(0);
+    });
+
+    it("skips issue creation and emits log when assignee is paused with pauseReason=budget_exhausted_auto", async () => {
+      const { agentId, routine, svc } = await seedFixture();
+      await db.update(agents)
+        .set({ status: "paused", pauseReason: "budget_exhausted_auto", pausedAt: new Date() })
+        .where(eq(agents.id, agentId));
+      const run = await svc.runRoutine(routine.id, { source: "manual" });
+      expect(run.status).toBe("assignee_paused");
+      expect(run.linkedIssueId).toBeNull();
+      const routineIssues = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(eq(issues.originId, routine.id));
+      expect(routineIssues).toHaveLength(0);
+    });
+
+    it("produces zero new issues across consecutive ticks while assignee is paused", async () => {
+      const { agentId, routine, svc } = await seedFixture();
+      await db.update(agents)
+        .set({ status: "paused", pauseReason: "budget_exhausted_auto", pausedAt: new Date() })
+        .where(eq(agents.id, agentId));
+      await svc.runRoutine(routine.id, { source: "manual" });
+      await svc.runRoutine(routine.id, { source: "manual" });
+      await svc.runRoutine(routine.id, { source: "manual" });
+      const routineIssues = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(eq(issues.originId, routine.id));
+      expect(routineIssues).toHaveLength(0);
+    });
+
+    it("resumes issue creation on the first tick after assignee is unpaused", async () => {
+      const { agentId, routine, svc } = await seedFixture();
+      await db.update(agents)
+        .set({ status: "paused", pauseReason: "budget_exhausted_auto", pausedAt: new Date() })
+        .where(eq(agents.id, agentId));
+      const skippedRun = await svc.runRoutine(routine.id, { source: "manual" });
+      expect(skippedRun.status).toBe("assignee_paused");
+      await db.update(agents)
+        .set({ status: "idle", pauseReason: null, pausedAt: null })
+        .where(eq(agents.id, agentId));
+      const resumedRun = await svc.runRoutine(routine.id, { source: "manual" });
+      expect(resumedRun.status).toBe("issue_created");
+      expect(resumedRun.linkedIssueId).toBeTruthy();
+    });
+  });
 });

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -812,9 +812,11 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
         }
 
 
-        // Pre-flight: skip issue creation if the assignee agent is currently paused.
+        // Pre-flight: skip issue creation if the assignee agent is paused or no longer exists.
         // Covers all pauseReason values: budget_exhausted_auto (AKS-1338.A), manual,
         // disciplinary, maintenance, etc. Emits routine_emit_skipped for MHDS (AKS-1338.C).
+        // Null-record guard (AKS-1350): defense-in-depth against agent deletion mid-dispatch or
+        // any future code path that bypasses the pre-transaction assigneeAgentId null check.
         // lastEnqueuedAt is intentionally NOT updated so the next legitimate tick fires cleanly.
         const assigneeRecord = await txDb
           .select({ status: agents.status, pauseReason: agents.pauseReason, pausedAt: agents.pausedAt })
@@ -822,23 +824,25 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
           .where(eq(agents.id, assigneeAgentId))
           .then((rows) => rows[0] ?? null);
 
-        if (assigneeRecord?.status === "paused") {
+        if (!assigneeRecord || assigneeRecord.status === "paused") {
           logger.info({
             routineId: input.routine.id,
             assigneeAgentId,
-            pauseReason: assigneeRecord.pauseReason,
-            pausedAt: assigneeRecord.pausedAt,
+            pauseReason: assigneeRecord?.pauseReason ?? null,
+            pausedAt: assigneeRecord?.pausedAt ?? null,
+            assigneeFound: !!assigneeRecord,
             wouldHaveFiredAt: triggeredAt,
           }, "routine_emit_skipped");
+          const runStatus = assigneeRecord ? "assignee_paused" : "assignee_not_found";
           const updated = await finalizeRun(createdRun.id, {
-            status: "assignee_paused",
+            status: runStatus,
             completedAt: triggeredAt,
           }, txDb);
           await updateRoutineTouchedState({
             routineId: input.routine.id,
             triggerId: input.trigger?.id ?? null,
             triggeredAt,
-            status: "assignee_paused",
+            status: runStatus,
             nextRunAt,
           }, txDb);
           return updated ?? createdRun;

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -811,6 +811,40 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
           return updated ?? createdRun;
         }
 
+
+        // Pre-flight: skip issue creation if the assignee agent is currently paused.
+        // Covers all pauseReason values: budget_exhausted_auto (AKS-1338.A), manual,
+        // disciplinary, maintenance, etc. Emits routine_emit_skipped for MHDS (AKS-1338.C).
+        // lastEnqueuedAt is intentionally NOT updated so the next legitimate tick fires cleanly.
+        const assigneeRecord = await txDb
+          .select({ status: agents.status, pauseReason: agents.pauseReason, pausedAt: agents.pausedAt })
+          .from(agents)
+          .where(eq(agents.id, assigneeAgentId))
+          .then((rows) => rows[0] ?? null);
+
+        if (assigneeRecord?.status === "paused") {
+          logger.info({
+            routineId: input.routine.id,
+            assigneeAgentId,
+            pauseReason: assigneeRecord.pauseReason,
+            pausedAt: assigneeRecord.pausedAt,
+            wouldHaveFiredAt: triggeredAt,
+          }, "routine_emit_skipped");
+          const updated = await finalizeRun(createdRun.id, {
+            status: "assignee_paused",
+            completedAt: triggeredAt,
+          }, txDb);
+          await updateRoutineTouchedState({
+            routineId: input.routine.id,
+            triggerId: input.trigger?.id ?? null,
+            triggeredAt,
+            status: "assignee_paused",
+            nextRunAt,
+          }, txDb);
+          return updated ?? createdRun;
+        }
+
+
         try {
           createdIssue = await issueSvc.create(input.routine.companyId, {
             projectId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies via routines (recurring tasks)
> - The routine-scan emitter fires on a schedule and creates an execution issue assigned to the target agent on each tick
> - CGR is 157% over budget but remains `status=idle`, so every routine tick creates another dead-letter todo issue (23/24h, 0 completed)
> - AKS-1349 adds auto-pause so over-budget agents transition to `status=paused`; without this companion guard the emitter would still fan out issues to a paused agent
> - CHO scan (AKS-1443) also found RO routine producing orphan `routine_execution` issues with `assigneeAgentId=null` (~14 rows, 1 per 15-min tick), likely from `issueSvc.create()` called directly with `originKind='routine_execution'`
> - This PR adds two guards: (1) emitter pre-flight before `issueSvc.create()` that skips when assignee is paused OR not found in DB; (2) DB `CHECK` constraint `NOT VALID` that blocks null-assignee inserts for `routine_execution` issues from any code path
> - The benefit is that dead-letter fan-out stops immediately after AKS-1349 auto-pause, and the constraint prevents the RO orphan pattern from recurring

## What Changed

- `server/src/services/routines.ts`: pre-flight in `dispatchRoutineRun`, after concurrency check and before `issueSvc.create()`. Queries `agents.status`, `pauseReason`, `pausedAt` within the dispatch transaction. On `!assigneeRecord` (agent deleted mid-dispatch): finalizes run as `assignee_not_found`. On `status='paused'`: finalizes as `assignee_paused`. Both emit `routine_emit_skipped` pino log with `assigneeFound` field. `lastEnqueuedAt` intentionally not updated.
- `packages/db/src/migrations/0060_routine_execution_assignee_guard.sql`: `NOT VALID` CHECK constraint on `issues` table — `origin_kind != 'routine_execution' OR assignee_agent_id IS NOT NULL`. `NOT VALID` skips backfill on 14 pre-existing orphan rows; run `VALIDATE CONSTRAINT` after cleanup.
- `packages/db/src/migrations/meta/_journal.json`: journal entry for migration 0060.
- `server/src/__tests__/routines-service.test.ts`: 7 acceptance tests covering idle, running, paused/manual, paused/budget_exhausted_auto, consecutive-ticks-0-issues, resume-after-unpause, and null-record (agent deleted).

## Verification

```bash
# Run routines service integration tests (requires embedded Postgres)
pnpm --filter @paperclipai/server test routines-service
```

All 7 new tests should pass alongside the existing suite. After deploying alongside AKS-1349, CGR routine fan-out should drop to 0 on the next tick post-auto-pause. The DB constraint immediately blocks any new null-assignee `routine_execution` rows.

## Risks

Low risk. The emitter guard is additive — only fires on `status='paused'` or missing agent. All other statuses are unaffected. The DB `CHECK` uses `NOT VALID` so no backfill scan occurs; existing 14 orphan rows are unaffected (but should be cleaned up in a follow-up). If this PR merges before AKS-1425 (routine trigger preconditions), the migration number 0060 will conflict with AKS-1425's migration — one team will need to renumber. No schema model change is needed for the constraint; it's a raw SQL migration.

AKS-1269 GC interaction: complementary — fewer ghost issues are created in the first place, reducing GC churn. No conflict with existing GC logic.

## Model Used

- **Provider:** Anthropic
- **Model:** Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- **Mode:** Agentic tool use (Paperclip DevOps Engineer heartbeat)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge