### PR TITLE
[AKS-1597] S5: Migration 028 + enforceStatusTransition middleware + JWT minter + AC-8-A/B

### DIFF
--- a/packages/db/src/migrations/0065_admin_override_audit.sql
+++ b/packages/db/src/migrations/0065_admin_override_audit.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS "admin_override_audit" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"override_jwt_jti" text NOT NULL,
+	"principal_user_id" uuid NOT NULL,
+	"origin_ip" inet NOT NULL,
+	"user_agent" text,
+	"reason" text NOT NULL,
+	"issue_id" uuid NOT NULL,
+	"old_status" text NOT NULL,
+	"new_status" text NOT NULL,
+	"request_id" text NOT NULL,
+	"jwt_iat" timestamp with time zone NOT NULL,
+	"jwt_exp" timestamp with time zone NOT NULL,
+	"ts" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "admin_override_audit_override_jwt_jti_unique" UNIQUE("override_jwt_jti"),
+	CONSTRAINT "admin_override_reason_min_length" CHECK (char_length("reason") >= 20),
+	CONSTRAINT "admin_override_exp_gt_iat" CHECK ("jwt_exp" > "jwt_iat"),
+	CONSTRAINT "admin_override_ttl_max" CHECK ("jwt_exp" - "jwt_iat" <= interval '5 minutes')
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'admin_override_audit_issue_id_issues_id_fk') THEN
+  ALTER TABLE "admin_override_audit" ADD CONSTRAINT "admin_override_audit_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE restrict ON UPDATE no action;
+ END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "admin_override_audit_ts_idx" ON "admin_override_audit" USING btree ("ts");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "admin_override_audit_principal_ts_idx" ON "admin_override_audit" USING btree ("principal_user_id","ts");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "admin_override_audit_issue_ts_idx" ON "admin_override_audit" USING btree ("issue_id","ts");
+--> statement-breakpoint
+COMMENT ON TABLE "admin_override_audit" IS 'AKS-1597/AKS-1509 §7.2a REV-A: atomic audit + replay store for CEO admin-override JWTs. Rows are inserted in the same transaction as the issues.status UPDATE; unique_violation on override_jwt_jti is the replay guard.';

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1776780002000,
       "tag": "0064_issue_thread_interaction_idempotency",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1777000000000,
+      "tag": "0065_admin_override_audit",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/admin_override_audit.ts
+++ b/packages/db/src/schema/admin_override_audit.ts
@@ -1,0 +1,38 @@
+import { sql } from "drizzle-orm";
+import { pgTable, uuid, text, timestamp, index, check } from "drizzle-orm/pg-core";
+import { issues } from "./issues.js";
+
+export const adminOverrideAudit = pgTable(
+  "admin_override_audit",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    overrideJwtJti: text("override_jwt_jti").notNull().unique(),
+    principalUserId: uuid("principal_user_id").notNull(),
+    originIp: text("origin_ip").notNull(),
+    userAgent: text("user_agent"),
+    reason: text("reason").notNull(),
+    issueId: uuid("issue_id")
+      .notNull()
+      .references(() => issues.id, { onDelete: "restrict" }),
+    oldStatus: text("old_status").notNull(),
+    newStatus: text("new_status").notNull(),
+    requestId: text("request_id").notNull(),
+    jwtIat: timestamp("jwt_iat", { withTimezone: true }).notNull(),
+    jwtExp: timestamp("jwt_exp", { withTimezone: true }).notNull(),
+    ts: timestamp("ts", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    tsIdx: index("admin_override_audit_ts_idx").on(table.ts),
+    principalTsIdx: index("admin_override_audit_principal_ts_idx").on(table.principalUserId, table.ts),
+    issueTsIdx: index("admin_override_audit_issue_ts_idx").on(table.issueId, table.ts),
+    reasonMinLength: check(
+      "admin_override_reason_min_length",
+      sql`char_length(${table.reason}) >= 20`,
+    ),
+    expGtIat: check("admin_override_exp_gt_iat", sql`${table.jwtExp} > ${table.jwtIat}`),
+    ttlMax: check(
+      "admin_override_ttl_max",
+      sql`${table.jwtExp} - ${table.jwtIat} <= interval '5 minutes'`,
+    ),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -37,6 +37,7 @@ export { issueApprovals } from "./issue_approvals.js";
 export { issueComments } from "./issue_comments.js";
 export { issueThreadInteractions } from "./issue_thread_interactions.js";
 export { issueExecutionDecisions } from "./issue_execution_decisions.js";
+export { adminOverrideAudit } from "./admin_override_audit.js";
 export { issueInboxArchives } from "./issue_inbox_archives.js";
 export { inboxDismissals } from "./inbox_dismissals.js";
 export { feedbackVotes } from "./feedback_votes.js";

--- a/server/src/__tests__/admin-override-jwt.test.ts
+++ b/server/src/__tests__/admin-override-jwt.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createHmac } from "node:crypto";
+import {
+  ADMIN_OVERRIDE_CONSTANTS,
+  createAdminOverrideJwt,
+  verifyAdminOverrideJwt,
+} from "../admin-override-jwt.js";
+
+const VALID_KEY = "test-admin-override-key-long-enough-for-prod";
+
+const sample = {
+  subject: "user-nikolaj",
+  issueId: "550e8400-e29b-41d4-a716-446655440000",
+  oldStatus: "in_review",
+  newStatus: "done",
+  reason: "ceo-binding-board-approval-2026-04-22",
+  jti: "0193b4c0-0000-7000-8000-000000000001",
+};
+
+function b64uEncode(value: string) {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function sign(key: string, signingInput: string) {
+  return createHmac("sha256", key).update(signingInput).digest("base64url");
+}
+
+function mintRaw(claims: Record<string, unknown>, header?: Record<string, unknown>, key = VALID_KEY) {
+  const headerObj = header ?? { alg: "HS256", typ: "JWT" };
+  const input = `${b64uEncode(JSON.stringify(headerObj))}.${b64uEncode(JSON.stringify(claims))}`;
+  const signature = sign(key, input);
+  return `${input}.${signature}`;
+}
+
+function freshClaims(overrides: Record<string, unknown> = {}) {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    iss: "paperclip-ui",
+    aud: "paperclip-admin-override",
+    sub: sample.subject,
+    jti: sample.jti,
+    iat: now,
+    exp: now + 60,
+    issue_id: sample.issueId,
+    old_status: sample.oldStatus,
+    new_status: sample.newStatus,
+    reason: sample.reason,
+    ...overrides,
+  };
+}
+
+describe("admin-override-jwt", () => {
+  beforeEach(() => {
+    process.env.PAPERCLIP_ADMIN_OVERRIDE_JWT_KEY = VALID_KEY;
+  });
+
+  describe("createAdminOverrideJwt", () => {
+    it("returns null when the signing key is not configured", () => {
+      delete process.env.PAPERCLIP_ADMIN_OVERRIDE_JWT_KEY;
+      expect(createAdminOverrideJwt({ ...sample, ttlSeconds: 60 })).toBeNull();
+    });
+
+    it("clamps ttl to <=300s", () => {
+      const token = createAdminOverrideJwt({ ...sample, ttlSeconds: 9999 });
+      expect(token).not.toBeNull();
+      const result = verifyAdminOverrideJwt(token!);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.claims.exp - result.claims.iat).toBeLessThanOrEqual(
+          ADMIN_OVERRIDE_CONSTANTS.ttlMaxSeconds,
+        );
+      }
+    });
+
+    it("uses the primary (first) key when multiple are configured", () => {
+      process.env.PAPERCLIP_ADMIN_OVERRIDE_JWT_KEY = `${VALID_KEY}, previous-key-for-rotation`;
+      const token = createAdminOverrideJwt({ ...sample, ttlSeconds: 60 });
+      expect(token).not.toBeNull();
+      const result = verifyAdminOverrideJwt(token!);
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("verifyAdminOverrideJwt rejection matrix", () => {
+    it("rejects empty token", () => {
+      const result = verifyAdminOverrideJwt("");
+      expect(result).toEqual({ ok: false, error: "admin_override_jwt_missing" });
+    });
+
+    it("rejects when signing key is not configured", () => {
+      delete process.env.PAPERCLIP_ADMIN_OVERRIDE_JWT_KEY;
+      const result = verifyAdminOverrideJwt("a.b.c");
+      expect(result).toEqual({ ok: false, error: "admin_override_jwt_secret_missing" });
+    });
+
+    it("rejects malformed token", () => {
+      expect(verifyAdminOverrideJwt("not-a-jwt").ok).toBe(false);
+      expect(verifyAdminOverrideJwt("only.two").ok).toBe(false);
+    });
+
+    it("rejects wrong algorithm", () => {
+      const token = mintRaw(freshClaims(), { alg: "none" });
+      const result = verifyAdminOverrideJwt(token);
+      expect(result).toEqual({ ok: false, error: "admin_override_jwt_alg_invalid" });
+    });
+
+    it("rejects forged signature", () => {
+      const token = mintRaw(freshClaims(), undefined, "wrong-key");
+      const result = verifyAdminOverrideJwt(token);
+      expect(result).toEqual({ ok: false, error: "admin_override_jwt_signature_invalid" });
+    });
+
+    it("accepts a valid signature from any configured key (rotation)", () => {
+      process.env.PAPERCLIP_ADMIN_OVERRIDE_JWT_KEY = `${VALID_KEY}, previous-rotation-key`;
+      const tokenFromOldKey = mintRaw(freshClaims(), undefined, "previous-rotation-key");
+      const result = verifyAdminOverrideJwt(tokenFromOldKey);
+      expect(result.ok).toBe(true);
+    });
+
+    it("rejects wrong issuer", () => {
+      const token = mintRaw(freshClaims({ iss: "not-paperclip-ui" }));
+      const result = verifyAdminOverrideJwt(token);
+      expect(result).toEqual({ ok: false, error: "admin_override_jwt_issuer_invalid" });
+    });
+
+    it("rejects wrong audience", () => {
+      const token = mintRaw(freshClaims({ aud: "different-audience" }));
+      const result = verifyAdminOverrideJwt(token);
+      expect(result).toEqual({ ok: false, error: "admin_override_jwt_audience_invalid" });
+    });
+
+    it("rejects expired token", () => {
+      const now = Math.floor(Date.now() / 1000);
+      const token = mintRaw(freshClaims({ iat: now - 120, exp: now - 10 }));
+      const result = verifyAdminOverrideJwt(token);
+      expect(result).toEqual({ ok: false, error: "admin_override_jwt_expired" });
+    });
+
+    it("rejects when TTL exceeds 300 seconds", () => {
+      const now = Math.floor(Date.now() / 1000);
+      const token = mintRaw(freshClaims({ iat: now, exp: now + 3600 }));
+      const result = verifyAdminOverrideJwt(token);
+      expect(result).toEqual({ ok: false, error: "admin_override_ttl_exceeded" });
+    });
+
+    it("rejects reason shorter than 20 chars", () => {
+      const token = mintRaw(freshClaims({ reason: "too short" }));
+      const result = verifyAdminOverrideJwt(token);
+      expect(result).toEqual({ ok: false, error: "admin_override_reason_invalid" });
+    });
+
+    it("rejects when claims are missing", () => {
+      const now = Math.floor(Date.now() / 1000);
+      const token = mintRaw({
+        iss: "paperclip-ui",
+        aud: "paperclip-admin-override",
+        iat: now,
+        exp: now + 60,
+      });
+      const result = verifyAdminOverrideJwt(token);
+      expect(result).toEqual({ ok: false, error: "admin_override_jwt_claims_missing" });
+    });
+
+    it("accepts a fully-valid token and returns strongly-typed claims", () => {
+      const token = createAdminOverrideJwt({ ...sample, ttlSeconds: 60 });
+      expect(token).not.toBeNull();
+      const result = verifyAdminOverrideJwt(token!);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.claims).toMatchObject({
+          iss: "paperclip-ui",
+          aud: "paperclip-admin-override",
+          sub: sample.subject,
+          jti: sample.jti,
+          issue_id: sample.issueId,
+          old_status: sample.oldStatus,
+          new_status: sample.newStatus,
+          reason: sample.reason,
+        });
+      }
+    });
+  });
+});

--- a/server/src/__tests__/admin-override-rate-limiter.test.ts
+++ b/server/src/__tests__/admin-override-rate-limiter.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADMIN_OVERRIDE_RATE_LIMITS,
+  AdminOverrideRateLimiter,
+} from "../admin-override-rate-limiter.js";
+
+function createClock(startMs = 1_700_000_000_000) {
+  let t = startMs;
+  return {
+    now: () => t,
+    advanceSeconds: (seconds: number) => {
+      t += seconds * 1000;
+    },
+  };
+}
+
+describe("AdminOverrideRateLimiter", () => {
+  it("allows up to 5 mints in the first hour (AC-8-B hourly limit)", () => {
+    const clock = createClock();
+    const limiter = new AdminOverrideRateLimiter({ hourlyLimit: 5, dailyLimit: 10, nowMs: clock.now });
+    for (let i = 0; i < 5; i += 1) {
+      const decision = limiter.record("user-a");
+      expect(decision.allowed).toBe(true);
+      expect(decision.hourlyRemaining).toBe(4 - i);
+    }
+    const sixth = limiter.record("user-a");
+    expect(sixth.allowed).toBe(false);
+    expect(sixth.retryAfterSeconds).toBeGreaterThan(0);
+    expect(sixth.retryAfterSeconds).toBeLessThanOrEqual(60 * 60);
+  });
+
+  it("6-in-1h test returns 429 on the 6th attempt (AC-8-B binding automated test)", () => {
+    const clock = createClock();
+    const limiter = new AdminOverrideRateLimiter({ hourlyLimit: 5, dailyLimit: 10, nowMs: clock.now });
+    for (let i = 0; i < 5; i += 1) {
+      expect(limiter.record("user-a").allowed).toBe(true);
+      clock.advanceSeconds(30);
+    }
+    const sixth = limiter.record("user-a");
+    expect(sixth.allowed).toBe(false);
+  });
+
+  it("11-in-24h test returns 429 on the 11th attempt (AC-8-B binding automated test)", () => {
+    const clock = createClock();
+    const limiter = new AdminOverrideRateLimiter({ hourlyLimit: 5, dailyLimit: 10, nowMs: clock.now });
+    for (let i = 0; i < 10; i += 1) {
+      expect(limiter.record("user-a").allowed).toBe(true);
+      clock.advanceSeconds(60 * 75); // 1h15m between mints to dodge hourly limit
+    }
+    const eleventh = limiter.record("user-a");
+    expect(eleventh.allowed).toBe(false);
+    expect(eleventh.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it("allows 6th mint after the hourly window slides past the oldest record", () => {
+    const clock = createClock();
+    const limiter = new AdminOverrideRateLimiter({ hourlyLimit: 5, dailyLimit: 10, nowMs: clock.now });
+    for (let i = 0; i < 5; i += 1) {
+      expect(limiter.record("user-a").allowed).toBe(true);
+    }
+    expect(limiter.record("user-a").allowed).toBe(false);
+    clock.advanceSeconds(60 * 61);
+    const allowed = limiter.record("user-a");
+    expect(allowed.allowed).toBe(true);
+  });
+
+  it("isolates limits per principal", () => {
+    const clock = createClock();
+    const limiter = new AdminOverrideRateLimiter({ hourlyLimit: 5, dailyLimit: 10, nowMs: clock.now });
+    for (let i = 0; i < 5; i += 1) {
+      expect(limiter.record("user-a").allowed).toBe(true);
+    }
+    expect(limiter.record("user-a").allowed).toBe(false);
+    expect(limiter.record("user-b").allowed).toBe(true);
+  });
+
+  it("inspect() does not consume a slot", () => {
+    const clock = createClock();
+    const limiter = new AdminOverrideRateLimiter({ hourlyLimit: 5, dailyLimit: 10, nowMs: clock.now });
+    limiter.record("user-a");
+    const before = limiter.inspect("user-a");
+    expect(before.hourlyRemaining).toBe(4);
+    const again = limiter.inspect("user-a");
+    expect(again.hourlyRemaining).toBe(4);
+  });
+
+  it("ships sensible defaults matching AC-8-B (5/hour, 10/day)", () => {
+    expect(ADMIN_OVERRIDE_RATE_LIMITS).toEqual({ hourlyLimit: 5, dailyLimit: 10 });
+  });
+});

--- a/server/src/__tests__/error-handler.test.ts
+++ b/server/src/__tests__/error-handler.test.ts
@@ -17,6 +17,7 @@ function makeRes(): Response {
   const res = {
     status: vi.fn(),
     json: vi.fn(),
+    setHeader: vi.fn(),
   } as unknown as Response;
   (res.status as unknown as ReturnType<typeof vi.fn>).mockReturnValue(res);
   return res;
@@ -49,5 +50,56 @@ describe("errorHandler", () => {
     expect(res.json).toHaveBeenCalledWith({ error: "db exploded" });
     expect(res.err).toBe(err);
     expect(res.__errorContext?.error?.message).toBe("db exploded");
+  });
+
+  it("maps postgres P0403 status-transition-guard to HTTP 422 with legalPaths", () => {
+    const req = makeReq();
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+    const err = Object.assign(new Error("Status transition blocked: todo -> done"), {
+      code: "P0403",
+    });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+    expect(res.status).toHaveBeenCalledWith(422);
+    const payload = (res.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.error).toBe("status_transition_blocked");
+    expect(payload.message).toContain("Status transition blocked:");
+    expect(Array.isArray(payload.legalPaths)).toBe(true);
+    expect(payload.legalPaths.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("maps unique_violation on override_jwt_jti to HTTP 422 admin_override_replay", () => {
+    const req = makeReq();
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+    const err = Object.assign(new Error("duplicate key value violates unique constraint"), {
+      code: "23505",
+      constraint_name: "admin_override_audit_override_jwt_jti_unique",
+    });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "admin_override_replay" }),
+    );
+  });
+
+  it("does NOT intercept unique_violation on unrelated constraints", () => {
+    const req = makeReq();
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+    const err = Object.assign(new Error("duplicate key"), {
+      code: "23505",
+      constraint_name: "some_other_unique_index",
+    });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
   });
 });

--- a/server/src/__tests__/status-transition-middleware.test.ts
+++ b/server/src/__tests__/status-transition-middleware.test.ts
@@ -1,0 +1,297 @@
+import type { NextFunction, Request, Response } from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAdminOverrideJwt } from "../admin-override-jwt.js";
+import { enforceStatusTransition } from "../middleware/status-transition.js";
+
+const JWT_KEY = "test-key-unit-middleware";
+
+function makeRequest(overrides: Partial<Request> & Record<string, unknown> = {}): Request {
+  const req: Record<string, unknown> = {
+    method: "PATCH",
+    params: { id: "issue-123" },
+    body: {},
+    headers: {},
+    get: vi.fn(function (this: Record<string, unknown>, header: string) {
+      const headers = (this.headers ?? {}) as Record<string, string | undefined>;
+      return headers[header.toLowerCase()];
+    }),
+    header: vi.fn(function (this: Record<string, unknown>, header: string) {
+      const headers = (this.headers ?? {}) as Record<string, string | undefined>;
+      return headers[header.toLowerCase()];
+    }),
+    ...overrides,
+  };
+  return req as unknown as Request;
+}
+
+function makeResponse() {
+  const state = {
+    status: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+  };
+  const res = {
+    status: vi.fn(function (this: Response, code: number) {
+      state.status = code;
+      return this;
+    }),
+    json: vi.fn(function (this: Response, payload: unknown) {
+      state.body = payload;
+      return this;
+    }),
+    setHeader: vi.fn((name: string, value: string) => {
+      state.headers[name] = value;
+    }),
+  } as unknown as Response;
+  return { res, state };
+}
+
+function makeNext() {
+  return vi.fn() as unknown as NextFunction;
+}
+
+const getIssueStatus = vi.fn(async (id: string) =>
+  id === "issue-missing" ? null : { status: "in_progress" },
+);
+
+describe("enforceStatusTransition middleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.PAPERCLIP_STATUS_GUARD_V2;
+    process.env.PAPERCLIP_ADMIN_OVERRIDE_JWT_KEY = JWT_KEY;
+  });
+
+  afterEach(() => {
+    delete process.env.PAPERCLIP_STATUS_GUARD_V2;
+    delete process.env.PAPERCLIP_ADMIN_OVERRIDE_JWT_KEY;
+  });
+
+  it("is a passthrough when PAPERCLIP_STATUS_GUARD_V2 is unset (dormant default)", async () => {
+    const mw = enforceStatusTransition({ getIssueStatus });
+    const req = makeRequest({ body: { status: "done" } });
+    const { res, state } = makeResponse();
+    const next = makeNext();
+
+    await mw(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(state.status).toBe(0);
+    expect(getIssueStatus).not.toHaveBeenCalled();
+  });
+
+  it("is a passthrough for non-PATCH methods even when flag is on", async () => {
+    process.env.PAPERCLIP_STATUS_GUARD_V2 = "true";
+    const mw = enforceStatusTransition({ getIssueStatus });
+    const req = makeRequest({ method: "GET", body: { status: "done" } });
+    const { res, state } = makeResponse();
+    const next = makeNext();
+
+    await mw(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(state.status).toBe(0);
+  });
+
+  it("is a passthrough when body does not touch governed fields", async () => {
+    process.env.PAPERCLIP_STATUS_GUARD_V2 = "true";
+    const mw = enforceStatusTransition({ getIssueStatus });
+    const req = makeRequest({ body: { title: "new title", priority: "high" } });
+    const { res, state } = makeResponse();
+    const next = makeNext();
+
+    await mw(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(state.status).toBe(0);
+  });
+
+  describe("with PAPERCLIP_STATUS_GUARD_V2=true", () => {
+    beforeEach(() => {
+      process.env.PAPERCLIP_STATUS_GUARD_V2 = "true";
+      getIssueStatus.mockClear();
+    });
+
+    it("Exception A: allows backlog <-> todo transitions", async () => {
+      getIssueStatus.mockResolvedValueOnce({ status: "backlog" });
+      const mw = enforceStatusTransition({ getIssueStatus });
+      const req = makeRequest({ body: { status: "todo" } });
+      const { res, state } = makeResponse();
+      const next = makeNext();
+
+      await mw(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(state.status).toBe(0);
+    });
+
+    it("Exception B: allows * -> blocked when blockReason is present", async () => {
+      getIssueStatus.mockResolvedValueOnce({ status: "in_progress" });
+      const mw = enforceStatusTransition({ getIssueStatus });
+      const req = makeRequest({
+        body: { status: "blocked", blockReason: "CI is down" },
+      });
+      const { res, state } = makeResponse();
+      const next = makeNext();
+
+      await mw(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(state.status).toBe(0);
+    });
+
+    it("Exception C: allows blocked -> * when unblockReason is present", async () => {
+      getIssueStatus.mockResolvedValueOnce({ status: "blocked" });
+      const mw = enforceStatusTransition({ getIssueStatus });
+      const req = makeRequest({
+        body: { status: "in_progress", unblockReason: "CI back up" },
+      });
+      const { res, state } = makeResponse();
+      const next = makeNext();
+
+      await mw(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(state.status).toBe(0);
+    });
+
+    it("Exception D: fails closed with 503 when X-PE-Transition-Id is presented (consume path not wired)", async () => {
+      getIssueStatus.mockResolvedValueOnce({ status: "in_progress" });
+      const mw = enforceStatusTransition({ getIssueStatus });
+      const req = makeRequest({
+        headers: { "x-pe-transition-id": "a1b2c3d4-0000-0000-0000-000000000000" },
+        body: { status: "done" },
+      });
+      const { res, state } = makeResponse();
+      const next = makeNext();
+
+      await mw(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(state.status).toBe(503);
+      expect((state.body as Record<string, unknown>).error).toBe("pe_artifact_verification_unavailable");
+      expect(state.headers["Cache-Control"]).toBe("no-store");
+    });
+
+    it("Exception E: rejects boolean X-Admin-Override: true with 422 admin_override_boolean_form_retired", async () => {
+      getIssueStatus.mockResolvedValueOnce({ status: "in_progress" });
+      const mw = enforceStatusTransition({ getIssueStatus });
+      const req = makeRequest({
+        headers: { "x-admin-override": "true" },
+        body: { status: "done" },
+      });
+      const { res, state } = makeResponse();
+      const next = makeNext();
+
+      await mw(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(state.status).toBe(422);
+      expect((state.body as Record<string, unknown>).error).toBe(
+        "admin_override_boolean_form_retired",
+      );
+    });
+
+    it("Exception E: accepts a well-formed CEO JWT and attaches statusGuard context", async () => {
+      getIssueStatus.mockResolvedValueOnce({ status: "in_progress" });
+      const token = createAdminOverrideJwt({
+        subject: "ceo-user",
+        issueId: "issue-123",
+        oldStatus: "in_progress",
+        newStatus: "done",
+        reason: "ceo-breakglass-approved-2026-04-22",
+        jti: "jti-1",
+        ttlSeconds: 60,
+      });
+      const mw = enforceStatusTransition({ getIssueStatus });
+      const req = makeRequest({
+        headers: { "x-admin-override": token ?? "" },
+        body: { status: "done" },
+      });
+      const { res, state } = makeResponse();
+      const next = makeNext();
+
+      await mw(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(state.status).toBe(0);
+      const statusGuard = (req as Request & {
+        statusGuard?: { adminOverride?: { jti: string; principalUserId: string } };
+      }).statusGuard;
+      expect(statusGuard?.adminOverride?.jti).toBe("jti-1");
+      expect(statusGuard?.adminOverride?.principalUserId).toBe("ceo-user");
+    });
+
+    it("Exception E: rejects a JWT that does not bind exactly to the requested transition", async () => {
+      getIssueStatus.mockResolvedValueOnce({ status: "in_progress" });
+      const token = createAdminOverrideJwt({
+        subject: "ceo-user",
+        issueId: "issue-123",
+        oldStatus: "in_progress",
+        newStatus: "done",
+        reason: "ceo-breakglass-approved-2026-04-22",
+        jti: "jti-2",
+        ttlSeconds: 60,
+      });
+      const mw = enforceStatusTransition({ getIssueStatus });
+      const req = makeRequest({
+        headers: { "x-admin-override": token ?? "" },
+        body: { status: "cancelled" }, // JWT bound to done, request says cancelled
+      });
+      const { res, state } = makeResponse();
+      const next = makeNext();
+
+      await mw(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(state.status).toBe(422);
+      expect((state.body as Record<string, unknown>).error).toBe(
+        "admin_override_bounds_mismatch",
+      );
+    });
+
+    it("denies with 422 status_transition_blocked when no exception matches", async () => {
+      getIssueStatus.mockResolvedValueOnce({ status: "in_progress" });
+      const mw = enforceStatusTransition({ getIssueStatus });
+      const req = makeRequest({ body: { status: "done" } });
+      const { res, state } = makeResponse();
+      const next = makeNext();
+
+      await mw(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(state.status).toBe(422);
+      const body = state.body as Record<string, unknown>;
+      expect(body.error).toBe("status_transition_blocked");
+      expect(Array.isArray(body.legalPaths)).toBe(true);
+      expect(typeof body.request_id).toBe("string");
+    });
+
+    it("echoes X-Request-Id when well-formed, otherwise generates a UUID", async () => {
+      getIssueStatus.mockResolvedValueOnce({ status: "in_progress" });
+      const mw = enforceStatusTransition({ getIssueStatus });
+      const req = makeRequest({
+        headers: { "x-request-id": "incident-42" },
+        body: { status: "done" },
+      });
+      const { res, state } = makeResponse();
+      const next = makeNext();
+
+      await mw(req, res, next);
+
+      expect(state.status).toBe(422);
+      expect((state.body as Record<string, unknown>).request_id).toBe("incident-42");
+    });
+
+    it("is a passthrough when the issue is not found (leaves 404 to downstream handler)", async () => {
+      const mw = enforceStatusTransition({ getIssueStatus });
+      const req = makeRequest({ params: { id: "issue-missing" }, body: { status: "done" } });
+      const { res, state } = makeResponse();
+      const next = makeNext();
+
+      await mw(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(state.status).toBe(0);
+    });
+  });
+});

--- a/server/src/admin-override-jwt.ts
+++ b/server/src/admin-override-jwt.ts
@@ -1,0 +1,184 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const ADMIN_OVERRIDE_ALG = "HS256";
+const ADMIN_OVERRIDE_ISSUER = "paperclip-ui";
+const ADMIN_OVERRIDE_AUDIENCE = "paperclip-admin-override";
+const ADMIN_OVERRIDE_TTL_MAX_SECONDS = 300;
+const ADMIN_OVERRIDE_REASON_MIN_LENGTH = 20;
+
+export interface AdminOverrideJwtClaims {
+  iss: string;
+  aud: string;
+  sub: string;
+  jti: string;
+  iat: number;
+  exp: number;
+  issue_id: string;
+  old_status: string;
+  new_status: string;
+  reason: string;
+}
+
+export type AdminOverrideVerifyError =
+  | "admin_override_jwt_missing"
+  | "admin_override_jwt_malformed"
+  | "admin_override_jwt_alg_invalid"
+  | "admin_override_jwt_signature_invalid"
+  | "admin_override_jwt_claims_missing"
+  | "admin_override_jwt_issuer_invalid"
+  | "admin_override_jwt_audience_invalid"
+  | "admin_override_jwt_expired"
+  | "admin_override_ttl_exceeded"
+  | "admin_override_reason_invalid"
+  | "admin_override_jwt_secret_missing";
+
+export type AdminOverrideVerifyResult =
+  | { ok: true; claims: AdminOverrideJwtClaims }
+  | { ok: false; error: AdminOverrideVerifyError };
+
+function base64UrlEncode(value: string) {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function base64UrlDecode(value: string) {
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+function signingKey() {
+  const raw = process.env.PAPERCLIP_ADMIN_OVERRIDE_JWT_KEY?.trim();
+  if (!raw) return null;
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function signPayload(secret: string, signingInput: string) {
+  return createHmac("sha256", secret).update(signingInput).digest("base64url");
+}
+
+function safeCompare(a: string, b: string) {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
+function parseJson(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function createAdminOverrideJwt(params: {
+  subject: string;
+  issueId: string;
+  oldStatus: string;
+  newStatus: string;
+  reason: string;
+  jti: string;
+  ttlSeconds: number;
+}): string | null {
+  const keys = signingKey();
+  if (!keys || keys.length === 0) return null;
+  const ttl = Math.min(Math.max(1, Math.floor(params.ttlSeconds)), ADMIN_OVERRIDE_TTL_MAX_SECONDS);
+  const now = Math.floor(Date.now() / 1000);
+  const claims: AdminOverrideJwtClaims = {
+    iss: ADMIN_OVERRIDE_ISSUER,
+    aud: ADMIN_OVERRIDE_AUDIENCE,
+    sub: params.subject,
+    jti: params.jti,
+    iat: now,
+    exp: now + ttl,
+    issue_id: params.issueId,
+    old_status: params.oldStatus,
+    new_status: params.newStatus,
+    reason: params.reason,
+  };
+  const header = { alg: ADMIN_OVERRIDE_ALG, typ: "JWT" };
+  const signingInput = `${base64UrlEncode(JSON.stringify(header))}.${base64UrlEncode(JSON.stringify(claims))}`;
+  const signature = signPayload(keys[0], signingInput);
+  return `${signingInput}.${signature}`;
+}
+
+export function verifyAdminOverrideJwt(token: string): AdminOverrideVerifyResult {
+  if (!token) return { ok: false, error: "admin_override_jwt_missing" };
+  const keys = signingKey();
+  if (!keys || keys.length === 0) return { ok: false, error: "admin_override_jwt_secret_missing" };
+
+  const parts = token.split(".");
+  if (parts.length !== 3) return { ok: false, error: "admin_override_jwt_malformed" };
+  const [headerB64, claimsB64, signature] = parts;
+
+  const header = parseJson(base64UrlDecode(headerB64));
+  if (!header || header.alg !== ADMIN_OVERRIDE_ALG) {
+    return { ok: false, error: "admin_override_jwt_alg_invalid" };
+  }
+
+  const signingInput = `${headerB64}.${claimsB64}`;
+  const signatureOk = keys.some((key) => {
+    const expected = signPayload(key, signingInput);
+    return safeCompare(signature, expected);
+  });
+  if (!signatureOk) return { ok: false, error: "admin_override_jwt_signature_invalid" };
+
+  const claims = parseJson(base64UrlDecode(claimsB64));
+  if (!claims) return { ok: false, error: "admin_override_jwt_claims_missing" };
+
+  const iss = isNonEmptyString(claims.iss) ? claims.iss : null;
+  const aud = isNonEmptyString(claims.aud) ? claims.aud : null;
+  const sub = isNonEmptyString(claims.sub) ? claims.sub : null;
+  const jti = isNonEmptyString(claims.jti) ? claims.jti : null;
+  const iat = typeof claims.iat === "number" ? claims.iat : null;
+  const exp = typeof claims.exp === "number" ? claims.exp : null;
+  const issueId = isNonEmptyString(claims.issue_id) ? claims.issue_id : null;
+  const oldStatus = isNonEmptyString(claims.old_status) ? claims.old_status : null;
+  const newStatus = isNonEmptyString(claims.new_status) ? claims.new_status : null;
+  const reason = typeof claims.reason === "string" ? claims.reason : null;
+
+  if (!sub || !jti || iat === null || exp === null || !issueId || !oldStatus || !newStatus || reason === null) {
+    return { ok: false, error: "admin_override_jwt_claims_missing" };
+  }
+  if (iss !== ADMIN_OVERRIDE_ISSUER) return { ok: false, error: "admin_override_jwt_issuer_invalid" };
+  if (aud !== ADMIN_OVERRIDE_AUDIENCE) return { ok: false, error: "admin_override_jwt_audience_invalid" };
+
+  const now = Math.floor(Date.now() / 1000);
+  if (exp <= now) return { ok: false, error: "admin_override_jwt_expired" };
+  if (exp - iat > ADMIN_OVERRIDE_TTL_MAX_SECONDS) {
+    return { ok: false, error: "admin_override_ttl_exceeded" };
+  }
+  if (reason.trim().length < ADMIN_OVERRIDE_REASON_MIN_LENGTH) {
+    return { ok: false, error: "admin_override_reason_invalid" };
+  }
+
+  return {
+    ok: true,
+    claims: {
+      iss,
+      aud,
+      sub,
+      jti,
+      iat,
+      exp,
+      issue_id: issueId,
+      old_status: oldStatus,
+      new_status: newStatus,
+      reason,
+    },
+  };
+}
+
+export const ADMIN_OVERRIDE_CONSTANTS = {
+  algorithm: ADMIN_OVERRIDE_ALG,
+  issuer: ADMIN_OVERRIDE_ISSUER,
+  audience: ADMIN_OVERRIDE_AUDIENCE,
+  ttlMaxSeconds: ADMIN_OVERRIDE_TTL_MAX_SECONDS,
+  reasonMinLength: ADMIN_OVERRIDE_REASON_MIN_LENGTH,
+};

--- a/server/src/admin-override-rate-limiter.ts
+++ b/server/src/admin-override-rate-limiter.ts
@@ -1,0 +1,117 @@
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  retryAfterSeconds?: number;
+  hourlyRemaining: number;
+  dailyRemaining: number;
+}
+
+export interface RateLimitConfig {
+  hourlyLimit: number;
+  dailyLimit: number;
+  nowMs?: () => number;
+}
+
+/**
+ * Per-principal rate limiter for admin-override mints.
+ *
+ * AC-8-B ([AKS-1597](/AKS/issues/AKS-1597)): <=5 mints/hour/user AND <=10 mints/day/user.
+ * In-memory ring-buffer of timestamps per principal; acceptable stale state on restart
+ * because AC-8-B only guards spammy minting, not the override JWT itself (replay guard
+ * is the database UNIQUE(override_jwt_jti) constraint).
+ */
+export class AdminOverrideRateLimiter {
+  private readonly timestamps = new Map<string, number[]>();
+  private readonly config: Required<RateLimitConfig>;
+
+  constructor(config: RateLimitConfig) {
+    this.config = {
+      hourlyLimit: config.hourlyLimit,
+      dailyLimit: config.dailyLimit,
+      nowMs: config.nowMs ?? (() => Date.now()),
+    };
+  }
+
+  /** Reports whether a fresh mint would be allowed without mutating state. */
+  inspect(principalId: string): RateLimitDecision {
+    const now = this.config.nowMs();
+    const kept = this.prune(principalId, now);
+    return this.decide(kept, now);
+  }
+
+  /**
+   * Attempts to record a mint. Returns allowed=true iff the mint is within
+   * both the hourly and daily limits; the timestamp is recorded only on allow.
+   */
+  record(principalId: string): RateLimitDecision {
+    const now = this.config.nowMs();
+    const kept = this.prune(principalId, now);
+    const decision = this.decide(kept, now);
+    if (!decision.allowed) return decision;
+    kept.push(now);
+    this.timestamps.set(principalId, kept);
+    return {
+      allowed: true,
+      hourlyRemaining: Math.max(0, decision.hourlyRemaining - 1),
+      dailyRemaining: Math.max(0, decision.dailyRemaining - 1),
+    };
+  }
+
+  /** Clears all state. Intended for tests. */
+  reset(): void {
+    this.timestamps.clear();
+  }
+
+  private prune(principalId: string, nowMs: number): number[] {
+    const entries = this.timestamps.get(principalId) ?? [];
+    const cutoff = nowMs - DAY_MS;
+    const kept = entries.filter((ts) => ts > cutoff);
+    if (kept.length !== entries.length) {
+      if (kept.length === 0) {
+        this.timestamps.delete(principalId);
+      } else {
+        this.timestamps.set(principalId, kept);
+      }
+    }
+    return kept;
+  }
+
+  private decide(entries: number[], nowMs: number): RateLimitDecision {
+    const hourCutoff = nowMs - HOUR_MS;
+    const hourCount = entries.reduce((n, ts) => (ts > hourCutoff ? n + 1 : n), 0);
+    const dayCount = entries.length;
+
+    const hourlyRemaining = Math.max(0, this.config.hourlyLimit - hourCount);
+    const dailyRemaining = Math.max(0, this.config.dailyLimit - dayCount);
+
+    if (hourCount >= this.config.hourlyLimit) {
+      const oldestInHour = entries.find((ts) => ts > hourCutoff) ?? nowMs;
+      const retryAfterMs = Math.max(0, oldestInHour + HOUR_MS - nowMs);
+      return {
+        allowed: false,
+        retryAfterSeconds: Math.ceil(retryAfterMs / 1000),
+        hourlyRemaining: 0,
+        dailyRemaining,
+      };
+    }
+    if (dayCount >= this.config.dailyLimit) {
+      const oldestInDay = entries[0] ?? nowMs;
+      const retryAfterMs = Math.max(0, oldestInDay + DAY_MS - nowMs);
+      return {
+        allowed: false,
+        retryAfterSeconds: Math.ceil(retryAfterMs / 1000),
+        hourlyRemaining,
+        dailyRemaining: 0,
+      };
+    }
+
+    return { allowed: true, hourlyRemaining, dailyRemaining };
+  }
+}
+
+export const ADMIN_OVERRIDE_RATE_LIMITS = {
+  hourlyLimit: 5,
+  dailyLimit: 10,
+};

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -61,6 +61,46 @@ export function errorHandler(
     return;
   }
 
+  // postgres.js raises with err.code === 'P0403' for the status-transition guard.
+  // Translate to 422 so clients receive an actionable error instead of an opaque 500.
+  if (
+    err &&
+    typeof err === "object" &&
+    (err as { code?: unknown }).code === "P0403" &&
+    typeof (err as { message?: unknown }).message === "string" &&
+    ((err as { message: string }).message).startsWith("Status transition blocked:")
+  ) {
+    res.setHeader("Cache-Control", "no-store");
+    res.status(422).json({
+      error: "status_transition_blocked",
+      message: (err as { message: string }).message,
+      legalPaths: [
+        "POST /functions/v1/policy-engine (preferred)",
+        "PATCH with blockReason to block",
+        "X-Admin-Override: <CEO-scoped JWT> for break-glass",
+      ],
+    });
+    return;
+  }
+
+  // Replay guard for admin-override audit: unique violation on override_jwt_jti
+  // (AKS-1597 §7.3) means the same CEO JWT was presented twice. Map to 422 so
+  // the UI can surface "re-sign required" instead of a 500.
+  if (
+    err &&
+    typeof err === "object" &&
+    (err as { code?: unknown }).code === "23505" &&
+    typeof (err as { constraint_name?: unknown }).constraint_name === "string" &&
+    (err as { constraint_name: string }).constraint_name.includes("override_jwt_jti")
+  ) {
+    res.setHeader("Cache-Control", "no-store");
+    res.status(422).json({
+      error: "admin_override_replay",
+      message: "This admin override JWT has already been consumed. Re-sign a fresh token.",
+    });
+    return;
+  }
+
   const rootError = err instanceof Error ? err : new Error(String(err));
   attachErrorContext(
     req,

--- a/server/src/middleware/status-transition.ts
+++ b/server/src/middleware/status-transition.ts
@@ -1,0 +1,213 @@
+import type { Request, Response, NextFunction, RequestHandler } from "express";
+import { randomUUID } from "node:crypto";
+import { verifyAdminOverrideJwt, type AdminOverrideJwtClaims } from "../admin-override-jwt.js";
+import { logger } from "./logger.js";
+
+export interface AdminOverrideContext {
+  jti: string;
+  principalUserId: string;
+  reason: string;
+  originIp: string;
+  userAgent: string | null;
+  jwtIat: Date;
+  jwtExp: Date;
+}
+
+export interface StatusGuardContext {
+  requestId: string;
+  peTransactionId?: string;
+  adminOverride?: AdminOverrideContext;
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      statusGuard?: StatusGuardContext;
+    }
+  }
+}
+
+const GOVERNED_FIELDS = ["status", "assigneeAgentId", "assigneeUserId", "completedAt", "track"] as const;
+
+const DEFAULT_LEGAL_PATHS = [
+  "POST /functions/v1/policy-engine (preferred)",
+  "PATCH with blockReason to block",
+  "X-Admin-Override: <CEO-scoped JWT> for break-glass",
+];
+
+function isStatusGuardEnabled() {
+  const raw = process.env.PAPERCLIP_STATUS_GUARD_V2?.trim().toLowerCase();
+  return raw === "true" || raw === "1" || raw === "yes";
+}
+
+function bodyTouchesGovernedFields(body: unknown): boolean {
+  if (!body || typeof body !== "object") return false;
+  const record = body as Record<string, unknown>;
+  return GOVERNED_FIELDS.some((key) => key in record);
+}
+
+function getIssueIdFromRequest(req: Request): string | null {
+  const fromParams = (req.params as Record<string, unknown> | undefined)?.id;
+  return typeof fromParams === "string" && fromParams.length > 0 ? fromParams : null;
+}
+
+function getNonEmptyString(source: Record<string, unknown>, key: string): string | null {
+  const value = source[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function respondDenied(
+  res: Response,
+  status: number,
+  payload: Record<string, unknown>,
+) {
+  res.setHeader("Cache-Control", "no-store");
+  res.status(status).json(payload);
+}
+
+type ExistingIssueLookup = (issueId: string) => Promise<{ status: string } | null>;
+
+export interface StatusTransitionOptions {
+  getIssueStatus: ExistingIssueLookup;
+}
+
+/**
+ * Layer 1 status-transition guard (AKS-1509 §7.3 / AKS-1597).
+ *
+ * Gated behind PAPERCLIP_STATUS_GUARD_V2 (default false — dormant no-op).
+ * When enabled, rejects any PATCH that mutates status / assignee / completedAt /
+ * track unless one of five allowlisted exceptions holds (A backlog, B block,
+ * C unblock, D PE-authored, E CEO break-glass JWT).
+ */
+export function enforceStatusTransition(options: StatusTransitionOptions): RequestHandler {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    if (!isStatusGuardEnabled()) return next();
+    if (req.method !== "PATCH") return next();
+
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    if (!bodyTouchesGovernedFields(body)) return next();
+
+    const requestIdHeader = req.header("x-request-id");
+    const requestId =
+      typeof requestIdHeader === "string" && /^[\w\-:.]{1,128}$/.test(requestIdHeader)
+        ? requestIdHeader
+        : randomUUID();
+    const issueId = getIssueIdFromRequest(req);
+    if (!issueId) return next();
+
+    const existing = await options.getIssueStatus(issueId);
+    if (!existing) return next();
+
+    const fromStatus = existing.status;
+    const toStatusRaw = body["status"];
+    const toStatus =
+      typeof toStatusRaw === "string" && toStatusRaw.length > 0 ? toStatusRaw : fromStatus;
+
+    const guardContext: StatusGuardContext = { requestId };
+    req.statusGuard = guardContext;
+
+    // Exception A: backlog maintenance (backlog <-> todo)
+    const backlogSet = new Set(["backlog", "todo"]);
+    if (backlogSet.has(fromStatus) && backlogSet.has(toStatus)) return next();
+
+    // Exception B: * -> blocked with non-empty blockReason
+    if (toStatus === "blocked" && getNonEmptyString(body, "blockReason")) return next();
+
+    // Exception C: blocked -> * with non-empty unblockReason
+    if (fromStatus === "blocked" && getNonEmptyString(body, "unblockReason")) return next();
+
+    // Exception D: PE-authored via X-PE-Transition-Id.
+    //
+    // Per AKS-1591 LCSO protocol, the consume is a two-transaction autonomous-commit pattern
+    // running on the shared Supabase `transition_artifacts` table (project rqrnplaswseoytjrhmcs).
+    // That client is not yet plumbed into this server. When enabled without the client wired,
+    // Exception D must fail-closed with 503 so callers treat the header as burned-not-retryable.
+    //
+    // Implementation of the consume + precise-error mapping lands alongside the shared-Supabase
+    // client wiring (tracked as a sibling to this PR — see AKS-1597 progress comment).
+    const peTransitionId = req.header("x-pe-transition-id");
+    if (peTransitionId && peTransitionId.length > 0) {
+      logger.warn(
+        {
+          event: "status_guard.pe_consume_unavailable",
+          requestId,
+          issueId,
+          fromStatus,
+          toStatus,
+        },
+        "PE-authored transition received but shared-Supabase consume path is not wired. Fail-closed.",
+      );
+      respondDenied(res, 503, {
+        error: "pe_artifact_verification_unavailable",
+        message:
+          "Exception D consume path not available. Shared-Supabase transition_artifacts client is not wired in this build. Retry when operational note clears.",
+        request_id: requestId,
+      });
+      return;
+    }
+
+    // Exception E: CEO break-glass JWT.
+    const rawOverride = req.header("x-admin-override");
+    if (rawOverride === "true") {
+      respondDenied(res, 422, {
+        error: "admin_override_boolean_form_retired",
+        message:
+          "Use a CEO-scoped override JWT. See AKS-1509 §4 Exception E / AKS-1597 REV-A.",
+        request_id: requestId,
+      });
+      return;
+    }
+
+    if (rawOverride && rawOverride.length > 0) {
+      const result = verifyAdminOverrideJwt(rawOverride);
+      if (!result.ok) {
+        respondDenied(res, 422, {
+          error: result.error,
+          message: "Admin override JWT rejected.",
+          request_id: requestId,
+        });
+        return;
+      }
+      const claims: AdminOverrideJwtClaims = result.claims;
+      if (
+        claims.issue_id !== issueId ||
+        claims.old_status !== fromStatus ||
+        claims.new_status !== toStatus
+      ) {
+        respondDenied(res, 422, {
+          error: "admin_override_bounds_mismatch",
+          message:
+            "Admin override JWT issue_id/old_status/new_status must bind exactly to the requested transition.",
+          request_id: requestId,
+        });
+        return;
+      }
+
+      const originIp = req.ip ?? "";
+      const userAgent = req.header("user-agent") ?? null;
+      guardContext.adminOverride = {
+        jti: claims.jti,
+        principalUserId: claims.sub,
+        reason: claims.reason,
+        originIp,
+        userAgent,
+        jwtIat: new Date(claims.iat * 1000),
+        jwtExp: new Date(claims.exp * 1000),
+      };
+      return next();
+    }
+
+    // No exception matched — deny with actionable error shape.
+    respondDenied(res, 422, {
+      error: "status_transition_blocked",
+      message: "PATCH status requires Policy Engine. See AKS-685 / AKS-1509.",
+      legalPaths: DEFAULT_LEGAL_PATHS,
+      request_id: requestId,
+    });
+  };
+}
+
+export const __testing = {
+  isStatusGuardEnabled,
+  bodyTouchesGovernedFields,
+};

--- a/server/src/routes/admin-override.ts
+++ b/server/src/routes/admin-override.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from "node:crypto";
+import { Router, type Request, type Response } from "express";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { authSessions } from "@paperclipai/db";
+import { validate } from "../middleware/validate.js";
+import { logger } from "../middleware/logger.js";
+import {
+  ADMIN_OVERRIDE_CONSTANTS,
+  createAdminOverrideJwt,
+} from "../admin-override-jwt.js";
+import {
+  ADMIN_OVERRIDE_RATE_LIMITS,
+  AdminOverrideRateLimiter,
+} from "../admin-override-rate-limiter.js";
+
+const CEO_REAUTH_WINDOW_SECONDS = 60;
+
+const mintRequestSchema = z.object({
+  issueId: z.string().uuid(),
+  oldStatus: z.string().min(1),
+  newStatus: z.string().min(1),
+  reason: z.string().min(ADMIN_OVERRIDE_CONSTANTS.reasonMinLength),
+  ttlSeconds: z.number().int().positive().max(ADMIN_OVERRIDE_CONSTANTS.ttlMaxSeconds).optional(),
+});
+
+function getConfiguredPrincipals(): Set<string> {
+  const raw = process.env.PAPERCLIP_ADMIN_OVERRIDE_PRINCIPALS?.trim();
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0),
+  );
+}
+
+function noStore(res: Response) {
+  res.setHeader("Cache-Control", "no-store");
+}
+
+export interface AdminOverrideRoutesOptions {
+  db: Db;
+  rateLimiter?: AdminOverrideRateLimiter;
+  nowMs?: () => number;
+}
+
+export function adminOverrideRoutes(opts: AdminOverrideRoutesOptions): Router {
+  const router = Router();
+  const limiter =
+    opts.rateLimiter ??
+    new AdminOverrideRateLimiter({
+      hourlyLimit: ADMIN_OVERRIDE_RATE_LIMITS.hourlyLimit,
+      dailyLimit: ADMIN_OVERRIDE_RATE_LIMITS.dailyLimit,
+      nowMs: opts.nowMs,
+    });
+  const now = opts.nowMs ?? (() => Date.now());
+
+  router.post(
+    "/admin-override/mint",
+    validate(mintRequestSchema),
+    async (req: Request, res: Response) => {
+      noStore(res);
+      const actor = req.actor;
+      if (!actor || actor.type === "none") {
+        res.status(401).json({ error: "minter_unauthenticated" });
+        return;
+      }
+      if (actor.type !== "board" || !actor.userId) {
+        res.status(403).json({ error: "admin_override_principal_forbidden" });
+        return;
+      }
+
+      const principals = getConfiguredPrincipals();
+      if (principals.size === 0) {
+        res.status(503).json({
+          error: "admin_override_minter_not_configured",
+          message:
+            "PAPERCLIP_ADMIN_OVERRIDE_PRINCIPALS is unset. Minter is disabled until a CEO principal is configured.",
+        });
+        return;
+      }
+      if (!principals.has(actor.userId)) {
+        res.status(403).json({ error: "admin_override_principal_forbidden" });
+        return;
+      }
+
+      if (!process.env.PAPERCLIP_ADMIN_OVERRIDE_JWT_KEY?.trim()) {
+        res.status(503).json({
+          error: "admin_override_signing_key_missing",
+          message: "PAPERCLIP_ADMIN_OVERRIDE_JWT_KEY is not configured on this host.",
+        });
+        return;
+      }
+
+      // AC-8-A: CEO session must be fresh (re-auth <=60s).
+      const sessionId = (actor as { keyId?: string }).keyId;
+      if (!sessionId) {
+        res.status(401).json({
+          error: "minter_reauth_required",
+          message: "No session context available. Re-authenticate within 60 seconds of minting.",
+        });
+        return;
+      }
+      const [sessionRow] = await opts.db
+        .select({ createdAt: authSessions.createdAt, userId: authSessions.userId })
+        .from(authSessions)
+        .where(eq(authSessions.id, sessionId))
+        .limit(1);
+      if (!sessionRow || sessionRow.userId !== actor.userId) {
+        res.status(401).json({
+          error: "minter_reauth_required",
+          message: "Session not found or principal mismatch.",
+        });
+        return;
+      }
+      const sessionAgeSeconds = Math.floor((now() - sessionRow.createdAt.getTime()) / 1000);
+      if (sessionAgeSeconds > CEO_REAUTH_WINDOW_SECONDS) {
+        res.status(401).json({
+          error: "minter_reauth_required",
+          message: `Session is ${sessionAgeSeconds}s old. Re-authenticate within ${CEO_REAUTH_WINDOW_SECONDS} seconds before minting.`,
+        });
+        return;
+      }
+
+      // AC-8-B: rate limit <=5/h, <=10/d per principal.
+      const decision = limiter.record(actor.userId);
+      if (!decision.allowed) {
+        if (decision.retryAfterSeconds !== undefined) {
+          res.setHeader("Retry-After", String(decision.retryAfterSeconds));
+        }
+        res.status(429).json({
+          error: "minter_rate_limit_exceeded",
+          message: "Admin override mint rate limit exceeded.",
+          retryAfterSeconds: decision.retryAfterSeconds,
+          hourlyRemaining: decision.hourlyRemaining,
+          dailyRemaining: decision.dailyRemaining,
+        });
+        return;
+      }
+
+      const body = req.body as z.infer<typeof mintRequestSchema>;
+      const jti = randomUUID();
+      const ttlSeconds = body.ttlSeconds ?? ADMIN_OVERRIDE_CONSTANTS.ttlMaxSeconds;
+
+      const token = createAdminOverrideJwt({
+        subject: actor.userId,
+        issueId: body.issueId,
+        oldStatus: body.oldStatus,
+        newStatus: body.newStatus,
+        reason: body.reason,
+        jti,
+        ttlSeconds,
+      });
+      if (!token) {
+        res.status(503).json({
+          error: "admin_override_signing_key_missing",
+          message: "Unable to mint admin override JWT — signing key not available.",
+        });
+        return;
+      }
+
+      const mintedAtMs = now();
+      const expiresAtMs = mintedAtMs + ttlSeconds * 1000;
+
+      logger.warn(
+        {
+          event: "admin_override.mint_issued",
+          principalUserId: actor.userId,
+          jti,
+          issueId: body.issueId,
+          oldStatus: body.oldStatus,
+          newStatus: body.newStatus,
+          ttlSeconds,
+          hourlyRemaining: decision.hourlyRemaining,
+          dailyRemaining: decision.dailyRemaining,
+        },
+        "Admin override JWT minted",
+      );
+
+      res.status(201).json({
+        token,
+        jti,
+        mintedAt: new Date(mintedAtMs).toISOString(),
+        expiresAt: new Date(expiresAtMs).toISOString(),
+        ttlSeconds,
+        rateLimit: {
+          hourlyRemaining: decision.hourlyRemaining,
+          dailyRemaining: decision.dailyRemaining,
+        },
+      });
+    },
+  );
+
+  return router;
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -4,6 +4,7 @@ export { companySkillRoutes } from "./company-skills.js";
 export { agentRoutes } from "./agents.js";
 export { projectRoutes } from "./projects.js";
 export { issueRoutes } from "./issues.js";
+export { adminOverrideRoutes } from "./admin-override.js";
 export { routineRoutes } from "./routines.js";
 export { goalRoutes } from "./goals.js";
 export { approvalRoutes } from "./approvals.js";

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -76,6 +76,7 @@ import {
   normalizeIssueExecutionPolicy,
   parseIssueExecutionState,
 } from "../services/issue-execution-policy.js";
+import { enforceStatusTransition } from "../middleware/status-transition.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -1745,7 +1746,16 @@ export function issueRoutes(
     res.status(201).json(issue);
   });
 
-  router.patch("/issues/:id", validate(updateIssueRouteSchema), async (req, res) => {
+  router.patch(
+    "/issues/:id",
+    validate(updateIssueRouteSchema),
+    enforceStatusTransition({
+      getIssueStatus: async (id) => {
+        const issue = await svc.getById(id);
+        return issue ? { status: issue.status } : null;
+      },
+    }),
+    async (req, res) => {
     const id = req.params.id as string;
     const existing = await svc.getById(id);
     if (!existing) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3,7 +3,7 @@ import { Router, type Request, type Response } from "express";
 import multer from "multer";
 import { z } from "zod";
 import type { Db } from "@paperclipai/db";
-import { issueExecutionDecisions } from "@paperclipai/db";
+import { adminOverrideAudit, issueExecutionDecisions } from "@paperclipai/db";
 import {
   addIssueCommentSchema,
   acceptIssueThreadInteractionSchema,
@@ -1914,6 +1914,29 @@ export function issueRoutes(
       }
     }
 
+    // AKS-1597 REV-A: when enforceStatusTransition accepted via Exception E (CEO
+    // break-glass JWT), the admin_override_audit INSERT must land in the same
+    // transaction as the issues UPDATE so the DB UNIQUE(override_jwt_jti) acts
+    // as the replay guard. Middleware attached the verified claim context at
+    // req.statusGuard.adminOverride; handler owns the atomic persistence.
+    const adminOverrideCtx = req.statusGuard?.adminOverride;
+    const overrideRequestId = req.statusGuard?.requestId ?? null;
+    const adminOverrideAuditValues = adminOverrideCtx && overrideRequestId
+      ? {
+          overrideJwtJti: adminOverrideCtx.jti,
+          principalUserId: adminOverrideCtx.principalUserId,
+          originIp: adminOverrideCtx.originIp,
+          userAgent: adminOverrideCtx.userAgent,
+          reason: adminOverrideCtx.reason,
+          oldStatus: existing.status,
+          newStatus:
+            typeof updateFields.status === "string" ? updateFields.status : existing.status,
+          requestId: overrideRequestId,
+          jwtIat: adminOverrideCtx.jwtIat,
+          jwtExp: adminOverrideCtx.jwtExp,
+        }
+      : null;
+
     let issue;
     try {
       if (transition.decision && decisionId) {
@@ -1943,6 +1966,31 @@ export function issueRoutes(
             createdByRunId: actor.runId ?? null,
           });
 
+          if (adminOverrideAuditValues) {
+            await tx.insert(adminOverrideAudit).values({
+              ...adminOverrideAuditValues,
+              issueId: updated.id,
+            });
+          }
+
+          return updated;
+        });
+      } else if (adminOverrideAuditValues) {
+        issue = await db.transaction(async (tx) => {
+          const updated = await svc.update(
+            id,
+            {
+              ...updateFields,
+              actorAgentId: actor.agentId ?? null,
+              actorUserId: actor.actorType === "user" ? actor.actorId : null,
+            },
+            tx,
+          );
+          if (!updated) return null;
+          await tx.insert(adminOverrideAudit).values({
+            ...adminOverrideAuditValues,
+            issueId: updated.id,
+          });
           return updated;
         });
       } else {


### PR DESCRIPTION
## Summary

Ships S5 of the [AKS-685](https://github.com/paperclipai/paperclip/issues) PATCH-bypass closure behind `PAPERCLIP_STATUS_GUARD_V2` (default false — Layer 1 is dormant until S6 flips it). Implements the [AKS-1509](/AKS/issues/AKS-1509) §7.2a, §7.3, and §8 step-5 deliverables:

- **Migration 0065** — `admin_override_audit` table with `UNIQUE(override_jwt_jti)` replay guard, `char_length(reason) >= 20`, `jwt_exp - jwt_iat <= interval '5 minutes'`, FK `issues(id) ON DELETE RESTRICT`.
- **enforceStatusTransition middleware** — Layer 1 API-boundary guard with five allowlisted exceptions (backlog / block / unblock / PE-authored / CEO break-glass).
- **CEO admin-override JWT helper + minter endpoint** — HS256 via `node:crypto` (no new dep; same pattern as existing `agent-auth-jwt.ts`), supports rotation, full REV-A claim set, minter enforces AC-8-A (Better-Auth session `createdAt <= 60s`) + AC-8-B (5 mints/h + 10 mints/d per principal; 429 + `Retry-After`).
- **Error-handler mappings (AC-7)** — `P0403 \"Status transition blocked:\" -> 422 status_transition_blocked{legalPaths[]}` and `unique_violation(override_jwt_jti) -> 422 admin_override_replay`.
- **Handler-side atomic INSERT (REV-A)** — `admin_override_audit` row is written in the same transaction as `UPDATE issues SET status=...` so the DB UNIQUE constraint acts as the replay guard.

## AC status

| AC | Status | Evidence |
|----|--------|----------|
| 1 replay -> 422 | green | migration UNIQUE constraint + error-handler mapping + regression test |
| 2 flag gates PATCH | green | middleware early-returns when flag is off |
| 3 Exception D consumed-flag | **partial** | see Exception D scope note below |
| 4 Exception E JWT rejection | green | 13-case matrix in `admin-override-jwt.test.ts` |
| 5 AC-8-A + AC-8-B | green | `admin-override-rate-limiter.test.ts` covers 6-in-1h and 11-in-24h |
| 6 L501-502 pseudocode nit | n/a | plan-text issue only; handler uses template literals |
| 7 P0403 -> 422 with legalPaths | green | error-handler test (duplicates `fork/fix/p0403-status-guard-422` — safe to drop my block if that fork merges first) |

## Exception D scope note (needs CTO decision)

Reading [AKS-1591](/AKS/issues/AKS-1591) LCSO sign-off (comment `2e772336`) revealed Exception D requires a shared-Supabase migration + PostgREST client + two-transaction autonomous-commit consume that are not present in `paperclip-platform`. My middleware stubs Exception D as `503 pe_artifact_verification_unavailable` — fail-closed, matches LCSO AC-1 \"burned, not retryable\" semantics, safe with flag off.

**Recommendation:** split into a sibling issue `AKS-1597/b: Exception D consume — shared-Supabase migration + client + full consume + rate-limit`. Full details in the AKS-1597 issue thread.

## Unrelated commit on the branch

`9c1a14db feat(slo): summary-coverage monitor script (AKS-1858)` appeared on this branch between heartbeats, authored by the CEO. Left in place — if it should move to its own branch, happy to rebase.

## Required env for go-live (not needed for dormant ship)

- `PAPERCLIP_STATUS_GUARD_V2=true` — flip in S6 ([AKS-1598](/AKS/issues/AKS-1598))
- `PAPERCLIP_ADMIN_OVERRIDE_JWT_KEY=<hmac-secret>[,<previous-secret-during-rotation>]`
- `PAPERCLIP_ADMIN_OVERRIDE_PRINCIPALS=<comma-separated-CEO-user-ids>`

Unset today = minter returns 503 and middleware no-ops. Safe default.

## Test plan

- [x] `npx tsx packages/db/src/check-migration-numbering.ts` passes
- [x] 13-case JWT rejection matrix covers all `AdminOverrideVerifyError` variants
- [x] Rate limiter: 6-in-1h + 11-in-24h binding tests pass with fake clock
- [x] Error-handler: P0403 -> 422, unique_violation -> 422 admin_override_replay, unrelated unique_violation still 500
- [ ] Integration test exercising middleware through a real Express app + PATCH `/api/issues/:id` (deferred — adds test infra, can follow up)
- [ ] Full consume path + Exception D binding ACs (sibling issue proposal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)