### PR TITLE
feat(ui): operator visibility for pause, auto-pause, queued runs; configurable runaway thresholds

### DIFF
--- a/server/src/routes/instance-settings.ts
+++ b/server/src/routes/instance-settings.ts
@@ -1,10 +1,14 @@
 import { Router, type Request } from "express";
 import type { Db } from "@paperclipai/db";
+import { agents, heartbeatRuns } from "@paperclipai/db";
 import { patchInstanceExperimentalSettingsSchema, patchInstanceGeneralSettingsSchema } from "@paperclipai/shared";
+import { z } from "zod";
+import { eq, count } from "drizzle-orm";
 import { forbidden } from "../errors.js";
 import { validate } from "../middleware/validate.js";
 import { instanceSettingsService, logActivity } from "../services/index.js";
 import { assertBoardOrgAccess, getActorInfo } from "./authz.js";
+import { logger } from "../middleware/logger.js";
 
 function assertCanManageInstanceSettings(req: Request) {
   if (req.actor.type !== "board") {
@@ -93,6 +97,78 @@ export function instanceSettingsRoutes(db: Db) {
       res.json(updated.experimental);
     },
   );
+
+  router.get("/admin/status", async (req, res) => {
+    assertCanManageInstanceSettings(req);
+    const [state, [{ value: queuedRunCount }]] = await Promise.all([
+      svc.getSystemPauseState(),
+      db.select({ value: count() }).from(heartbeatRuns).where(eq(heartbeatRuns.status, "queued")),
+    ]);
+    res.json({ ...state, queuedRunCount });
+  });
+
+  router.get("/admin/agents/queued-counts", async (req, res) => {
+    assertCanManageInstanceSettings(req);
+    const rows = await db
+      .select({
+        agentId: heartbeatRuns.agentId,
+        queuedCount: count(),
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.status, "queued"))
+      .groupBy(heartbeatRuns.agentId);
+    res.json(rows);
+  });
+
+  router.post("/admin/pause", validate(z.object({ reason: z.string().optional() })), async (req, res) => {
+    assertCanManageInstanceSettings(req);
+    await svc.pause(req.body.reason);
+    const state = await svc.getSystemPauseState();
+    const actor = getActorInfo(req);
+    logger.warn({ actor, reason: req.body.reason }, "system paused by operator");
+    const companyIds = await svc.listCompanyIds();
+    await Promise.all(
+      companyIds.map((companyId) =>
+        logActivity(db, {
+          companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "instance.system.paused",
+          entityType: "instance_settings",
+          entityId: "system",
+          details: { reason: req.body.reason ?? null },
+        }),
+      ),
+    );
+    res.json(state);
+  });
+
+  router.post("/admin/unpause", async (req, res) => {
+    assertCanManageInstanceSettings(req);
+    await svc.unpause();
+    const state = await svc.getSystemPauseState();
+    const actor = getActorInfo(req);
+    logger.info({ actor }, "system unpaused by operator");
+    const companyIds = await svc.listCompanyIds();
+    await Promise.all(
+      companyIds.map((companyId) =>
+        logActivity(db, {
+          companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "instance.system.unpaused",
+          entityType: "instance_settings",
+          entityId: "system",
+          details: {},
+        }),
+      ),
+    );
+    res.json(state);
+  });
 
   return router;
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -35,6 +35,7 @@ import { InstanceGeneralSettings } from "./pages/InstanceGeneralSettings";
 import { InstanceAccess } from "./pages/InstanceAccess";
 import { InstanceSettings } from "./pages/InstanceSettings";
 import { InstanceExperimentalSettings } from "./pages/InstanceExperimentalSettings";
+import { SystemHealth } from "./pages/SystemHealth";
 import { ProfileSettings } from "./pages/ProfileSettings";
 import { PluginManager } from "./pages/PluginManager";
 import { PluginSettings } from "./pages/PluginSettings";
@@ -265,6 +266,7 @@ export function App() {
             <Route path="general" element={<InstanceGeneralSettings />} />
             <Route path="access" element={<InstanceAccess />} />
             <Route path="heartbeats" element={<InstanceSettings />} />
+            <Route path="health" element={<SystemHealth />} />
             <Route path="experimental" element={<InstanceExperimentalSettings />} />
             <Route path="plugins" element={<PluginManager />} />
             <Route path="plugins/:pluginId" element={<PluginSettings />} />

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -146,6 +146,7 @@ export const agentsApi = {
     ),
   pause: (id: string, companyId?: string) => api.post<Agent>(agentPath(id, companyId, "/pause"), {}),
   resume: (id: string, companyId?: string) => api.post<Agent>(agentPath(id, companyId, "/resume"), {}),
+  unpauseAuto: (id: string, companyId?: string) => api.post<Agent>(agentPath(id, companyId, "/unpause-auto"), {}),
   approve: (id: string, companyId?: string) => api.post<Agent>(agentPath(id, companyId, "/approve"), {}),
   terminate: (id: string, companyId?: string) => api.post<Agent>(agentPath(id, companyId, "/terminate"), {}),
   remove: (id: string, companyId?: string) => api.delete<{ ok: true }>(agentPath(id, companyId)),

--- a/ui/src/api/instanceSettings.ts
+++ b/ui/src/api/instanceSettings.ts
@@ -6,6 +6,18 @@ import type {
 } from "@paperclipai/shared";
 import { api } from "./client";
 
+export interface SystemPauseState {
+  paused: boolean;
+  pausedAt: string | null;
+  pauseReason: string | null;
+  queuedRunCount: number;
+}
+
+export interface AgentQueuedCount {
+  agentId: string;
+  queuedCount: number;
+}
+
 export const instanceSettingsApi = {
   getGeneral: () =>
     api.get<InstanceGeneralSettings>("/instance/settings/general"),
@@ -15,4 +27,12 @@ export const instanceSettingsApi = {
     api.get<InstanceExperimentalSettings>("/instance/settings/experimental"),
   updateExperimental: (patch: PatchInstanceExperimentalSettings) =>
     api.patch<InstanceExperimentalSettings>("/instance/settings/experimental", patch),
+  getAdminStatus: () =>
+    api.get<SystemPauseState>("/admin/status"),
+  getAgentQueuedCounts: () =>
+    api.get<AgentQueuedCount[]>("/admin/agents/queued-counts"),
+  adminUnpause: () =>
+    api.post<SystemPauseState>("/admin/unpause", {}),
+  adminPause: (reason?: string) =>
+    api.post<SystemPauseState>("/admin/pause", { reason }),
 };

--- a/ui/src/components/InstanceSidebar.tsx
+++ b/ui/src/components/InstanceSidebar.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Clock3, Cpu, FlaskConical, Puzzle, Settings, Shield, SlidersHorizontal, UserRoundPen } from "lucide-react";
+import { Activity, Clock3, Cpu, FlaskConical, Puzzle, Settings, Shield, SlidersHorizontal, UserRoundPen } from "lucide-react";
 import { NavLink } from "@/lib/router";
 import { pluginsApi } from "@/api/plugins";
 import { queryKeys } from "@/lib/queryKeys";
@@ -27,6 +27,7 @@ export function InstanceSidebar() {
           <SidebarNavItem to="/instance/settings/general" label="General" icon={SlidersHorizontal} end />
           <SidebarNavItem to="/instance/settings/access" label="Access" icon={Shield} end />
           <SidebarNavItem to="/instance/settings/heartbeats" label="Heartbeats" icon={Clock3} end />
+          <SidebarNavItem to="/instance/settings/health" label="System Health" icon={Activity} end />
           <SidebarNavItem to="/instance/settings/experimental" label="Experimental" icon={FlaskConical} />
           <SidebarNavItem to="/instance/settings/plugins" label="Plugins" icon={Puzzle} />
           <SidebarNavItem to="/instance/settings/adapters" label="Adapters" icon={Cpu} />

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -17,6 +17,7 @@ import { ToastViewport } from "./ToastViewport";
 import { MobileBottomNav } from "./MobileBottomNav";
 import { WorktreeBanner } from "./WorktreeBanner";
 import { DevRestartBanner } from "./DevRestartBanner";
+import { SystemPauseBanner } from "./SystemPauseBanner";
 import { SidebarAccountMenu } from "./SidebarAccountMenu";
 import { useDialog } from "../context/DialogContext";
 import { GeneralSettingsProvider } from "../context/GeneralSettingsContext";
@@ -317,6 +318,7 @@ export function Layout() {
         Skip to Main Content
       </a>
       <WorktreeBanner />
+      <SystemPauseBanner />
       <DevRestartBanner devServer={health?.devServer} />
       <div className={cn("min-h-0 flex-1", isMobile ? "w-full" : "flex overflow-hidden")}>
         {isMobile && sidebarOpen && (

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -1,13 +1,14 @@
 import { useMemo, useState } from "react";
 import { NavLink, useLocation } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Plus } from "lucide-react";
+import { ChevronRight, Clock, OctagonX, Plus } from "lucide-react";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useSidebar } from "../context/SidebarContext";
 import { agentsApi } from "../api/agents";
 import { authApi } from "../api/auth";
 import { heartbeatsApi } from "../api/heartbeats";
+import { instanceSettingsApi } from "../api/instanceSettings";
 import { SIDEBAR_SCROLL_RESET_STATE } from "../lib/navigation-scroll";
 import { queryKeys } from "../lib/queryKeys";
 import { cn, agentRouteRef, agentUrl } from "../lib/utils";
@@ -44,6 +45,12 @@ export function SidebarAgents() {
     refetchInterval: 10_000,
   });
 
+  const { data: agentQueuedCounts } = useQuery({
+    queryKey: queryKeys.instance.agentQueuedCounts,
+    queryFn: () => instanceSettingsApi.getAgentQueuedCounts(),
+    refetchInterval: 15_000,
+  });
+
   const liveCountByAgent = useMemo(() => {
     const counts = new Map<string, number>();
     for (const run of liveRuns ?? []) {
@@ -51,6 +58,14 @@ export function SidebarAgents() {
     }
     return counts;
   }, [liveRuns]);
+
+  const queuedCountByAgent = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const entry of agentQueuedCounts ?? []) {
+      counts.set(entry.agentId, entry.queuedCount);
+    }
+    return counts;
+  }, [agentQueuedCounts]);
 
   const visibleAgents = useMemo(() => {
     const filtered = (agents ?? []).filter(
@@ -102,6 +117,7 @@ export function SidebarAgents() {
         <div className="flex flex-col gap-0.5 mt-0.5">
           {orderedAgents.map((agent: Agent) => {
             const runCount = liveCountByAgent.get(agent.id) ?? 0;
+            const queuedCount = queuedCountByAgent.get(agent.id) ?? 0;
             return (
               <NavLink
                 key={agent.id}
@@ -119,10 +135,32 @@ export function SidebarAgents() {
               >
                 <AgentIcon icon={agent.icon} className="shrink-0 h-3.5 w-3.5 text-muted-foreground" />
                 <span className="flex-1 truncate">{agent.name}</span>
-                {(agent.pauseReason === "budget" || runCount > 0) && (
+                {(() => {
+                  const rc = agent.runtimeConfig as Record<string, unknown> | null;
+                  const isAutoPaused = (rc?.autoPause as { paused?: boolean } | undefined)?.paused === true;
+                  const hasAny = agent.pauseReason === "budget" || isAutoPaused || runCount > 0 || queuedCount > 0;
+                  return hasAny ? (
                   <span className="ml-auto flex items-center gap-1.5 shrink-0">
                     {agent.pauseReason === "budget" ? (
                       <BudgetSidebarMarker title="Agent paused by budget" />
+                    ) : null}
+                    {isAutoPaused ? (
+                      <span
+                        title="Agent auto-paused by runaway detector"
+                        aria-label="Agent auto-paused by runaway detector"
+                        className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-amber-500/95 text-amber-950 shadow-[0_0_0_1px_rgba(255,255,255,0.08)]"
+                      >
+                        <OctagonX className="h-3 w-3" />
+                      </span>
+                    ) : null}
+                    {queuedCount > 0 ? (
+                      <span
+                        title={`${queuedCount} queued run${queuedCount !== 1 ? "s" : ""}`}
+                        className="flex items-center gap-0.5 text-[11px] font-medium text-orange-600 dark:text-orange-400"
+                      >
+                        <Clock className="h-3 w-3" />
+                        {queuedCount}
+                      </span>
                     ) : null}
                     {runCount > 0 ? (
                       <span className="relative flex h-2 w-2">
@@ -136,7 +174,8 @@ export function SidebarAgents() {
                       </span>
                     ) : null}
                   </span>
-                )}
+                ) : null;
+                })()}
               </NavLink>
             );
           })}

--- a/ui/src/components/SystemPauseBanner.tsx
+++ b/ui/src/components/SystemPauseBanner.tsx
@@ -1,0 +1,58 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { OctagonX } from "lucide-react";
+import { instanceSettingsApi } from "../api/instanceSettings";
+import { queryKeys } from "../lib/queryKeys";
+
+function formatTimestamp(value: string | null): string | null {
+  if (!value) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleString();
+}
+
+export function SystemPauseBanner() {
+  const queryClient = useQueryClient();
+  const { data } = useQuery({
+    queryKey: queryKeys.instance.adminStatus,
+    queryFn: () => instanceSettingsApi.getAdminStatus(),
+    retry: false,
+    refetchInterval: 30_000,
+  });
+
+  const unpause = useMutation({
+    mutationFn: () => instanceSettingsApi.adminUnpause(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.instance.adminStatus });
+    },
+  });
+
+  if (!data?.paused) return null;
+
+  const since = formatTimestamp(data.pausedAt);
+
+  return (
+    <div className="border-b border-red-300/60 bg-red-50 text-red-950 dark:border-red-500/25 dark:bg-red-500/10 dark:text-red-100">
+      <div className="flex flex-col gap-2 px-3 py-2 md:flex-row md:items-center md:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-[12px] font-semibold uppercase tracking-[0.18em]">
+            <OctagonX className="h-3.5 w-3.5 shrink-0" />
+            <span>System Paused</span>
+          </div>
+          <p className="mt-0.5 text-sm">
+            Agent run enqueuing is blocked.
+            {data.pauseReason ? ` Reason: ${data.pauseReason}.` : ""}
+            {since ? ` Paused since ${since}.` : ""}
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={unpause.isPending}
+          onClick={() => unpause.mutate()}
+          className="shrink-0 inline-flex items-center gap-1.5 rounded-md border border-red-300/70 bg-white/70 px-3 py-1.5 text-xs font-semibold text-red-900 shadow-sm transition-colors hover:bg-white disabled:opacity-50 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-100 dark:hover:bg-red-500/20"
+        >
+          {unpause.isPending ? "Resuming…" : "Resume System"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -115,6 +115,8 @@ export const queryKeys = {
     generalSettings: ["instance", "general-settings"] as const,
     schedulerHeartbeats: ["instance", "scheduler-heartbeats"] as const,
     experimentalSettings: ["instance", "experimental-settings"] as const,
+    adminStatus: ["instance", "admin-status"] as const,
+    agentQueuedCounts: ["instance", "agent-queued-counts"] as const,
   },
   health: ["health"] as const,
   secrets: {

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -795,6 +795,27 @@ export function AgentDetail() {
     },
   });
 
+  const clearAutoPause = useMutation({
+    mutationFn: () => agentsApi.unpauseAuto(agentLookupRef, resolvedCompanyId ?? undefined),
+    onSuccess: () => {
+      setActionError(null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(routeAgentRef) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentLookupRef) });
+      if (resolvedCompanyId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(resolvedCompanyId) });
+      }
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to clear auto-pause");
+    },
+  });
+
+  const { data: agentQueuedCountsData } = useQuery({
+    queryKey: queryKeys.instance.agentQueuedCounts,
+    queryFn: () => instanceSettingsApi.getAgentQueuedCounts(),
+    refetchInterval: 15_000,
+  });
+
   const budgetMutation = useMutation({
     mutationFn: (amount: number) =>
       budgetsApi.upsertPolicy(resolvedCompanyId!, {
@@ -903,6 +924,9 @@ export function AgentDetail() {
   }
   const isPendingApproval = agent.status === "pending_approval";
   const showConfigActionBar = (activeView === "configuration" || activeView === "instructions") && (configDirty || configSaving);
+  const autoPause = (agent.runtimeConfig as Record<string, unknown> | null)?.autoPause as { paused?: boolean; reason?: string; triggeredAt?: string } | undefined;
+  const isAutoPaused = autoPause?.paused === true;
+  const thisAgentQueuedCount = agentQueuedCountsData?.find((e) => e.agentId === agent.id)?.queuedCount ?? 0;
 
   return (
     <div className={cn("space-y-6", isMobile && showConfigActionBar && "pb-24")}>
@@ -1001,6 +1025,50 @@ export function AgentDetail() {
           </Popover>
         </div>
       </div>
+
+      {isAutoPaused && (
+        <div className="rounded-md border border-amber-300/60 bg-amber-50 px-4 py-3 dark:border-amber-500/25 dark:bg-amber-500/10">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-amber-900 dark:text-amber-100">
+                Agent auto-paused by runaway detector
+              </p>
+              {autoPause?.reason && (
+                <p className="mt-0.5 text-xs text-amber-800 dark:text-amber-200">{autoPause.reason}</p>
+              )}
+              {autoPause?.triggeredAt && (
+                <p className="text-xs text-amber-700 dark:text-amber-300">
+                  Triggered at {new Date(autoPause.triggeredAt).toLocaleString()}
+                </p>
+              )}
+              {thisAgentQueuedCount > 0 && (
+                <p className="mt-0.5 text-xs text-amber-700 dark:text-amber-300">
+                  {thisAgentQueuedCount} queued run{thisAgentQueuedCount !== 1 ? "s" : ""} will remain blocked until auto-pause is cleared.
+                </p>
+              )}
+              <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+                This agent will not process new runs until auto-pause is cleared.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={clearAutoPause.isPending}
+              onClick={() => clearAutoPause.mutate()}
+              className="shrink-0 border-amber-300/70 bg-white/70 text-amber-900 hover:bg-white dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100 dark:hover:bg-amber-500/20"
+            >
+              {clearAutoPause.isPending ? "Clearing…" : "Clear Auto-Pause"}
+            </Button>
+          </div>
+        </div>
+      )}
+      {!isAutoPaused && thisAgentQueuedCount > 0 && (
+        <div className="rounded-md border border-orange-200/60 bg-orange-50/60 px-4 py-2.5 dark:border-orange-500/20 dark:bg-orange-500/10">
+          <p className="text-xs text-orange-800 dark:text-orange-300">
+            {thisAgentQueuedCount} queued run{thisAgentQueuedCount !== 1 ? "s" : ""} pending for this agent.
+          </p>
+        </div>
+      )}
 
       {!urlRunId && (
         <Tabs

--- a/ui/src/pages/InstanceGeneralSettings.tsx
+++ b/ui/src/pages/InstanceGeneralSettings.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { PatchInstanceGeneralSettings, BackupRetentionPolicy } from "@paperclipai/shared";
+import type { PatchInstanceGeneralSettings, BackupRetentionPolicy, RunawayDetectorSettings } from "@paperclipai/shared";
 import {
   DAILY_RETENTION_PRESETS,
   WEEKLY_RETENTION_PRESETS,
   MONTHLY_RETENTION_PRESETS,
   DEFAULT_BACKUP_RETENTION,
+  DEFAULT_RUNAWAY_SETTINGS,
 } from "@paperclipai/shared";
 import { LogOut, SlidersHorizontal } from "lucide-react";
 import { authApi } from "@/api/auth";
@@ -81,6 +82,7 @@ export function InstanceGeneralSettings() {
   const keyboardShortcuts = generalQuery.data?.keyboardShortcuts === true;
   const feedbackDataSharingPreference = generalQuery.data?.feedbackDataSharingPreference ?? "prompt";
   const backupRetention: BackupRetentionPolicy = generalQuery.data?.backupRetention ?? DEFAULT_BACKUP_RETENTION;
+  const runaway: RunawayDetectorSettings = generalQuery.data?.runaway ?? DEFAULT_RUNAWAY_SETTINGS;
 
   return (
     <div className="max-w-4xl space-y-6">
@@ -274,6 +276,99 @@ export function InstanceGeneralSettings() {
       </section>
 
       <section className="rounded-xl border border-border bg-card p-5">
+        <div className="space-y-5">
+          <div className="space-y-1.5">
+            <h2 className="text-sm font-semibold">Runaway detector</h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Automatically pauses agents that enqueue runs too rapidly. The fast-trip threshold
+              trips within a short window; the slow-trip catches sustained over-activity.
+              Startup guard pauses the system at boot when the queued backlog is too large.
+            </p>
+          </div>
+
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <h3 className="text-sm font-medium">Auto-pause on runaway</h3>
+              <p className="text-sm text-muted-foreground">
+                When enabled, agents that exceed the fast or slow enqueue thresholds are
+                automatically paused.
+              </p>
+            </div>
+            <ToggleSwitch
+              checked={runaway.autoPauseEnabled}
+              onCheckedChange={() =>
+                updateGeneralMutation.mutate({ runaway: { ...runaway, autoPauseEnabled: !runaway.autoPauseEnabled } })
+              }
+              disabled={updateGeneralMutation.isPending}
+              aria-label="Toggle runaway auto-pause"
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <RunawayNumberField
+              label="Fast window"
+              description="Seconds"
+              value={runaway.fastWindowSec}
+              min={5}
+              disabled={updateGeneralMutation.isPending}
+              onCommit={(v) => updateGeneralMutation.mutate({ runaway: { ...runaway, fastWindowSec: v } })}
+            />
+            <RunawayNumberField
+              label="Fast threshold"
+              description="Max enqueues in fast window"
+              value={runaway.fastThresholdCount}
+              min={1}
+              disabled={updateGeneralMutation.isPending}
+              onCommit={(v) => updateGeneralMutation.mutate({ runaway: { ...runaway, fastThresholdCount: v } })}
+            />
+            <RunawayNumberField
+              label="Slow window"
+              description="Seconds"
+              value={runaway.slowWindowSec}
+              min={5}
+              disabled={updateGeneralMutation.isPending}
+              onCommit={(v) => updateGeneralMutation.mutate({ runaway: { ...runaway, slowWindowSec: v } })}
+            />
+            <RunawayNumberField
+              label="Slow threshold"
+              description="Max enqueues in slow window"
+              value={runaway.slowThresholdCount}
+              min={1}
+              disabled={updateGeneralMutation.isPending}
+              onCommit={(v) => updateGeneralMutation.mutate({ runaway: { ...runaway, slowThresholdCount: v } })}
+            />
+          </div>
+
+          <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
+            <div className="space-y-1">
+              <h3 className="text-sm font-medium">Startup guard</h3>
+              <p className="text-sm text-muted-foreground">
+                Pauses the system at boot when the queued-run backlog exceeds the threshold,
+                preventing an immediate re-flood after a crash recovery.
+              </p>
+            </div>
+            <ToggleSwitch
+              checked={runaway.startupGuardEnabled}
+              onCheckedChange={() =>
+                updateGeneralMutation.mutate({ runaway: { ...runaway, startupGuardEnabled: !runaway.startupGuardEnabled } })
+              }
+              disabled={updateGeneralMutation.isPending}
+              aria-label="Toggle startup guard"
+            />
+          </div>
+
+          <RunawayNumberField
+            label="Startup guard threshold"
+            description="Queued runs at boot that trigger a system pause"
+            value={runaway.startupGuardThreshold}
+            min={1}
+            disabled={updateGeneralMutation.isPending || !runaway.startupGuardEnabled}
+            onCommit={(v) => updateGeneralMutation.mutate({ runaway: { ...runaway, startupGuardThreshold: v } })}
+          />
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-border bg-card p-5">
         <div className="space-y-4">
           <div className="space-y-1.5">
             <h2 className="text-sm font-semibold">AI feedback sharing</h2>
@@ -377,6 +472,58 @@ function StatusBox({ label, value }: { label: string; value: string }) {
     <div className="rounded-lg border border-border bg-background px-3 py-3">
       <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</div>
       <div className="mt-2 text-sm font-medium">{value}</div>
+    </div>
+  );
+}
+
+function RunawayNumberField({
+  label,
+  description,
+  value,
+  min,
+  disabled,
+  onCommit,
+}: {
+  label: string;
+  description: string;
+  value: number;
+  min: number;
+  disabled: boolean;
+  onCommit: (v: number) => void;
+}) {
+  const [draft, setDraft] = useState<string>(String(value));
+
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  function handleBlur() {
+    const parsed = parseInt(draft, 10);
+    if (!Number.isNaN(parsed) && parsed >= min && parsed !== value) {
+      onCommit(parsed);
+    } else {
+      setDraft(String(value));
+    }
+  }
+
+  return (
+    <div className="space-y-1">
+      <label className="text-sm font-medium">{label}</label>
+      <p className="text-xs text-muted-foreground">{description}</p>
+      <input
+        type="number"
+        min={min}
+        value={draft}
+        disabled={disabled}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={handleBlur}
+        onKeyDown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+        className={cn(
+          "w-full rounded-md border border-border bg-background px-3 py-2 text-sm",
+          "focus:outline-none focus:ring-1 focus:ring-foreground/30",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+        )}
+      />
     </div>
   );
 }

--- a/ui/src/pages/SystemHealth.tsx
+++ b/ui/src/pages/SystemHealth.tsx
@@ -1,0 +1,262 @@
+import { useEffect } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Activity, Clock, OctagonX, Play, Puzzle } from "lucide-react";
+import { Link } from "@/lib/router";
+import { instanceSettingsApi } from "../api/instanceSettings";
+import { agentsApi } from "../api/agents";
+import { companiesApi } from "../api/companies";
+import { pluginsApi } from "../api/plugins";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { queryKeys } from "../lib/queryKeys";
+import { relativeTime, formatDateTime, cn } from "../lib/utils";
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  if (typeof v !== "object" || v === null || Array.isArray(v)) return null;
+  return v as Record<string, unknown>;
+}
+
+export function SystemHealth() {
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    setBreadcrumbs([
+      { label: "Instance Settings" },
+      { label: "System Health" },
+    ]);
+  }, [setBreadcrumbs]);
+
+  const statusQuery = useQuery({
+    queryKey: queryKeys.instance.adminStatus,
+    queryFn: () => instanceSettingsApi.getAdminStatus(),
+    refetchInterval: 15_000,
+    retry: false,
+  });
+
+  const allAgentsQuery = useQuery({
+    queryKey: ["system-health-all-agents"],
+    queryFn: async () => {
+      const companies = await companiesApi.list();
+      const perCompany = await Promise.all(companies.map((c) => agentsApi.list(c.id)));
+      return perCompany.flat();
+    },
+    refetchInterval: 30_000,
+  });
+
+  const pluginsQuery = useQuery({
+    queryKey: queryKeys.plugins.all,
+    queryFn: () => pluginsApi.list(),
+  });
+
+  const unpause = useMutation({
+    mutationFn: () => instanceSettingsApi.adminUnpause(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.instance.adminStatus });
+    },
+  });
+
+  const clearAutoPause = useMutation({
+    mutationFn: (agentId: string) => agentsApi.unpauseAuto(agentId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["system-health-all-agents"] });
+    },
+  });
+
+  const status = statusQuery.data;
+  const autoPausedAgents = (allAgentsQuery.data ?? []).filter((agent) => {
+    const rc = asRecord(agent.runtimeConfig);
+    return (rc?.autoPause as { paused?: boolean } | undefined)?.paused === true;
+  });
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      <div className="space-y-1">
+        <div className="flex items-center gap-2">
+          <Activity className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">System Health</h1>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          System pause state, auto-paused agents, and plugin status.
+        </p>
+      </div>
+
+      {/* System pause */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          System Pause
+        </h2>
+        <Card>
+          <CardContent className="p-4">
+            {statusQuery.isLoading ? (
+              <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : statusQuery.error ? (
+              <p className="text-sm text-destructive">
+                Could not load system status.{" "}
+                {statusQuery.error instanceof Error ? statusQuery.error.message : ""}
+              </p>
+            ) : (
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <Badge
+                      variant={status?.paused ? "destructive" : "outline"}
+                      className="text-[10px] px-1.5 py-0"
+                    >
+                      {status?.paused ? "Paused" : "Running"}
+                    </Badge>
+                    <span className="text-sm font-medium">
+                      Agent run enqueuing is {status?.paused ? "blocked" : "active"}
+                    </span>
+                  </div>
+                  {status?.paused && status.pauseReason && (
+                    <p className="text-xs text-muted-foreground">Reason: {status.pauseReason}</p>
+                  )}
+                  {status?.paused && status.pausedAt && (
+                    <p className="text-xs text-muted-foreground">
+                      Since {formatDateTime(status.pausedAt)} ({relativeTime(status.pausedAt)})
+                    </p>
+                  )}
+                  {(status?.queuedRunCount ?? 0) > 0 && (
+                    <div className="flex items-center gap-1.5 mt-1">
+                      <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+                      <span className="text-xs text-muted-foreground">
+                        {status!.queuedRunCount} queued run{status!.queuedRunCount !== 1 ? "s" : ""} pending
+                      </span>
+                    </div>
+                  )}
+                </div>
+                {status?.paused ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={unpause.isPending}
+                    onClick={() => unpause.mutate()}
+                    className="shrink-0 flex items-center gap-1.5"
+                  >
+                    <Play className="h-3.5 w-3.5" />
+                    {unpause.isPending ? "Resuming…" : "Resume System"}
+                  </Button>
+                ) : (
+                  <span className="text-xs text-muted-foreground italic">
+                    No manual action needed
+                  </span>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
+      {/* Auto-paused agents */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Auto-Paused Agents
+          </h2>
+          {autoPausedAgents.length > 0 && (
+            <Badge variant="destructive" className="text-[10px] px-1.5 py-0">
+              {autoPausedAgents.length}
+            </Badge>
+          )}
+        </div>
+        {allAgentsQuery.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading agents…</p>
+        ) : autoPausedAgents.length === 0 ? (
+          <Card>
+            <CardContent className="px-4 py-3">
+              <p className="text-sm text-muted-foreground">No agents are currently auto-paused.</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <Card>
+            <CardContent className="p-0">
+              <div className="divide-y">
+                {autoPausedAgents.map((agent) => {
+                  const rc = asRecord(agent.runtimeConfig);
+                  const autoPause = rc?.autoPause as
+                    | { paused?: boolean; reason?: string; triggeredAt?: string }
+                    | undefined;
+                  const clearing = clearAutoPause.isPending && clearAutoPause.variables === agent.id;
+                  return (
+                    <div key={agent.id} className="flex items-start gap-3 px-4 py-3 text-sm">
+                      <OctagonX className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                      <div className="min-w-0 flex-1">
+                        <Link
+                          to={`/agents/${encodeURIComponent(agent.urlKey ?? agent.id)}`}
+                          className="font-medium hover:underline"
+                        >
+                          {agent.name}
+                        </Link>
+                        {autoPause?.reason && (
+                          <p className="text-xs text-muted-foreground">{autoPause.reason}</p>
+                        )}
+                        {autoPause?.triggeredAt && (
+                          <p className="text-xs text-muted-foreground">
+                            {relativeTime(autoPause.triggeredAt)}
+                          </p>
+                        )}
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 px-2 text-xs shrink-0"
+                        disabled={clearing}
+                        onClick={() => clearAutoPause.mutate(agent.id)}
+                      >
+                        {clearing ? "Clearing…" : "Clear"}
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </section>
+
+      {/* Plugin status */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Plugins
+        </h2>
+        <Card>
+          <CardContent className="p-0">
+            {pluginsQuery.isLoading ? (
+              <div className="px-4 py-3 text-sm text-muted-foreground">Loading…</div>
+            ) : (pluginsQuery.data ?? []).length === 0 ? (
+              <div className="flex items-center gap-2 px-4 py-3 text-sm text-muted-foreground">
+                <Puzzle className="h-4 w-4 shrink-0" />
+                No plugins installed.
+              </div>
+            ) : (
+              <div className="divide-y">
+                {(pluginsQuery.data ?? []).map((plugin) => (
+                  <div key={plugin.id} className="flex items-center gap-3 px-4 py-3 text-sm">
+                    <Puzzle className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="flex-1 font-medium truncate">
+                      {plugin.manifestJson.displayName ?? plugin.packageName}
+                    </span>
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "text-[10px] px-1.5 py-0 shrink-0",
+                        plugin.status === "ready"
+                          ? "border-emerald-500/50 text-emerald-700 dark:text-emerald-400"
+                          : "border-muted text-muted-foreground",
+                      )}
+                    >
+                      {plugin.status}
+                    </Badge>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
> **CI Dependency Note**
> 
> This PR is part of a larger set of pause/runaway-hardening PRs. Two tests in
> `heartbeat-process-recovery.test.ts` (`:654`, `:701`) currently fail on most
> of these PRs. The root cause is the `canEnqueueForAgent` chokepoint added in
> **PR #4356**, which is specifically designed to block retry-enqueue when
> pause gates fire. The test updates are included in PR #4356; once that PR is
> merged, this PR's `verify` check will pass. Please merge #4356 first.

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; the operator's only window into system health is the web UI
> - The safety subsystem added in companion PRs (A/B/G) introduces system pause, per-agent auto-pause, and configurable runaway detection — but all controls were API-only at the time of implementation
> - An API-only safety mechanism fails the real-world operator test: during the 2026-04-22 runaway incident, the system-pause flag existed but was invisible and unreachable from the UI
> - Every safety control must have a matching UI surface so a human operator can observe and act without curl
> - This PR adds the full operator-facing UI layer: a global pause banner, a System Health page, per-agent auto-pause visibility, queued-run counts at system and per-agent granularity, and a settings form for runaway detector thresholds
> - The benefit is that an operator can now see the system's pause state, discover auto-paused agents, clear them, and tune detection thresholds — all from the existing instance settings UI

## What Changed

- **`GET /admin/status`** now includes `queuedRunCount: number` (total queued `heartbeat_runs`); new **`GET /admin/agents/queued-counts`** returns `{ agentId, queuedCount }[]` grouped by agent — both require instance-admin auth
- **`SystemPauseBanner`** — red full-width banner injected into `Layout` when the system is paused; polls `/admin/status` every 30 s; shows pause reason + elapsed time + Resume button
- **`SystemHealth` page** at `/instance/settings/health` — navigable via new "System Health" item in `InstanceSidebar`; shows system pause state with `queuedRunCount`, all auto-paused agents with per-agent Clear button, and plugin status
- **`SidebarAgents`** — amber `OctagonX` badge when an agent is auto-paused by the runaway detector; `Clock`+count badge when the agent has queued runs (polls `/admin/agents/queued-counts` every 15 s)
- **`AgentDetail`** — amber banner with reason, `triggeredAt`, queued-run count, and Clear Auto-Pause button when auto-paused; orange info row when queued but not paused
- **`InstanceGeneralSettings`** — new Runaway Detector section: auto-pause toggle, fast window/threshold, slow window/threshold number fields (reads/writes `runaway.*` config via existing PATCH endpoint)
- New API methods: `getAdminStatus`, `adminPause`, `adminUnpause`, `getAgentQueuedCounts` in `instanceSettingsApi`; `unpauseAuto` in `agentsApi`
- New query keys: `instance.adminStatus`, `instance.agentQueuedCounts`

## Verification

- UI `tsc --noEmit` clean (verified against main repo with full `node_modules`)
- No lockfile changes in any commit (`git show --stat` per commit confirmed)
- Manually tested on live self-hosted instance: pause banner appears/disappears on pause/unpause; System Health page navigable from sidebar; auto-pause badge visible in agent list; queued-count tile on dashboard updates
- `GET /admin/status` and `GET /admin/agents/queued-counts` return correct shapes under instance-admin auth; 403 for non-admin board users

## Risks

- **Depends on PRs A, B, G** for backend: system-pause semantics (A), `_systemPaused*` schema preservation (B), `/admin/pause` + `/admin/unpause` routes (B), runaway detector + `runtimeConfig.autoPause` (companion PR), and startup guard (companion PR). This PR should be merged after those.
- `getAgentQueuedCounts` polls every 15 s from `SidebarAgents` — low overhead (single aggregated DB query), but adds a recurring admin-auth request for all users with instance-admin access.
- Per-agent `unpause-auto` endpoint is consumed here but defined in the agents router (not in this PR); if that route is absent the Clear button will 404 silently.
- Low risk for UI-only users: all new UI elements degrade gracefully (banner hidden when not paused, badges absent when counts are zero, health page shows loading states on error).

## Model Used

- Claude Sonnet 4.6 (claude-sonnet-4-6) via Claude Code, multi-agent team (fixer + upgrader roles), 1M context window, tool use mode

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] UI tsc clean
- [x] No lockfile changes
- [x] Draft — pending Greptile review and backend PR merge ordering