### PR TITLE
feat: agent startup recovery, Hermes auth injection, dashboard filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ tests/release-smoke/test-results/
 tests/release-smoke/playwright-report/
 .superset/
 .claude/worktrees/
+.gstack/

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -2,9 +2,11 @@ export const type = "claude_local";
 export const label = "Claude Code (local)";
 
 export const models = [
+  { id: "opus", label: "Claude Opus (latest)" },
+  { id: "sonnet", label: "Claude Sonnet (latest)" },
+  { id: "haiku", label: "Claude Haiku (latest)" },
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
   { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-  { id: "claude-haiku-4-6", label: "Claude Haiku 4.6" },
   { id: "claude-sonnet-4-5-20250929", label: "Claude Sonnet 4.5" },
   { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
 ];

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import type { ServerAdapterModule } from "../adapters/index.js";
+
+const hermesExecuteMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+  })),
+);
+
+vi.mock("hermes-paperclip-adapter/server", () => ({
+  execute: hermesExecuteMock,
+  testEnvironment: async () => ({
+    adapterType: "hermes_local",
+    status: "pass",
+    checks: [],
+    testedAt: new Date(0).toISOString(),
+  }),
+  sessionCodec: null,
+  listSkills: async () => [],
+  syncSkills: async () => ({ entries: [] }),
+  detectModel: async () => null,
+}));
+
 import {
   detectAdapterModel,
   findActiveServerAdapter,
@@ -33,12 +56,14 @@ describe("server adapter registry", () => {
     unregisterServerAdapter("external_test");
     unregisterServerAdapter("claude_local");
     setOverridePaused("claude_local", false);
+    hermesExecuteMock.mockClear();
   });
 
   afterEach(() => {
     unregisterServerAdapter("external_test");
     unregisterServerAdapter("claude_local");
     setOverridePaused("claude_local", false);
+    hermesExecuteMock.mockClear();
   });
 
   it("registers external adapters and exposes them through lookup helpers", async () => {
@@ -139,5 +164,110 @@ describe("server adapter registry", () => {
     expect(await listAdapterModels("claude_local")).toEqual(builtIn?.models ?? []);
     expect(await detectAdapterModel("claude_local")).toBeNull();
     expect(detectModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("injects the local agent JWT and Paperclip run id into Hermes env", async () => {
+    const adapter = requireServerAdapter("hermes_local");
+
+    await adapter.execute({
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Hermes Agent",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {
+          env: {
+            OPENAI_API_KEY: "llm-token",
+          },
+          promptTemplate: "Existing prompt",
+        },
+      },
+      runtime: {},
+      config: {},
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "agent-run-jwt",
+    });
+
+    expect(hermesExecuteMock).toHaveBeenCalledTimes(1);
+    const [patchedCtx] = hermesExecuteMock.mock.calls[0];
+    expect(patchedCtx.agent.adapterConfig).toMatchObject({
+      env: {
+        OPENAI_API_KEY: "llm-token",
+        PAPERCLIP_API_KEY: "agent-run-jwt",
+        PAPERCLIP_RUN_ID: "run-123",
+      },
+    });
+    expect(patchedCtx.agent.adapterConfig.promptTemplate).toContain("Authorization: Bearer $PAPERCLIP_API_KEY");
+    expect(patchedCtx.agent.adapterConfig.promptTemplate).toContain("X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID");
+    expect(patchedCtx.agent.adapterConfig.promptTemplate).toContain("Existing prompt");
+  });
+
+  it("passes the original Hermes context through when authToken is absent", async () => {
+    const adapter = requireServerAdapter("hermes_local");
+    const ctx = {
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Hermes Agent",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {
+          env: {
+            PAPERCLIP_API_KEY: "server-level-key",
+          },
+          promptTemplate: "Existing prompt",
+        },
+      },
+      runtime: {},
+      config: {},
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+    };
+
+    await adapter.execute(ctx);
+
+    expect(hermesExecuteMock).toHaveBeenCalledTimes(1);
+    expect(hermesExecuteMock).toHaveBeenCalledWith(ctx);
+  });
+
+  it("preserves an explicit Hermes Paperclip API key and keeps the default prompt when none was configured", async () => {
+    const adapter = requireServerAdapter("hermes_local");
+
+    await adapter.execute({
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Hermes Agent",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {
+          env: {
+            PAPERCLIP_API_KEY: "explicit-agent-key",
+            PAPERCLIP_RUN_ID: "stale-run-id",
+          },
+        },
+      },
+      runtime: {},
+      config: {},
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "agent-run-jwt",
+    });
+
+    const [patchedCtx] = hermesExecuteMock.mock.calls[0];
+    expect(patchedCtx.agent.adapterConfig.env.PAPERCLIP_API_KEY).toBe("explicit-agent-key");
+    expect(patchedCtx.agent.adapterConfig.env.PAPERCLIP_RUN_ID).toBe("run-123");
+    expect(patchedCtx.agent.adapterConfig.promptTemplate).toBeUndefined();
   });
 });

--- a/server/src/__tests__/dashboard-service.test.ts
+++ b/server/src/__tests__/dashboard-service.test.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { agents, companies, createDb, issues } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { dashboardService } from "../services/dashboard.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres dashboard service tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("dashboardService.summary", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-dashboard-service-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("matches the default issue-list visibility rules for task counts", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Operator",
+      role: "general",
+      status: "idle",
+      adapterType: "opencode_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values([
+      {
+        id: randomUUID(),
+        companyId,
+        title: "Visible todo",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        title: "Visible in progress",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        title: "Visible blocked",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        title: "Visible done",
+        status: "done",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        title: "Hidden routine execution",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        originKind: "routine_execution",
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        title: "Hidden archived issue",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        hiddenAt: new Date(),
+      },
+    ]);
+
+    const summary = await dashboardService(db).summary(companyId);
+
+    expect(summary.tasks).toEqual({
+      open: 3,
+      inProgress: 1,
+      blocked: 1,
+      done: 1,
+    });
+  });
+});

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -180,9 +180,59 @@ const piLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: piAgentConfigurationDoc,
 };
 
+// hermes-paperclip-adapter predates the authToken field in the execution
+// context; cast is intentional until the adapter ships the updated type.
+const executeHermesLocal = hermesExecute as unknown as ServerAdapterModule["execute"];
+
 const hermesLocalAdapter: ServerAdapterModule = {
   type: "hermes_local",
-  execute: hermesExecute,
+  execute: async (ctx) => {
+    if (!ctx.authToken) return executeHermesLocal(ctx);
+
+    const existingConfig =
+      typeof ctx.agent.adapterConfig === "object" && ctx.agent.adapterConfig !== null
+        ? (ctx.agent.adapterConfig as Record<string, unknown>)
+        : {};
+    const existingEnv =
+      typeof existingConfig.env === "object" && existingConfig.env !== null && !Array.isArray(existingConfig.env)
+        ? (existingConfig.env as Record<string, string>)
+        : {};
+    const explicitApiKey =
+      typeof existingEnv.PAPERCLIP_API_KEY === "string" && existingEnv.PAPERCLIP_API_KEY.trim().length > 0;
+    const promptTemplate =
+      typeof existingConfig.promptTemplate === "string" && existingConfig.promptTemplate.trim().length > 0
+        ? existingConfig.promptTemplate
+        : "";
+    const authGuardPrompt = [
+      "Paperclip API safety rule:",
+      "Use Authorization: Bearer $PAPERCLIP_API_KEY on every Paperclip API request.",
+      "Use X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID on every Paperclip API request that writes or mutates data, including comments and issue updates.",
+      "Never use a board, browser, or local-board session for Paperclip API writes.",
+    ].join("\n");
+
+    const patchedConfig: Record<string, unknown> = {
+      ...existingConfig,
+      env: {
+        ...existingEnv,
+        ...(!explicitApiKey ? { PAPERCLIP_API_KEY: ctx.authToken } : {}),
+        PAPERCLIP_RUN_ID: ctx.runId,
+      },
+    };
+
+    // Only prepend the auth guard when the user already set a custom prompt.
+    // Otherwise Hermes should keep using its built-in default heartbeat prompt.
+    if (promptTemplate) {
+      patchedConfig.promptTemplate = `${authGuardPrompt}\n\n${promptTemplate}`;
+    }
+
+    return executeHermesLocal({
+      ...ctx,
+      agent: {
+        ...ctx.agent,
+        adapterConfig: patchedConfig,
+      },
+    });
+  },
   testEnvironment: hermesTestEnvironment,
   sessionCodec: hermesSessionCodec,
   listSkills: hermesListSkills,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -578,10 +578,21 @@ export async function startServer(): Promise<StartedServer> {
     const heartbeat = heartbeatService(db as any);
     const routines = routineService(db as any);
   
-    // Reap orphaned running runs at startup while in-memory execution state is empty,
-    // then resume any persisted queued runs that were waiting on the previous process.
+    // Recover stale runtime state at startup while in-memory execution state is empty:
+    // 1) reset agents stuck in "running" back to "idle"
+    // 2) reap orphaned run records
+    // 3) resume persisted queued runs that were waiting on the previous process
     void heartbeat
-      .reapOrphanedRuns()
+      .reconcileStaleRunningAgentsOnStartup()
+      .then((result) => {
+        if (result.reconciled > 0) {
+          logger.warn(
+            { reconciled: result.reconciled, agentIds: result.agentIds },
+            "startup reconciliation reset stale running agents to idle",
+          );
+        }
+      })
+      .then(() => heartbeat.reapOrphanedRuns())
       .then(() => heartbeat.resumeQueuedRuns())
       .catch((err) => {
         logger.error({ err }, "startup heartbeat recovery failed");

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, sql } from "drizzle-orm";
+import { and, eq, gte, isNull, ne, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, approvals, companies, costEvents, issues } from "@paperclipai/db";
 import { notFound } from "../errors.js";
@@ -25,7 +25,13 @@ export function dashboardService(db: Db) {
       const taskRows = await db
         .select({ status: issues.status, count: sql<number>`count(*)` })
         .from(issues)
-        .where(eq(issues.companyId, companyId))
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            ne(issues.originKind, "routine_execution"),
+            isNull(issues.hiddenAt),
+          ),
+        )
         .groupBy(issues.status);
 
       const pendingApprovals = await db

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2556,6 +2556,50 @@ export function heartbeatService(db: Db) {
     return { reaped: reaped.length, runIds: reaped };
   }
 
+  async function reconcileStaleRunningAgentsOnStartup() {
+    const staleAgents = await db
+      .select({
+        id: agents.id,
+        companyId: agents.companyId,
+      })
+      .from(agents)
+      .where(eq(agents.status, "running"));
+
+    if (staleAgents.length === 0) return { reconciled: 0, agentIds: [] as string[] };
+
+    const now = new Date();
+    const updatedAgents = await db
+      .update(agents)
+      .set({
+        status: "idle",
+        lastHeartbeatAt: now,
+        updatedAt: now,
+      })
+      .where(eq(agents.status, "running"))
+      .returning({
+        id: agents.id,
+        companyId: agents.companyId,
+      });
+
+    for (const agent of updatedAgents) {
+      publishLiveEvent({
+        companyId: agent.companyId,
+        type: "agent.status",
+        payload: {
+          agentId: agent.id,
+          status: "idle",
+          outcome: "startup_recovery",
+          lastHeartbeatAt: now.toISOString(),
+        },
+      });
+    }
+
+    return {
+      reconciled: updatedAgents.length,
+      agentIds: updatedAgents.map((agent) => agent.id),
+    };
+  }
+
   async function resumeQueuedRuns() {
     const queuedRuns = await db
       .select({ agentId: heartbeatRuns.agentId })
@@ -4621,6 +4665,8 @@ export function heartbeatService(db: Db) {
     reportRunActivity: clearDetachedRunWarning,
 
     reapOrphanedRuns,
+
+    reconcileStaleRunningAgentsOnStartup,
 
     resumeQueuedRuns,
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents run through various adapters (Claude, Codex, Hermes, etc.) and can be in different states
> - When the server restarts, agents previously marked as "running" may actually be stale (their process died)
> - Hermes agents need proper authentication to call Paperclip APIs, but the auth token wasn't being injected
> - Dashboard counts included routine execution issues and hidden issues, skewing the metrics
> - This pull request adds startup recovery for stale agents, injects auth tokens into Hermes environment,
>   filters dashboard counts to match issue-list visibility rules, and adds convenient model aliases
> - The benefit is more accurate agent state after restarts, working Hermes API authentication,
>   and dashboard counts that match what users see in the issue list

## What Changed

- **Heartbeat service**: Added `reconcileStaleRunningAgentsOnStartup()` that resets agents stuck in "running" status back to "idle" on server startup, with live event publishing
- **Server startup**: Integrated agent reconciliation into the startup sequence before `reapOrphanedRuns()`
- **Hermes adapter**: Patched `hermesLocalAdapter.execute` to:
  - Inject `PAPERCLIP_API_KEY` from the execution context's `authToken`
  - Inject `PAPERCLIP_RUN_ID` for request tracing
  - Add auth guard prompts when a custom prompt template is configured
  - Respect explicitly set API keys (doesn't override user-configured values)
- **Dashboard service**: Filtered out `routine_execution` origin issues and hidden issues (`hiddenAt`) from task counts to match issue-list visibility
- **Claude adapter**: Added generic `opus`, `sonnet`, `haiku` model aliases that always map to the latest versions
- **Tests**: Added comprehensive tests for adapter registry Hermes auth injection and dashboard service filtering

## Verification

```bash
# Run the new tests
pnpm vitest run server/src/__tests__/adapter-registry.test.ts
pnpm vitest run server/src/__tests__/dashboard-service.test.ts

# Run full typecheck
pnpm -r typecheck
```

Manual verification:
1. Start server with agents in "running" state → observe they reset to "idle"
2. Run a Hermes agent → verify `PAPERCLIP_API_KEY` and `PAPERCLIP_RUN_ID` are in env
3. Check dashboard → routine execution issues should not appear in counts

## Risks

- **Low**: Startup reconciliation could mask legitimate running agents if server restarts while agents are genuinely active. Mitigation: this only affects startup and agents will re-acquire running status on their next heartbeat.
- **Low**: Hermes auth injection changes adapter behavior for all Hermes agents. Mitigation: only activates when `authToken` is present (execution context), preserves explicit API keys, and keeps default prompts unchanged.
- **Low**: Dashboard filtering changes visible counts. Mitigation: aligns counts with issue-list visibility rules, which is the expected behavior.

## Model Used

Claude (Anthropic) — claude-opus-4-6, 1M context window, tool use enabled. Assisted with test writing, code review, and PR preparation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass (adapter registry tests pass; pre-existing network tests fail in this environment)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI changes)
- [ ] I have updated relevant documentation to reflect my changes (docs follow code)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge