### PR TITLE
feat(ui): add resizable properties panel with persisted width #4199

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -386,7 +386,7 @@ export function Layout() {
           >
             <BreadcrumbBar />
           </div>
-          <div className={cn(isMobile ? "block" : "flex flex-1 min-h-0")}>
+          <div className={cn(isMobile ? "block" : "flex flex-1 min-h-0 min-w-0")}>
             <main
               id="main-content"
               ref={mainContentRef}

--- a/ui/src/components/PropertiesPanel.tsx
+++ b/ui/src/components/PropertiesPanel.tsx
@@ -1,19 +1,77 @@
 import { X } from "lucide-react";
+import { useCallback, useRef } from "react";
 import { usePanel } from "../context/PanelContext";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
+const MIN_PANEL_WIDTH = 240;
+const MAX_PANEL_WIDTH = 600;
+
+function clampWidth(width: number): number {
+  return Math.max(MIN_PANEL_WIDTH, Math.min(MAX_PANEL_WIDTH, width));
+}
+
 export function PropertiesPanel() {
-  const { panelContent, panelVisible, setPanelVisible } = usePanel();
+  const { panelContent, panelVisible, panelWidth, setPanelVisible, setPanelWidth } = usePanel();
+  const asideRef = useRef<HTMLElement | null>(null);
 
   if (!panelContent) return null;
 
+  const handleResizeStart = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (!panelVisible) return;
+    event.preventDefault();
+
+    const aside = asideRef.current;
+    if (!aside) return;
+
+    const startX = event.clientX;
+    const startWidth = aside.getBoundingClientRect().width;
+    const previousTransition = aside.style.transition;
+    const previousUserSelect = document.body.style.userSelect;
+    const previousCursor = document.body.style.cursor;
+
+    aside.style.transition = "none";
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+
+    const updateWidth = (clientX: number) => {
+      const delta = startX - clientX;
+      const nextWidth = clampWidth(startWidth + delta);
+      aside.style.width = `${nextWidth}px`;
+      return nextWidth;
+    };
+
+    let finalWidth = startWidth;
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      finalWidth = updateWidth(moveEvent.clientX);
+    };
+
+    const onMouseUp = () => {
+      aside.style.transition = previousTransition;
+      document.body.style.userSelect = previousUserSelect;
+      document.body.style.cursor = previousCursor;
+      setPanelWidth(finalWidth);
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+  }, [panelVisible, setPanelWidth]);
+
   return (
     <aside
-      className="hidden md:flex border-l border-border bg-card flex-col shrink-0 overflow-hidden transition-[width,opacity] duration-200 ease-in-out h-full"
-      style={{ width: panelVisible ? 320 : 0, opacity: panelVisible ? 1 : 0 }}
+      ref={asideRef}
+      className="relative hidden md:flex border-l border-border bg-card flex-col shrink-0 overflow-hidden transition-[width,opacity] duration-200 ease-in-out h-full"
+      style={{ width: panelVisible ? panelWidth : 0, opacity: panelVisible ? 1 : 0 }}
     >
-      <div className="w-80 flex-1 flex flex-col min-w-[320px] min-h-0">
+      <div
+        className="absolute inset-y-0 left-0 w-1 cursor-col-resize hover:bg-border"
+        onMouseDown={handleResizeStart}
+        aria-hidden="true"
+      />
+      <div className="flex-1 flex flex-col min-w-0 min-h-0">
         <div className="flex items-center justify-between px-4 py-2 border-b border-border">
           <span className="text-sm font-medium">Properties</span>
           <Button variant="ghost" size="icon-xs" onClick={() => setPanelVisible(false)}>

--- a/ui/src/context/PanelContext.tsx
+++ b/ui/src/context/PanelContext.tsx
@@ -1,12 +1,22 @@
 import { createContext, useCallback, useContext, useState, type ReactNode } from "react";
 
 const STORAGE_KEY = "paperclip:panel-visible";
+const WIDTH_STORAGE_KEY = "paperclip:panel-width";
+const DEFAULT_PANEL_WIDTH = 320;
+const MIN_PANEL_WIDTH = 240;
+const MAX_PANEL_WIDTH = 600;
+
+function clampPanelWidth(width: number): number {
+  return Math.max(MIN_PANEL_WIDTH, Math.min(MAX_PANEL_WIDTH, width));
+}
 
 interface PanelContextValue {
   panelContent: ReactNode | null;
   panelVisible: boolean;
+  panelWidth: number;
   openPanel: (content: ReactNode) => void;
   closePanel: () => void;
+  setPanelWidth: (width: number) => void;
   setPanelVisible: (visible: boolean) => void;
   togglePanelVisible: () => void;
 }
@@ -30,9 +40,30 @@ function writePreference(visible: boolean) {
   }
 }
 
+function readPanelWidth(): number {
+  try {
+    const raw = localStorage.getItem(WIDTH_STORAGE_KEY);
+    if (raw === null) return DEFAULT_PANEL_WIDTH;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return DEFAULT_PANEL_WIDTH;
+    return clampPanelWidth(parsed);
+  } catch {
+    return DEFAULT_PANEL_WIDTH;
+  }
+}
+
+function writePanelWidth(width: number) {
+  try {
+    localStorage.setItem(WIDTH_STORAGE_KEY, String(width));
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
 export function PanelProvider({ children }: { children: ReactNode }) {
   const [panelContent, setPanelContent] = useState<ReactNode | null>(null);
   const [panelVisible, setPanelVisibleState] = useState(readPreference);
+  const [panelWidth, setPanelWidthState] = useState(readPanelWidth);
 
   const openPanel = useCallback((content: ReactNode) => {
     setPanelContent(content);
@@ -47,6 +78,12 @@ export function PanelProvider({ children }: { children: ReactNode }) {
     writePreference(visible);
   }, []);
 
+  const setPanelWidth = useCallback((width: number) => {
+    const clamped = clampPanelWidth(width);
+    setPanelWidthState(clamped);
+    writePanelWidth(clamped);
+  }, []);
+
   const togglePanelVisible = useCallback(() => {
     setPanelVisibleState((prev) => {
       const next = !prev;
@@ -57,7 +94,16 @@ export function PanelProvider({ children }: { children: ReactNode }) {
 
   return (
     <PanelContext.Provider
-      value={{ panelContent, panelVisible, openPanel, closePanel, setPanelVisible, togglePanelVisible }}
+      value={{
+        panelContent,
+        panelVisible,
+        panelWidth,
+        openPanel,
+        closePanel,
+        setPanelWidth,
+        setPanelVisible,
+        togglePanelVisible,
+      }}
     >
       {children}
     </PanelContext.Provider>


### PR DESCRIPTION
## Summary

Improve the usability of the Properties Panel by introducing a resizable and persistent panel width. This allows users to adjust the panel size while maintaining consistency across sessions.

### **Context / Motivation**

The Properties Panel currently has a fixed width (320px), which can be limiting for users working with different types of content or screen sizes.

Providing a resizable panel enhances flexibility and improves the overall user experience without impacting existing architecture or backend behavior.

### **Proposed Changes**

-  Add panelWidth state to manage panel size dynamically
-  Persist panel width in localStorage (paperclip:panel-width)
-  Enforce width bounds (240px – 600px, default 320px)
-   Replace hardcoded width with a dynamic, context-driven value
-   ntroduce a draggable resize handle for user interaction
-  Ensure smooth resizing behavior
-   Maintain existing panel animations and layout integrity

### **Expected Behavior**

-  Users can drag to resize the Properties Panel horizontally
-  Width is constrained within defined limits
-  Selected width persists after page reload
-   Panel behavior remains consistent when toggled (open/close)

### **Scope**

> -  UI/UX improvement only
> -  No changes to backend, APIs, or data models
> -  No new dependencies required

### **Acceptance Criteria**

- [ ] Panel can be resized smoothly via drag interaction
- [ ]  Width is clamped between 240px and 600px
- [ ]  Width persists across sessions
- [ ]  No layout breaking occurs during resize
- [ ]  Existing animations continue to work as expected

**Notes**
Implementation should follow existing UI state patterns (e.g., context usage)
Performance during drag interactions should remain smooth

**Related**
Closes #4199
