### PR TITLE
feat(routine-gc): class-aware routine-issue garbage collection (AKS-1269) — rebased

### DIFF
--- a/packages/db/src/migrations/0065_routine_gc_flags.sql
+++ b/packages/db/src/migrations/0065_routine_gc_flags.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "routines" ADD COLUMN "auto_gc_enabled" boolean DEFAULT false NOT NULL;
+--> statement-breakpoint
+-- Set scan-style (check-gate) routines to auto_gc_enabled=true per MHDS 2026-04-20 verdict (AKS-1244).
+-- Review Orchestrator keeps the default false.
+UPDATE "routines" SET "auto_gc_enabled" = true WHERE "id" IN (
+  '0284ad5a-5eb6-4da4-90b0-c686baa3ef9b',
+  '0612004f-160a-4570-a413-fdd7f6edb50f',
+  '387d5914-f225-455f-a083-c0e588ac726d'
+);

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1776780002000,
       "tag": "0064_issue_thread_interaction_idempotency",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1745107200000,
+      "tag": "0065_routine_gc_flags",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/routines.ts
+++ b/packages/db/src/schema/routines.ts
@@ -37,6 +37,7 @@ export const routines = pgTable(
     createdByUserId: text("created_by_user_id"),
     updatedByAgentId: uuid("updated_by_agent_id").references(() => agents.id, { onDelete: "set null" }),
     updatedByUserId: text("updated_by_user_id"),
+    autoGcEnabled: boolean("auto_gc_enabled").notNull().default(false),
     lastTriggeredAt: timestamp("last_triggered_at", { withTimezone: true }),
     lastEnqueuedAt: timestamp("last_enqueued_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -209,7 +209,7 @@ export const PROJECT_STATUSES = [
 ] as const;
 export type ProjectStatus = (typeof PROJECT_STATUSES)[number];
 
-export const ROUTINE_STATUSES = ["active", "paused", "archived"] as const;
+export const ROUTINE_STATUSES = ["active", "paused", "paused_with_backlog", "archived"] as const;
 export type RoutineStatus = (typeof ROUTINE_STATUSES)[number];
 
 export const ROUTINE_CONCURRENCY_POLICIES = ["coalesce_if_active", "always_enqueue", "skip_if_active"] as const;

--- a/packages/shared/src/types/routine.ts
+++ b/packages/shared/src/types/routine.ts
@@ -50,6 +50,7 @@ export interface Routine {
   concurrencyPolicy: string;
   catchUpPolicy: string;
   variables: RoutineVariable[];
+  autoGcEnabled: boolean;
   createdByAgentId: string | null;
   createdByUserId: string | null;
   updatedByAgentId: string | null;

--- a/packages/shared/src/validators/routine.ts
+++ b/packages/shared/src/validators/routine.ts
@@ -59,6 +59,7 @@ export const createRoutineSchema = z.object({
   concurrencyPolicy: z.enum(ROUTINE_CONCURRENCY_POLICIES).optional().default("coalesce_if_active"),
   catchUpPolicy: z.enum(ROUTINE_CATCH_UP_POLICIES).optional().default("skip_missed"),
   variables: z.array(routineVariableSchema).optional().default([]),
+  autoGcEnabled: z.boolean().optional().default(false),
 });
 
 export type CreateRoutine = z.infer<typeof createRoutineSchema>;

--- a/server/src/__tests__/log-redaction.test.ts
+++ b/server/src/__tests__/log-redaction.test.ts
@@ -3,6 +3,8 @@ import {
   maskUserNameForLogs,
   redactCurrentUserText,
   redactCurrentUserValue,
+  redactJwtTokens,
+  REDACTED_JWT_TOKEN,
 } from "../log-redaction.js";
 
 describe("log redaction", () => {
@@ -70,5 +72,45 @@ describe("log redaction", () => {
   it("skips redaction when disabled", () => {
     const input = "cwd=/Users/paperclipuser/paperclip";
     expect(redactCurrentUserText(input, { enabled: false })).toBe(input);
+  });
+
+  it("redacts JWT tokens embedded in text", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const input = `Authorization: Bearer ${jwt}`;
+    const result = redactCurrentUserText(input, { userNames: [], homeDirs: [] });
+    expect(result).toBe(`Authorization: Bearer ${REDACTED_JWT_TOKEN}`);
+    expect(result).not.toContain(jwt);
+  });
+
+  it("redacts multiple JWTs in the same text", () => {
+    const jwt1 =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    const jwt2 =
+      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJvbGUiOiJzZXJ2aWNlX3JvbGUifQ.abc123def456ghi789jkl012mno345pqr678stu901vwx";
+    const input = `token1=${jwt1} and token2=${jwt2}`;
+    const result = redactJwtTokens(input);
+    expect(result).not.toContain(jwt1);
+    expect(result).not.toContain(jwt2);
+    expect(result).toBe(`token1=${REDACTED_JWT_TOKEN} and token2=${REDACTED_JWT_TOKEN}`);
+  });
+
+  it("does not redact short dot-separated strings", () => {
+    const input = "version=1.2.3 and node.js.runtime";
+    const result = redactJwtTokens(input);
+    expect(result).toBe(input);
+  });
+
+  it("redacts JWTs in nested values via redactCurrentUserValue", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const result = redactCurrentUserValue(
+      { auth: `Bearer ${jwt}`, nested: { key: jwt } },
+      { userNames: [], homeDirs: [] },
+    );
+    expect(result).toEqual({
+      auth: `Bearer ${REDACTED_JWT_TOKEN}`,
+      nested: { key: REDACTED_JWT_TOKEN },
+    });
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,6 +33,7 @@ import {
   heartbeatService,
   instanceSettingsService,
   reconcilePersistedRuntimeServicesOnStartup,
+  routineGcService,
   routineService,
 } from "./services/index.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
@@ -741,8 +742,27 @@ export async function startServer(): Promise<StartedServer> {
           logger.error({ err }, "periodic heartbeat recovery failed");
         });
     }, config.heartbeatSchedulerIntervalMs);
+
+    // Nightly routine GC — runs once per day at approximately 02:00 UTC.
+    // Dry-run mode is active when GC_DRY_RUN=true (recommended for first 48h post-deploy).
+    const gc = routineGcService(db as any);
+    let lastGcDay = -1;
+    setInterval(() => {
+      const day = new Date().getUTCDate();
+      const hour = new Date().getUTCHours();
+      if (hour === 2 && day !== lastGcDay) {
+        lastGcDay = day;
+        void gc.runGc()
+          .then((result) => {
+            logger.info({ ...result }, "routine-gc: nightly run complete");
+          })
+          .catch((err) => {
+            logger.error({ err }, "routine-gc: nightly run failed");
+          });
+      }
+    }, 60_000);
   }
-  
+
   if (config.databaseBackupEnabled) {
     const backupIntervalMs = config.databaseBackupIntervalMinutes * 60 * 1000;
 

--- a/server/src/log-redaction.ts
+++ b/server/src/log-redaction.ts
@@ -1,6 +1,10 @@
 import os from "node:os";
 
 export const CURRENT_USER_REDACTION_TOKEN = "*";
+export const REDACTED_JWT_TOKEN = "***JWT_REDACTED***";
+
+const JWT_TEXT_RE =
+  /[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}(?:\.[A-Za-z0-9_-]{20,})?/g;
 
 export interface CurrentUserRedactionOptions {
   enabled?: boolean;
@@ -104,6 +108,11 @@ function resolveCurrentUserCandidates(opts?: CurrentUserRedactionOptions) {
   return { userNames, homeDirs, replacement };
 }
 
+export function redactJwtTokens(input: string): string {
+  if (!input) return input;
+  return input.replace(JWT_TEXT_RE, REDACTED_JWT_TOKEN);
+}
+
 export function redactCurrentUserText(input: string, opts?: CurrentUserRedactionOptions) {
   if (!input) return input;
   if (opts?.enabled === false) return input;
@@ -125,6 +134,8 @@ export function redactCurrentUserText(input: string, opts?: CurrentUserRedaction
     const pattern = new RegExp(`(?<![A-Za-z0-9._-])${escapeRegExp(userName)}(?![A-Za-z0-9._-])`, "g");
     result = result.replace(pattern, maskUserNameForLogs(userName, replacement));
   }
+
+  result = redactJwtTokens(result);
 
   return result;
 }

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -4442,6 +4442,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
                 ? routineDefinition.catchUpPolicy as typeof ROUTINE_CATCH_UP_POLICIES[number]
                 : "skip_missed",
             variables: routineDefinition.variables ?? [],
+            autoGcEnabled: false,
           }, {
             agentId: null,
             userId: actorUserId ?? null,

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -43,6 +43,7 @@ export { companyPortabilityService } from "./company-portability.js";
 export { executionWorkspaceService } from "./execution-workspaces.js";
 export { workspaceOperationService } from "./workspace-operations.js";
 export { workProductService } from "./work-products.js";
+export { routineGcService, type RoutineGcResult } from "./routine-gc.js";
 export { logActivity, type LogActivityInput } from "./activity-log.js";
 export { notifyHireApproved, type NotifyHireApprovedInput } from "./hire-hook.js";
 export { publishLiveEvent, subscribeCompanyLiveEvents } from "./live-events.js";

--- a/server/src/services/routine-gc.ts
+++ b/server/src/services/routine-gc.ts
@@ -1,0 +1,207 @@
+import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { issues, routines, routineTriggers } from "@paperclipai/db";
+import { nextCronTickFromExpression } from "./cron.js";
+import { issueService } from "./issues.js";
+import { logger } from "../middleware/logger.js";
+
+const R1_THRESHOLD_MS = 72 * 60 * 60 * 1000;
+const GC_BATCH_SIZE = 200;
+
+const GC_PAUSED_STATUSES = ["paused", "archived"];
+
+export interface RoutineGcResult {
+  dryRun: boolean;
+  r1Cancelled: number;
+  r2Cancelled: number;
+  affectedRoutines: number;
+}
+
+/**
+ * Compute the minimum firing interval (in hours) for a cron expression by
+ * sampling consecutive ticks over a 7-day window. Returns 24 as a safe fallback.
+ */
+function computeMinCronIntervalHours(expression: string): number {
+  const now = new Date();
+  let prev: Date | null = null;
+  let minGapMs = Infinity;
+  const windowEnd = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+  let cursor = new Date(now);
+
+  for (let i = 0; i < 10_000; i++) {
+    const tick = nextCronTickFromExpression(expression, cursor);
+    if (!tick || tick >= windowEnd) break;
+    if (prev !== null) {
+      const gap = tick.getTime() - prev.getTime();
+      if (gap < minGapMs) minGapMs = gap;
+    }
+    prev = tick;
+    cursor = tick;
+  }
+
+  if (!Number.isFinite(minGapMs)) return 24;
+  return Math.max(1, minGapMs / (60 * 60 * 1000));
+}
+
+export function routineGcService(db: Db) {
+  const issueSvc = issueService(db);
+  const isDryRun = process.env.GC_DRY_RUN === "true";
+
+  async function postAuditComment(
+    parentIssueId: string | null,
+    routineId: string,
+    routineTitle: string,
+    rule: "R1" | "R2",
+    count: number,
+    oldestAgeHours: number,
+  ) {
+    if (!parentIssueId) return;
+    try {
+      const body = [
+        `**GC audit (${rule})** — routine \`${routineTitle}\``,
+        "",
+        `- Issues cancelled: **${count}**`,
+        `- Rule: ${rule === "R1" ? "routine paused/archived (72h threshold)" : "stale scan backlog (2× interval threshold)"}`,
+        `- Oldest cancelled issue age: **${Math.round(oldestAgeHours)}h**`,
+        isDryRun ? "\n_(dry-run — no changes applied)_" : "",
+      ].filter((l) => l !== undefined).join("\n");
+      await issueSvc.addComment(parentIssueId, body, { agentId: undefined, userId: undefined });
+    } catch (err) {
+      logger.warn({ err, routineId }, "routine-gc: failed to post audit comment");
+    }
+  }
+
+  async function runGc(): Promise<RoutineGcResult> {
+    const now = new Date();
+    let r1Cancelled = 0;
+    let r2Cancelled = 0;
+    const affectedRoutineIds = new Set<string>();
+
+    // ── R1: paused/archived routines — todo issues older than 72h ──────────
+    const r1Cutoff = new Date(now.getTime() - R1_THRESHOLD_MS);
+
+    const r1Rows = await db
+      .select({
+        issueId: issues.id,
+        issueCreatedAt: issues.createdAt,
+        routineId: routines.id,
+        routineTitle: routines.title,
+        parentIssueId: routines.parentIssueId,
+      })
+      .from(issues)
+      .innerJoin(routines, and(
+        eq(routines.id, sql`${issues.originId}::uuid`),
+        inArray(routines.status, GC_PAUSED_STATUSES),
+      ))
+      .where(
+        and(
+          eq(issues.originKind, "routine_execution"),
+          eq(issues.status, "todo"),
+          lt(issues.createdAt, r1Cutoff),
+        ),
+      )
+      .limit(GC_BATCH_SIZE);
+
+    if (r1Rows.length > 0) {
+      const byRoutine = new Map<string, typeof r1Rows>();
+      for (const row of r1Rows) {
+        const group = byRoutine.get(row.routineId) ?? [];
+        group.push(row);
+        byRoutine.set(row.routineId, group);
+      }
+
+      for (const [routineId, rows] of byRoutine.entries()) {
+        const oldestAgeMs = now.getTime() - Math.min(...rows.map((r) => r.issueCreatedAt.getTime()));
+        const oldestAgeHours = oldestAgeMs / (60 * 60 * 1000);
+
+        if (!isDryRun) {
+          await db
+            .update(issues)
+            .set({ status: "cancelled", cancelledAt: now, updatedAt: now })
+            .where(inArray(issues.id, rows.map((r) => r.issueId)));
+        }
+
+        r1Cancelled += rows.length;
+        affectedRoutineIds.add(routineId);
+
+        const { routineTitle, parentIssueId } = rows[0]!;
+        await postAuditComment(parentIssueId, routineId, routineTitle, "R1", rows.length, oldestAgeHours);
+      }
+    }
+
+    // ── R2: active routines with auto_gc_enabled — stale scan backlog ───────
+    const activeGcRoutines = await db
+      .select({
+        routineId: routines.id,
+        routineTitle: routines.title,
+        parentIssueId: routines.parentIssueId,
+        cronExpression: routineTriggers.cronExpression,
+      })
+      .from(routines)
+      .leftJoin(routineTriggers, and(
+        eq(routineTriggers.routineId, routines.id),
+        eq(routineTriggers.kind, "schedule"),
+        eq(routineTriggers.enabled, true),
+      ))
+      .where(
+        and(
+          eq(routines.status, "active"),
+          eq(routines.autoGcEnabled, true),
+        ),
+      );
+
+    for (const routine of activeGcRoutines) {
+      const intervalHours = routine.cronExpression
+        ? computeMinCronIntervalHours(routine.cronExpression)
+        : 24;
+      const r2ThresholdMs = 2 * intervalHours * 60 * 60 * 1000;
+      const r2Cutoff = new Date(now.getTime() - r2ThresholdMs);
+
+      const r2Rows = await db
+        .select({ issueId: issues.id, issueCreatedAt: issues.createdAt })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.originKind, "routine_execution"),
+            eq(issues.originId, routine.routineId),
+            eq(issues.status, "todo"),
+            lt(issues.createdAt, r2Cutoff),
+          ),
+        )
+        .limit(GC_BATCH_SIZE);
+
+      if (r2Rows.length === 0) continue;
+
+      const oldestAgeMs = now.getTime() - Math.min(...r2Rows.map((r) => r.issueCreatedAt.getTime()));
+      const oldestAgeHours = oldestAgeMs / (60 * 60 * 1000);
+
+      if (!isDryRun) {
+        await db
+          .update(issues)
+          .set({ status: "cancelled", cancelledAt: now, updatedAt: now })
+          .where(inArray(issues.id, r2Rows.map((r) => r.issueId)));
+      }
+
+      r2Cancelled += r2Rows.length;
+      affectedRoutineIds.add(routine.routineId);
+      await postAuditComment(routine.parentIssueId, routine.routineId, routine.routineTitle, "R2", r2Rows.length, oldestAgeHours);
+    }
+
+    const total = r1Cancelled + r2Cancelled;
+    if (total > 0 || isDryRun) {
+      logger.info(
+        { dryRun: isDryRun, r1Cancelled, r2Cancelled, affectedRoutines: affectedRoutineIds.size },
+        "routine-gc: completed",
+      );
+    }
+
+    return {
+      dryRun: isDryRun,
+      r1Cancelled,
+      r2Cancelled,
+      affectedRoutines: affectedRoutineIds.size,
+    };
+  }
+
+  return { runGc };
+}

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -872,6 +872,45 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
           return updated ?? createdRun;
         }
 
+        // R3 dedup-on-enqueue: for auto_gc_enabled routines, coalesce into an
+        // existing blocked issue with the same title rather than stacking duplicates.
+        if (!activeIssue && input.routine.autoGcEnabled) {
+          const blockedDuplicate = await txDb
+            .select({ id: issues.id, originRunId: issues.originRunId })
+            .from(issues)
+            .where(
+              and(
+                eq(issues.companyId, input.routine.companyId),
+                eq(issues.originKind, "routine_execution"),
+                eq(issues.originId, input.routine.id),
+                eq(issues.status, "blocked"),
+                eq(issues.title, title),
+                isNull(issues.hiddenAt),
+              ),
+            )
+            .orderBy(desc(issues.updatedAt))
+            .limit(1)
+            .then((rows) => rows[0] ?? null);
+
+          if (blockedDuplicate) {
+            const updated = await finalizeRun(createdRun.id, {
+              status: "coalesced",
+              linkedIssueId: blockedDuplicate.id,
+              coalescedIntoRunId: blockedDuplicate.originRunId,
+              completedAt: triggeredAt,
+            }, txDb);
+            await updateRoutineTouchedState({
+              routineId: input.routine.id,
+              triggerId: input.trigger?.id ?? null,
+              triggeredAt,
+              status: "coalesced",
+              issueId: blockedDuplicate.id,
+              nextRunAt,
+            }, txDb);
+            return updated ?? createdRun;
+          }
+        }
+
         try {
           createdIssue = await issueSvc.create(input.routine.companyId, {
             projectId,
@@ -1154,6 +1193,7 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
           concurrencyPolicy: input.concurrencyPolicy,
           catchUpPolicy: input.catchUpPolicy,
           variables,
+          autoGcEnabled: input.autoGcEnabled ?? false,
           createdByAgentId: actor.agentId ?? null,
           createdByUserId: actor.userId ?? null,
           updatedByAgentId: actor.agentId ?? null,
@@ -1174,9 +1214,28 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
       if (patch.status === "active") {
         assertRoutineCanEnable(patch.status, nextAssigneeAgentId);
       }
-      const nextStatus = patch.assigneeAgentId === undefined
+      let nextStatus = patch.assigneeAgentId === undefined
         ? requestedStatus
         : normalizeDraftRoutineStatus(requestedStatus, nextAssigneeAgentId);
+
+      // paused_with_backlog guard: active → paused transition must check for outstanding todo issues
+      if (nextStatus === "paused" && existing.status === "active") {
+        const hasPendingIssue = await db
+          .select({ id: issues.id })
+          .from(issues)
+          .where(
+            and(
+              eq(issues.originKind, "routine_execution"),
+              eq(issues.originId, existing.id),
+              eq(issues.status, "todo"),
+              isNull(issues.hiddenAt),
+            ),
+          )
+          .limit(1)
+          .then((rows) => rows.length > 0);
+        if (hasPendingIssue) nextStatus = "paused_with_backlog";
+      }
+
       const nextVariables = syncRoutineVariablesWithTemplate(
         [nextTitle, nextDescription],
         patch.variables === undefined ? existing.variables : sanitizeRoutineVariableInputs(patch.variables),
@@ -1215,6 +1274,7 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
           concurrencyPolicy: patch.concurrencyPolicy ?? existing.concurrencyPolicy,
           catchUpPolicy: patch.catchUpPolicy ?? existing.catchUpPolicy,
           variables: nextVariables,
+          autoGcEnabled: patch.autoGcEnabled ?? existing.autoGcEnabled,
           updatedByAgentId: actor.agentId ?? null,
           updatedByUserId: actor.userId ?? null,
           updatedAt: new Date(),

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -225,6 +225,7 @@ function createRoutine(overrides: Partial<RoutineListItem>): RoutineListItem {
     concurrencyPolicy: "coalesce_if_active",
     catchUpPolicy: "skip_missed",
     variables: [],
+    autoGcEnabled: false,
     createdByAgentId: null,
     createdByUserId: null,
     updatedByAgentId: null,


### PR DESCRIPTION
## Summary

Rebase of `AKS-1269/routine-gc-impl` onto current `origin/master` (as of 2026-04-22, `a9573944`). Board-approved via approval b9820318 on 2026-04-21.

## Changes

- **Migration renamed**: `0057_routine_gc_flags` → `0065_routine_gc_flags` (upstream added entries 57–64 since the original branch)
- **Conflict resolved**: `_journal.json` — appended our migration as idx 65 after upstream entries 57–64
- **7 auto-merges accepted**: `packages/db/src/schema/routines.ts`, `packages/shared/src/constants.ts`, `packages/shared/src/types/routine.ts`, `packages/shared/src/validators/routine.ts`, `server/src/index.ts`, `server/src/services/index.ts`, `server/src/services/routines.ts`

## Semantic review of auto-merges

**Blocker-aware scheduling × `paused_with_backlog` guard (commit `1266954a`):**
Safe. The routine scheduler filters on `status = "active"` (routines.ts:1635) and the trigger fire path asserts `routine.status !== "active"` throws conflict (routines.ts:1479). Routines in `paused_with_backlog` will NOT be scheduled.

**Liveness-deadlock detection × paused routines (commit `1954eb30`):**
Safe. The liveness detector (`issue-liveness.ts`) checks assignee agent status only — not routine status. A `paused_with_backlog` routine with pending backlog issues will NOT be flagged as a deadlock.

**GC_PAUSED_STATUSES gap (non-blocking, pre-existing, out of scope):**
`routine-gc.ts:11` hardcodes `GC_PAUSED_STATUSES = ["paused", "archived"]` — does not include `paused_with_backlog`. Routines in `paused_with_backlog` will not have their backlog cleaned up by R1. This is a pre-existing design gap in the original branch (not introduced by the rebase). Flagged for follow-up; out of scope per AKS-1732.

## Test results

- 454 tests pass
- 7 pre-existing failures (3× worktree port management, 2× workspace-link resolution for drizzle-orm, 2× workspace-link resolution for zod) — all unrelated to routine GC

## Do not merge

Human review required before merge. Board reconfirmation needed per AKS-1282.