### PR TITLE
fix: resolve @mentions by first-name token and urlKey

### DIFF
--- a/server/src/__tests__/agent-mention-matching.test.ts
+++ b/server/src/__tests__/agent-mention-matching.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { agentMatchesMentionTokens } from "../services/issues.ts";
+
+describe("agentMatchesMentionTokens", () => {
+  const agent = "David Okonkwo";
+
+  it("matches full name (lowercase)", () => {
+    const tokens = new Set(["david okonkwo"]);
+    expect(agentMatchesMentionTokens(tokens, agent)).toBe(true);
+  });
+
+  it("matches first-name token", () => {
+    const tokens = new Set(["david"]);
+    expect(agentMatchesMentionTokens(tokens, agent)).toBe(true);
+  });
+
+  it("matches urlKey form", () => {
+    const tokens = new Set(["david-okonkwo"]);
+    expect(agentMatchesMentionTokens(tokens, agent)).toBe(true);
+  });
+
+  it("does not match last name alone", () => {
+    const tokens = new Set(["okonkwo"]);
+    expect(agentMatchesMentionTokens(tokens, agent)).toBe(false);
+  });
+
+  it("does not match partial first name", () => {
+    const tokens = new Set(["dav"]);
+    expect(agentMatchesMentionTokens(tokens, agent)).toBe(false);
+  });
+
+  it("does not match empty tokens", () => {
+    const tokens = new Set<string>();
+    expect(agentMatchesMentionTokens(tokens, agent)).toBe(false);
+  });
+
+  it("is case-insensitive (tokens are pre-lowercased by caller)", () => {
+    const tokens = new Set(["david-okonkwo"]);
+    expect(agentMatchesMentionTokens(tokens, "DAVID OKONKWO")).toBe(true);
+  });
+
+  it("matches single-word agent name as first name", () => {
+    const tokens = new Set(["kai"]);
+    expect(agentMatchesMentionTokens(tokens, "Kai")).toBe(true);
+  });
+
+  it("matches agent with hyphenated last name via urlKey", () => {
+    const tokens = new Set(["anna-van-der-berg"]);
+    expect(agentMatchesMentionTokens(tokens, "Anna Van Der Berg")).toBe(true);
+  });
+
+  it("matches agent with hyphenated last name via first name", () => {
+    const tokens = new Set(["anna"]);
+    expect(agentMatchesMentionTokens(tokens, "Anna Van Der Berg")).toBe(true);
+  });
+
+  it("does not match unrelated tokens", () => {
+    const tokens = new Set(["marcus", "iris"]);
+    expect(agentMatchesMentionTokens(tokens, agent)).toBe(false);
+  });
+
+  it("works with multiple tokens where one matches", () => {
+    const tokens = new Set(["marcus", "david", "iris"]);
+    expect(agentMatchesMentionTokens(tokens, agent)).toBe(true);
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -24,7 +24,7 @@ import {
   projects,
 } from "@paperclipai/db";
 import type { IssueRelationIssueSummary } from "@paperclipai/shared";
-import { extractAgentMentionIds, extractProjectMentionIds, isUuidLike } from "@paperclipai/shared";
+import { extractAgentMentionIds, extractProjectMentionIds, isUuidLike, normalizeAgentUrlKey } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import {
   defaultIssueExecutionWorkspaceSettingsForProject,
@@ -552,6 +552,23 @@ export function normalizeAgentMentionToken(raw: string): string {
     return decoded !== undefined ? decoded : full;
   });
   return s.trim();
+}
+
+/**
+ * Pure matching: checks whether a set of mention tokens matches an agent
+ * by full name, first-name token, or urlKey.
+ */
+export function agentMatchesMentionTokens(
+  tokens: ReadonlySet<string>,
+  agentName: string,
+): boolean {
+  const nameLower = agentName.toLowerCase();
+  if (tokens.has(nameLower)) return true;
+  const firstName = nameLower.split(/\s+/)[0];
+  if (firstName && tokens.has(firstName)) return true;
+  const urlKey = normalizeAgentUrlKey(agentName);
+  if (urlKey && tokens.has(urlKey)) return true;
+  return false;
 }
 
 export function deriveIssueUserContext(
@@ -2720,7 +2737,7 @@ export function issueService(db: Db) {
         .from(agents).where(eq(agents.companyId, companyId));
       const resolved = new Set<string>(explicitAgentMentionIds);
       for (const agent of rows) {
-        if (tokens.has(agent.name.toLowerCase())) {
+        if (agentMatchesMentionTokens(tokens, agent.name)) {
           resolved.add(agent.id);
         }
       }


### PR DESCRIPTION
## Summary

- `findMentionedAgents` only matched `@mention` tokens against `agent.name.toLowerCase()` (the full name). Since the mention regex `/\B@([^\s@,!?.]+)/g` captures single tokens like `david`, first-name mentions (`@david`) and urlKey mentions (`@david-okonkwo`) silently failed, preventing agent wake-on-mention.
- Now matches against three forms: full name (no regression), first-name token, and urlKey via `normalizeAgentUrlKey`.
- Extracts matching logic into exported `agentMatchesMentionTokens()` for unit testing.
- Adds 12 test cases covering all match forms, edge cases, and non-matches.

## Context

Reported as QUA-367 in QuantValidate. This bug was masking real agent quality issues — agents appeared unresponsive when they were simply not waking on mentions.

## Test plan

- [x] 12 new unit tests for `agentMatchesMentionTokens` — all pass
- [x] 9 existing `normalizeAgentMentionToken` tests — still pass
- [ ] Manual verification: post `@firstname` mention in issue comment, verify agent wakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)