### PR TITLE
Fix self-wake loop: guard selfComment in reopened-override wake gates

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1837,7 +1837,7 @@ export function issueRoutes(
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
         const skipAssigneeCommentWake = selfComment || isClosed;
 
-        if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
+        if (assigneeId && !assigneeChanged && !selfComment && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {
             source: "automation",
             triggerDetail: "system",
@@ -2428,7 +2428,7 @@ export function issueRoutes(
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;
       const skipWake = selfComment || isClosed;
-      if (assigneeId && (reopened || !skipWake)) {
+      if (assigneeId && !selfComment && (reopened || !skipWake)) {
         if (reopened) {
           wakeups.set(assigneeId, {
             source: "automation",


### PR DESCRIPTION
## Summary
Two wake-gate sites in `server/src/routes/issues.ts` let `reopened===true` override the `!selfComment` skip. When an agent comments on its own `done` issue, the comment also reopens the issue, which re-triggers the wake gate. Combined with auto-approved `DANGEROUS COMMAND` prompts in headless agents, this produces a tight self-wake loop.

Observed: an AI Workforce Hermes agent produced 13 sessions in 33 minutes on a single `done` issue before manual intervention.

Fix: add `!selfComment` as an explicit conjunct in both wake conditions so the `reopened` path cannot override the self-comment guard.

Sites touched:
- `server/src/routes/issues.ts:1840` — `PATCH /api/issues/:id` (status-change + commentBody)
- `server/src/routes/issues.ts:2429` — `POST /api/issues/:id/comments` (direct comment path)

## Test plan
- [ ] Self-comment on a `done` issue → no wake, no reopen-override
- [ ] External comment on a `done` issue → reopen + wake as before
- [ ] Normal assigned-issue comment path unchanged