### PR TITLE
fix(adapter-claude-local): treat parsed success envelope as authoritative

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -705,7 +705,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       : null;
     const clearSessionForMaxTurns = isClaudeMaxTurnsResult(parsed);
     const parsedIsError = asBoolean(parsed.is_error, false);
-    const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
+    const parsedSuccess =
+      asString(parsed.subtype, "") === "success" && !parsedIsError;
+    const failed = ((proc.exitCode ?? 0) !== 0 || parsedIsError) && !parsedSuccess;
     const errorMessage = failed
       ? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
       : null;

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -102,6 +102,23 @@ console.log(JSON.stringify({ type: "result", session_id: "claude-session-2", res
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeSuccessThenExit143ClaudeCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-143", model: "claude-sonnet" }));
+console.log(JSON.stringify({
+  type: "result",
+  subtype: "success",
+  is_error: false,
+  session_id: "claude-session-143",
+  result: "done",
+  usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 }
+}));
+process.exit(143);
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 async function setupExecuteEnv(
   root: string,
   options?: { commandWriter?: (commandPath: string) => Promise<void> },
@@ -321,6 +338,40 @@ describe("claude execute", () => {
       expect(metaEvents[1]?.commandNotes.some((note) => note.includes("--append-system-prompt-file"))).toBe(true);
       expect(result.sessionId).toBe("claude-session-2");
       expect(result.clearSession).toBe(false);
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null errorMessage when parsed envelope is success even if process exits 143", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-success-143-"));
+    const { workspace, commandPath, restore } = await setupExecuteEnv(root, {
+      commandWriter: writeSuccessThenExit143ClaudeCommand,
+    });
+    try {
+      const result = await execute({
+        runId: "run-success-143",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {},
+          promptTemplate: "Do work.",
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+        onMeta: async () => {},
+      });
+
+      expect(result.exitCode).toBe(143);
+      expect(result.resultJson).toMatchObject({
+        subtype: "success",
+        is_error: false,
+      });
+      expect(result.errorMessage).toBeNull();
     } finally {
       restore();
       await fs.rm(root, { recursive: true, force: true });

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -135,6 +135,75 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     await tempDb?.cleanup();
   });
 
+  it("marks run succeeded when adapter exits non-zero but reports success envelope", async () => {
+    mockAdapterExecute.mockResolvedValueOnce({
+      exitCode: 143,
+      signal: "SIGTERM",
+      timedOut: false,
+      errorMessage: "Claude run failed: subtype=success: done",
+      summary: "Done.",
+      provider: "anthropic",
+      model: "claude-sonnet",
+      resultJson: {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "done",
+      },
+    });
+
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+
+    const queued = await heartbeat.invoke(agentId, "on_demand", {}, "manual");
+    expect(queued).not.toBeNull();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, queued!.id))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const run = await db
+      .select({
+        status: heartbeatRuns.status,
+        errorCode: heartbeatRuns.errorCode,
+        error: heartbeatRuns.error,
+        resultJson: heartbeatRuns.resultJson,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, queued!.id))
+      .then((rows) => rows[0] ?? null);
+
+    expect(run?.status).toBe("succeeded");
+    expect(run?.errorCode).toBeNull();
+    expect(run?.error).toBeNull();
+    expect(run?.resultJson).toMatchObject({
+      subtype: "success",
+      is_error: false,
+    });
+  });
+
   it("keeps blocked descendants idle until their blockers resolve", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5401,6 +5401,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         rawUsage,
       });
       const normalizedUsage = sessionUsageResolution.normalizedUsage;
+      const adapterResultEnvelope = parseObject(adapterResult.resultJson);
 
       let outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
       const latestRun = await getRun(run.id);
@@ -5409,6 +5410,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       } else if (adapterResult.timedOut) {
         outcome = "timed_out";
       } else if ((adapterResult.exitCode ?? 0) === 0 && !adapterResult.errorMessage) {
+        outcome = "succeeded";
+      } else if (
+        readNonEmptyString(adapterResultEnvelope.subtype) === "success" &&
+        asBoolean(adapterResultEnvelope.is_error, false) !== true
+      ) {
         outcome = "succeeded";
       } else {
         outcome = "failed";


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents via adapters; `adapter-claude-local` wraps Claude Code and reports run outcomes back to `heartbeatService`
> - Claude Code's final NDJSON line is `{"type":"result","subtype":"success","is_error":false,...}`, but the parent process can still exit with SIGTERM (143) when it cleans up backgrounded `Task()` subagents that outlive the conversation
> - Today's `execute.ts` derives `errorMessage` only from `proc.exitCode`; when exit is non-zero it calls `describeClaudeFailure(parsed)` which dutifully stringifies the success envelope into `"Claude run failed: subtype=success: <success text>"`
> - Downstream `heartbeat.ts:5654` requires BOTH `exitCode === 0` AND empty `errorMessage` for `outcome === "succeeded"`, so a success run with any cleanup-time non-zero exit flips the run to `failed/adapter_failed`
> - Reporter saw 6 occurrences in a 9-hour production window on standing issues (Proactive Codebase, Daily Reconciliation) where last-step `mcp__qmd__update` Tasks outlived the final result event
> - This PR treats the parsed envelope as authoritative: success envelope means success, regardless of post-success cleanup exit. Bug stays closed for older adapters too via a belt-and-braces guard at the server layer
> - The benefit is standing issues stop auto-blocking on cleanup kills; no human CEO unblock rotation wasted on runs that actually succeeded

## What Changed

- `packages/adapters/claude-local/src/server/execute.ts` - compute `parsedSuccess = subtype === "success" && is_error !== true` once. In the `errorMessage` ternary, add a branch that returns `null` when `parsedSuccess` is true, even if `proc.exitCode !== 0`. Existing `exitCode === 0` short-circuit is preserved so the happy path is unchanged.
- `server/src/services/heartbeat.ts` - in `heartbeatService`'s outcome classification, parse `adapterResult.resultJson` once into `adapterResultEnvelope` and add a new else-if branch: if the envelope carries `subtype === "success"` and `is_error !== true`, classify `outcome = "succeeded"` even when `exitCode !== 0` or `errorMessage` is set. Protects against a stale adapter version loaded against a newer server.
- `server/src/__tests__/claude-local-execute.test.ts` - new test asserts `errorMessage === null` when exit=143 and the parsed result is `{subtype: "success", is_error: false}`.
- `server/src/__tests__/heartbeat-dependency-scheduling.test.ts` - new test asserts `outcome === "succeeded"` for the same combination at the heartbeat service layer.

## Verification

Run locally:

```
cd server && pnpm exec vitest run src/__tests__/claude-local-execute.test.ts src/__tests__/heartbeat-dependency-scheduling.test.ts
```

Result: 11 passed (the 9 pre-existing execute tests and 2 dependency-scheduling tests, plus the new assertions).

Typecheck passes on both touched workspaces:

```
pnpm --filter @paperclipai/adapter-claude-local typecheck
pnpm --filter @paperclipai/server typecheck
```

Manual reproduction (post-fix): trigger a Claude run whose final step spawns a backgrounded Task (e.g. `mcp__qmd__update`) that outlives the final `result` event. The adapter exits with code 143, heartbeat classifies the run as `succeeded` instead of `adapter_failed`, and the issue is not auto-blocked.

## Risks

- Low risk. The new branch in `execute.ts` only fires when `parsed.subtype === "success" && !is_error`; any other error envelope (`error_max_turns`, explicit `is_error: true`, missing envelope) still falls through to `describeClaudeFailure`.
- The server-side envelope guard is intentionally narrow (string equality + boolean check) and only runs after the existing `exitCode === 0` happy path has already been evaluated.
- Does not alter the `timed_out` or `cancelled` terminal paths, or the `runErrorCode` mapping for runs that genuinely fail.

## Model Used

- Codex CLI `gpt-5.3-codex` at `model_reasoning_effort=medium` for the implementation pass
- Claude Opus 4.7 (1M context) for review, commit authoring, and test validation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A - adapter + server change)
- [x] I have updated relevant documentation to reflect my changes (no doc changes needed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #4307
