### PR TITLE
polish(CLI-165): DbOrTx alias + queued-drain rationale comment

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1485,6 +1485,169 @@ describe("heartbeat comment wake batching", () => {
       await gateway.close();
     }
   }, 120_000);
+
+  it("drops deferred mention wakes when the issue is closed before promotion", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const primaryAgentId = randomUUID();
+    const mentionedAgentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values([
+        {
+          id: primaryAgentId,
+          companyId,
+          name: "Primary Agent",
+          role: "engineer",
+          status: "idle",
+          adapterType: "openclaw_gateway",
+          adapterConfig: {
+            url: gateway.url,
+            headers: { "x-openclaw-token": "gateway-token" },
+            payloadTemplate: { message: "wake now" },
+            waitTimeoutMs: 2_000,
+          },
+          runtimeConfig: {},
+          permissions: {},
+        },
+        {
+          id: mentionedAgentId,
+          companyId,
+          name: "Mentioned Agent",
+          role: "engineer",
+          status: "idle",
+          adapterType: "openclaw_gateway",
+          adapterConfig: {
+            url: gateway.url,
+            headers: { "x-openclaw-token": "gateway-token" },
+            payloadTemplate: { message: "wake now" },
+            waitTimeoutMs: 2_000,
+          },
+          runtimeConfig: {},
+          permissions: {},
+        },
+      ]);
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Deferred mention drop on close",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: primaryAgentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      // Wake the primary agent so it holds the execution lock
+      const primaryRun = await heartbeat.wakeup(primaryAgentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_assigned" },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+      expect(primaryRun).not.toBeNull();
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      // Mention the second agent while primary is running — gets deferred
+      const mentionComment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "@Mentioned Agent check this out.",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const mentionRun = await heartbeat.wakeup(mentionedAgentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_comment_mentioned",
+        payload: { issueId, commentId: mentionComment.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: mentionComment.id,
+          wakeCommentId: mentionComment.id,
+          wakeReason: "issue_comment_mentioned",
+          source: "comment.mention",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+      expect(mentionRun).toBeNull();
+
+      // Verify it's deferred
+      const deferred = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.agentId, mentionedAgentId),
+            eq(agentWakeupRequests.status, "deferred_issue_execution"),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      expect(deferred).not.toBeNull();
+
+      // Close the issue (primary agent finishes and marks done)
+      await db.update(issues).set({ status: "done", executionRunId: null }).where(eq(issues.id, issueId));
+
+      // Release primary agent — this triggers deferred-wake promotion
+      gateway.releaseFirstWait();
+
+      await waitFor(async () => {
+        const run = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, primaryRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "succeeded";
+      }, 30_000);
+
+      // Deferred mention wake must be dropped (failed), not promoted
+      await waitFor(async () => {
+        const req = await db
+          .select()
+          .from(agentWakeupRequests)
+          .where(eq(agentWakeupRequests.id, deferred!.id))
+          .then((rows) => rows[0] ?? null);
+        return req?.status === "failed";
+      }, 30_000);
+
+      // Issue must remain closed
+      const finalIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0]);
+      expect(finalIssue?.status).toBe("done");
+
+      // Mentioned agent must not have been woken
+      const mentionedRuns = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, mentionedAgentId));
+      expect(mentionedRuns).toHaveLength(0);
+
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
   it("treats the automatic run summary as fallback-only when the run already posted a comment", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -941,14 +941,28 @@ describe("heartbeat comment wake batching", () => {
 
       gateway.releaseFirstWait();
 
-      await waitFor(() => gateway.getAgentPayloads().length === 2, 90_000);
       await waitFor(async () => {
-        const runs = await db
-          .select()
-          .from(heartbeatRuns)
-          .where(eq(heartbeatRuns.companyId, companyId));
-        return runs.length === 2 && runs.every((run) => run.status === "succeeded");
+        const deferred = await db
+          .select({ status: agentWakeupRequests.status })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, mentionedAgentId),
+              eq(agentWakeupRequests.status, "failed"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return Boolean(deferred);
       }, 90_000);
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.companyId, companyId));
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.status).toBe("succeeded");
 
       const issueAfterPromotion = await db
         .select({
@@ -963,23 +977,6 @@ describe("heartbeat comment wake batching", () => {
         status: "done",
       });
       expect(issueAfterPromotion?.completedAt).not.toBeNull();
-
-      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_comment_mentioned",
-          commentIds: [comment.id],
-          latestCommentId: comment.id,
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Do not reopen from agent mention",
-            status: "done",
-            priority: "medium",
-          },
-        },
-      });
-      expect(String(secondPayload.message ?? "")).toContain("please review after I finish");
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2558,6 +2558,8 @@ export function issueRoutes(
 
         for (const mentionedId of mentionedIds) {
           if (actor.actorType === "agent" && actor.actorId === mentionedId) continue;
+          // Don't send mention wakes on issues that are closed and weren't reopened by this request
+          if (isClosed && !reopened) continue;
           addWakeup(mentionedId, {
             source: "automation",
             triggerDetail: "system",
@@ -3537,6 +3539,8 @@ export function issueRoutes(
       for (const mentionedId of mentionedIds) {
         if (wakeups.has(mentionedId)) continue;
         if (actorIsAgent && actor.actorId === mentionedId) continue;
+        // Don't send mention wakes on issues that are closed and weren't reopened by this request
+        if (isClosed && !reopened) continue;
         wakeups.set(mentionedId, {
           source: "automation",
           triggerDetail: "system",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5873,6 +5873,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+
+        // Drop deferred mention wakes on closed issues; only explicit reopen flows should revive closed work.
+        if (
+          deferredWakeReason === "issue_comment_mentioned" &&
+          (issue.status === "done" || issue.status === "cancelled")
+        ) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "failed",
+              finishedAt: new Date(),
+              error: "Dropped deferred mention wake: issue was closed before promotion",
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
+
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.
         const shouldReopenDeferredCommentWake =

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -141,6 +141,11 @@ type IssueUserContextInput = {
 };
 type ProjectGoalReader = Pick<Db, "select">;
 type DbReader = Pick<Db, "select">;
+// CLI-165: shared alias used by helpers that accept either the root db or a transaction from
+// db.transaction(). Using `Db | Tx` preserves Drizzle's query-builder types at both call sites
+// (inline root query and inside a transaction), which is especially important for the drain
+// chokepoint where losing type safety could mask a wrong-table reference.
+type DbOrTx = Db | Parameters<Parameters<Db["transaction"]>[0]>[0];
 type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
   labelIds?: string[];
   blockedByIssueIds?: string[];
@@ -620,7 +625,7 @@ function latestIssueActivityAt(...values: Array<Date | string | null | undefined
   return normalized[0] ?? null;
 }
 
-async function labelMapForIssues(dbOrTx: any, issueIds: string[]): Promise<Map<string, IssueLabelRow[]>> {
+async function labelMapForIssues(dbOrTx: DbOrTx, issueIds: string[]): Promise<Map<string, IssueLabelRow[]>> {
   const map = new Map<string, IssueLabelRow[]>();
   if (issueIds.length === 0) return map;
   for (const issueIdChunk of chunkList(issueIds, ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE)) {
@@ -643,7 +648,7 @@ async function labelMapForIssues(dbOrTx: any, issueIds: string[]): Promise<Map<s
   return map;
 }
 
-async function withIssueLabels(dbOrTx: any, rows: IssueRow[]): Promise<IssueWithLabels[]> {
+async function withIssueLabels(dbOrTx: DbOrTx, rows: IssueRow[]): Promise<IssueWithLabels[]> {
   if (rows.length === 0) return [];
   const labelsByIssueId = await labelMapForIssues(dbOrTx, rows.map((row) => row.id));
   return rows.map((row) => {
@@ -699,7 +704,7 @@ type IssueBlockerAttentionAgentRow = {
 };
 
 async function activeRunMapForIssues(
-  dbOrTx: any,
+  dbOrTx: DbOrTx,
   issueRows: IssueWithLabels[],
 ): Promise<Map<string, IssueActiveRunRow>> {
   const map = new Map<string, IssueActiveRunRow>();
@@ -867,7 +872,7 @@ async function terminalExplicitBlockersByRoot(
 }
 
 async function listIssueBlockerAttentionMap(
-  dbOrTx: any,
+  dbOrTx: DbOrTx,
   companyId: string,
   issueRows: IssueBlockerAttentionInputNode[],
 ): Promise<Map<string, IssueBlockerAttention>> {
@@ -1172,7 +1177,7 @@ function withActiveRuns(
 }
 
 async function userCommentStatsForIssues(
-  dbOrTx: any,
+  dbOrTx: DbOrTx,
   companyId: string,
   userId: string,
   issueIds: string[],
@@ -1208,7 +1213,7 @@ async function userCommentStatsForIssues(
 }
 
 async function userReadStatsForIssues(
-  dbOrTx: any,
+  dbOrTx: DbOrTx,
   companyId: string,
   userId: string,
   issueIds: string[],
@@ -1234,7 +1239,7 @@ async function userReadStatsForIssues(
 }
 
 async function lastActivityStatsForIssues(
-  dbOrTx: any,
+  dbOrTx: DbOrTx,
   companyId: string,
   issueIds: string[],
 ): Promise<IssueLastActivityStat[]> {
@@ -1442,7 +1447,7 @@ export function issueService(db: Db) {
     }
   }
 
-  async function assertValidLabelIds(companyId: string, labelIds: string[], dbOrTx: any = db) {
+  async function assertValidLabelIds(companyId: string, labelIds: string[], dbOrTx: DbOrTx = db) {
     if (labelIds.length === 0) return;
     const existing = await dbOrTx
       .select({ id: labels.id })
@@ -1457,7 +1462,7 @@ export function issueService(db: Db) {
     issueId: string,
     companyId: string,
     labelIds: string[],
-    dbOrTx: any = db,
+    dbOrTx: DbOrTx = db,
   ) {
     const deduped = [...new Set(labelIds)];
     await assertValidLabelIds(companyId, deduped, dbOrTx);
@@ -1597,7 +1602,7 @@ export function issueService(db: Db) {
     companyId: string,
     blockedByIssueIds: string[],
     actor: { agentId?: string | null; userId?: string | null } = {},
-    dbOrTx: any = db,
+    dbOrTx: DbOrTx = db,
   ) {
     const deduped = [...new Set(blockedByIssueIds)];
     if (deduped.some((candidate) => candidate === issueId)) {
@@ -1639,7 +1644,7 @@ export function issueService(db: Db) {
         companyId,
         issueId: blockerIssueId,
         relatedIssueId: issueId,
-        type: "blocks",
+        type: "blocks" as const,
         createdByAgentId: actor.agentId ?? null,
         createdByUserId: actor.userId ?? null,
       })),
@@ -1749,6 +1754,10 @@ export function issueService(db: Db) {
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, issue.executionRunId))
         .then((rows) => rows[0] ?? null);
+
+      // Queued and running execution runs are live handoffs. Stalled queued runs
+      // are reconciled by the heartbeat stale-run watchdog; this write-path drain
+      // only clears terminal or missing locks so it cannot orphan valid work.
       if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
 
       const updated = await tx
@@ -2084,7 +2093,7 @@ export function issueService(db: Db) {
       return relations.get(issueId) ?? { blockedBy: [], blocks: [] };
     },
 
-    getDependencyReadiness: async (issueId: string, dbOrTx: any = db) => {
+    getDependencyReadiness: async (issueId: string, dbOrTx: DbOrTx = db) => {
       const issue = await dbOrTx
         .select({ id: issues.id, companyId: issues.companyId })
         .from(issues)
@@ -2095,14 +2104,14 @@ export function issueService(db: Db) {
       return readiness.get(issueId) ?? createIssueDependencyReadiness(issueId);
     },
 
-    listDependencyReadiness: async (companyId: string, issueIds: string[], dbOrTx: any = db) => {
+    listDependencyReadiness: async (companyId: string, issueIds: string[], dbOrTx: DbOrTx = db) => {
       return listIssueDependencyReadinessMap(dbOrTx, companyId, issueIds);
     },
 
     listBlockerAttention: async (
       companyId: string,
       issueRows: IssueBlockerAttentionInputNode[],
-      dbOrTx: any = db,
+      dbOrTx: DbOrTx = db,
     ) => {
       return listIssueBlockerAttentionMap(dbOrTx, companyId, issueRows);
     },
@@ -2484,7 +2493,7 @@ export function issueService(db: Db) {
         actorAgentId?: string | null;
         actorUserId?: string | null;
       },
-      dbOrTx: any = db,
+      dbOrTx: DbOrTx = db,
     ) => {
       const existing = await dbOrTx
         .select()


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The affected subsystem is issue execution wakeup handling and issue service write-path helpers.
> - Deferred comment and mention wakes must not accidentally revive closed work or leave stale execution locks blocking valid ownership checks.
> - Current master already contains the newer stale execution lock implementation, so this rebase keeps that upstream behavior instead of reapplying the older CLI-126 helper body.
> - This pull request now carries the closed-issue mention wake guard, route context plumbing, tests for deferred wake batching, and the CLI-165 `DbOrTx` type-safety polish.
> - The benefit is safer closed-issue behavior plus clearer Drizzle typing at the issue service helper boundary, without changing the current master scheduling semantics.

## What Changed

- Drops deferred `issue_comment_mentioned` wakes when the target issue is closed before promotion, rather than promoting a mentioned-agent run against completed work.
- Preserves explicit human/comment-reopen paths so deliberate reopen interactions can still revive closed issues.
- Threads actor context through issue comment wakeup creation so the heartbeat service can distinguish human reopen intent from agent/system follow-ups.
- Adds and aligns heartbeat comment wake batching coverage for deferred comment promotion, closed-issue mention drops, and issue execution ownership behavior.
- Replaces broad `dbOrTx: any` helper typing in `server/src/services/issues.ts` with a shared `DbOrTx` alias and documents why queued/running execution locks are not drained by the write path.

## Verification

- `pnpm -r typecheck`
- `pnpm exec vitest run --project @paperclipai/server server/src/__tests__/heartbeat-comment-wake-batching.test.ts server/src/__tests__/issues-service.test.ts --pool=forks --poolOptions.forks.isolate=true`
- `npm_config_script_shell="C:\Program Files\Git\bin\bash.exe" pnpm build`

Note: `pnpm test:run` could not be executed directly on this Windows checkout because `scripts/run-vitest-stable.mjs` calls `spawnSync("pnpm")`, which resolves to `ENOENT` in this local PowerShell/Node environment. The focused server suites above were run directly, and the pushed branch will trigger the Linux CI verify workflow.

## Risks

- Low behavioral risk: this narrows deferred mention wake promotion only after the issue has already been closed.
- There is some workflow risk around agents expecting mentions on closed issues to start a new run automatically; explicit reopen/comment flows remain available for intentional revival.
- Rebase risk was handled by keeping current master's newer stale execution lock implementation and not reintroducing the older superseded CLI-126 helper body.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- GitHub Copilot CLI using GPT-5.5, model ID `gpt-5.5`, with tool-enabled repository inspection, conflict resolution, local command execution, and GitHub PR maintenance. Original branch commits also include prior AI-assisted implementation work; this rebase/update session was completed with GPT-5.5.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
