### PR TITLE
fix(ui): skip reassign auto-suggest when caller holds in-review stage

### DIFF
--- a/ui/src/lib/assignees.test.ts
+++ b/ui/src/lib/assignees.test.ts
@@ -89,4 +89,75 @@ describe("assignee selection helpers", () => {
       ),
     ).toBe("agent:agent-123");
   });
+
+  it("keeps the current assignee when the caller holds the in-review stage (user participant)", () => {
+    // Reproduces the board-approval trap: the policy engine rejects a reassign
+    // patch from the current participant without a stage decision, so the UI
+    // must not pre-seed a different assignee here.
+    expect(
+      suggestedCommentAssigneeValue(
+        {
+          assigneeUserId: "local-board",
+          status: "in_review",
+          executionState: {
+            currentParticipant: { type: "user", userId: "local-board", agentId: null },
+          },
+        },
+        [
+          { authorAgentId: "qa-agent" },
+          { authorAgentId: "backend-dev-agent" },
+        ],
+        "local-board",
+      ),
+    ).toBe("user:local-board");
+  });
+
+  it("keeps the current assignee when the caller holds the in-review stage (agent participant)", () => {
+    expect(
+      suggestedCommentAssigneeValue(
+        {
+          assigneeAgentId: "qa-agent",
+          status: "in_review",
+          executionState: {
+            currentParticipant: { type: "agent", userId: null, agentId: "qa-agent" },
+          },
+        },
+        [{ authorAgentId: "backend-dev-agent" }],
+        null,
+        "qa-agent",
+      ),
+    ).toBe("agent:qa-agent");
+  });
+
+  it("still suggests when in_review but the caller is not the current stage participant", () => {
+    expect(
+      suggestedCommentAssigneeValue(
+        {
+          assigneeUserId: "local-board",
+          status: "in_review",
+          executionState: {
+            currentParticipant: { type: "user", userId: "local-board", agentId: null },
+          },
+        },
+        [{ authorAgentId: "qa-agent" }],
+        "some-other-user",
+      ),
+    ).toBe("agent:qa-agent");
+  });
+
+  it("still suggests when the caller is currentParticipant but the issue is not in_review", () => {
+    expect(
+      suggestedCommentAssigneeValue(
+        {
+          assigneeUserId: "local-board",
+          status: "in_progress",
+          executionState: {
+            currentParticipant: { type: "user", userId: "local-board", agentId: null },
+          },
+        },
+        [{ authorAgentId: "qa-agent" }],
+        "local-board",
+      ),
+    ).toBe("agent:qa-agent");
+  });
 });

--- a/ui/src/lib/assignees.ts
+++ b/ui/src/lib/assignees.ts
@@ -9,9 +9,21 @@ export interface AssigneeOption {
   searchText?: string;
 }
 
+interface CommentAssigneeSuggestionParticipant {
+  type?: string | null;
+  userId?: string | null;
+  agentId?: string | null;
+}
+
+interface CommentAssigneeSuggestionExecutionState {
+  currentParticipant?: CommentAssigneeSuggestionParticipant | null;
+}
+
 interface CommentAssigneeSuggestionInput {
   assigneeAgentId?: string | null;
   assigneeUserId?: string | null;
+  status?: string | null;
+  executionState?: CommentAssigneeSuggestionExecutionState | null;
 }
 
 interface CommentAssigneeSuggestionComment {
@@ -25,12 +37,41 @@ export function assigneeValueFromSelection(selection: Partial<AssigneeSelection>
   return "";
 }
 
+function isCurrentStageParticipant(
+  participant: CommentAssigneeSuggestionParticipant | null | undefined,
+  currentUserId: string | null | undefined,
+  currentAgentId: string | null | undefined,
+): boolean {
+  if (!participant) return false;
+  if (participant.userId) {
+    return Boolean(currentUserId && participant.userId === currentUserId);
+  }
+  if (participant.agentId) {
+    return Boolean(currentAgentId && participant.agentId === currentAgentId);
+  }
+  return false;
+}
+
 export function suggestedCommentAssigneeValue(
   issue: CommentAssigneeSuggestionInput,
   comments: CommentAssigneeSuggestionComment[] | null | undefined,
   currentUserId: string | null | undefined,
   currentAgentId?: string | null | undefined,
 ): string {
+  // When the ticket is actively in review/approval AND the caller holds the
+  // current stage, skip the "last non-me commenter" hint. Auto-suggesting a
+  // different assignee here would make the composer silently send a reassign
+  // PATCH, which the execution-policy engine rejects with
+  // "Only the active reviewer or approver can advance the current execution
+  // stage" (see server/src/services/issue-execution-policy.ts).
+  // Non-participants opening the same ticket still get the normal suggestion.
+  if (
+    issue.status === "in_review" &&
+    isCurrentStageParticipant(issue.executionState?.currentParticipant, currentUserId, currentAgentId)
+  ) {
+    return assigneeValueFromSelection(issue);
+  }
+
   if (comments && comments.length > 0 && (currentUserId || currentAgentId)) {
     for (let i = comments.length - 1; i >= 0; i--) {
       const comment = comments[i];


### PR DESCRIPTION
## Thinking Path

> - Paperclip's issue comment flow has to preserve execution-stage integrity while still letting users leave plain comments during review.
> - The affected subsystem is the UI-side assignee suggestion logic that feeds the comment composer on issue detail screens.
> - The bug appeared when the current `in_review` stage participant opened the composer after someone else had commented most recently.
> - In that case the UI auto-seeded a reassignment target, which made a plain comment submit through the PATCH reassign path instead of the POST comment path.
> - The backend correctly rejected that PATCH because a stage participant cannot implicitly advance or reassign a governed review stage without an explicit decision.
> - This pull request fixes the mismatch in the UI layer so plain comments remain plain comments unless the user intentionally changes the assignee.
> - The benefit is that governed review stages keep their safety guarantees without surfacing a confusing 422 failure to legitimate commenters.

## What Changed

- Added an early-return guard in `ui/src/lib/assignees.ts` so `suggestedCommentAssigneeValue` keeps the current assignee when the caller is the active `in_review` stage participant.
- Extended the suggestion input shape to optionally read `status` and `executionState.currentParticipant`, keeping the change source-compatible with existing full-issue call sites.
- Added four focused unit tests in `ui/src/lib/assignees.test.ts` covering user participant, agent participant, non-participant, and non-`in_review` behavior.

## Verification

- `pnpm -w exec vitest run ui/src/lib ui/src/components/CommentThread`
- Manual: open a board-approval ticket where another actor commented last, submit a plain comment as the active stage participant, and confirm the comment posts without the 422 toast.
- This is a behavior-only UI fix with no visible layout change, so no before/after screenshots were added.

## Risks

- Low risk: the change only narrows auto-suggestion behavior for the active `in_review` stage participant and does not alter explicit reassignment.
- If current-participant detection ever drifts from the issue execution-state shape, the failure mode is conservative: the UI would skip a handoff suggestion rather than break stage integrity again.

> Checked `ROADMAP.md`; this is a targeted bug fix in existing issue-review UX, not overlapping planned core feature work.

## Model Used

- Anthropic Claude Code. The original authoring session recorded that Claude Code generated the change, but did not persist the exact underlying model ID/version. Tool-use coding assistant workflow with local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details available from the original authoring session)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect this change where needed
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
