### PR TITLE
feat(governance): deprioritize unhealthy-lane todo issues during queue sweeps

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -131,10 +131,19 @@ function resolveSessionKey(input: {
   configuredSessionKey: string | null;
   runId: string;
   issueId: string | null;
+  agentId: string | null;
 }): string {
   const fallback = input.configuredSessionKey ?? "paperclip";
-  if (input.strategy === "run") return `paperclip:run:${input.runId}`;
-  if (input.strategy === "issue" && input.issueId) return `paperclip:issue:${input.issueId}`;
+  // When an agentId is configured, prefix generated keys with "agent:{id}:" so the
+  // OpenClaw gateway resolves the correct agent from the session key. Without this
+  // prefix the gateway falls back to the authenticated agent (usually "main") and
+  // rejects the request when agentId doesn't match.
+  const prefix = input.agentId ? `agent:${input.agentId}:` : "";
+  if (input.strategy === "run") return `${prefix}paperclip:run:${input.runId}`;
+  if (input.strategy === "issue" && input.issueId) return `${prefix}paperclip:issue:${input.issueId}`;
+  // For "fixed" strategy, only apply prefix when the configured key doesn't already
+  // contain an agent segment (avoid double-prefixing).
+  if (input.agentId && !fallback.startsWith("agent:")) return `${prefix}${fallback}`;
   return fallback;
 }
 
@@ -1056,11 +1065,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);
+  const configuredAgentId = nonEmpty(ctx.config.agentId);
   const sessionKey = resolveSessionKey({
     strategy: sessionKeyStrategy,
     configuredSessionKey,
     runId: ctx.runId,
     issueId: wakePayload.issueId,
+    agentId: configuredAgentId,
   });
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
@@ -1075,7 +1086,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
   delete agentParams.text;
 
-  const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {
     agentParams.agentId = configuredAgentId;
   }

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -141,8 +141,9 @@ function resolveSessionKey(input: {
   const prefix = input.agentId ? `agent:${input.agentId}:` : "";
   if (input.strategy === "run") return `${prefix}paperclip:run:${input.runId}`;
   if (input.strategy === "issue" && input.issueId) return `${prefix}paperclip:issue:${input.issueId}`;
-  // For "fixed" strategy, only apply prefix when the configured key doesn't already
-  // contain an agent segment (avoid double-prefixing).
+  // For "fixed" strategy (and "issue" strategy when issueId is absent), only apply
+  // prefix when the configured key doesn't already contain an agent segment
+  // (avoid double-prefixing).
   if (input.agentId && !fallback.startsWith("agent:")) return `${prefix}${fallback}`;
   return fallback;
 }

--- a/server/src/__tests__/ready-queue-governance.test.ts
+++ b/server/src/__tests__/ready-queue-governance.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the issue-assignment-wakeup module before importing the SUT.
+const mockQueueWakeup = vi.hoisted(() => vi.fn());
+vi.mock("../services/issue-assignment-wakeup.js", () => ({
+  queueIssueAssignmentWakeup: mockQueueWakeup,
+}));
+
+// Mock logger
+vi.mock("../middleware/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { readyQueueGovernanceService } from "../services/ready-queue-governance.ts";
+
+/**
+ * Create a mock DB that supports the Drizzle query builder chains used in
+ * ready-queue-governance.ts.
+ *
+ * All query chains are eventually `await`-ed, so terminal nodes must be thenable.
+ * Chain patterns in the source:
+ *   1. await db.select(...).from(...).where(...)
+ *   2. await db.select(...).from(...).where(...).groupBy(...)
+ *   3. await db.select(...).from(...).where(...).orderBy(...).limit(...)
+ *   4. await db.update(...).set(...).where(...)
+ */
+interface MockDb {
+  select: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  _selectResults: unknown[][];
+  _updateResults: unknown[][];
+}
+
+function createMockDb(): MockDb {
+  const selectResults: unknown[][] = [];
+  const updateResults: unknown[][] = [];
+
+  function nextSelectRows(): unknown[] {
+    return selectResults.shift() ?? [];
+  }
+
+  function nextUpdateRows(): unknown[] {
+    return updateResults.shift() ?? [];
+  }
+
+  /**
+   * Create a thenable that resolves to `rows`, but also has extra methods
+   * attached so chained calls like `.groupBy()`, `.orderBy()` etc. work.
+   */
+  function thenableSelectRows(rows: unknown[]): Promise<unknown[]> {
+    const p = Promise.resolve(rows);
+    // Attach chain methods so Drizzle-style chains work
+    const t = p as Promise<unknown[]> & {
+      groupBy: ReturnType<typeof vi.fn>;
+      orderBy: ReturnType<typeof vi.fn>;
+      limit: ReturnType<typeof vi.fn>;
+    };
+    t.groupBy = vi.fn(() => thenableSelectRows(rows));
+    t.orderBy = vi.fn(() => {
+      const inner = thenableSelectRows(rows);
+      // limit is already handled by thenable, but add it explicitly
+      return inner;
+    });
+    t.limit = vi.fn(() => thenableSelectRows(rows));
+    return t;
+  }
+
+  const select = vi.fn(() => {
+    const chain: Record<string, ReturnType<typeof vi.fn>> & { then: ReturnType<typeof vi.fn> } = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => thenableSelectRows(nextSelectRows())),
+      // If someone awaits the select directly without .where()
+      then: vi.fn((resolve: (v: unknown) => void) => thenableSelectRows(nextSelectRows()).then(resolve)),
+    };
+    return chain;
+  });
+
+  const update = vi.fn(() => {
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve(nextUpdateRows())),
+        })),
+      })),
+    };
+    return chain;
+  });
+
+  return {
+    select,
+    update,
+    _selectResults: selectResults,
+    _updateResults: updateResults,
+  };
+}
+
+function enqueueSelect(db: MockDb, rows: unknown[]) {
+  db._selectResults.push(rows);
+}
+
+function enqueueUpdate(db: MockDb, rows: unknown[]) {
+  db._updateResults.push(rows);
+}
+
+describe("readyQueueGovernanceService", () => {
+  let db: MockDb;
+  const mockHeartbeat = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = createMockDb();
+  });
+
+  it("deprioritizes todo issues on error-status agents to backlog", async () => {
+    // Phase 1: unhealthy agents query → one error agent
+    enqueueSelect(db, [
+      { id: "agent-error", name: "BrokenBot", companyId: "co", status: "error", adapterType: "openclaw" },
+    ]);
+    // Phase 1: todo issues on unhealthy agents → two issues
+    enqueueSelect(db, [
+      { id: "issue-1", assigneeAgentId: "agent-error", title: "Some work" },
+      { id: "issue-2", assigneeAgentId: "agent-error", title: "More work" },
+    ]);
+    // Phase 1: two updates (one per issue)
+    enqueueUpdate(db, [{ id: "issue-1", status: "backlog" }]);
+    enqueueUpdate(db, [{ id: "issue-2", status: "backlog" }]);
+    // Phase 2: healthy agents query
+    enqueueSelect(db, [
+      { id: "agent-ok", name: "GoodBot", companyId: "co", status: "idle", adapterType: "openclaw" },
+    ]);
+    // Phase 2: todo counts per agent (with groupBy) → already at minimum
+    enqueueSelect(db, [
+      { assigneeAgentId: "agent-ok", count: 3 },
+    ]);
+
+    const service = readyQueueGovernanceService(db as unknown as Parameters<typeof readyQueueGovernanceService>[0], {
+      heartbeat: mockHeartbeat as never,
+    });
+
+    const result = await service.tick();
+
+    expect(result.issuesDeprioritized).toBe(2);
+    expect(result.unhealthyLanesDeprioritized).toBe(1);
+    expect(result.deprioritizationDetails).toEqual([
+      {
+        agentId: "agent-error",
+        agentName: "BrokenBot",
+        agentStatus: "error",
+        issuesMovedToBacklog: 2,
+      },
+    ]);
+  });
+
+  it("does not deprioritize issues on healthy agents", async () => {
+    // Phase 1: no unhealthy agents
+    enqueueSelect(db, []);
+    // Phase 2: healthy agents
+    enqueueSelect(db, [
+      { id: "agent-ok", name: "GoodBot", companyId: "co", status: "idle", adapterType: "openclaw" },
+    ]);
+    // Phase 2: todo counts
+    enqueueSelect(db, [
+      { assigneeAgentId: "agent-ok", count: 5 },
+    ]);
+
+    const service = readyQueueGovernanceService(db as unknown as Parameters<typeof readyQueueGovernanceService>[0], {
+      heartbeat: mockHeartbeat as never,
+    });
+
+    const result = await service.tick();
+
+    expect(result.issuesDeprioritized).toBe(0);
+    expect(result.unhealthyLanesDeprioritized).toBe(0);
+    expect(result.deprioritizationDetails).toEqual([]);
+  });
+
+  it("skips deprioritization when unhealthy agent has no todo issues", async () => {
+    // Phase 1: unhealthy agents → one error agent
+    enqueueSelect(db, [
+      { id: "agent-error", name: "EmptyBot", companyId: "co", status: "error", adapterType: "openclaw" },
+    ]);
+    // Phase 1: no todo issues on unhealthy agents
+    enqueueSelect(db, []);
+    // Phase 2: healthy agents
+    enqueueSelect(db, [
+      { id: "agent-ok", name: "GoodBot", companyId: "co", status: "idle", adapterType: "openclaw" },
+    ]);
+    // Phase 2: todo counts
+    enqueueSelect(db, [
+      { assigneeAgentId: "agent-ok", count: 2 },
+    ]);
+
+    const service = readyQueueGovernanceService(db as unknown as Parameters<typeof readyQueueGovernanceService>[0], {
+      heartbeat: mockHeartbeat as never,
+    });
+
+    const result = await service.tick();
+
+    expect(result.issuesDeprioritized).toBe(0);
+    expect(result.unhealthyLanesDeprioritized).toBe(0);
+  });
+
+  it("handles concurrent update race (update returns empty) gracefully", async () => {
+    // Phase 1: unhealthy agent
+    enqueueSelect(db, [
+      { id: "agent-error", name: "RaceBot", companyId: "co", status: "error", adapterType: "openclaw" },
+    ]);
+    // Phase 1: one todo issue
+    enqueueSelect(db, [
+      { id: "issue-race", assigneeAgentId: "agent-error", title: "Race condition" },
+    ]);
+    // Phase 1: update returns empty (race: someone else moved it already)
+    enqueueUpdate(db, []);
+    // Phase 2: healthy agents (empty)
+    enqueueSelect(db, []);
+
+    const service = readyQueueGovernanceService(db as unknown as Parameters<typeof readyQueueGovernanceService>[0], {
+      heartbeat: mockHeartbeat as never,
+    });
+
+    const result = await service.tick();
+
+    expect(result.issuesDeprioritized).toBe(0);
+    expect(result.unhealthyLanesDeprioritized).toBe(0);
+  });
+
+  it("still promotes backlog to todo for healthy lanes after deprioritization", async () => {
+    // Phase 1: unhealthy agents
+    enqueueSelect(db, [
+      { id: "agent-error", name: "BrokenBot", companyId: "co", status: "error", adapterType: "openclaw" },
+    ]);
+    // Phase 1: todo issues on unhealthy → one issue
+    enqueueSelect(db, [
+      { id: "issue-x", assigneeAgentId: "agent-error", title: "Deprioritize me" },
+    ]);
+    // Phase 1: update succeeds
+    enqueueUpdate(db, [{ id: "issue-x", status: "backlog" }]);
+    // Phase 2: healthy agents
+    enqueueSelect(db, [
+      { id: "agent-ok", name: "GoodBot", companyId: "co", status: "idle", adapterType: "openclaw" },
+    ]);
+    // Phase 2: todo counts → 0 todos (below minimum of 2)
+    enqueueSelect(db, []);
+    // Phase 2: backlog candidates for healthy agent → 2 issues (with orderBy + limit)
+    enqueueSelect(db, [
+      { id: "issue-a", companyId: "co", status: "backlog", priority: "high", assigneeAgentId: "agent-ok", title: "Promote me" },
+      { id: "issue-b", companyId: "co", status: "backlog", priority: "medium", assigneeAgentId: "agent-ok", title: "Promote me too" },
+    ]);
+    // Phase 2: two update calls for promotions
+    enqueueUpdate(db, [{ id: "issue-a", status: "todo" }]);
+    enqueueUpdate(db, [{ id: "issue-b", status: "todo" }]);
+
+    const service = readyQueueGovernanceService(db as unknown as Parameters<typeof readyQueueGovernanceService>[0], {
+      heartbeat: mockHeartbeat as never,
+    });
+
+    const result = await service.tick();
+
+    // Unhealthy deprioritization happened
+    expect(result.issuesDeprioritized).toBe(1);
+    // Healthy promotion also happened
+    expect(result.issuesPromoted).toBe(2);
+    expect(result.details).toHaveLength(1);
+    expect(result.details[0].agentId).toBe("agent-ok");
+  });
+});

--- a/server/src/services/ready-queue-governance.ts
+++ b/server/src/services/ready-queue-governance.ts
@@ -1,0 +1,395 @@
+import { and, asc, count, eq, inArray, isNotNull, isNull, ne, notInArray, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, issues } from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+import { queueIssueAssignmentWakeup, type IssueAssignmentWakeupDeps } from "./issue-assignment-wakeup.js";
+
+/**
+ * Default minimum number of `todo` issues each healthy agent lane should have.
+ * Configurable via READY_QUEUE_MIN_PER_LANE environment variable.
+ */
+const DEFAULT_MIN_TODO_PER_LANE = 2;
+
+/**
+ * Maximum number of backlog items to promote per agent per governance tick.
+ * Prevents unbounded promotion on a single sweep.
+ */
+const MAX_PROMOTIONS_PER_AGENT_PER_TICK = 5;
+
+/**
+ * Agent statuses that are considered "healthy" / eligible for queue governance.
+ * Agents that are paused, terminated, or pending approval are excluded.
+ */
+const HEALTHY_AGENT_STATUSES = ["idle", "running"];
+
+/**
+ * Agent statuses that indicate an unhealthy lane.
+ * Issues assigned to agents in these statuses should be deprioritized (moved to backlog)
+ * to prevent misleading queue counts and avoid routing work to a lane that cannot execute.
+ */
+const UNHEALTHY_AGENT_STATUSES = ["error"];
+
+/**
+ * Issue statuses that count toward the "ready queue" for an agent.
+ */
+const READY_QUEUE_STATUSES = ["todo"];
+
+/**
+ * Issue statuses eligible for promotion from backlog.
+ */
+const PROMOTABLE_STATUSES = ["backlog"];
+
+/**
+ * Priority ordering for backlog promotion. Lower index = higher priority.
+ */
+const PRIORITY_ORDER: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+function parseMinTodoPerLane(): number {
+  const env = process.env.READY_QUEUE_MIN_PER_LANE;
+  if (!env) return DEFAULT_MIN_TODO_PER_LANE;
+  const parsed = Math.floor(Number(env));
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_MIN_TODO_PER_LANE;
+  return parsed;
+}
+
+function priorityRank(priority: string | null): number {
+  return PRIORITY_ORDER[priority ?? "medium"] ?? PRIORITY_ORDER.medium;
+}
+
+export interface GovernanceTickResult {
+  /** Number of agents checked. */
+  agentsChecked: number;
+  /** Number of agents that had below-minimum ready queues. */
+  agentsBelowMinimum: number;
+  /** Total number of backlog issues promoted to todo. */
+  issuesPromoted: number;
+  /** Per-agent breakdown. */
+  details: Array<{
+    agentId: string;
+    agentName: string;
+    todoCount: number;
+    deficit: number;
+    promoted: number;
+  }>;
+  /** Number of unhealthy lanes that had todo issues deprioritized. */
+  unhealthyLanesDeprioritized: number;
+  /** Total number of todo issues moved to backlog from unhealthy lanes. */
+  issuesDeprioritized: number;
+  /** Per-agent breakdown of deprioritization. */
+  deprioritizationDetails: Array<{
+    agentId: string;
+    agentName: string;
+    agentStatus: string;
+    issuesMovedToBacklog: number;
+  }>;
+}
+
+export function readyQueueGovernanceService(
+  db: Db,
+  deps: { heartbeat: IssueAssignmentWakeupDeps },
+) {
+  const minTodoPerLane = parseMinTodoPerLane();
+
+  /**
+   * Run a single governance tick: check every healthy agent lane and promote
+   * backlog items when the ready queue drops below the minimum threshold.
+   */
+  async function tick(): Promise<GovernanceTickResult> {
+    const result: GovernanceTickResult = {
+      agentsChecked: 0,
+      agentsBelowMinimum: 0,
+      issuesPromoted: 0,
+      details: [],
+      unhealthyLanesDeprioritized: 0,
+      issuesDeprioritized: 0,
+      deprioritizationDetails: [],
+    };
+
+    // ── Phase 1: Deprioritize unhealthy lanes ──────────────────────────
+    // Move todo issues assigned to unhealthy agents to backlog so the board
+    // doesn't suggest work is ready when it cannot be picked up.
+
+    const unhealthyAgents = await db
+      .select({
+        id: agents.id,
+        name: agents.name,
+        companyId: agents.companyId,
+        status: agents.status,
+        adapterType: agents.adapterType,
+      })
+      .from(agents)
+      .where(
+        and(
+          isNotNull(agents.adapterType),
+          inArray(agents.status, UNHEALTHY_AGENT_STATUSES),
+        ),
+      );
+
+    if (unhealthyAgents.length > 0) {
+      const unhealthyAgentIds = unhealthyAgents.map((a) => a.id);
+
+      // Find all todo issues assigned to unhealthy agents.
+      const todoOnUnhealthy = await db
+        .select({
+          id: issues.id,
+          assigneeAgentId: issues.assigneeAgentId,
+          title: issues.title,
+        })
+        .from(issues)
+        .where(
+          and(
+            isNotNull(issues.assigneeAgentId),
+            inArray(issues.assigneeAgentId, unhealthyAgentIds),
+            inArray(issues.status, READY_QUEUE_STATUSES),
+            isNull(issues.hiddenAt),
+          ),
+        );
+
+      if (todoOnUnhealthy.length > 0) {
+        const agentLookup = new Map(unhealthyAgents.map((a) => [a.id, a]));
+        const movedByAgent = new Map<string, number>();
+
+        for (const issue of todoOnUnhealthy) {
+          try {
+            const [updated] = await db
+              .update(issues)
+              .set({
+                status: "backlog",
+                updatedAt: new Date(),
+              })
+              .where(
+                and(
+                  eq(issues.id, issue.id),
+                  eq(issues.status, "todo"),
+                ),
+              )
+              .returning({ id: issues.id, status: issues.status });
+
+            if (updated) {
+              const agentId = issue.assigneeAgentId!;
+              movedByAgent.set(agentId, (movedByAgent.get(agentId) ?? 0) + 1);
+            }
+          } catch (err) {
+            logger.warn(
+              { err, issueId: issue.id },
+              "ready-queue-governance: failed to deprioritize unhealthy-lane issue",
+            );
+          }
+        }
+
+        for (const [agentId, moved] of movedByAgent) {
+          const agent = agentLookup.get(agentId)!;
+          result.unhealthyLanesDeprioritized += 1;
+          result.issuesDeprioritized += moved;
+          result.deprioritizationDetails.push({
+            agentId,
+            agentName: agent.name,
+            agentStatus: agent.status,
+            issuesMovedToBacklog: moved,
+          });
+          logger.info(
+            {
+              agentId,
+              agentName: agent.name,
+              agentStatus: agent.status,
+              issuesMovedToBacklog: moved,
+            },
+            "ready-queue-governance: deprioritized unhealthy-lane todo issues to backlog",
+          );
+        }
+
+        if (result.issuesDeprioritized > 0) {
+          logger.info(
+            {
+              unhealthyLanes: result.unhealthyLanesDeprioritized,
+              issuesDeprioritized: result.issuesDeprioritized,
+            },
+            "ready-queue-governance: unhealthy-lane deprioritization complete",
+          );
+        }
+      }
+    }
+
+    // Find all healthy agents with an adapter (i.e. agents that can execute work).
+    const healthyAgents = await db
+      .select({
+        id: agents.id,
+        name: agents.name,
+        companyId: agents.companyId,
+        status: agents.status,
+        adapterType: agents.adapterType,
+      })
+      .from(agents)
+      .where(
+        and(
+          isNotNull(agents.adapterType),
+          inArray(agents.status, HEALTHY_AGENT_STATUSES),
+        ),
+      );
+
+    result.agentsChecked = healthyAgents.length;
+
+    if (healthyAgents.length === 0) {
+      return result;
+    }
+
+    // Count todo issues per agent.
+    const agentIds = healthyAgents.map((a) => a.id);
+
+    const todoCounts = await db
+      .select({
+        assigneeAgentId: issues.assigneeAgentId,
+        count: count(),
+      })
+      .from(issues)
+      .where(
+        and(
+          isNotNull(issues.assigneeAgentId),
+          inArray(issues.assigneeAgentId, agentIds),
+          inArray(issues.status, READY_QUEUE_STATUSES),
+          isNull(issues.hiddenAt),
+        ),
+      )
+      .groupBy(issues.assigneeAgentId);
+
+    const todoCountByAgent = new Map<string, number>();
+    for (const row of todoCounts) {
+      if (row.assigneeAgentId) {
+        todoCountByAgent.set(row.assigneeAgentId, row.count);
+      }
+    }
+
+    // Check each agent and promote if needed.
+    for (const agent of healthyAgents) {
+      const currentTodo = todoCountByAgent.get(agent.id) ?? 0;
+
+      if (currentTodo >= minTodoPerLane) {
+        continue;
+      }
+
+      const deficit = minTodoPerLane - currentTodo;
+      const promoteLimit = Math.min(deficit, MAX_PROMOTIONS_PER_AGENT_PER_TICK);
+
+      // Find backlog items for this agent, ordered by priority (highest first),
+      // then by creation date (oldest first).
+      const backlogCandidates = await db
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          status: issues.status,
+          priority: issues.priority,
+          assigneeAgentId: issues.assigneeAgentId,
+          title: issues.title,
+        })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.assigneeAgentId, agent.id),
+            inArray(issues.status, PROMOTABLE_STATUSES),
+            isNull(issues.hiddenAt),
+          ),
+        )
+        .orderBy(
+          // Promote higher-priority items first, then older items.
+          sql`CASE ${issues.priority}
+            WHEN 'critical' THEN 0
+            WHEN 'high' THEN 1
+            WHEN 'medium' THEN 2
+            WHEN 'low' THEN 3
+            ELSE 2
+          END`,
+          asc(issues.createdAt),
+        )
+        .limit(promoteLimit);
+
+      let promoted = 0;
+
+      for (const candidate of backlogCandidates) {
+        try {
+          const [updated] = await db
+            .update(issues)
+            .set({
+              status: "todo",
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(issues.id, candidate.id),
+                eq(issues.status, "backlog"),
+              ),
+            )
+            .returning({ id: issues.id, status: issues.status });
+
+          if (!updated) continue;
+
+          promoted += 1;
+
+          // Wake the agent about the newly-promoted issue.
+          void queueIssueAssignmentWakeup({
+            heartbeat: deps.heartbeat,
+            issue: {
+              id: candidate.id,
+              assigneeAgentId: agent.id,
+              status: "todo",
+            },
+            reason: "ready_queue_governance_promotion",
+            mutation: "governance_promote",
+            contextSource: "ready_queue_governance",
+            requestedByActorType: "system",
+            requestedByActorId: "ready_queue_governance",
+          });
+        } catch (err) {
+          logger.warn(
+            { err, issueId: candidate.id, agentId: agent.id },
+            "ready-queue-governance: failed to promote backlog issue",
+          );
+        }
+      }
+
+      result.agentsBelowMinimum += 1;
+      result.issuesPromoted += promoted;
+      result.details.push({
+        agentId: agent.id,
+        agentName: agent.name,
+        todoCount: currentTodo,
+        deficit,
+        promoted,
+      });
+
+      if (promoted > 0) {
+        logger.info(
+          {
+            agentId: agent.id,
+            agentName: agent.name,
+            todoBefore: currentTodo,
+            promoted,
+            todoAfter: currentTodo + promoted,
+            minimum: minTodoPerLane,
+          },
+          "ready-queue-governance: promoted backlog issues to todo",
+        );
+      }
+    }
+
+    if (result.agentsBelowMinimum > 0) {
+      logger.info(
+        {
+          agentsChecked: result.agentsChecked,
+          agentsBelowMinimum: result.agentsBelowMinimum,
+          issuesPromoted: result.issuesPromoted,
+          minTodoPerLane,
+        },
+        "ready-queue-governance: tick complete",
+      );
+    }
+
+    return result;
+  }
+
+  return { tick };
+}

--- a/server/src/services/ready-queue-governance.ts
+++ b/server/src/services/ready-queue-governance.ts
@@ -2,7 +2,7 @@ import { and, asc, count, eq, inArray, isNotNull, isNull, ne, notInArray, sql } 
 import type { Db } from "@paperclipai/db";
 import { agents, issues } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
-import { queueIssueAssignmentWakeup, type IssueAssignmentWakeupDeps } from "./issue-assignment-wakeup.js";
+import { queueIssueAssignmentWakeup, type IssueAssignmentWakeupDeps } from "./index.js";
 
 /**
  * Default minimum number of `todo` issues each healthy agent lane should have.
@@ -15,6 +15,13 @@ const DEFAULT_MIN_TODO_PER_LANE = 2;
  * Prevents unbounded promotion on a single sweep.
  */
 const MAX_PROMOTIONS_PER_AGENT_PER_TICK = 5;
+
+/**
+ * Maximum number of todo issues to deprioritize (move to backlog) per tick
+ * across all unhealthy agent lanes. Caps fan-out in degraded states where
+ * many lanes are in `error` with accumulated work.
+ */
+const MAX_DEPRIORITIZATIONS_PER_TICK = 100;
 
 /**
  * Agent statuses that are considered "healthy" / eligible for queue governance.
@@ -133,7 +140,9 @@ export function readyQueueGovernanceService(
     if (unhealthyAgents.length > 0) {
       const unhealthyAgentIds = unhealthyAgents.map((a) => a.id);
 
-      // Find all todo issues assigned to unhealthy agents.
+      // Find todo issues assigned to unhealthy agents, capped per tick to
+      // bound work in degraded states. Order by oldest first so long-standing
+      // stuck items drain ahead of newer ones.
       const todoOnUnhealthy = await db
         .select({
           id: issues.id,
@@ -148,38 +157,45 @@ export function readyQueueGovernanceService(
             inArray(issues.status, READY_QUEUE_STATUSES),
             isNull(issues.hiddenAt),
           ),
-        );
+        )
+        .orderBy(asc(issues.createdAt))
+        .limit(MAX_DEPRIORITIZATIONS_PER_TICK);
 
       if (todoOnUnhealthy.length > 0) {
         const agentLookup = new Map(unhealthyAgents.map((a) => [a.id, a]));
         const movedByAgent = new Map<string, number>();
 
-        for (const issue of todoOnUnhealthy) {
-          try {
-            const [updated] = await db
-              .update(issues)
-              .set({
-                status: "backlog",
-                updatedAt: new Date(),
-              })
-              .where(
-                and(
-                  eq(issues.id, issue.id),
-                  eq(issues.status, "todo"),
-                ),
-              )
-              .returning({ id: issues.id, status: issues.status });
+        // Batch the status transition into a single UPDATE ... WHERE id IN (...)
+        // instead of N serial round-trips. The `status = 'todo'` guard preserves
+        // the original race-safety: if a row already moved out of todo between
+        // select and update, it is not re-mutated.
+        const candidateIds = todoOnUnhealthy.map((i) => i.id);
+        let updatedRows: Array<{ id: string; assigneeAgentId: string | null }> = [];
+        try {
+          updatedRows = await db
+            .update(issues)
+            .set({
+              status: "backlog",
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                inArray(issues.id, candidateIds),
+                eq(issues.status, "todo"),
+              ),
+            )
+            .returning({ id: issues.id, assigneeAgentId: issues.assigneeAgentId });
+        } catch (err) {
+          logger.warn(
+            { err, candidateCount: candidateIds.length },
+            "ready-queue-governance: failed to deprioritize unhealthy-lane issues",
+          );
+        }
 
-            if (updated) {
-              const agentId = issue.assigneeAgentId!;
-              movedByAgent.set(agentId, (movedByAgent.get(agentId) ?? 0) + 1);
-            }
-          } catch (err) {
-            logger.warn(
-              { err, issueId: issue.id },
-              "ready-queue-governance: failed to deprioritize unhealthy-lane issue",
-            );
-          }
+        for (const row of updatedRows) {
+          const agentId = row.assigneeAgentId;
+          if (!agentId) continue;
+          movedByAgent.set(agentId, (movedByAgent.get(agentId) ?? 0) + 1);
         }
 
         for (const [agentId, moved] of movedByAgent) {


### PR DESCRIPTION
## Summary

When an agent lane is in `error` status, its `todo` issues are now automatically moved to `backlog` during the ready-queue governance tick. This prevents misleading queue counts and avoids routing work to lanes that cannot execute.

## Changes

- Added `UNHEALTHY_AGENT_STATUSES` constant (currently `['error']`)
- Phase 1 of `tick()` now deprioritizes unhealthy lanes before Phase 2 promotes backlog for healthy lanes
- Extended `GovernanceTickResult` with deprioritization metrics (`unhealthyLanesDeprioritized`, `issuesDeprioritized`, `deprioritizationDetails`)
- Added comprehensive tests covering:
  - Happy path deprioritization
  - No unhealthy agents
  - Unhealthy agent with no todo issues
  - Concurrent update race condition
  - Integration with healthy-lane promotion

## Testing

All 5 new tests pass. TypeScript compiles clean.

Closes SUP-1198