### PR TITLE
fix: avoid self-checkout collisions on agent heartbeats

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { seedCodexHomeFromShared } from "./codex-home.js";
+
+describe("seedCodexHomeFromShared", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (!dir) continue;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function createTempDir(name: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it("seeds explicit Codex homes from the shared authenticated home", async () => {
+    const sourceHome = createTempDir("paperclip-codex-shared");
+    const targetHome = createTempDir("paperclip-codex-target");
+    const onLog = vi.fn(async () => {});
+
+    fs.writeFileSync(path.join(sourceHome, "auth.json"), '{"token":"redacted"}');
+    fs.writeFileSync(path.join(sourceHome, "config.toml"), 'model = "gpt-5.4"\n');
+    fs.writeFileSync(path.join(sourceHome, "instructions.md"), "# shared\n");
+
+    await seedCodexHomeFromShared(
+      targetHome,
+      { CODEX_HOME: sourceHome },
+      onLog,
+      "adapter-config override",
+    );
+
+    const authStat = fs.lstatSync(path.join(targetHome, "auth.json"));
+    expect(authStat.isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(path.join(targetHome, "auth.json"))).toBe(
+      fs.realpathSync(path.join(sourceHome, "auth.json")),
+    );
+    expect(fs.readFileSync(path.join(targetHome, "config.toml"), "utf8")).toBe(
+      'model = "gpt-5.4"\n',
+    );
+    expect(fs.readFileSync(path.join(targetHome, "instructions.md"), "utf8")).toBe("# shared\n");
+    expect(onLog).toHaveBeenCalledOnce();
+  });
+
+  it("preserves existing override-local config files while still wiring shared auth", async () => {
+    const sourceHome = createTempDir("paperclip-codex-shared");
+    const targetHome = createTempDir("paperclip-codex-target");
+    const onLog = vi.fn(async () => {});
+
+    fs.writeFileSync(path.join(sourceHome, "auth.json"), '{"token":"redacted"}');
+    fs.writeFileSync(path.join(sourceHome, "config.toml"), 'model = "shared"\n');
+    fs.writeFileSync(path.join(targetHome, "config.toml"), 'model = "override"\n');
+
+    await seedCodexHomeFromShared(
+      targetHome,
+      { CODEX_HOME: sourceHome },
+      onLog,
+      "adapter-config override",
+    );
+
+    expect(fs.realpathSync(path.join(targetHome, "auth.json"))).toBe(
+      fs.realpathSync(path.join(sourceHome, "auth.json")),
+    );
+    expect(fs.readFileSync(path.join(targetHome, "config.toml"), "utf8")).toBe(
+      'model = "override"\n',
+    );
+  });
+});

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -71,15 +71,11 @@ async function ensureCopiedFile(target: string, source: string): Promise<void> {
   await fs.copyFile(source, target);
 }
 
-export async function prepareManagedCodexHome(
-  env: NodeJS.ProcessEnv,
-  onLog: AdapterExecutionContext["onLog"],
-  companyId?: string,
-): Promise<string> {
-  const targetHome = resolveManagedCodexHomeDir(env, companyId);
-
-  const sourceHome = resolveSharedCodexHomeDir(env);
-  if (path.resolve(sourceHome) === path.resolve(targetHome)) return targetHome;
+async function seedCodexHomeFromSource(
+  targetHome: string,
+  sourceHome: string,
+): Promise<void> {
+  if (path.resolve(sourceHome) === path.resolve(targetHome)) return;
 
   await fs.mkdir(targetHome, { recursive: true });
 
@@ -94,10 +90,36 @@ export async function prepareManagedCodexHome(
     if (!(await pathExists(source))) continue;
     await ensureCopiedFile(path.join(targetHome, name), source);
   }
+}
+
+export async function seedCodexHomeFromShared(
+  targetHome: string,
+  env: NodeJS.ProcessEnv,
+  onLog: AdapterExecutionContext["onLog"],
+  label: string,
+): Promise<string> {
+  const sourceHome = resolveSharedCodexHomeDir(env);
+  await seedCodexHomeFromSource(targetHome, sourceHome);
+
+  if (path.resolve(sourceHome) === path.resolve(targetHome)) return targetHome;
 
   await onLog(
     "stdout",
-    `[paperclip] Using ${isWorktreeMode(env) ? "worktree-isolated" : "Paperclip-managed"} Codex home "${targetHome}" (seeded from "${sourceHome}").\n`,
+    `[paperclip] Using ${label} Codex home "${targetHome}" (seeded from "${sourceHome}").\n`,
   );
   return targetHome;
+}
+
+export async function prepareManagedCodexHome(
+  env: NodeJS.ProcessEnv,
+  onLog: AdapterExecutionContext["onLog"],
+  companyId?: string,
+): Promise<string> {
+  const targetHome = resolveManagedCodexHomeDir(env, companyId);
+  return seedCodexHomeFromShared(
+    targetHome,
+    env,
+    onLog,
+    isWorktreeMode(env) ? "worktree-isolated" : "Paperclip-managed",
+  );
 }

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -26,8 +26,15 @@ import {
   parseCodexJsonl,
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
+  isCodexResumeModelError,
 } from "./parse.js";
-import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
+import {
+  pathExists,
+  prepareManagedCodexHome,
+  resolveManagedCodexHomeDir,
+  resolveSharedCodexHomeDir,
+  seedCodexHomeFromShared,
+} from "./codex-home.js";
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 import { buildCodexExecArgs } from "./codex-args.js";
 
@@ -312,8 +319,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const codexSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredSkillNames = resolveCodexDesiredSkillNames(config, codexSkillEntries);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
-  const preparedManagedCodexHome =
-    configuredCodexHome ? null : await prepareManagedCodexHome(process.env, onLog, agent.companyId);
+  const preparedManagedCodexHome = configuredCodexHome
+    ? await seedCodexHomeFromShared(
+        configuredCodexHome,
+        process.env,
+        onLog,
+        "adapter-config override",
+      )
+    : await prepareManagedCodexHome(process.env, onLog, agent.companyId);
   const defaultCodexHome = resolveManagedCodexHomeDir(process.env, agent.companyId);
   const effectiveCodexHome = configuredCodexHome ?? preparedManagedCodexHome ?? defaultCodexHome;
   await fs.mkdir(effectiveCodexHome, { recursive: true });
@@ -707,11 +720,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     sessionId &&
     !initial.proc.timedOut &&
     (initial.proc.exitCode ?? 0) !== 0 &&
-    isCodexUnknownSessionError(initial.proc.stdout, initial.rawStderr)
+    (
+      isCodexUnknownSessionError(initial.proc.stdout, initial.rawStderr) ||
+      isCodexResumeModelError(initial.proc.stdout, initial.rawStderr)
+    )
   ) {
     await onLog(
       "stdout",
-      `[paperclip] Codex resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+      `[paperclip] Codex resume session "${sessionId}" is unavailable or incompatible with the current model/account; retrying with a fresh session.\n`,
     );
     const retry = await runAttempt(null);
     return toResult(retry, true, true);

--- a/packages/adapters/codex-local/src/server/index.ts
+++ b/packages/adapters/codex-local/src/server/index.ts
@@ -1,7 +1,12 @@
 export { execute, ensureCodexSkillsInjected } from "./execute.js";
 export { listCodexSkills, syncCodexSkills } from "./skills.js";
 export { testEnvironment } from "./test.js";
-export { parseCodexJsonl, isCodexTransientUpstreamError, isCodexUnknownSessionError } from "./parse.js";
+export {
+  parseCodexJsonl,
+  isCodexTransientUpstreamError,
+  isCodexUnknownSessionError,
+  isCodexResumeModelError,
+} from "./parse.js";
 export {
   getQuotaWindows,
   readCodexAuthInfo,

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -97,3 +97,14 @@ export function isCodexTransientUpstreamError(input: {
   // failure shape; broader 429s may be caused by user or account limits.
   return CODEX_REMOTE_COMPACTION_RE.test(haystack) || /high\s+demand|temporary\s+errors/i.test(haystack);
 }
+
+export function isCodexResumeModelError(stdout: string, stderr: string): boolean {
+  const haystack = `${stdout}\n${stderr}`
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+  return /session was recorded with model .* but is resuming with|model is not supported when using codex with a chatgpt account/i.test(
+    haystack,
+  );
+}

--- a/server/src/__tests__/codex-local-adapter.test.ts
+++ b/server/src/__tests__/codex-local-adapter.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { isCodexUnknownSessionError, parseCodexJsonl } from "@paperclipai/adapter-codex-local/server";
+import {
+  isCodexResumeModelError,
+  isCodexUnknownSessionError,
+  parseCodexJsonl,
+} from "@paperclipai/adapter-codex-local/server";
 import { parseCodexStdoutLine } from "@paperclipai/adapter-codex-local/ui";
 import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 
@@ -30,6 +34,25 @@ describe("codex_local stale session detection", () => {
       "2026-02-19T19:58:53.281939Z ERROR codex_core::rollout::list: state db missing rollout path for thread 019c775d-967c-7ef1-acc7-e396dc2c87cc";
 
     expect(isCodexUnknownSessionError("", stderr)).toBe(true);
+  });
+
+  it("treats resume model mismatches as recoverable resume errors", () => {
+    const stdout = JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "error",
+        message: "This session was recorded with model `gpt-5.2-pro` but is resuming with `gpt-5.4`.",
+      },
+    });
+
+    expect(isCodexResumeModelError(stdout, "")).toBe(true);
+  });
+
+  it("treats ChatGPT account model compatibility errors as recoverable resume errors", () => {
+    const stderr =
+      "The 'gpt-5.1-codex-mini' model is not supported when using Codex with a ChatGPT account.";
+
+    expect(isCodexResumeModelError("", stderr)).toBe(true);
   });
 });
 

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -38,6 +38,48 @@ process.exit(1);
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeResumeRecoveryCodexCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const countPath = process.env.PAPERCLIP_TEST_COUNT_PATH;
+const attempt = countPath && fs.existsSync(countPath)
+  ? Number.parseInt(fs.readFileSync(countPath, "utf8"), 10) || 0
+  : 0;
+const nextAttempt = attempt + 1;
+if (countPath) {
+  fs.writeFileSync(countPath, String(nextAttempt), "utf8");
+}
+
+const payload = {
+  attempt: nextAttempt,
+  argv: process.argv.slice(2),
+  prompt: fs.readFileSync(0, "utf8"),
+  codexHome: process.env.CODEX_HOME || null,
+};
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+
+if (process.argv.includes("resume")) {
+  console.log(JSON.stringify({
+    type: "turn.failed",
+    error: {
+      message: "The 'gpt-5.1-codex-mini' model is not supported when using Codex with a ChatGPT account.",
+    },
+  }));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ type: "thread.started", thread_id: "codex-session-2" }));
+console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "fresh-session-ok" } }));
+console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 2, cached_input_tokens: 0, output_tokens: 1 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 type CapturePayload = {
   argv: string[];
   prompt: string;
@@ -857,6 +899,111 @@ describe("codex execute", () => {
       );
       expect(promptMetrics.instructionsChars).toBe(0);
       expect(promptMetrics.heartbeatPromptChars).toBe(0);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("retries with a fresh session when a resumed session fails with a stale model error", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-resume-retry-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    const countPath = path.join(root, "attempt-count.txt");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeResumeRecoveryCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const logs: LogEntry[] = [];
+      const result = await execute({
+        runId: "run-resume-retry",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: {
+            sessionId: "codex-session-stale",
+            cwd: workspace,
+          },
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          model: "gpt-5.4",
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+            PAPERCLIP_TEST_COUNT_PATH: countPath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          issueId: "issue-1",
+          taskId: "issue-1",
+          wakeReason: "issue_commented",
+          wakeCommentId: "comment-1",
+          paperclipWake: {
+            reason: "issue_commented",
+            issue: {
+              id: "issue-1",
+              identifier: "PAP-900",
+              title: "resume recovery",
+              status: "in_progress",
+              priority: "medium",
+            },
+            commentIds: ["comment-1"],
+            latestCommentId: "comment-1",
+            comments: [
+              {
+                id: "comment-1",
+                issueId: "issue-1",
+                body: "Wake up",
+                bodyTruncated: false,
+                createdAt: "2026-04-22T16:00:00.000Z",
+                author: { type: "user", id: "user-1" },
+              },
+            ],
+            commentWindow: {
+              requestedCount: 1,
+              includedCount: 1,
+              missingCount: 0,
+            },
+            truncated: false,
+            fallbackFetchNeeded: false,
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async (stream, chunk) => {
+          logs.push({ stream, chunk });
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+      expect(result.sessionId).toBe("codex-session-2");
+      expect(await fs.readFile(countPath, "utf8")).toBe("2");
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload & { attempt: number };
+      expect(capture.attempt).toBe(2);
+      expect(capture.argv).toEqual(expect.arrayContaining(["exec", "--json", "--model", "gpt-5.4", "-"]));
+      expect(capture.argv).not.toContain("resume");
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          stream: "stdout",
+          chunk: expect.stringContaining("retrying with a fresh session"),
+        }),
+      );
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;

--- a/server/src/__tests__/issue-assignment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup-routes.test.ts
@@ -1,0 +1,240 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const AGENT_ID = "11111111-1111-4111-8111-111111111111";
+const ISSUE_ID = "22222222-2222-4222-8222-222222222222";
+const COMPANY_ID = "company-1";
+const RUN_ID = "33333333-3333-4333-8333-333333333333";
+
+const mockIssueService = vi.hoisted(() => ({
+  create: vi.fn(),
+  update: vi.fn(),
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(),
+  getRelationSummaries: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+  findMentionedAgents: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(async () => true),
+    hasPermission: vi.fn(async () => true),
+  }),
+  agentService: () => ({
+    getById: vi.fn(async () => ({
+      id: AGENT_ID,
+      companyId: COMPANY_ID,
+      role: "engineer",
+      permissions: {},
+    })),
+    resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({
+      ambiguous: false,
+      agent: { id: raw },
+    })),
+    list: vi.fn(async () => [{
+      id: AGENT_ID,
+      companyId: COMPANY_ID,
+      role: "engineer",
+      reportsTo: null,
+      permissions: {},
+    }]),
+  }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+  }),
+  goalService: () => ({
+    getById: vi.fn(async () => null),
+    getDefaultCompanyGoal: vi.fn(async () => null),
+  }),
+  heartbeatService: () => mockHeartbeatService,
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    })),
+    listCompanyIds: vi.fn(async () => [COMPANY_ID]),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  ISSUE_LIST_DEFAULT_LIMIT: 500,
+  ISSUE_LIST_MAX_LIMIT: 1000,
+  clampIssueListLimit: vi.fn((limit: number) => limit),
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({
+    getById: vi.fn(async () => null),
+  }),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+}));
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => ({
+      canUser: vi.fn(async () => true),
+      hasPermission: vi.fn(async () => true),
+    }),
+    agentService: () => ({
+      getById: vi.fn(async () => ({
+        id: AGENT_ID,
+        companyId: COMPANY_ID,
+        role: "engineer",
+        permissions: {},
+      })),
+      resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({
+        ambiguous: false,
+        agent: { id: raw },
+      })),
+      list: vi.fn(async () => [{
+        id: AGENT_ID,
+        companyId: COMPANY_ID,
+        role: "engineer",
+        reportsTo: null,
+        permissions: {},
+      }]),
+    }),
+    documentService: () => ({}),
+    executionWorkspaceService: () => ({}),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+    }),
+    goalService: () => ({
+      getById: vi.fn(async () => null),
+      getDefaultCompanyGoal: vi.fn(async () => null),
+    }),
+    heartbeatService: () => mockHeartbeatService,
+    instanceSettingsService: () => ({
+      get: vi.fn(async () => ({
+        id: "instance-settings-1",
+        general: {
+          censorUsernameInLogs: false,
+          feedbackDataSharingPreference: "prompt",
+        },
+      })),
+      listCompanyIds: vi.fn(async () => [COMPANY_ID]),
+    }),
+    issueApprovalService: () => ({}),
+    issueService: () => mockIssueService,
+    ISSUE_LIST_DEFAULT_LIMIT: 500,
+    ISSUE_LIST_MAX_LIMIT: 1000,
+    clampIssueListLimit: vi.fn((limit: number) => limit),
+    logActivity: vi.fn(async () => undefined),
+    projectService: () => ({
+      getById: vi.fn(async () => null),
+    }),
+    routineService: () => ({
+      syncRunStatusForIssue: vi.fn(async () => undefined),
+    }),
+    workProductService: () => ({}),
+  }));
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ISSUE_ID,
+    companyId: COMPANY_ID,
+    status: "todo",
+    priority: "medium",
+    projectId: null,
+    goalId: null,
+    parentId: null,
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    createdByAgentId: AGENT_ID,
+    createdByUserId: null,
+    identifier: "PAP-1000",
+    title: "Self assignment wake test",
+    executionPolicy: null,
+    executionState: null,
+    hiddenAt: null,
+    ...overrides,
+  };
+}
+
+async function createApp() {
+  const [{ errorHandler }, { issueRoutes }] = await Promise.all([
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: AGENT_ID,
+      companyId: COMPANY_ID,
+      source: "agent_key",
+      runId: RUN_ID,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue assignment wakeups", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.resetAllMocks();
+    mockIssueService.getByIdentifier.mockResolvedValue(null);
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+  });
+
+  it("does not enqueue a follow-up wake when an agent self-assigns during issue creation", async () => {
+    mockIssueService.create.mockResolvedValue(makeIssue({ assigneeAgentId: AGENT_ID }));
+
+    const res = await request(await createApp())
+      .post(`/api/companies/${COMPANY_ID}/issues`)
+      .send({
+        title: "Self assigned issue",
+        priority: "medium",
+        status: "todo",
+        assigneeAgentId: AGENT_ID,
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue a follow-up wake when an agent reassigns an issue to itself", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue());
+    mockIssueService.update.mockResolvedValue(makeIssue({ assigneeAgentId: AGENT_ID }));
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({
+        assigneeAgentId: AGENT_ID,
+        assigneeUserId: null,
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issue-assignment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup-routes.test.ts
@@ -26,6 +26,17 @@ const mockHeartbeatService = vi.hoisted(() => ({
   cancelRun: vi.fn(async () => null),
 }));
 
+const mockIssueReferenceService = vi.hoisted(() => ({
+  syncIssue: vi.fn(async () => undefined),
+  listIssueReferenceSummary: vi.fn(async () => ({ inbound: [], outbound: [] })),
+  diffIssueReferenceSummary: vi.fn(() => ({
+    addedReferencedIssues: [],
+    removedReferencedIssues: [],
+    currentReferencedIssues: [],
+  })),
+  emptySummary: vi.fn(() => ({ inbound: [], outbound: [] })),
+}));
+
 vi.mock("../services/index.js", () => ({
   accessService: () => ({
     canUser: vi.fn(async () => true),
@@ -72,6 +83,7 @@ vi.mock("../services/index.js", () => ({
     listCompanyIds: vi.fn(async () => [COMPANY_ID]),
   }),
   issueApprovalService: () => ({}),
+  issueReferenceService: () => mockIssueReferenceService,
   issueService: () => mockIssueService,
   ISSUE_LIST_DEFAULT_LIMIT: 500,
   ISSUE_LIST_MAX_LIMIT: 1000,
@@ -133,6 +145,7 @@ function registerModuleMocks() {
       listCompanyIds: vi.fn(async () => [COMPANY_ID]),
     }),
     issueApprovalService: () => ({}),
+    issueReferenceService: () => mockIssueReferenceService,
     issueService: () => mockIssueService,
     ISSUE_LIST_DEFAULT_LIMIT: 500,
     ISSUE_LIST_MAX_LIMIT: 1000,
@@ -205,6 +218,14 @@ describe("issue assignment wakeups", () => {
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
     mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueReferenceService.syncIssue.mockResolvedValue(undefined);
+    mockIssueReferenceService.listIssueReferenceSummary.mockResolvedValue({ inbound: [], outbound: [] });
+    mockIssueReferenceService.diffIssueReferenceSummary.mockReturnValue({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    });
+    mockIssueReferenceService.emptySummary.mockReturnValue({ inbound: [], outbound: [] });
   });
 
   it("does not enqueue a follow-up wake when an agent self-assigns during issue creation", async () => {

--- a/server/src/__tests__/issue-checkout-adoption-service.test.ts
+++ b/server/src/__tests__/issue-checkout-adoption-service.test.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { issueService } from "../services/issues.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres checkout adoption tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issueService.assertCheckoutOwner adoption", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-checkout-adoption-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedBase() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Alex",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    return { companyId, agentId };
+  }
+
+  async function seedRun(companyId: string, agentId: string, runId: string) {
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId: "placeholder" },
+    });
+  }
+
+  it("adopts a lingering checkout lock when the issue has no live execution run", async () => {
+    const { companyId, agentId } = await seedBase();
+    const previousRunId = randomUUID();
+    const currentRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await seedRun(companyId, agentId, previousRunId);
+    await seedRun(companyId, agentId, currentRunId);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Adopt checkout without live execution",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: previousRunId,
+      executionRunId: null,
+      issueNumber: 1,
+      identifier: "PAP-1",
+    });
+
+    const ownership = await svc.assertCheckoutOwner(issueId, agentId, currentRunId);
+
+    expect(ownership.adoptedFromRunId).toBe(previousRunId);
+    expect(ownership.checkoutRunId).toBe(currentRunId);
+    expect(ownership.executionRunId).toBe(currentRunId);
+  });
+
+  it("adopts the checkout lock when the current run is already the live executor", async () => {
+    const { companyId, agentId } = await seedBase();
+    const previousRunId = randomUUID();
+    const currentRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await seedRun(companyId, agentId, previousRunId);
+    await seedRun(companyId, agentId, currentRunId);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Adopt checkout for current executor",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: previousRunId,
+      executionRunId: currentRunId,
+      issueNumber: 1,
+      identifier: "PAP-1",
+    });
+
+    const ownership = await svc.assertCheckoutOwner(issueId, agentId, currentRunId);
+
+    expect(ownership.adoptedFromRunId).toBe(previousRunId);
+    expect(ownership.checkoutRunId).toBe(currentRunId);
+    expect(ownership.executionRunId).toBe(currentRunId);
+  });
+});

--- a/server/src/__tests__/issues-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issues-assignment-wakeup.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { shouldWakeAssigneeOnAssignment } from "../routes/issues-assignment-wakeup.js";
+
+describe("shouldWakeAssigneeOnAssignment", () => {
+  it("keeps assignment wakeups for board actors", () => {
+    expect(
+      shouldWakeAssigneeOnAssignment({
+        actorType: "board",
+        actorAgentId: null,
+        actorRunId: null,
+        assignmentAgentId: "agent-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("skips self-assignment wakeups from an active agent run", () => {
+    expect(
+      shouldWakeAssigneeOnAssignment({
+        actorType: "agent",
+        actorAgentId: "agent-1",
+        actorRunId: "run-1",
+        assignmentAgentId: "agent-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("still wakes when the actor run id is missing", () => {
+    expect(
+      shouldWakeAssigneeOnAssignment({
+        actorType: "agent",
+        actorAgentId: "agent-1",
+        actorRunId: null,
+        assignmentAgentId: "agent-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("still wakes when assigning a different agent", () => {
+    expect(
+      shouldWakeAssigneeOnAssignment({
+        actorType: "agent",
+        actorAgentId: "agent-1",
+        actorRunId: "run-1",
+        assignmentAgentId: "agent-2",
+      }),
+    ).toBe(true);
+  });
+});

--- a/server/src/routes/issues-assignment-wakeup.ts
+++ b/server/src/routes/issues-assignment-wakeup.ts
@@ -1,0 +1,15 @@
+type AssignmentWakeInput = {
+  actorType: "board" | "agent" | "none";
+  actorAgentId: string | null;
+  actorRunId: string | null;
+  assignmentAgentId: string | null;
+};
+
+export function shouldWakeAssigneeOnAssignment(input: AssignmentWakeInput): boolean {
+  if (!input.assignmentAgentId) return false;
+  if (input.actorType !== "agent") return true;
+  if (!input.actorAgentId) return true;
+  if (input.actorAgentId !== input.assignmentAgentId) return true;
+  if (!input.actorRunId) return true;
+  return false;
+}

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -63,6 +63,7 @@ import {
   assertNoAgentHostWorkspaceCommandMutation,
   collectIssueWorkspaceCommandPaths,
 } from "./workspace-command-authz.js";
+import { shouldWakeAssigneeOnAssignment } from "./issues-assignment-wakeup.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
 import {
   isInlineAttachmentContentType,
@@ -1672,15 +1673,22 @@ export function issueRoutes(
       },
     });
 
-    void queueIssueAssignmentWakeup({
-      heartbeat,
-      issue,
-      reason: "issue_assigned",
-      mutation: "create",
-      contextSource: "issue.create",
-      requestedByActorType: actor.actorType,
-      requestedByActorId: actor.actorId,
-    });
+    if (shouldWakeAssigneeOnAssignment({
+      actorType: req.actor.type,
+      actorAgentId: req.actor.type === "agent" ? req.actor.agentId ?? null : null,
+      actorRunId: req.actor.type === "agent" ? req.actor.runId ?? null : null,
+      assignmentAgentId: issue.assigneeAgentId,
+    })) {
+      void queueIssueAssignmentWakeup({
+        heartbeat,
+        issue,
+        reason: "issue_assigned",
+        mutation: "create",
+        contextSource: "issue.create",
+        requestedByActorType: actor.actorType,
+        requestedByActorId: actor.actorId,
+      });
+    }
 
     res.status(201).json({
       ...issue,
@@ -1732,15 +1740,22 @@ export function issueRoutes(
       },
     });
 
-    void queueIssueAssignmentWakeup({
-      heartbeat,
-      issue,
-      reason: "issue_assigned",
-      mutation: "create",
-      contextSource: "issue.child_create",
-      requestedByActorType: actor.actorType,
-      requestedByActorId: actor.actorId,
-    });
+    if (shouldWakeAssigneeOnAssignment({
+      actorType: req.actor.type,
+      actorAgentId: req.actor.type === "agent" ? req.actor.agentId ?? null : null,
+      actorRunId: req.actor.type === "agent" ? req.actor.runId ?? null : null,
+      assignmentAgentId: issue.assigneeAgentId,
+    })) {
+      void queueIssueAssignmentWakeup({
+        heartbeat,
+        issue,
+        reason: "issue_assigned",
+        mutation: "create",
+        contextSource: "issue.child_create",
+        requestedByActorType: actor.actorType,
+        requestedByActorId: actor.actorId,
+      });
+    }
 
     res.status(201).json(issue);
   });
@@ -2245,7 +2260,17 @@ export function issueRoutes(
 
       if (executionStageWakeup) {
         addWakeup(executionStageWakeup.agentId, executionStageWakeup.wakeup);
-      } else if (assigneeChanged && issue.assigneeAgentId && issue.status !== "backlog") {
+      } else if (
+        assigneeChanged &&
+        issue.assigneeAgentId &&
+        issue.status !== "backlog" &&
+        shouldWakeAssigneeOnAssignment({
+          actorType: req.actor.type,
+          actorAgentId: req.actor.type === "agent" ? req.actor.agentId ?? null : null,
+          actorRunId: req.actor.type === "agent" ? req.actor.runId ?? null : null,
+          assignmentAgentId: issue.assigneeAgentId,
+        })
+      ) {
         addWakeup(issue.assigneeAgentId, {
           source: "assignment",
           triggerDetail: "system",

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1204,42 +1204,80 @@ export function issueService(db: Db) {
     return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
   }
 
-  async function adoptStaleCheckoutRun(input: {
+  async function adoptCheckoutRunIfSafe(input: {
     issueId: string;
     actorAgentId: string;
     actorRunId: string;
     expectedCheckoutRunId: string;
   }) {
-    const stale = await isTerminalOrMissingHeartbeatRun(input.expectedCheckoutRunId);
-    if (!stale) return null;
+    return db.transaction(async (tx) => {
+      await tx.execute(sql`select id from issues where id = ${input.issueId} for update`);
+      const current = await tx
+        .select({
+          id: issues.id,
+          status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
+        })
+        .from(issues)
+        .where(eq(issues.id, input.issueId))
+        .then((rows) => rows[0] ?? null);
 
-    const now = new Date();
-    const adopted = await db
-      .update(issues)
-      .set({
-        checkoutRunId: input.actorRunId,
-        executionRunId: input.actorRunId,
-        executionLockedAt: now,
-        updatedAt: now,
-      })
-      .where(
-        and(
-          eq(issues.id, input.issueId),
-          eq(issues.status, "in_progress"),
-          eq(issues.assigneeAgentId, input.actorAgentId),
-          eq(issues.checkoutRunId, input.expectedCheckoutRunId),
-        ),
-      )
-      .returning({
-        id: issues.id,
-        status: issues.status,
-        assigneeAgentId: issues.assigneeAgentId,
-        checkoutRunId: issues.checkoutRunId,
-        executionRunId: issues.executionRunId,
-      })
-      .then((rows) => rows[0] ?? null);
+      if (!current) return null;
+      if (
+        current.status !== "in_progress" ||
+        current.assigneeAgentId !== input.actorAgentId ||
+        current.checkoutRunId !== input.expectedCheckoutRunId
+      ) {
+        return null;
+      }
 
-    return adopted;
+      let canAdopt = false;
+
+      // If there is no live execution owner, or the current run is already the
+      // executor, the checkout lock is stale and can be moved immediately.
+      if (current.executionRunId == null || current.executionRunId === input.actorRunId) {
+        canAdopt = true;
+      } else if (current.executionRunId === input.expectedCheckoutRunId) {
+        // Fallback: the checkout owner still matches the execution owner, so only
+        // adopt once that old run is clearly terminal or missing.
+        canAdopt = await isTerminalOrMissingHeartbeatRun(input.expectedCheckoutRunId);
+      }
+
+      if (!canAdopt) return null;
+
+      const now = new Date();
+      const executionRunCondition = current.executionRunId
+        ? eq(issues.executionRunId, current.executionRunId)
+        : isNull(issues.executionRunId);
+
+      return tx
+        .update(issues)
+        .set({
+          checkoutRunId: input.actorRunId,
+          executionRunId: input.actorRunId,
+          executionLockedAt: now,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(issues.id, input.issueId),
+            eq(issues.status, "in_progress"),
+            eq(issues.assigneeAgentId, input.actorAgentId),
+            eq(issues.checkoutRunId, input.expectedCheckoutRunId),
+            executionRunCondition,
+          ),
+        )
+        .returning({
+          id: issues.id,
+          status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
+        })
+        .then((rows) => rows[0] ?? null);
+    });
   }
 
   async function adoptUnownedCheckoutRun(input: {
@@ -2285,7 +2323,7 @@ export function issueService(db: Db) {
         current.checkoutRunId &&
         current.checkoutRunId !== checkoutRunId
       ) {
-        const adopted = await adoptStaleCheckoutRun({
+        const adopted = await adoptCheckoutRunIfSafe({
           issueId: id,
           actorAgentId: agentId,
           actorRunId: checkoutRunId,
@@ -2372,7 +2410,7 @@ export function issueService(db: Db) {
         current.checkoutRunId &&
         current.checkoutRunId !== actorRunId
       ) {
-        const adopted = await adoptStaleCheckoutRun({
+        const adopted = await adoptCheckoutRunIfSafe({
           issueId: id,
           actorAgentId,
           actorRunId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The affected subsystem is issue execution ownership in heartbeat-driven agent runs, especially assignment wakes and checkout locking in the server layer.
> - Alex SEO heartbeats can create, reassign, and close self-assigned proactive audit issues from an already-active run.
> - The existing flow still queued assignment wakes back to the same agent/run and only let stale checkout ownership move after the old run became terminal.
> - That left finished audit work unable to attach its results back to the originating issue when the agent collided with its own stale run/session state.
> - A related Codex-local failure mode also showed up during continuation: resumed sessions could fail when the stored session belonged to a stale model/account combination, and explicit `CODEX_HOME` overrides were not seeded from the shared authenticated home.
> - This pull request removes the redundant self-wake path, allows safe same-agent checkout adoption, and makes Codex recover by reseeding auth/config and retrying with a fresh session when the stored resume context is incompatible.
> - The benefit is that self-assigned SEO heartbeats can finish and report back durably instead of deadlocking on stale ownership or stale Codex session state.

## What Changed

- Added `shouldWakeAssigneeOnAssignment` and used it in issue create/reassign flows to suppress redundant assignment wakeups when an active agent run self-assigns work to itself.
- Replaced stale checkout adoption with safe same-agent checkout adoption that can move the lock when the live executor is missing or already the current run, while still guarding with row-level checks.
- Updated the Codex local adapter to seed explicit `CODEX_HOME` overrides from the shared authenticated home and to treat resume model/account mismatches as recoverable fresh-session fallbacks.
- Added regression coverage for assignment wake suppression, checkout adoption, Codex home seeding, and Codex resume recovery.

## Verification

- `pnpm vitest run server/src/__tests__/issues-assignment-wakeup.test.ts server/src/__tests__/issue-assignment-wakeup-routes.test.ts server/src/__tests__/issues-checkout-wakeup.test.ts server/src/__tests__/issue-checkout-adoption-service.test.ts server/src/__tests__/codex-local-adapter.test.ts server/src/__tests__/codex-local-execute.test.ts packages/adapters/codex-local/src/server/codex-home.test.ts`
- `pnpm -r typecheck`
- `pnpm build`
- `pnpm test:run` is currently red outside this change set. Representative existing failures from this run:
  - `server/src/__tests__/company-portability.test.ts`
  - `server/src/__tests__/worktree-config.test.ts`
  - `src/__tests__/onboard.test.ts`
  - many UI tests failing with `act is not a function` / `localStorage.clear is not a function`

## Risks

- Checkout adoption now allows same-agent takeover before the previous run is terminal; the row lock plus exact `executionRunId` predicate are what prevent stealing a genuinely live run.
- Codex resume fallback now treats more resume errors as fresh-session retries; if upstream error wording changes again, new incompatible cases may still need parser updates.
- Low risk to non-agent and cross-agent assignment flows because those branches still wake exactly as before.

> I checked `ROADMAP.md`; this is a scoped bugfix and does not duplicate planned roadmap feature work.

## Model Used

- OpenAI Codex CLI (`codex-cli 0.103.0`), GPT-5-based Codex coding agent with local tool execution. The CLI/runtime did not expose a more specific backend model identifier in-session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
