### PR TITLE
feat(sdk): add state.list to PluginStateClient

### DIFF
--- a/packages/plugins/sdk/package.json
+++ b/packages/plugins/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/plugin-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Stable public API for Paperclip plugins — worker-side context and UI bridge hooks",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",
@@ -104,6 +104,7 @@
     "build": "pnpm --filter @paperclipai/shared build && tsc",
     "clean": "rm -rf dist",
     "typecheck": "pnpm --filter @paperclipai/shared build && tsc --noEmit",
+    "test": "vitest run --config ./vitest.config.ts",
     "dev:server": "tsx src/dev-cli.ts"
   },
   "dependencies": {
@@ -113,7 +114,8 @@
   "devDependencies": {
     "@types/node": "^24.6.0",
     "@types/react": "^19.0.8",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
   },
   "peerDependencies": {
     "react": ">=18"

--- a/packages/plugins/sdk/src/host-client-factory.ts
+++ b/packages/plugins/sdk/src/host-client-factory.ts
@@ -90,11 +90,12 @@ export interface HostServices {
     get(): Promise<Record<string, unknown>>;
   };
 
-  /** Provides `state.get`, `state.set`, `state.delete`. */
+  /** Provides `state.get`, `state.set`, `state.delete`, `state.list`. */
   state: {
     get(params: WorkerToHostMethods["state.get"][0]): Promise<WorkerToHostMethods["state.get"][1]>;
     set(params: WorkerToHostMethods["state.set"][0]): Promise<void>;
     delete(params: WorkerToHostMethods["state.delete"][0]): Promise<void>;
+    list(params: WorkerToHostMethods["state.list"][0]): Promise<WorkerToHostMethods["state.list"][1]>;
   };
 
   /** Provides restricted plugin database namespace methods. */
@@ -285,6 +286,7 @@ const METHOD_CAPABILITY_MAP: Record<WorkerToHostMethodName, PluginCapability | n
   "state.get": "plugin.state.read",
   "state.set": "plugin.state.write",
   "state.delete": "plugin.state.write",
+  "state.list": "plugin.state.read",
 
   "db.namespace": "database.namespace.read",
   "db.query": "database.namespace.read",
@@ -448,6 +450,9 @@ export function createHostClientHandlers(
     }),
     "state.delete": gated("state.delete", async (params) => {
       return services.state.delete(params);
+    }),
+    "state.list": gated("state.list", async (params) => {
+      return services.state.list(params);
     }),
 
     "db.namespace": gated("db.namespace", async (params) => {

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -579,6 +579,17 @@ export interface WorkerToHostMethods {
     params: { scopeKind: string; scopeId?: string; namespace?: string; stateKey: string },
     result: void,
   ];
+  "state.list": [
+    params: { scopeKind?: string; scopeId?: string; namespace?: string },
+    result: Array<{
+      scopeKind: string;
+      scopeId: string | null;
+      namespace: string;
+      stateKey: string;
+      value: unknown;
+      updatedAt: string;
+    }>,
+  ];
 
   // Restricted plugin database namespace
   "db.namespace": [

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -28,6 +28,8 @@ import type {
   PluginWorkspace,
   AgentSession,
   AgentSessionEvent,
+  ListStateFilter,
+  PluginStateEntry,
 } from "./types.js";
 import type {
   PluginEnvironmentValidateConfigParams,
@@ -414,7 +416,15 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
   const dbQueries: TestHarness["dbQueries"] = [];
   const dbExecutes: TestHarness["dbExecutes"] = [];
 
-  const state = new Map<string, unknown>();
+  interface StateEntry {
+    scopeKind: ScopeKey["scopeKind"];
+    scopeId: string | null;
+    namespace: string;
+    stateKey: string;
+    value: unknown;
+    updatedAt: string;
+  }
+  const state = new Map<string, StateEntry>();
   const entities = new Map<string, PluginEntityRecord>();
   const entityExternalIndex = new Map<string, string>();
   const companies = new Map<string, Company>();
@@ -547,15 +557,42 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
     state: {
       async get(input) {
         requireCapability(manifest, capabilitySet, "plugin.state.read");
-        return state.has(stateMapKey(input)) ? state.get(stateMapKey(input)) : null;
+        const entry = state.get(stateMapKey(input));
+        return entry ? entry.value : null;
       },
       async set(input, value) {
         requireCapability(manifest, capabilitySet, "plugin.state.write");
-        state.set(stateMapKey(input), value);
+        const normalized = normalizeScope(input);
+        state.set(stateMapKey(input), {
+          scopeKind: normalized.scopeKind,
+          scopeId: normalized.scopeId ?? null,
+          namespace: normalized.namespace ?? "default",
+          stateKey: normalized.stateKey,
+          value,
+          updatedAt: new Date().toISOString(),
+        });
       },
       async delete(input) {
         requireCapability(manifest, capabilitySet, "plugin.state.write");
         state.delete(stateMapKey(input));
+      },
+      async list(filter: ListStateFilter = {}): Promise<PluginStateEntry[]> {
+        requireCapability(manifest, capabilitySet, "plugin.state.read");
+        const out: PluginStateEntry[] = [];
+        for (const entry of state.values()) {
+          if (filter.scopeKind !== undefined && entry.scopeKind !== filter.scopeKind) continue;
+          if (filter.scopeId !== undefined && entry.scopeId !== filter.scopeId) continue;
+          if (filter.namespace !== undefined && entry.namespace !== filter.namespace) continue;
+          out.push({
+            scopeKind: entry.scopeKind,
+            scopeId: entry.scopeId,
+            namespace: entry.namespace,
+            stateKey: entry.stateKey,
+            value: entry.value,
+            updatedAt: entry.updatedAt,
+          });
+        }
+        return out;
       },
     },
     entities: {
@@ -1290,7 +1327,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       return await handler(params, ctxToPass) as T;
     },
     getState(input) {
-      return state.get(stateMapKey(input));
+      return state.get(stateMapKey(input))?.value;
     },
     simulateSessionEvent(sessionId, event) {
       const cb = sessionEventCallbacks.get(sessionId);

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -579,11 +579,26 @@ export interface PluginActivityClient {
  * await ctx.state.set({ scopeKind: "project", scopeId: projectId, namespace: "github", stateKey: "last-event" }, eventId);
  * ```
  *
- * `plugin.state.read` capability required for `get()`.
+ * `plugin.state.read` capability required for `get()` and `list()`.
  * `plugin.state.write` capability required for `set()` and `delete()`.
  *
  * @see PLUGIN_SPEC.md §21.3 `plugin_state`
  */
+export interface ListStateFilter {
+  scopeKind?: PluginStateScopeKind;
+  scopeId?: string;
+  namespace?: string;
+}
+
+export interface PluginStateEntry {
+  scopeKind: PluginStateScopeKind;
+  scopeId: string | null;
+  namespace: string;
+  stateKey: string;
+  value: unknown;
+  updatedAt: string;
+}
+
 export interface PluginStateClient {
   /**
    * Read a state value.
@@ -616,6 +631,25 @@ export interface PluginStateClient {
    * @param input - Scope key identifying the entry to delete
    */
   delete(input: ScopeKey): Promise<void>;
+
+  /**
+   * List all entries owned by this plugin matching the optional filter.
+   *
+   * Returns row-shaped entries (scope + key + value + `updatedAt`). Results
+   * are always scoped to the calling plugin's own rows — a plugin cannot
+   * enumerate state owned by other plugins.
+   *
+   * Intended for enumeration of bounded per-plugin state (startup
+   * reconciliation, TTL purge, metrics). Pagination is not provided in v1;
+   * plugins that need to enumerate large state should partition via
+   * `namespace` and filter per-namespace.
+   *
+   * Requires `plugin.state.read` capability.
+   *
+   * @param filter - Optional scope filters; omit for full enumeration
+   * @returns Array of matching entries (empty if none)
+   */
+  list(filter?: ListStateFilter): Promise<PluginStateEntry[]>;
 }
 
 /**

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -62,6 +62,8 @@ import type {
   ToolResult,
   EventFilter,
   AgentSessionEvent,
+  ListStateFilter,
+  PluginStateEntry,
 } from "./types.js";
 import type {
   JsonRpcId,
@@ -528,6 +530,15 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
             namespace: input.namespace,
             stateKey: input.stateKey,
           });
+        },
+
+        async list(filter: ListStateFilter = {}): Promise<PluginStateEntry[]> {
+          const rows = await callHost("state.list", {
+            scopeKind: filter.scopeKind,
+            scopeId: filter.scopeId,
+            namespace: filter.namespace,
+          });
+          return rows as PluginStateEntry[];
         },
       },
 

--- a/packages/plugins/sdk/tests/host-client-factory.spec.ts
+++ b/packages/plugins/sdk/tests/host-client-factory.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CapabilityDeniedError,
+  createHostClientHandlers,
+  type HostServices,
+} from "../src/host-client-factory.js";
+
+function stubServices(overrides: Partial<HostServices> = {}): HostServices {
+  const noop = async () => {
+    throw new Error("not stubbed");
+  };
+  const base = {
+    config: { get: noop },
+    state: { get: noop, set: noop, delete: noop, list: noop },
+    entities: { upsert: noop, list: noop },
+    events: { emit: noop, subscribe: noop },
+    http: { fetch: noop },
+    secrets: { resolve: noop },
+    activity: { log: noop },
+    metrics: { write: noop },
+    telemetry: { track: noop },
+    companies: { list: noop, get: noop },
+    projects: {
+      list: noop,
+      get: noop,
+      listWorkspaces: noop,
+      getPrimaryWorkspace: noop,
+      getWorkspaceForIssue: noop,
+    },
+    issues: {
+      list: noop,
+      get: noop,
+      create: noop,
+      update: noop,
+      listComments: noop,
+      createComment: noop,
+      documents: { list: noop, get: noop, upsert: noop, delete: noop },
+    },
+    agents: {
+      list: noop,
+      get: noop,
+      pause: noop,
+      resume: noop,
+      invoke: noop,
+      sessions: { create: noop, list: noop, sendMessage: noop, close: noop },
+    },
+    goals: { list: noop, get: noop, create: noop, update: noop },
+  } as unknown as HostServices;
+  return { ...base, ...overrides } as HostServices;
+}
+
+describe("host-client-factory state.list", () => {
+  it("delegates to services.state.list when capability is present", async () => {
+    const rows = [
+      {
+        scopeKind: "instance",
+        scopeId: null,
+        namespace: "default",
+        stateKey: "k1",
+        value: { hi: 1 },
+        updatedAt: "2026-04-23T00:00:00.000Z",
+      },
+    ];
+    const listSpy = vi.fn().mockResolvedValue(rows);
+    const services = stubServices({
+      state: {
+        get: vi.fn(),
+        set: vi.fn(),
+        delete: vi.fn(),
+        list: listSpy,
+      } as unknown as HostServices["state"],
+    });
+    const handlers = createHostClientHandlers({
+      pluginId: "test",
+      capabilities: ["plugin.state.read"],
+      services,
+    });
+
+    const result = await handlers["state.list"]({ scopeKind: "instance" });
+    expect(listSpy).toHaveBeenCalledWith({ scopeKind: "instance" });
+    expect(result).toEqual(rows);
+  });
+
+  it("throws CapabilityDeniedError without plugin.state.read", async () => {
+    const handlers = createHostClientHandlers({
+      pluginId: "test",
+      capabilities: ["plugin.state.write"],
+      services: stubServices(),
+    });
+
+    await expect(handlers["state.list"]({})).rejects.toBeInstanceOf(CapabilityDeniedError);
+  });
+});

--- a/packages/plugins/sdk/tests/testing.spec.ts
+++ b/packages/plugins/sdk/tests/testing.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import { createTestHarness } from "../src/testing.js";
+
+const baseManifest: PaperclipPluginManifestV1 = {
+  id: "test.state-list",
+  apiVersion: 1,
+  version: "0.1.0",
+  displayName: "State List Test",
+  description: "harness test",
+  author: "test",
+  categories: ["connector"],
+  capabilities: ["plugin.state.read", "plugin.state.write"],
+  entrypoints: { worker: "./worker.js" },
+};
+
+describe("state.list (test harness)", () => {
+  it("returns empty array when no entries exist", async () => {
+    const h = createTestHarness({ manifest: baseManifest });
+    expect(await h.ctx.state.list()).toEqual([]);
+  });
+
+  it("returns all plugin entries with row shape when no filter given", async () => {
+    const h = createTestHarness({ manifest: baseManifest });
+    await h.ctx.state.set({ scopeKind: "instance", stateKey: "a" }, { n: 1 });
+    await h.ctx.state.set({ scopeKind: "instance", stateKey: "b" }, { n: 2 });
+
+    const rows = await h.ctx.state.list();
+    expect(rows).toHaveLength(2);
+    const keys = rows.map((r) => r.stateKey).sort();
+    expect(keys).toEqual(["a", "b"]);
+    for (const r of rows) {
+      expect(r.scopeKind).toBe("instance");
+      expect(typeof r.updatedAt).toBe("string");
+      expect(new Date(r.updatedAt).toString()).not.toBe("Invalid Date");
+      expect(r.namespace).toBe("default");
+    }
+  });
+
+  it("filters by scopeKind", async () => {
+    const h = createTestHarness({ manifest: baseManifest });
+    await h.ctx.state.set({ scopeKind: "instance", stateKey: "k1" }, 1);
+    await h.ctx.state.set({ scopeKind: "company", scopeId: "c1", stateKey: "k2" }, 2);
+
+    const rows = await h.ctx.state.list({ scopeKind: "company" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].stateKey).toBe("k2");
+    expect(rows[0].scopeId).toBe("c1");
+  });
+
+  it("filters by scopeId", async () => {
+    const h = createTestHarness({ manifest: baseManifest });
+    await h.ctx.state.set({ scopeKind: "project", scopeId: "p1", stateKey: "k" }, 1);
+    await h.ctx.state.set({ scopeKind: "project", scopeId: "p2", stateKey: "k" }, 2);
+
+    const rows = await h.ctx.state.list({ scopeKind: "project", scopeId: "p2" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].value).toBe(2);
+  });
+
+  it("filters by namespace", async () => {
+    const h = createTestHarness({ manifest: baseManifest });
+    await h.ctx.state.set({ scopeKind: "instance", namespace: "sessions", stateKey: "k1" }, 1);
+    await h.ctx.state.set({ scopeKind: "instance", namespace: "cursors", stateKey: "k2" }, 2);
+
+    const rows = await h.ctx.state.list({ namespace: "sessions" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].stateKey).toBe("k1");
+  });
+
+  it("reflects delete in subsequent list", async () => {
+    const h = createTestHarness({ manifest: baseManifest });
+    await h.ctx.state.set({ scopeKind: "instance", stateKey: "a" }, 1);
+    await h.ctx.state.set({ scopeKind: "instance", stateKey: "b" }, 2);
+    await h.ctx.state.delete({ scopeKind: "instance", stateKey: "a" });
+
+    const rows = await h.ctx.state.list();
+    expect(rows.map((r) => r.stateKey)).toEqual(["b"]);
+  });
+
+  it("refreshes updatedAt when set() overwrites an existing key", async () => {
+    const h = createTestHarness({ manifest: baseManifest });
+    await h.ctx.state.set({ scopeKind: "instance", stateKey: "k" }, 1);
+    const [first] = await h.ctx.state.list();
+    await new Promise((r) => setTimeout(r, 2));
+    await h.ctx.state.set({ scopeKind: "instance", stateKey: "k" }, 2);
+    const [second] = await h.ctx.state.list();
+    expect(second.value).toBe(2);
+    expect(Date.parse(second.updatedAt)).toBeGreaterThanOrEqual(Date.parse(first.updatedAt));
+  });
+
+  it("denies list without plugin.state.read capability", async () => {
+    const h = createTestHarness({
+      manifest: baseManifest,
+      capabilities: ["plugin.state.write"],
+    });
+    await expect(h.ctx.state.list()).rejects.toThrow(/plugin\.state\.read/);
+  });
+});

--- a/packages/plugins/sdk/vitest.config.ts
+++ b/packages/plugins/sdk/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+  },
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",
   "bugs": {

--- a/server/src/adapters/plugin-loader.ts
+++ b/server/src/adapters/plugin-loader.ts
@@ -11,6 +11,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { ServerAdapterModule } from "./types.js";
 import { logger } from "../middleware/logger.js";
 
@@ -177,7 +178,7 @@ export async function loadExternalAdapterPackage(
 
   logger.info({ packageName, packageDir, entryPoint, modulePath, hasUiParser: !!uiParserSource }, "Loading external adapter package");
 
-  const mod = await import(modulePath);
+  const mod = await import(pathToFileURL(modulePath).href);
   const adapterModule = validateAdapterModule(mod, packageName);
 
   if (uiParserSource) {
@@ -212,7 +213,7 @@ export async function reloadExternalAdapter(
   const packageDir = resolvePackageDir(record);
   const entryPoint = resolvePackageEntryPoint(packageDir);
   const modulePath = path.resolve(packageDir, entryPoint);
-  const fileUrl = `file://${modulePath}`;
+  const fileUrl = pathToFileURL(modulePath).href;
 
   // Bust ESM module cache so re-import loads fresh code from disk.
   // Query-string trick (?t=...) works in Node; Bun may need the file:// URL

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -774,6 +774,21 @@ export function buildHostServices(
           namespace: params.namespace,
         });
       },
+      async list(params) {
+        const rows = await stateStore.list(pluginId, {
+          scopeKind: params.scopeKind as any,
+          scopeId: params.scopeId,
+          namespace: params.namespace,
+        });
+        return rows.map((r) => ({
+          scopeKind: r.scopeKind,
+          scopeId: r.scopeId,
+          namespace: r.namespace,
+          stateKey: r.stateKey,
+          value: r.valueJson,
+          updatedAt: r.updatedAt instanceof Date ? r.updatedAt.toISOString() : String(r.updatedAt),
+        }));
+      },
     },
 
     db: {

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -29,7 +29,7 @@ import { readdir, readFile, rm, stat } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import type { Db } from "@paperclipai/db";
 import type {
@@ -932,7 +932,7 @@ export function pluginLoader(
 
     try {
       // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests
-      const mod = await import(manifestPath) as Record<string, unknown>;
+      const mod = await import(pathToFileURL(manifestPath).href) as Record<string, unknown>;
       // The manifest may be the default export or the module itself
       raw = mod["default"] ?? mod;
     } catch (err) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       "packages/adapters/gemini-local",
       "packages/adapters/opencode-local",
       "packages/adapters/pi-local",
+      "packages/plugins/sdk",
       "server",
       "ui",
       "cli",


### PR DESCRIPTION
# Draft upstream PR — `feat(sdk): add state.list to PluginStateClient`

*Target repo: `paperclipai/paperclip`. Branch: `feat/sdk-state-list` (locally in `H:\Projects\paperclip`, based on `fix/windows-plugin-import-urls` at `d466aa3d`). Not yet pushed — William to decide when.*

## Title

`feat(sdk): add state.list to PluginStateClient`

## Summary

Completes the CRUD surface for plugin-scoped key-value state by adding
`state.list(filter)` to `@paperclipai/plugin-sdk`. `get` / `set` / `delete`
have shipped in the SDK since 1.0; `list` has existed on the host
(`server/src/services/plugin-state-store.ts:202`) since the same day but
was never exposed to plugin workers. The `plugin.state.list` capability
is already registered
(`server/src/services/plugin-capability-validator.ts:75`), and
`listPluginStateSchema` is already exported from `@paperclipai/shared`.

This PR fills in the four missing SDK-layer shims plus the one-line
server adapter that connects them — all purely additive, ~60 LOC net
(plus ~200 LOC of tests).

## Motivation — ACP plugin row accumulation

`paperclip-plugin-acp` writes one row per session to `plugin_state`
(`scopeKind=instance`, `stateKey=acp-session:<id>`) and has no way to
garbage-collect. A reaper loop ships in the plugin already (idle +
max-age, see `session-manager.js:43` and worker-side reaper interval),
but it can only act on sessions whose child processes are still tracked
in-memory. After a paperclip restart, the in-memory set is empty —
"orphaned" session rows whose subprocesses died while paperclip was off
cannot be marked `closed` because the plugin cannot enumerate them.

Concretely, A2 (TTL purge) and A3 (startup reconciliation) in the ACP
known-issues register (`tools/docs/diagnostics/acp-known-issues-2026-04-20.md`)
are both blocked on this gap, and the "no new pg pool" constraint rules
out the obvious workaround of the plugin opening its own DB connection.

More generally, any plugin that writes per-entity rows (per-issue
idempotency keys, per-run checkpoints, per-session metadata) currently
leaks rows forever. Common patterns blocked without `list`:

- Startup reconciliation ("mark dead sessions closed")
- TTL purge ("delete closed rows older than N days")
- Health / metrics reporting ("how many session rows am I holding")
- Data export on uninstall

## API surface

| Layer | Symbol | Status before | Change |
|---|---|---|---|
| `@paperclipai/shared` | `listPluginStateSchema`, `ListPluginState` | exported | no change |
| `server/src/services/plugin-state-store.ts` | `pluginStateStore().list()` | implemented | no change |
| `server/src/services/plugin-capability-validator.ts` | `plugin.state.list` capability | registered | no change |
| `packages/plugins/sdk/src/types.ts` | `PluginStateClient.list(filter)` | missing | **added** (+ `ListStateFilter`, `PluginStateEntry`) |
| `packages/plugins/sdk/src/protocol.ts` | `WorkerToHostMethods["state.list"]` | missing | **added** |
| `packages/plugins/sdk/src/host-client-factory.ts` | capability map + gated handler | missing | **added** (requires `plugin.state.read`) |
| `packages/plugins/sdk/src/worker-rpc-host.ts` | worker-side `state.list` client | missing | **added** |
| `packages/plugins/sdk/src/testing.ts` | in-memory `state.list` + per-entry metadata | missing | **added** |
| `server/src/services/plugin-host-services.ts` | `buildHostServices.state.list` adapter | missing | **added** (10-line row→wire mapper) |

### Return shape

```ts
export interface ListStateFilter {
  scopeKind?: PluginStateScopeKind;
  scopeId?: string;
  namespace?: string;
}

export interface PluginStateEntry {
  scopeKind: PluginStateScopeKind;
  scopeId: string | null;
  namespace: string;
  stateKey: string;
  value: unknown;
  updatedAt: string; // ISO 8601
}

// On PluginStateClient:
list(filter?: ListStateFilter): Promise<PluginStateEntry[]>;
```

Design choices (documented in
`H:\Projects\tools\docs\designs\2026-04-23-plugin-state-enumeration.md`):

- **Row shape, not map.** A2 needs `updatedAt` for TTL eviction; A3 needs
  `stateKey` for iteration. A `{ key → value }` map forecloses both.
- **No pagination in v1.** `plugin_state` is intended for bounded
  per-plugin data; large enumerations should partition via `namespace`.
  Pagination can be added later non-breakingly (`{ limit, offset }`).
- **No `stateKeyPrefix` filter.** The `namespace` field already provides
  the idiomatic prefix mechanism.
- **Plugin-scoped by construction.** `pluginStateStore.list()` pins
  `eq(pluginState.pluginId, pluginId)` unconditionally — a plugin cannot
  enumerate another plugin's rows.

## Backwards compatibility

**Non-breaking, purely additive.**

- SDK `1.0.0` → `1.1.0`. Consumers on `1.0.x` compile and run unchanged.
- Server `0.3.1` → `0.3.2`. No schema migration. No capability migration
  (capability was pre-registered).
- Plugin manifests may opt in by declaring `plugin.state.read` in
  `capabilities` (same capability already required for `state.get`).
- `testing.ts` internally changed the `state` Map value shape from bare
  value → `{ scope, value, updatedAt }`. Public harness contract is
  unchanged: `harness.getState(input)` still returns the value only.

## Test evidence

Run: `pnpm --filter @paperclipai/plugin-sdk test`

```
 ✓ tests/host-client-factory.spec.ts  (2 tests) 10ms
 ✓ tests/testing.spec.ts              (8 tests) 15ms

 Test Files  2 passed (2)
      Tests  10 passed (10)
   Duration  652ms
```

Typecheck: `pnpm --filter @paperclipai/plugin-sdk typecheck` — clean.
Server typecheck: `pnpm --filter @paperclipai/server typecheck` — clean.
Existing `plugin-authoring-smoke-example` test — unchanged, still passes
(regression check on the harness state-map refactor).

### Coverage

- `testing.spec.ts` — filter matrix (no filter, `scopeKind`, `scopeId`,
  `namespace`), empty-result case, delete-then-list reflection,
  `updatedAt` refresh on `set()` overwrite, capability denial without
  `plugin.state.read`.
- `host-client-factory.spec.ts` — `state.list` handler delegates to
  `services.state.list` with params; `CapabilityDeniedError` thrown
  when plugin is missing `plugin.state.read`.

## Follow-ups (not in this PR)

- `{ limit, offset }` pagination if a real plugin hits a ceiling.
- `stateKeyPrefix` filter if the `namespace` idiom proves insufficient.
- An end-to-end integration test that exercises the full worker-RPC
  boundary (current SDK tests cover the factory and the in-memory
  harness; the wire roundtrip is implicitly tested by the existing
  worker-manager suite).

## Commits

- `b3f958e0` — `feat(sdk): add state.list to PluginStateClient`
- `ced1568e` — `feat(server): wire state.list through buildHostServices`
