### PR TITLE
Fix: create approval records for imported agents

### DIFF
--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -65,6 +65,7 @@ import { validateCron } from "./cron.js";
 import { issueService } from "./issues.js";
 import { projectService } from "./projects.js";
 import { routineService } from "./routines.js";
+import { approvalService } from "./approvals.js";
 import { secretService } from "./secrets.js";
 
 /** Build OrgNode tree from manifest agent list (slug + reportsToSlug). */
@@ -2762,6 +2763,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
   const projects = projectService(db);
   const issues = issueService(db);
   const companySkills = companySkillService(db);
+  const approvals = approvalService(db);
   const secrets = secretService(db);
   const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
 
@@ -4220,7 +4222,8 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           continue;
         }
 
-        const createdStatus = "idle";
+        const requiresApproval = targetCompany.requireBoardApprovalForNewAgents;
+        const createdStatus = requiresApproval ? "pending_approval" : "idle";
         let created = await agents.create(targetCompany.id, {
           ...patch,
           status: createdStatus,
@@ -4242,6 +4245,22 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           created = await agents.update(created.id, { adapterConfig: materialized.adapterConfig }) ?? created;
         } catch (err) {
           warnings.push(`Failed to materialize instructions bundle for ${manifestAgent.slug}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        if (requiresApproval) {
+          await approvals.create(targetCompany.id, {
+            type: "hire_agent",
+            requestedByAgentId: null,
+            requestedByUserId: actorUserId ?? null,
+            status: "pending",
+            payload: {
+              agentId: created.id,
+              name: created.name,
+              role: created.role,
+              title: created.title,
+              summary: `Approve imported ${created.name} agent`,
+              recommendedAction: `Approve to activate the ${created.name} agent.`,
+            },
+          });
         }
         agentStatusById.set(created.id, created.status ?? createdStatus);
         importedSlugToAgentId.set(planAgent.slug, created.id);


### PR DESCRIPTION
## Problem

When importing a company package with `requireBoardApprovalForNewAgents` enabled, newly created agents are set to `pending_approval` status but no corresponding approval records are created. This leaves agents stuck — the UI shows "pending board approval" but there's no approval to act on.

The `POST /api/companies/:companyId/agent-hires` endpoint correctly creates both the agent and a `hire_agent` approval record, but the import flow in `company-portability.ts` hardcodes `status: "idle"` and skips approval creation entirely.

## Fix

The import flow now mirrors the `agent-hires` behavior:
- Checks `targetCompany.requireBoardApprovalForNewAgents`
- If true: creates agent with `pending_approval` status and a `hire_agent` approval record
- If false: creates agent with `idle` status (unchanged behavior)

Existing agents updated via "replace existing" collision strategy are not affected — they retain their current status without new approvals.

## Testing

Tested locally:
- Imported a company bundle with 4 agents into a company with `requireBoardApprovalForNewAgents: true`
- All 4 agents created as `pending_approval` with corresponding approval records
- Approvals visible in the UI and approvable through normal flow
- Re-importing with "replace existing" updates agents without creating duplicate approvals
- Importing into a company with `requireBoardApprovalForNewAgents: false` creates agents as `idle` (no approvals)