### PR TITLE
feat(heartbeat): AKS-2611 — inbox preflight gate + shell script

### DIFF
--- a/scripts/heartbeat-inbox-preflight.sh
+++ b/scripts/heartbeat-inbox-preflight.sh
@@ -7,15 +7,14 @@
 #
 # Required env: PAPERCLIP_API_KEY
 # Args:
-#   --agent-id  <uuid>  agent to check (required)
-#   --api-url   <url>   Paperclip API base URL, e.g. http://127.0.0.1:3100 (required)
+#   --api-url  <url>  Paperclip API base URL, e.g. http://127.0.0.1:3100 (required)
 
 set -euo pipefail
 
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/heartbeat-inbox-preflight.sh --agent-id <uuid> --api-url <url>
+  scripts/heartbeat-inbox-preflight.sh --api-url <url>
 
 Env:
   PAPERCLIP_API_KEY  short-lived run JWT (required, never passed in argv)
@@ -27,15 +26,10 @@ Exit codes:
 EOF
 }
 
-agent_id=""
 api_url=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --agent-id)
-      agent_id="${2:-}"
-      shift 2
-      ;;
     --api-url)
       api_url="${2:-}"
       shift 2
@@ -52,11 +46,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$agent_id" ]]; then
-  printf '[preflight] Missing --agent-id\n' >&2
-  exit 2
-fi
-
 if [[ -z "$api_url" ]]; then
   printf '[preflight] Missing --api-url\n' >&2
   exit 2
@@ -72,12 +61,17 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
+# Each invocation gets its own temp file to avoid races under concurrent runs.
+inbox_tmp=$(mktemp /tmp/paperclip_preflight_inbox.XXXXXX.json)
+trap 'rm -f "$inbox_tmp"' EXIT
+
 # Fetch compact inbox. Use --max-time so a hung API server does not block the run.
-http_code=$(curl -sS -o /tmp/paperclip_preflight_inbox.json -w "%{http_code}" \
+# The JWT in PAPERCLIP_API_KEY unambiguously identifies the agent — no explicit ID needed.
+http_code=$(curl -sS -o "$inbox_tmp" -w "%{http_code}" \
   --max-time 10 \
   "$api_url/api/agents/me/inbox-lite" \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" 2>/dev/null) || {
-  printf '[preflight] curl failed (exit %s) — proceeding with LLM\n' "$?" >&2
+  printf '[preflight] curl failed — proceeding with LLM\n' >&2
   exit 0
 }
 
@@ -86,14 +80,11 @@ if [[ "$http_code" != "200" ]]; then
   exit 0
 fi
 
-# Count todo / in_progress / in_review items assigned to this agent.
-# inbox-lite returns a compact list; items with status in this set represent
-# actionable work. Blocked items are excluded because the agent cannot proceed
-# without external input — a bare blocked-only inbox is treated as empty.
+# Count todo / in_progress / in_review items. Blocked items are excluded:
+# the agent cannot proceed without external input, so a blocked-only inbox
+# is treated as empty.
 actionable=$(jq '[.[] | select(.status == "todo" or .status == "in_progress" or .status == "in_review")] | length' \
-  /tmp/paperclip_preflight_inbox.json 2>/dev/null) || actionable="-1"
-
-rm -f /tmp/paperclip_preflight_inbox.json
+  "$inbox_tmp" 2>/dev/null) || actionable="-1"
 
 if [[ "$actionable" == "-1" ]]; then
   printf '[preflight] Failed to parse inbox response — proceeding with LLM\n' >&2

--- a/scripts/heartbeat-inbox-preflight.sh
+++ b/scripts/heartbeat-inbox-preflight.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Inbox preflight check for heartbeat runs.
+#
+# Exits 0 if the agent has actionable work in its inbox (LLM should proceed).
+# Exits 1 if the inbox is empty / all items are blocked with no new context
+# (heartbeat should be recorded as skipped_preflight, saving LLM tokens).
+#
+# Required env: PAPERCLIP_API_KEY
+# Args:
+#   --agent-id  <uuid>  agent to check (required)
+#   --api-url   <url>   Paperclip API base URL, e.g. http://127.0.0.1:3100 (required)
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/heartbeat-inbox-preflight.sh --agent-id <uuid> --api-url <url>
+
+Env:
+  PAPERCLIP_API_KEY  short-lived run JWT (required, never passed in argv)
+
+Exit codes:
+  0  inbox has actionable work — proceed with LLM invocation
+  1  inbox is empty — skip LLM invocation (record as skipped_preflight)
+  2  fatal error (API unreachable, missing args, etc.) — treat as pass-through (proceed)
+EOF
+}
+
+agent_id=""
+api_url=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent-id)
+      agent_id="${2:-}"
+      shift 2
+      ;;
+    --api-url)
+      api_url="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$agent_id" ]]; then
+  printf '[preflight] Missing --agent-id\n' >&2
+  exit 2
+fi
+
+if [[ -z "$api_url" ]]; then
+  printf '[preflight] Missing --api-url\n' >&2
+  exit 2
+fi
+
+if [[ -z "${PAPERCLIP_API_KEY:-}" ]]; then
+  printf '[preflight] Missing PAPERCLIP_API_KEY env var\n' >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '[preflight] jq not found — cannot parse inbox response, proceeding\n' >&2
+  exit 0
+fi
+
+# Fetch compact inbox. Use --max-time so a hung API server does not block the run.
+http_code=$(curl -sS -o /tmp/paperclip_preflight_inbox.json -w "%{http_code}" \
+  --max-time 10 \
+  "$api_url/api/agents/me/inbox-lite" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" 2>/dev/null) || {
+  printf '[preflight] curl failed (exit %s) — proceeding with LLM\n' "$?" >&2
+  exit 0
+}
+
+if [[ "$http_code" != "200" ]]; then
+  printf '[preflight] inbox-lite returned HTTP %s — proceeding with LLM\n' "$http_code" >&2
+  exit 0
+fi
+
+# Count todo / in_progress / in_review items assigned to this agent.
+# inbox-lite returns a compact list; items with status in this set represent
+# actionable work. Blocked items are excluded because the agent cannot proceed
+# without external input — a bare blocked-only inbox is treated as empty.
+actionable=$(jq '[.[] | select(.status == "todo" or .status == "in_progress" or .status == "in_review")] | length' \
+  /tmp/paperclip_preflight_inbox.json 2>/dev/null) || actionable="-1"
+
+rm -f /tmp/paperclip_preflight_inbox.json
+
+if [[ "$actionable" == "-1" ]]; then
+  printf '[preflight] Failed to parse inbox response — proceeding with LLM\n' >&2
+  exit 0
+fi
+
+if [[ "$actionable" -gt 0 ]]; then
+  printf '[preflight] %s actionable item(s) in inbox — proceeding with LLM\n' "$actionable" >&2
+  exit 0
+fi
+
+printf '[preflight] Inbox empty (0 actionable items) — skipping LLM invocation\n' >&2
+exit 1

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5570,29 +5570,33 @@ export function heartbeatService(db: Db) {
           readNonEmptyString(adapterEnv.PAPERCLIP_PREFLIGHT_SCRIPT_PATH) ??
           path.resolve(process.cwd(), "scripts/heartbeat-inbox-preflight.sh");
         const apiUrl = process.env.PAPERCLIP_API_URL ?? "";
-        try {
-          const { stderr: preflightStderr } = await execFile(
-            "bash",
-            [preflightScriptPath, "--agent-id", agent.id, "--api-url", apiUrl],
-            {
-              env: { ...process.env, ...(authToken ? { PAPERCLIP_API_KEY: authToken } : {}) },
-              timeout: 15_000,
-            },
-          );
-          if (preflightStderr) {
-            await onLog("stderr", `[paperclip] preflight: ${preflightStderr}`);
+        if (!apiUrl) {
+          await onLog("stderr", "[paperclip] preflight: PAPERCLIP_API_URL not set — skipping preflight check\n");
+        } else {
+          try {
+            const { stderr: preflightStderr } = await execFile(
+              "bash",
+              [preflightScriptPath, "--api-url", apiUrl],
+              {
+                env: { ...process.env, ...(authToken ? { PAPERCLIP_API_KEY: authToken } : {}) },
+                timeout: 15_000,
+              },
+            );
+            if (preflightStderr) {
+              await onLog("stderr", `[paperclip] preflight: ${preflightStderr}`);
+            }
+          } catch (preflightErr: unknown) {
+            const errCode = (preflightErr as { code?: number | string | null }).code;
+            if (errCode === 1) {
+              await onLog("stdout", "[paperclip] Inbox preflight: no actionable work — skipping LLM invocation\n");
+              await setRunStatus(run.id, "skipped_preflight", { finishedAt: new Date() });
+              await setWakeupStatus(run.wakeupRequestId, "skipped_preflight", { finishedAt: new Date() });
+              await finalizeAgentStatus(agent.id, "succeeded");
+              return;
+            }
+            const errMsg = preflightErr instanceof Error ? preflightErr.message : String(preflightErr);
+            await onLog("stderr", `[paperclip] preflight script error — proceeding with LLM: ${errMsg}\n`);
           }
-        } catch (preflightErr: unknown) {
-          const errCode = (preflightErr as { code?: number | string | null }).code;
-          if (errCode === 1) {
-            await onLog("stdout", "[paperclip] Inbox preflight: no actionable work — skipping LLM invocation\n");
-            await setRunStatus(run.id, "skipped_preflight", { finishedAt: new Date() });
-            await setWakeupStatus(run.wakeupRequestId, "skipped_preflight", { finishedAt: new Date() });
-            await finalizeAgentStatus(agent.id, "succeeded");
-            return;
-          }
-          const errMsg = preflightErr instanceof Error ? preflightErr.message : String(preflightErr);
-          await onLog("stderr", `[paperclip] preflight script error — proceeding with LLM: ${errMsg}\n`);
         }
       }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5561,6 +5561,41 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
+
+      // Inbox preflight gate: only active when PAPERCLIP_PREFLIGHT_ENABLED=true in
+      // adapterConfig.env. Always bypassed for event-driven wakes (wakeReason set)
+      // since those already have actionable context.
+      if (adapterEnv.PAPERCLIP_PREFLIGHT_ENABLED === "true" && !readNonEmptyString(context.wakeReason)) {
+        const preflightScriptPath =
+          readNonEmptyString(adapterEnv.PAPERCLIP_PREFLIGHT_SCRIPT_PATH) ??
+          path.resolve(process.cwd(), "scripts/heartbeat-inbox-preflight.sh");
+        const apiUrl = process.env.PAPERCLIP_API_URL ?? "";
+        try {
+          const { stderr: preflightStderr } = await execFile(
+            "bash",
+            [preflightScriptPath, "--agent-id", agent.id, "--api-url", apiUrl],
+            {
+              env: { ...process.env, ...(authToken ? { PAPERCLIP_API_KEY: authToken } : {}) },
+              timeout: 15_000,
+            },
+          );
+          if (preflightStderr) {
+            await onLog("stderr", `[paperclip] preflight: ${preflightStderr}`);
+          }
+        } catch (preflightErr: unknown) {
+          const errCode = (preflightErr as { code?: number | string | null }).code;
+          if (errCode === 1) {
+            await onLog("stdout", "[paperclip] Inbox preflight: no actionable work — skipping LLM invocation\n");
+            await setRunStatus(run.id, "skipped_preflight", { finishedAt: new Date() });
+            await setWakeupStatus(run.wakeupRequestId, "skipped_preflight", { finishedAt: new Date() });
+            await finalizeAgentStatus(agent.id, "succeeded");
+            return;
+          }
+          const errMsg = preflightErr instanceof Error ? preflightErr.message : String(preflightErr);
+          await onLog("stderr", `[paperclip] preflight script error — proceeding with LLM: ${errMsg}\n`);
+        }
+      }
+
       const adapterResult = await adapter.execute({
         runId: run.id,
         agent,


### PR DESCRIPTION
## Summary

- Adds `scripts/heartbeat-inbox-preflight.sh`: calls `GET /api/agents/me/inbox-lite` (auth via `PAPERCLIP_API_KEY` env, never argv), exits 1 on empty inbox (0 actionable items), exits 0 to proceed, exits 2 on errors (fail-open/pass-through)
- Adds preflight gate in `server/src/services/heartbeat.ts` immediately before `adapter.execute()`: only active when `PAPERCLIP_PREFLIGHT_ENABLED=true` in `adapterConfig.env`; unconditionally bypassed when `context.wakeReason` is set; fails open on script errors or missing `PAPERCLIP_API_URL`

## Thinking Path

Token waste was identified as the key cost driver for Chief of Staff timer wakes where the inbox is empty. The gate fits as a lightweight pre-check before LLM invocation: read the inbox-lite endpoint, skip the run if nothing is actionable, record the run as `skipped_preflight` so the skip is queryable and auditable. The bypass on `wakeReason` ensures event-driven wakes (assigned issues, comments, approvals) are never silently dropped.

The script uses `mktemp` + `trap` to avoid temp-file races under concurrent runs. The JWT bearer token unambiguously identifies the agent so no `--agent-id` arg is needed in the API call.

## Verification

1. Set `PAPERCLIP_PREFLIGHT_ENABLED=true` in an agent's `adapterConfig.env`
2. Trigger a timer-based heartbeat for that agent with an empty inbox
3. Confirm `heartbeat_runs.status = 'skipped_preflight'` and `finishedAt` is set for that run
4. Trigger an event-driven wake (assign an issue) — confirm the run proceeds normally (status = 'succeeded' or 'failed', not 'skipped_preflight')
5. Query: `SELECT id, status, finished_at FROM heartbeat_runs WHERE agent_id = '<id>' ORDER BY created_at DESC LIMIT 10`

## Risks

- `jq` and `curl` must be present in the server runtime environment (both are standard in the Paperclip Docker image)
- `bash` must be available as the shell interpreter (standard on all supported platforms)
- `PAPERCLIP_API_URL` must be set in the server process environment; if absent, the preflight is skipped with a warning log and the LLM proceeds normally (fail-open)

## ACs addressed

- **AC-1** ✅ Calls `scripts/heartbeat-inbox-preflight.sh --api-url <url>` before LLM; exit 1 → `status=skipped_preflight`, `finishedAt` set, 0 tokens consumed
- **AC-2** ✅ Gate bypassed when `context.wakeReason` is non-empty (event-driven/assigned wakes are always actionable)
- **AC-3** ✅ Per-agent opt-in via `PAPERCLIP_PREFLIGHT_ENABLED=true` in `adapterConfig.env`; script path overridable via `PAPERCLIP_PREFLIGHT_SCRIPT_PATH` in same map
- **AC-4** ✅ Remove or set `PAPERCLIP_PREFLIGHT_ENABLED=false` → single config change, no code revert
- **AC-6** ✅ `authToken` passed to subprocess via `PAPERCLIP_API_KEY` env var only (never in argv)
- **AC-7** ✅ `skipped_preflight` is plain-text in `heartbeat_runs.status`, queryable via SQL

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6) via Paperclip DevOps agent (c7d35741). Greptile P1 review finding (temp-file race condition) addressed in follow-up commit `7b73e175`.

## Related

- Issue: AKS-2611 (AKS-1984 follow-up)
- Rollout tracking: AKS-2001 (MHDS D-2 measurement)