### PR TITLE
fix(activity): ignore non-persisted agent JWT run ids

### DIFF
--- a/server/src/__tests__/agent-jwt-activity-log-runid-routes.test.ts
+++ b/server/src/__tests__/agent-jwt-activity-log-runid-routes.test.ts
@@ -132,4 +132,42 @@ describeEmbeddedPostgres("agent JWT activity log run_id handling", () => {
       runId: persistedRunId,
     });
   });
+
+  it("skips the heartbeat lookup when callers mark the run id as verified", async () => {
+    const { companyId, agentId } = await seedActorAgent();
+    const persistedRunId = randomUUID();
+
+    await db.insert(heartbeatRuns).values({
+      id: persistedRunId,
+      companyId,
+      agentId,
+      invocationSource: "manual",
+      status: "queued",
+      triggerDetail: "manual",
+    });
+
+    await logActivity(db, {
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId: persistedRunId,
+      runIdVerified: true,
+      action: "heartbeat.invoked",
+      entityType: "heartbeat_run",
+      entityId: persistedRunId,
+      details: { source: "verified_run" },
+    });
+
+    const rows = await db.select().from(activityLog);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      action: "heartbeat.invoked",
+      runId: persistedRunId,
+    });
+  });
 });

--- a/server/src/__tests__/agent-jwt-activity-log-runid-routes.test.ts
+++ b/server/src/__tests__/agent-jwt-activity-log-runid-routes.test.ts
@@ -1,0 +1,135 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { logActivity } from "../services/activity-log.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres agent JWT activity-log tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("agent JWT activity log run_id handling", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-jwt-activity-log-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedActorAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CTO",
+      role: "cto",
+      status: "running",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    return { companyId, agentId };
+  }
+
+  it("drops a non-persisted run id instead of violating the activity_log heartbeat FK", async () => {
+    const { companyId, agentId } = await seedActorAgent();
+    const invalidRunId = randomUUID();
+
+    await logActivity(db, {
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId: invalidRunId,
+      action: "issue.created",
+      entityType: "issue",
+      entityId: randomUUID(),
+      details: { source: "agent_jwt" },
+    });
+
+    const rows = await db.select().from(activityLog);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      action: "issue.created",
+      runId: null,
+    });
+  });
+
+  it("preserves a persisted heartbeat run id for activity rows", async () => {
+    const { companyId, agentId } = await seedActorAgent();
+    const persistedRunId = randomUUID();
+
+    await db.insert(heartbeatRuns).values({
+      id: persistedRunId,
+      companyId,
+      agentId,
+      invocationSource: "manual",
+      status: "queued",
+      triggerDetail: "manual",
+    });
+
+    await logActivity(db, {
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId: persistedRunId,
+      action: "heartbeat.invoked",
+      entityType: "heartbeat_run",
+      entityId: persistedRunId,
+      details: { source: "agent_jwt" },
+    });
+
+    const rows = await db.select().from(activityLog);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      action: "heartbeat.invoked",
+      runId: persistedRunId,
+    });
+  });
+});

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -60,23 +60,26 @@ export interface LogActivityInput {
   entityId: string;
   agentId?: string | null;
   runId?: string | null;
+  runIdVerified?: boolean;
   details?: Record<string, unknown> | null;
 }
 
 async function resolvePersistedHeartbeatRunId(db: Db, runId?: string | null): Promise<string | null> {
   if (!runId) return null;
 
-  const persistedRun = await db
+  const rows = await db
     .select({ id: heartbeatRuns.id })
     .from(heartbeatRuns)
     .where(eq(heartbeatRuns.id, runId))
-    .then((rows) => rows[0] ?? null);
+    .limit(1);
 
-  return persistedRun?.id ?? null;
+  return rows[0]?.id ?? null;
 }
 
 export async function logActivity(db: Db, input: LogActivityInput) {
-  const persistedRunId = await resolvePersistedHeartbeatRunId(db, input.runId);
+  const persistedRunId = input.runIdVerified
+    ? input.runId ?? null
+    : await resolvePersistedHeartbeatRunId(db, input.runId);
   const currentUserRedactionOptions = {
     enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
   };

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { activityLog } from "@paperclipai/db";
+import { activityLog, heartbeatRuns } from "@paperclipai/db";
 import { PLUGIN_EVENT_TYPES, type PluginEventType } from "@paperclipai/shared";
 import type { PluginEvent } from "@paperclipai/plugin-sdk";
 import { publishLiveEvent } from "./live-events.js";
@@ -62,7 +63,20 @@ export interface LogActivityInput {
   details?: Record<string, unknown> | null;
 }
 
+async function resolvePersistedHeartbeatRunId(db: Db, runId?: string | null): Promise<string | null> {
+  if (!runId) return null;
+
+  const persistedRun = await db
+    .select({ id: heartbeatRuns.id })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .then((rows) => rows[0] ?? null);
+
+  return persistedRun?.id ?? null;
+}
+
 export async function logActivity(db: Db, input: LogActivityInput) {
+  const persistedRunId = await resolvePersistedHeartbeatRunId(db, input.runId);
   const currentUserRedactionOptions = {
     enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
   };
@@ -78,7 +92,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
+    runId: persistedRunId,
     details: redactedDetails,
   });
 
@@ -92,7 +106,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       entityType: input.entityType,
       entityId: input.entityId,
       agentId: input.agentId ?? null,
-      runId: input.runId ?? null,
+      runId: persistedRunId,
       details: redactedDetails,
     },
   });
@@ -111,7 +125,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       payload: {
         ...redactedDetails,
         agentId: input.agentId ?? null,
-        runId: input.runId ?? null,
+        runId: persistedRunId,
       },
     };
     publishPluginDomainEvent(event);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, so control-plane mutations need durable audit records.
> - Agent-authenticated requests flow through the server auth middleware and route helpers before they are recorded by the activity logging service.
> - `activity_log.run_id` is schema-bound to `heartbeat_runs.id`, so it must only store persisted heartbeat run identifiers.
> - Local agent JWTs can carry a `run_id` claim that identifies request context even when no `heartbeat_runs` row exists yet.
> - The activity logger previously forwarded that JWT run id directly into the FK column, which caused issue creation and wakeup mutations to fail with `activity_log_run_id_heartbeat_runs_id_fk` errors.
> - This pull request narrows the fix to the shared activity logging service so every caller keeps working without schema churn or route-by-route conditionals.
> - The benefit is that agent JWT requests no longer 500 on activity logging, while real persisted heartbeat run ids are still preserved in the ledger.

## What Changed

- Added a persisted-run resolver in `server/src/services/activity-log.ts` that keeps `runId` only when it exists in `heartbeat_runs`, otherwise stores `null`.
- Updated live event and plugin event payloads from `logActivity()` to emit the sanitized persisted run id value instead of the raw JWT claim.
- Added `server/src/__tests__/agent-jwt-activity-log-runid-routes.test.ts` to cover both behaviors: dropping a non-persisted agent JWT run id and preserving a real heartbeat run id.

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-jwt-activity-log-runid-routes.test.ts`
- `pnpm exec vitest run server/src/__tests__/activity-service.test.ts server/src/__tests__/agent-jwt-activity-log-runid-routes.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low risk: the change is isolated to activity logging, but any consumer that expected raw JWT `run_id` values in live/plugin activity payloads will now receive `null` unless that id maps to a persisted heartbeat run.

> Checked `ROADMAP.md`; this is a focused bug fix for invalid activity-log FK writes, not overlapping planned core feature work.

## Model Used

- OpenAI Codex via Hermes Agent, model `gpt-5.4`, tool-enabled coding workflow with repository inspection, targeted file edits, git operations, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
