### PR TITLE
CLI-156: classifyAdapterFailure + wire heartbeat catch paths

### DIFF
--- a/docs/specs/adapter-circuit-breaker.md
+++ b/docs/specs/adapter-circuit-breaker.md
@@ -1,0 +1,193 @@
+---
+title: Adapter-Level Circuit Breaker and Quarantine
+summary: Isolate a failing adapter so one bad adapter cannot wedge the entire fleet
+---
+
+# Adapter-Level Circuit Breaker and Quarantine
+
+**Issue:** CLI-121
+**Parent:** CLI-75 (fleet outage postmortem, 2026-04-20)
+**Status:** Approved (v4) — ClippyQA + ClippyArch + ClippyEng review complete; ready for implementation sub-tickets
+
+**Revision history:**
+- v1 — initial draft (ClippyArch, 01:39 UTC).
+- v2 — rubber-duck design review, 10 substantive findings folded (two-shape keying, Open=DEFERS, probe CAS lease, failure classification, etc.).
+- v3 — QA spec review @ 02:32 UTC: 3 acceptance gaps closed, 2 §-level clarifications, 2 minor hardenings (this revision).
+- v4 — Eng implementation-binding addendum: classify thrown startup/config failures in heartbeat catch paths, preserve `errorCode` as operator/UI surface, and reset re-trip halving after a stable Closed window.
+
+## Problem
+
+On 2026-04-20 06:59 UTC, a single `copilot_local` adapter failure stranded 8 of 9 agents in `status=error` for ~19 minutes and auto-blocked 30+ in-flight issues. Every agent bound to that adapter hit the same `adapter_failed - Process adapter missing command` on its next heartbeat, and there was no mechanism to *isolate* the bad adapter from the rest of the fleet while recovery ran.
+
+The CLI-75 follow-ups shipped detection (CLI-77), gating (CLI-79), and alerting (CLI-84). **This spec covers the missing axis: isolation.** A failing adapter should fail in place without consuming the fleet.
+
+## Non-goals
+
+- Not a retry/back-off policy for individual heartbeats (that lives in the execution loop).
+- Not a replacement for CLI-79 release-channel gating; this kicks in *after* a bad adapter is already live.
+- Not a cross-adapter failover (we do not migrate agents from `copilot_local` → `codex_local` automatically).
+
+## Design
+
+### 1. Failure accounting
+
+For each `adapterType` (e.g., `copilot_local`), the server maintains a rolling window of adapter-layer failures:
+
+- **Counted:** `adapter_failed`, missing-command errors, adapter-bootstrap timeouts, probe timeouts (`adapter_probe_timeout`), and any error classified as originating in the adapter itself (not the agent run).
+- **Not counted:** agent-side errors (tool call failures, run-timeouts inside the agent, non-zero exits surfaced as run output).
+
+Classification uses a breaker-only `adapterFailureReason` signal on `AdapterExecutionResult`, or an equivalent `classifyAdapterFailure(err, adapterType)` path in heartbeat for thrown startup/config failures. `errorCode` remains the operator/UI surface so existing run UX (for example, auth-specific CTAs keyed off adapter error codes) does not regress. This is binding on implementation: the heartbeat catch paths that currently flatten thrown startup failures to plain `adapter_failed` must classify those throws so `process adapter missing command` / `http adapter missing url`-class failures count toward the breaker.
+
+### 2. Trip conditions
+
+The breaker trips for an `adapterType` when either:
+
+- **Burst:** ≥ `N_burst` adapter-origin failures across distinct agents within `T_burst` seconds (defaults: `N_burst=3`, `T_burst=60s` — matches the CLI-84 alert threshold so alert-fires-and-breaker-trips-together by default).
+- **Sustained:** ≥ `N_sustained` adapter-origin failures in `T_sustained` (defaults: `N_sustained=10`, `T_sustained=600s`) — catches slower-rolling outages that would miss the burst window.
+
+Both thresholds are configurable per adapter type via server config (see §6).
+
+### 3. Quarantine state
+
+When the breaker trips for `adapterType=X`:
+
+1. Mark the adapter type `quarantined` in server state, with `quarantinedAt`, `tripReason`, and `tripEvidence` (the last N failure records).
+2. For every agent whose current adapter is `X`, transition them to a **new** status `quarantined` (not `error`). Distinction matters:
+   - `error` = agent-specific failure, operator investigates this agent.
+   - `quarantined` = agent is fine, its adapter is not; no per-agent investigation required.
+3. Issues assigned to quarantined agents are **not** auto-blocked. They retain their current status with a `quarantineHold` flag on their execution record. This avoids the CLI-75 secondary symptom where 30+ issues flipped to blocked and required manual rehydration.
+4. Emit a single `adapter.quarantined` event (distinct from the per-agent `adapter_failed` events) so alerting/dashboards can show one row, not N.
+
+**Assignment to a quarantined agent (QA gap #3).** New issue assignment to an agent whose current adapter circuit is Open is **permitted** and stamps `quarantineHold=true` on the execution record at assignment time (no run is started). The first wake is deferred to the circuit's `resumeAt`, and the hold is visible in UI. Rationale: blocking assignment would flip the failure mode back to "fleet stalls on assignment," which is exactly what quarantine is designed to avoid.
+
+### 4. Release (two paths)
+
+The breaker releases `X` when **either**:
+
+- **Automatic probe-based release.** A background health probe runs every `probeIntervalSec` (default `30s`) and executes the adapter's `healthCheck()` (new required adapter method; see §5). After `probeSuccessCount` consecutive successes (default `3`), the breaker releases automatically. Agents transition `quarantined → idle` and resume on their next heartbeat.
+- **Manual operator reset.** A board-operator-only admin reset clears quarantine immediately, optionally with `force=true` to skip probe confirmation. If the quarantined adapter is an override of a builtin adapter, resuming the override via the existing override-pause route is also a Closed transition. Release emits `adapter.quarantine_released` with `releasedBy` and `reason`.
+
+On release, the trip counters reset **and** every `quarantineHold=true` flag belonging to issues bound to adapter `X` is cleared in the same transaction (QA gap #2). This applies to probe-based release, admin reset, and override-pause resume. The next agent heartbeat for those issues then resumes normal execution via the existing `deferred_issue_execution` re-promotion loop; no manual rehydration or new wake path is needed. If the breaker trips again within `reTripGraceSec` (default `120s`), the trip thresholds are halved for the next window — repeated flapping should escalate, not silently cycle. If the breaker remains Closed for `>= reTripGraceSec` without a re-trip, thresholds reset to their configured defaults.
+
+### 5. Adapter contract changes
+
+Every adapter gains a required method:
+
+```ts
+interface Adapter {
+  // ...existing methods
+  healthCheck(ctx: HealthCheckContext): Promise<HealthCheckResult>;
+}
+
+interface HealthCheckResult {
+  ok: boolean;
+  reason?: string;       // human-readable, logged with quarantine events
+  details?: unknown;     // structured, surfaced in admin UI
+}
+```
+
+Semantics:
+
+- MUST NOT spawn a full agent run. Lightweight only (e.g., `copilot --version`, SDK connectivity check, `which` on the adapter's configured `command`).
+- MUST respect `ctx.timeoutMs` (default `5000`). A hung probe counts as `adapter_probe_timeout`, and a timeout **and** an explicit `{ ok: false }` return are weighted equally as probe failures (QA minor #2). Both reset `probeSuccessCount` and count toward the next trip evidence.
+- MUST be idempotent and side-effect-free.
+
+For built-ins, the work is small (copilot_local: reuse the CLI-77 adapter-health-probe check; process: verify `command` resolves; http: HEAD/GET against the configured URL). External adapters get a one-release deprecation window where a missing `healthCheck` degrades to "probe unavailable → manual release only" rather than breaking the plugin.
+
+### 6. Configuration
+
+New server config section (env + config file):
+
+```yaml
+adapters:
+  circuitBreaker:
+    enabled: true                  # global kill-switch
+    defaults:
+      nBurst: 3
+      tBurstSec: 60
+      nSustained: 10
+      tSustainedSec: 600
+      probeIntervalSec: 30
+      probeSuccessCount: 3
+      reTripGraceSec: 120
+    overrides:
+      copilot_local:
+        nBurst: 3                  # same as default; explicit for the adapter that caused CLI-75
+```
+
+Env vars mirror the defaults: `PAPERCLIP_ADAPTER_BREAKER_ENABLED`, `PAPERCLIP_ADAPTER_BREAKER_N_BURST`, etc.
+
+### 7. Observability
+
+- `adapter.quarantined` event: `{adapterType, trippedAt, reason, evidence}`.
+- `adapter.quarantine_released` event: `{adapterType, releasedAt, releasedBy, mode: "probe"|"manual"}`.
+- `GET /api/adapters/quarantine` returns current quarantine state for all adapter types.
+- Dashboard: a banner on the agent-fleet view when any adapter is quarantined, listing affected agents.
+- Run/stop summarization must preserve `adapter_quarantined` as distinct from `adapter_failed`; dashboards must not collapse the two states.
+- Metrics: `adapter_quarantine_trips_total{adapter_type}`, `adapter_quarantine_duration_seconds{adapter_type}`, `adapter_health_probe_failures_total{adapter_type}`.
+
+### 8. Interaction with CLI-84 alerts
+
+The CLI-84 alert fires when ≥3 agents hit `adapter_failed` within 60s. With this breaker active and using default thresholds, the alert and the trip fire on the same evidence. Recommend: the alert payload includes `quarantined: true|false` so on-call can see at a glance whether isolation already kicked in and whether a human response is still required.
+
+### 9. Interaction with CLI-91 actor-trust
+
+Quarantine release is a state-changing action. It MUST honor the CLI-91 default-deny actor-trust rule: only `"user"` actors can trigger manual reset or override-pause resume. **Agent actors are explicitly forbidden** from triggering either path, including `force=true` (QA minor #1) — a compromised agent must not be able to lift its own quarantine. Rejected attempts still write an audit row. Probe-based automatic release is permitted because the probe itself is a first-class trusted signal, not an actor-authored comment.
+
+## Failure modes and mitigations
+
+| Failure | Mitigation |
+|---|---|
+| `healthCheck` gives false positives (returns ok while adapter is broken) | Require `probeSuccessCount=3` consecutive passes; log probe results; operator can force-quarantine via API. |
+| `healthCheck` gives false negatives (never passes despite adapter being fine) | Manual `force=true` release path; probe result history visible in admin UI so operator can override. |
+| Trip storm across every adapter type simultaneously | Global kill-switch (`enabled=false`); per-adapter overrides don't stack into a fleet-wide outage of the breaker itself. |
+| External adapter plugin without `healthCheck` | Deprecation window: quarantine still works, but release is manual-only until the plugin updates. |
+| Breaker trips during legitimate adapter upgrade | CLI-79 release-channel gating should prevent the new adapter from going live until canaries pass, so the breaker tripping during upgrade is a *signal*, not a bug. |
+| Flapping adapter (trips, releases, re-trips) | `reTripGraceSec` halves thresholds on re-trip within the grace window, but resets to configured defaults after a stable Closed period of `>= reTripGraceSec` — escalates fast without degrading into a permanent hair-trigger. |
+
+## Rollout plan
+
+1. **Ship the `healthCheck` contract** (no-op breaker). Built-in adapters implement it; external adapters get a warning in the plugin log.
+2. **Ship the breaker in shadow mode.** Trip conditions evaluated; events emitted; agent state **not** mutated. Run for one week; compare shadow trips against real-world adapter-origin failures to validate thresholds.
+3. **Enable enforcement for `copilot_local` only.** The adapter that triggered CLI-75 is the first real beneficiary.
+4. **Enable enforcement fleet-wide** after one clean week on `copilot_local`.
+5. **Remove shadow-mode code path** after fleet-wide enforcement is stable for two weeks.
+
+## Acceptance criteria
+
+- [ ] `healthCheck` method added to the `Adapter` interface and implemented for every built-in adapter.
+- [ ] Breaker trips on both burst and sustained conditions; unit tests cover both.
+- [ ] `adapterFailureReason` (or equivalent heartbeat-side `classifyAdapterFailure`) is wired without changing operator/UI-facing `errorCode`, and both heartbeat catch paths classify thrown startup/config failures so `missing command` / `missing url` faults count toward the breaker.
+- [ ] Quarantined agents transition to `quarantined` status (distinct from `error`); issues assigned to them are **not** auto-blocked.
+- [ ] Automatic release after probe confirmation; manual release via API (gated to `user` actors per CLI-91).
+- [ ] End-to-end test: simulate `copilot_local` adapter failure → verify breaker trips, agents move to `quarantined`, issues stay open with `quarantineHold`, probe restores → breaker releases → agents resume.
+- [ ] **Re-trip threshold halving test (QA gap #1).** Trip → release → re-trip within `reTripGraceSec` → verify `nBurst`/`nSustained` are halved (rounded up) for the next window. Subsequent re-trip within grace halves again until floor of 1. Holding Closed for `>= reTripGraceSec` resets thresholds to configured defaults.
+- [ ] **quarantineHold cleanup on release.** Unit test verifying that on probe-based release, manual reset, and override-pause resume, every `quarantineHold` flag for the released adapter type is cleared in the same transaction; assigned-while-quarantined issues then execute on next heartbeat via the existing deferred re-promotion loop.
+- [ ] **Assignment-to-quarantined-agent.** Unit test: assigning a new issue while the circuit is Open succeeds, stamps `quarantineHold=true` at assignment time, and defers the first wake to `resumeAt` (no run started); release path then drains it.
+- [ ] Dashboard/run summaries preserve `adapter_quarantined` as a separate stop reason rather than collapsing it into `adapter_failed`.
+- [ ] Dashboard banner + `/api/adapters/quarantine` endpoint.
+- [ ] Runbook entry in `docs/runbooks/` for "how to force-release / force-quarantine an adapter."
+- [ ] Shadow-mode rollout validated with one week of data before enforcement.
+
+## Open questions (resolved)
+
+1. **Issue-level hold semantics.** ✅ **Surface in UI.** ClippyQA confirmed: an explicit "held — adapter quarantined" badge prevents "why is my ticket not moving" support noise. Internal-only is a support liability.
+2. **Cross-project scope.** ✅ **Per adapter type for v1.** ClippyQA confirmed: the v2 two-shape keying already differentiates by module identity for shared-env adapters; revisit per-instance only if a real incident demands it.
+3. **Healthcheck sampling cost.** Tracked but unresolved — `30s` probe interval × N adapter types is cheap for built-ins but could matter for external HTTP adapters. Revisit interval per-adapter if probes become a load issue. Not a blocker for v1.
+
+## Follow-up tickets (to open after this spec is approved)
+
+- Implementation ticket for the breaker core + `healthCheck` contract.
+- Per-adapter `healthCheck` implementation tickets (one per built-in).
+- Dashboard quarantine banner UI ticket.
+- Runbook ticket for operator force-release/force-quarantine procedures.
+
+## References
+
+- CLI-75 postmortem: `docs/postmortems/2026-04-20-fleet-outage.md`
+- CLI-77 adapter health probe (detection)
+- CLI-79 adapter release-channel guardrail (gating)
+- CLI-84 adapter fleet failure alert (alerting)
+- CLI-91 deferred-wake reopen bug / actor-trust invariant
+- CLI-122 adapter go-live checklist enforcement (sibling follow-up)
+- CLI-123 actor-trust invariant spec (sibling follow-up)

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -68,6 +68,15 @@ export interface AdapterExecutionResult {
   errorMessage?: string | null;
   errorCode?: string | null;
   errorMeta?: Record<string, unknown>;
+  /**
+   * Circuit-breaker failure classification (CLI-121 / CLI-156).
+   *
+   * This is the breaker-only counter input — kept separate from `errorCode`
+   * which remains the operator/UI surface. Populated either by adapters that
+   * return classified results directly, or by `classifyAdapterFailure` in the
+   * heartbeat catch paths for thrown startup/config failures.
+   */
+  adapterFailureReason?: string | null;
   usage?: UsageSummary;
   /**
    * Legacy single session id output. Prefer `sessionParams` + `sessionDisplayId`.

--- a/server/src/adapters/adapter-failure-reasons.test.ts
+++ b/server/src/adapters/adapter-failure-reasons.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADAPTER_FAILURE_REASONS,
+  classifyAdapterFailure,
+} from "./adapter-failure-reasons.js";
+
+describe("classifyAdapterFailure", () => {
+  it("classifies the CLI-66 fault shape as adapter_missing_command", () => {
+    const result = classifyAdapterFailure(
+      new Error("Process adapter missing command"),
+      "copilot_local",
+    );
+
+    expect(result.adapterFailureReason).toBe("adapter_missing_command");
+    expect(result.countsTowardBreaker).toBe(true);
+    // Operator/UI surface is preserved — do not regress claude_auth_required
+    // style CTAs for unrelated fault categories.
+    expect(result.surfaceErrorCode).toBe("adapter_failed");
+  });
+
+  it("classifies missing HTTP url as adapter_missing_url", () => {
+    const result = classifyAdapterFailure(
+      new Error("HTTP adapter missing url"),
+      "http",
+    );
+    expect(result.adapterFailureReason).toBe("adapter_missing_url");
+    expect(result.countsTowardBreaker).toBe(true);
+  });
+
+  it("classifies probe timeouts as adapter_probe_timeout", () => {
+    const err = Object.assign(new Error("The operation was aborted."), {
+      name: "AbortError",
+    });
+    const result = classifyAdapterFailure(err, "http");
+    expect(result.adapterFailureReason).toBe("adapter_probe_timeout");
+    expect(result.countsTowardBreaker).toBe(true);
+  });
+
+  it("classifies HTTP status errors as adapter_http_error", () => {
+    const result = classifyAdapterFailure(
+      new Error("HTTP invoke failed with status 502"),
+      "http",
+    );
+    expect(result.adapterFailureReason).toBe("adapter_http_error");
+    expect(result.countsTowardBreaker).toBe(true);
+  });
+
+  it("classifies ENOENT spawn failures as adapter_spawn_failed", () => {
+    const err = Object.assign(new Error("spawn copilot ENOENT"), {
+      code: "ENOENT",
+    });
+    const result = classifyAdapterFailure(err, "copilot_local");
+    expect(result.adapterFailureReason).toBe("adapter_spawn_failed");
+    expect(result.countsTowardBreaker).toBe(true);
+  });
+
+  it("classifies claude-style auth errors with auth surface code", () => {
+    const result = classifyAdapterFailure(
+      new Error("Claude credentials not found, please run claude login"),
+      "claude_local",
+    );
+    expect(result.adapterFailureReason).toBe("adapter_auth_failed");
+    // UI CTA at ui/src/pages/AgentDetail.tsx keys off claude_auth_required —
+    // classification MUST preserve that surface.
+    expect(result.surfaceErrorCode).toBe("claude_auth_required");
+    expect(result.countsTowardBreaker).toBe(true);
+  });
+
+  it("falls back to adapter_unknown_error for opaque errors but still counts", () => {
+    const result = classifyAdapterFailure(
+      new Error("something odd happened"),
+      "copilot_local",
+    );
+    expect(result.adapterFailureReason).toBe("adapter_unknown_error");
+    // Default behaviour MUST preserve fleet protection (CLI-75): unknown
+    // adapter-thrown failures still count toward the breaker.
+    expect(result.countsTowardBreaker).toBe(true);
+  });
+
+  it("never collapses quarantined runs into breaker counters", () => {
+    // The quarantine reason is emitted by the breaker itself when it refuses
+    // a run; it is NOT an adapter failure and must not feed back into trip
+    // accounting (would cause infinite trip loops).
+    expect(ADAPTER_FAILURE_REASONS.adapter_quarantined.countsTowardBreaker).toBe(false);
+    expect(ADAPTER_FAILURE_REASONS.adapter_quarantined.surfaceErrorCode).toBe("adapter_quarantined");
+  });
+
+  it("does not count mid-run timeouts toward the breaker", () => {
+    expect(ADAPTER_FAILURE_REASONS.adapter_mid_run_timeout.countsTowardBreaker).toBe(false);
+  });
+
+  it("handles non-Error thrown values gracefully", () => {
+    expect(classifyAdapterFailure("Process adapter missing command", "process").adapterFailureReason).toBe(
+      "adapter_missing_command",
+    );
+    expect(classifyAdapterFailure(undefined, "process").adapterFailureReason).toBe("adapter_unknown_error");
+    expect(classifyAdapterFailure(null, "process").adapterFailureReason).toBe("adapter_unknown_error");
+  });
+});

--- a/server/src/adapters/adapter-failure-reasons.ts
+++ b/server/src/adapters/adapter-failure-reasons.ts
@@ -1,0 +1,155 @@
+/**
+ * Adapter failure classification — single source of truth for the
+ * circuit-breaker reason keys (CLI-121 / CLI-156).
+ *
+ * Spec: docs/specs/adapter-circuit-breaker.md (v4)
+ *
+ * Design notes (carried forward from ClippyArch's design comment on CLI-156):
+ *   - `adapterFailureReason` is the breaker-only counter input.
+ *   - `errorCode` remains the operator/UI surface (e.g. the Claude auth CTA is
+ *     keyed off `claude_auth_required`), so it MUST stay independent.
+ *   - Both heartbeat thrown-startup catch paths classify through here so
+ *     "Process adapter missing command" style faults count toward the breaker
+ *     instead of being flattened to opaque `adapter_failed`.
+ */
+
+export interface AdapterFailureReasonEntry {
+  /** Whether this reason should count toward circuit breaker trip thresholds. */
+  readonly countsTowardBreaker: boolean;
+  /**
+   * Operator/UI-facing error code to surface when the adapter did not provide
+   * a more specific `errorCode` itself. This preserves existing UX (e.g. the
+   * claude-auth CTA) without entangling UI state with breaker counters.
+   */
+  readonly surfaceErrorCode: string;
+}
+
+export const ADAPTER_FAILURE_REASONS = {
+  /** Process adapter threw "Process adapter missing command" (CLI-66 fault). */
+  adapter_missing_command: { countsTowardBreaker: true, surfaceErrorCode: "adapter_failed" },
+  /** HTTP adapter threw "HTTP adapter missing url". */
+  adapter_missing_url: { countsTowardBreaker: true, surfaceErrorCode: "adapter_failed" },
+  /** Child process spawn failure (ENOENT, permission denied, etc). */
+  adapter_spawn_failed: { countsTowardBreaker: true, surfaceErrorCode: "adapter_failed" },
+  /** Adapter-level authentication failure. Surfaces auth CTA in UI. */
+  adapter_auth_failed: { countsTowardBreaker: true, surfaceErrorCode: "claude_auth_required" },
+  /** Adapter stream/protocol violation. */
+  adapter_protocol_error: { countsTowardBreaker: true, surfaceErrorCode: "adapter_failed" },
+  /** Health probe timed out or failed. */
+  adapter_probe_timeout: { countsTowardBreaker: true, surfaceErrorCode: "adapter_failed" },
+  /** HTTP adapter returned a non-2xx status or the fetch itself failed. */
+  adapter_http_error: { countsTowardBreaker: true, surfaceErrorCode: "adapter_failed" },
+  /** The breaker itself refused this run because the adapter is quarantined. */
+  adapter_quarantined: { countsTowardBreaker: false, surfaceErrorCode: "adapter_quarantined" },
+  /** Mid-run timeout — agent-side, not counted toward the breaker. */
+  adapter_mid_run_timeout: { countsTowardBreaker: false, surfaceErrorCode: "adapter_failed" },
+  /** Fallback classification — counts toward breaker to preserve CLI-75 fleet protection. */
+  adapter_unknown_error: { countsTowardBreaker: true, surfaceErrorCode: "adapter_failed" },
+} as const satisfies Record<string, AdapterFailureReasonEntry>;
+
+export type AdapterFailureReason = keyof typeof ADAPTER_FAILURE_REASONS;
+
+/**
+ * Stop reasons that must NOT collapse back into `adapter_failed` in
+ * dashboards / run summaries. CLI-156 acceptance criterion.
+ */
+export const QUARANTINE_STOP_REASON = "adapter_quarantined" as const;
+
+export interface ClassifiedAdapterFailure {
+  adapterFailureReason: AdapterFailureReason;
+  /** The operator/UI-facing error code. */
+  surfaceErrorCode: string;
+  /** True when this reason should count toward breaker trip thresholds. */
+  countsTowardBreaker: boolean;
+}
+
+function readErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message ?? "";
+  if (typeof err === "string") return err;
+  if (err && typeof err === "object" && "message" in err) {
+    const m = (err as { message?: unknown }).message;
+    if (typeof m === "string") return m;
+  }
+  return "";
+}
+
+function readErrorCodeProp(err: unknown): string | null {
+  if (err && typeof err === "object" && "code" in err) {
+    const c = (err as { code?: unknown }).code;
+    if (typeof c === "string" && c.length > 0) return c;
+  }
+  return null;
+}
+
+function readErrorName(err: unknown): string {
+  if (err instanceof Error) return err.name ?? "";
+  if (err && typeof err === "object" && "name" in err) {
+    const n = (err as { name?: unknown }).name;
+    if (typeof n === "string") return n;
+  }
+  return "";
+}
+
+/**
+ * Classify a thrown error from an adapter or adapter-setup path into a
+ * circuit-breaker reason + surface error code.
+ *
+ * This is pure: it takes the raw thrown value and the adapter type and
+ * returns a classification. No logging, no I/O. Safe to unit-test.
+ */
+export function classifyAdapterFailure(
+  err: unknown,
+  adapterType: string | null | undefined,
+): ClassifiedAdapterFailure {
+  const message = readErrorMessage(err);
+  const lower = message.toLowerCase();
+  const name = readErrorName(err);
+  const codeProp = readErrorCodeProp(err);
+
+  let reason: AdapterFailureReason = "adapter_unknown_error";
+
+  // --- explicit shapes we know about ---------------------------------------
+  if (/process adapter missing command/i.test(message)) {
+    reason = "adapter_missing_command";
+  } else if (/http adapter missing url/i.test(message)) {
+    reason = "adapter_missing_url";
+  } else if (
+    codeProp === "ENOENT" ||
+    /\bENOENT\b/.test(message) ||
+    /command not found/i.test(message) ||
+    /not recognized as .* (cmdlet|command)/i.test(message) ||
+    /spawn .* ENOENT/i.test(message)
+  ) {
+    reason = "adapter_spawn_failed";
+  } else if (
+    /claude .*(auth|login|credential)/i.test(message) ||
+    /please (run|log in|login|sign in)/i.test(lower) ||
+    /not (logged in|authenticated)/i.test(lower) ||
+    /missing .*(api key|token|credential)/i.test(lower) ||
+    /401\b|403\b/.test(message) && /auth/i.test(message)
+  ) {
+    reason = "adapter_auth_failed";
+  } else if (
+    name === "AbortError" ||
+    /probe .*(timed? out|timeout)/i.test(message) ||
+    /health ?check .*(timed? out|timeout)/i.test(message)
+  ) {
+    reason = "adapter_probe_timeout";
+  } else if (
+    /http .*(invoke failed|status \d{3})/i.test(message) ||
+    /\bHTTP \d{3}\b/.test(message) ||
+    /fetch failed/i.test(message) ||
+    adapterType === "http"
+  ) {
+    reason = "adapter_http_error";
+  } else if (/protocol|parse|unexpected token|invalid json/i.test(message)) {
+    reason = "adapter_protocol_error";
+  }
+
+  const entry = ADAPTER_FAILURE_REASONS[reason];
+  return {
+    adapterFailureReason: reason,
+    surfaceErrorCode: entry.surfaceErrorCode,
+    countsTowardBreaker: entry.countsTowardBreaker,
+  };
+}

--- a/server/src/services/heartbeat-stop-metadata.test.ts
+++ b/server/src/services/heartbeat-stop-metadata.test.ts
@@ -83,4 +83,28 @@ describe("heartbeat stop metadata", () => {
       timeoutFired: false,
     });
   });
+
+  it("keeps adapter_quarantined stop reason distinct from adapter_failed (CLI-156)", () => {
+    // CLI-156 acceptance criterion: dashboards must NOT collapse the quarantine
+    // state back into plain adapter_failed.
+    const metadata = buildHeartbeatRunStopMetadata({
+      adapterType: "copilot_local",
+      adapterConfig: {},
+      outcome: "failed",
+      errorCode: "adapter_quarantined",
+      errorMessage: "adapter copilot_local is quarantined",
+    });
+    expect(metadata.stopReason).toBe("adapter_quarantined");
+
+    // Other failed runs still classify as adapter_failed.
+    expect(
+      buildHeartbeatRunStopMetadata({
+        adapterType: "copilot_local",
+        adapterConfig: {},
+        outcome: "failed",
+        errorCode: "adapter_failed",
+        errorMessage: "boom",
+      }).stopReason,
+    ).toBe("adapter_failed");
+  });
 });

--- a/server/src/services/heartbeat-stop-metadata.ts
+++ b/server/src/services/heartbeat-stop-metadata.ts
@@ -7,6 +7,7 @@ export type HeartbeatRunStopReason =
   | "budget_paused"
   | "paused"
   | "process_lost"
+  | "adapter_quarantined"
   | "adapter_failed";
 
 export interface HeartbeatRunTimeoutPolicy {
@@ -78,6 +79,9 @@ export function inferHeartbeatRunStopReason(input: {
   if (input.outcome === "succeeded") return "completed";
   if (input.outcome === "timed_out") return "timeout";
   if (input.outcome === "failed" && input.errorCode === "process_lost") return "process_lost";
+  // CLI-156: adapter_quarantined must NOT collapse back into adapter_failed
+  // in dashboards / run summaries — it is a distinct breaker state.
+  if (input.outcome === "failed" && input.errorCode === "adapter_quarantined") return "adapter_quarantined";
   if (input.outcome === "cancelled") {
     const message = (input.errorMessage ?? "").toLowerCase();
     if (message.includes("budget")) return "budget_paused";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -38,6 +38,7 @@ import { publishLiveEvent } from "./live-events.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
 import { getServerAdapter, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
+import { classifyAdapterFailure } from "../adapters/adapter-failure-reasons.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { parseObject, asBoolean, asNumber, appendWithByteCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
 import { costService } from "./costs.js";
@@ -5147,11 +5148,19 @@ export function heartbeatService(db: Db) {
           : null;
 
       const persistedResultJson = mergeHeartbeatRunResultJson(
-        mergeRunStopMetadataForAgent(agent, outcome, {
-          resultJson: adapterResult.resultJson ?? null,
-          errorCode: runErrorCode,
-          errorMessage: runErrorMessage,
-        }),
+        {
+          ...mergeRunStopMetadataForAgent(agent, outcome, {
+            resultJson: adapterResult.resultJson ?? null,
+            errorCode: runErrorCode,
+            errorMessage: runErrorMessage,
+          }),
+          // CLI-156: surface adapter-provided classification in the persisted
+          // run result so dashboards/breaker counters can read it from the run
+          // record. Only populated when the adapter returned a classification.
+          ...(adapterResult.adapterFailureReason
+            ? { adapterFailureReason: adapterResult.adapterFailureReason }
+            : {}),
+        },
         adapterResult.summary ?? null,
       );
 
@@ -5240,11 +5249,16 @@ export function heartbeatService(db: Db) {
       }
       await finalizeAgentStatus(agent.id, outcome);
     } catch (err) {
-      const message = redactCurrentUserText(
-        err instanceof Error ? err.message : "Unknown adapter failure",
-        await getCurrentUserRedactionOptions(),
-      );
+      const rawMessage = err instanceof Error ? err.message : "Unknown adapter failure";
+      const message = redactCurrentUserText(rawMessage, await getCurrentUserRedactionOptions());
       logger.error({ err, runId }, "heartbeat execution failed");
+
+      // CLI-156: classify the thrown failure so the breaker can distinguish
+      // process_adapter_missing_command from other errors. errorCode remains
+      // the operator/UI surface (preserves claude_auth_required CTA).
+      const classification = classifyAdapterFailure(err, agent.adapterType);
+      const surfaceErrorCode = classification.surfaceErrorCode;
+      const adapterFailureReason = classification.adapterFailureReason;
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {
@@ -5257,12 +5271,15 @@ export function heartbeatService(db: Db) {
 
       const failedRun = await setRunStatus(run.id, "failed", {
         error: message,
-        errorCode: "adapter_failed",
+        errorCode: surfaceErrorCode,
         finishedAt: new Date(),
-        resultJson: mergeRunStopMetadataForAgent(agent, "failed", {
-          errorCode: "adapter_failed",
-          errorMessage: message,
-        }),
+        resultJson: {
+          ...mergeRunStopMetadataForAgent(agent, "failed", {
+            errorCode: surfaceErrorCode,
+            errorMessage: message,
+          }),
+          adapterFailureReason,
+        },
         stdoutExcerpt,
         stderrExcerpt,
         logBytes: logSummary?.bytes,
@@ -5317,15 +5334,27 @@ export function heartbeatService(db: Db) {
           const message = outerErr instanceof Error ? outerErr.message : "Unknown setup failure";
           logger.error({ err: outerErr, runId }, "heartbeat execution setup failed");
           const setupFailureAgent = await getAgent(run.agentId).catch(() => null);
+          // CLI-156: classify setup-time throws (missing command, missing url,
+          // ENOENT spawn, etc.) so the breaker counts them. errorCode remains
+          // the operator/UI surface.
+          const outerClassification = classifyAdapterFailure(
+            outerErr,
+            setupFailureAgent?.adapterType ?? null,
+          );
+          const outerSurfaceErrorCode = outerClassification.surfaceErrorCode;
+          const outerAdapterFailureReason = outerClassification.adapterFailureReason;
           await setRunStatus(runId, "failed", {
             error: message,
-            errorCode: "adapter_failed",
+            errorCode: outerSurfaceErrorCode,
             finishedAt: new Date(),
             ...(setupFailureAgent ? {
-              resultJson: mergeRunStopMetadataForAgent(setupFailureAgent, "failed", {
-                errorCode: "adapter_failed",
-                errorMessage: message,
-              }),
+              resultJson: {
+                ...mergeRunStopMetadataForAgent(setupFailureAgent, "failed", {
+                  errorCode: outerSurfaceErrorCode,
+                  errorMessage: message,
+                }),
+                adapterFailureReason: outerAdapterFailureReason,
+              },
             } : {}),
           }).catch(() => undefined);
           await setWakeupStatus(run.wakeupRequestId, "failed", {


### PR DESCRIPTION
## Summary

Implements CLI-156 per docs/specs/adapter-circuit-breaker.md v4. Introduces a table-driven classifyAdapterFailure so the circuit breaker (CLI-121) can distinguish the CLI-66 `Process adapter missing command` fault shape from opaque `adapter_failed`.

- `adapterFailureReason` is the breaker-only counter input (new field on `AdapterExecutionResult`).
- `errorCode` stays the operator/UI surface — preserves the `claude_auth_required` CTA at `ui/src/pages/AgentDetail.tsx`.
- Both thrown-failure catch paths in `heartbeat.ts` (inner `adapter.execute` + outer setup) now classify through the helper.
- `adapter_quarantined` is a new distinct stop reason so dashboards do not collapse it back into `adapter_failed`.
- v4 spec copied from the CLI-121 branch into `docs/specs/adapter-circuit-breaker.md`.

## Validation

- `npx vitest run` over `server/src/adapters/adapter-failure-reasons.test.ts` (10) and `server/src/services/heartbeat-stop-metadata.test.ts` (5): all pass.
- `server/src/__tests__/heartbeat-process-recovery.test.ts` and `issue-continuation-summary.test.ts`: all pass (no regression from the catch-path rewire).
- `pnpm --filter @paperclipai/server typecheck`: clean.

## Acceptance criteria

- [x] `classifyAdapterFailure` called at both heartbeat catch paths (inner + outer).
- [x] `adapterFailureReason` populated in adapter execution results (optional field) and in the persisted run resultJson.
- [x] `errorCode` unchanged as the operator/UI surface (claude_auth_required preserved).
- [x] Probe timeout maps to `adapter_probe_timeout`.
- [x] Stop-reason summarization does not collapse `adapter_quarantined` into `adapter_failed`.
- [x] `docs/specs/adapter-circuit-breaker.md` at v4.
- [x] Unit tests for missing-command, probe-timeout, HTTP error (plus ENOENT spawn, auth surface, fallback, quarantine constant).

Issue: CLI-156
Branch: `dayour/cli-156-cb-classify`