### PR TITLE
fix(opencode-local): dedupe concurrent model discovery calls

### DIFF
--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -20,6 +20,7 @@ function resolveOpenCodeCommand(input: unknown): string {
 }
 
 const discoveryCache = new Map<string, { expiresAt: number; models: AdapterModel[] }>();
+const discoveryInFlight = new Map<string, Promise<AdapterModel[]>>();
 const VOLATILE_ENV_KEY_PREFIXES = ["PAPERCLIP_", "npm_", "NPM_"] as const;
 const VOLATILE_ENV_KEY_EXACT = new Set(["PWD", "OLDPWD", "SHLVL", "_", "TERM_SESSION_ID", "HOME"]);
 
@@ -158,12 +159,24 @@ export async function discoverOpenCodeModelsCached(input: {
   const key = discoveryCacheKey(command, cwd, env);
   const now = Date.now();
   pruneExpiredDiscoveryCache(now);
+
   const cached = discoveryCache.get(key);
   if (cached && cached.expiresAt > now) return cached.models;
 
-  const models = await discoverOpenCodeModels({ command, cwd, env });
-  discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
-  return models;
+  const inFlight = discoveryInFlight.get(key);
+  if (inFlight) return inFlight;
+
+  const pending = discoverOpenCodeModels({ command, cwd, env })
+    .then((models) => {
+      discoveryCache.set(key, { expiresAt: Date.now() + MODELS_CACHE_TTL_MS, models });
+      return models;
+    })
+    .finally(() => {
+      discoveryInFlight.delete(key);
+    });
+
+  discoveryInFlight.set(key, pending);
+  return pending;
 }
 
 export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
@@ -207,4 +220,5 @@ export async function listOpenCodeModels(): Promise<AdapterModel[]> {
 
 export function resetOpenCodeModelsCacheForTests() {
   discoveryCache.clear();
+  discoveryInFlight.clear();
 }


### PR DESCRIPTION
## Summary

Deduplicate concurrent calls to `discoverOpenCodeModelsCached` so parallel agent runs don't race the OpenCode model discovery fetch.

## Problem

When multiple agents (e.g. Renami + Finami runs) start around the same time, each one independently calls `discoverOpenCodeModelsCached`. Because there was no in-flight guard, N concurrent callers each spawned their own discovery request. On flaky network or cold-start conditions, this produced intermittent `opencode models failed` errors — even though the cache itself was fine, the burst of duplicate fetches was the actual trigger.

## Fix

Add a single-flight / in-flight promise dedupe in `packages/adapters/opencode-local/src/server/models.ts`:

- If a discovery call is already in-flight, subsequent callers await the same promise.
- Cache-hit path is unchanged.
- On completion (success or failure), the in-flight slot is cleared so the next miss can try again.

## Verification

- `pnpm --filter @paperclipai/adapter-opencode-local typecheck` → OK
- Post-patch re-smoke / stress runs: no more `opencode models failed`, majority of runs succeed.

## Scope

- Single file: `packages/adapters/opencode-local/src/server/models.ts`
- No schema, API, or UI changes.
