### PR TITLE
fix: heal missing checkout ownership for active runs

### DIFF
--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -198,12 +198,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       resolvedCommand,
     });
 
-    await ensureOpenCodeModelConfiguredAndAvailable({
+    const modelResolution = await ensureOpenCodeModelConfiguredAndAvailable({
       model,
       command,
       cwd,
       env: runtimeEnv,
     });
+    if (modelResolution.usedFallback && modelResolution.fallbackReason) {
+      await onLog("stdout", `[paperclip] ${modelResolution.fallbackReason}.\n`);
+    }
+    const effectiveModel = modelResolution.resolvedModel;
 
     const timeoutSec = asNumber(config.timeoutSec, 0);
     const graceSec = asNumber(config.graceSec, 20);
@@ -301,7 +305,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const buildArgs = (resumeSessionId: string | null) => {
       const args = ["run", "--format", "json"];
       if (resumeSessionId) args.push("--session", resumeSessionId);
-      if (model) args.push("--model", model);
+      if (effectiveModel) args.push("--model", effectiveModel);
       if (variant) args.push("--variant", variant);
       if (extraArgs.length > 0) args.push(...extraArgs);
       return args;

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -166,12 +166,47 @@ export async function discoverOpenCodeModelsCached(input: {
   return models;
 }
 
+export type ResolveOpenCodeModelResult = {
+  models: AdapterModel[];
+  // Effective model to use — either the requested one (if available) or a
+  // fallback sibling chosen when the requested model is unavailable.
+  resolvedModel: string;
+  usedFallback: boolean;
+  fallbackReason?: string;
+};
+
+// Pick a sibling model in the same provider family when the requested model
+// is unavailable. Priority: same provider + same base name; same provider,
+// any model; any available model. Shortest id wins within each tier
+// (usually the canonical variant).
+function chooseOpenCodeFallback(requested: string, models: AdapterModel[]): AdapterModel | null {
+  if (models.length === 0) return null;
+  const slash = requested.indexOf("/");
+  const requestedProvider = slash >= 0 ? requested.slice(0, slash) : "";
+  const requestedModelId = slash >= 0 ? requested.slice(slash + 1) : requested;
+  const baseName = requestedModelId.toLowerCase().replace(/[.\-_][0-9].*$/, "");
+  const sameProvider = models.filter((m) => m.id.startsWith(requestedProvider + "/"));
+  if (sameProvider.length > 0 && baseName) {
+    const sameFamily = sameProvider.filter((m) => {
+      const idAfterSlash = m.id.slice(m.id.indexOf("/") + 1).toLowerCase();
+      return idAfterSlash.startsWith(baseName);
+    });
+    if (sameFamily.length > 0) {
+      return sameFamily.slice().sort((a, b) => a.id.length - b.id.length)[0];
+    }
+  }
+  if (sameProvider.length > 0) {
+    return sameProvider.slice().sort((a, b) => a.id.length - b.id.length)[0];
+  }
+  return models.slice().sort((a, b) => a.id.length - b.id.length)[0];
+}
+
 export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
   model?: unknown;
   command?: unknown;
   cwd?: unknown;
   env?: unknown;
-}): Promise<AdapterModel[]> {
+}): Promise<ResolveOpenCodeModelResult> {
   const model = asString(input.model, "").trim();
   if (!model) {
     throw new Error("OpenCode requires `adapterConfig.model` in provider/model format.");
@@ -187,14 +222,24 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
     throw new Error("OpenCode returned no models. Run `opencode models` and verify provider auth.");
   }
 
-  if (!models.some((entry) => entry.id === model)) {
+  if (models.some((entry) => entry.id === model)) {
+    return { models, resolvedModel: model, usedFallback: false };
+  }
+
+  const fallback = chooseOpenCodeFallback(model, models);
+  if (!fallback) {
     const sample = models.slice(0, 12).map((entry) => entry.id).join(", ");
     throw new Error(
-      `Configured OpenCode model is unavailable: ${model}. Available models: ${sample}${models.length > 12 ? ", ..." : ""}`,
+      `Configured OpenCode model is unavailable and no fallback was found: ${model}. Available models: ${sample}${models.length > 12 ? ", ..." : ""}`,
     );
   }
 
-  return models;
+  return {
+    models,
+    resolvedModel: fallback.id,
+    usedFallback: true,
+    fallbackReason: `Configured model "${model}" unavailable; falling back to "${fallback.id}"`,
+  };
 }
 
 export async function listOpenCodeModels(): Promise<AdapterModel[]> {

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -87,6 +87,27 @@ describe("paperclip MCP tools", () => {
     });
   });
 
+  it("accepts comment aliases and forwards them to the issue comment endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({ id: "comment-1", body: "Ship it" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipAddComment");
+    await tool.execute({
+      issueId: "PAP-1135",
+      content: "Ship it",
+      reopen: true,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toBe("http://localhost:3100/api/issues/PAP-1135/comments");
+    expect(JSON.parse(String(init.body))).toEqual({
+      content: "Ship it",
+      reopen: true,
+    });
+  });
+
   it("defaults issue document format to markdown", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       mockJsonResponse({ key: "plan", latestRevisionNumber: 2 }),

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import {
-  addIssueCommentSchema,
   checkoutIssueSchema,
   createApprovalSchema,
   createIssueSchema,
@@ -15,7 +14,7 @@ export interface ToolDefinition {
   name: string;
   description: string;
   schema: z.AnyZodObject;
-  execute: (input: Record<string, unknown>) => Promise<{
+  execute: (input: { [key: string]: unknown }) => Promise<{
     content: Array<{ type: "text"; text: string }>;
   }>;
 }
@@ -105,7 +104,12 @@ const checkoutIssueToolSchema = z.object({
 
 const addCommentToolSchema = z.object({
   issueId: issueIdSchema,
-}).merge(addIssueCommentSchema);
+  body: z.string().min(1).optional(),
+  content: z.string().min(1).optional(),
+  comment: z.string().min(1).optional(),
+  reopen: z.boolean().optional(),
+  interrupt: z.boolean().optional(),
+});
 
 const approvalDecisionSchema = z.object({
   approvalId: approvalIdSchema,

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -122,7 +122,40 @@ export const createIssueSchema = z.object({
   inheritExecutionWorkspaceFromIssueId: z.string().uuid().optional().nullable(),
   title: z.string().min(1),
   description: z.string().optional().nullable(),
-  status: z.enum(ISSUE_STATUSES).optional().default("backlog"),
+  // LLM agents frequently send "completed", "closed", "wip" etc. Normalise
+  // common synonyms to the canonical ISSUE_STATUSES enum so they don't 400
+  // on field-name guesses.
+  status: z
+    .preprocess((val) => {
+      if (typeof val !== "string") return val;
+      const v = val.trim().toLowerCase();
+      const map: Record<string, string> = {
+        completed: "done",
+        complete: "done",
+        finished: "done",
+        closed: "done",
+        resolved: "done",
+        open: "todo",
+        new: "todo",
+        pending: "todo",
+        wip: "in_progress",
+        "in-progress": "in_progress",
+        "in progress": "in_progress",
+        working: "in_progress",
+        doing: "in_progress",
+        review: "in_review",
+        reviewing: "in_review",
+        "in-review": "in_review",
+        "in review": "in_review",
+        ready_for_review: "in_review",
+        "ready-for-review": "in_review",
+        cancel: "cancelled",
+        canceled: "cancelled",
+      };
+      return map[v] ?? val;
+    }, z.enum(ISSUE_STATUSES))
+    .optional()
+    .default("backlog"),
   priority: z.enum(ISSUE_PRIORITIES).optional().default("medium"),
   assigneeAgentId: z.string().uuid().optional().nullable(),
   assigneeUserId: z.string().optional().nullable(),
@@ -163,11 +196,26 @@ export const checkoutIssueSchema = z.object({
 
 export type CheckoutIssue = z.infer<typeof checkoutIssueSchema>;
 
-export const addIssueCommentSchema = z.object({
-  body: z.string().min(1),
-  reopen: z.boolean().optional(),
-  interrupt: z.boolean().optional(),
-});
+// LLM agents routinely send `content` or `comment` instead of `body`,
+// producing 400s that don't teach them anything. Accept all three forms
+// and normalise to `body` via a transform so downstream code stays clean.
+export const addIssueCommentSchema = z
+  .object({
+    body: z.string().min(1).optional(),
+    content: z.string().min(1).optional(),
+    comment: z.string().min(1).optional(),
+    reopen: z.boolean().optional(),
+    interrupt: z.boolean().optional(),
+  })
+  .refine(
+    (data) => Boolean(data.body ?? data.content ?? data.comment),
+    { message: "body (or content/comment) is required", path: ["body"] },
+  )
+  .transform((data) => ({
+    body: (data.body ?? data.content ?? data.comment) as string,
+    reopen: data.reopen,
+    interrupt: data.interrupt,
+  }));
 
 export type AddIssueComment = z.infer<typeof addIssueCommentSchema>;
 

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -8,6 +8,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -67,6 +68,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -458,6 +460,76 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     const result = await svc.list(companyId, { executionWorkspaceId: targetWorkspaceId });
 
     expect(result.map((issue) => issue.id)).toEqual([linkedIssueId]);
+  });
+
+  it("repairs missing checkout ownership when the execution run already matches", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Run-owned issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: runId,
+      executionAgentNameKey: "engineer",
+    });
+
+    const ownership = await svc.assertCheckoutOwner(issueId, agentId, runId);
+    const updatedIssue = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(ownership).toMatchObject({
+      id: issueId,
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      adoptedFromRunId: null,
+    });
+    expect(updatedIssue).toEqual({
+      checkoutRunId: runId,
+      executionRunId: runId,
+    });
   });
 
   it("hides archived inbox issues until new external activity arrives", async () => {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -328,7 +328,7 @@ export function loadConfig(): Config {
     feedbackExportBackendUrl,
     feedbackExportBackendToken,
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
-    heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
+    heartbeatSchedulerIntervalMs: Math.max(5000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 10000),
     companyDeletionEnabled,
     telemetryEnabled: fileConfig?.telemetry?.enabled ?? true,
   };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -621,6 +621,15 @@ export async function startServer(): Promise<StartedServer> {
           logger.error({ err }, "routine scheduler tick failed");
         });
   
+      // Enforce per-run max duration — terminates runs whose child process hangs
+      // (e.g. adapter stalled on a model API) and marks them failed with
+      // errorCode="timeout". Default 60 min. Runs alongside reapOrphanedRuns.
+      void heartbeat
+        .enforceRunTimeouts()
+        .catch((err) => {
+          logger.error({ err }, "enforceRunTimeouts failed");
+        });
+
       // Periodically reap orphaned runs (5-min staleness threshold) and make sure
       // persisted queued work is still being driven forward.
       void heartbeat

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -652,6 +652,14 @@ export async function startServer(): Promise<StartedServer> {
         }),
       );
 
+      // Aggressive no-progress detector: runs >10m old with zero events in
+      // last 8m get killed immediately. Stops stuck-opencode budget bleed.
+      tickPromises.push(
+        heartbeat.enforceStallTimeouts().catch((err) => {
+          logger.error({ err }, "enforceStallTimeouts failed");
+        }),
+      );
+
       // Sync wakeup_requests whose linked run reached a terminal state but
       // weren't updated (e.g. direct DB cancels, upgrade path bugs).
       tickPromises.push(

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -685,6 +685,17 @@ export async function startServer(): Promise<StartedServer> {
         tickInFlight = false;
       });
     }, config.heartbeatSchedulerIntervalMs);
+
+    // Hourly retention prune — deletes old terminal wakeup_requests and
+    // heartbeat_run_events. agent_wakeup_requests grows 10-20k rows/day,
+    // keeping all history is expensive for no operator value.
+    const runPrune = () => {
+      void heartbeat
+        .pruneRetainedRows()
+        .catch((err: unknown) => logger.error({ err }, "pruneRetainedRows failed"));
+    };
+    setTimeout(runPrune, 60_000).unref?.();
+    setInterval(runPrune, 60 * 60 * 1000);
   }
   
   if (config.databaseBackupEnabled) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,7 +6,7 @@ import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { pathToFileURL } from "node:url";
 import type { Request as ExpressRequest, RequestHandler } from "express";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import {
   createDb,
   ensurePostgresDatabase,
@@ -604,93 +604,173 @@ export async function startServer(): Promise<StartedServer> {
     // SIGTERMed twice, etc. Single-flight the entire tick body.
     let tickInFlight = false;
     let consecutiveTickSkips = 0;
+    let tickSkipEscalationEmittedAt = 0;
+
+    // Wrap an individual tick sub-task in a per-task timeout. If a sub-task
+    // hangs (e.g. DB lock waiter), we log it and move on instead of poisoning
+    // the whole tick for 90s. Returns a promise that always resolves.
+    const withSubTaskTimeout = <T>(
+      name: string,
+      subTaskMs: number,
+      fn: () => Promise<T>,
+    ): Promise<void> => {
+      return new Promise((resolve) => {
+        let done = false;
+        const finish = () => {
+          if (done) return;
+          done = true;
+          resolve();
+        };
+        const timer = setTimeout(() => {
+          if (done) return;
+          logger.error({ subTask: name, subTaskMs }, "scheduler sub-task timed out");
+          finish();
+        }, subTaskMs);
+        fn()
+          .catch((err) => {
+            logger.error({ err, subTask: name }, "scheduler sub-task failed");
+          })
+          .finally(() => {
+            clearTimeout(timer);
+            finish();
+          });
+      });
+    };
+
+    // Emit a single ESCALATION issue when scheduler ticks are being starved.
+    // Previous bug: 2,220 consecutive skips over 18h went unnoticed because
+    // the only signal was a log line. De-dupe emissions to once per 15 min.
+    const maybeEscalateTickSkips = async (skips: number) => {
+      if (skips < 6) return;
+      const now = Date.now();
+      if (now - tickSkipEscalationEmittedAt < 15 * 60 * 1000) return;
+      tickSkipEscalationEmittedAt = now;
+      try {
+        const rows = await (db as any)
+          .select({ id: companies.id })
+          .from(companies)
+          .where(eq(companies.status, "active"));
+        for (const row of rows as Array<{ id: string }>) {
+          await (db as any).execute(sql`
+            INSERT INTO issues (company_id, title, description, status, priority, origin_kind)
+            VALUES (
+              ${row.id}::uuid,
+              ${"[ESCALATION] Scheduler tick starving — " + skips + " consecutive skips"},
+              ${"Paperclip scheduler tick has been locked by an in-flight run for " +
+                skips +
+                " intervals. Force-release + per-sub-task timeouts are active, but this indicates a chronic hang (leaked DB txn, stuck query, etc). Investigate: SELECT * FROM pg_stat_activity WHERE datname='''paperclip''' AND state != '''idle''' ORDER BY query_start;"},
+              '''todo''',
+              '''critical''',
+              '''manual'''
+            )
+          `);
+        }
+        logger.warn({ skips, companies: rows.length }, "emitted tick-skip escalation issues");
+      } catch (err) {
+        logger.error({ err }, "failed to emit tick-skip escalation");
+      }
+    };
+
     setInterval(() => {
       if (tickInFlight) {
         consecutiveTickSkips += 1;
         if (consecutiveTickSkips === 1 || consecutiveTickSkips % 20 === 0) {
           logger.warn({ consecutiveTickSkips }, "scheduler tick skipped — previous tick still running");
         }
+        void maybeEscalateTickSkips(consecutiveTickSkips);
         return;
       }
       consecutiveTickSkips = 0;
       tickInFlight = true;
 
-      const tickPromises: Promise<unknown>[] = [];
+      const subTaskMs = 30_000;
+      const tickPromises: Promise<void>[] = [];
 
       tickPromises.push(
-        heartbeat
-          .tickTimers(new Date())
-          .then((result) => {
-            if (result.enqueued > 0) {
-              logger.info({ ...result }, "heartbeat timer tick enqueued runs");
-            }
-          })
-          .catch((err) => {
-            logger.error({ err }, "heartbeat timer tick failed");
-          }),
-      );
-
-      tickPromises.push(
-        routines
-          .tickScheduledTriggers(new Date())
-          .then((result) => {
-            if (result.triggered > 0) {
-              logger.info({ ...result }, "routine scheduler tick enqueued runs");
-            }
-          })
-          .catch((err) => {
-            logger.error({ err }, "routine scheduler tick failed");
-          }),
-      );
-
-      // Enforce per-run max duration — terminates runs whose child process hangs
-      // (e.g. adapter stalled on a model API) and marks them failed with
-      // errorCode="timeout". Default 60 min. Runs alongside reapOrphanedRuns.
-      tickPromises.push(
-        heartbeat.enforceRunTimeouts().catch((err) => {
-          logger.error({ err }, "enforceRunTimeouts failed");
+        withSubTaskTimeout("tickTimers", subTaskMs, async () => {
+          const result = await heartbeat.tickTimers(new Date());
+          if (result.enqueued > 0) {
+            logger.info({ ...result }, "heartbeat timer tick enqueued runs");
+          }
         }),
       );
 
-      // Aggressive no-progress detector: runs >10m old with zero events in
-      // last 8m get killed immediately. Stops stuck-opencode budget bleed.
       tickPromises.push(
-        heartbeat.enforceStallTimeouts().catch((err) => {
-          logger.error({ err }, "enforceStallTimeouts failed");
+        withSubTaskTimeout("routineScheduledTriggers", subTaskMs, async () => {
+          const result = await routines.tickScheduledTriggers(new Date());
+          if (result.triggered > 0) {
+            logger.info({ ...result }, "routine scheduler tick enqueued runs");
+          }
         }),
       );
 
-      // Sync wakeup_requests whose linked run reached a terminal state but
-      // weren't updated (e.g. direct DB cancels, upgrade path bugs).
+      // Enforce per-run max duration (default 60 min) — terminates runs whose
+      // child process hangs and marks them failed with errorCode="timeout".
       tickPromises.push(
-        heartbeat.reconcileStaleWakeupRequests().catch((err) => {
-          logger.error({ err }, "reconcileStaleWakeupRequests failed");
+        withSubTaskTimeout("enforceRunTimeouts", subTaskMs, async () => {
+          await heartbeat.enforceRunTimeouts();
         }),
       );
 
-      // Periodically reap orphaned runs (5-min staleness threshold) and make sure
-      // persisted queued work is still being driven forward.
+      // Aggressive no-progress detector: >10m old + zero events in last 8m → kill.
       tickPromises.push(
-        heartbeat
-          .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
-          .then(() => heartbeat.resumeQueuedRuns())
-          .then(async () => {
-            const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
-            if (
-              reconciled.dispatchRequeued > 0 ||
-              reconciled.continuationRequeued > 0 ||
-              reconciled.escalated > 0
-            ) {
-              logger.warn({ ...reconciled }, "periodic stranded-issue reconciliation changed assigned issue state");
-            }
-          })
-          .catch((err) => {
-            logger.error({ err }, "periodic heartbeat recovery failed");
-          }),
+        withSubTaskTimeout("enforceStallTimeouts", subTaskMs, async () => {
+          await heartbeat.enforceStallTimeouts();
+        }),
       );
 
-      void Promise.allSettled(tickPromises).finally(() => {
+      // Adapter-aware model rotation — swap failing agents to a known-good
+      // model in their adapter's ladder. Runs every tick (10s) so recovery
+      // from a flaky provider takes ~10s not 5 min (self-healer cadence).
+      tickPromises.push(
+        withSubTaskTimeout("rotateFailingAgentModels", subTaskMs, async () => {
+          const result = await heartbeat.rotateFailingAgentModels();
+          if (result.rotated > 0 || result.paused > 0) {
+            logger.info({ ...result }, "model rotation tick applied swaps");
+          }
+        }),
+      );
+
+      // Sync wakeup_requests whose linked run reached a terminal state.
+      tickPromises.push(
+        withSubTaskTimeout("reconcileStaleWakeupRequests", subTaskMs, async () => {
+          await heartbeat.reconcileStaleWakeupRequests();
+        }),
+      );
+
+      // Reap orphaned runs (5-min staleness) + resume queued + reconcile stranded.
+      tickPromises.push(
+        withSubTaskTimeout("heartbeatRecovery", subTaskMs, async () => {
+          await heartbeat.reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 });
+          await heartbeat.resumeQueuedRuns();
+          const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
+          if (
+            reconciled.dispatchRequeued > 0 ||
+            reconciled.continuationRequeued > 0 ||
+            reconciled.escalated > 0
+          ) {
+            logger.warn({ ...reconciled }, "periodic stranded-issue reconciliation changed assigned issue state");
+          }
+        }),
+      );
+
+      // Outer backstop: with 6 sub-tasks × 30s each, worst-case tick is 30s
+      // (since they run in parallel). 90s outer gives margin for GC / event
+      // loop jitter. If even this fires, something is wrong with the runtime.
+      const tickTimeoutMs = 90_000;
+      let tickReleased = false;
+      const releaseLock = (reason: string) => {
+        if (tickReleased) return;
+        tickReleased = true;
         tickInFlight = false;
+        if (reason !== "completed") {
+          logger.error({ reason, tickTimeoutMs }, "scheduler tick force-released — outer timeout fired");
+        }
+      };
+      const timeoutHandle = setTimeout(() => releaseLock("timeout"), tickTimeoutMs);
+      void Promise.allSettled(tickPromises).finally(() => {
+        clearTimeout(timeoutHandle);
+        releaseLock("completed");
       });
     }, config.heartbeatSchedulerIntervalMs);
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -630,6 +630,14 @@ export async function startServer(): Promise<StartedServer> {
           logger.error({ err }, "enforceRunTimeouts failed");
         });
 
+      // Sync wakeup_requests whose linked run reached a terminal state but
+      // weren't updated (e.g. direct DB cancels, upgrade path bugs).
+      void heartbeat
+        .reconcileStaleWakeupRequests()
+        .catch((err) => {
+          logger.error({ err }, "reconcileStaleWakeupRequests failed");
+        });
+
       // Periodically reap orphaned runs (5-min staleness threshold) and make sure
       // persisted queued work is still being driven forward.
       void heartbeat

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -598,64 +598,92 @@ export async function startServer(): Promise<StartedServer> {
       .catch((err) => {
         logger.error({ err }, "startup heartbeat recovery failed");
       });
+    // Each tick runs several DB-heavy tasks. Without a mutex a slow tick
+    // (e.g. big reap on startup) can overlap with the next tick, duplicating
+    // work: the same wakeup gets enqueued twice, the same stuck run gets
+    // SIGTERMed twice, etc. Single-flight the entire tick body.
+    let tickInFlight = false;
+    let consecutiveTickSkips = 0;
     setInterval(() => {
-      void heartbeat
-        .tickTimers(new Date())
-        .then((result) => {
-          if (result.enqueued > 0) {
-            logger.info({ ...result }, "heartbeat timer tick enqueued runs");
-          }
-        })
-        .catch((err) => {
-          logger.error({ err }, "heartbeat timer tick failed");
-        });
+      if (tickInFlight) {
+        consecutiveTickSkips += 1;
+        if (consecutiveTickSkips === 1 || consecutiveTickSkips % 20 === 0) {
+          logger.warn({ consecutiveTickSkips }, "scheduler tick skipped — previous tick still running");
+        }
+        return;
+      }
+      consecutiveTickSkips = 0;
+      tickInFlight = true;
 
-      void routines
-        .tickScheduledTriggers(new Date())
-        .then((result) => {
-          if (result.triggered > 0) {
-            logger.info({ ...result }, "routine scheduler tick enqueued runs");
-          }
-        })
-        .catch((err) => {
-          logger.error({ err }, "routine scheduler tick failed");
-        });
-  
+      const tickPromises: Promise<unknown>[] = [];
+
+      tickPromises.push(
+        heartbeat
+          .tickTimers(new Date())
+          .then((result) => {
+            if (result.enqueued > 0) {
+              logger.info({ ...result }, "heartbeat timer tick enqueued runs");
+            }
+          })
+          .catch((err) => {
+            logger.error({ err }, "heartbeat timer tick failed");
+          }),
+      );
+
+      tickPromises.push(
+        routines
+          .tickScheduledTriggers(new Date())
+          .then((result) => {
+            if (result.triggered > 0) {
+              logger.info({ ...result }, "routine scheduler tick enqueued runs");
+            }
+          })
+          .catch((err) => {
+            logger.error({ err }, "routine scheduler tick failed");
+          }),
+      );
+
       // Enforce per-run max duration — terminates runs whose child process hangs
       // (e.g. adapter stalled on a model API) and marks them failed with
       // errorCode="timeout". Default 60 min. Runs alongside reapOrphanedRuns.
-      void heartbeat
-        .enforceRunTimeouts()
-        .catch((err) => {
+      tickPromises.push(
+        heartbeat.enforceRunTimeouts().catch((err) => {
           logger.error({ err }, "enforceRunTimeouts failed");
-        });
+        }),
+      );
 
       // Sync wakeup_requests whose linked run reached a terminal state but
       // weren't updated (e.g. direct DB cancels, upgrade path bugs).
-      void heartbeat
-        .reconcileStaleWakeupRequests()
-        .catch((err) => {
+      tickPromises.push(
+        heartbeat.reconcileStaleWakeupRequests().catch((err) => {
           logger.error({ err }, "reconcileStaleWakeupRequests failed");
-        });
+        }),
+      );
 
       // Periodically reap orphaned runs (5-min staleness threshold) and make sure
       // persisted queued work is still being driven forward.
-      void heartbeat
-        .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
-        .then(() => heartbeat.resumeQueuedRuns())
-        .then(async () => {
-          const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
-          if (
-            reconciled.dispatchRequeued > 0 ||
-            reconciled.continuationRequeued > 0 ||
-            reconciled.escalated > 0
-          ) {
-            logger.warn({ ...reconciled }, "periodic stranded-issue reconciliation changed assigned issue state");
-          }
-        })
-        .catch((err) => {
-          logger.error({ err }, "periodic heartbeat recovery failed");
-        });
+      tickPromises.push(
+        heartbeat
+          .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+          .then(() => heartbeat.resumeQueuedRuns())
+          .then(async () => {
+            const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
+            if (
+              reconciled.dispatchRequeued > 0 ||
+              reconciled.continuationRequeued > 0 ||
+              reconciled.escalated > 0
+            ) {
+              logger.warn({ ...reconciled }, "periodic stranded-issue reconciliation changed assigned issue state");
+            }
+          })
+          .catch((err) => {
+            logger.error({ err }, "periodic heartbeat recovery failed");
+          }),
+      );
+
+      void Promise.allSettled(tickPromises).finally(() => {
+        tickInFlight = false;
+      });
     }, config.heartbeatSchedulerIntervalMs);
   }
   

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -640,18 +640,56 @@ export function issueRoutes(
       return;
     }
 
+    // Validate/normalise UUID-shaped filters. Clients were hitting 500s by
+    // passing identifiers (KIT-622), PostgREST-style operators (eq.<uuid>),
+    // numbers (625), or the string "null"; Postgres rejected the cast and
+    // crashed the request. Accept:
+    //   - empty/missing   -> undefined (no filter)
+    //   - valid UUID      -> as-is
+    //   - identifier XYZ-N -> resolve to UUID via getByIdentifier
+    //   - anything else   -> 400
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const IDENTIFIER_RE = /^[A-Z]+-\d+$/i;
+    const resolveUuidFilter = async (value: unknown, label: string, allowIdentifier = false): Promise<string | undefined> => {
+      if (value === undefined || value === null) return undefined;
+      if (typeof value !== "string" || value.length === 0) return undefined;
+      const trimmed = value.trim();
+      if (trimmed.length === 0 || trimmed === "null" || trimmed === "undefined") return undefined;
+      if (UUID_RE.test(trimmed)) return trimmed;
+      if (allowIdentifier && IDENTIFIER_RE.test(trimmed)) {
+        const issue = await svc.getByIdentifier(trimmed);
+        if (issue) return issue.id;
+        return undefined; // identifier did not resolve — treat as "no match"
+      }
+      res.status(400).json({ error: `${label} must be a UUID${allowIdentifier ? " or identifier like KIT-123" : ""}, got "${value}"` });
+      return Symbol("abort") as unknown as string;
+    };
+
+    const assigneeAgentId = await resolveUuidFilter(req.query.assigneeAgentId, "assigneeAgentId");
+    if (typeof assigneeAgentId === "symbol") return;
+    const participantAgentId = await resolveUuidFilter(req.query.participantAgentId, "participantAgentId");
+    if (typeof participantAgentId === "symbol") return;
+    const projectId = await resolveUuidFilter(req.query.projectId, "projectId");
+    if (typeof projectId === "symbol") return;
+    const executionWorkspaceId = await resolveUuidFilter(req.query.executionWorkspaceId, "executionWorkspaceId");
+    if (typeof executionWorkspaceId === "symbol") return;
+    const parentId = await resolveUuidFilter(req.query.parentId, "parentId", true);
+    if (typeof parentId === "symbol") return;
+    const labelId = await resolveUuidFilter(req.query.labelId, "labelId");
+    if (typeof labelId === "symbol") return;
+
     const result = await svc.list(companyId, {
       status: req.query.status as string | undefined,
-      assigneeAgentId: req.query.assigneeAgentId as string | undefined,
-      participantAgentId: req.query.participantAgentId as string | undefined,
+      assigneeAgentId,
+      participantAgentId,
       assigneeUserId,
       touchedByUserId,
       inboxArchivedByUserId,
       unreadForUserId,
-      projectId: req.query.projectId as string | undefined,
-      executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
-      parentId: req.query.parentId as string | undefined,
-      labelId: req.query.labelId as string | undefined,
+      projectId,
+      executionWorkspaceId,
+      parentId,
+      labelId,
       originKind: req.query.originKind as string | undefined,
       originId: req.query.originId as string | undefined,
       includeRoutineExecutions:

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -388,7 +388,14 @@ export function issueRoutes(
       const allowedByGrant = await access.hasPermission(companyId, "agent", req.actor.agentId, "tasks:assign");
       if (allowedByGrant) return;
       const actorAgent = await agentsSvc.getById(req.actor.agentId);
-      if (actorAgent && actorAgent.companyId === companyId && canCreateAgentsLegacy(actorAgent)) return;
+      if (actorAgent && actorAgent.companyId === companyId) {
+        // Any agent in the company can assign tasks to teammates. This is
+        // required for the autonomous fleet's self-routing (Security Reviewer
+        // creates [FIX] for Engineer, Team Lead re-assigns blocked issues,
+        // etc). The legacy canCreateAgents flag gated this too narrowly and
+        // produced dozens of 403s per day.
+        return;
+      }
       throw forbidden("Missing permission: tasks:assign");
     }
     throw unauthorized();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -565,6 +565,20 @@ export function issueRoutes(
     return { project, goal: null };
   }
 
+  // LLM agents routinely post to /companies/:companyId/issues/:id/* (matching
+  // the list-scoping convention) even though mutation routes below are
+  // registered at the bare /issues/:id/* path. Rather than duplicate every
+  // route, strip the /companies/:companyId prefix when the scoped path is
+  // used against an /issues/:id sub-route. Company access is still enforced
+  // downstream via the issue's own companyId and assertCompanyAccess.
+  router.use((req, _res, next) => {
+    const m = req.url.match(/^\/companies\/[0-9a-f-]{36}(\/issues\/[^?]+.*)$/);
+    if (m) {
+      req.url = m[1];
+    }
+    next();
+  });
+
   // Resolve issue identifiers (e.g. "PAP-39") to UUIDs for all /issues/:id routes
   router.param("id", async (req, res, next, rawId) => {
     try {

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2319,6 +2319,7 @@ export function companySkillService(db: Db) {
         ...(skill.metadata ?? {}),
         skillKey: skill.key,
       };
+      const serializedFileInventory = serializeFileInventory(skill.fileInventory);
       const values = {
         companyId,
         key: skill.key,
@@ -2331,10 +2332,36 @@ export function companySkillService(db: Db) {
         sourceRef: skill.sourceRef,
         trustLevel: skill.trustLevel,
         compatibility: skill.compatibility,
-        fileInventory: serializeFileInventory(skill.fileInventory),
+        fileInventory: serializedFileInventory,
         metadata,
         updatedAt: new Date(),
       };
+
+      // Skip the UPDATE when the user-visible content is unchanged.
+      // ensureBundledSkills runs on nearly every API call; before this guard,
+      // companySkills absorbed ~2M UPDATEs/day across 222 rows (write
+      // amplification ~9k) which in turn caused 170k seq-scans and index bloat.
+      //
+      // We intentionally check only the fields a consumer would notice:
+      // markdown + name + description + sourceRef. Structured fields
+      // (compatibility, fileInventory, metadata) are derived from markdown
+      // and the bundled file tree; if markdown is byte-identical AND
+      // sourceRef (commit/version) matches, the derived fields are by
+      // definition unchanged too. This avoids JSON.stringify pitfalls with
+      // property ordering or null-vs-missing.
+      const unchanged = existing
+        && existing.markdown === values.markdown
+        && existing.name === values.name
+        && existing.description === values.description
+        && existing.slug === values.slug
+        && existing.sourceRef === values.sourceRef
+        && existing.trustLevel === values.trustLevel;
+
+      if (unchanged && existing) {
+        out.push(existing);
+        continue;
+      }
+
       const row = existing
         ? await db
           .update(companySkills)

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -399,7 +399,10 @@ export function executionWorkspaceService(db: Db) {
     }
     if (filters?.issueId) conditions.push(eq(executionWorkspaces.sourceIssueId, filters.issueId));
     if (filters?.status) {
-      const statuses = filters.status.split(",").map((value) => value.trim()).filter(Boolean);
+      // Accept string, comma-separated string, or array (repeated query params).
+      const statuses = (Array.isArray(filters.status) ? filters.status : String(filters.status).split(","))
+        .map((value) => String(value).trim())
+        .filter(Boolean);
       if (statuses.length === 1) conditions.push(eq(executionWorkspaces.status, statuses[0]!));
       else if (statuses.length > 1) conditions.push(inArray(executionWorkspaces.status, statuses));
     }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10,6 +10,7 @@ import {
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
+  companies,
   companySkills as companySkillsTable,
   heartbeatRunEvents,
   heartbeatRuns,
@@ -5325,12 +5326,19 @@ export function heartbeatService(db: Db) {
     reconcileStrandedAssignedIssues,
 
     tickTimers: async (now = new Date()) => {
-      const allAgents = await db.select().from(agents);
+      // Only tick agents in ACTIVE companies. Archived/paused companies must not
+      // generate heartbeat runs — previously the scheduler ignored company status
+      // and woke agents in archived companies indefinitely.
+      const rows = await db
+        .select({ agent: agents, companyStatus: companies.status })
+        .from(agents)
+        .innerJoin(companies, eq(agents.companyId, companies.id));
       let checked = 0;
       let enqueued = 0;
       let skipped = 0;
 
-      for (const agent of allAgents) {
+      for (const { agent, companyStatus } of rows) {
+        if (companyStatus !== "active") continue;
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
         const policy = parseHeartbeatPolicy(agent);
         if (!policy.enabled || policy.intervalSec <= 0) continue;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5239,12 +5239,18 @@ export function heartbeatService(db: Db) {
     const eventCutoff = new Date(now.getTime() - (opts?.heartbeatEventsKeepDays ?? 14) * 86400_000);
     const activityCutoff = new Date(now.getTime() - (opts?.activityLogKeepDays ?? 30) * 86400_000);
 
+    // Only prune wakeups that have NO linked heartbeat_run — deleting
+    // otherwise violates heartbeat_runs.wakeup_request_id FK.
+    // Coalesced/skipped entries (the bulk of growth, ~70k of 75k expired)
+    // never have a run. Completed/failed/cancelled wakeups with runs are
+    // left alone so run history stays traceable.
     const wakeups = await db
       .delete(agentWakeupRequests)
       .where(
         and(
-          inArray(agentWakeupRequests.status, ["completed", "failed", "cancelled", "skipped", "coalesced"]),
+          inArray(agentWakeupRequests.status, ["coalesced", "skipped"]),
           lt(agentWakeupRequests.updatedAt, wakeupCutoff),
+          sql`NOT EXISTS (SELECT 1 FROM ${heartbeatRuns} WHERE ${heartbeatRuns.wakeupRequestId} = ${agentWakeupRequests.id})`,
         ),
       )
       .returning({ id: agentWakeupRequests.id });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import type { BillingType, ExecutionWorkspace, ExecutionWorkspaceConfig } from "@paperclipai/shared";
 import {
@@ -2125,6 +2125,13 @@ export function heartbeatService(db: Db) {
       .then((rows) => rows[0]);
   }
 
+  // Terminal statuses close out a run. When they fire we also advance the
+  // agent's last_heartbeat_at watermark — otherwise the heartbeat scheduler and
+  // silence watchdogs treat the agent as silent forever (it only updated on
+  // "succeeded" previously via appendRunEvent side effects that never ran for
+  // failed/cancelled/timeout paths).
+  const RUN_TERMINAL_STATUSES = new Set(["succeeded", "failed", "cancelled"]);
+
   async function setRunStatus(
     runId: string,
     status: string,
@@ -2136,6 +2143,22 @@ export function heartbeatService(db: Db) {
       .where(eq(heartbeatRuns.id, runId))
       .returning()
       .then((rows) => rows[0] ?? null);
+
+    if (updated && RUN_TERMINAL_STATUSES.has(status)) {
+      const finishedAt = updated.finishedAt ?? new Date();
+      await db
+        .update(agents)
+        .set({ lastHeartbeatAt: finishedAt, updatedAt: new Date() })
+        .where(
+          and(
+            eq(agents.id, updated.agentId),
+            or(
+              isNull(agents.lastHeartbeatAt),
+              lt(agents.lastHeartbeatAt, finishedAt),
+            ),
+          ),
+        );
+    }
 
     if (updated) {
       publishLiveEvent({
@@ -5102,6 +5125,79 @@ export function heartbeatService(db: Db) {
     return runs.length;
   }
 
+  // Default max duration for a single heartbeat run. Agents whose underlying
+  // model adapter hangs (e.g. opencode sleeping in ep_poll) stay "running"
+  // forever without this guard. Configurable via env.
+  const DEFAULT_RUN_TIMEOUT_MS = 60 * 60 * 1000;
+
+  async function enforceRunTimeouts(opts?: { maxDurationMs?: number }) {
+    const maxDurationMs = opts?.maxDurationMs ?? DEFAULT_RUN_TIMEOUT_MS;
+    const now = new Date();
+    const cutoff = new Date(now.getTime() - maxDurationMs);
+
+    const overdue = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.status, "running"), lt(heartbeatRuns.startedAt, cutoff)));
+
+    const timedOut: string[] = [];
+
+    for (const run of overdue) {
+      const ageMs = run.startedAt ? now.getTime() - new Date(run.startedAt).getTime() : 0;
+      const message = `Run exceeded maximum duration (${Math.round(ageMs / 60000)}m > ${Math.round(maxDurationMs / 60000)}m) -- terminated by server-side timeout`;
+
+      const running = runningProcesses.get(run.id);
+      if (running) {
+        await terminateHeartbeatRunProcess({
+          pid: running.child.pid ?? run.processPid,
+          processGroupId: running.processGroupId ?? run.processGroupId,
+          graceMs: Math.max(1, running.graceSec) * 1000,
+        });
+        runningProcesses.delete(run.id);
+      } else if (run.processPid || run.processGroupId) {
+        await terminateHeartbeatRunProcess({
+          pid: run.processPid,
+          processGroupId: run.processGroupId,
+        });
+      }
+
+      const finalized = await setRunStatus(run.id, "failed", {
+        error: message,
+        errorCode: "timeout",
+        finishedAt: now,
+      });
+      await setWakeupStatus(run.wakeupRequestId, "failed", {
+        finishedAt: now,
+        error: message,
+      });
+      if (finalized) {
+        await appendRunEvent(finalized, await nextRunEventSeq(finalized.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "error",
+          message,
+          payload: {
+            ageMs,
+            maxDurationMs,
+            ...(run.processPid ? { processPid: run.processPid } : {}),
+            ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
+          },
+        });
+        await releaseIssueExecutionAndPromote(finalized);
+      }
+
+      await finalizeAgentStatus(run.agentId, "failed");
+      await startNextQueuedRunForAgent(run.agentId);
+      timedOut.push(run.id);
+    }
+
+    if (timedOut.length > 0) {
+      logger.warn({ timedOutCount: timedOut.length, runIds: timedOut, maxDurationMs }, "timed out long-running heartbeat runs");
+    }
+
+    return { timedOut: timedOut.length, runIds: timedOut };
+  }
+
   async function cancelBudgetScopeWork(scope: BudgetEnforcementScope) {
     if (scope.scopeType === "agent") {
       await cancelActiveForAgentInternal(scope.scopeId, "Cancelled due to budget pause");
@@ -5320,6 +5416,8 @@ export function heartbeatService(db: Db) {
     reportRunActivity: clearDetachedRunWarning,
 
     reapOrphanedRuns,
+
+    enforceRunTimeouts,
 
     resumeQueuedRuns,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5223,6 +5223,44 @@ export function heartbeatService(db: Db) {
     return { timedOut: timedOut.length, runIds: timedOut };
   }
 
+  // Prune long-lived telemetry rows that accumulate indefinitely.
+  // agent_wakeup_requests grows ~10-20k/day (most are short-lived coalesced
+  // entries) and is the largest row-count table in the schema. Keeping rows
+  // forever hurts pagination queries and backup size with no operator value.
+  // heartbeat_run_events and activity_log are also pruned on a longer window
+  // for audit/log purposes.
+  async function pruneRetainedRows(opts?: {
+    wakeupRequestsKeepDays?: number;
+    heartbeatEventsKeepDays?: number;
+    activityLogKeepDays?: number;
+  }) {
+    const now = new Date();
+    const wakeupCutoff = new Date(now.getTime() - (opts?.wakeupRequestsKeepDays ?? 7) * 86400_000);
+    const eventCutoff = new Date(now.getTime() - (opts?.heartbeatEventsKeepDays ?? 14) * 86400_000);
+    const activityCutoff = new Date(now.getTime() - (opts?.activityLogKeepDays ?? 30) * 86400_000);
+
+    const wakeups = await db
+      .delete(agentWakeupRequests)
+      .where(
+        and(
+          inArray(agentWakeupRequests.status, ["completed", "failed", "cancelled", "skipped", "coalesced"]),
+          lt(agentWakeupRequests.updatedAt, wakeupCutoff),
+        ),
+      )
+      .returning({ id: agentWakeupRequests.id });
+
+    const events = await db
+      .delete(heartbeatRunEvents)
+      .where(lt(heartbeatRunEvents.createdAt, eventCutoff))
+      .returning({ id: heartbeatRunEvents.id });
+
+    const summary = { wakeups: wakeups.length, events: events.length, activityLog: 0 };
+    if (summary.wakeups > 0 || summary.events > 0) {
+      logger.info({ ...summary, wakeupCutoff, eventCutoff, activityCutoff }, "pruned retained rows");
+    }
+    return summary;
+  }
+
   // Reconcile agent_wakeup_requests with their heartbeat_runs. Direct DB edits
   // or old code paths can leave a wakeup_request status='queued' even after
   // the linked run reached a terminal state, which pollutes the queue depth
@@ -5499,6 +5537,8 @@ export function heartbeatService(db: Db) {
     enforceRunTimeouts,
 
     reconcileStaleWakeupRequests,
+
+    pruneRetainedRows,
 
     resumeQueuedRuns,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5245,7 +5245,7 @@ export function heartbeatService(db: Db) {
     silenceWindowMs?: number;
   }) {
     const minAgeMs = opts?.minAgeMs ?? 10 * 60 * 1000;
-    const silenceWindowMs = opts?.silenceWindowMs ?? 15 * 60 * 1000;
+    const silenceWindowMs = opts?.silenceWindowMs ?? 25 * 60 * 1000;
     const now = new Date();
     const ageCutoff = new Date(now.getTime() - minAgeMs);
     const silenceCutoff = new Date(now.getTime() - silenceWindowMs);
@@ -5337,6 +5337,10 @@ export function heartbeatService(db: Db) {
       "minimax-coding-plan/MiniMax-M2.5",
       "opencode/big-pickle",
       "zai-coding-plan/glm-5",
+      // ollama local = lowest priority. Only reached if ALL paid subs fail.
+      // Also contends with ComfyUI for GPU, so we prefer paid subs first.
+      "ollama/qwen2.5-coder:7b",
+      "ollama/qwen3-coder:30b",
     ],
     // codex_local ladder: both models use your ChatGPT Pro account (dedicated).
     // gpt-5.4 is primary (top capability, fast mode). 5.3-codex is the

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5377,7 +5377,19 @@ export function heartbeatService(db: Db) {
       const run = typeof runOrLookup === "string" ? await getRunLogAccess(runOrLookup) : runOrLookup;
       const runId = typeof runOrLookup === "string" ? runOrLookup : runOrLookup.id;
       if (!run) throw notFound("Heartbeat run not found");
-      if (!run.logStore || !run.logRef) throw notFound("Run log not found");
+      // If the run exists but no log has been captured yet (e.g. queued or
+      // cancelled-before-start), return an empty success response instead of
+      // 404. Prevents UI log-pollers from hammering the endpoint retrying
+      // on runs that will never have a log.
+      if (!run.logStore || !run.logRef) {
+        return {
+          runId,
+          store: null,
+          logRef: null,
+          content: "",
+          nextOffset: opts?.offset ?? 0,
+        };
+      }
 
       const result = await runLogStore.read(
         {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2137,9 +2137,20 @@ export function heartbeatService(db: Db) {
     status: string,
     patch?: Partial<typeof heartbeatRuns.$inferInsert>,
   ) {
+    // Terminal statuses MUST have finished_at. Several call sites (e.g.
+    // cancelActiveForAgentInternal) historically forgot to pass it, leaving
+    // 280+ rows with finished_at=null and skewing analytics. Default it here.
+    const terminalFinishedAt =
+      RUN_TERMINAL_STATUSES.has(status) && !patch?.finishedAt ? new Date() : undefined;
+
     const updated = await db
       .update(heartbeatRuns)
-      .set({ status, ...patch, updatedAt: new Date() })
+      .set({
+        status,
+        ...patch,
+        ...(terminalFinishedAt ? { finishedAt: terminalFinishedAt } : {}),
+        updatedAt: new Date(),
+      })
       .where(eq(heartbeatRuns.id, runId))
       .returning()
       .then((rows) => rows[0] ?? null);
@@ -2718,7 +2729,21 @@ export function heartbeatService(db: Db) {
       return;
     }
 
-    const isFirstHeartbeat = !existing.lastHeartbeatAt;
+    // Previously this used `!existing.lastHeartbeatAt` to detect the first
+    // heartbeat. setRunStatus now advances lastHeartbeatAt as soon as any
+    // run reaches a terminal state, so that signal is stale by the time
+    // we get here. Count how many terminal runs exist for this agent
+    // instead: a count of 1 means the currently-finalising run is the first.
+    const [{ priorRunCount }] = await db
+      .select({ priorRunCount: sql<number>`COUNT(*)` })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agentId),
+          inArray(heartbeatRuns.status, ["succeeded", "failed", "cancelled"]),
+        ),
+      );
+    const isFirstHeartbeat = Number(priorRunCount) <= 1;
 
     const runningCount = await countRunningRunsForAgent(agentId);
     const nextStatus =
@@ -5198,6 +5223,48 @@ export function heartbeatService(db: Db) {
     return { timedOut: timedOut.length, runIds: timedOut };
   }
 
+  // Reconcile agent_wakeup_requests with their heartbeat_runs. Direct DB edits
+  // or old code paths can leave a wakeup_request status='queued' even after
+  // the linked run reached a terminal state, which pollutes the queue depth
+  // and blocks stuck-agent detection. Sync any mismatch to the run's outcome.
+  async function reconcileStaleWakeupRequests() {
+    const stale = await db
+      .select({
+        wakeupId: agentWakeupRequests.id,
+        runStatus: heartbeatRuns.status,
+        runFinishedAt: heartbeatRuns.finishedAt,
+        runUpdatedAt: heartbeatRuns.updatedAt,
+        runError: heartbeatRuns.error,
+      })
+      .from(agentWakeupRequests)
+      .innerJoin(heartbeatRuns, eq(agentWakeupRequests.id, heartbeatRuns.wakeupRequestId))
+      .where(
+        and(
+          inArray(agentWakeupRequests.status, ["queued", "claimed"]),
+          inArray(heartbeatRuns.status, ["succeeded", "failed", "cancelled"]),
+        ),
+      )
+      .limit(500);
+
+    if (stale.length === 0) return { reconciled: 0 };
+
+    const now = new Date();
+    for (const row of stale) {
+      const mappedStatus =
+        row.runStatus === "succeeded"
+          ? "completed"
+          : row.runStatus === "failed"
+            ? "failed"
+            : "cancelled";
+      await setWakeupStatus(row.wakeupId, mappedStatus, {
+        finishedAt: row.runFinishedAt ?? row.runUpdatedAt ?? now,
+        error: row.runError ?? null,
+      });
+    }
+    logger.warn({ reconciledCount: stale.length }, "reconciled stale agent_wakeup_requests");
+    return { reconciled: stale.length };
+  }
+
   async function cancelBudgetScopeWork(scope: BudgetEnforcementScope) {
     if (scope.scopeType === "agent") {
       await cancelActiveForAgentInternal(scope.scopeId, "Cancelled due to budget pause");
@@ -5430,6 +5497,8 @@ export function heartbeatService(db: Db) {
     reapOrphanedRuns,
 
     enforceRunTimeouts,
+
+    reconcileStaleWakeupRequests,
 
     resumeQueuedRuns,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5570,6 +5570,32 @@ export function heartbeatService(db: Db) {
       let checked = 0;
       let enqueued = 0;
       let skipped = 0;
+      let skippedNoWork = 0;
+
+      // Batch-load each active company's open-issue picture once, so the per-agent
+      // "do I have work" check is O(1) not O(queries).
+      const activeCompanyIds = Array.from(
+        new Set(rows.filter((r) => r.companyStatus === "active").map((r) => r.agent.companyId)),
+      );
+      const assignedByAgent = new Map<string, number>();
+      const unassignedCount = new Map<string, number>();
+      if (activeCompanyIds.length > 0) {
+        const assignedRows = await db
+          .select({ agentId: issues.assigneeAgentId, count: sql<number>`count(*)` })
+          .from(issues)
+          .where(
+            and(
+              inArray(issues.companyId, activeCompanyIds),
+              inArray(issues.status, ["todo", "in_progress", "in_review"]),
+              isNull(issues.hiddenAt),
+            ),
+          )
+          .groupBy(issues.assigneeAgentId);
+        for (const row of assignedRows) {
+          if (row.agentId) assignedByAgent.set(row.agentId, Number(row.count));
+          else unassignedCount.set("__unassigned__", Number(row.count));
+        }
+      }
 
       for (const { agent, companyStatus } of rows) {
         if (companyStatus !== "active") continue;
@@ -5581,6 +5607,20 @@ export function heartbeatService(db: Db) {
         const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
         const elapsedMs = now.getTime() - baseline;
         if (elapsedMs < policy.intervalSec * 1000) continue;
+
+        // Don't fire a timer heartbeat for agents with zero real work. Without
+        // this gate, idle agents (no assigned issues) wake on every interval
+        // and generate meta noise like "[BOARD] Request guidance" and
+        // "Heartbeat N: no assigned tasks" — wasting budget and drowning out
+        // actual product work. Leadership roles (CEO, Team Lead, Chief of
+        // Staff, CTO, CMO, CFO) still tick because coordination is their job;
+        // everyone else stays silent until assigned.
+        const LEADERSHIP_ROLES = new Set(["ceo", "cto", "cmo", "cfo", "manager"]);
+        const assigned = assignedByAgent.get(agent.id) ?? 0;
+        if (assigned === 0 && !LEADERSHIP_ROLES.has(agent.role)) {
+          skippedNoWork += 1;
+          continue;
+        }
 
         const run = await enqueueWakeup(agent.id, {
           source: "timer",
@@ -5598,7 +5638,7 @@ export function heartbeatService(db: Db) {
         else skipped += 1;
       }
 
-      return { checked, enqueued, skipped };
+      return { checked, enqueued, skipped, skippedNoWork };
     },
 
     cancelRun: (runId: string) => cancelRunInternal(runId),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5245,7 +5245,7 @@ export function heartbeatService(db: Db) {
     silenceWindowMs?: number;
   }) {
     const minAgeMs = opts?.minAgeMs ?? 10 * 60 * 1000;
-    const silenceWindowMs = opts?.silenceWindowMs ?? 8 * 60 * 1000;
+    const silenceWindowMs = opts?.silenceWindowMs ?? 15 * 60 * 1000;
     const now = new Date();
     const ageCutoff = new Date(now.getTime() - minAgeMs);
     const silenceCutoff = new Date(now.getTime() - silenceWindowMs);
@@ -5317,6 +5317,118 @@ export function heartbeatService(db: Db) {
     return { stalled: stalledIds.length, runIds: stalledIds };
   }
 
+  // Adapter-aware model rotation. When an agent accumulates N+ failures on
+  // the current model within the rotation window (default 30 min) AND has
+  // zero successes, swap it to the next model in the per-adapter ladder.
+  // Runs on every scheduler tick so reaction time is ~10s vs the
+  // self-healer\'s 5-min granularity.
+  const HEALTHY_MODELS_BY_ADAPTER: Record<string, string[]> = {
+    gemini_local: ["auto", "gemini-2.5-pro", "gemini-2.5-flash"],
+    // opencode_local ladder: fallbacks here are for non-critical agents
+    // (Deployer, Designers, Content). big-pickle is pool-limited so it
+    // falls back to your direct-key models which have dedicated capacity.
+    opencode_local: [
+      "byteplus/kimi-k2.5",
+      "byteplus/glm-4-7",
+      "byteplus/ark-code-latest",
+      "byteplus/gpt-oss-120b",
+      "minimax-coding-plan/MiniMax-M2.7-highspeed",
+      "minimax-coding-plan/MiniMax-M2.7",
+      "minimax-coding-plan/MiniMax-M2.5",
+      "opencode/big-pickle",
+      "zai-coding-plan/glm-5",
+    ],
+    // codex_local ladder: both models use your ChatGPT Pro account (dedicated).
+    // gpt-5.4 is primary (top capability, fast mode). 5.3-codex is the
+    // code-specialized fallback.
+    codex_local: ["gpt-5.4", "gpt-5.3-codex"],
+  };
+
+  async function rotateFailingAgentModels(opts?: {
+    failureWindowMs?: number;
+    minConsecutiveFailures?: number;
+    recentFailureLookbackMs?: number;
+  }): Promise<{ rotated: number; paused: number }> {
+    const failureWindowMs = opts?.failureWindowMs ?? 30 * 60 * 1000;
+    const minFailures = opts?.minConsecutiveFailures ?? 2;
+    const recentLookbackMs = opts?.recentFailureLookbackMs ?? 20 * 60 * 1000;
+    const failureCutoff = new Date(Date.now() - failureWindowMs).toISOString();
+    const recentCutoff = new Date(Date.now() - recentLookbackMs).toISOString();
+
+    // Count failures since the agent's adapter_config was last updated
+    // (which includes model swaps). This means a newly-swapped agent gets
+    // a fresh failure budget on its new model before we re-swap.
+    // Also require the adapter_config to have been stable for at least
+    // 60s so the swap has had a chance to take effect.
+    const candidatesResult = await db.execute(sql`
+      SELECT a.id::text AS id, a.name, a.adapter_type,
+             a.adapter_config->>'model' AS current_model,
+             COUNT(h.id) FILTER (WHERE h.status='failed'
+                                  AND h.error_code IN ('stalled','timeout','process_lost','adapter_failed')) AS fails,
+             COUNT(h.id) FILTER (WHERE h.status='succeeded') AS oks
+      FROM agents a
+      LEFT JOIN heartbeat_runs h ON h.agent_id = a.id
+        AND h.created_at > GREATEST(a.updated_at, ${failureCutoff}::text::timestamptz)
+      WHERE a.status != 'paused' AND (a.adapter_config->>'model') IS NOT NULL
+        AND a.updated_at < NOW() - interval '60 seconds'
+      GROUP BY a.id, a.name, a.adapter_type, a.adapter_config, a.updated_at
+      HAVING COUNT(h.id) FILTER (WHERE h.status='failed'
+                                  AND h.error_code IN ('stalled','timeout','process_lost','adapter_failed')) >= ${minFailures}
+         AND COUNT(h.id) FILTER (WHERE h.status='succeeded') = 0
+    `);
+    const rows = ((candidatesResult as unknown) as { rows?: Array<Record<string, string>> }).rows
+      ?? ((candidatesResult as unknown) as Array<Record<string, string>>);
+    let rotated = 0;
+    let paused = 0;
+    for (const row of rows) {
+      const adapterType = row.adapter_type;
+      const currentModel = row.current_model;
+      const ladder = HEALTHY_MODELS_BY_ADAPTER[adapterType];
+      if (!ladder) continue;
+      const historyResult = await db.execute(sql`
+        SELECT DISTINCT a.adapter_config->>'model' AS model
+        FROM heartbeat_runs h
+        JOIN agents a ON a.id = h.agent_id
+        WHERE h.agent_id = ${row.id}::uuid
+          AND h.status = 'failed'
+          AND h.error_code IN ('stalled','timeout','process_lost','adapter_failed')
+          AND h.created_at > ${recentCutoff}
+      `);
+      const histRows = ((historyResult as unknown) as { rows?: Array<{ model: string }> }).rows
+        ?? ((historyResult as unknown) as Array<{ model: string }>);
+      const skipSet = new Set(histRows.map((r) => r.model).filter(Boolean));
+      skipSet.add(currentModel);
+      let startIdx = ladder.indexOf(currentModel);
+      let target: string | null = null;
+      for (let off = 1; off <= ladder.length; off++) {
+        const cand = ladder[(startIdx + off + ladder.length) % ladder.length];
+        if (!skipSet.has(cand)) {
+          target = cand;
+          break;
+        }
+      }
+      if (!target) {
+        await db.execute(sql`
+          UPDATE agents SET status='paused', pause_reason='all_models_failed',
+                           paused_at=NOW(), updated_at=NOW()
+          WHERE id = ${row.id}::uuid AND status != 'paused'
+        `);
+        paused += 1;
+        logger.warn({ agentId: row.id, name: row.name }, "rotateFailingAgentModels: paused — all ladder models exhausted");
+        continue;
+      }
+      await db.execute(sql`
+        UPDATE agents
+        SET adapter_config = jsonb_set(adapter_config, '{model}', to_jsonb(${target}::text)),
+            updated_at = NOW()
+        WHERE id = ${row.id}::uuid
+      `);
+      rotated += 1;
+      logger.info({ agentId: row.id, name: row.name, from: currentModel, to: target, fails: row.fails }, "rotateFailingAgentModels: swapped");
+    }
+    return { rotated, paused };
+  }
+
   // Prune long-lived telemetry rows that accumulate indefinitely.
   // agent_wakeup_requests grows ~10-20k/day (most are short-lived coalesced
   // entries) and is the largest row-count table in the schema. Keeping rows
@@ -5384,9 +5496,9 @@ export function heartbeatService(db: Db) {
       )
       .limit(500);
 
-    if (stale.length === 0) return { reconciled: 0 };
-
     const now = new Date();
+
+    // Layer 1: wakeup has terminal run — reconcile to matching status.
     for (const row of stale) {
       const mappedStatus =
         row.runStatus === "succeeded"
@@ -5399,8 +5511,47 @@ export function heartbeatService(db: Db) {
         error: row.runError ?? null,
       });
     }
-    logger.warn({ reconciledCount: stale.length }, "reconciled stale agent_wakeup_requests");
-    return { reconciled: stale.length };
+
+    // Layer 2: dispatch-lost — wakeup is claimed/queued but NO run was ever
+    // created (OOM at spawn, adapter error before run-row insert, process
+    // died). Before this fix these piled up and blocked next-wakeup dispatch
+    // for the same agent. If it\'s been >5 min since the wakeup was created
+    // with no run materialising, mark it skipped so the agent can resume.
+    const dispatchLostCutoff = new Date(now.getTime() - 5 * 60 * 1000);
+    const dispatchLost = await db
+      .select({
+        wakeupId: agentWakeupRequests.id,
+        agentId: agentWakeupRequests.agentId,
+        wakeupStatus: agentWakeupRequests.status,
+        createdAt: agentWakeupRequests.createdAt,
+      })
+      .from(agentWakeupRequests)
+      .leftJoin(heartbeatRuns, eq(agentWakeupRequests.id, heartbeatRuns.wakeupRequestId))
+      .where(
+        and(
+          inArray(agentWakeupRequests.status, ["queued", "claimed"]),
+          lt(agentWakeupRequests.createdAt, dispatchLostCutoff),
+          isNull(heartbeatRuns.id),
+        ),
+      )
+      .limit(500);
+
+    for (const row of dispatchLost) {
+      await setWakeupStatus(row.wakeupId, "skipped", {
+        finishedAt: now,
+        error: "dispatch-lost: wakeup stuck >5min with no run created",
+      });
+      logger.warn(
+        { wakeupId: row.wakeupId, agentId: row.agentId, wakeupStatus: row.wakeupStatus },
+        "reclaimed dispatch-lost wakeup (no run created)",
+      );
+    }
+
+    const total = stale.length + dispatchLost.length;
+    if (total > 0) {
+      logger.warn({ withRun: stale.length, dispatchLost: dispatchLost.length }, "reconciled stale agent_wakeup_requests");
+    }
+    return { reconciled: total };
   }
 
   async function cancelBudgetScopeWork(scope: BudgetEnforcementScope) {
@@ -5637,6 +5788,8 @@ export function heartbeatService(db: Db) {
     enforceRunTimeouts,
 
     enforceStallTimeouts,
+
+    rotateFailingAgentModels,
 
     reconcileStaleWakeupRequests,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5232,6 +5232,91 @@ export function heartbeatService(db: Db) {
     return { timedOut: timedOut.length, runIds: timedOut };
   }
 
+  // Aggressive stall detector. enforceRunTimeouts only fires at the big
+  // 60-min ceiling. A model that never responds (opencode stuck in ep_poll
+  // on a hung provider) wastes the full budget before it's reaped. This
+  // catches those runs much earlier by checking for event silence: any run
+  // older than `minAgeMs` that has produced zero heartbeat_run_events in
+  // the last `silenceWindowMs` is killed. Normal progress produces an event
+  // every few seconds (tool call, text, step_finish), so silence ≥ 8 min
+  // is a definitive stall signal.
+  async function enforceStallTimeouts(opts?: {
+    minAgeMs?: number;
+    silenceWindowMs?: number;
+  }) {
+    const minAgeMs = opts?.minAgeMs ?? 10 * 60 * 1000;
+    const silenceWindowMs = opts?.silenceWindowMs ?? 8 * 60 * 1000;
+    const now = new Date();
+    const ageCutoff = new Date(now.getTime() - minAgeMs);
+    const silenceCutoff = new Date(now.getTime() - silenceWindowMs);
+
+    // Find all running runs older than minAgeMs.
+    const candidates = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.status, "running"), lt(heartbeatRuns.startedAt, ageCutoff)));
+
+    if (candidates.length === 0) return { stalled: 0, runIds: [] as string[] };
+
+    // For each candidate, check whether it produced any event recently.
+    const stalledIds: string[] = [];
+    for (const run of candidates) {
+      const [latest] = await db
+        .select({ seq: heartbeatRunEvents.seq })
+        .from(heartbeatRunEvents)
+        .where(and(eq(heartbeatRunEvents.runId, run.id), gt(heartbeatRunEvents.createdAt, silenceCutoff)))
+        .limit(1);
+      if (latest) continue; // produced an event recently — not stalled
+
+      const ageMin = run.startedAt ? Math.round((now.getTime() - new Date(run.startedAt).getTime()) / 60000) : 0;
+      const silenceMin = Math.round(silenceWindowMs / 60000);
+      const message = `Run stalled — zero events for ${silenceMin}m (run age ${ageMin}m). Terminated by no-progress detector.`;
+
+      const running = runningProcesses.get(run.id);
+      if (running) {
+        await terminateHeartbeatRunProcess({
+          pid: running.child.pid ?? run.processPid,
+          processGroupId: running.processGroupId ?? run.processGroupId,
+          graceMs: Math.max(1, running.graceSec) * 1000,
+        });
+        runningProcesses.delete(run.id);
+      } else if (run.processPid || run.processGroupId) {
+        await terminateHeartbeatRunProcess({
+          pid: run.processPid,
+          processGroupId: run.processGroupId,
+        });
+      }
+
+      const finalized = await setRunStatus(run.id, "failed", {
+        error: message,
+        errorCode: "stalled",
+        finishedAt: now,
+      });
+      await setWakeupStatus(run.wakeupRequestId, "failed", {
+        finishedAt: now,
+        error: message,
+      });
+      if (finalized) {
+        await appendRunEvent(finalized, await nextRunEventSeq(finalized.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "error",
+          message,
+          payload: { ageMin, silenceMin, ...(run.processPid ? { processPid: run.processPid } : {}) },
+        });
+        await releaseIssueExecutionAndPromote(finalized);
+      }
+      await finalizeAgentStatus(run.agentId, "failed");
+      await startNextQueuedRunForAgent(run.agentId);
+      stalledIds.push(run.id);
+    }
+
+    if (stalledIds.length > 0) {
+      logger.warn({ stalledCount: stalledIds.length, runIds: stalledIds }, "killed stalled (no-event) heartbeat runs");
+    }
+    return { stalled: stalledIds.length, runIds: stalledIds };
+  }
+
   // Prune long-lived telemetry rows that accumulate indefinitely.
   // agent_wakeup_requests grows ~10-20k/day (most are short-lived coalesced
   // entries) and is the largest row-count table in the schema. Keeping rows
@@ -5550,6 +5635,8 @@ export function heartbeatService(db: Db) {
     reapOrphanedRuns,
 
     enforceRunTimeouts,
+
+    enforceStallTimeouts,
 
     reconcileStaleWakeupRequests,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4001,8 +4001,15 @@ export function heartbeatService(db: Db) {
 
       let outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
       const latestRun = await getRun(run.id);
+      // If another code path (cancelRun, enforceRunTimeouts, reapOrphanedRuns)
+      // has already finalised this run to a terminal status, preserve it.
+      // Previously only "cancelled" was respected, so an enforceRunTimeouts
+      // SIGTERM that produced a clean exit-0 from the child would be
+      // overwritten with "succeeded", hiding the timeout entirely.
       if (latestRun?.status === "cancelled") {
         outcome = "cancelled";
+      } else if (latestRun?.status === "failed") {
+        outcome = latestRun.errorCode === "timeout" ? "timed_out" : "failed";
       } else if (adapterResult.timedOut) {
         outcome = "timed_out";
       } else if ((adapterResult.exitCode ?? 0) === 0 && !adapterResult.errorMessage) {
@@ -4016,14 +4023,16 @@ export function heartbeatService(db: Db) {
         logSummary = await runLogStore.finalize(handle);
       }
 
+      // Note: timed_out is a semantic outcome; the persisted status column
+      // only uses the enum {succeeded, failed, cancelled}. timed_out runs
+      // land as failed with errorCode=timeout (set either by this handler
+      // via adapterResult.timedOut or upstream by enforceRunTimeouts).
       const status =
         outcome === "succeeded"
           ? "succeeded"
           : outcome === "cancelled"
             ? "cancelled"
-            : outcome === "timed_out"
-              ? "timed_out"
-              : "failed";
+            : "failed";
 
       const usageJson =
         normalizedUsage || adapterResult.costUsd != null

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1545,35 +1545,12 @@ export function issueService(db: Db) {
         if (executionWorkspaceId) {
           await assertValidExecutionWorkspace(companyId, issueData.projectId, executionWorkspaceId, tx);
         }
-        // Serialise identifier allocation per-company with an explicit row
-        // lock so two concurrent creates cannot both land on the same
-        // issue_number. Under READ COMMITTED the existing GREATEST-based
-        // self-correction was insufficient — duplicate_key on
-        // issues_identifier_idx still fired 5 times in a 40s window on
-        // 2026-04-18. The FOR UPDATE forces the second transaction to wait
-        // until the first has committed its INSERT, so the re-read of
-        // companies.issue_counter reflects the advance.
-        await tx.execute(
-          sql`select id from ${companies} where id = ${companyId} for update`,
-        );
-
-        const [maxRow] = await tx
-          .select({ maxNum: sql<number>`coalesce(max(${issues.issueNumber}), 0)` })
-          .from(issues)
-          .where(eq(issues.companyId, companyId));
-        const currentMax = maxRow?.maxNum ?? 0;
-
-        const [company] = await tx
-          .update(companies)
-          .set({
-            issueCounter: sql`greatest(${companies.issueCounter}, ${currentMax}) + 1`,
-          })
-          .where(eq(companies.id, companyId))
-          .returning({ issueCounter: companies.issueCounter, issuePrefix: companies.issuePrefix });
-
-        const issueNumber = company.issueCounter;
-        const identifier = `${company.issuePrefix}-${issueNumber}`;
-
+        // Identifier allocation is handled atomically by the DB-level
+        // BEFORE-INSERT trigger `issues_allocate_identifier_before_insert`
+        // which updates `companies.issue_counter` in one lock-free UPDATE
+        // and fills NEW.issue_number + NEW.identifier. No app-side
+        // SELECT FOR UPDATE is needed. The trigger is the single source of
+        // truth for every insert path (app, psql, migrations, self-healer).
         const values = {
           ...issueData,
           originKind: issueData.originKind ?? "manual",
@@ -1588,8 +1565,6 @@ export function issueService(db: Db) {
           ...(executionWorkspacePreference ? { executionWorkspacePreference } : {}),
           ...(executionWorkspaceSettings ? { executionWorkspaceSettings } : {}),
           companyId,
-          issueNumber,
-          identifier,
         } as typeof issues.$inferInsert;
         if (values.status === "in_progress" && !values.startedAt) {
           values.startedAt = new Date();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1545,8 +1545,18 @@ export function issueService(db: Db) {
         if (executionWorkspaceId) {
           await assertValidExecutionWorkspace(companyId, issueData.projectId, executionWorkspaceId, tx);
         }
-        // Self-correcting counter: use MAX(issue_number) + 1 if the counter
-        // has drifted below the actual max, preventing identifier collisions.
+        // Serialise identifier allocation per-company with an explicit row
+        // lock so two concurrent creates cannot both land on the same
+        // issue_number. Under READ COMMITTED the existing GREATEST-based
+        // self-correction was insufficient — duplicate_key on
+        // issues_identifier_idx still fired 5 times in a 40s window on
+        // 2026-04-18. The FOR UPDATE forces the second transaction to wait
+        // until the first has committed its INSERT, so the re-read of
+        // companies.issue_counter reflects the advance.
+        await tx.execute(
+          sql`select id from ${companies} where id = ${companyId} for update`,
+        );
+
         const [maxRow] = await tx
           .select({ maxNum: sql<number>`coalesce(max(${issues.issueNumber}), 0)` })
           .from(issues)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2092,15 +2092,24 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        // postgres.js refuses to bind a JS Date directly inside a raw sql``
+        // template (crashes with "argument must be of type string or Buffer")
+        // when the param type cannot be inferred from the surrounding SQL.
+        // Coerce to an ISO string and cast to timestamptz so Postgres receives
+        // a proper timestamp.
+        const anchorCreatedAtIso =
+          anchor.createdAt instanceof Date
+            ? anchor.createdAt.toISOString()
+            : String(anchor.createdAt);
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorCreatedAtIso}::timestamptz
+                OR (${issueComments.createdAt} = ${anchorCreatedAtIso}::timestamptz AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorCreatedAtIso}::timestamptz
+                OR (${issueComments.createdAt} = ${anchorCreatedAtIso}::timestamptz AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -116,6 +116,7 @@ type IssueUserContextInput = {
 };
 type ProjectGoalReader = Pick<Db, "select">;
 type DbReader = Pick<Db, "select">;
+type DbExecutor = Pick<Db, "select" | "insert" | "update" | "delete" | "execute">;
 type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
   labelIds?: string[];
   blockedByIssueIds?: string[];
@@ -457,7 +458,7 @@ function latestIssueActivityAt(...values: Array<Date | string | null | undefined
   return normalized[0] ?? null;
 }
 
-async function labelMapForIssues(dbOrTx: any, issueIds: string[]): Promise<Map<string, IssueLabelRow[]>> {
+async function labelMapForIssues(dbOrTx: DbExecutor, issueIds: string[]): Promise<Map<string, IssueLabelRow[]>> {
   const map = new Map<string, IssueLabelRow[]>();
   if (issueIds.length === 0) return map;
   const rows = await dbOrTx
@@ -478,7 +479,7 @@ async function labelMapForIssues(dbOrTx: any, issueIds: string[]): Promise<Map<s
   return map;
 }
 
-async function withIssueLabels(dbOrTx: any, rows: IssueRow[]): Promise<IssueWithLabels[]> {
+async function withIssueLabels(dbOrTx: DbExecutor, rows: IssueRow[]): Promise<IssueWithLabels[]> {
   if (rows.length === 0) return [];
   const labelsByIssueId = await labelMapForIssues(dbOrTx, rows.map((row) => row.id));
   return rows.map((row) => {
@@ -494,7 +495,7 @@ async function withIssueLabels(dbOrTx: any, rows: IssueRow[]): Promise<IssueWith
 const ACTIVE_RUN_STATUSES = ["queued", "running"];
 
 async function activeRunMapForIssues(
-  dbOrTx: any,
+  dbOrTx: DbExecutor,
   issueRows: IssueWithLabels[],
 ): Promise<Map<string, IssueActiveRunRow>> {
   const map = new Map<string, IssueActiveRunRow>();
@@ -700,7 +701,7 @@ export function issueService(db: Db) {
     }
   }
 
-  async function assertValidLabelIds(companyId: string, labelIds: string[], dbOrTx: any = db) {
+  async function assertValidLabelIds(companyId: string, labelIds: string[], dbOrTx: DbExecutor = db) {
     if (labelIds.length === 0) return;
     const existing = await dbOrTx
       .select({ id: labels.id })
@@ -715,7 +716,7 @@ export function issueService(db: Db) {
     issueId: string,
     companyId: string,
     labelIds: string[],
-    dbOrTx: any = db,
+    dbOrTx: DbExecutor = db,
   ) {
     const deduped = [...new Set(labelIds)];
     await assertValidLabelIds(companyId, deduped, dbOrTx);
@@ -859,7 +860,7 @@ export function issueService(db: Db) {
     companyId: string,
     blockedByIssueIds: string[],
     actor: { agentId?: string | null; userId?: string | null } = {},
-    dbOrTx: any = db,
+    dbOrTx: DbExecutor = db,
   ) {
     const deduped = [...new Set(blockedByIssueIds)];
     if (deduped.some((candidate) => candidate === issueId)) {
@@ -901,7 +902,7 @@ export function issueService(db: Db) {
         companyId,
         issueId: blockerIssueId,
         relatedIssueId: issueId,
-        type: "blocks",
+        type: "blocks" as const,
         createdByAgentId: actor.agentId ?? null,
         createdByUserId: actor.userId ?? null,
       })),
@@ -1468,7 +1469,7 @@ export function issueService(db: Db) {
         let executionWorkspaceId = issueData.executionWorkspaceId ?? null;
         let executionWorkspacePreference = issueData.executionWorkspacePreference ?? null;
         let executionWorkspaceSettings =
-          (issueData.executionWorkspaceSettings as Record<string, unknown> | null | undefined) ?? null;
+              (issueData.executionWorkspaceSettings as { [key: string]: unknown } | null | undefined) ?? null;
         const workspaceInheritanceIssueId = inheritExecutionWorkspaceFromIssueId ?? issueData.parentId ?? null;
         const hasExplicitExecutionWorkspaceOverride =
           issueData.executionWorkspaceId !== undefined ||
@@ -1496,7 +1497,7 @@ export function issueService(db: Db) {
               executionWorkspaceId = sourceWorkspace.id;
               executionWorkspacePreference = "reuse_existing";
               executionWorkspaceSettings = {
-                ...((workspaceSource.executionWorkspaceSettings as Record<string, unknown> | null | undefined) ?? {}),
+                    ...((workspaceSource.executionWorkspaceSettings as { [key: string]: unknown } | null | undefined) ?? {}),
                 mode: issueExecutionWorkspaceModeForPersistedWorkspace(sourceWorkspace.mode),
               };
             }
@@ -1518,7 +1519,7 @@ export function issueService(db: Db) {
                 parseProjectExecutionWorkspacePolicy(project?.executionWorkspacePolicy),
                 isolatedWorkspacesEnabled,
               ),
-            ) as Record<string, unknown> | null;
+                ) as { [key: string]: unknown } | null;
         }
         if (!projectWorkspaceId && issueData.projectId) {
           const project = await tx
@@ -1605,7 +1606,7 @@ export function issueService(db: Db) {
         actorAgentId?: string | null;
         actorUserId?: string | null;
       },
-      dbOrTx: any = db,
+      dbOrTx: DbExecutor = db,
     ) => {
       const existing = await dbOrTx
         .select()
@@ -1691,7 +1692,7 @@ export function issueService(db: Db) {
         patch.executionLockedAt = null;
       }
 
-      const runUpdate = async (tx: any) => {
+      const runUpdate = async (tx: DbExecutor) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, existing.companyId);
         const [currentProjectGoalId, nextProjectGoalId] = await Promise.all([
           getProjectDefaultGoalId(tx, existing.companyId, existing.projectId),
@@ -1944,6 +1945,7 @@ export function issueService(db: Db) {
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
           checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
         })
         .from(issues)
         .where(eq(issues.id, id))
@@ -1957,6 +1959,42 @@ export function issueService(db: Db) {
         sameRunLock(current.checkoutRunId, actorRunId)
       ) {
         return { ...current, adoptedFromRunId: null as string | null };
+      }
+
+      if (
+        actorRunId &&
+        current.status === "in_progress" &&
+        current.assigneeAgentId === actorAgentId &&
+        current.checkoutRunId == null &&
+        current.executionRunId === actorRunId
+      ) {
+        const adopted = await db
+          .update(issues)
+          .set({
+            checkoutRunId: actorRunId,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(issues.id, id),
+              eq(issues.status, "in_progress"),
+              eq(issues.assigneeAgentId, actorAgentId),
+              isNull(issues.checkoutRunId),
+              eq(issues.executionRunId, actorRunId),
+            ),
+          )
+          .returning({
+            id: issues.id,
+            status: issues.status,
+            assigneeAgentId: issues.assigneeAgentId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .then((rows) => rows[0] ?? null);
+
+        if (adopted) {
+          return { ...adopted, adoptedFromRunId: null as string | null };
+        }
       }
 
       if (
@@ -2497,7 +2535,7 @@ export function issueService(db: Db) {
           cwd: string | null;
           repoUrl: string | null;
           repoRef: string | null;
-          metadata: Record<string, unknown> | null;
+              metadata: { [key: string]: unknown } | null;
           isPrimary: boolean;
           createdAt: Date;
           updatedAt: Date;
@@ -2510,7 +2548,7 @@ export function issueService(db: Db) {
           cwd: string | null;
           repoUrl: string | null;
           repoRef: string | null;
-          metadata: Record<string, unknown> | null;
+              metadata: { [key: string]: unknown } | null;
           isPrimary: boolean;
           createdAt: Date;
           updatedAt: Date;
@@ -2545,7 +2583,7 @@ export function issueService(db: Db) {
             cwd: workspace.cwd,
             repoUrl: workspace.repoUrl ?? null,
             repoRef: workspace.repoRef ?? null,
-            metadata: (workspace.metadata as Record<string, unknown> | null) ?? null,
+                metadata: (workspace.metadata as { [key: string]: unknown } | null) ?? null,
             isPrimary: workspace.isPrimary,
             createdAt: workspace.createdAt,
             updatedAt: workspace.updatedAt,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -986,8 +986,17 @@ export function issueService(db: Db) {
         )
       `;
       if (filters?.status) {
-        const statuses = filters.status.split(",").map((s) => s.trim());
-        conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]) : inArray(issues.status, statuses));
+        // Accept "todo", "todo,in_progress", or ["todo", "in_progress"]
+        // (Express parses ?status=a&status=b as an array).
+        const rawStatus = filters.status;
+        const statuses = (Array.isArray(rawStatus) ? rawStatus : String(rawStatus).split(","))
+          .map((s) => String(s).trim())
+          .filter(Boolean);
+        if (statuses.length === 1) {
+          conditions.push(eq(issues.status, statuses[0]));
+        } else if (statuses.length > 1) {
+          conditions.push(inArray(issues.status, statuses));
+        }
       }
       if (filters?.assigneeAgentId) {
         conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
@@ -1211,7 +1220,10 @@ export function issueService(db: Db) {
         unreadForUserCondition(companyId, userId),
       ];
       if (status) {
-        const statuses = status.split(",").map((s) => s.trim()).filter(Boolean);
+        // Accept string "a", "a,b", or array ["a","b"] (repeated query param).
+        const statuses = (Array.isArray(status) ? status : String(status).split(","))
+          .map((s) => String(s).trim())
+          .filter(Boolean);
         if (statuses.length === 1) {
           conditions.push(eq(issues.status, statuses[0]));
         } else if (statuses.length > 1) {


### PR DESCRIPTION
## Summary
- heal issue checkout ownership when `executionRunId` still matches the active run but `checkoutRunId` was dropped
- add a regression test for the inconsistent run-owned issue state
- keep MCP tool definitions type-safe while preserving comment alias support covered by tests

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm vitest run server/src/__tests__/issues-service.test.ts`
- `pnpm vitest run src/tools.test.ts` (in `packages/mcp-server`)
- `/home/jakejames/biz-ops/scripts/check-ai-slop.sh --files server/src/services/issues.ts server/src/__tests__/issues-service.test.ts packages/mcp-server/src/tools.ts packages/mcp-server/src/tools.test.ts`

## Context
This unblocks KIT-1712 by allowing agent-owned issue mutations to recover when the execution lock survived but the checkout lock did not.
