### PR TITLE
fix: embed paperclip context inside message field instead of top-level key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ ENV NODE_ENV=production \
   PAPERCLIP_DEPLOYMENT_EXPOSURE=private \
   OPENCODE_ALLOW_ALL_MODELS=true
 
-VOLUME ["/paperclip"]
+# VOLUME /paperclip removed for Railway
 EXPOSE 3100
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1136,7 +1136,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  // Embed paperclip context inside message instead of top-level (OpenClaw rejects unknown root keys)
+  const paperclipBlock = `\n<!-- paperclip-context\n${JSON.stringify(paperclipPayload)}\n-->`;
+  agentParams.message = `${message}${paperclipBlock}`;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {


### PR DESCRIPTION
Fixes #617.

OpenClaw gateway rejects unknown top-level properties in agent params. The 'paperclip' key was being sent as a top-level property, causing 'unexpected property paperclip' errors.

This change embeds the paperclip context as an HTML comment block within the message field instead, avoiding OpenClaw strict validation while preserving full Paperclip context for the agent.

Also removes VOLUME directive from Dockerfile for Railway compatibility.