### PR TITLE
chore(ci): add e2e test compile preflight to catch early failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+
+      - name: Validate e2e test files compile
+        # Fast preflight: catch bad imports, syntax errors, missing symbols before
+        # spinning up the full server + browser lifecycle. Fails fast if test specs don't parse.
+        run: pnpm playwright test --list --config tests/e2e/playwright.config.ts
+
       - run: npx playwright install --with-deps chromium
 
       - name: Run e2e tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -152,6 +152,11 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Validate e2e test files compile
+        # Fast preflight: catch bad imports, syntax errors, missing symbols before
+        # spinning up the full server + browser lifecycle. Fails fast if test specs don't parse.
+        run: pnpm playwright test --list --config tests/e2e/playwright.config.ts
+
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
 


### PR DESCRIPTION
## Summary

Adds a fast preflight step to both \`e2e.yml\` and \`pr.yml\` that runs \`pnpm playwright test --list --config tests/e2e/playwright.config.ts\` before the full browser lifecycle starts.

The \`--list\` flag validates that every spec file parses — bad imports, syntax errors, missing symbols surface in seconds instead of after a 10-minute Playwright timeout when Chromium finally can't find what it's looking for.

## Why
Hit this pattern multiple times on a downstream fork: a spec file had an import that compiled via the fork's TS path but broke something in the e2e pipeline. The first signal was always a Playwright timeout 10+ minutes into CI. \`--list\` catches it before \`npx playwright install\` even runs.

## Changes
- \`.github/workflows/e2e.yml\`: one step added after \`pnpm build\`
- \`.github/workflows/pr.yml\`: same step added after \`Build\` in the e2e job

Total: 11 added lines, no configuration or dependency changes.

## Test plan
- [x] Cherry-picked cleanly onto \`master\` at \`854fa817\`
- [x] Confirmed \`tests/e2e/playwright.config.ts\` is unchanged upstream
- [x] Confirmed \`playwright\` + \`@playwright/test\` are already in \`package.json\`
- [ ] Upstream CI run on this PR