### PR TITLE
fix(adapters/process): inject authToken as PAPERCLIP_API_KEY

### DIFF
--- a/server/src/__tests__/process-adapter-authtoken.test.ts
+++ b/server/src/__tests__/process-adapter-authtoken.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "../adapters/process/execute.js";
+
+async function writeCapturingCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const payload = {
+  PAPERCLIP_API_KEY: process.env.PAPERCLIP_API_KEY ?? null,
+  PAPERCLIP_API_URL: process.env.PAPERCLIP_API_URL ?? null,
+  PAPERCLIP_AGENT_ID: process.env.PAPERCLIP_AGENT_ID ?? null,
+};
+fs.writeFileSync(process.env.PAPERCLIP_TEST_CAPTURE_PATH, JSON.stringify(payload), "utf8");
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+async function runProcessAdapter(opts: {
+  workspace: string;
+  commandPath: string;
+  capturePath: string;
+  authToken?: string;
+  userEnv?: Record<string, string>;
+}) {
+  return execute({
+    runId: `run-${Date.now()}`,
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Process Worker",
+      adapterType: "process",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: opts.commandPath,
+      cwd: opts.workspace,
+      env: {
+        PAPERCLIP_TEST_CAPTURE_PATH: opts.capturePath,
+        ...(opts.userEnv ?? {}),
+      },
+    },
+    context: {},
+    authToken: opts.authToken,
+    onLog: async () => {},
+  });
+}
+
+describe("process adapter authToken injection", () => {
+  it("injects authToken as PAPERCLIP_API_KEY when user has not set one", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-authtoken-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "agent");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeCapturingCommand(commandPath);
+
+    try {
+      const result = await runProcessAdapter({
+        workspace,
+        commandPath,
+        capturePath,
+        authToken: "run-jwt-token",
+      });
+
+      expect(result.exitCode).toBe(0);
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as Record<string, string | null>;
+      expect(capture.PAPERCLIP_API_KEY).toBe("run-jwt-token");
+      expect(capture.PAPERCLIP_AGENT_ID).toBe("agent-1");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("respects a user-provided PAPERCLIP_API_KEY and does not overwrite with authToken", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-authtoken-override-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "agent");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeCapturingCommand(commandPath);
+
+    try {
+      const result = await runProcessAdapter({
+        workspace,
+        commandPath,
+        capturePath,
+        authToken: "run-jwt-token",
+        userEnv: { PAPERCLIP_API_KEY: "user-provided-key" },
+      });
+
+      expect(result.exitCode).toBe(0);
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as Record<string, string | null>;
+      expect(capture.PAPERCLIP_API_KEY).toBe("user-provided-key");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves PAPERCLIP_API_KEY unset when no authToken is available and user did not set one", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-authtoken-absent-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "agent");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeCapturingCommand(commandPath);
+
+    try {
+      const result = await runProcessAdapter({
+        workspace,
+        commandPath,
+        capturePath,
+      });
+
+      expect(result.exitCode).toBe(0);
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as Record<string, string | null>;
+      expect(capture.PAPERCLIP_API_KEY).toBeNull();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -12,7 +12,7 @@ import {
 } from "../utils.js";
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { runId, agent, config, onLog, onMeta } = ctx;
+  const { runId, agent, config, onLog, onMeta, authToken } = ctx;
   const command = asString(config.command, "");
   if (!command) throw new Error("Process adapter missing command");
 
@@ -22,6 +22,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;
+  }
+  if (authToken && !env.PAPERCLIP_API_KEY) {
+    env.PAPERCLIP_API_KEY = authToken;
   }
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
   const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The adapter layer is how paperclip hands off work to a specific agent runtime (Claude Code, Cursor, Codex, Cline, arbitrary subprocesses, etc.)
> - Every local adapter is expected to inject the run's authToken into the spawned process as \`PAPERCLIP_API_KEY\`, so the agent can call back into the Paperclip API for issue state, skills, comments, etc.
> - The \`process\` adapter is the only local adapter that doesn't do this. claude-local, codex-local, cursor-local, gemini-local, opencode-local, and qwen-local (in #1490) all set \`env.PAPERCLIP_API_KEY = authToken\`. \`process\` adapter silently drops it.
> - Any subprocess dispatched through \`process\` that tries to authenticate back to Paperclip gets a 401. That breaks the adapter's usefulness for anything beyond fire-and-forget shell commands.
> - This PR injects the authToken matching the established convention — only when the user has not explicitly configured a \`PAPERCLIP_API_KEY\` in the adapter's env config.

## What Changed

- \`server/src/adapters/process/execute.ts\`: destructure \`authToken\` from the execution context and set \`env.PAPERCLIP_API_KEY = authToken\` when the user has not already set it in \`config.env\`. Three lines of real change (one-line conditional + destructure + formatting).
- \`server/src/__tests__/process-adapter-authtoken.test.ts\`: three tests covering the three cases — authToken injected when user key is absent, user key preserved when both are present, and \`PAPERCLIP_API_KEY\` absent when neither source provides one.

## Verification

```
# from repo root
pnpm install --frozen-lockfile
pnpm run typecheck    # all 21 workspace projects pass
pnpm test             # 328 test files, 1876 passed + 1 skipped, 0 failed (36s)
```

Targeted test run:
```
cd server && pnpm exec vitest run src/__tests__/process-adapter-authtoken.test.ts
# 3 passed
```

## Risks

- **Low behavioral risk.** The change only adds an env var when one is missing; it never overwrites a user-provided value. Existing \`process\` adapter users who don't rely on \`PAPERCLIP_API_KEY\` see no difference. Users who do rely on it (if any) keep their explicit override.
- **Possible surprise**: subprocesses that previously got a stray \`PAPERCLIP_API_KEY\` from the ambient \`process.env\` of the Paperclip server (inherited via \`ensurePathInEnv({ ...process.env, ...env })\` downstream) would now receive the run's authToken instead. This is almost certainly the intent — the run-scoped token is the right identity for callbacks — but worth calling out.

## Model Used

- **Provider**: Anthropic
- **Model**: Claude Opus 4.7
- **Exact model ID**: \`claude-opus-4-7\` (1M-context variant: \`claude-opus-4-7[1m]\`)
- **Context window**: 1,000,000 tokens
- **Harness**: Claude Code (Anthropic's official CLI), orchestrated by @superbiche as human-in-the-loop. Full file-editing, shell, and \`gh\` tool use.
- **Authoring split**: @superbiche identified the gap (while investigating whether \`process\` adapter could wrap custom agent harnesses without requiring per-brick adapter PRs in Paperclip) and directed the fix; Opus 4.7 executed the patch, authored the tests, and drafted this PR body under review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (convention-aligned adapter fix, not net-new feature)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (3 new tests)
- [x] If this change affects the UI, I have included before/after screenshots (no UI touched)
- [x] I have updated relevant documentation to reflect my changes (the \`agentConfigurationDoc\` in \`process/index.ts\` already mentions env injection — no change needed; PAPERCLIP_API_KEY was already the documented convention)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge