### PR TITLE
fix(issues): convert anchor.createdAt to ISO string in comment pagination

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2395,15 +2395,16 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        const anchorCreatedAt = anchor.createdAt.toISOString();
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }


### PR DESCRIPTION
## Summary

`GET /api/issues/:id/comments?after=<cursor>&order=asc` returned 500 for any paginated request.

**Root cause**: `listComments` cursor query embeds `anchor.createdAt` (a JS `Date` from the ORM) directly into a `sql\`\`` template. The `postgres@3` driver serialises parameters via `Buffer.byteLength()`, which rejects `Date` objects — only strings/Buffers are valid — causing a `TypeError: "string" arg must be string/Buffer; received Date`.

**Fix**: call `.toISOString()` before interpolation so the driver receives a plain string.

## Test

```bash
# Paginated comments endpoint now returns 200:
curl -s "http://localhost:3100/api/issues/<id>/comments?after=<cursor>&order=asc" | jq .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)