### PR TITLE
feat(cli): unify issue flag matrix (A+B) — -C optional + per-subcommand guards (DGG-4116)

### DIFF
--- a/cli/src/__tests__/flag-matrix.test.ts
+++ b/cli/src/__tests__/flag-matrix.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitFlagHintsFromArgv } from "../commands/client/common.js";
+
+describe("emitFlagHintsFromArgv", () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it("is silent when no known-wrong flag is present", () => {
+    emitFlagHintsFromArgv([
+      "issue",
+      "create",
+      "--title",
+      "hi",
+      "--project-id",
+      "proj-1",
+    ]);
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("hints when --project-name is used (CLI accepts --project-id only)", () => {
+    emitFlagHintsFromArgv(["issue", "list", "--project-name", "gBETA"]);
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toMatch(/--project-name/);
+    expect(output).toMatch(/--project-id/);
+  });
+
+  it("hints when --parent-issue-id is used (real flag is --parent-id)", () => {
+    emitFlagHintsFromArgv([
+      "issue",
+      "create",
+      "--title",
+      "child",
+      "--parent-issue-id",
+      "abc",
+    ]);
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toMatch(/--parent-issue-id is not a recognized option/);
+    expect(output).toMatch(/--parent-id/);
+  });
+
+  it("hints when `issue update` is combined with -C/--company-id", () => {
+    emitFlagHintsFromArgv([
+      "issue",
+      "update",
+      "abc",
+      "-C",
+      "company-1",
+      "--status",
+      "in_progress",
+    ]);
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toMatch(/`issue update` does NOT accept -C\/--company-id/);
+  });
+
+  it("hints when `issue comment` is combined with --content (real flag is --body)", () => {
+    emitFlagHintsFromArgv([
+      "issue",
+      "comment",
+      "abc",
+      "--content",
+      "hello",
+    ]);
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toMatch(/--body <text>, not --content/);
+  });
+
+  it("does NOT hint on -C when the subcommand is `issue create`", () => {
+    emitFlagHintsFromArgv([
+      "issue",
+      "create",
+      "-C",
+      "company-1",
+      "--title",
+      "ok",
+    ]);
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join("\n");
+    // The company-flag hint is scoped to `issue update` only.
+    expect(output).not.toMatch(/does NOT accept -C/);
+  });
+});

--- a/cli/src/__tests__/flag-matrix.test.ts
+++ b/cli/src/__tests__/flag-matrix.test.ts
@@ -84,4 +84,71 @@ describe("emitFlagHintsFromArgv", () => {
     // The company-flag hint is scoped to `issue update` only.
     expect(output).not.toMatch(/does NOT accept -C/);
   });
+
+  it("hints when --project-title is used (symmetric with --project-name)", () => {
+    emitFlagHintsFromArgv(["issue", "list", "--project-title", "gBETA"]);
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toMatch(/--project-title/);
+    expect(output).toMatch(/--project-id/);
+  });
+
+  it("does NOT false-positive when a --title VALUE contains 'issue update -C'", () => {
+    // Regression: the previous `argv.join(' ')` sweep would misfire here.
+    emitFlagHintsFromArgv([
+      "issue",
+      "create",
+      "--title",
+      "Fix issue update -C handling",
+      "-C",
+      "company-1",
+    ]);
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join("\n");
+    // `issue create` + explicit -C is valid; the update-only hint must NOT fire.
+    expect(output).not.toMatch(/`issue update` does NOT accept/);
+  });
+
+  it("does NOT false-positive when a --title VALUE mentions --project-name", () => {
+    emitFlagHintsFromArgv([
+      "issue",
+      "create",
+      "--title",
+      "use --project-name or --project-id",
+      "--description",
+      "note",
+    ]);
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).not.toMatch(/--project-name \/ --project-title are not supported/);
+  });
+
+  it("does NOT false-positive when a --description VALUE mentions --parent-issue-id", () => {
+    emitFlagHintsFromArgv([
+      "issue",
+      "create",
+      "--title",
+      "t",
+      "--description",
+      "note about --parent-issue-id naming history",
+    ]);
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).not.toMatch(/--parent-issue-id is not a recognized option/);
+  });
+
+  it("does NOT false-positive when a --body VALUE mentions --content", () => {
+    emitFlagHintsFromArgv([
+      "issue",
+      "comment",
+      "abc-uuid",
+      "--body",
+      "deprecated name was --content",
+    ]);
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).not.toMatch(/`issue comment` uses --body <text>, not --content/);
+  });
+
+  it("supports --flag=value syntax for project hints", () => {
+    emitFlagHintsFromArgv(["issue", "list", "--project-name=gBETA"]);
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toMatch(/--project-name/);
+    expect(output).toMatch(/--project-id/);
+  });
 });

--- a/cli/src/commands/client/common.ts
+++ b/cli/src/commands/client/common.ts
@@ -219,3 +219,58 @@ export function handleCommandError(error: unknown): never {
   console.error(pc.red(message));
   process.exit(1);
 }
+
+/**
+ * Known-wrong flag → friendly hint. Emits a guidance line (to stderr) BEFORE
+ * commander renders its generic "unknown option" error, so the user sees the
+ * actionable remediation first.
+ *
+ * This is a best-effort pre-parse sweep: it scans process.argv for a short
+ * allow-list of common mistakes. It does NOT short-circuit commander —
+ * commander still runs and still exits non-zero, which preserves scripted
+ * workflows that rely on a failure exit code.
+ */
+export function emitFlagHintsFromArgv(argv: readonly string[]): void {
+  const joined = argv.join(" ");
+
+  // --project-name / --project-title: not supported; CLI accepts --project-id only.
+  if (/(^|\s)(--project-name|--project-title)(=|\s|$)/.test(joined)) {
+    console.error(
+      pc.yellow(
+        "[paperclipai] Flag hint: --project-name / --project-title are not supported. Use --project-id <uuid>.\n" +
+          "  Resolve a project UUID from its name via REST: curl -u admin:<pw> http://localhost:3100/api/companies/$CID/projects | jq '.[] | {id, name}'",
+      ),
+    );
+  }
+
+  // --parent-issue-id: legacy/expected name, actual flag is --parent-id.
+  if (/(^|\s)--parent-issue-id(=|\s|$)/.test(joined)) {
+    console.error(
+      pc.yellow(
+        "[paperclipai] Flag hint: --parent-issue-id is not a recognized option. Use --parent-id <uuid> on `issue create`.",
+      ),
+    );
+  }
+
+  // `issue update ... -C/--company-id ...` — unsupported on update.
+  const isIssueUpdate = /(^|\s)issue(\s+)update(\s|$)/.test(joined);
+  const hasCompanyFlag = /(^|\s)(-C|--company-id)(=|\s|$)/.test(joined);
+  if (isIssueUpdate && hasCompanyFlag) {
+    console.error(
+      pc.yellow(
+        "[paperclipai] Flag hint: `issue update` does NOT accept -C/--company-id. The issue is resolved from the <issueId> argument alone.\n" +
+          "  Correct usage: paperclipai issue update <issueId> --status in_progress [--comment \"activity log entry\"]",
+      ),
+    );
+  }
+
+  // `issue comment` with --content (expected name is --body).
+  const isIssueComment = /(^|\s)issue(\s+)comment(\s|$)/.test(joined);
+  if (isIssueComment && /(^|\s)--content(=|\s|$)/.test(joined)) {
+    console.error(
+      pc.yellow(
+        "[paperclipai] Flag hint: `issue comment` uses --body <text>, not --content.",
+      ),
+    );
+  }
+}

--- a/cli/src/commands/client/common.ts
+++ b/cli/src/commands/client/common.ts
@@ -221,20 +221,73 @@ export function handleCommandError(error: unknown): never {
 }
 
 /**
+ * Tokenize argv so we can reason about flags and the command/subcommand pair
+ * WITHOUT confusing flag names with user-supplied argument values.
+ *
+ * Rules (conservative, sufficient for hint detection):
+ *  - `commandPath` = leading positional tokens (everything before the first
+ *    token that starts with `-`). For `paperclipai issue update <uuid> --status done`
+ *    this yields `["issue", "update", "<uuid>"]`, which is enough to match the
+ *    `issue update` subcommand prefix.
+ *  - `flagTokens` = exact argv entries that start with `-`, split on `=` so
+ *    that `--project-name=gBETA` becomes `--project-name`. Values (the argv
+ *    entry after a flag, or any entry after the first flag that isn't itself
+ *    a flag) are NOT inspected, which is what prevents false positives when a
+ *    value (e.g. a `--title`) contains flag-like substrings.
+ */
+function tokenizeArgvForHints(argv: readonly string[]): {
+  commandPath: string[];
+  flagTokens: Set<string>;
+} {
+  const commandPath: string[] = [];
+  const flagTokens = new Set<string>();
+  let sawFlag = false;
+
+  for (const raw of argv) {
+    if (raw.startsWith("-")) {
+      sawFlag = true;
+      const name = raw.includes("=") ? raw.slice(0, raw.indexOf("=")) : raw;
+      flagTokens.add(name);
+    } else if (!sawFlag) {
+      commandPath.push(raw);
+    }
+    // Once we've seen a flag, any subsequent non-flag token is treated as a
+    // value and deliberately ignored for hint-matching purposes.
+  }
+
+  return { commandPath, flagTokens };
+}
+
+function matchesSubcommand(
+  commandPath: readonly string[],
+  expected: readonly string[],
+): boolean {
+  if (commandPath.length < expected.length) return false;
+  for (let i = 0; i < expected.length; i++) {
+    if (commandPath[i] !== expected[i]) return false;
+  }
+  return true;
+}
+
+/**
  * Known-wrong flag → friendly hint. Emits a guidance line (to stderr) BEFORE
  * commander renders its generic "unknown option" error, so the user sees the
  * actionable remediation first.
  *
- * This is a best-effort pre-parse sweep: it scans process.argv for a short
- * allow-list of common mistakes. It does NOT short-circuit commander —
- * commander still runs and still exits non-zero, which preserves scripted
- * workflows that rely on a failure exit code.
+ * This is a best-effort pre-parse sweep over argv. It scans flag NAMES (not
+ * argument values) for a short allow-list of common mistakes, and it does NOT
+ * short-circuit commander — commander still runs and still exits non-zero,
+ * which preserves scripted workflows that rely on a failure exit code.
+ *
+ * Scanning flag names rather than the joined argv string avoids false
+ * positives when a user-supplied value (e.g. an `--title` containing the
+ * literal text "issue update -C") accidentally matches a hint pattern.
  */
 export function emitFlagHintsFromArgv(argv: readonly string[]): void {
-  const joined = argv.join(" ");
+  const { commandPath, flagTokens } = tokenizeArgvForHints(argv);
 
   // --project-name / --project-title: not supported; CLI accepts --project-id only.
-  if (/(^|\s)(--project-name|--project-title)(=|\s|$)/.test(joined)) {
+  if (flagTokens.has("--project-name") || flagTokens.has("--project-title")) {
     console.error(
       pc.yellow(
         "[paperclipai] Flag hint: --project-name / --project-title are not supported. Use --project-id <uuid>.\n" +
@@ -244,7 +297,7 @@ export function emitFlagHintsFromArgv(argv: readonly string[]): void {
   }
 
   // --parent-issue-id: legacy/expected name, actual flag is --parent-id.
-  if (/(^|\s)--parent-issue-id(=|\s|$)/.test(joined)) {
+  if (flagTokens.has("--parent-issue-id")) {
     console.error(
       pc.yellow(
         "[paperclipai] Flag hint: --parent-issue-id is not a recognized option. Use --parent-id <uuid> on `issue create`.",
@@ -253,8 +306,9 @@ export function emitFlagHintsFromArgv(argv: readonly string[]): void {
   }
 
   // `issue update ... -C/--company-id ...` — unsupported on update.
-  const isIssueUpdate = /(^|\s)issue(\s+)update(\s|$)/.test(joined);
-  const hasCompanyFlag = /(^|\s)(-C|--company-id)(=|\s|$)/.test(joined);
+  const isIssueUpdate = matchesSubcommand(commandPath, ["issue", "update"]);
+  const hasCompanyFlag =
+    flagTokens.has("-C") || flagTokens.has("--company-id");
   if (isIssueUpdate && hasCompanyFlag) {
     console.error(
       pc.yellow(
@@ -265,8 +319,8 @@ export function emitFlagHintsFromArgv(argv: readonly string[]): void {
   }
 
   // `issue comment` with --content (expected name is --body).
-  const isIssueComment = /(^|\s)issue(\s+)comment(\s|$)/.test(joined);
-  if (isIssueComment && /(^|\s)--content(=|\s|$)/.test(joined)) {
+  const isIssueComment = matchesSubcommand(commandPath, ["issue", "comment"]);
+  if (isIssueComment && flagTokens.has("--content")) {
     console.error(
       pc.yellow(
         "[paperclipai] Flag hint: `issue comment` uses --body <text>, not --content.",

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -84,6 +84,27 @@ interface IssueFeedbackOptions extends BaseClientOptions {
 export function registerIssueCommands(program: Command): void {
   const issue = program.command("issue").description("Issue operations");
 
+  issue.addHelpText(
+    "after",
+    [
+      "",
+      "Flag matrix (per-subcommand support — flags are NOT uniform across subcommands):",
+      "  issue list     : -C/--company-id (optional, profile fallback), --status, --assignee-agent-id, --project-id, --match",
+      "  issue get      : -C optional, --api-key may be required for agent-scoped reads. Accepts UUID or identifier (PC-12).",
+      "  issue create   : -C optional (profile fallback, PAPERCLIP_COMPANY_ID env), --title (required), --description, --assignee-agent-id, --project-id, --parent-id, --goal-id, --priority, --status",
+      "  issue update   : -C NOT accepted. Argument = full issue UUID. --status, --description, --comment (activity-log), etc.",
+      "  issue comment  : -C NOT accepted. Argument = full issue UUID. --body (required), --reopen.",
+      "  issue checkout : --agent-id (required), --expected-statuses (csv, default todo,backlog,blocked)",
+      "  issue release  : no extra flags (argument = full issue UUID)",
+      "",
+      "UUID rule: issue update/get/comment require the FULL UUID, not the 8-char Slack prefix.",
+      "  First resolve with `paperclipai issue list --json` or `paperclipai issue get <identifier>` to get the full UUID.",
+      "Project names: this CLI accepts --project-id only. There is no --project-name flag.",
+      "  Resolve names via REST: curl -u admin:... http://localhost:3100/api/companies/$CID/projects",
+      "",
+    ].join("\n"),
+  );
+
   addCommonClientOptions(
     issue
       .command("list")
@@ -156,7 +177,10 @@ export function registerIssueCommands(program: Command): void {
     issue
       .command("create")
       .description("Create an issue")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option(
+        "-C, --company-id <id>",
+        "Company ID (falls back to PAPERCLIP_COMPANY_ID or default context profile)",
+      )
       .requiredOption("--title <title>", "Issue title")
       .option("--description <text>", "Issue description")
       .option("--status <status>", "Issue status")
@@ -167,6 +191,10 @@ export function registerIssueCommands(program: Command): void {
       .option("--parent-id <id>", "Parent issue ID")
       .option("--request-depth <n>", "Request depth integer")
       .option("--billing-code <code>", "Billing code")
+      .addHelpText(
+        "after",
+        "\nNotes:\n  --company-id is optional if a default context profile is set or PAPERCLIP_COMPANY_ID is exported.\n  Parent issue uses --parent-id (not --parent-issue-id).\n  Use --project-id <id> to attach a project (use `paperclipai --help` → project list via REST API).\n",
+      )
       .action(async (opts: IssueCreateOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -196,7 +224,7 @@ export function registerIssueCommands(program: Command): void {
     issue
       .command("update")
       .description("Update an issue")
-      .argument("<issueId>", "Issue ID")
+      .argument("<issueId>", "Issue ID (full UUID — 8-char prefix not accepted)")
       .option("--title <title>", "Issue title")
       .option("--description <text>", "Issue description")
       .option("--status <status>", "Issue status")
@@ -209,6 +237,10 @@ export function registerIssueCommands(program: Command): void {
       .option("--billing-code <code>", "Billing code")
       .option("--comment <text>", "Optional comment to add with update")
       .option("--hidden-at <iso8601|null>", "Set hiddenAt timestamp or literal 'null'")
+      .addHelpText(
+        "after",
+        "\nNotes:\n  `issue update` resolves the issue directly from <issueId>; -C/--company-id is NOT accepted here (use it on `issue create`/`issue list`).\n  Status transitions go through this command with --status and optional --comment (comment becomes an activity-log entry).\n",
+      )
       .action(async (issueId: string, opts: IssueUpdateOptions) => {
         try {
           const ctx = resolveCommandContext(opts);

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -217,6 +217,11 @@ export function registerIssueCommands(program: Command): void {
           handleCommandError(err);
         }
       }),
+    // `includeCompany: false` is intentional: this subcommand registers its
+    // own `-C/--company-id` option inline (above) as an OPTIONAL flag with
+    // explicit help text describing the profile/env fallback, so the shared
+    // `addCommonClientOptions` helper must NOT re-register it. Keep these two
+    // in sync: if inline `-C` is removed, flip this back to the default.
     { includeCompany: false },
   );
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,6 +9,7 @@ import { runCommand } from "./commands/run.js";
 import { bootstrapCeoInvite } from "./commands/auth-bootstrap-ceo.js";
 import { dbBackupCommand } from "./commands/db-backup.js";
 import { registerEnvLabCommands } from "./commands/env-lab.js";
+import { emitFlagHintsFromArgv } from "./commands/client/common.js";
 import { registerContextCommands } from "./commands/client/context.js";
 import { registerCompanyCommands } from "./commands/client/company.js";
 import { registerIssueCommands } from "./commands/client/issue.js";
@@ -33,7 +34,10 @@ const DATA_DIR_OPTION_HELP =
 program
   .name("paperclipai")
   .description("Paperclip CLI — setup, diagnose, and configure your instance")
-  .version(cliVersion);
+  .version(cliVersion)
+  .showHelpAfterError(
+    "(run the command with --help to see supported flags; flag support varies per subcommand — see `issue --help` / `issue create --help` / `issue update --help`)",
+  );
 
 program.hook("preAction", (_thisCommand, actionCommand) => {
   const options = actionCommand.optsWithGlobals() as DataDirOptionLike;
@@ -166,6 +170,10 @@ auth
 registerClientAuthCommands(auth);
 
 async function main(): Promise<void> {
+  // Pre-parse sweep: print actionable hints for well-known wrong flags BEFORE
+  // commander's generic "unknown option" error. Does not change exit code.
+  emitFlagHintsFromArgv(process.argv.slice(2));
+
   let failed = false;
   try {
     await program.parseAsync();


### PR DESCRIPTION
## Summary

Paperclip CLI (`paperclipai`) `issue …` subcommands have inconsistent flag support. This causes a high first-call failure rate for automation and agents (documented per-flag in the Paperclip knowledge base, which teams now had to read before every call).

This PR implements the **A + B** approach:

- **A. `-C` auto-fallback on `issue create`** — `-C` / `--company-id` is now **optional** on `issue create` and falls back to the context profile's `companyId` or the `PAPERCLIP_COMPANY_ID` env var. Explicit `-C` still overrides. `issue list` already worked this way; this aligns `create` with it.
- **B. Flag matrix guard** — a pre-parse sweep prints an actionable hint to stderr *before* commander's generic `unknown option` error, for a short allow-list of well-known mistakes (does not change exit codes; commander still exits non-zero, so scripting is unaffected):
    - `issue update -C …`         → "update does not accept -C/--company-id"
    - `--project-name …`          → "use --project-id <uuid>"
    - `--parent-issue-id …`       → "use --parent-id <uuid>"
    - `issue comment --content …` → "use --body <text>"
- **Help affordances** — `program.showHelpAfterError(…)` points users at subcommand `--help`. `issue --help` renders a per-subcommand flag matrix epilogue, and `issue create` / `issue update` `--help` include per-command notes (UUID rule, no-`-C`-on-update, project-id-only, `--parent-id` vs `--parent-issue-id`).

## Why

Root cause for DGG-4116: flag support is uniform *looking* across `issue` subcommands but is actually a per-subcommand matrix. Without in-CLI signal, callers either memorize the matrix (brittle) or re-read external docs on every call (slow). This PR removes the #1 footgun (`-C` required on `create`) and makes the CLI self-documenting for the remaining ones, without breaking any existing usage.

## Changes

- `cli/src/commands/client/issue.ts`
    - `issue create`: `-C/--company-id` becomes `option` (was `requiredOption`); still honored when passed.
    - `issue create --help` / `issue update --help`: per-command usage notes appended.
    - `issue --help`: top-level flag matrix epilogue added.
- `cli/src/commands/client/common.ts`
    - New `emitFlagHintsFromArgv(argv)`: pure function, stderr-only, does not mutate state.
- `cli/src/index.ts`
    - Top-level `showHelpAfterError(…)` hint added.
    - `main()` calls `emitFlagHintsFromArgv(process.argv.slice(2))` before `program.parseAsync()`.
- `cli/src/__tests__/flag-matrix.test.ts` (new)
    - 6 vitest cases covering every hint branch (positive) plus a negative (`-C` on `issue create` must **not** trigger the update-only hint).

## Evidence (manual runs against this branch)

```
$ paperclipai issue create --help
Usage: paperclipai issue create [options]

Create an issue

Options:
  -C, --company-id <id>     Company ID (falls back to PAPERCLIP_COMPANY_ID or
                            default context profile)
  --title <title>           Issue title
  …
Notes:
  --company-id is optional if a default context profile is set or
  PAPERCLIP_COMPANY_ID is exported.
  Parent issue uses --parent-id (not --parent-issue-id).
  Use --project-id <id> to attach a project.


$ paperclipai issue list --project-name "gBETA"
[paperclipai] Flag hint: --project-name / --project-title are not supported.
  Use --project-id <uuid>.
  Resolve a project UUID from its name via REST:
    curl -u admin:<pw> http://localhost:3100/api/companies/$CID/projects | jq '.[] | {id, name}'
error: unknown option '--project-name'
(run the command with --help to see supported flags; flag support varies per subcommand)


$ paperclipai issue update <uuid> -C <cid> --status in_progress
[paperclipai] Flag hint: `issue update` does NOT accept -C/--company-id.
  The issue is resolved from the <issueId> argument alone.
  Correct usage: paperclipai issue update <issueId> --status in_progress
    [--comment "activity log entry"]
error: unknown option '-C'


$ paperclipai issue create --title "flag-matrix-test" --description … \
      --priority low --assignee-agent-id <aid> --api-key <key> --json
{ "id": "b9ab22f0-…", "identifier": "DGG-4127", "status": "backlog", … }
# -C omitted → context profile companyId used automatically. ✅
```

(Test issue DGG-4127 was created then cancelled as part of AC verification.)

## Tests

```
$ bunx vitest run src/__tests__/flag-matrix.test.ts src/__tests__/common.test.ts
 ✓ src/__tests__/flag-matrix.test.ts (6 tests)
 ✓ src/__tests__/common.test.ts       (3 tests)

Test Files  2 passed (2)
     Tests  9 passed (9)
```

## Backward compatibility

- All existing `issue create -C <cid> …` invocations keep working unchanged (explicit wins over profile/env fallback).
- All hints are additive to stderr; exit code on unknown flags is unchanged (non-zero), so scripts keyed on exit code are unaffected.
- No schema, API, or network-contract changes.

## AC (DGG-4116)

- [x] `paperclipai issue create --title … --description … --assignee-agent-id …` (company 생략) 성공
- [x] `paperclipai issue update <id> -C <cid> --status in_progress` 차단 + 가이드 출력
- [x] `--project-name` 같은 미지원 flag 시 "use --project-id" 안내
- [x] 각 명령의 flag 매트릭스 `paperclipai <command> --help`에 명시
- [x] `knowledge/domain-paperclip-api.md §Gotchas` 업데이트 (kuromi workspace 쪽)