### PR TITLE
fix(execution-policy): allow returnAssignee as next-stage reviewer when actor differs

### DIFF
--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -970,6 +970,48 @@ describe("issue execution policy transitions", () => {
       });
     });
 
+    it("treats unknown actor identity as a non-participant before any fallback can apply", () => {
+      const ctoAgentId = "33333333-3333-4333-8333-333333333333";
+      const policy = makePolicy([
+        {
+          type: "review",
+          participants: [{ type: "agent", agentId: qaAgentId }],
+        },
+        {
+          type: "review",
+          participants: [{ type: "agent", agentId: ctoAgentId }],
+        },
+      ]);
+      const reviewStageId = policy.stages[0].id;
+
+      expect(() =>
+        applyIssueExecutionPolicyTransition({
+          issue: {
+            status: "in_review",
+            assigneeAgentId: qaAgentId,
+            assigneeUserId: null,
+            executionPolicy: policy,
+            executionState: {
+              status: "pending",
+              currentStageId: reviewStageId,
+              currentStageIndex: 0,
+              currentStageType: "review",
+              currentParticipant: { type: "agent", agentId: qaAgentId },
+              returnAssignee: { type: "agent", agentId: ctoAgentId },
+              completedStageIds: [],
+              lastDecisionId: null,
+              lastDecisionOutcome: null,
+            },
+          },
+          policy,
+          requestedStatus: "done",
+          requestedAssigneePatch: {},
+          actor: {},
+          commentBody: "Approval without actor identity should not unlock fallback.",
+        }),
+      ).toThrow("Only the active reviewer or approver can advance the current execution stage");
+    });
+
     it("skips a self-review-only review stage and advances to approval", () => {
       const policy = makePolicy([
         {

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -912,6 +912,64 @@ describe("issue execution policy transitions", () => {
       expect(result.patch.assigneeAgentId).toBeUndefined();
     });
 
+    it("allows returnAssignee to be next-stage reviewer when actor is a different agent", () => {
+      // Scenario: issue was assigned to ctoAgentId when moved to in_review, so
+      // returnAssignee = cto. Stage 0 is QA review; stage 1 is CTO review.
+      // QA approves stage 0 — CTO must be allowed into stage 1 despite being returnAssignee.
+      const ctoAgentId = "33333333-3333-4333-8333-333333333333";
+      const policy = makePolicy([
+        {
+          type: "review",
+          participants: [{ type: "agent", agentId: qaAgentId }],
+        },
+        {
+          type: "review",
+          participants: [{ type: "agent", agentId: ctoAgentId }],
+        },
+      ]);
+      const reviewStageId = policy.stages[0].id;
+
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_review",
+          assigneeAgentId: qaAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: {
+            status: "pending",
+            currentStageId: reviewStageId,
+            currentStageIndex: 0,
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: qaAgentId },
+            // CTO was the issue assignee when in_review was set — they are returnAssignee
+            // but also the explicit reviewer at stage 1.
+            returnAssignee: { type: "agent", agentId: ctoAgentId },
+            completedStageIds: [],
+            lastDecisionId: null,
+            lastDecisionOutcome: null,
+          },
+        },
+        policy,
+        requestedStatus: "done",
+        requestedAssigneePatch: {},
+        // QA (not the returnAssignee) is approving stage 0
+        actor: { agentId: qaAgentId },
+        commentBody: "QA sign-off complete.",
+      });
+
+      // Stage 1 should advance to CTO even though CTO is returnAssignee
+      expect(result.patch).toMatchObject({
+        status: "in_review",
+        assigneeAgentId: ctoAgentId,
+        executionState: {
+          status: "pending",
+          currentStageType: "review",
+          currentParticipant: { type: "agent", agentId: ctoAgentId },
+          completedStageIds: [reviewStageId],
+        },
+      });
+    });
+
     it("skips a self-review-only review stage and advances to approval", () => {
       const policy = makePolicy([
         {

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -390,10 +390,20 @@ export function applyIssueExecutionPolicyTransition(input: TransitionInput): Tra
           };
         }
 
-        const participant = selectStageParticipant(nextStage, {
-          preferred: explicitAssignee,
-          exclude: existingState?.returnAssignee ?? null,
-        });
+        // When the actor IS the returnAssignee (code executor approving their own stage),
+        // keep returnAssignee excluded so a self-review can never slip through to the next stage.
+        // When the actor is a DIFFERENT agent (e.g. TechLead approving stage 0 while CTO is
+        // returnAssignee), fall back to including the returnAssignee — they may be an explicitly
+        // named participant at a later stage and should not be silently blocked.
+        const actorIsReturnAssignee = principalsEqual(actor, existingState?.returnAssignee ?? null);
+        const participant =
+          selectStageParticipant(nextStage, {
+            preferred: explicitAssignee,
+            exclude: existingState?.returnAssignee ?? null,
+          }) ??
+          (!actorIsReturnAssignee
+            ? selectStageParticipant(nextStage, { preferred: explicitAssignee })
+            : null);
         if (!participant) {
           throw unprocessable(`No eligible ${nextStage.type} participant is configured for this issue`);
         }

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -396,12 +396,13 @@ export function applyIssueExecutionPolicyTransition(input: TransitionInput): Tra
         // returnAssignee), fall back to including the returnAssignee — they may be an explicitly
         // named participant at a later stage and should not be silently blocked.
         const actorIsReturnAssignee = principalsEqual(actor, existingState?.returnAssignee ?? null);
+        const canFallbackToReturnAssignee = actor !== null && !actorIsReturnAssignee;
         const participant =
           selectStageParticipant(nextStage, {
             preferred: explicitAssignee,
             exclude: existingState?.returnAssignee ?? null,
           }) ??
-          (!actorIsReturnAssignee
+          (canFallbackToReturnAssignee
             ? selectStageParticipant(nextStage, { preferred: explicitAssignee })
             : null);
         if (!participant) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip's governed issue workflow depends on execution-stage routing choosing the correct next reviewer or approver without breaking self-review protections.
> - The affected subsystem is `applyIssueExecutionPolicyTransition`, which advances an issue from one execution stage to the next after an approval decision.
> - The regression appeared because `returnAssignee` was excluded from participant selection too broadly, not just in the self-review case it was designed to prevent.
> - That meant a legitimate next-stage reviewer could be filtered out solely because they had previously been the issue's return assignee.
> - In the failing POI-238 scenario, QA approved stage 0, CTO was the only configured reviewer for stage 1, and the engine threw `422 No eligible review participant` instead of advancing.
> - This pull request narrows the exclusion rule so it still blocks self-review when the actor and `returnAssignee` are the same principal, but allows the configured next-stage reviewer when a different actor is approving.
> - The benefit is that explicit stage routing works again for multi-stage review chains without reopening the self-review hole the original exclusion was trying to close.

## What Changed

- Updated `server/src/services/issue-execution-policy.ts` so next-stage participant selection first applies the existing `returnAssignee` exclusion, then falls back to including that participant only when the approving actor is known and is not the `returnAssignee`.
- Added a regression test proving the intended POI-238 case: QA can advance a stage into a CTO-only next review stage even when CTO is also the `returnAssignee`.
- Added a guard test showing that an unknown actor identity is still treated as a non-participant, so the fallback never weakens stage-advance access control.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-execution-policy.test.ts server/src/__tests__/issue-execution-policy-routes.test.ts`
- Runtime smoke: stage advance no longer stalls on the POI-238 live scenario where the next stage's only participant is the `returnAssignee` and the approving actor is a different principal.

## Risks

- Low risk: the change is limited to next-stage participant selection after an approval and leaves the initial self-review skip behavior intact.
- The main behavioral risk would be allowing `returnAssignee` back into a path that should stay blocked; the new fallback is therefore explicitly gated on a known actor who differs from the `returnAssignee`, and covered by regression tests.

> Checked `ROADMAP.md`; this is a targeted workflow regression fix, not overlapping planned core feature work.

## Model Used

- Anthropic Claude Code. The original authoring session did not preserve the exact underlying model ID/version in the PR branch metadata, but the change was produced with Claude Code in a local tool-use coding workflow with focused test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with the exact details available from the original authoring session)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect this change where needed
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
