### PR TITLE
fix(server): degrade gracefully when budget rows reference deleted agents

### DIFF
--- a/server/src/__tests__/cleanup-removal-service.test.ts
+++ b/server/src/__tests__/cleanup-removal-service.test.ts
@@ -4,6 +4,8 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
   agents,
+  budgetIncidents,
+  budgetPolicies,
   companies,
   companySkills,
   createDb,
@@ -43,6 +45,8 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     await db.delete(issueReadStates);
     await db.delete(issueComments);
     await db.delete(issueExecutionDecisions);
+    await db.delete(budgetIncidents);
+    await db.delete(budgetPolicies);
     await db.delete(companySkills);
     await db.delete(heartbeatRuns);
     await db.delete(issues);
@@ -184,5 +188,43 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     await expect(db.select().from(issues).where(eq(issues.id, issueId))).resolves.toHaveLength(0);
     await expect(db.select().from(issueReadStates).where(eq(issueReadStates.companyId, companyId))).resolves.toHaveLength(0);
     await expect(db.select().from(activityLog).where(eq(activityLog.companyId, companyId))).resolves.toHaveLength(0);
+  });
+
+  it("removes agent-scoped budget rows when deleting an agent", async () => {
+    const { agentId, companyId } = await seedFixture();
+    const policyId = randomUUID();
+
+    await db.insert(budgetPolicies).values({
+      id: policyId,
+      companyId,
+      scopeType: "agent",
+      scopeId: agentId,
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      amount: 5000,
+    });
+
+    await db.insert(budgetIncidents).values({
+      id: randomUUID(),
+      companyId,
+      policyId,
+      scopeType: "agent",
+      scopeId: agentId,
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      windowStart: new Date(Date.UTC(2026, 3, 1, 0, 0, 0, 0)),
+      windowEnd: new Date(Date.UTC(2026, 4, 1, 0, 0, 0, 0)),
+      thresholdType: "hard",
+      amountLimit: 5000,
+      amountObserved: 5100,
+      status: "open",
+      approvalId: null,
+    });
+
+    const removed = await agentService(db).remove(agentId);
+
+    expect(removed?.id).toBe(agentId);
+    await expect(db.select().from(budgetPolicies).where(eq(budgetPolicies.scopeId, agentId))).resolves.toHaveLength(0);
+    await expect(db.select().from(budgetIncidents).where(eq(budgetIncidents.scopeId, agentId))).resolves.toHaveLength(0);
   });
 });

--- a/server/src/__tests__/dashboard-service.test.ts
+++ b/server/src/__tests__/dashboard-service.test.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import { agents, budgetIncidents, budgetPolicies, companies, createDb, heartbeatRuns } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { dashboardService, getUtcMonthStart } from "../services/dashboard.ts";
+import { budgetService } from "../services/budgets.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -47,6 +48,8 @@ describeEmbeddedPostgres("dashboard service", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(budgetIncidents);
+    await db.delete(budgetPolicies);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
@@ -164,6 +167,65 @@ describeEmbeddedPostgres("dashboard service", () => {
       failed: 2,
       other: 1,
       total: 3,
+    });
+  });
+
+  it("degrades gracefully when budget rows reference a deleted agent", async () => {
+    const companyId = randomUUID();
+    const danglingAgentId = randomUUID();
+    const policyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(budgetPolicies).values({
+      id: policyId,
+      companyId,
+      scopeType: "agent",
+      scopeId: danglingAgentId,
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      amount: 5000,
+    });
+
+    await db.insert(budgetIncidents).values({
+      id: randomUUID(),
+      companyId,
+      policyId,
+      scopeType: "agent",
+      scopeId: danglingAgentId,
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      windowStart: new Date(Date.UTC(2026, 3, 1, 0, 0, 0, 0)),
+      windowEnd: new Date(Date.UTC(2026, 4, 1, 0, 0, 0, 0)),
+      thresholdType: "hard",
+      amountLimit: 5000,
+      amountObserved: 5100,
+      status: "open",
+      approvalId: null,
+    });
+
+    await expect(budgetService(db).overview(companyId)).resolves.toMatchObject({
+      companyId,
+      policies: [],
+      activeIncidents: [],
+      pausedAgentCount: 0,
+      pausedProjectCount: 0,
+      pendingApprovalCount: 0,
+    });
+
+    await expect(dashboardService(db).summary(companyId)).resolves.toMatchObject({
+      companyId,
+      budgets: {
+        activeIncidents: 0,
+        pendingApprovals: 0,
+        pausedAgents: 0,
+        pausedProjects: 0,
+      },
     });
   });
 });

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -10,6 +10,8 @@ import {
   agentWakeupRequests,
   activityLog,
   costEvents,
+  budgetIncidents,
+  budgetPolicies,
   heartbeatRunEvents,
   heartbeatRuns,
   issueExecutionDecisions,
@@ -516,6 +518,12 @@ export function agentService(db: Db) {
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.agentId, id));
         await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.agentId, id));
+        await tx
+          .delete(budgetIncidents)
+          .where(and(eq(budgetIncidents.scopeType, "agent"), eq(budgetIncidents.scopeId, id)));
+        await tx
+          .delete(budgetPolicies)
+          .where(and(eq(budgetPolicies.scopeType, "agent"), eq(budgetPolicies.scopeId, id)));
         const deleted = await tx
           .delete(agents)
           .where(eq(agents.id, id))

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -21,7 +21,7 @@ import type {
   BudgetThresholdType,
   BudgetWindowKind,
 } from "@paperclipai/shared";
-import { notFound, unprocessable } from "../errors.js";
+import { HttpError, notFound, unprocessable } from "../errors.js";
 import { logActivity } from "./activity-log.js";
 
 type ScopeRecord = {
@@ -76,6 +76,12 @@ function budgetStatusFromObserved(
 function normalizeScopeName(scopeType: BudgetScopeType, name: string) {
   if (scopeType === "company") return name;
   return name.trim().length > 0 ? name : scopeType;
+}
+
+function isDanglingScopeError(error: unknown) {
+  return error instanceof HttpError
+    && error.status === 404
+    && (error.message === "Agent not found" || error.message === "Project not found");
 }
 
 async function resolveScopeRecord(db: Db, scopeType: BudgetScopeType, scopeId: string): Promise<ScopeRecord> {
@@ -627,13 +633,28 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
 
     overview: async (companyId: string): Promise<BudgetOverview> => {
       const rows = await listPolicyRows(companyId);
-      const policies = await Promise.all(rows.map((row) => buildPolicySummary(row)));
+      const policies: BudgetPolicySummary[] = [];
+      for (const row of rows) {
+        try {
+          policies.push(await buildPolicySummary(row));
+        } catch (error) {
+          if (!isDanglingScopeError(error)) throw error;
+        }
+      }
       const activeIncidentRows = await db
         .select()
         .from(budgetIncidents)
         .where(and(eq(budgetIncidents.companyId, companyId), eq(budgetIncidents.status, "open")))
         .orderBy(desc(budgetIncidents.createdAt));
-      const activeIncidents = await hydrateIncidentRows(activeIncidentRows);
+      const activeIncidents: BudgetIncident[] = [];
+      for (const row of activeIncidentRows) {
+        try {
+          const [hydrated] = await hydrateIncidentRows([row]);
+          if (hydrated) activeIncidents.push(hydrated);
+        } catch (error) {
+          if (!isDanglingScopeError(error)) throw error;
+        }
+      }
       return {
         companyId,
         policies,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Three company-level endpoints surface a rollup of agent, cost, and budget state: `/dashboard`, `/sidebar-badges`, `/budgets/overview`
> - Reporter @epro1506 saw all three go 404 `{"error":"Agent not found"}` on 2026.416.0, in the same window where an internal recovery deleted and recreated a CEO agent (#4262)
> - `budgetService.overview` iterates budget policies and incidents and resolves each scope via `resolveScopeRecord`, which throws `notFound("Agent not found")` when the referenced agent row is gone but the `budget_policies`/`budget_incidents` rows survive
> - That 404 bubbled out of `budgetService.overview`, which is called by `dashboardService.summary`, so the whole dashboard/sidebar-badges/budgets-overview payload failed instead of just dropping the dangling row
> - This PR degrades gracefully on dangling rows and cleans up agent-scoped budget rows on agent delete so new dangling rows stop being created
> - The benefit is the dashboard stays up through operator-visible agent churn, matching the reporter's hypothesis that the affected endpoints should return an empty/degraded payload rather than 404

## What Changed

- `server/src/services/budgets.ts` - wrap the policy-summary and incident-hydration loops in `overview()` with try/catch; swallow `isDanglingScopeError` 404s so individual dangling rows get skipped instead of failing the entire overview payload
- `server/src/services/agents.ts` - inside `agentService.remove`'s transaction, also delete `budget_policies` and `budget_incidents` whose `scopeType = "agent"` matches the agent being removed, so new dangling rows stop being created
- `server/src/__tests__/dashboard-service.test.ts` - new test `degrades gracefully when budget rows reference a deleted agent`: seeds a company + dangling agent-scoped policy + dangling incident, asserts `budgets.overview()` and `dashboardService.summary()` both resolve to a valid payload
- `server/src/__tests__/cleanup-removal-service.test.ts` - new test `removes agent-scoped budget rows when deleting an agent`: seeds an agent with budget policy + incident, calls `agentService.remove`, asserts both budget rows are gone

## Verification

Run locally:

```
cd server && pnpm exec vitest run src/__tests__/dashboard-service.test.ts src/__tests__/cleanup-removal-service.test.ts
```

Result: 6 passed (the 4 pre-existing tests plus the 2 new ones).

Full typecheck: `pnpm -r typecheck` — server workspaces pass. UI workspace has pre-existing Storybook `@storybook/react-vite` errors unrelated to this change.

Manual reproduction (post-fix): create a CEO agent, add a budget policy scoped to it, delete the agent, hit `GET /api/companies/{id}/dashboard`. The handler now returns 200 with an empty `budgets` section instead of 404.

## Risks

- Low risk. The catch in `overview()` is narrowly scoped to `isDanglingScopeError` (HttpError, status 404, exact message match); all other errors still propagate.
- The agent-delete cascade to `budget_policies` and `budget_incidents` is additive inside the existing removal transaction, so the existing rollback semantics hold.
- Does not touch the `notFound("Company not found")` behavior — a missing company still legitimately 404s.
- Follow-up not in this PR: the reporter also asked for a heartbeat-recovery audit trail so operators can see when Paperclip internally deletes/recreates agents. That's a new feature and should be tracked as its own issue.

## Model Used

- Codex CLI `gpt-5.3-codex` at `model_reasoning_effort=medium` for the implementation pass
- Claude Opus 4.7 (1M context) for review, commit authoring, and test validation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A - server-only change)
- [x] I have updated relevant documentation to reflect my changes (no doc changes needed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #4262
