### PR TITLE
feat: add flake.nix so paperclip can be installed on nixos

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,138 @@
+{
+  description = "Paperclip — AI agent orchestration platform";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      # Non-per-system outputs
+      nonSystemOutputs = {
+        nixosModules.paperclip = import ./nix/modules/nixos/paperclip.nix;
+
+        overlays.default = final: prev: {
+          paperclip = self.packages.${final.system}.default;
+        };
+      };
+
+      # Per-system outputs (packages, devShells)
+      perSystemOutputs = flake-utils.lib.eachDefaultSystem (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          nodejs = pkgs.nodejs_22;
+          pnpm = pkgs.pnpm_9;
+        in
+        {
+          packages.default = pkgs.stdenv.mkDerivation (finalAttrs: {
+            pname = "paperclip";
+            version = "0.3.1";
+            src = ./.;
+
+            nativeBuildInputs = [
+              nodejs
+              pnpm
+              pkgs.pnpmConfigHook
+              pkgs.makeWrapper
+              pkgs.python3 # node-gyp
+              pkgs.pkg-config
+            ];
+
+            buildInputs = [
+              pkgs.vips # sharp
+              pkgs.postgresql # embedded-postgres runtime
+            ];
+
+            # Hoist all deps to root node_modules so Node ESM resolution works
+            # from any package in the monorepo.
+            prePnpmInstall = ''
+              echo "shamefully-hoist=true" >> .npmrc
+            '';
+
+            # First build: run `nix build`, Nix will error with the correct hash.
+            pnpmDeps = pkgs.fetchPnpmDeps {
+              inherit (finalAttrs) pname version src prePnpmInstall;
+              inherit pnpm;
+              fetcherVersion = 3;
+              hash = "sha256-5SgY5W5xrY2p8DN9fZ38SNhR+BIXm7hOXILpfyQcRsQ=";
+            };
+
+            buildPhase = ''
+              runHook preBuild
+              pnpm --filter @paperclipai/shared build
+              pnpm --filter @paperclipai/db build
+              pnpm --filter @paperclipai/adapter-utils build
+              pnpm --filter @paperclipai/plugin-sdk build
+              pnpm --filter @paperclipai/ui build
+              pnpm --filter @paperclipai/server build
+              pnpm --filter paperclipai build
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+
+              # Copy the full built tree
+              mkdir -p $out/lib/paperclip
+              cp -r node_modules package.json pnpm-workspace.yaml $out/lib/paperclip/
+              for dir in cli server ui packages; do
+                cp -r $dir $out/lib/paperclip/
+              done
+
+              # CLI entrypoint
+              mkdir -p $out/bin
+              makeWrapper ${nodejs}/bin/node $out/bin/paperclip \
+                --add-flags "$out/lib/paperclip/cli/dist/index.js" \
+                --set NODE_ENV production
+
+              # Server entrypoint (for running as a service)
+              # PORT, HOST, and SERVE_UI can be overridden at runtime via env vars,
+              # e.g.: PORT=8080 HOST=127.0.0.1 paperclip-server
+              makeWrapper ${nodejs}/bin/node $out/bin/paperclip-server \
+                --add-flags "--import $out/lib/paperclip/server/node_modules/tsx/dist/loader.mjs" \
+                --add-flags "$out/lib/paperclip/server/dist/index.js" \
+                --set-default NODE_ENV production \
+                --set-default SERVE_UI true \
+                --set-default HOST 0.0.0.0 \
+                --set-default PORT 3100 \
+                --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.git pkgs.gh pkgs.ripgrep ]}
+
+              runHook postInstall
+            '';
+
+            meta = with pkgs.lib; {
+              description = "Orchestrate AI agent teams";
+              homepage = "https://github.com/paperclipai/paperclip";
+              license = licenses.mit;
+              mainProgram = "paperclip";
+            };
+          });
+
+          devShells.default = pkgs.mkShell {
+            buildInputs = [
+              nodejs
+              pkgs.corepack_22
+              pkgs.git
+              pkgs.gh
+              pkgs.ripgrep
+              pkgs.python3
+              pkgs.jq
+              pkgs.openssh
+              pkgs.curl
+              pkgs.wget
+              pkgs.vips
+              pkgs.pkg-config
+              pkgs.playwright-driver.browsers
+            ];
+
+            shellHook = ''
+              export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
+              export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+              corepack enable
+            '';
+          };
+        });
+    in
+    perSystemOutputs // nonSystemOutputs;
+}

--- a/nix/modules/nixos/paperclip.nix
+++ b/nix/modules/nixos/paperclip.nix
@@ -1,0 +1,320 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.paperclip;
+  instanceDir = "${cfg.stateDir}/instances/${cfg.instanceId}";
+
+  configJson = pkgs.writeText "paperclip-config.json" (builtins.toJSON (lib.recursiveUpdate {
+    "$meta" = {
+      version = 1;
+      source = "nixos-module";
+    };
+    server = {
+      deploymentMode = if cfg.auth.enable then "authenticated" else "local_trusted";
+      exposure = if cfg.publicExposure then "public" else "private";
+      host = cfg.host;
+      port = cfg.port;
+      serveUi = cfg.serveUi;
+    };
+    database = {
+      mode = if cfg.database.external.enable then "postgres" else "embedded-postgres";
+      embeddedPostgresDataDir = "${instanceDir}/db";
+      backup = {
+        enabled = cfg.database.backup.enable;
+        intervalMinutes = cfg.database.backup.intervalMinutes;
+        retentionDays = cfg.database.backup.retentionDays;
+        dir = "${instanceDir}/data/backups";
+      };
+    } // lib.optionalAttrs cfg.database.external.enable {
+      connectionString = cfg.database.external.url;
+    };
+    storage = {
+      provider = if cfg.storage.s3.enable then "s3" else "local_disk";
+      localDisk = {
+        baseDir = "${instanceDir}/data/storage";
+      };
+    } // lib.optionalAttrs cfg.storage.s3.enable {
+      s3 = {
+        inherit (cfg.storage.s3) bucket region prefix forcePathStyle;
+      } // lib.optionalAttrs (cfg.storage.s3.endpoint != null) {
+        inherit (cfg.storage.s3) endpoint;
+      };
+    };
+    logging = {
+      logDir = "${instanceDir}/logs";
+    };
+    secrets = {
+      provider = "local_encrypted";
+      localEncrypted = {
+        keyFilePath = "${instanceDir}/secrets/master.key";
+      };
+    };
+  } cfg.settings));
+
+in
+{
+  options.services.paperclip = {
+    enable = lib.mkEnableOption "Paperclip AI agent orchestration platform";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.paperclip;
+      defaultText = lib.literalExpression "pkgs.paperclip";
+      description = "The Paperclip package to use.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3100;
+      description = "Port the server listens on.";
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = "Address the server binds to.";
+    };
+
+    serveUi = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to serve the bundled web UI.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to open the server port in the firewall.";
+    };
+
+    auth.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Enable authenticated deployment mode.
+        When false, uses local_trusted mode (loopback only).
+      '';
+    };
+
+    publicExposure = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Expose the server publicly.
+        When false, the server runs in private mode.
+      '';
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/paperclip";
+      description = "Base directory for Paperclip state (database, logs, storage, secrets).";
+    };
+
+    instanceId = lib.mkOption {
+      type = lib.types.str;
+      default = "default";
+      description = "Instance identifier. Allows running multiple isolated instances.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "paperclip";
+      description = "User account under which Paperclip runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "paperclip";
+      description = "Group under which Paperclip runs.";
+    };
+
+    # Database
+    database.external = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Use an external PostgreSQL database instead of the embedded one.
+          When enabled, set the connection URL via `database.external.url`
+          or pass `DATABASE_URL` through `environmentFiles`.
+        '';
+      };
+
+      url = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = ''
+          PostgreSQL connection string for external mode.
+          Prefer using `environmentFiles` for this to avoid storing
+          credentials in the Nix store.
+        '';
+      };
+    };
+
+    database.backup = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Enable automated database backups.";
+      };
+
+      intervalMinutes = lib.mkOption {
+        type = lib.types.ints.between 1 10080;
+        default = 60;
+        description = "Minutes between automated backups.";
+      };
+
+      retentionDays = lib.mkOption {
+        type = lib.types.ints.between 1 3650;
+        default = 7;
+        description = "Days to retain old backups.";
+      };
+    };
+
+    # Storage
+    storage.s3 = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Use S3 for file storage instead of local disk.";
+      };
+
+      bucket = lib.mkOption {
+        type = lib.types.str;
+        default = "paperclip";
+        description = "S3 bucket name.";
+      };
+
+      region = lib.mkOption {
+        type = lib.types.str;
+        default = "us-east-1";
+        description = "S3 region.";
+      };
+
+      endpoint = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Custom S3 endpoint for S3-compatible services (e.g. MinIO).";
+      };
+
+      prefix = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = "Key prefix for all S3 objects.";
+      };
+
+      forcePathStyle = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Use path-style S3 URLs instead of virtual-hosted-style.";
+      };
+    };
+
+    # Escape hatches
+    environment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = {};
+      description = "Extra environment variables passed to the server.";
+    };
+
+    environmentFiles = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = ''
+        Paths to files containing environment variables (systemd EnvironmentFile).
+        Use this for secrets like API keys or DATABASE_URL.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      default = {};
+      description = ''
+        Freeform JSON attributes deep-merged into the generated config.json.
+        Use this for options not covered by the typed module options.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !cfg.publicExposure || cfg.auth.enable;
+        message = "services.paperclip: public exposure requires auth.enable = true.";
+      }
+      {
+        assertion = !(!cfg.auth.enable && cfg.host != "127.0.0.1" && cfg.host != "::1" && cfg.host != "localhost");
+        message = "services.paperclip: local_trusted mode (auth.enable = false) requires host to be loopback (127.0.0.1, ::1, or localhost).";
+      }
+    ];
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.stateDir;
+      description = "Paperclip service user";
+    };
+
+    users.groups.${cfg.group} = {};
+
+    systemd.tmpfiles.rules = [
+      "d ${instanceDir}/db 0750 ${cfg.user} ${cfg.group} -"
+      "d ${instanceDir}/data/storage 0750 ${cfg.user} ${cfg.group} -"
+      "d ${instanceDir}/data/backups 0750 ${cfg.user} ${cfg.group} -"
+      "d ${instanceDir}/logs 0750 ${cfg.user} ${cfg.group} -"
+      "d ${instanceDir}/secrets 0700 ${cfg.user} ${cfg.group} -"
+    ];
+
+    environment.etc."paperclip/config.json" = {
+      source = configJson;
+      mode = "0644";
+    };
+
+    systemd.services.paperclip = {
+      description = "Paperclip AI agent orchestration platform";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      environment = {
+        PAPERCLIP_HOME = cfg.stateDir;
+        PAPERCLIP_INSTANCE_ID = cfg.instanceId;
+        PAPERCLIP_CONFIG = "/etc/paperclip/config.json";
+        PORT = toString cfg.port;
+        HOST = cfg.host;
+        SERVE_UI = lib.boolToString cfg.serveUi;
+        PAPERCLIP_DEPLOYMENT_MODE = if cfg.auth.enable then "authenticated" else "local_trusted";
+        PAPERCLIP_DEPLOYMENT_EXPOSURE = if cfg.publicExposure then "public" else "private";
+        PAPERCLIP_MIGRATION_AUTO_APPLY = "true";
+        PAPERCLIP_MIGRATION_PROMPT = "never";
+        NODE_ENV = "production";
+      } // cfg.environment;
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${cfg.package}/bin/paperclip-server";
+        Restart = "on-failure";
+        RestartSec = 5;
+
+        WorkingDirectory = cfg.stateDir;
+        StateDirectory = lib.removePrefix "/var/lib/" cfg.stateDir;
+
+        EnvironmentFile = cfg.environmentFiles;
+
+        # Hardening
+        ProtectHome = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = [ cfg.stateDir ];
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+  };
+}


### PR DESCRIPTION
## Thinking Path

The benefit is that NixOS users can nix run paperclip, develop with nix develop, or deploy Paperclip as a managed systemd service with `services.paperclip.enable = true`

## What Changed

- Added flake.nix (builds CLI + server from the pnpm monorepo), dev shell, overlay, and nixosModules.paperclip output
- Config.json is generated from Nix options at build time
- Secrets are handled via environmentFiles

## Verification

- `nix flake check` passes
- `nix build` outputs working binaries to `./result/`
- `nix develop` enters a shell with node, pnpm, and the dev dependencies

## Model Use
  - Claude Opus 4.6

## Risks

- The pnpmdeps hash needs to be updated whenever the `pnpm-lock.yaml` updates.


## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
