### PR TITLE
fix: multer 한글 파일명 인코딩 깨짐 수정

### DIFF
--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -9,6 +9,16 @@ import { assetService, logActivity } from "../services/index.js";
 import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 const SVG_CONTENT_TYPE = "image/svg+xml";
+
+/** Re-decode multer's latin1-decoded filename as UTF-8 to fix non-ASCII names. */
+function fixMulterFilename(raw: string): string {
+  if (!raw) return raw;
+  try {
+    return Buffer.from(raw, "latin1").toString("utf8");
+  } catch {
+    return raw;
+  }
+}
 const ALLOWED_COMPANY_LOGO_CONTENT_TYPES = new Set([
   "image/png",
   "image/jpeg",
@@ -161,7 +171,7 @@ export function assetRoutes(db: Db, storage: StorageService) {
     const stored = await storage.putFile({
       companyId,
       namespace: `assets/${namespaceSuffix}`,
-      originalFilename: file.originalname || null,
+      originalFilename: fixMulterFilename(file.originalname) || null,
       contentType,
       body: fileBody,
     });
@@ -259,7 +269,7 @@ export function assetRoutes(db: Db, storage: StorageService) {
     const stored = await storage.putFile({
       companyId,
       namespace: "assets/companies",
-      originalFilename: file.originalname || null,
+      originalFilename: fixMulterFilename(file.originalname) || null,
       contentType,
       body: fileBody,
     });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -66,6 +66,20 @@ import {
   parseIssueExecutionState,
 } from "../services/issue-execution-policy.js";
 
+/**
+ * multer decodes multipart filenames as latin1 per RFC 7578.
+ * Browsers send UTF-8, so non-ASCII names (e.g. Korean) get mangled.
+ * Re-encode as latin1 bytes then decode as UTF-8 to recover the original name.
+ */
+function fixMulterFilename(raw: string): string {
+  if (!raw) return raw;
+  try {
+    return Buffer.from(raw, "latin1").toString("utf8");
+  } catch {
+    return raw;
+  }
+}
+
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
@@ -2670,6 +2684,8 @@ export function issueRoutes(
       res.status(400).json({ error: "Missing file field 'file'" });
       return;
     }
+    // multer decodes multipart filenames as latin1; re-decode as UTF-8 for non-ASCII names
+    const decodedFilename = fixMulterFilename(file.originalname);
     const contentType = normalizeContentType(file.mimetype);
     if (file.buffer.length <= 0) {
       res.status(422).json({ error: "Attachment is empty" });
@@ -2686,7 +2702,7 @@ export function issueRoutes(
     const stored = await storage.putFile({
       companyId,
       namespace: `issues/${issueId}`,
-      originalFilename: file.originalname || null,
+      originalFilename: decodedFilename || null,
       contentType,
       body: file.buffer,
     });


### PR DESCRIPTION
## Summary
- multer가 multipart/form-data 파일명을 latin1로 디코딩하여 한글 등 non-ASCII 파일명이 깨지는 문제 수정
- `Buffer.from(raw, 'latin1').toString('utf8')` 변환으로 원본 파일명 복원
- 이슈 첨부파일 업로드(`issues.ts`)와 에셋 업로드(`assets.ts`) 양쪽에 적용

## Test plan
- [ ] 한글 파일명 엑셀(.xls/.xlsx) 첨부 후 파일명 정상 표시 확인
- [ ] 영문 파일명 첨부 시 기존 동작 유지 확인
- [ ] 회사 로고 업로드 시 한글 파일명 정상 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)