### PR TITLE
Harden Paperclip control plane and queue hygiene

### DIFF
--- a/cli/src/commands/routines.ts
+++ b/cli/src/commands/routines.ts
@@ -9,6 +9,9 @@ import {
   createEmbeddedPostgresLogBuffer,
   ensurePostgresDatabase,
   formatEmbeddedPostgresError,
+  readPidFilePort,
+  readRunningPostmasterPid,
+  reapStoppingPostmaster,
   routines,
 } from "@paperclipai/db";
 import { eq, inArray } from "drizzle-orm";
@@ -82,28 +85,6 @@ async function findAvailablePort(preferredPort: number): Promise<number> {
   return port;
 }
 
-function readPidFilePort(postmasterPidFile: string): number | null {
-  if (!fs.existsSync(postmasterPidFile)) return null;
-  try {
-    const lines = fs.readFileSync(postmasterPidFile, "utf8").split("\n");
-    const port = Number(lines[3]?.trim());
-    return Number.isInteger(port) && port > 0 ? port : null;
-  } catch {
-    return null;
-  }
-}
-
-function readRunningPostmasterPid(postmasterPidFile: string): number | null {
-  if (!fs.existsSync(postmasterPidFile)) return null;
-  try {
-    const pid = Number(fs.readFileSync(postmasterPidFile, "utf8").split("\n")[0]?.trim());
-    if (!Number.isInteger(pid) || pid <= 0) return null;
-    process.kill(pid, 0);
-    return pid;
-  } catch {
-    return null;
-  }
-}
 
 async function ensureEmbeddedPostgres(dataDir: string, preferredPort: number): Promise<EmbeddedPostgresHandle> {
   const moduleName = "embedded-postgres";
@@ -118,6 +99,7 @@ async function ensureEmbeddedPostgres(dataDir: string, preferredPort: number): P
   }
 
   const postmasterPidFile = path.resolve(dataDir, "postmaster.pid");
+  await reapStoppingPostmaster(postmasterPidFile);
   const runningPid = readRunningPostmasterPid(postmasterPidFile);
   if (runningPid) {
     return {

--- a/doc/plans/2026-04-23-paperclip-hybrid-control-plane-autoplan.md
+++ b/doc/plans/2026-04-23-paperclip-hybrid-control-plane-autoplan.md
@@ -1,0 +1,336 @@
+# Paperclip hybrid control plane Autoplan
+
+Date: 2026-04-23
+Repo: `/Users/nathanskene/Projects/paperclip`
+Related NEU repo: `/Users/nathanskene/Projects/CellxGene-Census`
+
+## Autoplan verdict
+
+Nathan's objection is right: a fully deterministic controller is too brittle if it tries to encode project judgment, ambiguous recovery, scientific interpretation, or prioritisation. But using cheap models for polling, dependency checks, file checks, or queue control would recreate the current failure mode with lower-cost tokens.
+
+The right design is a hybrid control plane:
+
+1. Deterministic gates for facts, invariants, idempotency, and "do nothing" decisions.
+2. Cheap model triage only for ambiguous interpretation.
+3. Strong agents only when there is real implementation/review/science work to do.
+4. Project Lead for exception/stage-transition decisions, not generic CEO cosplay.
+
+This means: do not build a deterministic "CEO". Build deterministic safety rails plus model-assisted exception handling.
+
+## Facts observed during Autoplan
+
+Paperclip core already has useful pieces:
+
+- `doc/execution-semantics.md` distinguishes hierarchy from dependency semantics and says blocked issues should stay idle until blockers resolve.
+- `packages/db/src/schema/issue_relations.ts` stores explicit blocker edges with `type = "blocks"`.
+- `server/src/services/heartbeat.ts` has a dependency gate in `enqueueWakeup`: it calls `issuesSvc.listDependencyReadiness` and skips with `issue_dependencies_blocked` when unresolved blockers exist.
+- `server/src/services/heartbeat.ts` also coalesces/defer wakes when an issue already has an active execution run.
+- The heartbeat run schema already has liveness fields that can support run-health classification.
+
+But the live NEU company state previously showed the actual control-plane gap:
+
+- Many issues are visually/status-wise blocked, but explicit blocker metadata is absent or not exposed consistently.
+- Queued Founding Engineer runs exist against blocked issues.
+- D-07's final artifact is missing while HPC jobs are/were running, so downstream LLM wakes are wasteful.
+
+So the problem is not "no deterministic logic exists". It is that the authoritative graph, wake gates, stale queued-run hygiene, and external-state monitoring are not yet coherent end-to-end.
+
+## Principle: deterministic first, not deterministic only
+
+Use deterministic code for:
+
+- issue status checks
+- dependency readiness
+- wake eligibility
+- queued/running run hygiene
+- artifact existence
+- HPC/buildctl status parsing
+- parquet shape/readability checks
+- idempotency keys and cooldown windows
+- safe transitions and "do nothing" decisions
+- budget caps
+
+Use cheap models for:
+
+- interpreting ambiguous issue text when blocker graph is missing
+- proposing graph repair when charter and board disagree
+- classifying run logs/transcripts as useful progress vs stall/waiting/handoff-needed
+- summarising project health for humans
+- triaging failure logs into likely infra/code/data/science classes
+- breaking ties between several ready frontier tickets
+
+Use strong agents for:
+
+- code changes
+- technical review
+- biological/scientific review
+- exception handling when the cheap triage is low confidence
+- charter/scope changes
+
+Do not use models for:
+
+- polling
+- checking whether a file exists
+- waiting for jobs
+- deciding whether an issue with unresolved blockers should run
+- repeated heartbeat nudging
+- queue hygiene
+
+Cheap model output should be advisory structured JSON. It should not directly mutate Paperclip state. Deterministic checks must validate every recommended action before apply mode.
+
+## Target architecture
+
+```text
+Paperclip API / DB
+  |
+  | issues, blocker relations, runs, wakeups, comments
+  v
+Deterministic controller
+  |-- wake eligibility
+  |-- graph health
+  |-- run health
+  |-- artifact/HPC checks for project plugins
+  |
+  | emits:
+  | no_change | safe_transition | ambiguous_exception | hard_failure
+  v
+Decision router
+  |-- no_change: do nothing
+  |-- safe_transition: apply idempotent mutation if apply mode enabled
+  |-- ambiguous_exception: cheap Project Lead triage
+  |-- hard_failure: Project Lead/human escalation
+  v
+Agents
+  |-- Founding Engineer: implementation/finalisation
+  |-- Code Reviewer: technical review
+  |-- Bioinformatics Scientist: biological validation
+  |-- Project Lead: exception/stage transition
+  |-- Nathan: real scientific/product decision only
+```
+
+## Component A: Paperclip wake eligibility service
+
+Create one central `wakeEligibility` service in Paperclip core.
+
+Inputs:
+
+- companyId
+- issueId if present
+- agentId
+- wake source/reason/context
+- requester actor
+
+Output:
+
+- `allowed | skipped | deferred | interaction_allowed`
+- machine reason
+- human-readable reason
+- unresolved blockers
+- issue status
+- active/queued run summary
+- wake class
+
+Rules:
+
+- `done`/`cancelled`: no executor wake except explicit human reopen/comment interaction.
+- `blocked` with unresolved blockers: no executor wake.
+- `blocked` with no explicit blockers: do not run executor; classify as `blocked_no_blocker_edges` and surface graph repair.
+- `in_review`: reviewer wakes allowed; executor wakes only on explicit reopen/assignment.
+- `in_progress`: continuation allowed only when dependency-ready and no active execution run.
+- `todo`: start/assignment allowed only when dependency-ready and no duplicate active/queued run.
+- human comment/mention can allow bounded interaction mode, but not full implementation on blocked work.
+
+Call this service from every wake path:
+
+- issue assignment/status updates
+- issue comments/mentions
+- manual wake endpoints
+- `enqueueWakeup`
+- queued-run claim path
+- startup/periodic reconciliation
+
+Why this matters: Paperclip already has partial gating inside `enqueueWakeup`, but all wake sources need one policy, and already-queued bad runs need cleanup.
+
+## Component B: queued-run hygiene
+
+Add periodic/read-only-then-apply hygiene for pending runs.
+
+Classifications:
+
+- queued_healthy
+- queued_stale
+- queued_ineligible_blocked
+- queued_ineligible_terminal_issue
+- queued_missing_issue
+- duplicate_queued
+- running_active
+- running_quiet
+- running_stalled
+- running_external_wait
+- terminal_success
+- terminal_failed
+- terminal_inconclusive
+
+Apply policy:
+
+- queued run on blocked/done/cancelled issue: cancel/skip with visible reason.
+- queued run whose issue has no explicit blockers but is status `blocked`: quarantine/cancel; ask Project Lead/graph repair rather than run.
+- duplicate queued run for same agent+issue: coalesce/cancel duplicate.
+- running quiet: do not immediately kill; classify and surface evidence.
+- running stalled beyond threshold: retry once if safe, otherwise block issue with evidence.
+- repeated recovery failure: block/comment; do not infinite-wake.
+
+This specifically closes the observed failure mode of queued Founding Engineer runs against blocked downstream work.
+
+## Component C: blocker graph health
+
+Paperclip should treat explicit blocker graph as the source of truth for autonomous execution.
+
+Add a graph-health diagnostic service/endpoint returning:
+
+- blocked issues with no explicit blockers
+- blockers all done but issue still blocked
+- unresolved blockers
+- cycles/impossible edges
+- parent/child structures that look like implicit dependencies but have no blocker edges
+- downstream ready frontier
+- queued/running runs against blocked issues
+
+Required API/product behaviour:
+
+- list/get issue APIs should expose blocker summaries consistently.
+- Board/UI should show `blocked but no blockers` as invalid/incomplete, not normal.
+- status=`blocked` alone must not be treated as an executable dependency graph.
+
+## Component D: NEU project controller/plugin
+
+Keep NEU-specific logic out of generic Paperclip core initially.
+
+In `/Users/nathanskene/Projects/CellxGene-Census`, build/finish `tools/neu_control.py` with dry-run first:
+
+Commands:
+
+- `status`
+- `queue-audit`
+- `graph-audit`
+- `reconcile-blockers --dry-run/--apply`
+- `monitor-d07 --dry-run/--apply`
+- `route-reviews --dry-run/--apply`
+- `unlock-frontier --dry-run/--apply`
+- `summary --json`
+
+D-07 state machine:
+
+- jobs queued/running + final artifact missing: no Paperclip mutation; no LLM wake.
+- jobs failed + final artifact missing: comment evidence, set NEU-18 blocked, wake Project Lead.
+- jobs complete + final artifact missing: wake Founding Engineer to merge/finalise.
+- final artifact exists + shape passes: comment evidence and route to review.
+- final artifact exists + shape fails: block NEU-18 with evidence; wake Project Lead or Founding Engineer depending on error class.
+- NEU-18 in review: wake Code Reviewer; then Bioinformatics Scientist if biological signoff needed.
+
+Artifact checks for D-07:
+
+- `builds/shards/human-2025-11-08-log1p/manifest.json`
+- `data/full-human-2025-11-08-raw-merged/census_pseudobulk_log1p_mean.parquet`
+- shard output counts
+- failed job logs if available
+- final parquet readability and expected metadata/shape where cheap enough
+
+Current interpretation from the earlier live state: if HPC jobs are running and final artifact is missing, the correct action is wait/no wake.
+
+## Component E: cheap model triage
+
+Add a narrow optional model triage command/service after deterministic classification.
+
+Input JSON:
+
+- issue summary
+- blocker graph summary
+- recent comments/activity
+- run log excerpts
+- artifact/HPC state
+- deterministic classification
+
+Output JSON:
+
+- `classification`: `useful_progress | waiting_external | needs_human | likely_looping | likely_done_no_handoff | graph_repair_needed | failure_triage`
+- confidence
+- evidence lines
+- recommended next action
+- whether strong Project Lead escalation is needed
+
+Guardrails:
+
+- no mutation authority
+- deterministic verifier checks recommendation before apply
+- confidence threshold
+- cooldown: at most one triage per issue/run per window
+- store the triage as evidence/activity when useful
+- fallback is Project Lead/human escalation, not waking a Founding Engineer loop
+
+## Phased implementation plan
+
+### Phase 1: Paperclip core diagnostics and hygiene
+
+1. Add central wake eligibility service.
+2. Refactor existing wake paths to use it.
+3. Add queued-run hygiene in read-only mode first.
+4. Expose blocker summaries consistently in issue list/get API.
+5. Add graph/run health diagnostic endpoint.
+6. Add tests:
+   - blocked issue with unresolved blocker does not enqueue executor run.
+   - blocked issue with no blocker edges is classified invalid and does not run executor.
+   - queued run on blocked issue is cancelled/skipped by hygiene.
+   - done/cancelled issue wake is skipped.
+   - human comment/mention interaction exception still works.
+   - blocker completion wakes only direct dependents whose blockers are all done.
+
+### Phase 2: NEU controller dry-run
+
+1. Implement/read-only `tools/neu_control.py` in CellxGene-Census.
+2. Report queue health, graph health, and D-07 state.
+3. Verify it says no wake when jobs are running and final artifact is missing.
+4. No Paperclip mutations.
+
+### Phase 3: NEU safe apply mode
+
+1. Apply only idempotent, evidence-backed mutations.
+2. Reconcile blockers only when D-ticket mapping is unambiguous.
+3. Unlock only direct dependents of completed blockers.
+4. Route reviews with dedupe/cooldown.
+5. Keep all ambiguous cases as cheap model triage or Project Lead escalation.
+
+### Phase 4: cheap model triage
+
+1. Implement structured triage as advisory only.
+2. Add deterministic verifier for suggested actions.
+3. Add cooldowns and evidence persistence.
+4. Use it for ambiguity, not polling.
+
+### Phase 5: productise from NEU learnings
+
+Promote generic pieces into Paperclip core/UI:
+
+- wake eligibility preview
+- graph health panel
+- run health dashboard
+- queued-run hygiene actions
+- suppressed wake logs
+- frontier-ready view
+- project controller/plugin interface
+
+Keep project-specific artifact/HPC/parquet checks in NEU plugin/controller.
+
+## Immediate recommendation
+
+Do not manually wake more agents while D-07 jobs are running and the final artifact is missing.
+
+Next engineering issue should be:
+
+`Paperclip wake eligibility + queued-run hygiene + graph health diagnostics`
+
+Separate NEU issue should be:
+
+`NEU controller dry-run: queue audit, blocker graph audit, D-07 monitor`
+
+This resolves the objection by not pretending everything can be deterministic, while still keeping models away from the parts where they are most wasteful and unsafe.

--- a/doc/plans/2026-04-24-paperclip-mimeograph-overlays.md
+++ b/doc/plans/2026-04-24-paperclip-mimeograph-overlays.md
@@ -1,0 +1,204 @@
+# Paperclip mimeograph overlays
+
+Goal: use mimeographs to improve Paperclip's judgment without turning the control plane into persona soup.
+
+## Core position
+
+Mimeographs should not replace roles, routing, blockers, or deterministic checks.
+They should act as auditable thinking overlays that can be attached to:
+- a company
+- a project/repo
+- an issue type
+- a review step
+
+Paperclip's deterministic control plane should still decide:
+- whether work is ready
+- whether blockers are resolved
+- whether artifacts exist
+- whether a run should wake
+- whether a run should no-op
+
+Mimeographs should only shape how an agent thinks once a real task is ready.
+
+## What to import from mimeo / mimeographs
+
+The useful idea is not "pretend to be Buffett".
+The useful idea is:
+- take a specific expert's frameworks, anti-patterns, and default questions
+- package them as a small auditable text artifact
+- load them only when they help a concrete task
+- log which overlay fired and why
+
+That maps well to Paperclip because Paperclip already has:
+- role-specific instructions on disk
+- repo-scoped execution
+- issue-scoped heartbeats
+- explicit review stages
+
+## Immediate design for Nathan's setup
+
+### 1. Add overlay classes, not new fake executives
+
+Paperclip should expose overlays such as:
+- `domain-science/genomics-atlas`
+- `research-design/causal-inference`
+- `engineering/release-hardening`
+- `clarity/ambiguity-disambiguation`
+- `nathan-lab/repo-first-contract-first`
+
+These overlays should be attachable independently of role.
+Example:
+- Founding Engineer + `nathan-lab/repo-first-contract-first`
+- Bioinformatics Scientist + `domain-science/genomics-atlas`
+- Code Reviewer + `engineering/release-hardening`
+- Scientific Planner + `clarity/ambiguity-disambiguation`
+
+This avoids multiplying agents just to get a way of thinking.
+
+### 2. Attach overlays by issue contract
+
+Overlay activation should be deterministic.
+Use issue metadata / tags / deliverable class / repo path to decide which overlay loads.
+
+Examples:
+- atlas bundle build issues -> `domain-science/genomics-atlas`
+- release artifact verification -> `engineering/release-hardening`
+- charter/acceptance-criteria ambiguity -> `clarity/ambiguity-disambiguation`
+- canonical repo work for Nathan -> `nathan-lab/repo-first-contract-first`
+
+Do not let the model decide ad hoc whether to cosplay a person.
+
+### 3. Keep overlays review-facing and evidence-facing
+
+Each overlay should contribute:
+- what to notice first
+- what tradeoffs to weigh
+- anti-patterns to push back on
+- required evidence patterns
+
+For Paperclip this matters most in:
+- charter review
+- implementation review
+- scientific sanity review
+- release sign-off
+
+It matters much less for pure mechanical execution.
+
+### 4. Log overlay provenance on every run
+
+Every heartbeat run that loads an overlay should record:
+- overlay id
+- activation reason
+- issue id
+- repo/workspace path
+
+And every completion summary should say:
+- which overlay(s) were active
+- which judgment they materially changed
+
+That keeps the system auditable.
+
+## What we should build first
+
+### A. Nathan-specific overlay
+
+Highest-value first overlay: a Nathan/VKS/Paperclip operating overlay distilled from:
+- repo-first behavior
+- contract-first / deterministic-first behavior
+- grant-workflow-safe repo discipline
+- honest gap reporting
+- verification-before-claim
+
+This is more important than importing celebrity founder overlays.
+It should become the default local overlay for Nathan-owned Paperclip companies.
+
+### B. Genomics-atlas overlay
+
+For the NEU / CellxGene-Census run, the most useful domain overlay is a genomics atlas / specificity overlay.
+It should bias agents toward:
+- artifact-contract thinking
+- row/column metadata integrity
+- ontology alignment
+- assay/tissue confounding awareness
+- release-surface verification over narrative completion
+
+Candidate upstream figures to distill later:
+- Aviv Regev
+- Stacey Gabriel
+- Walter Willett only where confounding / study-design reasoning is relevant
+
+### C. Review overlays before implementation overlays
+
+The first runtime use should be in review and planning, not in always-on implementation.
+That is lower risk and easier to validate.
+
+Suggested first sequence:
+1. planner overlay for charter and unblock reasoning
+2. reviewer overlay for release / artifact checks
+3. scientist overlay for atlas sanity checks
+4. only then optional implementation overlays
+
+## How this improves the current Paperclip system
+
+### Better than adding more prose to AGENTS.md
+
+Today, we keep stuffing behavior into AGENTS.md / HEARTBEAT.md.
+That works, but it mixes:
+- hard runtime policy
+- project-specific contracts
+- cognitive style
+
+Mimeograph overlays let us separate these layers.
+
+### Better than adding more roles
+
+Right now, if we want different judgment we tend to add another agent.
+That increases:
+- board complexity
+- routing complexity
+- wake complexity
+- review complexity
+
+Overlays let one role keep its permissions while swapping the reasoning lens.
+
+### Better than generic frontier-model mush
+
+The current failure mode is not just crashes.
+It is also generic plausible reasoning that sounds fine but misses the real contract boundary.
+The NEU run already showed that:
+- the system could talk coherently about completion
+- while the actual atlas prerequisite stage did not yet exist
+
+A good overlay should make that kind of contract miss less likely.
+
+## Guardrails
+
+1. Overlays must never override deterministic wake/block rules.
+2. Overlays must be versioned, named, and auditable.
+3. Overlays should be small and composable.
+4. Overlays should declare anti-patterns explicitly.
+5. The default should be local/domain overlays, not generic celebrity imports.
+6. For Nathan, repo-first and contract-first behavior remains the top-level authority.
+
+## Immediate recommendations for the first NEU run
+
+1. Do not change the NEU control plane into a mimeograph experiment mid-run.
+2. Finish the run with the deterministic frontier now in place:
+   - `atlas/assay_specific`
+   - `atlas/combined`
+   - downstream `final/*`
+3. Use mimeographs first for review overlays around:
+   - release artifact validation
+   - biological sanity review
+   - acceptance-criteria ambiguity cleanup
+4. Build the Nathan-specific overlay next, then a genomics-atlas overlay.
+
+## Concrete next build after the first successful run
+
+1. Add first-class overlay metadata to agent/project config.
+2. Add deterministic overlay routing by issue/repo class.
+3. Emit overlay provenance into heartbeat-run summaries.
+4. Distill and install:
+   - `nathan-lab/repo-first-contract-first`
+   - `domain-science/genomics-atlas`
+5. Use those overlays first in planner/reviewer paths before implementation paths.

--- a/doc/plans/2026-04-24-paperclip-self-managing-neu-control-plane.md
+++ b/doc/plans/2026-04-24-paperclip-self-managing-neu-control-plane.md
@@ -1,0 +1,317 @@
+# Paperclip self-managing NEU control plane
+
+Date: 2026-04-24
+Repo: `/Users/nathanskene/Projects/paperclip`
+Related project repo: `/Users/nathanskene/Projects/CellxGene-Census`
+
+## Real question
+
+Why did the Paperclip company not work out the right next step itself, and what architecture would let it keep a NEU-style project moving without Nathan manually heartbeating agents, re-planning the frontier, or restating the execution strategy?
+
+## Live evidence
+
+Observed from the live localhost company on 2026-04-24:
+
+- Paperclip is reachable at `http://127.0.0.1:3100`.
+- Company `NeurogenomicsLab` has 51 issues total.
+- 31 issues are open and all 31 are `blocked`.
+- The issue list/API currently exposes zero explicit `blockedByIssueIds` across those 31 blocked issues.
+- `NEU-50` is blocked after repeated process-loss / operational-failure comments.
+- `NEU-50` currently has no explicit blocker edge in the API, no live execution run, and no checkout run.
+- The Founding Engineer previously looped on `NEU-50`, and the diagnostic script still flags a possible loop on that issue.
+
+Observed from Paperclip core/docs:
+
+- `doc/execution-semantics.md` says blocked issues should stay idle until blockers resolve.
+- `server/src/services/heartbeat.ts` already checks dependency readiness during wake enqueue and queued-run claim.
+- `server/src/services/heartbeat.ts` also skips wakes for `issue.status === "blocked"` when there is no allowed interaction wake.
+- Release `v2026.416.0` already advertises first-class blocker dependencies with automatic wake-on-dependency-resolved.
+
+## Verdict
+
+Paperclip did not fail because the agents were too dumb.
+It failed because the control plane still has an authority gap between:
+
+1. issue status labels,
+2. explicit dependency graph,
+3. queued-run hygiene,
+4. external-state monitoring, and
+5. project-level execution-mode pivots.
+
+In short: the company cannot reliably self-manage because Paperclip still knows how to wake agents, but it does not yet know enough to decide when not to wake them, when a blocked board is malformed, or when a project should pivot from one execution strategy to another.
+
+## Why it did not work itself out
+
+### 1. `blocked` is present, but the graph is not authoritative
+
+The NEU board is visually/status-wise blocked, but the live issue API exposes no explicit blocker edges for the blocked frontier.
+
+That means Paperclip cannot safely infer:
+
+- which issue should unlock next,
+- which blocked issue is malformed versus legitimately waiting,
+- whether a blocked issue should be automatically unblocked,
+- whether a parent/meta issue should be decomposed before waking an executor.
+
+Status alone is not enough for autonomous execution.
+
+### 2. Wake gating exists, but only protects against obviously bad wakes
+
+Paperclip already has useful protections:
+
+- skip blocked issues with unresolved blockers,
+- skip blocked issues without allowed interaction wakes,
+- coalesce duplicate same-agent runs,
+- avoid some duplicated execution on an already-running issue.
+
+But those are defensive gates, not a full project controller.
+They stop some waste; they do not decide the next correct frontier.
+
+### 3. No deterministic project watcher is monitoring the real external state
+
+For NEU, the real frontier depends on facts outside the issue thread:
+
+- release artifacts on disk,
+- HPC/build status,
+- whether `atlas/combined` exists,
+- whether a monolithic build has failed enough times to be declared unfit,
+- whether shard outputs are complete and merge-ready.
+
+Paperclip core does not know those things by default.
+Without a project-specific controller, the company can only reread issue comments and guess.
+
+### 4. No execution-mode pivot is encoded
+
+`NEU-50` is the clear example.
+The company learned that the monolithic local atlas build is operationally fragile, but there is no explicit control-plane rule that says:
+
+- classify repeated storage / SIGKILL / process-loss failures as `monolith_unfit`
+- stop retrying the same shape
+- switch the project to `sharded_local` or `sharded_hpc`
+- create or wake the concrete next implementation task
+
+So the company stalls instead of pivoting.
+
+### 5. Parent/meta issue overload prevents an executable frontier
+
+`NEU-50` is still doing too many jobs at once:
+
+- strategy choice,
+- code-path implementation,
+- production execution,
+- validation,
+- handoff.
+
+A self-managing company needs smaller first-class issues so the control plane can advance one real frontier step at a time.
+
+## What Paperclip needs to do this itself
+
+## A. Core Paperclip upgrades
+
+### A1. Central wake-eligibility service
+
+One authoritative service in Paperclip core should classify every wake request before queueing or claiming it.
+
+Output should include:
+
+- `allowed`
+- `skipped`
+- `deferred`
+- machine reason
+- human reason
+- issue status
+- blocker summary
+- run summary
+- interaction allowance
+
+Use it for:
+
+- issue assignment wakes
+- comment/mention wakes
+- manual wakes
+- scheduler wakes
+- startup recovery
+- queued-run claim path
+
+### A2. Graph-health diagnostics
+
+Paperclip should treat `blocked + no blocker edges` as an invalid/incomplete execution graph, not a normal resting state.
+
+Need a graph-health service / endpoint / UI surface that reports:
+
+- blocked issues with no explicit blockers
+- blockers all done but issue still blocked
+- cycles / impossible edges
+- queued or running wakes against blocked issues
+- direct frontier-ready dependents
+
+### A3. Queued-run hygiene
+
+Add deterministic hygiene that continuously classifies runs as:
+
+- queued healthy
+- queued stale
+- queued blocked-ineligible
+- queued terminal-ineligible
+- duplicate queued
+- running active
+- running stalled
+- running external-wait
+- terminal success / failure / inconclusive
+
+Policy:
+
+- cancel or suppress queued runs on blocked/done/cancelled issues
+- cancel duplicates
+- surface stalled runs with evidence
+- do not keep infinite-waking the same failure mode
+
+### A4. Better blocker exposure in list/get APIs and UI
+
+Project controllers and operators need blocker summaries directly in the list/get surfaces they already use.
+The graph cannot be authoritative if it is difficult to see or absent from the main issue data path.
+
+### A5. Project-controller/plugin contract
+
+Paperclip core should not hardcode NEU-specific HPC logic.
+Instead, it should provide a plugin/controller contract for deterministic external-state checks.
+
+Controller responsibilities:
+
+- queue audit
+- graph audit
+- artifact existence checks
+- job-status checks
+- safe idempotent issue transitions
+- review routing
+- frontier unlocking
+
+## B. NEU-specific controller behavior
+
+Implement a deterministic NEU controller in `CellxGene-Census`, then let Paperclip invoke it.
+
+### B1. Queue and graph audit
+
+Commands should include:
+
+- `status`
+- `queue-audit`
+- `graph-audit`
+- `reconcile-blockers --dry-run/--apply`
+- `route-reviews --dry-run/--apply`
+- `unlock-frontier --dry-run/--apply`
+
+### B2. External-state checks
+
+The controller should inspect:
+
+- audited release root
+- shard manifests
+- shard output counts
+- `atlas/assay_specific/*`
+- `atlas/combined/*`
+- HPC/buildctl state
+- final artifact readability / shape
+
+### B3. Execution-mode pivot logic
+
+For atlas-stage work, make execution mode explicit:
+
+- `monolithic_local`
+- `sharded_local`
+- `sharded_hpc`
+
+Pivot rule:
+
+If repeated failures show storage exhaustion, process loss, exit 137, or equivalent monolithic fragility, classify the current mode as `monolith_unfit` and stop retrying it.
+
+Then:
+
+1. comment evidence on the issue,
+2. set or persist execution mode,
+3. materialize concrete shard-first child tasks,
+4. wake only the next implementation role.
+
+### B4. Meta-issue decomposition
+
+Convert overloaded frontier issues into explicit child tasks such as:
+
+- add atlas shard selection support
+- add atlas shard manifest and runner
+- add assay-specific shard merge validator
+- run production shards
+- merge and verify assay-specific root
+- run / verify `atlas/combined`
+
+That creates an actually executable frontier.
+
+## C. Cheap-model triage, but only for ambiguity
+
+Use a cheaper model only when deterministic checks cannot resolve ambiguity, for example:
+
+- the graph is missing and needs repair suggestions,
+- run logs need failure-class classification,
+- several ready issues exist and a tie-break is needed,
+- a summary for a human/operator is needed.
+
+Do not use models for:
+
+- polling,
+- waiting,
+- file existence,
+- job status,
+- queue hygiene,
+- blocker readiness,
+- repeated "check again" wakes.
+
+Cheap-model output should be structured advisory JSON and never mutate state directly.
+
+## Recommended phased plan
+
+### Phase 1: Paperclip core control-plane hygiene
+
+1. Add central wake-eligibility service.
+2. Route all wake sources through it.
+3. Add graph-health diagnostics.
+4. Add queued-run hygiene.
+5. Expose blocker summaries consistently in API/UI.
+
+### Phase 2: NEU controller dry-run
+
+1. Finish the deterministic NEU controller in `CellxGene-Census`.
+2. Prove it says `do nothing` when frontier state is unchanged.
+3. Prove it detects malformed blocked issues and monolith-unfit evidence.
+
+### Phase 3: Safe apply mode
+
+1. Allow only idempotent controller mutations.
+2. Reconcile blocker edges.
+3. Unlock direct dependents only.
+4. Route reviews without duplicate wakes.
+5. Apply execution-mode pivots with evidence.
+
+### Phase 4: Productise the generic pieces
+
+Promote reusable pieces from NEU into Paperclip core/UI:
+
+- wake-eligibility preview
+- graph-health panel
+- queued-run hygiene actions
+- suppressed-wake logs
+- frontier-ready view
+- project-controller/plugin hooks
+
+## Bottom line
+
+The answer is not "make the CEO smarter".
+
+The answer is:
+
+- make the blocker graph authoritative,
+- make wake eligibility universal,
+- add queued-run hygiene,
+- give Paperclip a deterministic project-controller hook for external state,
+- encode execution-mode pivots like `monolith_unfit -> shard-first`,
+- and use models only for ambiguity, not polling.
+
+That is how Paperclip starts doing this itself instead of waiting for Nathan to notice the board is blocked in a way the control plane cannot yet interpret.

--- a/docs/api/issues.md
+++ b/docs/api/issues.md
@@ -21,6 +21,28 @@ Query parameters:
 
 Results sorted by priority.
 
+Each issue row may also include dependency diagnostics when available:
+
+- `blockedBy` / `blocks` — relation summaries for first-class blocker edges
+- `blockedByIssueIds` — blocker issue IDs for quick machine checks
+- `dependency` — readiness summary (`unresolvedBlockerCount`, `isDependencyReady`, etc.)
+- `graphState` — one of `ready`, `blocked_no_relations`, `blocked_waiting_on_relations`, or `blocked_relations_resolved`
+
+## Issue Graph Health
+
+```
+GET /api/companies/{companyId}/issues/graph-health
+```
+
+Returns company-scoped issue graph diagnostics for autonomous execution, including:
+
+- summary counts for blocked issues with and without explicit blockers
+- blocked issues still waiting on unresolved blockers
+- blocked issues whose blockers are all done and are therefore ready to unblock
+- `livenessFindings` from the issue-graph liveness classifier
+
+Use this route when the board looks blocked/stalled and you need to know whether the blocker graph is malformed or whether the next frontier is ready.
+
 ## Get Issue
 
 ```

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -30,6 +30,15 @@ export {
   createEmbeddedPostgresLogBuffer,
   formatEmbeddedPostgresError,
 } from "./embedded-postgres-error.js";
+export {
+  isPidAlive,
+  parsePostmasterPidText,
+  readPidFilePort,
+  readPostmasterPidInfo,
+  readRunningPostmasterPid,
+  reapStoppingPostmaster,
+  type PostmasterPidInfo,
+} from "./postmaster-pid.js";
 export { issueRelations } from "./schema/issue_relations.js";
 export { issueReferenceMentions } from "./schema/issue_reference_mentions.js";
 export * from "./schema/index.js";

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -1,8 +1,9 @@
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
 import path from "node:path";
 import { ensurePostgresDatabase, getPostgresDataDirectory } from "./client.js";
 import { createEmbeddedPostgresLogBuffer, formatEmbeddedPostgresError } from "./embedded-postgres-error.js";
+import { readPidFilePort, readRunningPostmasterPid, reapStoppingPostmaster } from "./postmaster-pid.js";
 import { resolveDatabaseTarget } from "./runtime-config.js";
 
 type EmbeddedPostgresInstance = {
@@ -28,28 +29,6 @@ export type MigrationConnection = {
   stop: () => Promise<void>;
 };
 
-function readRunningPostmasterPid(postmasterPidFile: string): number | null {
-  if (!existsSync(postmasterPidFile)) return null;
-  try {
-    const pid = Number(readFileSync(postmasterPidFile, "utf8").split("\n")[0]?.trim());
-    if (!Number.isInteger(pid) || pid <= 0) return null;
-    process.kill(pid, 0);
-    return pid;
-  } catch {
-    return null;
-  }
-}
-
-function readPidFilePort(postmasterPidFile: string): number | null {
-  if (!existsSync(postmasterPidFile)) return null;
-  try {
-    const lines = readFileSync(postmasterPidFile, "utf8").split("\n");
-    const port = Number(lines[3]?.trim());
-    return Number.isInteger(port) && port > 0 ? port : null;
-  } catch {
-    return null;
-  }
-}
 
 async function isPortInUse(port: number): Promise<boolean> {
   return await new Promise((resolve) => {
@@ -92,9 +71,9 @@ async function ensureEmbeddedPostgresConnection(
   preferredPort: number,
 ): Promise<MigrationConnection> {
   const EmbeddedPostgres = await loadEmbeddedPostgresCtor();
-  const selectedPort = await findAvailablePort(preferredPort);
   const postmasterPidFile = path.resolve(dataDir, "postmaster.pid");
   const pgVersionFile = path.resolve(dataDir, "PG_VERSION");
+  await reapStoppingPostmaster(postmasterPidFile);
   const runningPid = readRunningPostmasterPid(postmasterPidFile);
   const runningPort = readPidFilePort(postmasterPidFile);
   const preferredAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${preferredPort}/postgres`;
@@ -134,6 +113,7 @@ async function ensureEmbeddedPostgresConnection(
     };
   }
 
+  const selectedPort = await findAvailablePort(preferredPort);
   const instance = new EmbeddedPostgres({
     databaseDir: dataDir,
     user: "paperclip",

--- a/packages/db/src/postmaster-pid.test.ts
+++ b/packages/db/src/postmaster-pid.test.ts
@@ -1,0 +1,107 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parsePostmasterPidText, readRunningPostmasterPid, reapStoppingPostmaster } from "./postmaster-pid.js";
+
+const ORIGINAL_KILL = process.kill;
+
+afterEach(() => {
+  process.kill = ORIGINAL_KILL;
+  vi.restoreAllMocks();
+});
+
+function makePidFile(body: string) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "paperclip-postmaster-pid-"));
+  const file = path.join(dir, "postmaster.pid");
+  writeFileSync(file, body, "utf8");
+  return { dir, file };
+}
+
+describe("postmaster pid helpers", () => {
+  it("parses status and stopping state from postmaster.pid text", () => {
+    const info = parsePostmasterPidText([
+      "30029",
+      "/tmp/db",
+      "1776932567",
+      "54329",
+      "/tmp",
+      "localhost",
+      " 32167972    983041",
+      "stopping",
+      "",
+    ].join("\n"));
+
+    expect(info).toEqual({
+      pid: 30029,
+      port: 54329,
+      status: "stopping",
+      isStopping: true,
+    });
+  });
+
+  it("does not treat a stopping postmaster as reusable even if the pid is still alive", () => {
+    const { dir, file } = makePidFile([
+      "30029",
+      "/tmp/db",
+      "1776932567",
+      "54329",
+      "/tmp",
+      "localhost",
+      " 32167972    983041",
+      "stopping",
+      "",
+    ].join("\n"));
+    process.kill = vi.fn((pid: number, signal?: number | NodeJS.Signals) => {
+      if (pid !== 30029 || signal !== 0) {
+        throw new Error(`unexpected signal ${String(signal)} for pid ${pid}`);
+      }
+      return true;
+    }) as typeof process.kill;
+
+    expect(readRunningPostmasterPid(file)).toBeNull();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("force-kills and removes a stuck stopping postmaster pid file", async () => {
+    const { dir, file } = makePidFile([
+      "30029",
+      "/tmp/db",
+      "1776932567",
+      "54329",
+      "/tmp",
+      "localhost",
+      " 32167972    983041",
+      "stopping",
+      "",
+    ].join("\n"));
+    let alive = true;
+    const signals: Array<number | NodeJS.Signals | undefined> = [];
+    process.kill = vi.fn((pid: number, signal?: number | NodeJS.Signals) => {
+      if (pid !== 30029) {
+        throw new Error(`unexpected pid ${pid}`);
+      }
+      signals.push(signal);
+      if (signal === 0) {
+        if (!alive) {
+          const err = new Error("not running") as NodeJS.ErrnoException;
+          err.code = "ESRCH";
+          throw err;
+        }
+        return true;
+      }
+      if (signal === "SIGKILL") {
+        alive = false;
+        return true;
+      }
+      throw new Error(`unexpected signal ${String(signal)}`);
+    }) as typeof process.kill;
+
+    const result = await reapStoppingPostmaster(file, { gracePeriodMs: 1, pollMs: 1 });
+
+    expect(result).toMatchObject({ reaped: true, forceKilled: true, pid: 30029, status: "stopping" });
+    expect(existsSync(file)).toBe(false);
+    expect(signals).toContain("SIGKILL");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/db/src/postmaster-pid.ts
+++ b/packages/db/src/postmaster-pid.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
+
+export type PostmasterPidInfo = {
+  pid: number | null;
+  port: number | null;
+  status: string | null;
+  isStopping: boolean;
+};
+
+export function parsePostmasterPidText(text: string): PostmasterPidInfo {
+  const lines = text.split("\n");
+  const pid = Number(lines[0]?.trim());
+  const port = Number(lines[3]?.trim());
+  const rawStatus = lines[7]?.trim() ?? "";
+  const status = rawStatus.length > 0 ? rawStatus : null;
+  return {
+    pid: Number.isInteger(pid) && pid > 0 ? pid : null,
+    port: Number.isInteger(port) && port > 0 ? port : null,
+    status,
+    isStopping: status?.toLowerCase().startsWith("stopping") ?? false,
+  };
+}
+
+export function readPostmasterPidInfo(postmasterPidFile: string): PostmasterPidInfo | null {
+  if (!existsSync(postmasterPidFile)) return null;
+  try {
+    return parsePostmasterPidText(readFileSync(postmasterPidFile, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function isPidAlive(pid: number | null | undefined): boolean {
+  if (pid == null || !Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function readPidFilePort(postmasterPidFile: string): number | null {
+  return readPostmasterPidInfo(postmasterPidFile)?.port ?? null;
+}
+
+export function readRunningPostmasterPid(postmasterPidFile: string): number | null {
+  const info = readPostmasterPidInfo(postmasterPidFile);
+  if (!info?.pid || info.isStopping || !isPidAlive(info.pid)) return null;
+  return info.pid;
+}
+
+async function waitForPidExit(pid: number, timeoutMs: number, pollMs: number): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) return true;
+    await delay(Math.max(1, pollMs));
+  }
+  return !isPidAlive(pid);
+}
+
+export async function reapStoppingPostmaster(
+  postmasterPidFile: string,
+  opts: {
+    gracePeriodMs?: number;
+    pollMs?: number;
+  } = {},
+): Promise<{ reaped: boolean; forceKilled: boolean; pid: number | null; status: string | null }> {
+  const info = readPostmasterPidInfo(postmasterPidFile);
+  if (!info?.pid) {
+    return { reaped: false, forceKilled: false, pid: null, status: info?.status ?? null };
+  }
+  if (!info.isStopping) {
+    if (!isPidAlive(info.pid) && existsSync(postmasterPidFile)) {
+      rmSync(postmasterPidFile, { force: true });
+    }
+    return { reaped: false, forceKilled: false, pid: info.pid, status: info.status };
+  }
+  let forceKilled = false;
+  if (!(await waitForPidExit(info.pid, opts.gracePeriodMs ?? 1_500, opts.pollMs ?? 100))) {
+    try {
+      process.kill(info.pid, "SIGKILL");
+      forceKilled = true;
+    } catch {
+      // Ignore already-exited or permission errors; final state check below decides the result.
+    }
+  }
+  const reaped = await waitForPidExit(info.pid, opts.pollMs ?? 100, opts.pollMs ?? 100);
+  if (reaped && existsSync(postmasterPidFile)) {
+    rmSync(postmasterPidFile, { force: true });
+  }
+  return {
+    reaped,
+    forceKilled,
+    pid: info.pid,
+    status: info.status,
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -312,6 +312,8 @@ export type {
   IssueRelatedWorkSummary,
   IssueRelation,
   IssueRelationIssueSummary,
+  IssueDependencySummary,
+  IssueGraphState,
   IssueExecutionPolicy,
   IssueExecutionState,
   IssueExecutionStage,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -108,6 +108,8 @@ export type {
   IssueRelatedWorkSummary,
   IssueRelation,
   IssueRelationIssueSummary,
+  IssueDependencySummary,
+  IssueGraphState,
   IssueExecutionPolicy,
   IssueExecutionState,
   IssueExecutionStage,

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -127,6 +127,21 @@ export interface IssueRelation {
   relatedIssue: IssueRelationIssueSummary;
 }
 
+export interface IssueDependencySummary {
+  issueId: string;
+  blockerIssueIds: string[];
+  unresolvedBlockerIssueIds: string[];
+  unresolvedBlockerCount: number;
+  allBlockersDone: boolean;
+  isDependencyReady: boolean;
+}
+
+export type IssueGraphState =
+  | "ready"
+  | "blocked_no_relations"
+  | "blocked_waiting_on_relations"
+  | "blocked_relations_resolved";
+
 export interface IssueReferenceSource {
   kind: IssueReferenceSourceKind;
   sourceRecordId: string | null;
@@ -237,6 +252,9 @@ export interface Issue {
   labels?: IssueLabel[];
   blockedBy?: IssueRelationIssueSummary[];
   blocks?: IssueRelationIssueSummary[];
+  blockedByIssueIds?: string[];
+  dependency?: IssueDependencySummary;
+  graphState?: IssueGraphState;
   relatedWork?: IssueRelatedWorkSummary;
   referencedIssueIdentifiers?: string[];
   planDocument?: IssueDocument | null;

--- a/server/src/__tests__/default-agent-instructions.test.ts
+++ b/server/src/__tests__/default-agent-instructions.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  loadDefaultAgentInstructionsBundle,
+  resolveDefaultAgentInstructionsBundleRole,
+} from "../services/default-agent-instructions.js";
+
+describe("default agent instructions bundle", () => {
+  it("maps the ceo role to the ceo onboarding bundle", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("ceo")).toBe("ceo");
+    expect(resolveDefaultAgentInstructionsBundleRole("engineer")).toBe("default");
+  });
+
+  it("includes charter-driven execution rules for CEO agents", async () => {
+    const bundle = await loadDefaultAgentInstructionsBundle("ceo");
+
+    expect(bundle["AGENTS.md"]).toContain("Project Charter Protocol");
+    expect(bundle["AGENTS.md"]).toContain("Definition of Done");
+    expect(bundle["HEARTBEAT.md"]).toContain("Project Charter Audit");
+    expect(bundle["HEARTBEAT.md"]).toContain("Never self-assign unowned implementation work");
+  });
+});

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1312,4 +1312,193 @@ describe("heartbeat comment wake batching", () => {
       await gateway.close();
     }
   }, 20_000);
+
+  it("skips automation comment wakes for status-blocked issues without blocker edges", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const commentId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Blocked without explicit blocker graph",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      await db.insert(issueComments).values({
+        id: commentId,
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        authorUserId: null,
+        body: "Automated blocked-ticket bookkeeping comment.",
+      });
+
+      const run = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId,
+          source: "automation",
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "agent",
+        requestedByActorId: agentId,
+      });
+
+      expect(run).toBeNull();
+      expect(gateway.getAgentPayloads()).toHaveLength(0);
+
+      const wakeups = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.agentId, agentId)));
+
+      expect(wakeups).toHaveLength(1);
+      expect(wakeups[0]).toMatchObject({
+        status: "skipped",
+        reason: "issue_status_blocked",
+      });
+      expect(wakeups[0]?.payload).toMatchObject({ issueId, commentId });
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 20_000);
+
+  it("allows user comment wakes for status-blocked issues without blocker edges", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const commentId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Blocked but asking for clarification",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      await db.insert(issueComments).values({
+        id: commentId,
+        companyId,
+        issueId,
+        authorUserId: "user-1",
+        body: "Please explain what is still blocked and what input you need.",
+      });
+
+      const run = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId,
+          source: "automation",
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+
+      expect(run).not.toBeNull();
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      const payloads = gateway.getAgentPayloads();
+      const firstPayload = payloads[0] ?? {};
+      expect(firstPayload.paperclip).toMatchObject({
+        wake: {
+          reason: "issue_commented",
+          issue: {
+            id: issueId,
+            status: "in_progress",
+          },
+          checkedOutByHarness: true,
+          commentIds: [commentId],
+        },
+      });
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 20_000);
 });

--- a/server/src/__tests__/heartbeat-queued-wake-hygiene.test.ts
+++ b/server/src/__tests__/heartbeat-queued-wake-hygiene.test.ts
@@ -1,0 +1,234 @@
+import { randomUUID } from "node:crypto";
+import { and, asc, eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agentWakeupRequests,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "Queued wake hygiene test run.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function ensureIssueRelationsTable(db: ReturnType<typeof createDb>) {
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS "issue_relations" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "company_id" uuid NOT NULL,
+      "issue_id" uuid NOT NULL,
+      "related_issue_id" uuid NOT NULL,
+      "type" text NOT NULL,
+      "created_by_agent_id" uuid,
+      "created_by_user_id" text,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "updated_at" timestamptz NOT NULL DEFAULT now()
+    );
+  `));
+}
+
+describeEmbeddedPostgres("heartbeat queued wake hygiene", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-queued-hygiene-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agents);
+    await db.delete(companies);
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompanyAndAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  async function insertQueuedWake(input: {
+    companyId: string;
+    agentId: string;
+    issueId: string;
+    requestStatus?: "queued" | "deferred_issue_execution";
+    requestedAt?: Date;
+    requestedByActorType?: string | null;
+    withRun?: boolean;
+  }) {
+    const wakeupRequestId = randomUUID();
+    const runId = input.withRun === false ? null : randomUUID();
+    const now = input.requestedAt ?? new Date();
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: input.issueId },
+      status: input.requestStatus ?? "queued",
+      requestedByActorType: input.requestedByActorType ?? "agent",
+      requestedByActorId: input.requestedByActorType ? "actor-1" : input.agentId,
+      runId,
+      requestedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+    if (runId) {
+      await db.insert(heartbeatRuns).values({
+        id: runId,
+        companyId: input.companyId,
+        agentId: input.agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "queued",
+        wakeupRequestId,
+        contextSnapshot: { issueId: input.issueId },
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+    return { wakeupRequestId, runId };
+  }
+
+  it("cancels queued runs whose issues are still dependency-blocked", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const blockerId = randomUUID();
+    const blockedIssueId = randomUUID();
+    await db.insert(issues).values([
+      { id: blockerId, companyId, title: "Blocker", status: "todo", priority: "medium" },
+      { id: blockedIssueId, companyId, title: "Blocked issue", status: "todo", priority: "medium", assigneeAgentId: agentId },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+    const seeded = await insertQueuedWake({ companyId, agentId, issueId: blockedIssueId });
+
+    const result = await (heartbeat as any).reconcileQueuedIssueWakeEligibility();
+
+    expect(result.cancelledDependencyBlocked).toBe(1);
+    const wake = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.id, seeded.wakeupRequestId)).then((rows) => rows[0]);
+    expect(wake).toMatchObject({ status: "skipped", reason: "issue_dependencies_blocked" });
+    const run = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, seeded.runId!)).then((rows) => rows[0]);
+    expect(run).toMatchObject({ status: "cancelled", errorCode: "issue_dependencies_blocked" });
+  });
+
+  it("cancels blocked-without-edges and terminal pending wakes", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const blockedIssueId = randomUUID();
+    const doneIssueId = randomUUID();
+    await db.insert(issues).values([
+      { id: blockedIssueId, companyId, title: "Blocked no edges", status: "blocked", priority: "medium", assigneeAgentId: agentId },
+      { id: doneIssueId, companyId, title: "Done issue", status: "done", priority: "medium", assigneeAgentId: agentId },
+    ]);
+    const blockedWake = await insertQueuedWake({ companyId, agentId, issueId: blockedIssueId });
+    const doneWake = await insertQueuedWake({ companyId, agentId, issueId: doneIssueId, requestStatus: "deferred_issue_execution", withRun: false });
+
+    const result = await (heartbeat as any).reconcileQueuedIssueWakeEligibility();
+
+    expect(result.cancelledBlockedStatus).toBe(1);
+    expect(result.cancelledTerminal).toBe(1);
+
+    const wakes = await db
+      .select({ id: agentWakeupRequests.id, status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.agentId, agentId)))
+      .orderBy(asc(agentWakeupRequests.requestedAt));
+    expect(wakes).toEqual([
+      expect.objectContaining({ id: blockedWake.wakeupRequestId, status: "skipped", reason: "issue_status_blocked" }),
+      expect.objectContaining({ id: doneWake.wakeupRequestId, status: "skipped", reason: "issue_terminal" }),
+    ]);
+  });
+
+  it("cancels duplicate queued wakes for the same agent and issue while preserving the earliest request", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({ id: issueId, companyId, title: "Duplicate target", status: "todo", priority: "medium", assigneeAgentId: agentId });
+    const first = await insertQueuedWake({ companyId, agentId, issueId, requestedAt: new Date("2026-04-24T10:00:00Z") });
+    const second = await insertQueuedWake({ companyId, agentId, issueId, requestedAt: new Date("2026-04-24T10:01:00Z") });
+
+    const result = await (heartbeat as any).reconcileQueuedIssueWakeEligibility();
+
+    expect(result.cancelledDuplicateQueued).toBe(1);
+    const wakes = await db
+      .select({ id: agentWakeupRequests.id, status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.agentId, agentId)))
+      .orderBy(asc(agentWakeupRequests.requestedAt));
+    expect(wakes).toEqual([
+      expect.objectContaining({ id: first.wakeupRequestId, status: "queued", reason: "issue_assigned" }),
+      expect.objectContaining({ id: second.wakeupRequestId, status: "skipped", reason: "issue_duplicate_queued" }),
+    ]);
+    const duplicateRun = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, second.runId!)).then((rows) => rows[0]);
+    expect(duplicateRun).toMatchObject({ status: "cancelled", errorCode: "issue_duplicate_queued" });
+  });
+});

--- a/server/src/__tests__/issue-graph-health-routes.test.ts
+++ b/server/src/__tests__/issue-graph-health-routes.test.ts
@@ -1,0 +1,142 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(async () => null),
+  getAncestors: vi.fn(async () => []),
+  getComment: vi.fn(async () => null),
+  getCommentCursor: vi.fn(async () => ({ totalComments: 0, latestCommentId: null, latestCommentAt: null })),
+  getRelationSummaries: vi.fn(async () => ({ blockedBy: [], blocks: [] })),
+  getCompanyGraphHealth: vi.fn(),
+  findMentionedAgents: vi.fn(async () => []),
+  listWakeableBlockedDependents: vi.fn(async () => []),
+  getWakeableParentAfterChildCompletion: vi.fn(async () => null),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(),
+  reportRunActivity: vi.fn(async () => undefined),
+  listIssueGraphLivenessFindings: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({ canUser: vi.fn(), hasPermission: vi.fn() }),
+  agentService: () => ({ getById: vi.fn() }),
+  documentService: () => ({ getIssueDocumentPayload: vi.fn(async () => ({})) }),
+  executionWorkspaceService: () => ({ getById: vi.fn() }),
+  feedbackService: () => ({}),
+  goalService: () => ({ getById: vi.fn(), getDefaultCompanyGoal: vi.fn() }),
+  heartbeatService: () => mockHeartbeatService,
+  instanceSettingsService: () => ({ get: vi.fn(), listCompanyIds: vi.fn() }),
+  issueApprovalService: () => ({}),
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({ addedReferencedIssues: [], removedReferencedIssues: [], currentReferencedIssues: [] }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({ getById: vi.fn(), listByIds: vi.fn(async () => []) }),
+  routineService: () => ({ syncRunStatusForIssue: vi.fn(async () => undefined) }),
+  workProductService: () => ({ listForIssue: vi.fn(async () => []) }),
+  ISSUE_LIST_DEFAULT_LIMIT: 500,
+  ISSUE_LIST_MAX_LIMIT: 1000,
+  clampIssueListLimit: (limit: number) => limit,
+}));
+
+async function createApp() {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue graph health route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.resetAllMocks();
+  });
+
+  it("returns company graph health plus current liveness findings", async () => {
+    mockIssueService.getCompanyGraphHealth.mockResolvedValue({
+      summary: {
+        blockedIssues: 3,
+        blockedWithoutExplicitBlockers: 1,
+        blockedWithUnresolvedBlockers: 1,
+        blockedReadyToUnblock: 1,
+        frontierReadyIssues: 1,
+      },
+      blockedWithoutExplicitBlockers: [{ issueId: "issue-1", title: "Blocked without edges", graphState: "blocked_no_relations" }],
+      blockedWithUnresolvedBlockers: [{ issueId: "issue-2", title: "Blocked waiting", graphState: "blocked_waiting_on_relations" }],
+      blockedReadyToUnblock: [{ issueId: "issue-3", title: "Blocked but ready", graphState: "blocked_relations_resolved" }],
+      frontierReady: [{ issueId: "issue-3", title: "Blocked but ready", graphState: "blocked_relations_resolved" }],
+    });
+    mockHeartbeatService.listIssueGraphLivenessFindings.mockResolvedValue([
+      {
+        issueId: "issue-2",
+        companyId: "company-1",
+        identifier: "PAP-2",
+        state: "blocked_by_unassigned_issue",
+        severity: "critical",
+        reason: "PAP-2 is blocked by unassigned issue PAP-3.",
+        dependencyPath: [],
+        recommendedOwnerAgentId: "agent-9",
+        recommendedOwnerCandidateAgentIds: ["agent-9"],
+        recommendedAction: "Assign the blocker.",
+        incidentKey: "harness_liveness:company-1:issue-2:blocked_by_unassigned_issue:issue-3",
+      },
+    ]);
+
+    const res = await request(await createApp()).get("/api/companies/company-1/issues/graph-health");
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.getCompanyGraphHealth).toHaveBeenCalledWith("company-1");
+    expect(mockHeartbeatService.listIssueGraphLivenessFindings).toHaveBeenCalledWith({ companyId: "company-1" });
+    expect(res.body).toMatchObject({
+      companyId: "company-1",
+      summary: {
+        blockedIssues: 3,
+        blockedWithoutExplicitBlockers: 1,
+        blockedWithUnresolvedBlockers: 1,
+        blockedReadyToUnblock: 1,
+        frontierReadyIssues: 1,
+        livenessFindings: 1,
+      },
+      blockedWithoutExplicitBlockers: [{ issueId: "issue-1" }],
+      blockedWithUnresolvedBlockers: [{ issueId: "issue-2" }],
+      blockedReadyToUnblock: [{ issueId: "issue-3" }],
+      frontierReady: [{ issueId: "issue-3" }],
+      livenessFindings: [
+        expect.objectContaining({
+          issueId: "issue-2",
+          state: "blocked_by_unassigned_issue",
+        }),
+      ],
+    });
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2012,3 +2012,150 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     expect(row).toEqual({ executionRunId: null, executionLockedAt: null });
   });
 });
+
+describeEmbeddedPostgres("issueService graph health and dependency metadata", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-graph-health-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("enriches listed issues with blocker summaries and dependency graph state", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const blockedWithoutEdgesId = randomUUID();
+    const unresolvedBlockerId = randomUUID();
+    const blockedWaitingId = randomUUID();
+    const resolvedBlockerId = randomUUID();
+    const blockedReadyId = randomUUID();
+    await db.insert(issues).values([
+      { id: blockedWithoutEdgesId, companyId, title: "Blocked without edges", status: "blocked", priority: "medium" },
+      { id: unresolvedBlockerId, companyId, title: "Unresolved blocker", status: "todo", priority: "medium" },
+      { id: blockedWaitingId, companyId, title: "Blocked waiting", status: "blocked", priority: "medium" },
+      { id: resolvedBlockerId, companyId, title: "Resolved blocker", status: "done", priority: "medium" },
+      { id: blockedReadyId, companyId, title: "Blocked but ready", status: "blocked", priority: "medium" },
+    ]);
+
+    await svc.update(blockedWaitingId, { blockedByIssueIds: [unresolvedBlockerId] });
+    await svc.update(blockedReadyId, { blockedByIssueIds: [resolvedBlockerId] });
+
+    const listed = await svc.list(companyId);
+    const byId = new Map(listed.map((issue) => [issue.id, issue]));
+
+    expect(byId.get(blockedWithoutEdgesId)).toMatchObject({
+      blockedBy: [],
+      blockedByIssueIds: [],
+      dependency: {
+        blockerIssueIds: [],
+        unresolvedBlockerIssueIds: [],
+        unresolvedBlockerCount: 0,
+        allBlockersDone: true,
+        isDependencyReady: true,
+      },
+      graphState: "blocked_no_relations",
+    });
+
+    expect(byId.get(blockedWaitingId)).toMatchObject({
+      blockedBy: [expect.objectContaining({ id: unresolvedBlockerId, title: "Unresolved blocker" })],
+      blockedByIssueIds: [unresolvedBlockerId],
+      dependency: {
+        blockerIssueIds: [unresolvedBlockerId],
+        unresolvedBlockerIssueIds: [unresolvedBlockerId],
+        unresolvedBlockerCount: 1,
+        allBlockersDone: false,
+        isDependencyReady: false,
+      },
+      graphState: "blocked_waiting_on_relations",
+    });
+
+    expect(byId.get(blockedReadyId)).toMatchObject({
+      blockedBy: [expect.objectContaining({ id: resolvedBlockerId, title: "Resolved blocker" })],
+      blockedByIssueIds: [resolvedBlockerId],
+      dependency: {
+        blockerIssueIds: [resolvedBlockerId],
+        unresolvedBlockerIssueIds: [],
+        unresolvedBlockerCount: 0,
+        allBlockersDone: true,
+        isDependencyReady: true,
+      },
+      graphState: "blocked_relations_resolved",
+    });
+
+    await expect(svc.getById(blockedReadyId)).resolves.toMatchObject({
+      id: blockedReadyId,
+      blockedByIssueIds: [resolvedBlockerId],
+      graphState: "blocked_relations_resolved",
+    });
+  });
+
+  it("reports company graph health for malformed, unresolved, and frontier-ready blocked issues", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const blockedWithoutEdgesId = randomUUID();
+    const unresolvedBlockerId = randomUUID();
+    const blockedWaitingId = randomUUID();
+    const resolvedBlockerId = randomUUID();
+    const blockedReadyId = randomUUID();
+    await db.insert(issues).values([
+      { id: blockedWithoutEdgesId, companyId, title: "Blocked without edges", status: "blocked", priority: "medium" },
+      { id: unresolvedBlockerId, companyId, title: "Unresolved blocker", status: "todo", priority: "medium" },
+      { id: blockedWaitingId, companyId, title: "Blocked waiting", status: "blocked", priority: "medium" },
+      { id: resolvedBlockerId, companyId, title: "Resolved blocker", status: "done", priority: "medium" },
+      { id: blockedReadyId, companyId, title: "Blocked but ready", status: "blocked", priority: "medium" },
+    ]);
+
+    await svc.update(blockedWaitingId, { blockedByIssueIds: [unresolvedBlockerId] });
+    await svc.update(blockedReadyId, { blockedByIssueIds: [resolvedBlockerId] });
+
+    await expect(svc.getCompanyGraphHealth(companyId)).resolves.toMatchObject({
+      summary: {
+        blockedIssues: 3,
+        blockedWithoutExplicitBlockers: 1,
+        blockedWithUnresolvedBlockers: 1,
+        blockedReadyToUnblock: 1,
+        frontierReadyIssues: 1,
+      },
+      blockedWithoutExplicitBlockers: [expect.objectContaining({ issueId: blockedWithoutEdgesId, graphState: "blocked_no_relations" })],
+      blockedWithUnresolvedBlockers: [expect.objectContaining({ issueId: blockedWaitingId, graphState: "blocked_waiting_on_relations" })],
+      blockedReadyToUnblock: [expect.objectContaining({ issueId: blockedReadyId, graphState: "blocked_relations_resolved" })],
+      frontierReady: [expect.objectContaining({ issueId: blockedReadyId, graphState: "blocked_relations_resolved" })],
+    });
+  });
+});

--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -26,6 +26,52 @@ You MUST delegate work rather than doing it yourself. When a task is assigned to
 - Approve or reject proposals from your reports
 - Hire new agents when the team needs capacity
 - Unblock your direct reports when they escalate to you
+- Own project completion as a CEO responsibility: charters, acceptance criteria, verification, and follow-through stay with you even when implementation is delegated
+
+## Project Charter Protocol (critical)
+
+Before you delegate implementation work for a new project, program, or major initiative, you MUST create or update a project charter.
+
+The charter is the canonical definition of what "done" means. Put it in the project workspace when one exists; otherwise attach the equivalent structure to the root issue/plan document.
+
+Every charter must include:
+
+1. **Goal** -- the project outcome in business terms, explicitly tied to the company goal.
+2. **Deliverables** -- a concrete list of outputs that must exist when the project is complete. Prefer file paths, API surfaces, dashboards, documents, or other inspectable artifacts.
+3. **Acceptance Criteria** -- testable checks for each deliverable. These must be specific enough that another agent can verify them.
+4. **Definition of Done** -- the project is done only when every deliverable exists, every acceptance criterion passes, and the required verifier has signed off.
+5. **Independent Verifier** -- the agent or board role that must confirm judgment-heavy work.
+6. **Audit Cadence** -- how the charter will be re-checked (heartbeat review, routine, or explicit milestone review).
+
+Do not treat implementation progress as project completion. Code written is not enough unless the charter's acceptance criteria and visible outputs are satisfied.
+
+## Issue Creation Rule
+
+Every issue you create for a project must anchor back to the charter.
+
+- Reference the specific deliverable or acceptance criterion it advances.
+- State the issue-level definition of done in concrete, verifiable terms.
+- Assign implementation to the appropriate report; do not keep engineering, design, or marketing execution on yourself.
+- Use subtasks and follow-up issues to cover every missing charter element. Gaps without tickets are your responsibility.
+
+## Issue Closing Rule
+
+No project issue should be accepted as done without evidence.
+
+- Require a closing update that cites the artifact, output path, API result, test output, or other verification evidence.
+- For judgment-heavy work, require the independent verifier's comment or sign-off.
+- If an issue was closed on implementation progress alone, reopen it or move it back to `in_review` with a concise explanation of the missing acceptance evidence.
+- If the charter itself is incomplete or outdated, fix the charter first, then re-plan the work.
+
+## Standing audit responsibility
+
+You are responsible for continuously auditing active projects against their charter.
+
+This means:
+- checking whether supposedly completed deliverables actually exist
+- creating follow-up issues for uncovered gaps
+- reopening falsely-complete work when verification fails
+- escalating to the board when the charter itself is ambiguous or needs a product decision
 
 ## Keeping work moving
 

--- a/server/src/onboarding-assets/ceo/HEARTBEAT.md
+++ b/server/src/onboarding-assets/ceo/HEARTBEAT.md
@@ -15,6 +15,22 @@ Run this checklist on every heartbeat. This covers both your local planning/memo
 4. If you're ahead, start on the next highest priority.
 5. Record progress updates in the daily notes.
 
+## 2.5 Project Charter Audit
+
+On every heartbeat, audit active projects before you settle into assignment-only execution.
+
+1. Identify each active project or project-root issue you are responsible for overseeing. This includes projects explicitly assigned to you, projects where you own the root issue, and recurring audits/routines already under your care.
+2. Ensure each one has a canonical charter. If it does not, create or delegate a charter task before more implementation work proceeds.
+3. For each charter deliverable and acceptance criterion:
+   - check whether the required artifact, endpoint, report, or decision actually exists
+   - verify any available evidence, tests, or reviewer sign-off
+4. If the work is incomplete or unverified:
+   - find the responsible issue
+   - if it was marked `done`, reopen it or move it back to `in_review` with evidence
+   - if no issue exists, create one and assign it to the right owner
+5. Ensure the project has recurring audit coverage. If the project needs ongoing completion checks, create or maintain a CEO routine/timer path so the charter gets revisited without waiting for a human reminder.
+6. Post one concise audit summary comment when you create, reopen, or materially reprioritize work because of the audit.
+
 ## 3. Approval Follow-Up
 
 If `PAPERCLIP_APPROVAL_ID` is set:
@@ -64,7 +80,7 @@ Status quick guide:
 ## 8. Exit
 
 - Comment on any in_progress work before exiting.
-- If no assignments and no valid mention-handoff, exit cleanly.
+- If no assignments, no audit actions, and no valid mention-handoff remain, exit cleanly.
 
 ---
 
@@ -74,7 +90,7 @@ Status quick guide:
 - Hiring: Spin up new agents when capacity is needed.
 - Unblocking: Escalate or resolve blockers for reports.
 - Budget awareness: Above 80% spend, focus only on critical tasks.
-- Never look for unassigned work -- only work on what is assigned to you.
+- Never self-assign unowned implementation work -- charter audits, reopening false-done work, and creating missing follow-up issues are core parts of your role.
 - Never cancel cross-team tasks -- reassign to the relevant manager with a comment.
 
 ## Rules
@@ -82,4 +98,5 @@ Status quick guide:
 - Always use the Paperclip skill for coordination.
 - Always include `X-Paperclip-Run-Id` header on mutating API calls.
 - Comment in concise markdown: status line + bullets + links.
+- When you audit or close work, cite the relevant charter element and the evidence you checked.
 - Self-assign via checkout only when explicitly @-mentioned.

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -829,6 +829,24 @@ export function issueRoutes(
     res.json(result);
   });
 
+  router.get("/companies/:companyId/issues/graph-health", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const [graphHealth, livenessFindings] = await Promise.all([
+      svc.getCompanyGraphHealth(companyId),
+      heartbeat.listIssueGraphLivenessFindings({ companyId }),
+    ]);
+    res.json({
+      companyId,
+      ...graphHealth,
+      summary: {
+        ...graphHealth.summary,
+        livenessFindings: livenessFindings.length,
+      },
+      livenessFindings,
+    });
+  });
+
   router.get("/companies/:companyId/labels", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -3115,7 +3133,7 @@ export function issueRoutes(
     let reopened = false;
     let reopenFromStatus: string | null = null;
     let interruptedRunId: string | null = null;
-    let currentIssue = issue;
+    let currentIssue: any = issue;
     const commentReferenceSummaryBefore = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
 
     if (effectiveMoveToTodoRequested && (isClosed || (isBlocked && !hasUnresolvedFirstClassBlockers))) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7437,6 +7437,11 @@ export function heartbeatService(db: Db) {
 
     reconcileIssueGraphLiveness,
 
+    listIssueGraphLivenessFindings: async (opts?: { companyId?: string }) => {
+      const findings = await collectIssueGraphLivenessFindings();
+      return opts?.companyId ? findings.filter((finding) => finding.companyId === opts.companyId) : findings;
+    },
+
     tickTimers: async (now = new Date()) => {
       const allAgents = await db.select().from(agents);
       let checked = 0;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1266,9 +1266,10 @@ function allowsBlockedIssueInteractionWake(
   if (!deriveCommentId(contextSnapshot, null)) return false;
 
   // Blocked issue interaction wakes are intentionally reserved for human
-  // clarification/triage comments. Automation or agent bookkeeping comments
-  // must not turn blocked tickets into implementation runs.
-  return opts?.requestedByActorType === "user";
+  // clarification/triage comments. When actor attribution is missing, preserve
+  // the historical default of allowing the comment wake rather than silently
+  // dropping it; explicit agent/system actors remain disallowed.
+  return !opts?.requestedByActorType || opts.requestedByActorType === "user";
 }
 
 async function listUnresolvedBlockerSummaries(
@@ -3493,7 +3494,7 @@ export function heartbeatService(db: Db) {
       return null;
     }
 
-    const context = parseObject(run.contextSnapshot);
+    let context = parseObject(run.contextSnapshot);
     const budgetBlock = await budgets.getInvocationBlock(run.companyId, run.agentId, {
       issueId: readNonEmptyString(context.issueId),
       projectId: readNonEmptyString(context.projectId),
@@ -3505,11 +3506,65 @@ export function heartbeatService(db: Db) {
 
     const issueId = readNonEmptyString(context.issueId);
     if (issueId) {
-      const dependencyReadiness = await issuesSvc.listDependencyReadiness(run.companyId, [issueId]);
-      const unresolvedBlockerCount = dependencyReadiness.get(issueId)?.unresolvedBlockerCount ?? 0;
-      if (unresolvedBlockerCount > 0 && !allowsBlockedIssueInteractionWake(context)) {
-        logger.debug({ runId: run.id, issueId, unresolvedBlockerCount }, "claimQueuedRun: skipping blocked run");
+      const wakeupRequest = run.wakeupRequestId
+        ? await db
+          .select({
+            id: agentWakeupRequests.id,
+            payload: agentWakeupRequests.payload,
+            requestedByActorType: agentWakeupRequests.requestedByActorType,
+          })
+          .from(agentWakeupRequests)
+          .where(eq(agentWakeupRequests.id, run.wakeupRequestId))
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+        : null;
+      const issue = await db
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          status: issues.status,
+        })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      const decision = await evaluateIssueWakeEligibility({
+        dbOrTx: db,
+        issue,
+        contextSnapshot: context,
+        requestedByActorType: wakeupRequest?.requestedByActorType ?? null,
+      });
+      if (decision.kind !== "allowed") {
+        logger.debug({ runId: run.id, issueId, reason: decision.reason }, "claimQueuedRun: cancelling ineligible queued run");
+        if (wakeupRequest) {
+          await cancelPendingWakeRequestAndRun({
+            request: {
+              id: wakeupRequest.id,
+              runId: run.id,
+              payload: wakeupRequest.payload,
+            },
+            reason: decision.reason,
+            error: decision.error,
+            payloadPatch: decision.payloadPatch,
+          });
+        } else {
+          await setRunStatus(run.id, "cancelled", {
+            finishedAt: new Date(),
+            error: decision.error,
+            errorCode: decision.reason,
+          });
+        }
         return null;
+      }
+      if (JSON.stringify(decision.contextSnapshot) !== JSON.stringify(context)) {
+        context = decision.contextSnapshot;
+        await db
+          .update(heartbeatRuns)
+          .set({
+            contextSnapshot: context,
+            updatedAt: new Date(),
+          })
+          .where(eq(heartbeatRuns.id, run.id));
       }
     }
 
@@ -3939,7 +3994,157 @@ export function heartbeatService(db: Db) {
     return { reaped: reaped.length, runIds: reaped };
   }
 
+  async function reconcileQueuedIssueWakeEligibility() {
+    const pendingRequests = await db
+      .select({
+        id: agentWakeupRequests.id,
+        companyId: agentWakeupRequests.companyId,
+        agentId: agentWakeupRequests.agentId,
+        status: agentWakeupRequests.status,
+        payload: agentWakeupRequests.payload,
+        runId: agentWakeupRequests.runId,
+        requestedAt: agentWakeupRequests.requestedAt,
+        requestedByActorType: agentWakeupRequests.requestedByActorType,
+      })
+      .from(agentWakeupRequests)
+      .where(inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]))
+      .orderBy(asc(agentWakeupRequests.requestedAt), asc(agentWakeupRequests.createdAt));
+
+    const result = {
+      scanned: pendingRequests.length,
+      cancelledDependencyBlocked: 0,
+      cancelledBlockedStatus: 0,
+      cancelledTerminal: 0,
+      cancelledMissingIssue: 0,
+      cancelledDuplicateQueued: 0,
+      unchanged: 0,
+      wakeupRequestIds: [] as string[],
+    };
+    if (pendingRequests.length === 0) return result;
+
+    const runIds = pendingRequests
+      .map((request) => request.runId)
+      .filter((runId): runId is string => Boolean(runId));
+    const runRows = runIds.length === 0
+      ? []
+      : await db
+        .select({
+          id: heartbeatRuns.id,
+          status: heartbeatRuns.status,
+          contextSnapshot: heartbeatRuns.contextSnapshot,
+        })
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.id, runIds));
+    const runById = new Map(runRows.map((run) => [run.id, run]));
+
+    const refs = pendingRequests.map((request) => {
+      const run = request.runId ? runById.get(request.runId) ?? null : null;
+      const issueId = issueIdFromWakePayload(request.payload) ?? issueIdFromRunContext(run?.contextSnapshot);
+      return {
+        request,
+        run,
+        issueId,
+        contextSnapshot: contextSnapshotFromPendingWakeRequest(request, run),
+      };
+    });
+
+    const issueIds = [...new Set(refs.map((entry) => entry.issueId).filter((issueId): issueId is string => Boolean(issueId)))];
+    const issueRows = issueIds.length === 0
+      ? []
+      : await db
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          status: issues.status,
+        })
+        .from(issues)
+        .where(inArray(issues.id, issueIds));
+    const issueById = new Map(issueRows.map((issue) => [issue.id, issue]));
+
+    const activeExecutionRuns = await db
+      .select({
+        id: heartbeatRuns.id,
+        companyId: heartbeatRuns.companyId,
+        status: heartbeatRuns.status,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(inArray(heartbeatRuns.status, ["running", "scheduled_retry"]));
+    const activeExecutionRunByIssueKey = new Map<string, { id: string; companyId: string; status: string }>();
+    for (const run of activeExecutionRuns) {
+      const issueId = issueIdFromRunContext(run.contextSnapshot);
+      if (!issueId || !issueById.has(issueId)) continue;
+      activeExecutionRunByIssueKey.set(`${run.companyId}:${issueId}`, {
+        id: run.id,
+        companyId: run.companyId,
+        status: run.status,
+      });
+    }
+
+    const cancelledRequestIds = new Set<string>();
+    const queuedByAgentIssueKey = new Map<string, typeof refs>();
+    for (const ref of refs) {
+      if (ref.request.status !== "queued" || !ref.issueId) continue;
+      const key = `${ref.request.agentId}:${ref.issueId}`;
+      const group = queuedByAgentIssueKey.get(key) ?? [];
+      group.push(ref);
+      queuedByAgentIssueKey.set(key, group);
+    }
+    for (const group of queuedByAgentIssueKey.values()) {
+      if (group.length <= 1) continue;
+      group.sort((left, right) => left.request.requestedAt.getTime() - right.request.requestedAt.getTime());
+      for (const duplicate of group.slice(1)) {
+        await cancelPendingWakeRequestAndRun({
+          request: duplicate.request,
+          reason: "issue_duplicate_queued",
+          error: "Cancelled duplicate queued wake for the same agent and issue",
+          payloadPatch: duplicate.issueId ? { issueId: duplicate.issueId } : undefined,
+        });
+        cancelledRequestIds.add(duplicate.request.id);
+        result.cancelledDuplicateQueued += 1;
+        result.wakeupRequestIds.push(duplicate.request.id);
+      }
+    }
+
+    for (const ref of refs) {
+      if (cancelledRequestIds.has(ref.request.id)) continue;
+      if (!ref.issueId) {
+        result.unchanged += 1;
+        continue;
+      }
+      const issue = issueById.get(ref.issueId) ?? null;
+      const activeExecutionRun = issue
+        ? activeExecutionRunByIssueKey.get(`${issue.companyId}:${issue.id}`) ?? null
+        : null;
+      const decision = await evaluateIssueWakeEligibility({
+        dbOrTx: db,
+        issue,
+        contextSnapshot: ref.contextSnapshot,
+        requestedByActorType: ref.request.requestedByActorType,
+        activeExecutionRun,
+      });
+      if (decision.kind === "allowed") {
+        result.unchanged += 1;
+        continue;
+      }
+      await cancelPendingWakeRequestAndRun({
+        request: ref.request,
+        reason: decision.reason,
+        error: decision.error,
+        payloadPatch: decision.payloadPatch,
+      });
+      result.wakeupRequestIds.push(ref.request.id);
+      if (decision.reason === "issue_dependencies_blocked") result.cancelledDependencyBlocked += 1;
+      else if (decision.reason === "issue_status_blocked") result.cancelledBlockedStatus += 1;
+      else if (decision.reason === "issue_terminal") result.cancelledTerminal += 1;
+      else if (decision.reason === "issue_execution_issue_not_found") result.cancelledMissingIssue += 1;
+    }
+
+    return result;
+  }
+
   async function resumeQueuedRuns() {
+    await reconcileQueuedIssueWakeEligibility();
     const queuedRuns = await db
       .select({ agentId: heartbeatRuns.agentId })
       .from(heartbeatRuns)
@@ -4372,6 +4577,134 @@ export function heartbeatService(db: Db) {
     return readNonEmptyString(parsed.issueId) ??
       readNonEmptyString(nestedContext.issueId) ??
       readNonEmptyString(nestedContext.taskId);
+  }
+
+  function contextSnapshotFromPendingWakeRequest(request: { payload: unknown }, run?: { contextSnapshot: unknown } | null) {
+    if (run?.contextSnapshot) return parseObject(run.contextSnapshot);
+    const parsed = parseObject(request.payload);
+    const nestedContext = parseObject(parsed[DEFERRED_WAKE_CONTEXT_KEY]);
+    return Object.keys(nestedContext).length > 0 ? nestedContext : parsed;
+  }
+
+  async function evaluateIssueWakeEligibility(input: {
+    dbOrTx: any;
+    issue: { id: string; companyId: string; status: string } | null;
+    contextSnapshot: Record<string, unknown>;
+    requestedByActorType?: string | null;
+    activeExecutionRun?: unknown;
+  }) {
+    if (!input.issue) {
+      return {
+        kind: "skipped" as const,
+        reason: "issue_execution_issue_not_found",
+        error: "Cancelled because the issue no longer exists",
+        payloadPatch: {},
+        contextSnapshot: input.contextSnapshot,
+      };
+    }
+
+    const dependencyReadiness = await issuesSvc.listDependencyReadiness(
+      input.issue.companyId,
+      [input.issue.id],
+      input.dbOrTx,
+    ).then((rows) => rows.get(input.issue.id) ?? null);
+
+    const allowedBlockedInteractionWake = allowsBlockedIssueInteractionWake(input.contextSnapshot, {
+      requestedByActorType: input.requestedByActorType ?? null,
+    });
+    const blockedInteractionWake =
+      dependencyReadiness &&
+      !dependencyReadiness.isDependencyReady &&
+      allowedBlockedInteractionWake;
+
+    let nextContextSnapshot = input.contextSnapshot;
+    if (blockedInteractionWake) {
+      nextContextSnapshot = {
+        ...nextContextSnapshot,
+        dependencyBlockedInteraction: true,
+        unresolvedBlockerIssueIds: dependencyReadiness.unresolvedBlockerIssueIds,
+        unresolvedBlockerCount: dependencyReadiness.unresolvedBlockerCount,
+        unresolvedBlockerSummaries: await listUnresolvedBlockerSummaries(
+          input.dbOrTx,
+          input.issue.companyId,
+          input.issue.id,
+          dependencyReadiness.unresolvedBlockerIssueIds,
+        ),
+      };
+    }
+
+    if (!input.activeExecutionRun && (input.issue.status === "done" || input.issue.status === "cancelled")) {
+      return {
+        kind: "skipped" as const,
+        reason: "issue_terminal",
+        error: `Cancelled because issue ${input.issue.id} is ${input.issue.status}`,
+        payloadPatch: { issueId: input.issue.id, issueStatus: input.issue.status },
+        contextSnapshot: nextContextSnapshot,
+      };
+    }
+
+    if (!input.activeExecutionRun && dependencyReadiness && !dependencyReadiness.isDependencyReady && !blockedInteractionWake) {
+      return {
+        kind: "skipped" as const,
+        reason: "issue_dependencies_blocked",
+        error: `Cancelled because issue ${input.issue.id} still has unresolved blockers`,
+        payloadPatch: {
+          issueId: input.issue.id,
+          issueStatus: input.issue.status,
+          unresolvedBlockerIssueIds: dependencyReadiness.unresolvedBlockerIssueIds,
+        },
+        contextSnapshot: nextContextSnapshot,
+      };
+    }
+
+    if (!input.activeExecutionRun && input.issue.status === "blocked" && !allowedBlockedInteractionWake) {
+      return {
+        kind: "skipped" as const,
+        reason: "issue_status_blocked",
+        error: `Cancelled because issue ${input.issue.id} is blocked`,
+        payloadPatch: {
+          issueId: input.issue.id,
+          issueStatus: input.issue.status,
+          blockedStatusWithoutReadyWake: true,
+        },
+        contextSnapshot: nextContextSnapshot,
+      };
+    }
+
+    return {
+      kind: "allowed" as const,
+      contextSnapshot: nextContextSnapshot,
+      dependencyReadiness,
+    };
+  }
+
+  async function cancelPendingWakeRequestAndRun(input: {
+    request: {
+      id: string;
+      runId?: string | null;
+      payload: unknown;
+    };
+    reason: string;
+    error: string;
+    payloadPatch?: Record<string, unknown>;
+  }) {
+    const now = new Date();
+    if (input.request.runId) {
+      await setRunStatus(input.request.runId, "cancelled", {
+        finishedAt: now,
+        error: input.error,
+        errorCode: input.reason,
+      });
+    }
+    await setWakeupStatus(input.request.id, "skipped", {
+      finishedAt: now,
+      reason: input.reason,
+      error: input.error,
+      payload: {
+        ...parseObject(input.request.payload),
+        ...(input.payloadPatch ?? {}),
+      },
+    });
   }
 
   async function collectIssueGraphLivenessFindings() {
@@ -6584,67 +6917,26 @@ export function heartbeatService(db: Db) {
           }
         }
 
-        const dependencyReadiness = await issuesSvc.listDependencyReadiness(
-          issue.companyId,
-          [issue.id],
-          tx,
-        ).then((rows) => rows.get(issue.id) ?? null);
-        const allowedBlockedInteractionWake = allowsBlockedIssueInteractionWake(enrichedContextSnapshot, {
+        const eligibility = await evaluateIssueWakeEligibility({
+          dbOrTx: tx,
+          issue,
+          contextSnapshot: enrichedContextSnapshot,
           requestedByActorType: opts.requestedByActorType ?? null,
+          activeExecutionRun,
         });
+        Object.assign(enrichedContextSnapshot, eligibility.contextSnapshot);
 
-        // Blocked descendants should stay idle until the final blocker resolves.
-        // Human comment/mention wakes are the exception: they may run in a
-        // bounded interaction mode so the assignee can answer or triage.
-        const blockedInteractionWake =
-          dependencyReadiness &&
-          !dependencyReadiness.isDependencyReady &&
-          allowedBlockedInteractionWake;
-
-        if (blockedInteractionWake) {
-          enrichedContextSnapshot.dependencyBlockedInteraction = true;
-          enrichedContextSnapshot.unresolvedBlockerIssueIds = dependencyReadiness.unresolvedBlockerIssueIds;
-          enrichedContextSnapshot.unresolvedBlockerCount = dependencyReadiness.unresolvedBlockerCount;
-          enrichedContextSnapshot.unresolvedBlockerSummaries = await listUnresolvedBlockerSummaries(
-            tx,
-            issue.companyId,
-            issue.id,
-            dependencyReadiness.unresolvedBlockerIssueIds,
-          );
-        }
-
-        if (!activeExecutionRun && dependencyReadiness && !dependencyReadiness.isDependencyReady && !blockedInteractionWake) {
+        if (eligibility.kind === "skipped") {
           await tx.insert(agentWakeupRequests).values({
             companyId: agent.companyId,
             agentId,
             source,
             triggerDetail,
-            reason: "issue_dependencies_blocked",
+            reason: eligibility.reason,
             payload: {
               ...(payload ?? {}),
               issueId,
-              unresolvedBlockerIssueIds: dependencyReadiness.unresolvedBlockerIssueIds,
-            },
-            status: "skipped",
-            requestedByActorType: opts.requestedByActorType ?? null,
-            requestedByActorId: opts.requestedByActorId ?? null,
-            idempotencyKey: opts.idempotencyKey ?? null,
-            finishedAt: new Date(),
-          });
-          return { kind: "skipped" as const };
-        }
-
-        if (!activeExecutionRun && issue.status === "blocked" && !allowedBlockedInteractionWake) {
-          await tx.insert(agentWakeupRequests).values({
-            companyId: agent.companyId,
-            agentId,
-            source,
-            triggerDetail,
-            reason: "issue_status_blocked",
-            payload: {
-              ...(payload ?? {}),
-              issueId,
-              blockedStatusWithoutReadyWake: true,
+              ...(eligibility.payloadPatch ?? {}),
             },
             status: "skipped",
             requestedByActorType: opts.requestedByActorType ?? null,
@@ -7416,6 +7708,8 @@ export function heartbeatService(db: Db) {
     promoteDueScheduledRetries,
 
     resumeQueuedRuns,
+
+    reconcileQueuedIssueWakeEligibility,
 
     scheduleBoundedRetry: async (
       runId: string,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1259,10 +1259,16 @@ const BLOCKED_INTERACTION_WAKE_REASONS = new Set([
 
 function allowsBlockedIssueInteractionWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
+  opts?: { requestedByActorType?: string | null },
 ) {
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (!wakeReason || !BLOCKED_INTERACTION_WAKE_REASONS.has(wakeReason)) return false;
-  return Boolean(deriveCommentId(contextSnapshot, null));
+  if (!deriveCommentId(contextSnapshot, null)) return false;
+
+  // Blocked issue interaction wakes are intentionally reserved for human
+  // clarification/triage comments. Automation or agent bookkeeping comments
+  // must not turn blocked tickets into implementation runs.
+  return opts?.requestedByActorType === "user";
 }
 
 async function listUnresolvedBlockerSummaries(
@@ -6487,6 +6493,7 @@ export function heartbeatService(db: Db) {
           .select({
             id: issues.id,
             companyId: issues.companyId,
+            status: issues.status,
             executionRunId: issues.executionRunId,
             executionAgentNameKey: issues.executionAgentNameKey,
           })
@@ -6582,6 +6589,9 @@ export function heartbeatService(db: Db) {
           [issue.id],
           tx,
         ).then((rows) => rows.get(issue.id) ?? null);
+        const allowedBlockedInteractionWake = allowsBlockedIssueInteractionWake(enrichedContextSnapshot, {
+          requestedByActorType: opts.requestedByActorType ?? null,
+        });
 
         // Blocked descendants should stay idle until the final blocker resolves.
         // Human comment/mention wakes are the exception: they may run in a
@@ -6589,7 +6599,7 @@ export function heartbeatService(db: Db) {
         const blockedInteractionWake =
           dependencyReadiness &&
           !dependencyReadiness.isDependencyReady &&
-          allowsBlockedIssueInteractionWake(enrichedContextSnapshot);
+          allowedBlockedInteractionWake;
 
         if (blockedInteractionWake) {
           enrichedContextSnapshot.dependencyBlockedInteraction = true;
@@ -6614,6 +6624,27 @@ export function heartbeatService(db: Db) {
               ...(payload ?? {}),
               issueId,
               unresolvedBlockerIssueIds: dependencyReadiness.unresolvedBlockerIssueIds,
+            },
+            status: "skipped",
+            requestedByActorType: opts.requestedByActorType ?? null,
+            requestedByActorId: opts.requestedByActorId ?? null,
+            idempotencyKey: opts.idempotencyKey ?? null,
+            finishedAt: new Date(),
+          });
+          return { kind: "skipped" as const };
+        }
+
+        if (!activeExecutionRun && issue.status === "blocked" && !allowedBlockedInteractionWake) {
+          await tx.insert(agentWakeupRequests).values({
+            companyId: agent.companyId,
+            agentId,
+            source,
+            triggerDetail,
+            reason: "issue_status_blocked",
+            payload: {
+              ...(payload ?? {}),
+              issueId,
+              blockedStatusWithoutReadyWake: true,
             },
             status: "skipped",
             requestedByActorType: opts.requestedByActorType ?? null,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -223,6 +223,147 @@ function createIssueDependencyReadiness(issueId: string): IssueDependencyReadine
   };
 }
 
+function issueGraphStateFor(input: {
+  status: string;
+  readiness: IssueDependencyReadiness;
+}) {
+  if (input.status !== "blocked") return "ready" as const;
+  if (input.readiness.blockerIssueIds.length === 0) return "blocked_no_relations" as const;
+  if (input.readiness.unresolvedBlockerCount > 0) return "blocked_waiting_on_relations" as const;
+  return "blocked_relations_resolved" as const;
+}
+
+async function listIssueRelationSummaryMap(
+  dbOrTx: Pick<Db, "select">,
+  companyId: string,
+  issueIds: string[],
+): Promise<Map<string, IssueRelationSummaryMap>> {
+  const uniqueIssueIds = [...new Set(issueIds)];
+  const empty = new Map<string, IssueRelationSummaryMap>();
+  for (const issueId of uniqueIssueIds) {
+    empty.set(issueId, { blockedBy: [], blocks: [] });
+  }
+  if (uniqueIssueIds.length === 0) return empty;
+
+  const [blockedByRows, blockingRows] = await Promise.all([
+    dbOrTx
+      .select({
+        currentIssueId: issueRelations.relatedIssueId,
+        relatedId: issues.id,
+        identifier: issues.identifier,
+        title: issues.title,
+        status: issues.status,
+        priority: issues.priority,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+      })
+      .from(issueRelations)
+      .innerJoin(issues, eq(issueRelations.issueId, issues.id))
+      .where(
+        and(
+          eq(issueRelations.companyId, companyId),
+          eq(issueRelations.type, "blocks"),
+          inArray(issueRelations.relatedIssueId, uniqueIssueIds),
+        ),
+      ),
+    dbOrTx
+      .select({
+        currentIssueId: issueRelations.issueId,
+        relatedId: issues.id,
+        identifier: issues.identifier,
+        title: issues.title,
+        status: issues.status,
+        priority: issues.priority,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+      })
+      .from(issueRelations)
+      .innerJoin(issues, eq(issueRelations.relatedIssueId, issues.id))
+      .where(
+        and(
+          eq(issueRelations.companyId, companyId),
+          eq(issueRelations.type, "blocks"),
+          inArray(issueRelations.issueId, uniqueIssueIds),
+        ),
+      ),
+  ]);
+
+  for (const row of blockedByRows) {
+    empty.get(row.currentIssueId)?.blockedBy.push({
+      id: row.relatedId,
+      identifier: row.identifier,
+      title: row.title,
+      status: row.status as IssueRelationIssueSummary["status"],
+      priority: row.priority as IssueRelationIssueSummary["priority"],
+      assigneeAgentId: row.assigneeAgentId,
+      assigneeUserId: row.assigneeUserId,
+    });
+  }
+  for (const row of blockingRows) {
+    empty.get(row.currentIssueId)?.blocks.push({
+      id: row.relatedId,
+      identifier: row.identifier,
+      title: row.title,
+      status: row.status as IssueRelationIssueSummary["status"],
+      priority: row.priority as IssueRelationIssueSummary["priority"],
+      assigneeAgentId: row.assigneeAgentId,
+      assigneeUserId: row.assigneeUserId,
+    });
+  }
+
+  for (const relations of empty.values()) {
+    relations.blockedBy.sort((a, b) => a.title.localeCompare(b.title));
+    relations.blocks.sort((a, b) => a.title.localeCompare(b.title));
+  }
+
+  return empty;
+}
+
+async function enrichIssueGraphRows<T extends { id: string; companyId: string; status: string }>(
+  dbOrTx: Pick<Db, "select">,
+  rows: T[],
+) {
+  if (rows.length === 0) return [] as Array<T & {
+    blockedBy: IssueRelationIssueSummary[];
+    blocks: IssueRelationIssueSummary[];
+    blockedByIssueIds: string[];
+    dependency: IssueDependencyReadiness;
+    graphState: ReturnType<typeof issueGraphStateFor>;
+  }>;
+
+  const relationMap = new Map<string, IssueRelationSummaryMap>();
+  const readinessMap = new Map<string, IssueDependencyReadiness>();
+  const issueIdsByCompany = new Map<string, string[]>();
+
+  for (const row of rows) {
+    const existing = issueIdsByCompany.get(row.companyId) ?? [];
+    existing.push(row.id);
+    issueIdsByCompany.set(row.companyId, existing);
+  }
+
+  for (const [companyId, issueIds] of issueIdsByCompany) {
+    const [relations, readiness] = await Promise.all([
+      listIssueRelationSummaryMap(dbOrTx, companyId, issueIds),
+      listIssueDependencyReadinessMap(dbOrTx, companyId, issueIds),
+    ]);
+    for (const [issueId, summary] of relations) relationMap.set(issueId, summary);
+    for (const [issueId, summary] of readiness) readinessMap.set(issueId, summary);
+  }
+
+  return rows.map((row) => {
+    const relations = relationMap.get(row.id) ?? { blockedBy: [], blocks: [] };
+    const dependency = readinessMap.get(row.id) ?? createIssueDependencyReadiness(row.id);
+    return {
+      ...row,
+      blockedBy: relations.blockedBy,
+      blocks: relations.blocks,
+      blockedByIssueIds: relations.blockedBy.map((relation) => relation.id),
+      dependency,
+      graphState: issueGraphStateFor({ status: row.status, readiness: dependency }),
+    };
+  });
+}
+
 async function listIssueDependencyReadinessMap(
   dbOrTx: Pick<Db, "select">,
   companyId: string,
@@ -880,7 +1021,8 @@ export function issueService(db: Db) {
       .then((rows) => rows[0] ?? null);
     if (!row) return null;
     const [enriched] = await withIssueLabels(db, [row]);
-    return enriched;
+    const [withGraph] = await enrichIssueGraphRows(db, [enriched]);
+    return withGraph ?? enriched;
   }
 
   async function getIssueByIdentifier(identifier: string) {
@@ -891,7 +1033,8 @@ export function issueService(db: Db) {
       .then((rows) => rows[0] ?? null);
     if (!row) return null;
     const [enriched] = await withIssueLabels(db, [row]);
-    return enriched;
+    const [withGraph] = await enrichIssueGraphRows(db, [enriched]);
+    return withGraph ?? enriched;
   }
 
   function redactIssueComment<T extends { body: string }>(comment: T, censorUsernameInLogs: boolean): T {
@@ -1439,11 +1582,12 @@ export function issueService(db: Db) {
       const withLabels = await withIssueLabels(db, rows);
       const runMap = await activeRunMapForIssues(db, withLabels);
       const withRuns = withActiveRuns(withLabels, runMap);
-      if (withRuns.length === 0) {
-        return withRuns;
+      const withGraph = await enrichIssueGraphRows(db, withRuns);
+      if (withGraph.length === 0) {
+        return withGraph;
       }
 
-      const issueIds = withRuns.map((row) => row.id);
+      const issueIds = withGraph.map((row) => row.id);
       const [statsRows, readRows, lastActivityRows] = await Promise.all([
         contextUserId
           ? userCommentStatsForIssues(db, companyId, contextUserId, issueIds)
@@ -1457,7 +1601,7 @@ export function issueService(db: Db) {
       const lastActivityByIssueId = new Map(lastActivityRows.map((row) => [row.issueId, row]));
 
       if (!contextUserId) {
-        return withRuns.map((row) => {
+        return withGraph.map((row) => {
           const activity = lastActivityByIssueId.get(row.id);
           const lastActivityAt = latestIssueActivityAt(
             row.updatedAt,
@@ -1473,7 +1617,7 @@ export function issueService(db: Db) {
 
       const readByIssueId = new Map(readRows.map((row) => [row.issueId, row.myLastReadAt]));
 
-      return withRuns.map((row) => {
+      return withGraph.map((row) => {
         const activity = lastActivityByIssueId.get(row.id);
         const lastActivityAt = latestIssueActivityAt(
           row.updatedAt,
@@ -1624,6 +1768,53 @@ export function issueService(db: Db) {
 
     listDependencyReadiness: async (companyId: string, issueIds: string[], dbOrTx: any = db) => {
       return listIssueDependencyReadinessMap(dbOrTx, companyId, issueIds);
+    },
+
+    getCompanyGraphHealth: async (companyId: string) => {
+      const rows = await db
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          identifier: issues.identifier,
+          title: issues.title,
+          status: issues.status,
+          priority: issues.priority,
+          assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), isNull(issues.hiddenAt)));
+      const enriched = await enrichIssueGraphRows(db, rows);
+      const blockedIssues = enriched.filter((issue) => issue.status === "blocked");
+      const blockedWithoutExplicitBlockers = blockedIssues.filter((issue) => issue.graphState === "blocked_no_relations");
+      const blockedWithUnresolvedBlockers = blockedIssues.filter((issue) => issue.graphState === "blocked_waiting_on_relations");
+      const blockedReadyToUnblock = blockedIssues.filter((issue) => issue.graphState === "blocked_relations_resolved");
+      const toHealthEntry = (issue: any) => ({
+        issueId: issue.id,
+        identifier: issue.identifier,
+        title: issue.title,
+        status: issue.status,
+        priority: issue.priority,
+        assigneeAgentId: issue.assigneeAgentId,
+        assigneeUserId: issue.assigneeUserId,
+        blockedBy: issue.blockedBy,
+        blockedByIssueIds: issue.blockedByIssueIds,
+        dependency: issue.dependency,
+        graphState: issue.graphState,
+      });
+      return {
+        summary: {
+          blockedIssues: blockedIssues.length,
+          blockedWithoutExplicitBlockers: blockedWithoutExplicitBlockers.length,
+          blockedWithUnresolvedBlockers: blockedWithUnresolvedBlockers.length,
+          blockedReadyToUnblock: blockedReadyToUnblock.length,
+          frontierReadyIssues: blockedReadyToUnblock.length,
+        },
+        blockedWithoutExplicitBlockers: blockedWithoutExplicitBlockers.map(toHealthEntry),
+        blockedWithUnresolvedBlockers: blockedWithUnresolvedBlockers.map(toHealthEntry),
+        blockedReadyToUnblock: blockedReadyToUnblock.map(toHealthEntry),
+        frontierReady: blockedReadyToUnblock.map(toHealthEntry),
+      };
     },
 
     listWakeableBlockedDependents: async (blockerIssueId: string) => {


### PR DESCRIPTION
## Summary

This branch now contains a broader Paperclip control-plane hardening slice than the original CEO charter audit change alone.

Included work:
- strengthen CEO/project-control guidance and planning docs for charter-driven supervision
- recover embedded PostgreSQL cleanly when the local instance gets stuck in a stopping state
- add issue graph health diagnostics so malformed / unowned blocker state is visible through the product surface
- tighten heartbeat wake eligibility so blocked / terminal / duplicate issue work is cancelled or skipped deterministically before it burns agent effort

## Key behavior changes

### Heartbeat / queue hygiene
- central shared issue wake-eligibility evaluator in `server/src/services/heartbeat.ts`
- `enqueueWakeup`, queued-run claim, and queued-run resumption now use the same eligibility rules
- stale queued or deferred issue-bound work is cleaned up for:
  - unresolved dependency blockers
  - `blocked` issues without a valid execution path
  - terminal issues (`done` / `cancelled`)
  - missing issues
  - duplicate queued wakes for the same agent + issue
- blocked interaction/comment wakes are still preserved where intended

### Diagnostics / control plane visibility
- issue graph health diagnostics added to help surface blocker-graph problems explicitly

### Local reliability
- embedded PostgreSQL recovery hardened for the local Paperclip instance lifecycle

## Verification

Focused verification completed locally:
- [x] `server/src/__tests__/heartbeat-queued-wake-hygiene.test.ts`
- [x] `server/src/__tests__/heartbeat-dependency-scheduling.test.ts`
- [x] `server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts`
- [x] `packages/db/src/postmaster-pid.test.ts`
- [x] earlier CEO onboarding regression coverage remains in branch

## Notes

The PR title/body were updated because the branch has accumulated multiple related Paperclip hardening commits beyond the original CEO charter audit change, and the old explanation no longer matched the actual contents of the branch.
