### PR TITLE
fix(heartbeat): deferred-wake freshness guard to stop terminal drift (POI-237)

### DIFF
--- a/server/src/__tests__/heartbeat-deferred-wake-freshness.test.ts
+++ b/server/src/__tests__/heartbeat-deferred-wake-freshness.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -8,7 +8,6 @@ import {
   agentWakeupRequests,
   companies,
   createDb,
-  heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
   issues,
@@ -243,15 +242,21 @@ describeEmbeddedPostgres("deferred-wake freshness guard (POI-237 Option 1)", () 
   afterEach(async () => {
     vi.clearAllMocks();
     runningProcesses.clear();
-    await db.delete(activityLog);
-    await db.delete(issueComments);
-    await db.delete(heartbeatRunEvents);
-    await db.delete(heartbeatRuns);
-    await db.delete(agentWakeupRequests);
-    await db.delete(issues);
-    await db.delete(agentRuntimeState);
-    await db.delete(agents);
-    await db.delete(companies);
+    // Wait for any background void executeRun() calls to finish before truncating.
+    let idlePolls = 0;
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const runs = await db.select({ status: heartbeatRuns.status }).from(heartbeatRuns);
+      const hasActiveRun = runs.some((r) => r.status === "queued" || r.status === "running");
+      if (!hasActiveRun) {
+        idlePolls += 1;
+        if (idlePolls >= 3) break;
+      } else {
+        idlePolls = 0;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
   });
 
   afterAll(async () => {

--- a/server/src/__tests__/heartbeat-deferred-wake-freshness.test.ts
+++ b/server/src/__tests__/heartbeat-deferred-wake-freshness.test.ts
@@ -1,0 +1,451 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+vi.mock("../telemetry.ts", () => ({
+  getTelemetryClient: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return { ...actual, trackAgentFirstHeartbeat: vi.fn() };
+});
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: vi.fn(async () => ({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "test",
+        provider: "test",
+        model: "test-model",
+      })),
+    })),
+  };
+});
+
+import { heartbeatService } from "../services/heartbeat.ts";
+import { runningProcesses } from "../adapters/index.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping deferred-wake freshness guard tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
+
+/**
+ * Seed a minimal company + active agent and return their ids.
+ */
+async function seedCompanyAndAgent(db: ReturnType<typeof createDb>) {
+  const companyId = randomUUID();
+  const agentId = randomUUID();
+  const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+  await db.insert(companies).values({
+    id: companyId,
+    name: "Paperclip",
+    issuePrefix,
+    requireBoardApprovalForNewAgents: false,
+  });
+
+  await db.insert(agents).values({
+    id: agentId,
+    companyId,
+    name: "Coder",
+    role: "engineer",
+    status: "active",
+    adapterType: "codex_local",
+    adapterConfig: {},
+    runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+    permissions: {},
+  });
+
+  return { companyId, agentId, issuePrefix };
+}
+
+/**
+ * Seed a `done` issue whose executionRunId points to a `running` run.
+ * Returns { issueId, runId, wakeupId }.
+ */
+async function seedTerminalIssueWithRunningExec(
+  db: ReturnType<typeof createDb>,
+  companyId: string,
+  agentId: string,
+  issuePrefix: string,
+) {
+  const issueId = randomUUID();
+  const runId = randomUUID();
+  const wakeupId = randomUUID();
+
+  // Insert wakeup first (no FK on runId), then run referencing wakeup,
+  // then issue referencing run — satisfies all FK constraints.
+  await db.insert(agentWakeupRequests).values({
+    id: wakeupId,
+    companyId,
+    agentId,
+    source: "automation",
+    triggerDetail: "system",
+    reason: "test_wake",
+    payload: { issueId },
+    status: "queued",
+  });
+
+  await db.insert(heartbeatRuns).values({
+    id: runId,
+    companyId,
+    agentId,
+    invocationSource: "automation",
+    triggerDetail: "system",
+    status: "running",
+    wakeupRequestId: wakeupId,
+    contextSnapshot: { issueId, wakeReason: "test_wake" },
+    startedAt: new Date(),
+  });
+
+  await db.insert(issues).values({
+    id: issueId,
+    companyId,
+    title: "Freshness guard test issue",
+    status: "done",
+    priority: "medium",
+    assigneeAgentId: agentId,
+    issueNumber: 1,
+    identifier: `${issuePrefix}-1`,
+    executionRunId: runId,
+    executionAgentNameKey: "coder",
+  });
+
+  return { issueId, runId, wakeupId };
+}
+
+/**
+ * Insert an activity-log entry that records the issue transitioning to `done`
+ * at the given timestamp.
+ */
+async function seedCloseActivityLog(
+  db: ReturnType<typeof createDb>,
+  companyId: string,
+  issueId: string,
+  closedAt: Date,
+) {
+  await db.insert(activityLog).values({
+    companyId,
+    actorType: "agent",
+    actorId: "test-actor",
+    action: "issue.updated",
+    entityType: "issue",
+    entityId: issueId,
+    details: { status: "done" },
+    createdAt: closedAt,
+  });
+}
+
+/**
+ * Seed an issue comment with an explicit createdAt timestamp.
+ * Returns the commentId.
+ */
+async function seedComment(
+  db: ReturnType<typeof createDb>,
+  companyId: string,
+  issueId: string,
+  createdAt: Date,
+) {
+  const commentId = randomUUID();
+  await db.insert(issueComments).values({
+    id: commentId,
+    companyId,
+    issueId,
+    body: "test comment",
+    authorAgentId: null,
+    authorUserId: null,
+    createdAt,
+    updatedAt: createdAt,
+  });
+  return commentId;
+}
+
+/**
+ * Seed a deferred_issue_execution wake for the given commentIds.
+ * Returns the wakeup request id.
+ */
+async function seedDeferredCommentWake(
+  db: ReturnType<typeof createDb>,
+  companyId: string,
+  agentId: string,
+  issueId: string,
+  commentIds: string[],
+) {
+  const deferredId = randomUUID();
+  await db.insert(agentWakeupRequests).values({
+    id: deferredId,
+    companyId,
+    agentId,
+    source: "automation",
+    triggerDetail: "system",
+    reason: "issue_execution_deferred",
+    payload: {
+      issueId,
+      [DEFERRED_WAKE_CONTEXT_KEY]: {
+        issueId,
+        wakeCommentIds: commentIds,
+        wakeReason: "issue_commented",
+      },
+    },
+    status: "deferred_issue_execution",
+  });
+  return deferredId;
+}
+
+// ─── suite ─────────────────────────────────────────────────────────────────
+
+describeEmbeddedPostgres("deferred-wake freshness guard (POI-237 Option 1)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-deferred-wake-freshness-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 30_000);
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    runningProcesses.clear();
+    await db.delete(activityLog);
+    await db.delete(issueComments);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(issues);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  // ── Case 1: stale comment → drop ─────────────────────────────────────────
+  it("drops a deferred comment wake when the comment predates the issue close", async () => {
+    // T1 < T2 < T3: comment posted before close; wake fires after
+    const T1 = new Date("2026-04-01T10:00:00.000Z"); // comment created
+    const T2 = new Date("2026-04-01T11:00:00.000Z"); // issue closed
+    const { companyId, agentId, issuePrefix } = await seedCompanyAndAgent(db);
+    const { issueId, runId } = await seedTerminalIssueWithRunningExec(db, companyId, agentId, issuePrefix);
+
+    await seedCloseActivityLog(db, companyId, issueId, T2);
+    const commentId = await seedComment(db, companyId, issueId, T1);
+    await seedDeferredCommentWake(db, companyId, agentId, issueId, [commentId]);
+
+    await heartbeat.cancelRun(runId);
+
+    // Issue must remain done
+    const [issue] = await db.select({ status: issues.status }).from(issues).where(eq(issues.id, issueId));
+    expect(issue?.status).toBe("done");
+
+    // Deferred wake must be failed with the stale-skip error
+    const [deferredWake] = await db
+      .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.status, "failed"),
+        ),
+      );
+    expect(deferredWake?.error).toBe("deferred_comment_wake_terminal_skipped");
+
+    // No activity log entry for a reopen
+    const reopenEvents = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.entityId, issueId),
+          eq(activityLog.action, "issue.updated"),
+        ),
+      );
+    // Only the seeded close entry; no reopen entry
+    expect(reopenEvents.every((e) => (e.details as Record<string, unknown>)?.reopened !== true)).toBe(true);
+  });
+
+  // ── Case 2: fresh comment → reopen ────────────────────────────────────────
+  it("reopens the issue and promotes the run when the comment is newer than the close", async () => {
+    // T1 < T2 < T3: issue closed first, comment posted after
+    const T1 = new Date("2026-04-01T10:00:00.000Z"); // issue closed
+    const T2 = new Date("2026-04-01T11:00:00.000Z"); // comment created
+    const { companyId, agentId, issuePrefix } = await seedCompanyAndAgent(db);
+    const { issueId, runId } = await seedTerminalIssueWithRunningExec(db, companyId, agentId, issuePrefix);
+
+    await seedCloseActivityLog(db, companyId, issueId, T1);
+    const commentId = await seedComment(db, companyId, issueId, T2);
+    await seedDeferredCommentWake(db, companyId, agentId, issueId, [commentId]);
+
+    await heartbeat.cancelRun(runId);
+
+    // Issue must have been reopened to todo
+    const [issue] = await db.select({ status: issues.status }).from(issues).where(eq(issues.id, issueId));
+    expect(issue?.status).toBe("todo");
+
+    // An activity log entry must record the reopen
+    const reopenEvents = await db
+      .select({ details: activityLog.details })
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.entityId, issueId),
+          eq(activityLog.action, "issue.updated"),
+        ),
+      );
+    const reopenEntry = reopenEvents.find(
+      (e) => (e.details as Record<string, unknown>)?.reopened === true,
+    );
+    expect(reopenEntry).toBeDefined();
+    expect((reopenEntry!.details as Record<string, unknown>)?.source).toBe("deferred_comment_wake");
+
+    // A new run must have been created for the deferred wake agent. The
+    // original (cancelled) run is still there, so the promoted run makes 2.
+    // We don't assert on status here because the heartbeat scheduler can
+    // claim the queued run before this select lands.
+    const agentRuns = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(agentRuns.length).toBeGreaterThan(1);
+  });
+
+  // ── Case 3: mixed batch — one stale, one fresh → reopen ──────────────────
+  it("reopens when batch contains one stale and one fresh comment", async () => {
+    const closedAt = new Date("2026-04-01T11:00:00.000Z");
+    const staleTime = new Date("2026-04-01T10:00:00.000Z");
+    const freshTime = new Date("2026-04-01T12:00:00.000Z");
+    const { companyId, agentId, issuePrefix } = await seedCompanyAndAgent(db);
+    const { issueId, runId } = await seedTerminalIssueWithRunningExec(db, companyId, agentId, issuePrefix);
+
+    await seedCloseActivityLog(db, companyId, issueId, closedAt);
+    const staleCommentId = await seedComment(db, companyId, issueId, staleTime);
+    const freshCommentId = await seedComment(db, companyId, issueId, freshTime);
+    await seedDeferredCommentWake(db, companyId, agentId, issueId, [staleCommentId, freshCommentId]);
+
+    await heartbeat.cancelRun(runId);
+
+    // Fresh wins — issue must be reopened
+    const [issue] = await db.select({ status: issues.status }).from(issues).where(eq(issues.id, issueId));
+    expect(issue?.status).toBe("todo");
+
+    // Must NOT emit a double stale-skip (the skip only fires when all comments are stale)
+    const skipWakes = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.error, "deferred_comment_wake_terminal_skipped"),
+        ),
+      );
+    expect(skipWakes).toHaveLength(0);
+  });
+
+  // ── Case 4: no activity log entry → treat as fresh (lenient fallback) ────
+  it("treats deferred comment as fresh when no terminal activity log entry exists", async () => {
+    // Issue is done but activity_log has no terminal transition entry (e.g., imported/backfilled).
+    // Defensive fallback: closedAt = null → all comments are considered fresh.
+    const commentTime = new Date("2026-04-01T10:00:00.000Z");
+    const { companyId, agentId, issuePrefix } = await seedCompanyAndAgent(db);
+    const { issueId, runId } = await seedTerminalIssueWithRunningExec(db, companyId, agentId, issuePrefix);
+
+    // Deliberately skip seedCloseActivityLog — no terminal log entry
+    const commentId = await seedComment(db, companyId, issueId, commentTime);
+    await seedDeferredCommentWake(db, companyId, agentId, issueId, [commentId]);
+
+    await heartbeat.cancelRun(runId);
+
+    // With closedAt = null the guard is lenient: treat comment as fresh → reopen
+    const [issue] = await db.select({ status: issues.status }).from(issues).where(eq(issues.id, issueId));
+    expect(issue?.status).toBe("todo");
+  });
+
+  // ── Case 5: non-comment deferred wake on terminal issue → unchanged path ──
+  it("promotes non-comment deferred wakes on terminal issues without the freshness check", async () => {
+    // A deferred wake with no wakeCommentIds must bypass the freshness guard entirely.
+    // This verifies Path B (shouldImplicitlyMoveCommentedIssueToTodoForAgent) is not touched.
+    const closedAt = new Date("2026-04-01T10:00:00.000Z");
+    const { companyId, agentId, issuePrefix } = await seedCompanyAndAgent(db);
+    const { issueId, runId } = await seedTerminalIssueWithRunningExec(db, companyId, agentId, issuePrefix);
+
+    await seedCloseActivityLog(db, companyId, issueId, closedAt);
+
+    // Deferred wake with NO comment ids (e.g., assignment-triggered)
+    const deferredId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: deferredId,
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_execution_deferred",
+      payload: {
+        issueId,
+        [DEFERRED_WAKE_CONTEXT_KEY]: {
+          issueId,
+          wakeReason: "issue_assigned",
+          // no wakeCommentIds
+        },
+      },
+      status: "deferred_issue_execution",
+    });
+
+    await heartbeat.cancelRun(runId);
+
+    // The deferred wake must be promoted (reason flipped, runId attached) —
+    // and explicitly NOT failed with the stale-skip error. We don't assert on
+    // status, because the heartbeat scheduler can claim the promoted wake
+    // before this select runs.
+    const [promoted] = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        runId: agentWakeupRequests.runId,
+        error: agentWakeupRequests.error,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, deferredId));
+    expect(promoted?.status).not.toBe("failed");
+    expect(promoted?.error).not.toBe("deferred_comment_wake_terminal_skipped");
+    expect(promoted?.reason).toBe("issue_execution_promoted");
+    expect(promoted?.runId).not.toBeNull();
+  });
+});

--- a/server/src/__tests__/heartbeat-deferred-wake-freshness.test.ts
+++ b/server/src/__tests__/heartbeat-deferred-wake-freshness.test.ts
@@ -403,7 +403,38 @@ describeEmbeddedPostgres("deferred-wake freshness guard (POI-237 Option 1)", () 
     expect(issue?.status).toBe("todo");
   });
 
-  // ── Case 5: non-comment deferred wake on terminal issue → unchanged path ──
+  // ── Case 5: deleted comment rows → treat as fresh (lenient fallback) ──────
+  it("treats deleted deferred comment rows as fresh instead of silently dropping the wake", async () => {
+    const closedAt = new Date("2026-04-01T11:00:00.000Z");
+    const commentTime = new Date("2026-04-01T12:00:00.000Z");
+    const { companyId, agentId, issuePrefix } = await seedCompanyAndAgent(db);
+    const { issueId, runId } = await seedTerminalIssueWithRunningExec(db, companyId, agentId, issuePrefix);
+
+    await seedCloseActivityLog(db, companyId, issueId, closedAt);
+    const commentId = await seedComment(db, companyId, issueId, commentTime);
+    await seedDeferredCommentWake(db, companyId, agentId, issueId, [commentId]);
+
+    await db.delete(issueComments).where(eq(issueComments.id, commentId));
+
+    await heartbeat.cancelRun(runId);
+
+    const [issue] = await db.select({ status: issues.status }).from(issues).where(eq(issues.id, issueId));
+    expect(issue?.status).toBe("todo");
+
+    const [deferredWake] = await db
+      .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.reason, "issue_execution_promoted"),
+        ),
+      );
+    expect(deferredWake?.status).not.toBe("failed");
+    expect(deferredWake?.error).not.toBe("deferred_comment_wake_terminal_skipped");
+  });
+
+  // ── Case 6: non-comment deferred wake on terminal issue → unchanged path ──
   it("promotes non-comment deferred wakes on terminal issues without the freshness check", async () => {
     // A deferred wake with no wakeCommentIds must bypass the freshness guard entirely.
     // This verifies Path B (shouldImplicitlyMoveCommentedIssueToTodoForAgent) is not touched.

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16,6 +16,7 @@ import {
   type RunLivenessState,
 } from "@paperclipai/shared";
 import {
+  activityLog,
   agents,
   agentRuntimeState,
   agentTaskSessions,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5930,7 +5930,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           // No audit entry — lenient fallback: treat as fresh and proceed with reopen.
         }
 
-        const shouldReopenDeferredCommentWake = deferredCommentIds.length > 0 && issueIsTerminal;
+        // Mention wakes (`issue_comment_mentioned`) are notifications targeted at
+        // another agent — they must not flip a finished issue back to todo. Other
+        // comment-bearing deferred wakes (e.g. `issue_commented`) keep the existing
+        // implicit reopen behaviour, still gated by the freshness check above.
+        const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        const shouldReopenDeferredCommentWake =
+          deferredCommentIds.length > 0 &&
+          issueIsTerminal &&
+          deferredWakeReason !== "issue_comment_mentioned";
         let reopenedActivity: LogActivityInput | null = null;
 
         if (shouldReopenDeferredCommentWake) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5908,21 +5908,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                   inArray(issueComments.id, deferredCommentIds),
                 ),
               );
-            const anyFresh = commentRows.some(
-              (row) => row.createdAt.getTime() > closedAt.getTime(),
-            );
-            if (!anyFresh) {
-              await tx
-                .update(agentWakeupRequests)
-                .set({
-                  status: "failed",
-                  finishedAt: new Date(),
-                  error: "deferred_comment_wake_terminal_skipped",
-                  updatedAt: new Date(),
-                })
-                .where(eq(agentWakeupRequests.id, deferred.id));
-              continue;
+            if (commentRows.length > 0) {
+              const anyFresh = commentRows.some(
+                (row) => row.createdAt.getTime() > closedAt.getTime(),
+              );
+              if (!anyFresh) {
+                await tx
+                  .update(agentWakeupRequests)
+                  .set({
+                    status: "failed",
+                    finishedAt: new Date(),
+                    error: "deferred_comment_wake_terminal_skipped",
+                    updatedAt: new Date(),
+                  })
+                  .where(eq(agentWakeupRequests.id, deferred.id));
+                continue;
+              }
             }
+            // Deleted/missing comment rows are treated leniently so comment cleanup
+            // cannot suppress a potentially fresh deferred reopen.
           }
           // No audit entry — lenient fallback: treat as fresh and proceed with reopen.
         }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -21,7 +21,6 @@ import {
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
-  activityLog,
   companySkills as companySkillsTable,
   documentRevisions,
   issueDocuments,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5872,16 +5872,61 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           };
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
-        const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
-        // Only human/comment-reopen interactions should revive completed issues;
-        // system follow-ups such as retry or cleanup wakes must not reopen closed work.
-        const shouldReopenDeferredCommentWake =
-          deferredCommentIds.length > 0 &&
-          (issue.status === "done" || issue.status === "cancelled") &&
-          (
-            deferred.requestedByActorType === "user" ||
-            deferredWakeReason === "issue_reopened_via_comment"
-          );
+        const issueIsTerminal = issue.status === "done" || issue.status === "cancelled";
+
+        // POI-237 Option 1 — deferred-wake freshness guard. When a comment-bearing
+        // deferred wake targets a terminal issue, only allow the implicit reopen if
+        // at least one deferred comment was created AFTER the last terminal
+        // transition. Otherwise treat the wake as stale (it was enqueued while the
+        // issue was still active and the run has since closed it) and drop it.
+        if (deferredCommentIds.length > 0 && issueIsTerminal) {
+          const closureRow = await tx
+            .select({ createdAt: activityLog.createdAt })
+            .from(activityLog)
+            .where(
+              and(
+                eq(activityLog.companyId, issue.companyId),
+                eq(activityLog.entityType, "issue"),
+                eq(activityLog.entityId, issue.id),
+                eq(activityLog.action, "issue.updated"),
+                sql`${activityLog.details} ->> 'status' in ('done','cancelled')`,
+              ),
+            )
+            .orderBy(desc(activityLog.createdAt))
+            .limit(1)
+            .then((rows) => rows[0] ?? null);
+
+          const closedAt = closureRow?.createdAt ?? null;
+          if (closedAt) {
+            const commentRows = await tx
+              .select({ id: issueComments.id, createdAt: issueComments.createdAt })
+              .from(issueComments)
+              .where(
+                and(
+                  eq(issueComments.issueId, issue.id),
+                  inArray(issueComments.id, deferredCommentIds),
+                ),
+              );
+            const anyFresh = commentRows.some(
+              (row) => row.createdAt.getTime() > closedAt.getTime(),
+            );
+            if (!anyFresh) {
+              await tx
+                .update(agentWakeupRequests)
+                .set({
+                  status: "failed",
+                  finishedAt: new Date(),
+                  error: "deferred_comment_wake_terminal_skipped",
+                  updatedAt: new Date(),
+                })
+                .where(eq(agentWakeupRequests.id, deferred.id));
+              continue;
+            }
+          }
+          // No audit entry — lenient fallback: treat as fresh and proceed with reopen.
+        }
+
+        const shouldReopenDeferredCommentWake = deferredCommentIds.length > 0 && issueIsTerminal;
         let reopenedActivity: LogActivityInput | null = null;
 
         if (shouldReopenDeferredCommentWake) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip's deferred wake promotion flow must decide whether a terminal issue should be reopened based on whether a deferred comment still represents fresh user intent.
> - The affected subsystem is the heartbeat promotion path in `server/src/services/heartbeat.ts`, specifically the deferred comment-wake freshness guard added for POI-237.
> - That guard compares deferred comment timestamps against the issue's most recent terminal transition so stale queued wakes do not reopen already-resolved issues.
> - A new edge case appears when the wake still references comment IDs, but those comments have been deleted after enqueue.
> - In that situation the previous implementation treated an empty `commentRows` result as "all stale", which could silently suppress a valid reopen purely because the backing comments were cleaned up later.
> - This pull request makes the guard lenient in that deleted-comment case, matching the existing no-audit fallback philosophy.
> - The benefit is that comment cleanup can no longer produce a false-negative stale classification for an otherwise valid deferred wake.

## What Changed

- Updated the deferred-wake freshness guard in `server/src/services/heartbeat.ts` so an empty `commentRows` result is treated leniently instead of marking the wake stale.
- Added an embedded-Postgres regression test covering the deleted-comment case: a fresh deferred wake still reopens the issue even after the referenced comment row is removed.
- Kept the original stale/fresh/mixed/no-audit/non-comment behavior intact.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-deferred-wake-freshness.test.ts`
- Covered scenarios now include:
  - stale deferred comment → dropped
  - fresh deferred comment → reopened
  - mixed stale/fresh batch → reopened
  - no terminal audit entry → lenient reopen
  - deleted referenced comment row → lenient reopen
  - non-comment deferred wake → bypass freshness guard

## Risks

- Low risk: the change only affects the terminal-issue deferred comment freshness guard and only in the empty-result edge case.
- The main tradeoff is intentional leniency: a deleted referenced comment will now behave like the existing no-audit fallback, preferring not to suppress a potentially legitimate reopen.

> Checked `ROADMAP.md`; this is a narrow bug fix in existing heartbeat behavior, not overlapping planned core feature work.

## Model Used

- Original PR authoring: Anthropic Claude Code (exact model revision not preserved in the PR metadata available to this follow-up).
- Review-fix follow-up for the deleted-comment edge case: OpenAI Codex desktop using GPT-5-family reasoning with local repo editing, shell/test execution, and focused embedded-Postgres regression coverage.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with the exact details available from the original authoring session)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect this change where needed
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
