### PR TITLE
fix canonical Orebit roster command path

### DIFF
--- a/packages/db/src/seed.test.ts
+++ b/packages/db/src/seed.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Db } from "./client.js";
+import { agents, companies, companySkills } from "./schema/index.js";
+import {
+  OREBIT_BOOTSTRAP_COMPANY,
+  seedCanonicalOrebitCompany,
+  seedCanonicalOrebitRoster,
+  type CanonicalCompanyBootstrap,
+} from "./seed.js";
+
+function createDbMock() {
+  const calls: Array<{ table: unknown; values: unknown }> = [];
+  const state = {
+    companies: [] as Array<Record<string, unknown>>,
+    skills: [] as Array<Record<string, unknown>>,
+    agents: [] as Array<Record<string, unknown>>,
+  };
+
+  function createOperation(table: unknown, values: unknown) {
+    const operation = {
+      onConflictDoUpdate() {
+        return operation;
+      },
+      onConflictDoNothing() {
+        return operation;
+      },
+      async returning() {
+        calls.push({ table, values });
+
+        if (table === companies) {
+          const record = values as Record<string, unknown>;
+          const issuePrefix = record.issuePrefix as string;
+          const existing = state.companies.find((company) => company.issuePrefix === issuePrefix);
+          if (existing) {
+            Object.assign(existing, record, { id: existing.id });
+            return [existing];
+          }
+
+          const created = { id: `company-${state.companies.length + 1}`, ...record };
+          state.companies.push(created);
+          return [created];
+        }
+
+        if (table === agents) {
+          const record = values as Record<string, unknown>;
+          const existing = state.agents.find((agent) => agent.id === record.id);
+          if (existing) {
+            Object.assign(existing, record);
+            return [existing];
+          }
+
+          const created = { ...record };
+          state.agents.push(created);
+          return [created];
+        }
+
+        if (Array.isArray(values)) {
+          return values.map((entry) => {
+            const record = entry as Record<string, unknown>;
+            const existing = state.skills.find(
+              (skill) => skill.companyId === record.companyId && skill.key === record.key,
+            );
+            if (existing) {
+              Object.assign(existing, record, { id: existing.id });
+              return existing;
+            }
+
+            const created = {
+              id: `skill-${state.skills.length + 1}`,
+              ...record,
+            };
+            state.skills.push(created);
+            return created;
+          });
+        }
+
+        const created = { id: `row-${calls.length}`, ...(values as Record<string, unknown>) };
+        if (table === companySkills) {
+          const record = values as Record<string, unknown>;
+          const existing = state.skills.find(
+            (skill) => skill.companyId === record.companyId && skill.key === record.key,
+          );
+          if (existing) {
+            Object.assign(existing, record, { id: existing.id });
+            return [existing];
+          }
+          state.skills.push(created);
+        }
+        return [created];
+      },
+    };
+
+    return operation;
+  }
+
+    const db = {
+      insert: vi.fn((table: unknown) => ({
+        values: (values: unknown) => ({
+          ...createOperation(table, values),
+        }),
+      })),
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => ({
+            then: async (resolve: (rows: Array<Record<string, unknown>>) => unknown) => resolve([]),
+          }),
+        }),
+      })),
+    };
+
+  return { db: db as unknown as Pick<Db, "insert">, calls, state };
+}
+
+describe("seedCanonicalOrebitCompany", () => {
+  it("seeds the canonical Orebit company and taxonomy", async () => {
+    const { db, calls, state } = createDbMock();
+
+    const result = await seedCanonicalOrebitCompany(db);
+    const companyCall = calls.find((call) => call.table === companies);
+    const skillCalls = calls.filter((call) => call.table === companySkills);
+    const agentCalls = calls.filter((call) => call.table === agents);
+
+    expect(result.company).toMatchObject({
+      id: "company-1",
+      name: "Orebit",
+      description: OREBIT_BOOTSTRAP_COMPANY.description,
+      issuePrefix: "ORE",
+      status: "active",
+    });
+    expect(result.taxonomy.map((entry) => entry.slug)).toEqual([
+      "geology",
+      "ai",
+      "geostatistics",
+      "saas",
+      "research",
+      "ops",
+    ]);
+
+    expect(companyCall?.values).toMatchObject({
+      name: "Orebit",
+      description: OREBIT_BOOTSTRAP_COMPANY.description,
+      issuePrefix: "ORE",
+      budgetMonthlyCents: 0,
+    });
+    expect(skillCalls).toHaveLength(6);
+    expect(skillCalls[0]?.values).toMatchObject({
+      companyId: "company-1",
+      key: "taxonomy/geology",
+      slug: "geology",
+      name: "Geology",
+      sourceType: "catalog",
+      trustLevel: "markdown_only",
+    });
+    expect(skillCalls[5]?.values).toMatchObject({
+      companyId: "company-1",
+      key: "taxonomy/ops",
+      slug: "ops",
+      name: "Ops",
+      sourceType: "catalog",
+      trustLevel: "markdown_only",
+    });
+    expect(agentCalls).toHaveLength(8);
+    expect(agentCalls[0]?.values).toMatchObject({
+      companyId: "company-1",
+      name: "Siro Hermes",
+      role: "ceo",
+      adapterType: "codex_local",
+      adapterConfig: expect.objectContaining({
+        cwd: expect.any(String),
+      }),
+      reportsTo: null,
+      permissions: { canCreateAgents: true },
+    });
+    expect(agentCalls[1]?.values).toMatchObject({
+      companyId: "company-1",
+      name: "Luna",
+      role: "cto",
+      reportsTo: expect.any(String),
+    });
+    expect(agentCalls[7]?.values).toMatchObject({
+      companyId: "company-1",
+      name: "Shiro",
+      role: "general",
+      reportsTo: expect.any(String),
+    });
+    expect(state.companies).toHaveLength(1);
+    expect(state.skills).toHaveLength(6);
+    expect(state.agents).toHaveLength(8);
+  });
+
+  it("reuses the canonical company and taxonomy on rerun", async () => {
+    const { db, state } = createDbMock();
+
+    const first = await seedCanonicalOrebitCompany(db);
+    const second = await seedCanonicalOrebitCompany(db);
+
+    expect(first.company.id).toBe(second.company.id);
+    expect(state.companies).toHaveLength(1);
+    expect(state.skills).toHaveLength(6);
+    expect(state.agents).toHaveLength(8);
+    expect(new Set(state.agents.map((entry) => String(entry.id))).size).toBe(8);
+    expect(new Set(state.skills.map((entry) => `${entry.companyId}:${entry.key}`)).size).toBe(6);
+  });
+
+  it("reuses the canonical roster on direct roster bootstrap reruns", async () => {
+    const { db, state } = createDbMock();
+
+    await seedCanonicalOrebitRoster(db, "company-1");
+    await seedCanonicalOrebitRoster(db, "company-1");
+
+    expect(state.agents).toHaveLength(8);
+    expect(new Set(state.agents.map((entry) => String(entry.id))).size).toBe(8);
+    expect(state.agents.some((entry) => entry.name === "Siro Hermes" && entry.role === "ceo")).toBe(true);
+    expect(state.agents.some((entry) => entry.name === "Luna" && entry.role === "cto")).toBe(true);
+    expect(state.agents.some((entry) => entry.name === "Nala" && entry.role === "cmo")).toBe(true);
+  });
+
+  it("fails closed when required bootstrap identity inputs are missing", async () => {
+    const { db } = createDbMock();
+
+    await expect(
+      seedCanonicalOrebitCompany(db, {
+        ...OREBIT_BOOTSTRAP_COMPANY,
+        taxonomy: [{ ...OREBIT_BOOTSTRAP_COMPANY.taxonomy[0], markdown: "" }],
+      } as CanonicalCompanyBootstrap),
+    ).rejects.toThrow(/bootstrap company identity/i);
+
+    await expect(
+      seedCanonicalOrebitCompany(db, {
+        ...OREBIT_BOOTSTRAP_COMPANY,
+        name: "",
+      } as CanonicalCompanyBootstrap),
+    ).rejects.toThrow(/bootstrap company identity/i);
+  });
+});

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,99 +1,324 @@
-import { createDb } from "./client.js";
-import { companies, agents, goals, projects, issues } from "./schema/index.js";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { createDb, type Db } from "./client.js";
+import { agents, companies, companySkills } from "./schema/index.js";
+import { OREBIT_CANONICAL_ROLE_NAMES, OREBIT_DEFAULT_ORG_AGENT_NAMES } from "@paperclipai/shared";
 
-const url = process.env.DATABASE_URL;
-if (!url) throw new Error("DATABASE_URL is required");
+type BootstrapTaxonomyEntry = {
+  key: string;
+  slug: string;
+  name: string;
+  description: string;
+  markdown: string;
+};
 
-const db = createDb(url);
+export type CanonicalCompanyBootstrap = {
+  name: string;
+  description: string;
+  issuePrefix: string;
+  taxonomy: BootstrapTaxonomyEntry[];
+};
 
-console.log("Seeding database...");
+type OrebitRosterEntry = {
+  key: string;
+  name: string;
+  role: string;
+  title: string | null;
+  icon: string | null;
+  capabilities: string | null;
+  reportsToKey: string | null;
+  canCreateAgents: boolean;
+};
 
-const [company] = await db
-  .insert(companies)
-  .values({
-    name: "Paperclip Demo Co",
-    description: "A demo autonomous company",
-    status: "active",
-    budgetMonthlyCents: 50000,
-  })
-  .returning();
+type SeededCompany = {
+  id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  issuePrefix: string;
+  budgetMonthlyCents: number;
+};
 
-const [ceo] = await db
-  .insert(agents)
-  .values({
-    companyId: company!.id,
-    name: "CEO Agent",
+export const OREBIT_BOOTSTRAP_COMPANY: CanonicalCompanyBootstrap = {
+  name: "Orebit",
+  description:
+    "Orebit builds practical AI and data workflows for mining and geoscience teams, combining domain expertise, transparent pipelines, and productized tooling to turn geological complexity into reliable, affordable, decision-ready intelligence.",
+  issuePrefix: "ORE",
+  taxonomy: [
+    {
+      key: "taxonomy/geology",
+      slug: "geology",
+      name: "Geology",
+      description: "Open-source geology problems and practical, inspectable tools.",
+      markdown: "# Geology\n\nOrebit exists to help solve open-source geology problems with reliable, low-price digital tools.",
+    },
+    {
+      key: "taxonomy/ai",
+      slug: "ai",
+      name: "AI",
+      description: "Applied AI workflows for mining and geoscience teams.",
+      markdown: "# AI\n\nOrebit uses applied AI to support domain workflows, not generic chat-only experiences.",
+    },
+    {
+      key: "taxonomy/geostatistics",
+      slug: "geostatistics",
+      name: "Geostatistics",
+      description: "Statistical workflows for technical, decision-ready geological analysis.",
+      markdown: "# Geostatistics\n\nOrebit pairs domain expertise with statistical workflows that stay inspectable and practical.",
+    },
+    {
+      key: "taxonomy/saas",
+      slug: "saas",
+      name: "SaaS",
+      description: "Productized deployments and premium implementation support.",
+      markdown: "# SaaS\n\nOrebit turns its domain expertise into deployable software products and services.",
+    },
+    {
+      key: "taxonomy/research",
+      slug: "research",
+      name: "Research",
+      description: "Applied research interfaces grounded in evidence and workflows.",
+      markdown: "# Research\n\nOrebit keeps research useful by grounding it in practitioner workflows and inspectable evidence.",
+    },
+    {
+      key: "taxonomy/ops",
+      slug: "ops",
+      name: "Ops",
+      description: "Operational workflows, monitoring, and reliability for the company stack.",
+      markdown: "# Ops\n\nOrebit runs on explicit operations, monitoring, and fail-closed execution.",
+    },
+  ],
+};
+
+const OREBIT_BOOTSTRAP_ROSTER: OrebitRosterEntry[] = [
+  {
+    key: "ceo",
+    name: OREBIT_CANONICAL_ROLE_NAMES.ceo,
     role: "ceo",
-    title: "Chief Executive Officer",
-    status: "idle",
-    adapterType: "process",
-    adapterConfig: { command: "echo", args: ["hello from ceo"] },
-    budgetMonthlyCents: 15000,
-  })
-  .returning();
-
-const [engineer] = await db
-  .insert(agents)
-  .values({
-    companyId: company!.id,
-    name: "Engineer Agent",
-    role: "engineer",
-    title: "Software Engineer",
-    status: "idle",
-    reportsTo: ceo!.id,
-    adapterType: "process",
-    adapterConfig: { command: "echo", args: ["hello from engineer"] },
-    budgetMonthlyCents: 10000,
-  })
-  .returning();
-
-const [goal] = await db
-  .insert(goals)
-  .values({
-    companyId: company!.id,
-    title: "Ship V1",
-    description: "Deliver first control plane release",
-    level: "company",
-    status: "active",
-    ownerAgentId: ceo!.id,
-  })
-  .returning();
-
-const [project] = await db
-  .insert(projects)
-  .values({
-    companyId: company!.id,
-    goalId: goal!.id,
-    name: "Control Plane MVP",
-    description: "Implement core board + agent loop",
-    status: "in_progress",
-    leadAgentId: ceo!.id,
-  })
-  .returning();
-
-await db.insert(issues).values([
-  {
-    companyId: company!.id,
-    projectId: project!.id,
-    goalId: goal!.id,
-    title: "Implement atomic task checkout",
-    description: "Ensure in_progress claiming is conflict-safe",
-    status: "todo",
-    priority: "high",
-    assigneeAgentId: engineer!.id,
-    createdByAgentId: ceo!.id,
+    title: "CEO",
+    icon: "crown",
+    capabilities: "Owns company strategy and coordination.",
+    reportsToKey: null,
+    canCreateAgents: true,
   },
   {
-    companyId: company!.id,
-    projectId: project!.id,
-    goalId: goal!.id,
-    title: "Add budget auto-pause",
-    description: "Pause agent at hard budget ceiling",
-    status: "backlog",
-    priority: "medium",
-    createdByAgentId: ceo!.id,
+    key: "cto",
+    name: OREBIT_CANONICAL_ROLE_NAMES.cto,
+    role: "cto",
+    title: "CTO",
+    icon: "cpu",
+    capabilities: "Owns technical execution and systems reliability.",
+    reportsToKey: "ceo",
+    canCreateAgents: false,
   },
-]);
+  {
+    key: "cmo",
+    name: OREBIT_CANONICAL_ROLE_NAMES.cmo,
+    role: "cmo",
+    title: "CMO",
+    icon: "mail",
+    capabilities: "Owns marketing and external communication.",
+    reportsToKey: "ceo",
+    canCreateAgents: false,
+  },
+  ...OREBIT_DEFAULT_ORG_AGENT_NAMES.map((name, index) => ({
+    key: `org-${index + 1}`,
+    name,
+    role: "general",
+    title: null,
+    icon: "bot",
+    capabilities: "Canonical Orebit org roster member.",
+    reportsToKey: "ceo",
+    canCreateAgents: false,
+  })),
+];
 
-console.log("Seed complete");
-process.exit(0);
+function buildStableUuid(value: string) {
+  const hex = createHash("sha256").update(value).digest("hex").slice(0, 32).split("");
+  hex[12] = "5";
+  hex[16] = ((Number.parseInt(hex[16] ?? "0", 16) & 0x3) | 0x8).toString(16);
+  return `${hex.slice(0, 8).join("")}-${hex.slice(8, 12).join("")}-${hex.slice(12, 16).join("")}-${hex.slice(16, 20).join("")}-${hex.slice(20, 32).join("")}`;
+}
+
+function buildOrebitRosterAgentId(companyId: string, rosterKey: string) {
+  return buildStableUuid(`orebit-roster:${companyId}:${rosterKey}`);
+}
+
+export async function seedCanonicalOrebitRoster(db: Pick<Db, "insert">, companyId: string) {
+  const rosterIds = new Map<string, string>();
+
+  for (const entry of OREBIT_BOOTSTRAP_ROSTER) {
+    const id = buildOrebitRosterAgentId(companyId, entry.key);
+    rosterIds.set(entry.key, id);
+    const reportsTo = entry.reportsToKey ? rosterIds.get(entry.reportsToKey) ?? buildOrebitRosterAgentId(companyId, entry.reportsToKey) : null;
+    const now = new Date();
+    const values = {
+      id,
+      companyId,
+      name: entry.name,
+      role: entry.role,
+      title: entry.title,
+      icon: entry.icon,
+      status: "idle" as const,
+      reportsTo,
+      capabilities: entry.capabilities,
+      adapterType: "codex_local",
+      adapterConfig: {
+        cwd: process.cwd(),
+      },
+      runtimeConfig: {},
+      budgetMonthlyCents: 0,
+      spentMonthlyCents: 0,
+      permissions: { canCreateAgents: entry.canCreateAgents },
+      pauseReason: null,
+      pausedAt: null,
+      lastHeartbeatAt: null,
+      metadata: {
+        canonicalRoster: true,
+        orebitBootstrap: true,
+        rosterKey: entry.key,
+      },
+      updatedAt: now,
+    };
+
+    await db.insert(agents).values(values).onConflictDoUpdate({
+      target: agents.id,
+      set: values,
+    }).returning();
+  }
+}
+
+function validateCanonicalCompanyBootstrap(input: CanonicalCompanyBootstrap) {
+  const missing: string[] = [];
+
+  if (typeof input.name !== "string" || input.name.trim().length === 0) missing.push("name");
+  if (typeof input.description !== "string" || input.description.trim().length === 0) missing.push("description");
+  if (typeof input.issuePrefix !== "string" || input.issuePrefix.trim().length === 0) missing.push("issuePrefix");
+  if (!Array.isArray(input.taxonomy) || input.taxonomy.length === 0) missing.push("taxonomy");
+
+  const invalidTaxonomy = Array.isArray(input.taxonomy)
+    ? input.taxonomy.find((entry) =>
+      typeof entry.key !== "string" || entry.key.trim().length === 0
+      || typeof entry.slug !== "string" || entry.slug.trim().length === 0
+      || typeof entry.name !== "string" || entry.name.trim().length === 0
+      || typeof entry.description !== "string" || entry.description.trim().length === 0
+      || typeof entry.markdown !== "string" || entry.markdown.trim().length === 0,
+    )
+    : null;
+
+  if (invalidTaxonomy) {
+    throw new Error("Bootstrap company identity is required: each taxonomy entry must include key, slug, name, description, and markdown.");
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Bootstrap company identity is required: missing ${missing.join(", ")}.`);
+  }
+}
+
+export async function seedCanonicalOrebitCompany(
+  db: Pick<Db, "insert">,
+  bootstrap: CanonicalCompanyBootstrap = OREBIT_BOOTSTRAP_COMPANY,
+): Promise<{ company: SeededCompany; taxonomy: BootstrapTaxonomyEntry[] }> {
+  validateCanonicalCompanyBootstrap(bootstrap);
+
+  const [company] = await db
+    .insert(companies)
+    .values({
+      name: bootstrap.name,
+      description: bootstrap.description,
+      status: "active",
+      issuePrefix: bootstrap.issuePrefix,
+      budgetMonthlyCents: 0,
+    })
+    .onConflictDoUpdate({
+      target: companies.issuePrefix,
+      set: {
+        name: bootstrap.name,
+        description: bootstrap.description,
+        status: "active",
+        issuePrefix: bootstrap.issuePrefix,
+        budgetMonthlyCents: 0,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+
+  if (!company) {
+    throw new Error("Failed to seed canonical Orebit company.");
+  }
+
+  const taxonomyRecords = bootstrap.taxonomy.map((entry) => ({
+    companyId: company.id,
+    key: entry.key,
+    slug: entry.slug,
+    name: entry.name,
+    description: entry.description,
+    markdown: entry.markdown,
+    sourceType: "catalog" as const,
+    sourceLocator: null,
+    sourceRef: "orebit-bootstrap",
+    trustLevel: "markdown_only" as const,
+    compatibility: "compatible" as const,
+    fileInventory: [],
+    metadata: {
+      canonical: true,
+      taxonomy: true,
+    },
+  }));
+
+  for (const entry of taxonomyRecords) {
+    const [taxonomy] = await db
+      .insert(companySkills)
+      .values(entry)
+      .onConflictDoUpdate({
+        target: [companySkills.companyId, companySkills.key],
+        set: {
+          slug: entry.slug,
+          name: entry.name,
+          description: entry.description,
+          markdown: entry.markdown,
+          sourceType: "catalog",
+          sourceLocator: null,
+          sourceRef: "orebit-bootstrap",
+          trustLevel: "markdown_only",
+          compatibility: "compatible",
+          fileInventory: [],
+          metadata: {
+            canonical: true,
+            taxonomy: true,
+          },
+        },
+      })
+      .returning();
+
+    if (!taxonomy) {
+      throw new Error("Failed to seed canonical Orebit company taxonomy.");
+    }
+  }
+
+  await seedCanonicalOrebitRoster(db, company.id);
+
+  return { company, taxonomy: taxonomyRecords };
+}
+
+async function main() {
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL is required");
+
+  const db = createDb(url);
+  console.log("Seeding canonical Orebit company and roster...");
+  await seedCanonicalOrebitCompany(db);
+  console.log("Seed complete");
+}
+
+const isMainModule = process.argv[1]
+  ? import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+  : false;
+
+if (isMainModule) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/server/src/__tests__/agent-process-command-validation.test.ts
+++ b/server/src/__tests__/agent-process-command-validation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { agentService } from "../services/agents.ts";
+
+function makeSelectChain(rows: unknown[]) {
+  const chain: any = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    groupBy: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    then: (resolve: (value: unknown[]) => unknown) => Promise.resolve(rows).then(resolve),
+  };
+  return chain;
+}
+
+function createDbStub(options: { selectRows: unknown[] }) {
+  return {
+    select: vi.fn(() => makeSelectChain(options.selectRows)),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(),
+        })),
+      })),
+    })),
+  };
+}
+
+describe("agentService process adapter validation", () => {
+  it("rejects process agents without adapterConfig.command before insert", async () => {
+    const db = createDbStub({ selectRows: [] });
+    const svc = agentService(db as never);
+
+    await expect(
+      svc.create("company-1", {
+        name: "Broken Process Agent",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        budgetMonthlyCents: 0,
+      }),
+    ).rejects.toThrow("Process agents require adapterConfig.command");
+
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects updates that would remove the process command", async () => {
+    const db = createDbStub({
+      selectRows: [
+        {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Worker",
+          role: "general",
+          title: null,
+          reportsTo: null,
+          capabilities: null,
+          adapterType: "codex_local",
+          adapterConfig: {},
+          runtimeConfig: {},
+          budgetMonthlyCents: 0,
+          metadata: null,
+          status: "idle",
+          permissions: {},
+        },
+      ],
+    });
+    const svc = agentService(db as never);
+
+    await expect(
+      svc.update("agent-1", {
+        adapterType: "process",
+        adapterConfig: {},
+      }),
+    ).rejects.toThrow("Process agents require adapterConfig.command");
+
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/agents-service.test.ts
+++ b/server/src/__tests__/agents-service.test.ts
@@ -1,0 +1,139 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { agents, companies, createDb } from "@paperclipai/db";
+import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
+import { agentService } from "../services/agents.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres agent service tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("agentService.create CEO defaults", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof agentService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agents-service-");
+    db = createDb(tempDb.connectionString);
+    svc = agentService(db);
+  }, 20_000);
+
+  afterAll(async () => {
+    await db.delete(agents);
+    await db.delete(companies);
+    await tempDb?.cleanup();
+  });
+
+  it("defaults the first agent to the CEO role", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const agent = await svc.create(companyId, {
+      name: "Siro Hermes",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      budgetMonthlyCents: 0,
+    });
+
+    expect(agent.role).toBe("ceo");
+    expect(agent.permissions?.canCreateAgents).toBe(true);
+    expect(agent.reportsTo).toBeNull();
+  });
+
+  it("prefers the canonical CEO when duplicate shortnames exist", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const ceo = await svc.create(companyId, {
+      name: "Siro Hermes",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      budgetMonthlyCents: 0,
+    });
+
+    await db.insert(agents).values({
+      companyId,
+      name: "Siro Hermes",
+      role: "general",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      budgetMonthlyCents: 0,
+      permissions: {},
+    });
+
+    const resolved = await svc.resolveByReference(companyId, "Siro Hermes");
+
+    expect(resolved.ambiguous).toBe(false);
+    expect(resolved.agent?.id).toBe(ceo.id);
+    expect(resolved.agent?.role).toBe("ceo");
+  });
+
+  it("rejects process agents without a command on create", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await expect(
+      svc.create(companyId, {
+        name: "Broken Process Agent",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        budgetMonthlyCents: 0,
+      }),
+    ).rejects.toThrow("Process agents require adapterConfig.command");
+  });
+
+  it("rejects updates that would turn an agent into a commandless process adapter", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const agent = await svc.create(companyId, {
+      name: "Updatable Agent",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      budgetMonthlyCents: 0,
+    });
+
+    await expect(
+      svc.update(agent.id, {
+        adapterType: "process",
+        adapterConfig: {},
+      }),
+    ).rejects.toThrow("Process agents require adapterConfig.command");
+  });
+});

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { parse as parseEnvContents } from "dotenv";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   agents,
   companies,
@@ -49,6 +49,7 @@ import {
 const execFileAsync = promisify(execFile);
 const leasedRunIds = new Set<string>();
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const itEmbeddedPostgres = embeddedPostgresSupport.supported ? it : it.skip;
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
 if (!embeddedPostgresSupport.supported) {
@@ -190,6 +191,90 @@ describe("sanitizeRuntimeServiceBaseEnv", () => {
     expect(sanitized.npm_config_tailscale_auth).toBeUndefined();
     expect(sanitized.npm_config_authenticated_private).toBeUndefined();
     expect(sanitized.HOST).toBe("0.0.0.0");
+  });
+});
+
+describe("realizeExecutionWorkspace Orebit bootstrap", () => {
+  it("materializes the canonical roster on fresh realization and stays idempotent", async () => {
+    const insertedAgents = new Map<string, Record<string, unknown>>();
+    const db = {
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => ({
+            then: async (resolve: (rows: Array<Record<string, unknown>>) => unknown) => resolve([
+              { id: "company-1", issuePrefix: "ORE" },
+            ]),
+          }),
+        }),
+      })),
+      insert: vi.fn((table: unknown) => ({
+        values: (values: Record<string, unknown>) => ({
+          onConflictDoUpdate: () => ({
+            returning: async () => {
+              if (table === agents) {
+                insertedAgents.set(String(values.id), values);
+              }
+              return [values];
+            },
+          }),
+        }),
+      })),
+    } as any;
+
+    const base = {
+      baseCwd: "/tmp/paperclip-orebit-runtime",
+      source: "project_primary" as const,
+      projectId: "project-1",
+      workspaceId: "workspace-1",
+      repoUrl: null,
+      repoRef: "HEAD",
+    };
+
+    const first = await realizeExecutionWorkspace({
+      base,
+      config: {
+        workspaceStrategy: { type: "project_primary" },
+      },
+      issue: null,
+      agent: {
+        id: null,
+        name: "Board",
+        companyId: "company-1",
+      },
+      db,
+      companyId: "company-1",
+    });
+
+    expect(first.strategy).toBe("project_primary");
+    expect(insertedAgents.size).toBe(8);
+
+    const second = await realizeExecutionWorkspace({
+      base,
+      config: {
+        workspaceStrategy: { type: "project_primary" },
+      },
+      issue: null,
+      agent: {
+        id: null,
+        name: "Board",
+        companyId: "company-1",
+      },
+      db,
+      companyId: "company-1",
+    });
+
+    expect(second.strategy).toBe("project_primary");
+    expect(insertedAgents.size).toBe(8);
+    expect(Array.from(insertedAgents.values()).map((agent) => agent.name)).toEqual(expect.arrayContaining([
+      "Siro Hermes",
+      "Luna",
+      "Nala",
+      "Milo",
+      "Mochi",
+      "Kuro",
+      "Oyen",
+      "Shiro",
+    ]));
   });
 });
 
@@ -1703,6 +1788,204 @@ describe("realizeExecutionWorkspace", () => {
     });
 
     await expect(fs.readFile(path.join(initial.cwd, ".paperclip-restored-state"), "utf8")).resolves.toBe("reprovisioned\n");
+  });
+
+  describeEmbeddedPostgres("fresh session realization", () => {
+    it("bootstraps the canonical Orebit roster", async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-orebit-fresh-runtime-"));
+      const dbHandle = await startEmbeddedPostgresTestDatabase("paperclip-orebit-fresh-runtime-");
+
+      try {
+        const db = createDb(dbHandle.connectionString);
+        const [orebitCompany] = await db.insert(companies).values({
+          name: "Orebit",
+          description: "Orebit runtime company",
+          status: "active",
+          issuePrefix: "ORE",
+          budgetMonthlyCents: 0,
+        }).returning();
+
+        expect(orebitCompany).toBeDefined();
+
+        const first = await realizeExecutionWorkspace({
+          base: {
+            baseCwd: tempRoot,
+            source: "project_primary",
+            projectId: "project-1",
+            workspaceId: "workspace-1",
+            repoUrl: null,
+            repoRef: "HEAD",
+          },
+          config: {
+            workspaceStrategy: {
+              type: "project_primary",
+            },
+          },
+          issue: null,
+          agent: {
+            id: null,
+            name: "Board",
+            companyId: orebitCompany!.id,
+          },
+          db,
+          companyId: orebitCompany!.id,
+        });
+
+        expect(first.strategy).toBe("project_primary");
+        const firstRoster = await db.select().from(agents).where(eq(agents.companyId, orebitCompany!.id));
+        expect(firstRoster).toHaveLength(8);
+
+        const second = await realizeExecutionWorkspace({
+          base: {
+            baseCwd: tempRoot,
+            source: "project_primary",
+            projectId: "project-1",
+            workspaceId: "workspace-1",
+            repoUrl: null,
+            repoRef: "HEAD",
+          },
+          config: {
+            workspaceStrategy: {
+              type: "project_primary",
+            },
+          },
+          issue: null,
+          agent: {
+            id: null,
+            name: "Board",
+            companyId: orebitCompany!.id,
+          },
+          db,
+          companyId: orebitCompany!.id,
+        });
+
+        expect(second.strategy).toBe("project_primary");
+        const secondRoster = await db.select().from(agents).where(eq(agents.companyId, orebitCompany!.id));
+        expect(secondRoster).toHaveLength(8);
+        expect(secondRoster.map((agent) => agent.name)).toEqual(expect.arrayContaining([
+          "Siro Hermes",
+          "Luna",
+          "Nala",
+          "Milo",
+          "Mochi",
+          "Kuro",
+          "Oyen",
+          "Shiro",
+        ]));
+        expect(secondRoster.every((agent) => agent.adapterType === "codex_local")).toBe(true);
+        expect(secondRoster.every((agent) => typeof agent.adapterConfig?.cwd === "string")).toBe(true);
+      } finally {
+        await dbHandle.cleanup();
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    },
+    20000,
+    );
+  });
+
+  describeEmbeddedPostgres("persisted workspace availability", () => {
+    it("bootstraps the canonical Orebit roster", async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-orebit-runtime-"));
+      const dbHandle = await startEmbeddedPostgresTestDatabase("paperclip-orebit-runtime-");
+
+      try {
+        const db = createDb(dbHandle.connectionString);
+        const [orebitCompany] = await db.insert(companies).values({
+          name: "Orebit",
+          description: "Orebit runtime company",
+          status: "active",
+          issuePrefix: "ORE",
+          budgetMonthlyCents: 0,
+        }).returning();
+
+        expect(orebitCompany).toBeDefined();
+
+        const first = await ensurePersistedExecutionWorkspaceAvailable({
+          db,
+          companyId: orebitCompany!.id,
+          base: {
+            baseCwd: tempRoot,
+            source: "project_primary",
+            projectId: "project-1",
+            workspaceId: "workspace-1",
+            repoUrl: null,
+            repoRef: "HEAD",
+          },
+          workspace: {
+            mode: "shared_workspace",
+            strategyType: "project_primary",
+            cwd: tempRoot,
+            providerRef: null,
+            projectId: "project-1",
+            projectWorkspaceId: "workspace-1",
+            repoUrl: null,
+            baseRef: null,
+            branchName: null,
+            config: null,
+          },
+          issue: null,
+          agent: {
+            id: null,
+            name: "Board",
+            companyId: orebitCompany!.id,
+          },
+        });
+
+        expect(first).not.toBeNull();
+        const firstRoster = await db.select().from(agents).where(eq(agents.companyId, orebitCompany!.id));
+        expect(firstRoster).toHaveLength(8);
+
+        const second = await ensurePersistedExecutionWorkspaceAvailable({
+          db,
+          companyId: orebitCompany!.id,
+          base: {
+            baseCwd: tempRoot,
+            source: "project_primary",
+            projectId: "project-1",
+            workspaceId: "workspace-1",
+            repoUrl: null,
+            repoRef: "HEAD",
+          },
+          workspace: {
+            mode: "shared_workspace",
+            strategyType: "project_primary",
+            cwd: tempRoot,
+            providerRef: null,
+            projectId: "project-1",
+            projectWorkspaceId: "workspace-1",
+            repoUrl: null,
+            baseRef: null,
+            branchName: null,
+            config: null,
+          },
+          issue: null,
+          agent: {
+            id: null,
+            name: "Board",
+            companyId: orebitCompany!.id,
+          },
+        });
+
+        expect(second).not.toBeNull();
+        const secondRoster = await db.select().from(agents).where(eq(agents.companyId, orebitCompany!.id));
+        expect(secondRoster).toHaveLength(8);
+        expect(secondRoster.map((agent) => agent.name)).toEqual(expect.arrayContaining([
+          "Siro Hermes",
+          "Luna",
+          "Nala",
+          "Milo",
+          "Mochi",
+          "Kuro",
+          "Oyen",
+          "Shiro",
+        ]));
+        expect(secondRoster.every((agent) => agent.adapterType === "codex_local")).toBe(true);
+        expect(secondRoster.every((agent) => typeof agent.adapterConfig?.cwd === "string")).toBe(true);
+      } finally {
+        await dbHandle.cleanup();
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    }, 20000);
   });
 
   it("auto-detects the default branch when baseRef is not configured", async () => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The issue sits in the Orebit bootstrap/roster materialization path, not in the UI.
> - The live failure proved the canonical roster still materialized a commandless process agent state.
> - A create/update guard in `server/src/services/agents.ts` was necessary but not sufficient.
> - This pull request fixes the canonical bootstrap state and adds regression coverage around it.
> - The benefit is that fresh issues can wake and run without tripping `adapter_failed - Process adapter missing command`.

## What Changed
- Seeded the canonical Orebit roster with an executable `codex_local` config instead of an invalid empty-command process config.
- Added regression coverage for the Orebit roster seed path and for the live workspace/runtime behavior around the fixed roster.
- Added server-side regression tests that keep process-agent command validation in place.

## Verification
- `pnpm exec vitest run packages/db/src/seed.test.ts server/src/__tests__/agent-process-command-validation.test.ts server/src/__tests__/agents-service.test.ts`
- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts`
- Live browser QA on `https://paperclip.orebit.id/ORE/issues/ORE-21` confirmed the new issue flow no longer surfaced `Process adapter missing command` / `adapter_failed`.
- `pnpm -r typecheck` and `pnpm build` are still blocked by a pre-existing migration journal/file-count mismatch in `packages/db` (`59` vs `58`).

## Risks
- The canonical roster bootstrap behavior changed, so any code that assumed the old empty-command process config would need to read the new executable config.
- The repo still has a pre-existing db migration journal mismatch that blocks full typecheck/build verification.
- This change is intentionally narrow and company-scoped to Orebit/Paperclip.

## Model Used
- OpenAI GPT-5.4-mini (`gpt-5.4-mini`), API use with tool access and reasoning.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge