### PR TITLE
[codex] Harden heartbeat route-suite isolation

### DIFF
--- a/cli/src/__tests__/network-bind.test.ts
+++ b/cli/src/__tests__/network-bind.test.ts
@@ -1,8 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveRuntimeBind, validateConfiguredBindMode } from "@paperclipai/shared";
 import { buildPresetServerConfig } from "../config/server-bind.js";
 
+const ORIGINAL_ENV = { ...process.env };
+
 describe("network bind helpers", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
   it("rejects non-loopback bind modes in local_trusted", () => {
     expect(
       validateConfiguredBindMode({
@@ -50,6 +60,7 @@ describe("network bind helpers", () => {
 
   it("falls back to loopback when no tailscale address is available for tailnet presets", () => {
     delete process.env.PAPERCLIP_TAILNET_BIND_HOST;
+    process.env.PAPERCLIP_DISABLE_TAILSCALE_DETECT = "1";
 
     const preset = buildPresetServerConfig("tailnet", {
       port: 3100,

--- a/cli/src/__tests__/onboard.test.ts
+++ b/cli/src/__tests__/onboard.test.ts
@@ -141,6 +141,7 @@ describe("onboard", () => {
   it("keeps tailnet quickstart on loopback until tailscale is available", async () => {
     const configPath = createFreshConfigPath();
     delete process.env.PAPERCLIP_TAILNET_BIND_HOST;
+    process.env.PAPERCLIP_DISABLE_TAILSCALE_DETECT = "1";
 
     await onboard({ config: configPath, yes: true, invokedByRun: true, bind: "tailnet" });
 

--- a/cli/src/config/server-bind.ts
+++ b/cli/src/config/server-bind.ts
@@ -12,6 +12,7 @@ import {
 import type { AuthConfig, ServerConfig } from "./schema.js";
 
 const TAILSCALE_DETECT_TIMEOUT_MS = 3000;
+const TAILSCALE_DETECT_DISABLE_VALUES = new Set(["1", "true", "yes"]);
 
 type BaseServerInput = {
   port: number;
@@ -27,6 +28,8 @@ export function inferConfiguredBind(server?: Partial<ServerConfig>): BindMode {
 export function detectTailnetBindHost(): string | undefined {
   const explicit = process.env.PAPERCLIP_TAILNET_BIND_HOST?.trim();
   if (explicit) return explicit;
+  const detectDisabled = process.env.PAPERCLIP_DISABLE_TAILSCALE_DETECT?.trim().toLowerCase();
+  if (detectDisabled && TAILSCALE_DETECT_DISABLE_VALUES.has(detectDisabled)) return undefined;
 
   try {
     const stdout = execFileSync("tailscale", ["ip", "-4"], {

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -104,6 +104,14 @@ pnpm test
 pnpm test:watch
 ```
 
+The default `pnpm test:run` runner strips inherited `PAPERCLIP_*` runtime
+environment variables and gives each Vitest child process an isolated home
+directory. It also builds dist-exported local workspace packages when their
+compiled output is missing. Server tests that use module mocks or process-global
+test hooks run in isolated Vitest processes. This keeps heartbeat/runtime state,
+fresh-checkout build artifacts, and route test globals from leaking when the
+suite is run by a Paperclip agent.
+
 Browser suites stay separate:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typecheck": "pnpm run preflight:workspace-links && pnpm -r typecheck",
     "test": "pnpm run test:run",
     "test:watch": "pnpm run preflight:workspace-links && vitest",
-    "test:run": "pnpm run preflight:workspace-links && vitest run",
+    "test:run": "pnpm run preflight:workspace-links && node scripts/run-tests.mjs",
     "db:generate": "pnpm --filter @paperclipai/db generate",
     "db:migrate": "pnpm --filter @paperclipai/db migrate",
     "issue-references:backfill": "pnpm run preflight:workspace-links && tsx scripts/backfill-issue-reference-mentions.ts",

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -483,7 +483,8 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
   const retention = opts.retention;
   const connectTimeout = Math.max(1, Math.trunc(opts.connectTimeoutSeconds ?? 5));
   const backupEngine = opts.backupEngine ?? "auto";
-  const canUsePgDump = !hasBackupTransforms(opts);
+  const hasTransforms = hasBackupTransforms(opts);
+  const canUsePgDump = !hasTransforms;
   const includeMigrationJournal = opts.includeMigrationJournal === true;
   const excludedTableNames = normalizeTableNameSet(opts.excludeTables);
   const nullifiedColumnsByTable = normalizeNullifyColumnMap(opts.nullifyColumns);
@@ -861,7 +862,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
       emit(`-- Data for: ${schema_name}.${tablename} (${count[0]!.n} rows)`);
 
       const nullifiedColumns = nullifiedColumnsByTable.get(tablename) ?? new Set<string>();
-      if (backupEngine !== "javascript" && nullifiedColumns.size === 0) {
+      if (backupEngine !== "javascript" && !hasTransforms && nullifiedColumns.size === 0) {
         emit(`COPY ${qualifiedTableName} (${colNames}) FROM stdin;`);
         await writer.writeRaw("\n");
         const copySql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const vitestBin = join(
+  repoRoot,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "vitest.cmd" : "vitest",
+);
+const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const cliArgs = process.argv.slice(2).filter((arg) => arg !== "--");
+const testFilePattern = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
+const moduleMockPattern =
+  /\bvi\.(?:doMock|mock|hoisted|stub(?:Env|Global)?|unstub(?:AllEnvs|AllGlobals)?|resetModules|unmock|doUnmock)\b/;
+const globalTestHookPattern = /\bset[A-Za-z0-9_]+ForTest\(/;
+const pluginSdkEntry = join(repoRoot, "packages", "plugins", "sdk", "dist", "index.js");
+
+function walkFiles(dirPath) {
+  const files = [];
+  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+    const entryPath = join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(entryPath));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+function discoverServerMockTests() {
+  const serverTestsDir = join(repoRoot, "server", "src", "__tests__");
+  if (!existsSync(serverTestsDir)) return [];
+
+  return walkFiles(serverTestsDir)
+    .filter((filePath) => testFilePattern.test(filePath))
+    .filter((filePath) => {
+      const source = readFileSync(filePath, "utf8");
+      return moduleMockPattern.test(source) || globalTestHookPattern.test(source);
+    })
+    .map((filePath) => relative(repoRoot, filePath))
+    .sort();
+}
+
+function isLikelyTestFilter(arg) {
+  if (arg.startsWith("-")) return false;
+  const normalized = arg.replace(/\\/g, "/");
+  return testFilePattern.test(normalized) || normalized.includes("/") || normalized.startsWith(".");
+}
+
+function normalizeFilterPath(arg) {
+  return arg
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "")
+    .replace(/^server\//, "");
+}
+
+function testFilterMatchesFile(filter, filePath) {
+  const normalizedFilter = normalizeFilterPath(filter);
+  const normalizedFile = filePath.replace(/\\/g, "/");
+  const serverRelativeFile = normalizedFile.replace(/^server\//, "");
+  return (
+    normalizedFile === normalizedFilter ||
+    serverRelativeFile === normalizedFilter ||
+    normalizedFile.endsWith(`/${normalizedFilter}`) ||
+    serverRelativeFile.endsWith(`/${normalizedFilter}`) ||
+    normalizedFilter.endsWith(`/${normalizedFile}`) ||
+    normalizedFilter.endsWith(`/${serverRelativeFile}`)
+  );
+}
+
+function excludeArgsFor(filePath) {
+  const serverRelativePath = filePath.replace(/^server\//, "");
+  return ["--exclude", filePath, "--exclude", serverRelativePath];
+}
+
+function runVitest(label, args, options = {}) {
+  console.log(`\n[paperclip:test] ${label}`);
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("PAPERCLIP_")) {
+      delete env[key];
+    }
+  }
+  const isolatedHome = mkdtempSync(join(tmpdir(), "paperclip-vitest-home-"));
+  env.HOME = isolatedHome;
+  env.USERPROFILE = isolatedHome;
+  const result = spawnSync(vitestBin, [
+    "run",
+    ...(options.noCache ? ["--no-cache"] : []),
+    "--reporter=dot",
+    ...args,
+  ], {
+    cwd: repoRoot,
+    env,
+    stdio: "inherit",
+  });
+  rmSync(isolatedHome, { recursive: true, force: true });
+
+  if (result.error) {
+    console.error(`[paperclip:test] Failed to start Vitest: ${result.error.message}`);
+    return 1;
+  }
+
+  return result.status ?? 1;
+}
+
+function ensureDistOnlyWorkspaceBuilds() {
+  if (existsSync(pluginSdkEntry)) return;
+
+  console.log("\n[paperclip:test] Building @paperclipai/plugin-sdk because its workspace export points at dist/.");
+  const result = spawnSync(pnpmBin, ["--filter", "@paperclipai/plugin-sdk", "build"], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    console.error(`[paperclip:test] Failed to start plugin SDK build: ${result.error.message}`);
+    process.exit(1);
+  }
+  if ((result.status ?? 1) !== 0) {
+    console.error("[paperclip:test] Failed to build @paperclipai/plugin-sdk before running tests.");
+    process.exit(result.status ?? 1);
+  }
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function cleanupLeakedRuntimeTestServers() {
+  if (process.platform === "win32") return;
+
+  const result = spawnSync(
+    "pgrep",
+    ["-f", String.raw`node -e require\('node:http'\)\.createServer\(\(req,res\)=>res\.end`],
+    {
+      encoding: "utf8",
+    },
+  );
+  if (result.status !== 0 || !result.stdout.trim()) return;
+
+  const pids = result.stdout
+    .split("\n")
+    .map((line) => Number.parseInt(line.trim(), 10))
+    .filter((pid) => Number.isInteger(pid) && pid > 0 && pid !== process.pid);
+  if (pids.length === 0) return;
+
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Ignore stale process races.
+    }
+  }
+  sleep(250);
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      continue;
+    }
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Ignore stale process races.
+    }
+  }
+  console.log(`[paperclip:test] Cleaned up ${pids.length} stale runtime test server process(es).`);
+}
+
+ensureDistOnlyWorkspaceBuilds();
+cleanupLeakedRuntimeTestServers();
+
+const serverMockTests = discoverServerMockTests();
+const requestedTestFilters = cliArgs.filter(isLikelyTestFilter);
+const nonFilterCliArgs = cliArgs.filter((arg) => !isLikelyTestFilter(arg));
+const serverMockTestsToRun = requestedTestFilters.length === 0
+  ? serverMockTests
+  : serverMockTests.filter((filePath) =>
+      requestedTestFilters.some((filter) => testFilterMatchesFile(filter, filePath)),
+    );
+const failures = [];
+
+for (const filePath of serverMockTestsToRun) {
+  const status = runVitest(
+    `isolated server mock test without Vitest cache: ${filePath}`,
+    [filePath, ...nonFilterCliArgs],
+    { noCache: true },
+  );
+  if (status !== 0) {
+    failures.push(filePath);
+  }
+}
+
+const onlyExplicitServerMockFiles = requestedTestFilters.length > 0
+  && requestedTestFilters.every((filter) =>
+    testFilePattern.test(filter)
+    && serverMockTestsToRun.some((filePath) => testFilterMatchesFile(filter, filePath)),
+  );
+const shouldRunRemainingSuite = requestedTestFilters.length === 0 || !onlyExplicitServerMockFiles;
+
+if (shouldRunRemainingSuite) {
+  const excludeServerMockTests = serverMockTestsToRun.flatMap(excludeArgsFor);
+  const remainingStatus = runVitest("remaining test suite", [...excludeServerMockTests, ...cliArgs]);
+  if (remainingStatus !== 0) {
+    failures.push("remaining test suite");
+  }
+}
+
+if (failures.length > 0) {
+  console.error("\n[paperclip:test] Failed test groups:");
+  for (const failure of failures) {
+    console.error(`[paperclip:test] - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("\n[paperclip:test] All test groups passed.");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -15,8 +15,8 @@ const vitestBin = join(
 const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const cliArgs = process.argv.slice(2).filter((arg) => arg !== "--");
 const testFilePattern = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
-const moduleMockPattern =
-  /\bvi\.(?:doMock|mock|hoisted|stub(?:Env|Global)?|unstub(?:AllEnvs|AllGlobals)?|resetModules|unmock|doUnmock)\b/;
+const explicitModuleMockPattern = /\bvi\.(?:doMock|mock|hoisted)\b/;
+const internalModuleUnmockPattern = /\bvi\.(?:doUnmock|unmock)\(\s*["'](?:\.\.\/|@paperclipai\/)/;
 const globalTestHookPattern = /\bset[A-Za-z0-9_]+ForTest\(/;
 const pluginSdkEntry = join(repoRoot, "packages", "plugins", "sdk", "dist", "index.js");
 
@@ -41,7 +41,11 @@ function discoverServerMockTests() {
     .filter((filePath) => testFilePattern.test(filePath))
     .filter((filePath) => {
       const source = readFileSync(filePath, "utf8");
-      return moduleMockPattern.test(source) || globalTestHookPattern.test(source);
+      return (
+        explicitModuleMockPattern.test(source) ||
+        internalModuleUnmockPattern.test(source) ||
+        globalTestHookPattern.test(source)
+      );
     })
     .map((filePath) => relative(repoRoot, filePath))
     .sort();

--- a/server/src/__tests__/instance-settings-routes.test.ts
+++ b/server/src/__tests__/instance-settings-routes.test.ts
@@ -1,6 +1,8 @@
 import express from "express";
 import request from "supertest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.ts";
+import { instanceSettingsRoutes } from "../routes/instance-settings.ts";
 
 const mockInstanceSettingsService = vi.hoisted(() => ({
   getGeneral: vi.fn(),
@@ -11,18 +13,17 @@ const mockInstanceSettingsService = vi.hoisted(() => ({
 }));
 const mockLogActivity = vi.hoisted(() => vi.fn());
 
-function registerModuleMocks() {
-  vi.doMock("../services/index.js", () => ({
+function servicesIndexMock() {
+  return {
     instanceSettingsService: () => mockInstanceSettingsService,
     logActivity: mockLogActivity,
-  }));
+  };
 }
 
-async function createApp(actor: any) {
-  const [{ errorHandler }, { instanceSettingsRoutes }] = await Promise.all([
-    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
-    vi.importActual<typeof import("../routes/instance-settings.js")>("../routes/instance-settings.js"),
-  ]);
+vi.mock("../services/index.js", servicesIndexMock);
+vi.mock("../services/index.ts", servicesIndexMock);
+
+function createApp(actor: any) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -36,12 +37,6 @@ async function createApp(actor: any) {
 
 describe("instance settings routes", () => {
   beforeEach(() => {
-    vi.resetModules();
-    vi.doUnmock("../services/index.js");
-    vi.doUnmock("../routes/instance-settings.js");
-    vi.doUnmock("../routes/authz.js");
-    vi.doUnmock("../middleware/index.js");
-    registerModuleMocks();
     vi.resetAllMocks();
     mockInstanceSettingsService.getGeneral.mockReset();
     mockInstanceSettingsService.getExperimental.mockReset();
@@ -76,8 +71,12 @@ describe("instance settings routes", () => {
     mockInstanceSettingsService.listCompanyIds.mockResolvedValue(["company-1", "company-2"]);
   });
 
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
   it("allows local board users to read and update experimental settings", async () => {
-    const app = await createApp({
+    const app = createApp({
       type: "board",
       userId: "local-board",
       source: "local_implicit",
@@ -103,7 +102,7 @@ describe("instance settings routes", () => {
   });
 
   it("allows local board users to update guarded dev-server auto-restart", async () => {
-    const app = await createApp({
+    const app = createApp({
       type: "board",
       userId: "local-board",
       source: "local_implicit",
@@ -121,7 +120,7 @@ describe("instance settings routes", () => {
   });
 
   it("allows local board users to read and update general settings", async () => {
-    const app = await createApp({
+    const app = createApp({
       type: "board",
       userId: "local-board",
       source: "local_implicit",
@@ -154,7 +153,7 @@ describe("instance settings routes", () => {
   });
 
   it("allows non-admin board users to read general settings", async () => {
-    const app = await createApp({
+    const app = createApp({
       type: "board",
       userId: "user-1",
       source: "session",
@@ -173,7 +172,7 @@ describe("instance settings routes", () => {
   });
 
   it("rejects signed-in users without company access from reading general settings", async () => {
-    const app = await createApp({
+    const app = createApp({
       type: "board",
       userId: "user-2",
       source: "session",
@@ -189,7 +188,7 @@ describe("instance settings routes", () => {
   });
 
   it("rejects non-admin board users from updating general settings", async () => {
-    const app = await createApp({
+    const app = createApp({
       type: "board",
       userId: "user-1",
       source: "session",
@@ -206,7 +205,7 @@ describe("instance settings routes", () => {
   });
 
   it("rejects agent callers", async () => {
-    const app = await createApp({
+    const app = createApp({
       type: "agent",
       agentId: "agent-1",
       companyId: "company-1",

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -2891,7 +2891,7 @@ describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
     expect(service?.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
     await expect(fetch(service!.url!)).resolves.toMatchObject({ ok: true });
 
-    await resetRuntimeServicesForTests();
+    await resetRuntimeServicesForTests({ preserveLocalServices: true });
 
     const result = await reconcilePersistedRuntimeServicesOnStartup(db);
     expect(result).toMatchObject({ reconciled: 1, adopted: 1, stopped: 0 });

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -46,6 +46,7 @@ if (!isSameFile && existsSync(CWD_ENV_PATH)) {
 maybeRepairLegacyWorktreeConfigAndEnvFiles();
 
 const TAILSCALE_DETECT_TIMEOUT_MS = 3000;
+const TAILSCALE_DETECT_DISABLE_VALUES = new Set(["1", "true", "yes"]);
 
 type DatabaseMode = "embedded-postgres" | "postgres";
 
@@ -92,6 +93,8 @@ export interface Config {
 function detectTailnetBindHost(): string | undefined {
   const explicit = process.env.PAPERCLIP_TAILNET_BIND_HOST?.trim();
   if (explicit) return explicit;
+  const detectDisabled = process.env.PAPERCLIP_DISABLE_TAILSCALE_DETECT?.trim().toLowerCase();
+  if (detectDisabled && TAILSCALE_DETECT_DISABLE_VALUES.has(detectDisabled)) return undefined;
 
   try {
     const stdout = execFileSync("tailscale", ["ip", "-4"], {

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -124,9 +124,27 @@ type ProcessOutputAccumulator = {
   finish(): ProcessOutputCapture;
 };
 
-export async function resetRuntimeServicesForTests() {
-  for (const record of runtimeServicesById.values()) {
+export async function resetRuntimeServicesForTests(opts?: { preserveLocalServices?: boolean }) {
+  const records = Array.from(runtimeServicesById.values());
+  for (const record of records) {
     clearIdleTimer(record);
+    if (!opts?.preserveLocalServices) {
+      if (record.child?.pid) {
+        await terminateLocalService({
+          pid: record.child.pid,
+          processGroupId: record.processGroupId ?? record.child.pid,
+        });
+      } else if (record.providerRef) {
+        const pid = Number.parseInt(record.providerRef, 10);
+        if (Number.isInteger(pid) && pid > 0) {
+          await terminateLocalService({
+            pid,
+            processGroupId: record.processGroupId,
+          });
+        }
+      }
+      await removeLocalServiceRegistryRecord(record.serviceKey);
+    }
   }
   runtimeServicesById.clear();
   runtimeServicesByReuseKey.clear();


### PR DESCRIPTION
## Summary

- Replaces the root `pnpm test:run` path with a deterministic repo runner for heartbeat/route-suite isolation.
- Strips inherited `PAPERCLIP_*` runtime environment from Vitest child processes and gives each child an isolated home directory.
- Runs server tests that use module mocks or process-global test hooks in isolated Vitest processes without cache, while the remaining suite runs once.
- Cleans leaked runtime test servers, builds the dist-exported plugin SDK when a fresh checkout lacks `dist/`, and removes retry-dependent success from the test runner.
- Hardens workspace runtime test cleanup so local runtime services are terminated unless a test explicitly preserves them for startup reconciliation.
- Adds an explicit Tailscale autodetect disable env for deterministic bind/onboarding tests.
- Makes transformed database backups avoid `COPY` output so worktree seed restores do not depend on psql-only replay.

## Why

This is the PAPA-31 recovery slice from the oversized recovery branch, rebuilt from current `master` as a small reviewable PR. The goal is for `pnpm test:run` to pass or fail honestly in the Paperclip heartbeat environment instead of relying on retry fallback or inherited local runtime state.

## Validation

- `pnpm test:run server/src/__tests__/workspace-runtime.test.ts`
- Focused route/auth set: `activity-routes`, `express5-auth-wildcard`, `issue-comment-reopen-routes`, `workspace-runtime-routes-authz`, `workspace-runtime-service-authz`
- Focused env/worktree/plugin/db set: `cli/src/__tests__/network-bind.test.ts`, `cli/src/__tests__/onboard.test.ts`, `packages/db/src/backup-lib.test.ts`, `cli/src/__tests__/worktree.test.ts`, `server/src/__tests__/plugin-routes-authz.test.ts`, `server/src/__tests__/plugin-scoped-api-routes.test.ts`
- `pnpm test:run` passed twice after final isolation behavior
- `pnpm -r typecheck`
- `pnpm build`

## Notes

- Supersedes only the PAPA-31 route-suite hardening portion of draft PR #4242.
- PR is intentionally scoped to 1 commit / 10 files to stay reviewable.
