### PR TITLE
fix(tests): isolate temp git repos from host core.hooksPath

### DIFF
--- a/cli/src/__tests__/helpers/git.ts
+++ b/cli/src/__tests__/helpers/git.ts
@@ -1,6 +1,18 @@
-import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
+import {
+  execFileSync,
+  type ExecFileSyncOptions,
+  type ExecFileSyncOptionsWithStringEncoding,
+} from "node:child_process";
 
-export function execGitSync(args: string[], options: ExecFileSyncOptions = {}) {
+export function execGitSync(
+  args: string[],
+  options: ExecFileSyncOptionsWithStringEncoding,
+): string;
+export function execGitSync(args: string[], options?: ExecFileSyncOptions): Buffer;
+export function execGitSync(
+  args: string[],
+  options: ExecFileSyncOptions = {},
+): string | Buffer {
   return execFileSync("git", args, {
     ...options,
     env: {

--- a/cli/src/__tests__/helpers/git.ts
+++ b/cli/src/__tests__/helpers/git.ts
@@ -1,0 +1,13 @@
+import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
+
+export function execGitSync(args: string[], options: ExecFileSyncOptions = {}) {
+  return execFileSync("git", args, {
+    ...options,
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+      ...(options.env ?? {}),
+    },
+  });
+}

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -48,6 +47,7 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
+import { execGitSync } from "./helpers/git.js";
 
 const ORIGINAL_CWD = process.cwd();
 const ORIGINAL_ENV = { ...process.env };
@@ -992,6 +992,29 @@ describe("worktree helpers", () => {
     ).toBeNull();
   });
 
+  it("ignores inherited global hooksPath when creating temp git repos", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-worktree-hooks-isolation-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const fakeGlobalConfigPath = path.join(tempRoot, "global-gitconfig");
+
+    try {
+      fs.mkdirSync(repoRoot, { recursive: true });
+      fs.writeFileSync(fakeGlobalConfigPath, "[core]\n\thooksPath = /tmp/blocked-hooks\n", "utf8");
+      process.env.GIT_CONFIG_GLOBAL = fakeGlobalConfigPath;
+
+      execGitSync(["init"], { cwd: repoRoot, stdio: "ignore" });
+      const hooksPath = execGitSync(["rev-parse", "--git-path", "hooks"], {
+        cwd: repoRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+
+      expect(path.resolve(repoRoot, hooksPath)).toBe(path.join(repoRoot, ".git", "hooks"));
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("copies shared git hooks into a linked worktree git dir", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-worktree-hooks-"));
     const repoRoot = path.join(tempRoot, "repo");
@@ -999,12 +1022,12 @@ describe("worktree helpers", () => {
 
     try {
       fs.mkdirSync(repoRoot, { recursive: true });
-      execFileSync("git", ["init"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["init"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
       fs.writeFileSync(path.join(repoRoot, "README.md"), "# temp\n", "utf8");
-      execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
 
       const sourceHooksDir = path.join(repoRoot, ".git", "hooks");
       const sourceHookPath = path.join(sourceHooksDir, "pre-commit");
@@ -1013,10 +1036,10 @@ describe("worktree helpers", () => {
       fs.chmodSync(sourceHookPath, 0o755);
       fs.writeFileSync(sourceTokensPath, "secret-token\n", "utf8");
 
-      execFileSync("git", ["worktree", "add", "--detach", worktreePath], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["worktree", "add", "--detach", worktreePath], { cwd: repoRoot, stdio: "ignore" });
 
       const copied = copyGitHooksToWorktreeGitDir(worktreePath);
-      const worktreeGitDir = execFileSync("git", ["rev-parse", "--git-dir"], {
+      const worktreeGitDir = execGitSync(["rev-parse", "--git-dir"], {
         cwd: worktreePath,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
@@ -1035,7 +1058,7 @@ describe("worktree helpers", () => {
       expect(fs.statSync(targetHookPath).mode & 0o111).not.toBe(0);
       expect(fs.readFileSync(targetTokensPath, "utf8")).toBe("secret-token\n");
     } finally {
-      execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["worktree", "remove", "--force", worktreePath], { cwd: repoRoot, stdio: "ignore" });
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   }, 15_000);
@@ -1051,12 +1074,12 @@ describe("worktree helpers", () => {
     try {
       fs.mkdirSync(repoRoot, { recursive: true });
       fs.mkdirSync(fakeHome, { recursive: true });
-      execFileSync("git", ["init"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["init"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
       fs.writeFileSync(path.join(repoRoot, "README.md"), "# temp\n", "utf8");
-      execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
 
       process.chdir(repoRoot);
 
@@ -1082,12 +1105,12 @@ describe("worktree helpers", () => {
 
     try {
       fs.mkdirSync(repoRoot, { recursive: true });
-      execFileSync("git", ["init"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["init"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
       fs.writeFileSync(path.join(repoRoot, "README.md"), "# temp\n", "utf8");
-      execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
 
       process.chdir(repoRoot);
       await worktreeRepairCommand({});
@@ -1115,14 +1138,14 @@ describe("worktree helpers", () => {
 
     try {
       fs.mkdirSync(repoRoot, { recursive: true });
-      execFileSync("git", ["init"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["init"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
       fs.writeFileSync(path.join(repoRoot, "README.md"), "# temp\n", "utf8");
-      execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
       fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
-      execFileSync("git", ["worktree", "add", "-b", "repair-me", worktreePath, "HEAD"], {
+      execGitSync(["worktree", "add", "-b", "repair-me", worktreePath, "HEAD"], {
         cwd: repoRoot,
         stdio: "ignore",
       });
@@ -1157,12 +1180,12 @@ describe("worktree helpers", () => {
 
     try {
       fs.mkdirSync(repoRoot, { recursive: true });
-      execFileSync("git", ["init"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["init"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["config", "user.email", "test@example.com"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["config", "user.name", "Test User"], { cwd: repoRoot, stdio: "ignore" });
       fs.writeFileSync(path.join(repoRoot, "README.md"), "# temp\n", "utf8");
-      execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
-      execFileSync("git", ["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["add", "README.md"], { cwd: repoRoot, stdio: "ignore" });
+      execGitSync(["commit", "-m", "Initial commit"], { cwd: repoRoot, stdio: "ignore" });
       fs.writeFileSync(sourceConfigPath, JSON.stringify(buildSourceConfig(), null, 2), "utf8");
 
       process.chdir(repoRoot);

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -1,9 +1,7 @@
-import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { promisify } from "node:util";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   companies,
@@ -17,13 +15,12 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
+import { runGitIsolated } from "./helpers/git.js";
 import {
   executionWorkspaceService,
   mergeExecutionWorkspaceConfig,
   readExecutionWorkspaceConfig,
 } from "../services/execution-workspaces.ts";
-
-const execFileAsync = promisify(execFile);
 
 describe("execution workspace config helpers", () => {
   it("reads typed config from persisted metadata", () => {
@@ -106,7 +103,7 @@ if (!embeddedPostgresSupport.supported) {
 }
 
 async function runGit(cwd: string, args: string[]) {
-  await execFileAsync("git", ["-C", cwd, ...args], { cwd });
+  await runGitIsolated(cwd, args);
 }
 
 async function createTempRepo() {

--- a/server/src/__tests__/helpers/git.ts
+++ b/server/src/__tests__/helpers/git.ts
@@ -1,0 +1,15 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export async function runGitIsolated(cwd: string, args: string[]) {
+  await execFileAsync("git", args, {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+    },
+  });
+}

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -45,6 +45,7 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
+import { runGitIsolated } from "./helpers/git.js";
 
 const execFileAsync = promisify(execFile);
 const leasedRunIds = new Set<string>();
@@ -59,7 +60,7 @@ if (!embeddedPostgresSupport.supported) {
 const provisionWorktreeScriptPath = new URL("../../../scripts/provision-worktree.sh", import.meta.url);
 
 async function runGit(cwd: string, args: string[]) {
-  await execFileAsync("git", args, { cwd });
+  await runGitIsolated(cwd, args);
 }
 
 async function runPnpm(cwd: string, args: string[]) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip has tests that create ephemeral git repos in `/tmp` to exercise worktree and workspace-runtime behavior
> - Developers on teams with shared governance hooks (e.g. mojo guardrails) set `core.hooksPath` globally so every repo on their machine picks up a shared `pre-commit`
> - Tests were shelling out to `git init` / `git commit` without overriding the host git environment, so the temp repo inherited the global `pre-commit` that blocks commits to `main`/`master`
> - This gives 25+ false failures on `pnpm test:run` for anyone running with that setup. CI is unaffected because runners don't set `core.hooksPath`
> - The `worktree helpers > copies shared git hooks into a linked worktree git dir` test manifests the same root cause differently - it reads `core.hooksPath` expecting repo-local `.git/hooks` but receives the global path
> - This PR routes every test git child process through a shared helper that sets `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null`, so the temp repo sees only its own local config
> - The benefit is the full gate (`pnpm -r typecheck && pnpm test:run && pnpm build`) runs clean on any dev machine regardless of global git setup

## What Changed

- `server/src/__tests__/helpers/git.ts` - new helper `runGitIsolated(cwd, args)` that spawns `git` with `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null`.
- `cli/src/__tests__/helpers/git.ts` - sibling `execGitSync` helper for the CLI test tree (synchronous, mirrors the same isolation).
- `server/src/__tests__/workspace-runtime.test.ts` - local `runGit(cwd, args)` now delegates to `runGitIsolated`.
- `server/src/__tests__/execution-workspaces-service.test.ts` - same, and drops the now-unused `execFile`/`promisify` imports.
- `cli/src/__tests__/worktree.test.ts` - every `execFileSync("git", ...)` call routes through `execGitSync`. Adds a focused test `ignores inherited global hooksPath when creating temp git repos` that writes a fake `GIT_CONFIG_GLOBAL` with a blocking `hooksPath`, initialises a temp repo through the helper, and asserts `rev-parse --git-path hooks` resolves to the temp repo's `.git/hooks`.

## Verification

Run locally:

```
cd server && pnpm exec vitest run src/__tests__/workspace-runtime.test.ts src/__tests__/execution-workspaces-service.test.ts
cd ../cli && pnpm exec vitest run src/__tests__/worktree.test.ts
```

Server tests: 61 passed. CLI tests: 34 passed (the pre-existing `seeds authenticated users into minimally cloned worktree instances` failure is a pg_dump/COPY issue unrelated to this change - reproduces on upstream master too).

Simulate the bug before the fix:

```
git config --global core.hooksPath /tmp/blocking-hooks
mkdir -p /tmp/blocking-hooks
printf '#!/bin/sh\nexit 1\n' > /tmp/blocking-hooks/pre-commit && chmod +x /tmp/blocking-hooks/pre-commit
pnpm test:run
```

Before: ~25 failures in `workspace-runtime.test.ts`, `execution-workspaces-service.test.ts`, `worktree.test.ts`. After: suite passes.

## Risks

- Low risk. Changes are test-only and test-helper-only. No production code path is touched.
- The isolation is narrowly scoped to each child git invocation spawned by tests; anything the tests don't shell out for is unchanged.
- CI behavior is unchanged because CI runners don't set `core.hooksPath`; the helper's `/dev/null` overrides are additive, not destructive.

## Model Used

- Codex CLI `gpt-5.3-codex` at `model_reasoning_effort=medium` for the helper + test refactor
- Claude Opus 4.7 (1M context) for review, commit authoring, and test validation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A - test-only change)
- [x] I have updated relevant documentation to reflect my changes (no doc changes needed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #4301
