### PR TITLE
Fix issue #4304 typo cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ This starts the API server at `http://localhost:3100`. An embedded PostgreSQL da
 **What does a typical setup look like?**
 Locally, a single Node.js process manages an embedded Postgres and local file storage. For production, point it at your own Postgres and deploy however you like. Configure projects, agents, and goals — the agents take care of the rest.
 
-If you're a solo-entreprenuer you can use Tailscale to access Paperclip on the go. Then later you can deploy to e.g. Vercel when you need it.
+If you're a solo-entrepreneur you can use Tailscale to access Paperclip on the go. Then later you can deploy to e.g. Vercel when you need it.
 
 **Can I run multiple companies?**
 Yes. A single deployment can run an unlimited number of companies with complete data isolation.

--- a/cli/README.md
+++ b/cli/README.md
@@ -207,7 +207,7 @@ This starts the API server at `http://localhost:3100`. An embedded PostgreSQL da
 **What does a typical setup look like?**
 Locally, a single Node.js process manages an embedded Postgres and local file storage. For production, point it at your own Postgres and deploy however you like. Configure projects, agents, and goals — the agents take care of the rest.
 
-If you're a solo-entreprenuer you can use Tailscale to access Paperclip on the go. Then later you can deploy to e.g. Vercel when you need it.
+If you're a solo-entrepreneur you can use Tailscale to access Paperclip on the go. Then later you can deploy to e.g. Vercel when you need it.
 
 **Can I run multiple companies?**
 Yes. A single deployment can run an unlimited number of companies with complete data isolation.

--- a/doc/CLIPHUB.md
+++ b/doc/CLIPHUB.md
@@ -52,7 +52,7 @@ The homepage surfaces companies across several dimensions:
 - **Featured** — editorially curated, high-quality templates
 - **Popular** — ranked by downloads, stars, and forks
 - **Recent** — latest published or updated
-- **Categories** — browseable by use case (see Categories below)
+- **Categories** — browsable by use case (see Categories below)
 
 Each listing shows: name, short description, org size (agent count), category, adapter types used, star count, download count, and a mini org chart preview.
 

--- a/doc/plans/2026-02-16-module-system.md
+++ b/doc/plans/2026-02-16-module-system.md
@@ -552,7 +552,7 @@ You can also export a running company as a template:
 GET /api/templates/export → downloads the current company as a template JSON
 ```
 
-This makes companies shareable and clonable.
+This makes companies shareable and cloneable.
 
 ---
 

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -436,7 +436,7 @@ export function createPluginWorkerHandle(
       message = parseMessage(line);
     } catch (err) {
       if (err instanceof JsonRpcParseError) {
-        log.warn({ rawLine: line.slice(0, 200) }, "unparseable message from worker");
+        log.warn({ rawLine: line.slice(0, 200) }, "unparsable message from worker");
       } else {
         log.warn({ err }, "error parsing worker message");
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a control plane for AI-agent companies, so even small repo changes should preserve the operator-facing workflow and audit trail.
> - This work sits in the repo content and server logging surface rather than a new product subsystem or roadmap feature.
> - GitHub issue #4304 requested a narrowly scoped cleanup: four documentation typo fixes and one warning-string spelling correction.
> - Because the requested change is wording-only, the main risk is accidental scope expansion or introducing unrelated code churn.
> - The right response is a minimal patch touching only the exact typo locations and preserving all behavior.
> - This pull request applies those five wording fixes and leaves runtime logic unchanged.
> - The benefit is cleaner docs and one corrected warning message with effectively zero product-surface risk.

## What Changed

- Corrected `entreprenuer` to `entrepreneur` in `README.md` and `cli/README.md`.
- Corrected `browseable` to `browsable` in `doc/CLIPHUB.md`.
- Corrected `clonable` to `cloneable` in `doc/plans/2026-02-16-module-system.md`.
- Corrected the warning string `unparseable message from worker` to `unparsable message from worker` in `server/src/services/plugin-worker-manager.ts`.

## Verification

- Confirmed the five original spellings existed in the checkout before editing.
- Confirmed the old spellings are removed from the touched files after the patch.
- Ran `git diff --check`.
- Not run: `pnpm -r typecheck` because this workspace does not have local `node_modules` and `tsc` is unavailable.

## Risks

- Low risk: the docs changes are text-only and the server change only updates log message wording.
- Operational note: any external alerting keyed to the exact warning string text would need to tolerate the spelling change.

## Model Used

- OpenAI Codex, GPT-5-based coding agent via the Paperclip/Codex runtime in this workspace, with tool use, shell execution, patch application, and GitHub CLI interaction.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
