### PR TITLE
fix: stop leaking paperclip params to openclaw gateway

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,5 +1,22 @@
-import { describe, expect, it } from "vitest";
-import { resolveSessionKey } from "./execute.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import { execute, resolveSessionKey } from "./execute.js";
+
+const serversToClose: WebSocketServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    serversToClose.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((err) => {
+            if (err) reject(err);
+            else resolve();
+          });
+        }),
+    ),
+  );
+});
 
 describe("resolveSessionKey", () => {
   it("prefixes run-scoped session keys with the configured agent", () => {
@@ -48,5 +65,69 @@ describe("resolveSessionKey", () => {
         issueId: null,
       }),
     ).toBe("agent:meridian:paperclip");
+  });
+});
+
+describe("execute", () => {
+  it("does not send top-level paperclip metadata in outbound agent params", async () => {
+    const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    serversToClose.push(wss);
+    await new Promise<void>((resolve) => wss.once("listening", () => resolve()));
+    const address = wss.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected WebSocketServer to bind to an ephemeral TCP port");
+    }
+
+    let capturedAgentParams: Record<string, unknown> | null = null;
+
+    wss.on("connection", (socket) => {
+      socket.send(JSON.stringify({ type: "event", event: "connect.challenge", payload: { nonce: "nonce-123" } }));
+      socket.on("message", (raw) => {
+        const frame = JSON.parse(raw.toString("utf8")) as {
+          id: string;
+          method: string;
+          params?: Record<string, unknown>;
+        };
+
+        if (frame.method === "connect") {
+          socket.send(JSON.stringify({ type: "res", id: frame.id, ok: true, payload: { protocol: 3 } }));
+          return;
+        }
+
+        if (frame.method === "agent") {
+          capturedAgentParams = (frame.params ?? null) as Record<string, unknown> | null;
+          socket.send(
+            JSON.stringify({
+              type: "res",
+              id: frame.id,
+              ok: true,
+              payload: { status: "ok", runId: "run-123", result: { text: "done" }, meta: {} },
+            }),
+          );
+        }
+      });
+    });
+
+    const logs: string[] = [];
+    const result = await execute({
+      runId: "run-123",
+      agent: { id: "agent-1", companyId: "company-1", name: "Rook" },
+      config: {
+        url: `ws://127.0.0.1:${address.port}/`,
+        headers: { "x-openclaw-token": "token-1234567890123456" },
+        disableDeviceAuth: true,
+        paperclipApiUrl: "http://127.0.0.1:3100/",
+      },
+      context: {},
+      onLog: async (_stream: string, chunk: string) => {
+        logs.push(chunk);
+      },
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(logs.join("")).toContain("agent accepted");
+    expect(capturedAgentParams).toBeTruthy();
+    expect(capturedAgentParams).not.toHaveProperty("paperclip");
   });
 });

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1125,7 +1125,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
   const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
 
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
@@ -1134,7 +1133,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {


### PR DESCRIPTION
## Summary

This PR came out of a **local Luke/OpenClaw environment fix**, not a planned product change for Paperclip broadly.

In Luke's local setup, the OpenClaw gateway adapter was emitting a top-level `paperclip` field inside outbound `agent` params. That local OpenClaw runtime validates params strictly and rejected the request with:

- `invalid agent params: at root: unexpected property 'paperclip'`

The result was that a locally configured Paperclip-backed agent could not complete heartbeat/wakeup execution.

This PR simply lifts the already-proven **local hotfix** into source so the adapter no longer leaks that top-level field.

## What this is, and what it is not

**This is:**
- a narrow adapter-boundary cleanup
- derived from a real local compatibility failure in Luke's OpenClaw environment
- intended to document and preserve the exact fix that made that local setup work again

**This is not:**
- a claim that Paperclip core had a broad platform-wide product bug
- a new contract proposal for all runtimes
- a major architecture change

If maintainers do not want to carry local-runtime compatibility behavior in upstream Paperclip, that is completely fair. In that case, this PR should be treated as a documented local patch reference, not as something that must merge.

## Exact local failure context

- local Paperclip API base: `http://127.0.0.1:3100`
- local OpenClaw gateway: `ws://127.0.0.1:18789/`
- failing path used during validation:
  - `POST /api/agents/424642b2-968a-407d-9e18-9d072c8c1449/heartbeat/invoke`
- local failure before fix:
  - OpenClaw rejected the payload because of the top-level `paperclip` param
- local result after fix:
  - heartbeat path succeeded
  - agent recovered from `error` to `idle`

## What changed

- removed the top-level `agentParams.paperclip` field from the OpenClaw gateway adapter execution path
- added a regression test that captures outbound websocket `agent` params and asserts that `paperclip` is absent at the top level

## Why this may still be useful upstream

Even though the bug surfaced in one local setup, the fix is still intentionally small and conservative:
- OpenClaw was already rejecting the field
- the field was undocumented at that boundary
- removing it narrows the adapter payload to the contract the runtime actually accepts

So this may be a reasonable upstream cleanup, but the motivating context was **local compatibility**, not a broad Paperclip roadmap item.

## Verification performed locally

- focused regression test:
  - `npm exec vitest -- run --config /Users/lukesmacminim41/.openclaw/workspace/paperclip-openclaw-vitest.config.ts -t "does not send top-level paperclip metadata in outbound agent params"`
- rebuilt adapter dist
- rebuilt CLI npm bundle
- reinstalled rebuilt local runtime
- re-ran the real local heartbeat invoke path successfully

## Model / agent context

This patch was prepared via Luke's local agent workflow, with Nova/Hermes doing the implementation work inside Luke's environment.

## Maintainer guidance

If the Paperclip maintainers consider this too environment-specific for upstream, I’m happy for it to remain just a local fix reference. The goal here is clarity and preservation of the exact patch, not trying to smuggle in an unexplained platform change.
