### PR TITLE
feat(platform): extend stale execution run drain to comment/PATCH paths (CLI-126)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4,6 +4,8 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { sql } from "drizzle-orm";
 import {
   activityLog,
+  agentWakeupRequests,
+  heartbeatRuns,
   agents,
   companies,
   createDb,
@@ -1768,5 +1770,263 @@ describeEmbeddedPostgres("issueService.findMentionedProjectIds", () => {
       titleProjectId,
       commentProjectId,
     ]);
+  });
+});
+
+// CLI-126 — stale execution run auto-drain regression tests
+// These cover both the checkout path (CLI-104 regression guard) and the assertCheckoutOwner path
+// (comment POST / PATCH write paths), using embedded Postgres for full DB fidelity.
+describeEmbeddedPostgres("issueService stale execution run drain (CLI-126)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-cli-126-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(agentWakeupRequests);
+    await db.delete(heartbeatRuns);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedBaseFixture() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `CLI${companyId.replace(/-/g, "").slice(0, 4).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ClippyEng",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    return { companyId, agentId };
+  }
+
+  async function seedIssueWithStaleExecRun(
+    companyId: string,
+    agentId: string,
+    runStatus: string,
+  ) {
+    const runId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: runStatus,
+      invocationSource: "on_demand",
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale lock test issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionAgentNameKey: "clippyeng",
+      executionLockedAt: new Date(),
+    });
+
+    return { issueId, runId };
+  }
+
+  // ── checkout path (CLI-104 regression guard) ────────────────────────────
+
+  it("checkout: clears stale terminal execution run and lets checkout proceed", async () => {
+    const { companyId, agentId } = await seedBaseFixture();
+    const { issueId, runId } = await seedIssueWithStaleExecRun(companyId, agentId, "timed_out");
+
+    const freshRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: freshRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "on_demand",
+    });
+
+    // Checkout with a new runId — stale lock should be drained automatically.
+    const updated = await svc.checkout(issueId, agentId, ["in_progress"], freshRunId);
+    expect(updated.executionRunId).toBe(freshRunId);
+    expect(updated.checkoutRunId).toBe(freshRunId);
+
+    // Activity log must record the drain.
+    const drainLogs = await db
+      .select({ action: activityLog.action, entityId: activityLog.entityId })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.execution_run_auto_drained"));
+    expect(drainLogs).toHaveLength(1);
+    expect(drainLogs[0]!.entityId).toBe(issueId);
+  });
+
+  it("checkout: clears stale cancelled execution run and lets checkout proceed", async () => {
+    const { companyId, agentId } = await seedBaseFixture();
+    const { issueId } = await seedIssueWithStaleExecRun(companyId, agentId, "cancelled");
+
+    const freshRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: freshRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "on_demand",
+    });
+
+    const updated = await svc.checkout(issueId, agentId, ["in_progress"], freshRunId);
+    expect(updated.executionRunId).toBe(freshRunId);
+
+    const drainLogs = await db
+      .select({ action: activityLog.action })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.execution_run_auto_drained"));
+    expect(drainLogs).toHaveLength(1);
+  });
+
+  it("checkout: preserves active (running) execution run — no drain", async () => {
+    const { companyId, agentId } = await seedBaseFixture();
+    const { issueId, runId } = await seedIssueWithStaleExecRun(companyId, agentId, "running");
+
+    // Checkout with the same runId — same-run lock should pass through.
+    const updated = await svc.checkout(issueId, agentId, ["in_progress"], runId);
+    expect(updated.executionRunId).toBe(runId);
+
+    const drainLogs = await db
+      .select({ action: activityLog.action })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.execution_run_auto_drained"));
+    expect(drainLogs).toHaveLength(0);
+  });
+
+  // ── assertCheckoutOwner path (comment POST / PATCH, CLI-126) ────────────
+
+  it("assertCheckoutOwner: drains stale terminal execution run and passes ownership check", async () => {
+    const { companyId, agentId } = await seedBaseFixture();
+    const { issueId, runId } = await seedIssueWithStaleExecRun(companyId, agentId, "timed_out");
+
+    const freshRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: freshRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "on_demand",
+    });
+
+    // Update issue to use freshRunId as checkoutRunId but keep stale executionRunId.
+    await db.update(issues).set({ checkoutRunId: freshRunId }).where(eq(issues.id, issueId));
+
+    // Must not throw a 409 — the stale execution run should be drained automatically.
+    const ownership = await svc.assertCheckoutOwner(issueId, agentId, freshRunId);
+    expect(ownership.id).toBe(issueId);
+    expect(ownership.adoptedFromRunId).toBeNull();
+
+    // Execution run must be cleared.
+    const [row] = await db.select({ executionRunId: issues.executionRunId }).from(issues).where(eq(issues.id, issueId));
+    expect(row!.executionRunId).toBeNull();
+
+    // Drain activity must be logged.
+    const drainLogs = await db
+      .select({ action: activityLog.action, entityId: activityLog.entityId })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.execution_run_auto_drained"));
+    expect(drainLogs).toHaveLength(1);
+    expect(drainLogs[0]!.entityId).toBe(issueId);
+  });
+
+  it("assertCheckoutOwner: drains stale cancelled execution run — cancels linked wakeup requests", async () => {
+    const { companyId, agentId } = await seedBaseFixture();
+    const { issueId, runId } = await seedIssueWithStaleExecRun(companyId, agentId, "cancelled");
+
+    const freshRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: freshRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "on_demand",
+    });
+
+    // Seed a deferred wakeup request linked to this issue.
+    const wakeupId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupId,
+      companyId,
+      agentId,
+      source: "issue_execution",
+      status: "deferred_issue_execution",
+      payload: { issueId },
+    });
+
+    await db.update(issues).set({ checkoutRunId: freshRunId }).where(eq(issues.id, issueId));
+
+    await svc.assertCheckoutOwner(issueId, agentId, freshRunId);
+
+    // Linked wakeup request must be cancelled.
+    const [wakeup] = await db
+      .select({ status: agentWakeupRequests.status })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupId));
+    expect(wakeup!.status).toBe("cancelled");
+
+    const drainLogs = await db
+      .select({ action: activityLog.action })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.execution_run_auto_drained"));
+    expect(drainLogs).toHaveLength(1);
+  });
+
+  it("assertCheckoutOwner: preserves active (running) execution run — no drain, no 409", async () => {
+    const { companyId, agentId } = await seedBaseFixture();
+    const { issueId, runId } = await seedIssueWithStaleExecRun(companyId, agentId, "running");
+
+    // Same-run checkout — execution run IS active and belongs to the same run.
+    const ownership = await svc.assertCheckoutOwner(issueId, agentId, runId);
+    expect(ownership.id).toBe(issueId);
+
+    const [row] = await db.select({ executionRunId: issues.executionRunId }).from(issues).where(eq(issues.id, issueId));
+    expect(row!.executionRunId).toBe(runId);
+
+    const drainLogs = await db
+      .select({ action: activityLog.action })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.execution_run_auto_drained"));
+    expect(drainLogs).toHaveLength(0);
   });
 });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
+  agentWakeupRequests,
   agents,
   assets,
   companies,
@@ -32,6 +33,7 @@ import {
   parseProjectExecutionWorkspacePolicy,
 } from "./execution-workspace-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
+import { logActivity } from "./activity-log.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
 import { getDefaultCompanyGoal } from "./goals.js";
@@ -1185,6 +1187,71 @@ export function issueService(db: Db) {
     return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
   }
 
+  // CLI-126: shared pre-check that drains a stale execution run before write-path ownership assertion.
+  // Runs in its own SELECT FOR UPDATE transaction to be atomic. Returns drain metadata if a drain
+  // occurred (null if executionRunId was absent or the run is still active). Callers must log the
+  // `issue.execution_run_auto_drained` activity AFTER this transaction commits.
+  async function drainStaleExecutionRunIfNeeded(issueId: string): Promise<{
+    drainedRunId: string;
+    companyId: string;
+    drainedAgentNameKey: string | null;
+  } | null> {
+    let drained: { drainedRunId: string; companyId: string; drainedAgentNameKey: string | null } | null = null;
+
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT id FROM issues WHERE id = ${issueId} FOR UPDATE`);
+
+      const row = await tx
+        .select({
+          companyId: issues.companyId,
+          executionRunId: issues.executionRunId,
+          executionAgentNameKey: issues.executionAgentNameKey,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+
+      if (!row?.executionRunId) return;
+
+      const lockRun = await tx
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, row.executionRunId))
+        .then((rows) => rows[0] ?? null);
+
+      // Active execution run — do not drain.
+      if (lockRun && (lockRun.status === "queued" || lockRun.status === "running")) return;
+
+      const now = new Date();
+
+      await tx
+        .update(issues)
+        .set({ executionRunId: null, executionAgentNameKey: null, executionLockedAt: null, updatedAt: now })
+        .where(and(eq(issues.id, issueId), eq(issues.executionRunId, row.executionRunId)));
+
+      // Cancel any deferred wakeup requests linked to this issue so they do not re-lock it.
+      await tx
+        .update(agentWakeupRequests)
+        .set({
+          status: "cancelled",
+          finishedAt: now,
+          error: "Execution run drain: linked run is no longer active",
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, row.companyId),
+            eq(agentWakeupRequests.status, "deferred_issue_execution"),
+            sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+          ),
+        );
+
+      drained = { drainedRunId: row.executionRunId, companyId: row.companyId, drainedAgentNameKey: row.executionAgentNameKey };
+    });
+
+    return drained;
+  }
+
   async function adoptStaleCheckoutRun(input: {
     issueId: string;
     actorAgentId: string;
@@ -2084,38 +2151,23 @@ export function issueService(db: Db) {
 
       const now = new Date();
 
-      // Fix C: staleness detection — if executionRunId references a run that is no
-      // longer queued or running, clear it before applying the execution lock condition
-      // so a dead lock can't produce a spurious 409.
-      // Wrapped in a transaction with SELECT FOR UPDATE to make the read + clear atomic,
-      // matching the existing pattern in enqueueWakeup().
-      await db.transaction(async (tx) => {
-        await tx.execute(
-          sql`select id from issues where id = ${id} for update`,
-        );
-        const preCheckRow = await tx
-          .select({ executionRunId: issues.executionRunId })
-          .from(issues)
-          .where(eq(issues.id, id))
-          .then((rows) => rows[0] ?? null);
-        if (!preCheckRow?.executionRunId) return;
-        const lockRun = await tx
-          .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
-          .from(heartbeatRuns)
-          .where(eq(heartbeatRuns.id, preCheckRow.executionRunId))
-          .then((rows) => rows[0] ?? null);
-        if (!lockRun || (lockRun.status !== "queued" && lockRun.status !== "running")) {
-          await tx
-            .update(issues)
-            .set({ executionRunId: null, executionAgentNameKey: null, executionLockedAt: null, updatedAt: now })
-            .where(
-              and(
-                eq(issues.id, id),
-                eq(issues.executionRunId, preCheckRow.executionRunId),
-              ),
-            );
-        }
-      });
+      // Use the shared stale-execution-run drain before applying the execution lock condition,
+      // so a dead lock can't produce a spurious 409. Wakeup cancellation and activity logging
+      // are included in the helper and its post-commit call below.
+      const checkoutDrained = await drainStaleExecutionRunIfNeeded(id);
+      if (checkoutDrained) {
+        await logActivity(db, {
+          companyId: checkoutDrained.companyId,
+          actorType: "agent",
+          actorId: agentId,
+          agentId,
+          runId: checkoutRunId,
+          action: "issue.execution_run_auto_drained",
+          entityType: "issue",
+          entityId: id,
+          details: { drainedRunId: checkoutDrained.drainedRunId, drainedAgentNameKey: checkoutDrained.drainedAgentNameKey },
+        });
+      }
 
       const dependencyReadiness = await listIssueDependencyReadinessMap(db, issueCompany.companyId, [id]);
       const unresolvedBlockerIssueIds = dependencyReadiness.get(id)?.unresolvedBlockerIssueIds ?? [];
@@ -2244,6 +2296,23 @@ export function issueService(db: Db) {
     },
 
     assertCheckoutOwner: async (id: string, actorAgentId: string, actorRunId: string | null) => {
+      // CLI-126: drain any stale execution run before checking ownership so comment/PATCH
+      // write paths self-recover instead of emitting a spurious 409.
+      const ownerDrained = await drainStaleExecutionRunIfNeeded(id);
+      if (ownerDrained) {
+        await logActivity(db, {
+          companyId: ownerDrained.companyId,
+          actorType: "agent",
+          actorId: actorAgentId,
+          agentId: actorAgentId,
+          runId: actorRunId,
+          action: "issue.execution_run_auto_drained",
+          entityType: "issue",
+          entityId: id,
+          details: { drainedRunId: ownerDrained.drainedRunId, drainedAgentNameKey: ownerDrained.drainedAgentNameKey },
+        });
+      }
+
       const current = await db
         .select({
           id: issues.id,


### PR DESCRIPTION
Resolves CLI-126. Extends the stale execution-run drain logic to comment and PATCH paths so orphan executionRunIds are cleared. QA validated. Verified locally; tests + typecheck green.