### PR TITLE
feat: add adapter-auggie-local

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.10.0",
+    "@paperclipai/adapter-auggie-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -3,6 +3,7 @@ import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
 import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
+import { printAuggieStreamEvent } from "@paperclipai/adapter-auggie-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
@@ -39,6 +40,11 @@ const geminiLocalCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printGeminiStreamEvent,
 };
 
+const auggieLocalCLIAdapter: CLIAdapterModule = {
+  type: "auggie_local",
+  formatStdoutEvent: printAuggieStreamEvent,
+};
+
 const openclawGatewayCLIAdapter: CLIAdapterModule = {
   type: "openclaw_gateway",
   formatStdoutEvent: printOpenClawGatewayStreamEvent,
@@ -52,6 +58,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     piLocalCLIAdapter,
     cursorLocalCLIAdapter,
     geminiLocalCLIAdapter,
+    auggieLocalCLIAdapter,
     openclawGatewayCLIAdapter,
     processCLIAdapter,
     httpCLIAdapter,

--- a/packages/adapters/auggie-local/package.json
+++ b/packages/adapters/auggie-local/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@paperclipai/adapter-auggie-local",
+  "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/auggie-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist",
+    "skills"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/auggie-local/src/cli/format-event.ts
+++ b/packages/adapters/auggie-local/src/cli/format-event.ts
@@ -1,0 +1,81 @@
+import pc from "picocolors";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function errorText(value: unknown): string {
+  if (typeof value === "string") return value;
+  const rec = asRecord(value);
+  if (!rec) return "";
+  const msg =
+    (typeof rec.message === "string" && rec.message) ||
+    (typeof rec.error === "string" && rec.error) ||
+    (typeof rec.code === "string" && rec.code) ||
+    "";
+  if (msg) return msg;
+  try {
+    return JSON.stringify(rec);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Auggie's `--print --output-format json` mode emits a single JSON object on
+ * stdout (optionally preceded by plain-text preamble lines). We print the
+ * preamble verbatim and summarize the result object as a structured line.
+ */
+export function printAuggieStreamEvent(raw: string, _debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    parsed = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    console.log(line);
+    return;
+  }
+
+  const type = asString(parsed.type);
+
+  if (type === "result") {
+    const sessionId =
+      asString(parsed.session_id) ||
+      asString(parsed.sessionId) ||
+      asString(parsed.sessionID);
+    const subtype = asString(parsed.subtype, "result");
+    const isError = parsed.is_error === true;
+    const numTurns = asNumber(parsed.num_turns, 0);
+    const resultText = asString(parsed.result, "").trim();
+    if (resultText) console.log(pc.green(`assistant: ${resultText}`));
+    const details = [
+      `subtype=${subtype}`,
+      `is_error=${isError ? "true" : "false"}`,
+      `turns=${numTurns}`,
+      sessionId ? `session=${sessionId}` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    console.log((isError ? pc.red : pc.blue)(`result: ${details}`));
+    return;
+  }
+
+  if (type === "error") {
+    const text = errorText(parsed.error ?? parsed.message ?? parsed.detail);
+    if (text) console.log(pc.red(`error: ${text}`));
+    return;
+  }
+
+  console.log(line);
+}

--- a/packages/adapters/auggie-local/src/cli/index.ts
+++ b/packages/adapters/auggie-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printAuggieStreamEvent } from "./format-event.js";

--- a/packages/adapters/auggie-local/src/index.ts
+++ b/packages/adapters/auggie-local/src/index.ts
@@ -2,8 +2,24 @@ export const type = "auggie_local";
 export const label = "Auggie CLI (local)";
 export const DEFAULT_AUGGIE_LOCAL_MODEL = "auto";
 
+// Model short names come from `auggie models list --json`. Selecting "auto"
+// skips passing `--model` so Auggie chooses its account default.
 export const models = [
-  { id: DEFAULT_AUGGIE_LOCAL_MODEL, label: "Auto" },
+  { id: DEFAULT_AUGGIE_LOCAL_MODEL, label: "Auto (account default)" },
+  { id: "opus4.7", label: "Opus 4.7" },
+  { id: "opus4.6", label: "Opus 4.6" },
+  { id: "opus4.6-500k", label: "Opus 4.6 (500K)" },
+  { id: "sonnet4.6", label: "Sonnet 4.6" },
+  { id: "sonnet4.6-500k", label: "Sonnet 4.6 (500K)" },
+  { id: "haiku4.5", label: "Haiku 4.5" },
+  { id: "gpt5.4", label: "GPT-5.4" },
+  { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
+  { id: "sonnet4.5", label: "Sonnet 4.5 (legacy)" },
+  { id: "opus4.5", label: "Opus 4.5 (legacy)" },
+  { id: "sonnet4", label: "Sonnet 4 (legacy)" },
+  { id: "gpt5.2", label: "GPT-5.2 (legacy)" },
+  { id: "gpt5.1", label: "GPT-5.1 (legacy)" },
+  { id: "gpt5", label: "GPT-5 (legacy)" },
 ];
 
 export const agentConfigurationDoc = `# auggie_local agent configuration
@@ -24,7 +40,7 @@ Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
 - promptTemplate (string, optional): run prompt template
-- model (string, optional): Auggie model id (passed via --model). Defaults to auto.
+- model (string, optional): Auggie model short name (passed via --model, e.g. "opus4.7", "sonnet4.6", "haiku4.5", "gpt5.4", "gemini-3.1-pro-preview"). Defaults to "auto" which omits --model so Auggie uses its account default. Run \`auggie models list\` to see the authoritative list for your account.
 - command (string, optional): defaults to "auggie"
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables

--- a/packages/adapters/auggie-local/src/index.ts
+++ b/packages/adapters/auggie-local/src/index.ts
@@ -1,0 +1,43 @@
+export const type = "auggie_local";
+export const label = "Auggie CLI (local)";
+export const DEFAULT_AUGGIE_LOCAL_MODEL = "auto";
+
+export const models = [
+  { id: DEFAULT_AUGGIE_LOCAL_MODEL, label: "Auto" },
+];
+
+export const agentConfigurationDoc = `# auggie_local agent configuration
+
+Adapter: auggie_local
+
+Use when:
+- You want Paperclip to run the Auggie CLI (Augment Code) locally on the host machine
+- You want Auggie sessions resumed across heartbeats with --resume
+- You want Paperclip skills injected locally without polluting the global environment
+
+Don't use when:
+- You need webhook-style external invocation (use http or openclaw_gateway)
+- You only need a one-shot script without an AI coding agent loop (use process)
+- Auggie CLI is not installed on the machine that runs Paperclip (requires Node 22+)
+
+Core fields:
+- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
+- promptTemplate (string, optional): run prompt template
+- model (string, optional): Auggie model id (passed via --model). Defaults to auto.
+- command (string, optional): defaults to "auggie"
+- extraArgs (string[], optional): additional CLI args
+- env (object, optional): KEY=VALUE environment variables
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+- maxTurns (number, optional): limit the number of agentic turns via --max-turns
+
+Notes:
+- Runs pass the prompt via -i <text> in --print --output-format json mode.
+- Auggie's JSON print mode emits a single final object { type: "result", result, is_error, session_id, ... }; intermediate tool_call and thinking events are not currently available in this mode.
+- Sessions resume with --resume <sessionId> when stored session cwd matches the current cwd.
+- Paperclip auto-injects local skills into \`~/.augment/skills/\` via symlinks so Auggie discovers both credentials and skills in their natural home.
+- Authentication uses \`auggie login\` (OAuth) by default; alternatively set AUGMENT_SESSION_AUTH (session JSON) or --augment-session-json.
+`;

--- a/packages/adapters/auggie-local/src/index.ts
+++ b/packages/adapters/auggie-local/src/index.ts
@@ -14,6 +14,7 @@ export const models = [
   { id: "haiku4.5", label: "Haiku 4.5" },
   { id: "gpt5.4", label: "GPT-5.4" },
   { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
+  { id: "kimi-k2.6", label: "Kimi K2.6" },
   { id: "sonnet4.5", label: "Sonnet 4.5 (legacy)" },
   { id: "opus4.5", label: "Opus 4.5 (legacy)" },
   { id: "sonnet4", label: "Sonnet 4 (legacy)" },

--- a/packages/adapters/auggie-local/src/server/execute.ts
+++ b/packages/adapters/auggie-local/src/server/execute.ts
@@ -1,0 +1,459 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asNumber,
+  asString,
+  asStringArray,
+  buildPaperclipEnv,
+  buildInvocationEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePaperclipSkillSymlink,
+  joinPromptSections,
+  ensurePathInEnv,
+  readPaperclipRuntimeSkillEntries,
+  resolveCommandForLogs,
+  resolvePaperclipDesiredSkillNames,
+  removeMaintainerOnlySkillSymlinks,
+  parseObject,
+  renderTemplate,
+  renderPaperclipWakePrompt,
+  stringifyPaperclipWakePayload,
+  DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_AUGGIE_LOCAL_MODEL } from "../index.js";
+import {
+  describeAuggieFailure,
+  detectAuggieAuthRequired,
+  isAuggieTurnLimitResult,
+  isAuggieUnknownSessionError,
+  parseAuggieJsonResult,
+} from "./parse.js";
+import { firstNonEmptyLine } from "./utils.js";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function renderPaperclipEnvNote(env: Record<string, string>): string {
+  const paperclipKeys = Object.keys(env)
+    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .sort();
+  if (paperclipKeys.length === 0) return "";
+  return [
+    "Paperclip runtime note:",
+    `The following PAPERCLIP_* environment variables are available in this run: ${paperclipKeys.join(", ")}`,
+    "Do not assume these variables are missing without checking your shell environment.",
+    "",
+    "",
+  ].join("\n");
+}
+
+function renderApiAccessNote(env: Record<string, string>): string {
+  if (!(env.PAPERCLIP_API_URL && env.PAPERCLIP_API_KEY)) return "";
+  return [
+    "Paperclip API access note:",
+    "Use a shell tool with curl to make Paperclip API requests.",
+    "GET example:",
+    `  curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "$PAPERCLIP_API_URL/api/agents/me"`,
+    "POST/PATCH example:",
+    `  curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H 'Content-Type: application/json' -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" -d '{...}' "$PAPERCLIP_API_URL/api/issues/{id}/checkout"`,
+    "",
+    "",
+  ].join("\n");
+}
+
+function auggieSkillsHome(): string {
+  return path.join(os.homedir(), ".augment", "skills");
+}
+
+/**
+ * Inject Paperclip skills directly into `~/.augment/skills/` via symlinks so
+ * Auggie picks them up from its natural skill location alongside OAuth
+ * credentials, without requiring any AUGMENT_HOME override.
+ */
+async function ensureAuggieSkillsInjected(
+  onLog: AdapterExecutionContext["onLog"],
+  skillsEntries: Array<{ key: string; runtimeName: string; source: string }>,
+  desiredSkillNames?: string[],
+): Promise<void> {
+  const desiredSet = new Set(desiredSkillNames ?? skillsEntries.map((entry) => entry.key));
+  const selectedEntries = skillsEntries.filter((entry) => desiredSet.has(entry.key));
+  if (selectedEntries.length === 0) return;
+
+  const skillsHome = auggieSkillsHome();
+  try {
+    await fs.mkdir(skillsHome, { recursive: true });
+  } catch (err) {
+    await onLog(
+      "stderr",
+      `[paperclip] Failed to prepare Auggie skills directory ${skillsHome}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return;
+  }
+  const removedSkills = await removeMaintainerOnlySkillSymlinks(
+    skillsHome,
+    selectedEntries.map((entry) => entry.runtimeName),
+  );
+  for (const skillName of removedSkills) {
+    await onLog(
+      "stderr",
+      `[paperclip] Removed maintainer-only Auggie skill "${skillName}" from ${skillsHome}\n`,
+    );
+  }
+
+  for (const entry of selectedEntries) {
+    const target = path.join(skillsHome, entry.runtimeName);
+    try {
+      const result = await ensurePaperclipSkillSymlink(entry.source, target);
+      if (result === "skipped") continue;
+      await onLog(
+        "stderr",
+        `[paperclip] ${result === "repaired" ? "Repaired" : "Linked"} Auggie skill: ${entry.key}\n`,
+      );
+    } catch (err) {
+      await onLog(
+        "stderr",
+        `[paperclip] Failed to link Auggie skill "${entry.key}": ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  );
+  const command = asString(config.command, "auggie");
+  const model = asString(config.model, DEFAULT_AUGGIE_LOCAL_MODEL).trim();
+  const maxTurns = asNumber(config.maxTurns, 0);
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceId = asString(workspaceContext.workspaceId, "");
+  const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
+  const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const agentHome = asString(workspaceContext.agentHome, "");
+  const workspaceHints = Array.isArray(context.paperclipWorkspaces)
+    ? context.paperclipWorkspaces.filter(
+      (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+    )
+    : [];
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  const auggieSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredAuggieSkillNames = resolvePaperclipDesiredSkillNames(config, auggieSkillEntries);
+  await ensureAuggieSkillsInjected(onLog, auggieSkillEntries, desiredAuggieSkillNames);
+
+  const envConfig = parseObject(config.env);
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
+  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
+  if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
+  if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (agentHome) env.AGENT_HOME = agentHome;
+  if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+  const effectiveEnv = Object.fromEntries(
+    Object.entries({ ...process.env, ...env }).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+  const runtimeEnv = ensurePathInEnv(effectiveEnv);
+  await ensureCommandResolvable(command, cwd, runtimeEnv);
+  const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
+  const loggedEnv = buildInvocationEnvForLogs(env, {
+    runtimeEnv,
+    includeRuntimeKeys: ["HOME", "AUGMENT_SESSION_AUTH"],
+    resolvedCommand,
+  });
+
+  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const graceSec = asNumber(config.graceSec, 20);
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const canResumeSession =
+    runtimeSessionId.length > 0 &&
+    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
+  const sessionId = canResumeSession ? runtimeSessionId : null;
+  if (runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stdout",
+      `[paperclip] Auggie session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  let instructionsPrefix = "";
+  if (instructionsFilePath) {
+    try {
+      const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
+      instructionsPrefix =
+        `${instructionsContents}\n\n` +
+        `The above agent instructions were loaded from ${instructionsFilePath}. ` +
+        `Resolve any relative file references from ${instructionsDir}.\n\n`;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stdout",
+        `[paperclip] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`,
+      );
+    }
+  }
+  const commandNotes = (() => {
+    const notes: string[] = [
+      "Prompt is passed to Auggie via -i <text> in --print --output-format json mode.",
+    ];
+    if (maxTurns > 0) notes.push(`Applied --max-turns ${maxTurns}.`);
+    if (!instructionsFilePath) return notes;
+    if (instructionsPrefix.length > 0) {
+      notes.push(
+        `Loaded agent instructions from ${instructionsFilePath}`,
+        `Prepended instructions + path directive to prompt (relative references from ${instructionsDir}).`,
+      );
+      return notes;
+    }
+    notes.push(
+      `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
+    );
+    return notes;
+  })();
+
+  const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const renderedBootstrapPrompt =
+    !sessionId && bootstrapPromptTemplate.trim().length > 0
+      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      : "";
+  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: Boolean(sessionId) });
+  const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
+  const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const paperclipEnvNote = renderPaperclipEnvNote(env);
+  const apiAccessNote = renderApiAccessNote(env);
+  const prompt = joinPromptSections([
+    instructionsPrefix,
+    renderedBootstrapPrompt,
+    wakePrompt,
+    sessionHandoffNote,
+    paperclipEnvNote,
+    apiAccessNote,
+    renderedPrompt,
+  ]);
+  const promptMetrics = {
+    promptChars: prompt.length,
+    instructionsChars: instructionsPrefix.length,
+    bootstrapPromptChars: renderedBootstrapPrompt.length,
+    wakePromptChars: wakePrompt.length,
+    sessionHandoffChars: sessionHandoffNote.length,
+    runtimeNoteChars: paperclipEnvNote.length + apiAccessNote.length,
+    heartbeatPromptChars: renderedPrompt.length,
+  };
+
+  const buildArgs = (resumeSessionId: string | null) => {
+    const args = ["--print", "--output-format", "json"];
+    if (resumeSessionId) args.push("--resume", resumeSessionId);
+    if (model && model !== DEFAULT_AUGGIE_LOCAL_MODEL) args.push("--model", model);
+    if (maxTurns > 0) args.push("--max-turns", String(maxTurns));
+    if (extraArgs.length > 0) args.push(...extraArgs);
+    args.push("-i", prompt);
+    return args;
+  };
+
+  const runAttempt = async (resumeSessionId: string | null) => {
+    const args = buildArgs(resumeSessionId);
+    if (onMeta) {
+      await onMeta({
+        adapterType: "auggie_local",
+        command: resolvedCommand,
+        cwd,
+        commandNotes,
+        commandArgs: args.map((value, index) => (
+          index === args.length - 1 ? `<prompt ${prompt.length} chars>` : value
+        )),
+        env: loggedEnv,
+        prompt,
+        promptMetrics,
+        context,
+      });
+    }
+
+    const proc = await runChildProcess(runId, command, args, {
+      cwd,
+      env,
+      timeoutSec,
+      graceSec,
+      onSpawn,
+      onLog,
+    });
+    return {
+      proc,
+      parsed: parseAuggieJsonResult(proc.stdout),
+    };
+  };
+
+  const toResult = (
+    attempt: {
+      proc: {
+        exitCode: number | null;
+        signal: string | null;
+        timedOut: boolean;
+        stdout: string;
+        stderr: string;
+      };
+      parsed: ReturnType<typeof parseAuggieJsonResult>;
+    },
+    clearSessionOnMissingSession = false,
+    isRetry = false,
+  ): AdapterExecutionResult => {
+    const authMeta = detectAuggieAuthRequired({
+      parsed: attempt.parsed.resultEvent,
+      stdout: attempt.proc.stdout,
+      stderr: attempt.proc.stderr,
+    });
+
+    if (attempt.proc.timedOut) {
+      return {
+        exitCode: attempt.proc.exitCode,
+        signal: attempt.proc.signal,
+        timedOut: true,
+        errorMessage: `Timed out after ${timeoutSec}s`,
+        errorCode: authMeta.requiresAuth ? "auggie_auth_required" : null,
+        clearSession: clearSessionOnMissingSession,
+      };
+    }
+
+    const clearSessionForTurnLimit = isAuggieTurnLimitResult(attempt.parsed.resultEvent);
+
+    const canFallbackToRuntimeSession = !isRetry;
+    const resolvedSessionId = attempt.parsed.sessionId
+      ?? (canFallbackToRuntimeSession ? (runtimeSessionId ?? runtime.sessionId ?? null) : null);
+    const resolvedSessionParams = resolvedSessionId
+      ? ({
+        sessionId: resolvedSessionId,
+        cwd,
+        ...(workspaceId ? { workspaceId } : {}),
+        ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+        ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+      } as Record<string, unknown>)
+      : null;
+    const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
+    const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const structuredFailure = attempt.parsed.resultEvent
+      ? describeAuggieFailure(attempt.parsed.resultEvent)
+      : null;
+    const fallbackErrorMessage =
+      parsedError ||
+      structuredFailure ||
+      stderrLine ||
+      `Auggie exited with code ${attempt.proc.exitCode ?? -1}`;
+
+    return {
+      exitCode: attempt.proc.exitCode,
+      signal: attempt.proc.signal,
+      timedOut: false,
+      errorMessage: (attempt.proc.exitCode ?? 0) === 0 ? null : fallbackErrorMessage,
+      errorCode: (attempt.proc.exitCode ?? 0) !== 0 && authMeta.requiresAuth ? "auggie_auth_required" : null,
+      usage: attempt.parsed.usage,
+      sessionId: resolvedSessionId,
+      sessionParams: resolvedSessionParams,
+      sessionDisplayId: resolvedSessionId,
+      provider: "augment",
+      biller: "augment",
+      model,
+      billingType: "subscription",
+      costUsd: attempt.parsed.costUsd,
+      resultJson: attempt.parsed.resultEvent ?? {
+        stdout: attempt.proc.stdout,
+        stderr: attempt.proc.stderr,
+      },
+      summary: attempt.parsed.summary,
+      question: attempt.parsed.question,
+      clearSession: clearSessionForTurnLimit || Boolean(clearSessionOnMissingSession && !resolvedSessionId),
+    };
+  };
+
+  const initial = await runAttempt(sessionId);
+  if (
+    sessionId &&
+    !initial.proc.timedOut &&
+    (initial.proc.exitCode ?? 0) !== 0 &&
+    isAuggieUnknownSessionError(initial.proc.stdout, initial.proc.stderr)
+  ) {
+    await onLog(
+      "stdout",
+      `[paperclip] Auggie resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+    );
+    const retry = await runAttempt(null);
+    return toResult(retry, true, true);
+  }
+
+  return toResult(initial);
+}

--- a/packages/adapters/auggie-local/src/server/index.ts
+++ b/packages/adapters/auggie-local/src/server/index.ts
@@ -1,0 +1,71 @@
+export { execute } from "./execute.js";
+export { listAuggieSkills, syncAuggieSkills } from "./skills.js";
+export { testEnvironment } from "./test.js";
+export {
+  parseAuggieJsonResult,
+  isAuggieUnknownSessionError,
+  describeAuggieFailure,
+  detectAuggieAuthRequired,
+  isAuggieTurnLimitResult,
+} from "./parse.js";
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId =
+      readNonEmptyString(record.sessionId) ??
+      readNonEmptyString(record.session_id) ??
+      readNonEmptyString(record.sessionID);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(record.cwd) ??
+      readNonEmptyString(record.workdir) ??
+      readNonEmptyString(record.folder);
+    const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+    const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId =
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.sessionID);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(params.cwd) ??
+      readNonEmptyString(params.workdir) ??
+      readNonEmptyString(params.folder);
+    const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
+    const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
+    const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return (
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.sessionID)
+    );
+  },
+};

--- a/packages/adapters/auggie-local/src/server/index.ts
+++ b/packages/adapters/auggie-local/src/server/index.ts
@@ -8,15 +8,25 @@ export {
   detectAuggieAuthRequired,
   isAuggieTurnLimitResult,
 } from "./parse.js";
+export {
+  listAuggieModels,
+  discoverAuggieModels,
+  discoverAuggieModelsCached,
+  parseAuggieModelsJson,
+  resetAuggieModelsCacheForTests,
+} from "./models.js";
 import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
 
 function readNonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
 }
 
 export const sessionCodec: AdapterSessionCodec = {
   deserialize(raw: unknown) {
-    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw))
+      return null;
     const record = raw as Record<string, unknown>;
     const sessionId =
       readNonEmptyString(record.sessionId) ??
@@ -27,9 +37,13 @@ export const sessionCodec: AdapterSessionCodec = {
       readNonEmptyString(record.cwd) ??
       readNonEmptyString(record.workdir) ??
       readNonEmptyString(record.folder);
-    const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
-    const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
-    const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    const workspaceId =
+      readNonEmptyString(record.workspaceId) ??
+      readNonEmptyString(record.workspace_id);
+    const repoUrl =
+      readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    const repoRef =
+      readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
     return {
       sessionId,
       ...(cwd ? { cwd } : {}),
@@ -49,9 +63,13 @@ export const sessionCodec: AdapterSessionCodec = {
       readNonEmptyString(params.cwd) ??
       readNonEmptyString(params.workdir) ??
       readNonEmptyString(params.folder);
-    const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
-    const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
-    const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    const workspaceId =
+      readNonEmptyString(params.workspaceId) ??
+      readNonEmptyString(params.workspace_id);
+    const repoUrl =
+      readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
+    const repoRef =
+      readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
     return {
       sessionId,
       ...(cwd ? { cwd } : {}),

--- a/packages/adapters/auggie-local/src/server/models.test.ts
+++ b/packages/adapters/auggie-local/src/server/models.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  __setAuggieDiscoveryImplForTests,
+  discoverAuggieModelsCached,
   listAuggieModels,
   parseAuggieModelsJson,
   resetAuggieModelsCacheForTests,
@@ -103,7 +105,44 @@ describe("listAuggieModels", () => {
   });
 
   it("returns [] when discovery command is unavailable (so the server falls back to static models)", async () => {
-    process.env.PAPERCLIP_AUGGIE_COMMAND = "__paperclip_missing_auggie_command__";
+    process.env.PAPERCLIP_AUGGIE_COMMAND =
+      "__paperclip_missing_auggie_command__";
     await expect(listAuggieModels()).resolves.toEqual([]);
+  });
+});
+
+describe("discoverAuggieModelsCached singleflight", () => {
+  afterEach(() => {
+    resetAuggieModelsCacheForTests();
+  });
+
+  it("coalesces concurrent cache misses into a single discovery call", async () => {
+    let callCount = 0;
+    const sampleModels = [{ id: "auto", label: "Auto (account default)" }];
+    __setAuggieDiscoveryImplForTests(async () => {
+      callCount++;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return sampleModels;
+    });
+    const results = await Promise.all([
+      discoverAuggieModelsCached(),
+      discoverAuggieModelsCached(),
+      discoverAuggieModelsCached(),
+    ]);
+    expect(callCount).toBe(1);
+    for (const result of results) {
+      expect(result).toEqual(sampleModels);
+    }
+  });
+
+  it("clears the in-flight entry after rejection so subsequent calls retry", async () => {
+    let callCount = 0;
+    __setAuggieDiscoveryImplForTests(async () => {
+      callCount++;
+      throw new Error("boom");
+    });
+    await expect(discoverAuggieModelsCached()).rejects.toThrow("boom");
+    await expect(discoverAuggieModelsCached()).rejects.toThrow("boom");
+    expect(callCount).toBe(2);
   });
 });

--- a/packages/adapters/auggie-local/src/server/models.test.ts
+++ b/packages/adapters/auggie-local/src/server/models.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  listAuggieModels,
+  parseAuggieModelsJson,
+  resetAuggieModelsCacheForTests,
+} from "./models.js";
+
+const SAMPLE_STDOUT = JSON.stringify({
+  registryAvailable: true,
+  defaultModelId: "claude-sonnet-4-5-agent",
+  models: [
+    {
+      displayName: "Haiku 4.5",
+      shortName: "haiku4.5",
+      description: "Fast",
+      modelGroupPriority: 1,
+      costTier: 1,
+    },
+    {
+      displayName: "Opus 4.7",
+      shortName: "opus4.7",
+      modelGroupPriority: 1,
+      costTier: 3,
+      isDefault: true,
+    },
+    {
+      displayName: "Sonnet 4.6",
+      shortName: "sonnet4.6",
+      modelGroupPriority: 1,
+      costTier: 2,
+    },
+    {
+      displayName: "Sonnet 4.5",
+      shortName: "sonnet4.5",
+      costTier: 2,
+      isLegacyModel: true,
+    },
+    {
+      displayName: "GPT-5",
+      shortName: "gpt5",
+      costTier: 2,
+      isLegacyModel: true,
+    },
+  ],
+});
+
+describe("parseAuggieModelsJson", () => {
+  it("puts the auto sentinel first, sorts current models by priority/cost/id, and legacy last", () => {
+    const parsed = parseAuggieModelsJson(SAMPLE_STDOUT);
+    expect(parsed[0]).toEqual({ id: "auto", label: "Auto (account default)" });
+    // Non-legacy sorted by costTier asc (priority all == 1): haiku(1), sonnet(2), opus(3)
+    expect(parsed.slice(1, 4).map((m) => m.id)).toEqual([
+      "haiku4.5",
+      "sonnet4.6",
+      "opus4.7",
+    ]);
+    // Legacy tail, suffixed
+    const legacy = parsed.slice(4);
+    expect(legacy.map((m) => m.id).sort()).toEqual(["gpt5", "sonnet4.5"]);
+    expect(legacy.every((m) => m.label.endsWith("(legacy)"))).toBe(true);
+  });
+
+  it("uses displayName for label and falls back to shortName when missing", () => {
+    const stdout = JSON.stringify({
+      models: [
+        { shortName: "foo" },
+        { shortName: "bar", displayName: "Bar Model" },
+      ],
+    });
+    const parsed = parseAuggieModelsJson(stdout);
+    // auto + 2 entries
+    expect(parsed).toHaveLength(3);
+    const byId = Object.fromEntries(parsed.map((m) => [m.id, m.label]));
+    expect(byId.foo).toBe("foo");
+    expect(byId.bar).toBe("Bar Model");
+  });
+
+  it("returns [] when JSON is invalid", () => {
+    expect(parseAuggieModelsJson("not json")).toEqual([]);
+  });
+
+  it("returns [] when models array is empty", () => {
+    expect(parseAuggieModelsJson(JSON.stringify({ models: [] }))).toEqual([]);
+  });
+
+  it("skips entries without a shortName", () => {
+    const stdout = JSON.stringify({
+      models: [
+        { shortName: "", displayName: "Empty" },
+        { displayName: "NoShort" },
+        { shortName: "ok", displayName: "Ok" },
+      ],
+    });
+    const parsed = parseAuggieModelsJson(stdout);
+    expect(parsed.map((m) => m.id)).toEqual(["auto", "ok"]);
+  });
+});
+
+describe("listAuggieModels", () => {
+  afterEach(() => {
+    delete process.env.PAPERCLIP_AUGGIE_COMMAND;
+    resetAuggieModelsCacheForTests();
+  });
+
+  it("returns [] when discovery command is unavailable (so the server falls back to static models)", async () => {
+    process.env.PAPERCLIP_AUGGIE_COMMAND = "__paperclip_missing_auggie_command__";
+    await expect(listAuggieModels()).resolves.toEqual([]);
+  });
+});

--- a/packages/adapters/auggie-local/src/server/models.ts
+++ b/packages/adapters/auggie-local/src/server/models.ts
@@ -133,6 +133,7 @@ const discoveryCache = new Map<
   string,
   { expiresAt: number; models: AdapterModel[] }
 >();
+const discoveryInFlight = new Map<string, Promise<AdapterModel[]>>();
 const VOLATILE_ENV_KEY_PREFIXES = ["PAPERCLIP_", "npm_", "NPM_"] as const;
 const VOLATILE_ENV_KEY_EXACT = new Set([
   "PWD",
@@ -206,6 +207,14 @@ export async function discoverAuggieModels(
   return parsed;
 }
 
+// Indirection so tests can stub the subprocess call while exercising the
+// real cache + singleflight logic. Defaults to the real discovery function.
+let discoverAuggieModelsImpl: (input: {
+  command?: unknown;
+  cwd?: unknown;
+  env?: unknown;
+}) => Promise<AdapterModel[]> = discoverAuggieModels;
+
 export async function discoverAuggieModelsCached(
   input: { command?: unknown; cwd?: unknown; env?: unknown } = {},
 ): Promise<AdapterModel[]> {
@@ -219,9 +228,22 @@ export async function discoverAuggieModelsCached(
   }
   const cached = discoveryCache.get(key);
   if (cached && cached.expiresAt > now) return cached.models;
-  const models = await discoverAuggieModels({ command, cwd, env });
-  discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
-  return models;
+  const existing = discoveryInFlight.get(key);
+  if (existing) return existing;
+  const promise = (async () => {
+    try {
+      const models = await discoverAuggieModelsImpl({ command, cwd, env });
+      discoveryCache.set(key, {
+        expiresAt: Date.now() + MODELS_CACHE_TTL_MS,
+        models,
+      });
+      return models;
+    } finally {
+      discoveryInFlight.delete(key);
+    }
+  })();
+  discoveryInFlight.set(key, promise);
+  return promise;
 }
 
 export async function listAuggieModels(): Promise<AdapterModel[]> {
@@ -236,4 +258,18 @@ export async function listAuggieModels(): Promise<AdapterModel[]> {
 
 export function resetAuggieModelsCacheForTests() {
   discoveryCache.clear();
+  discoveryInFlight.clear();
+  discoverAuggieModelsImpl = discoverAuggieModels;
+}
+
+export function __setAuggieDiscoveryImplForTests(
+  fn:
+    | ((input: {
+        command?: unknown;
+        cwd?: unknown;
+        env?: unknown;
+      }) => Promise<AdapterModel[]>)
+    | null,
+) {
+  discoverAuggieModelsImpl = fn ?? discoverAuggieModels;
 }

--- a/packages/adapters/auggie-local/src/server/models.ts
+++ b/packages/adapters/auggie-local/src/server/models.ts
@@ -1,0 +1,239 @@
+import { createHash } from "node:crypto";
+import type { AdapterModel } from "@paperclipai/adapter-utils";
+import {
+  asString,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_AUGGIE_LOCAL_MODEL } from "../index.js";
+import { firstNonEmptyLine } from "./utils.js";
+
+const MODELS_CACHE_TTL_MS = 300_000;
+const MODELS_DISCOVERY_TIMEOUT_SEC = 20;
+
+function resolveAuggieCommand(input: unknown): string {
+  const envOverride =
+    typeof process.env.PAPERCLIP_AUGGIE_COMMAND === "string" &&
+    process.env.PAPERCLIP_AUGGIE_COMMAND.trim().length > 0
+      ? process.env.PAPERCLIP_AUGGIE_COMMAND.trim()
+      : "auggie";
+  return asString(input, envOverride);
+}
+
+interface AuggieModelEntry {
+  displayName?: unknown;
+  shortName?: unknown;
+  description?: unknown;
+  isLegacyModel?: unknown;
+  isDefault?: unknown;
+  modelGroupPriority?: unknown;
+  costTier?: unknown;
+}
+
+interface AuggieModelsResponse {
+  registryAvailable?: unknown;
+  defaultModelId?: unknown;
+  models?: unknown;
+}
+
+function normalizeEntries(payload: AuggieModelsResponse): Array<{
+  id: string;
+  displayName: string;
+  isLegacy: boolean;
+  priority: number;
+  costTier: number;
+}> {
+  const raw = Array.isArray(payload.models)
+    ? (payload.models as AuggieModelEntry[])
+    : [];
+  const out: Array<{
+    id: string;
+    displayName: string;
+    isLegacy: boolean;
+    priority: number;
+    costTier: number;
+  }> = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const id =
+      typeof entry.shortName === "string" ? entry.shortName.trim() : "";
+    if (!id) continue;
+    const displayName =
+      typeof entry.displayName === "string" &&
+      entry.displayName.trim().length > 0
+        ? entry.displayName.trim()
+        : id;
+    const isLegacy = entry.isLegacyModel === true;
+    const priority =
+      typeof entry.modelGroupPriority === "number"
+        ? entry.modelGroupPriority
+        : 999;
+    const costTier = typeof entry.costTier === "number" ? entry.costTier : 0;
+    out.push({ id, displayName, isLegacy, priority, costTier });
+  }
+  return out;
+}
+
+export function parseAuggieModelsJson(stdout: string): AdapterModel[] {
+  let payload: AuggieModelsResponse;
+  try {
+    payload = JSON.parse(stdout) as AuggieModelsResponse;
+  } catch {
+    return [];
+  }
+  const entries = normalizeEntries(payload);
+  if (entries.length === 0) return [];
+
+  // Non-legacy first (by priority asc, cost tier asc, id), then legacy (alpha).
+  const current = entries
+    .filter((e) => !e.isLegacy)
+    .sort((a, b) => {
+      if (a.priority !== b.priority) return a.priority - b.priority;
+      if (a.costTier !== b.costTier) return a.costTier - b.costTier;
+      return a.id.localeCompare(b.id, "en", {
+        numeric: true,
+        sensitivity: "base",
+      });
+    });
+  const legacy = entries
+    .filter((e) => e.isLegacy)
+    .sort((a, b) =>
+      a.id.localeCompare(b.id, "en", { numeric: true, sensitivity: "base" }),
+    );
+
+  const mapped: AdapterModel[] = [
+    { id: DEFAULT_AUGGIE_LOCAL_MODEL, label: "Auto (account default)" },
+    ...current.map((e) => ({ id: e.id, label: e.displayName })),
+    ...legacy.map((e) => ({ id: e.id, label: `${e.displayName} (legacy)` })),
+  ];
+
+  // Dedupe by id while keeping first occurrence (preserves "auto" sentinel).
+  const seen = new Set<string>();
+  const deduped: AdapterModel[] = [];
+  for (const m of mapped) {
+    if (!m.id || seen.has(m.id)) continue;
+    seen.add(m.id);
+    deduped.push(m);
+  }
+  return deduped;
+}
+
+function normalizeEnv(input: unknown): Record<string, string> {
+  const envInput =
+    typeof input === "object" && input !== null && !Array.isArray(input)
+      ? (input as Record<string, unknown>)
+      : {};
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envInput)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  return env;
+}
+
+const discoveryCache = new Map<
+  string,
+  { expiresAt: number; models: AdapterModel[] }
+>();
+const VOLATILE_ENV_KEY_PREFIXES = ["PAPERCLIP_", "npm_", "NPM_"] as const;
+const VOLATILE_ENV_KEY_EXACT = new Set([
+  "PWD",
+  "OLDPWD",
+  "SHLVL",
+  "_",
+  "TERM_SESSION_ID",
+]);
+
+function isVolatileEnvKey(key: string): boolean {
+  if (VOLATILE_ENV_KEY_EXACT.has(key)) return true;
+  return VOLATILE_ENV_KEY_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+function discoveryCacheKey(
+  command: string,
+  cwd: string,
+  env: Record<string, string>,
+) {
+  const envKey = Object.entries(env)
+    .filter(([key]) => !isVolatileEnvKey(key))
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(
+      ([key, value]) =>
+        `${key}=${createHash("sha256").update(value).digest("hex")}`,
+    )
+    .join("\n");
+  return `${command}\n${cwd}\n${envKey}`;
+}
+
+export async function discoverAuggieModels(
+  input: { command?: unknown; cwd?: unknown; env?: unknown } = {},
+): Promise<AdapterModel[]> {
+  const command = resolveAuggieCommand(input.command);
+  const cwd = asString(input.cwd, process.cwd());
+  const env = normalizeEnv(input.env);
+  const runtimeEnv = normalizeEnv({ ...process.env, ...env });
+
+  const result = await runChildProcess(
+    `auggie-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    command,
+    ["models", "list", "--json"],
+    {
+      cwd,
+      env: runtimeEnv,
+      timeoutSec: MODELS_DISCOVERY_TIMEOUT_SEC,
+      graceSec: 3,
+      onLog: async () => {},
+    },
+  );
+
+  if (result.timedOut) {
+    throw new Error(
+      `\`auggie models list --json\` timed out after ${MODELS_DISCOVERY_TIMEOUT_SEC}s.`,
+    );
+  }
+  if ((result.exitCode ?? 1) !== 0) {
+    const detail =
+      firstNonEmptyLine(result.stderr) || firstNonEmptyLine(result.stdout);
+    throw new Error(
+      detail
+        ? `\`auggie models list --json\` failed: ${detail}`
+        : "`auggie models list --json` failed.",
+    );
+  }
+
+  const parsed = parseAuggieModelsJson(result.stdout);
+  if (parsed.length === 0) {
+    throw new Error("`auggie models list --json` returned no models.");
+  }
+  return parsed;
+}
+
+export async function discoverAuggieModelsCached(
+  input: { command?: unknown; cwd?: unknown; env?: unknown } = {},
+): Promise<AdapterModel[]> {
+  const command = resolveAuggieCommand(input.command);
+  const cwd = asString(input.cwd, process.cwd());
+  const env = normalizeEnv(input.env);
+  const key = discoveryCacheKey(command, cwd, env);
+  const now = Date.now();
+  for (const [k, v] of discoveryCache.entries()) {
+    if (v.expiresAt <= now) discoveryCache.delete(k);
+  }
+  const cached = discoveryCache.get(key);
+  if (cached && cached.expiresAt > now) return cached.models;
+  const models = await discoverAuggieModels({ command, cwd, env });
+  discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
+  return models;
+}
+
+export async function listAuggieModels(): Promise<AdapterModel[]> {
+  try {
+    return await discoverAuggieModelsCached();
+  } catch {
+    // Return [] to let the server's listAdapterModels fall back to the
+    // static `models` export (same pattern as pi-local / opencode-local).
+    return [];
+  }
+}
+
+export function resetAuggieModelsCacheForTests() {
+  discoveryCache.clear();
+}

--- a/packages/adapters/auggie-local/src/server/parse.test.ts
+++ b/packages/adapters/auggie-local/src/server/parse.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeAuggieFailure,
+  detectAuggieAuthRequired,
+  isAuggieTurnLimitResult,
+  isAuggieUnknownSessionError,
+  parseAuggieJsonResult,
+} from "./parse.js";
+
+describe("parseAuggieJsonResult", () => {
+  it("extracts session id, result summary, and turn count from a successful run", () => {
+    const stdout = JSON.stringify({
+      type: "result",
+      result: "Done. All tests pass.",
+      is_error: false,
+      subtype: "success",
+      session_id: "11111111-2222-3333-4444-555555555555",
+      num_turns: 3,
+      request_id: "req_abc",
+    });
+
+    const parsed = parseAuggieJsonResult(stdout);
+    expect(parsed.sessionId).toBe("11111111-2222-3333-4444-555555555555");
+    expect(parsed.summary).toBe("Done. All tests pass.");
+    expect(parsed.errorMessage).toBeNull();
+    expect(parsed.numTurns).toBe(3);
+    expect(parsed.usage).toEqual({
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+    });
+  });
+
+  it("skips plain-text preamble lines before the JSON result", () => {
+    const stdout = [
+      "Applying --max-turns override: 2 over agentMaxIterations=500",
+      JSON.stringify({
+        type: "result",
+        result: "Hi there",
+        is_error: false,
+        subtype: "success",
+        session_id: "abc",
+        num_turns: 1,
+      }),
+    ].join("\n");
+
+    const parsed = parseAuggieJsonResult(stdout);
+    expect(parsed.sessionId).toBe("abc");
+    expect(parsed.summary).toBe("Hi there");
+  });
+
+  it("captures error text when is_error is true", () => {
+    const stdout = JSON.stringify({
+      type: "result",
+      result: "",
+      is_error: true,
+      subtype: "error",
+      error: { message: "model overloaded" },
+      session_id: "err_session",
+      num_turns: 0,
+    });
+
+    const parsed = parseAuggieJsonResult(stdout);
+    expect(parsed.errorMessage).toBe("model overloaded");
+    expect(parsed.sessionId).toBe("err_session");
+  });
+
+  it("returns null session id and empty summary when stdout contains no JSON", () => {
+    const parsed = parseAuggieJsonResult("not json at all\n   \n");
+    expect(parsed.sessionId).toBeNull();
+    expect(parsed.summary).toBe("");
+    expect(parsed.errorMessage).toBeNull();
+    expect(parsed.resultEvent).toBeNull();
+  });
+});
+
+describe("isAuggieUnknownSessionError", () => {
+  it("detects explicit resume-failure wordings", () => {
+    expect(isAuggieUnknownSessionError("", "Unknown session id foo")).toBe(
+      true,
+    );
+    expect(isAuggieUnknownSessionError("", "Session abc not found")).toBe(true);
+    expect(isAuggieUnknownSessionError("", "Failed to resume session")).toBe(
+      true,
+    );
+    expect(isAuggieUnknownSessionError("", "no such session: abc")).toBe(true);
+  });
+
+  it("does not classify unrelated failures as stale sessions", () => {
+    expect(isAuggieUnknownSessionError("", "network timeout")).toBe(false);
+    expect(isAuggieUnknownSessionError("", "model overloaded")).toBe(false);
+  });
+});
+
+describe("detectAuggieAuthRequired", () => {
+  it("flags typical login-required wordings", () => {
+    expect(
+      detectAuggieAuthRequired({
+        parsed: null,
+        stdout: "",
+        stderr: "Please authenticate by running `auggie login`",
+      }).requiresAuth,
+    ).toBe(true);
+    expect(
+      detectAuggieAuthRequired({
+        parsed: null,
+        stdout: "",
+        stderr: "not authenticated",
+      }).requiresAuth,
+    ).toBe(true);
+    expect(
+      detectAuggieAuthRequired({
+        parsed: { error: "AUGMENT_SESSION_AUTH is invalid" },
+        stdout: "",
+        stderr: "",
+      }).requiresAuth,
+    ).toBe(true);
+  });
+
+  it("does not flag unrelated errors as auth failures", () => {
+    expect(
+      detectAuggieAuthRequired({
+        parsed: null,
+        stdout: "",
+        stderr: "disk full",
+      }).requiresAuth,
+    ).toBe(false);
+  });
+});
+
+describe("describeAuggieFailure", () => {
+  it("formats a subtype + error description", () => {
+    expect(
+      describeAuggieFailure({
+        subtype: "error",
+        result: "",
+        error: "model overloaded",
+      }),
+    ).toBe("Auggie run failed: subtype=error: model overloaded");
+  });
+
+  it("still reports a failure when only is_error is set", () => {
+    expect(
+      describeAuggieFailure({ is_error: true, result: "partial output" }),
+    ).toBe("Auggie run failed: partial output");
+  });
+
+  it("returns null when the event does not represent a failure", () => {
+    expect(
+      describeAuggieFailure({ subtype: "success", result: "ok" }),
+    ).toBeNull();
+    expect(describeAuggieFailure({ result: "ok" })).toBeNull();
+  });
+});
+
+describe("isAuggieTurnLimitResult", () => {
+  it("detects turn-limit subtype and error messages", () => {
+    expect(isAuggieTurnLimitResult({ subtype: "turn_limit" })).toBe(true);
+    expect(isAuggieTurnLimitResult({ subtype: "max_turns" })).toBe(true);
+    expect(isAuggieTurnLimitResult({ error: "Maximum turns reached" })).toBe(
+      true,
+    );
+  });
+
+  it("returns false for normal completions and null input", () => {
+    expect(isAuggieTurnLimitResult({ subtype: "success" })).toBe(false);
+    expect(isAuggieTurnLimitResult(null)).toBe(false);
+  });
+});

--- a/packages/adapters/auggie-local/src/server/parse.ts
+++ b/packages/adapters/auggie-local/src/server/parse.ts
@@ -1,0 +1,178 @@
+import {
+  asNumber,
+  asString,
+  parseJson,
+  parseObject,
+} from "@paperclipai/adapter-utils/server-utils";
+
+function readSessionId(event: Record<string, unknown>): string | null {
+  return (
+    asString(event.session_id, "").trim() ||
+    asString(event.sessionId, "").trim() ||
+    asString(event.sessionID, "").trim() ||
+    null
+  );
+}
+
+function asErrorText(value: unknown): string {
+  if (typeof value === "string") return value;
+  const rec = parseObject(value);
+  const message =
+    asString(rec.message, "") ||
+    asString(rec.error, "") ||
+    asString(rec.code, "") ||
+    asString(rec.detail, "");
+  if (message) return message;
+  try {
+    return JSON.stringify(rec);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Auggie's `--print --output-format json` mode emits a single JSON object on
+ * stdout, optionally preceded by plain-text preamble lines such as
+ * "Applying --max-turns override: 2 over agentMaxIterations=500".
+ *
+ * Shape (observed against auggie 0.24.0):
+ *   {
+ *     "type": "result",
+ *     "result": "<final assistant text>",
+ *     "is_error": false,
+ *     "subtype": "success",
+ *     "session_id": "<uuid>",
+ *     "num_turns": 0,
+ *     "request_id": "<uuid>"
+ *   }
+ *
+ * Intermediate assistant / tool-call events are not emitted in JSON mode today.
+ */
+export function parseAuggieJsonResult(stdout: string) {
+  let sessionId: string | null = null;
+  const messages: string[] = [];
+  let errorMessage: string | null = null;
+  let resultEvent: Record<string, unknown> | null = null;
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const event = parseJson(line);
+    if (!event) continue; // skip plain-text preamble lines
+
+    const foundSessionId = readSessionId(event);
+    if (foundSessionId) sessionId = foundSessionId;
+
+    const type = asString(event.type, "").trim();
+
+    if (type === "result") {
+      resultEvent = event;
+      const resultText =
+        asString(event.result, "").trim() ||
+        asString(event.text, "").trim() ||
+        asString(event.response, "").trim();
+      if (resultText) messages.push(resultText);
+      const isError =
+        event.is_error === true ||
+        asString(event.subtype, "").toLowerCase() === "error";
+      if (isError) {
+        const text = asErrorText(
+          event.error ?? event.message ?? event.result,
+        ).trim();
+        if (text) errorMessage = text;
+      }
+      continue;
+    }
+
+    if (type === "error") {
+      const text = asErrorText(
+        event.error ?? event.message ?? event.detail,
+      ).trim();
+      if (text) errorMessage = text;
+      continue;
+    }
+  }
+
+  return {
+    sessionId,
+    summary: messages.join("\n\n").trim(),
+    // Usage tokens are not reported in the current JSON print-mode schema.
+    usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+    costUsd: null as number | null,
+    errorMessage,
+    resultEvent,
+    // Auggie JSON mode does not surface structured choice prompts, so question
+    // is always null here. Exposed for shape parity with other adapters.
+    question: null as null | {
+      prompt: string;
+      choices: Array<{ key: string; label: string; description?: string }>;
+    },
+    numTurns: resultEvent
+      ? asNumber((resultEvent as Record<string, unknown>).num_turns, 0)
+      : 0,
+  };
+}
+
+export function isAuggieUnknownSessionError(
+  stdout: string,
+  stderr: string,
+): boolean {
+  const haystack = `${stdout}\n${stderr}`
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+  return /unknown\s+session|session\s+.*\s+not\s+found|resume\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume|no\s+such\s+session/i.test(
+    haystack,
+  );
+}
+
+const AUGGIE_AUTH_REQUIRED_RE =
+  /(?:not\s+authenticated|please\s+authenticate|authentication\s+required|unauthorized|invalid\s+credentials|not\s+logged\s+in|login\s+required|run\s+`?auggie\s+login`?|augment_session_auth)/i;
+
+export function detectAuggieAuthRequired(input: {
+  parsed: Record<string, unknown> | null;
+  stdout: string;
+  stderr: string;
+}): { requiresAuth: boolean } {
+  const parsedError =
+    asString((input.parsed ?? {}).error, "") ||
+    asString((input.parsed ?? {}).message, "") ||
+    "";
+  const messages = [parsedError, input.stdout, input.stderr]
+    .join("\n")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const requiresAuth = messages.some((line) =>
+    AUGGIE_AUTH_REQUIRED_RE.test(line),
+  );
+  return { requiresAuth };
+}
+
+export function describeAuggieFailure(
+  parsed: Record<string, unknown>,
+): string | null {
+  const subtype = asString(parsed.subtype, "");
+  const isError = parsed.is_error === true;
+  const looksLikeFailure = isError || (!!subtype && subtype !== "success");
+  if (!looksLikeFailure) return null;
+  const result = asString(parsed.result, "");
+  const error = asString(parsed.error, "") || asString(parsed.message, "");
+  const detail = error || result;
+  const parts = ["Auggie run failed"];
+  if (subtype && subtype !== "success") parts.push(`subtype=${subtype}`);
+  if (detail) parts.push(detail);
+  return parts.join(": ");
+}
+
+export function isAuggieTurnLimitResult(
+  parsed: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!parsed) return false;
+  const subtype = asString(parsed.subtype, "").trim().toLowerCase();
+  if (subtype === "turn_limit" || subtype === "max_turns") return true;
+  const error = asString(parsed.error, "").trim();
+  return /turn\s*limit|max(?:imum)?\s+turns?/i.test(error);
+}

--- a/packages/adapters/auggie-local/src/server/skills.ts
+++ b/packages/adapters/auggie-local/src/server/skills.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  AdapterSkillContext,
+  AdapterSkillSnapshot,
+} from "@paperclipai/adapter-utils";
+import {
+  buildPersistentSkillSnapshot,
+  ensurePaperclipSkillSymlink,
+  readPaperclipRuntimeSkillEntries,
+  readInstalledSkillTargets,
+  resolvePaperclipDesiredSkillNames,
+} from "@paperclipai/adapter-utils/server-utils";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function resolveAuggieSkillsHome(config: Record<string, unknown>) {
+  const env =
+    typeof config.env === "object" && config.env !== null && !Array.isArray(config.env)
+      ? (config.env as Record<string, unknown>)
+      : {};
+  const configuredHome = asString(env.HOME);
+  const home = configuredHome ? path.resolve(configuredHome) : os.homedir();
+  return path.join(home, ".augment", "skills");
+}
+
+async function buildAuggieSkillSnapshot(config: Record<string, unknown>): Promise<AdapterSkillSnapshot> {
+  const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredSkills = resolvePaperclipDesiredSkillNames(config, availableEntries);
+  const skillsHome = resolveAuggieSkillsHome(config);
+  const installed = await readInstalledSkillTargets(skillsHome);
+  return buildPersistentSkillSnapshot({
+    adapterType: "auggie_local",
+    availableEntries,
+    desiredSkills,
+    installed,
+    skillsHome,
+    locationLabel: "~/.augment/skills",
+    missingDetail: "Configured but not currently linked into the Auggie skills home.",
+    externalConflictDetail: "Skill name is occupied by an external installation.",
+    externalDetail: "Installed outside Paperclip management.",
+  });
+}
+
+export async function listAuggieSkills(ctx: AdapterSkillContext): Promise<AdapterSkillSnapshot> {
+  return buildAuggieSkillSnapshot(ctx.config);
+}
+
+export async function syncAuggieSkills(
+  ctx: AdapterSkillContext,
+  desiredSkills: string[],
+): Promise<AdapterSkillSnapshot> {
+  const availableEntries = await readPaperclipRuntimeSkillEntries(ctx.config, __moduleDir);
+  const desiredSet = new Set([
+    ...desiredSkills,
+    ...availableEntries.filter((entry) => entry.required).map((entry) => entry.key),
+  ]);
+  const skillsHome = resolveAuggieSkillsHome(ctx.config);
+  await fs.mkdir(skillsHome, { recursive: true });
+  const installed = await readInstalledSkillTargets(skillsHome);
+  const availableByRuntimeName = new Map(availableEntries.map((entry) => [entry.runtimeName, entry]));
+
+  for (const available of availableEntries) {
+    if (!desiredSet.has(available.key)) continue;
+    const target = path.join(skillsHome, available.runtimeName);
+    await ensurePaperclipSkillSymlink(available.source, target);
+  }
+
+  for (const [name, installedEntry] of installed.entries()) {
+    const available = availableByRuntimeName.get(name);
+    if (!available) continue;
+    if (desiredSet.has(available.key)) continue;
+    if (installedEntry.targetPath !== available.source) continue;
+    await fs.unlink(path.join(skillsHome, name)).catch(() => {});
+  }
+
+  return buildAuggieSkillSnapshot(ctx.config);
+}

--- a/packages/adapters/auggie-local/src/server/test.ts
+++ b/packages/adapters/auggie-local/src/server/test.ts
@@ -1,0 +1,203 @@
+import path from "node:path";
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asNumber,
+  asString,
+  asStringArray,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  parseObject,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_AUGGIE_LOCAL_MODEL } from "../index.js";
+import { detectAuggieAuthRequired, parseAuggieJsonResult } from "./parse.js";
+import { firstNonEmptyLine } from "./utils.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function isNonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function commandLooksLike(command: string, expected: string): boolean {
+  const base = path.basename(command).toLowerCase();
+  return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
+}
+
+function summarizeProbeDetail(stdout: string, stderr: string, parsedError: string | null): string | null {
+  const raw = parsedError?.trim() || firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  if (!raw) return null;
+  const clean = raw.replace(/\s+/g, " ").trim();
+  const max = 240;
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "auggie");
+  const cwd = asString(config.cwd, process.cwd());
+
+  try {
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+    checks.push({
+      code: "auggie_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "auggie_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  try {
+    await ensureCommandResolvable(command, cwd, runtimeEnv);
+    checks.push({
+      code: "auggie_command_resolvable",
+      level: "info",
+      message: `Command is executable: ${command}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "auggie_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+    });
+  }
+
+  const configSessionAuth = env.AUGMENT_SESSION_AUTH;
+  const hostSessionAuth = process.env.AUGMENT_SESSION_AUTH;
+  if (isNonEmpty(configSessionAuth) || isNonEmpty(hostSessionAuth)) {
+    const source = isNonEmpty(configSessionAuth) ? "adapter config env" : "server environment";
+    checks.push({
+      code: "auggie_session_auth_present",
+      level: "info",
+      message: "AUGMENT_SESSION_AUTH is set for Auggie CLI authentication.",
+      detail: `Detected in ${source}.`,
+    });
+  } else {
+    checks.push({
+      code: "auggie_session_auth_missing",
+      level: "info",
+      message: "No AUGMENT_SESSION_AUTH detected. Auggie CLI may still authenticate via `auggie login` (OAuth).",
+      hint: "If the hello probe fails with an auth error, run `auggie login` or set AUGMENT_SESSION_AUTH in adapter env.",
+    });
+  }
+
+  const canRunProbe =
+    checks.every((check) => check.code !== "auggie_cwd_invalid" && check.code !== "auggie_command_unresolvable");
+  if (canRunProbe) {
+    if (!commandLooksLike(command, "auggie")) {
+      checks.push({
+        code: "auggie_hello_probe_skipped_custom_command",
+        level: "info",
+        message: "Skipped hello probe because command is not `auggie`.",
+        detail: command,
+        hint: "Use the `auggie` CLI command to run the automatic installation and auth probe.",
+      });
+    } else {
+      const model = asString(config.model, DEFAULT_AUGGIE_LOCAL_MODEL).trim();
+      const helloProbeTimeoutSec = Math.max(1, asNumber(config.helloProbeTimeoutSec, 20));
+      const extraArgs = (() => {
+        const fromExtraArgs = asStringArray(config.extraArgs);
+        if (fromExtraArgs.length > 0) return fromExtraArgs;
+        return asStringArray(config.args);
+      })();
+
+      const args = ["--print", "--output-format", "json", "--max-turns", "1"];
+      if (model && model !== DEFAULT_AUGGIE_LOCAL_MODEL) args.push("--model", model);
+      if (extraArgs.length > 0) args.push(...extraArgs);
+      args.push("-i", "Respond with hello.");
+
+      const probe = await runChildProcess(
+        `auggie-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        command,
+        args,
+        {
+          cwd,
+          env,
+          timeoutSec: helloProbeTimeoutSec,
+          graceSec: 5,
+          onLog: async () => { },
+        },
+      );
+      const parsed = parseAuggieJsonResult(probe.stdout);
+      const detail = summarizeProbeDetail(probe.stdout, probe.stderr, parsed.errorMessage);
+      const authMeta = detectAuggieAuthRequired({
+        parsed: parsed.resultEvent,
+        stdout: probe.stdout,
+        stderr: probe.stderr,
+      });
+
+      if (probe.timedOut) {
+        checks.push({
+          code: "auggie_hello_probe_timed_out",
+          level: "warn",
+          message: "Auggie hello probe timed out.",
+          hint: "Retry the probe. If this persists, verify `auggie --print --output-format json -i \"Respond with hello.\"` runs manually from this directory.",
+        });
+      } else if ((probe.exitCode ?? 1) === 0) {
+        const summary = parsed.summary.trim();
+        const hasHello = /\bhello\b/i.test(summary);
+        checks.push({
+          code: hasHello ? "auggie_hello_probe_passed" : "auggie_hello_probe_unexpected_output",
+          level: hasHello ? "info" : "warn",
+          message: hasHello
+            ? "Auggie hello probe succeeded."
+            : "Auggie probe ran but did not return `hello` as expected.",
+          ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+          ...(hasHello
+            ? {}
+            : {
+              hint: "Try `auggie --print --output-format json -i \"Respond with hello.\"` manually to inspect full output.",
+            }),
+        });
+      } else if (authMeta.requiresAuth) {
+        checks.push({
+          code: "auggie_hello_probe_auth_required",
+          level: "warn",
+          message: "Auggie CLI is installed, but authentication is not ready.",
+          ...(detail ? { detail } : {}),
+          hint: "Run `auggie login` or set AUGMENT_SESSION_AUTH in adapter env/shell, then retry the probe.",
+        });
+      } else {
+        checks.push({
+          code: "auggie_hello_probe_failed",
+          level: "error",
+          message: "Auggie hello probe failed.",
+          ...(detail ? { detail } : {}),
+          hint: "Run `auggie --print --output-format json -i \"Respond with hello.\"` manually in this working directory to debug.",
+        });
+      }
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/auggie-local/src/server/utils.ts
+++ b/packages/adapters/auggie-local/src/server/utils.ts
@@ -1,0 +1,8 @@
+export function firstNonEmptyLine(text: string): string {
+    return (
+        text
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .find(Boolean) ?? ""
+    );
+}

--- a/packages/adapters/auggie-local/src/ui/build-config.test.ts
+++ b/packages/adapters/auggie-local/src/ui/build-config.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { buildAuggieLocalConfig } from "./build-config.js";
+import { DEFAULT_AUGGIE_LOCAL_MODEL } from "../index.js";
+
+function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "auggie_local",
+    cwd: "",
+    instructionsFilePath: "",
+    promptTemplate: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    dangerouslySkipPermissions: false,
+    search: false,
+    fastMode: false,
+    dangerouslyBypassSandbox: false,
+    command: "",
+    args: "",
+    extraArgs: "",
+    envVars: "",
+    envBindings: {},
+    url: "",
+    bootstrapPrompt: "",
+    payloadTemplateJson: "",
+    workspaceStrategyType: "project_primary",
+    workspaceBaseRef: "",
+    workspaceBranchTemplate: "",
+    worktreeParentDir: "",
+    runtimeServicesJson: "",
+    maxTurnsPerRun: 1000,
+    heartbeatEnabled: false,
+    intervalSec: 300,
+    ...overrides,
+  };
+}
+
+describe("buildAuggieLocalConfig", () => {
+  it("falls back to the default model when none is supplied", () => {
+    const config = buildAuggieLocalConfig(makeValues());
+    expect(config).toMatchObject({
+      model: DEFAULT_AUGGIE_LOCAL_MODEL,
+      timeoutSec: 0,
+      graceSec: 20,
+    });
+    expect(config).not.toHaveProperty("env");
+    expect(config).not.toHaveProperty("cwd");
+  });
+
+  it("persists cwd, instructions, prompt template and bootstrap prompt", () => {
+    const config = buildAuggieLocalConfig(
+      makeValues({
+        cwd: "/tmp/work",
+        instructionsFilePath: "/tmp/AGENTS.md",
+        promptTemplate: "{{issue.title}}",
+        bootstrapPrompt: "Start by reading AGENTS.md",
+      }),
+    );
+    expect(config).toMatchObject({
+      cwd: "/tmp/work",
+      instructionsFilePath: "/tmp/AGENTS.md",
+      promptTemplate: "{{issue.title}}",
+      bootstrapPromptTemplate: "Start by reading AGENTS.md",
+    });
+  });
+
+  it("parses newline-separated env vars into plain bindings", () => {
+    const config = buildAuggieLocalConfig(
+      makeValues({ envVars: "FOO=bar\n# comment\nBAZ=qux\ninvalid line\n" }),
+    );
+    expect(config.env).toEqual({
+      FOO: { type: "plain", value: "bar" },
+      BAZ: { type: "plain", value: "qux" },
+    });
+  });
+
+  it("preserves structured envBindings and only augments with legacy envVars that are not already present", () => {
+    const config = buildAuggieLocalConfig(
+      makeValues({
+        envBindings: {
+          AUGMENT_SESSION_AUTH: { type: "secret_ref", secretId: "sec_123", version: "latest" },
+          FOO: { type: "plain", value: "structured" },
+        },
+        envVars: "FOO=legacy\nBAR=added",
+      }),
+    );
+    expect(config.env).toEqual({
+      AUGMENT_SESSION_AUTH: {
+        type: "secret_ref",
+        secretId: "sec_123",
+        version: "latest",
+      },
+      FOO: { type: "plain", value: "structured" },
+      BAR: { type: "plain", value: "added" },
+    });
+  });
+
+  it("parses comma-separated extraArgs into a list", () => {
+    const config = buildAuggieLocalConfig(
+      makeValues({ extraArgs: "--max-turns,5, --verbose ,  " }),
+    );
+    expect(config.extraArgs).toEqual(["--max-turns", "5", "--verbose"]);
+  });
+
+  it("persists a custom command when provided", () => {
+    const config = buildAuggieLocalConfig(makeValues({ command: "/usr/local/bin/auggie" }));
+    expect(config.command).toBe("/usr/local/bin/auggie");
+  });
+});

--- a/packages/adapters/auggie-local/src/ui/build-config.ts
+++ b/packages/adapters/auggie-local/src/ui/build-config.ts
@@ -1,0 +1,75 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_AUGGIE_LOCAL_MODEL } from "../index.js";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest"
+          ? { version: rec.version }
+          : {}),
+      };
+    }
+  }
+  return env;
+}
+
+export function buildAuggieLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
+  ac.model = v.model || DEFAULT_AUGGIE_LOCAL_MODEL;
+  ac.timeoutSec = 0;
+  ac.graceSec = 20;
+  const env = parseEnvBindings(v.envBindings);
+  const legacy = parseEnvVars(v.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) ac.env = env;
+
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  return ac;
+}

--- a/packages/adapters/auggie-local/src/ui/index.ts
+++ b/packages/adapters/auggie-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseAuggieStdoutLine } from "./parse-stdout.js";
+export { buildAuggieLocalConfig } from "./build-config.js";

--- a/packages/adapters/auggie-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/auggie-local/src/ui/parse-stdout.ts
@@ -1,0 +1,92 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function errorText(value: unknown): string {
+  if (typeof value === "string") return value;
+  const rec = asRecord(value);
+  if (!rec) return "";
+  const msg =
+    (typeof rec.message === "string" && rec.message) ||
+    (typeof rec.error === "string" && rec.error) ||
+    (typeof rec.code === "string" && rec.code) ||
+    "";
+  if (msg) return msg;
+  try {
+    return JSON.stringify(rec);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Parse a single stdout line emitted by `auggie --print --output-format json`.
+ *
+ * Auggie emits a single JSON result object on success. Intermediate assistant
+ * / tool-call events are not surfaced in JSON print-mode today, so the
+ * transcript for a run is typically just one `result` entry plus an assistant
+ * entry carrying the final text. Non-JSON preamble lines (e.g. "Applying
+ * --max-turns override: ...") are treated as stdout so they remain visible.
+ */
+export function parseAuggieStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  const type = asString(parsed.type);
+
+  if (type === "result") {
+    const resultText =
+      asString(parsed.result, "").trim() ||
+      asString(parsed.text, "").trim() ||
+      asString(parsed.response, "").trim();
+    const isError = parsed.is_error === true;
+    const errors = isError
+      ? [errorText(parsed.error ?? parsed.message ?? parsed.result)].filter(Boolean)
+      : [];
+    const entries: TranscriptEntry[] = [];
+    if (resultText && !isError) {
+      entries.push({ kind: "assistant", ts, text: resultText });
+    }
+    entries.push({
+      kind: "result",
+      ts,
+      text: resultText,
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedTokens: 0,
+      costUsd: asNumber(parsed.total_cost_usd, asNumber(parsed.cost_usd, asNumber(parsed.cost))),
+      subtype: asString(parsed.subtype, "result"),
+      isError,
+      errors,
+    });
+    return entries;
+  }
+
+  if (type === "error") {
+    const text = errorText(parsed.error ?? parsed.message ?? parsed.detail);
+    return [{ kind: "stderr", ts, text: text || "error" }];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/auggie-local/tsconfig.json
+++ b/packages/adapters/auggie-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/auggie-local/vitest.config.ts
+++ b/packages/adapters/auggie-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -30,6 +30,7 @@ export const AGENT_ADAPTER_TYPES = [
   "claude_local",
   "codex_local",
   "gemini_local",
+  "auggie_local",
   "opencode_local",
   "pi_local",
   "cursor",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.10.0
         version: 0.10.1
+      '@paperclipai/adapter-auggie-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/auggie-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -97,6 +100,22 @@ importers:
         version: 5.9.3
 
   packages/adapter-utils:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/auggie-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
     devDependencies:
       '@types/node':
         specifier: ^24.6.0
@@ -465,6 +484,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.888.0
         version: 3.994.0
+      '@paperclipai/adapter-auggie-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/auggie-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -622,6 +644,9 @@ importers:
       '@mdxeditor/editor':
         specifier: ^3.52.4
         version: 3.52.4(@codemirror/language@6.12.1)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.29)
+      '@paperclipai/adapter-auggie-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/auggie-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local

--- a/server/package.json
+++ b/server/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.888.0",
+    "@paperclipai/adapter-auggie-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -6,6 +6,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "codex_local",
   "cursor",
   "gemini_local",
+  "auggie_local",
   "openclaw_gateway",
   "opencode_local",
   "pi_local",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -9,7 +9,10 @@ import {
   sessionCodec as claudeSessionCodec,
   getQuotaWindows as claudeGetQuotaWindows,
 } from "@paperclipai/adapter-claude-local/server";
-import { agentConfigurationDoc as claudeAgentConfigurationDoc, models as claudeModels } from "@paperclipai/adapter-claude-local";
+import {
+  agentConfigurationDoc as claudeAgentConfigurationDoc,
+  models as claudeModels,
+} from "@paperclipai/adapter-claude-local";
 import {
   execute as codexExecute,
   listCodexSkills,
@@ -18,7 +21,10 @@ import {
   sessionCodec as codexSessionCodec,
   getQuotaWindows as codexGetQuotaWindows,
 } from "@paperclipai/adapter-codex-local/server";
-import { agentConfigurationDoc as codexAgentConfigurationDoc, models as codexModels } from "@paperclipai/adapter-codex-local";
+import {
+  agentConfigurationDoc as codexAgentConfigurationDoc,
+  models as codexModels,
+} from "@paperclipai/adapter-codex-local";
 import {
   execute as cursorExecute,
   listCursorSkills,
@@ -26,7 +32,10 @@ import {
   testEnvironment as cursorTestEnvironment,
   sessionCodec as cursorSessionCodec,
 } from "@paperclipai/adapter-cursor-local/server";
-import { agentConfigurationDoc as cursorAgentConfigurationDoc, models as cursorModels } from "@paperclipai/adapter-cursor-local";
+import {
+  agentConfigurationDoc as cursorAgentConfigurationDoc,
+  models as cursorModels,
+} from "@paperclipai/adapter-cursor-local";
 import {
   execute as geminiExecute,
   listGeminiSkills,
@@ -34,15 +43,22 @@ import {
   testEnvironment as geminiTestEnvironment,
   sessionCodec as geminiSessionCodec,
 } from "@paperclipai/adapter-gemini-local/server";
-import { agentConfigurationDoc as geminiAgentConfigurationDoc, models as geminiModels } from "@paperclipai/adapter-gemini-local";
+import {
+  agentConfigurationDoc as geminiAgentConfigurationDoc,
+  models as geminiModels,
+} from "@paperclipai/adapter-gemini-local";
 import {
   execute as auggieExecute,
   listAuggieSkills,
   syncAuggieSkills,
   testEnvironment as auggieTestEnvironment,
   sessionCodec as auggieSessionCodec,
+  listAuggieModels,
 } from "@paperclipai/adapter-auggie-local/server";
-import { agentConfigurationDoc as auggieAgentConfigurationDoc, models as auggieModels } from "@paperclipai/adapter-auggie-local";
+import {
+  agentConfigurationDoc as auggieAgentConfigurationDoc,
+  models as auggieModels,
+} from "@paperclipai/adapter-auggie-local";
 import {
   execute as openCodeExecute,
   listOpenCodeSkills,
@@ -73,9 +89,7 @@ import {
   sessionCodec as piSessionCodec,
   listPiModels,
 } from "@paperclipai/adapter-pi-local/server";
-import {
-  agentConfigurationDoc as piAgentConfigurationDoc,
-} from "@paperclipai/adapter-pi-local";
+import { agentConfigurationDoc as piAgentConfigurationDoc } from "@paperclipai/adapter-pi-local";
 import {
   execute as hermesExecute,
   testEnvironment as hermesTestEnvironment,
@@ -94,13 +108,23 @@ import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
 
-function normalizeHermesConfig<T extends { config?: unknown; agent?: unknown }>(ctx: T): T {
+function normalizeHermesConfig<T extends { config?: unknown; agent?: unknown }>(
+  ctx: T,
+): T {
   const config =
-    ctx && typeof ctx === "object" && "config" in ctx && ctx.config && typeof ctx.config === "object"
+    ctx &&
+    typeof ctx === "object" &&
+    "config" in ctx &&
+    ctx.config &&
+    typeof ctx.config === "object"
       ? (ctx.config as Record<string, unknown>)
       : null;
   const agent =
-    ctx && typeof ctx === "object" && "agent" in ctx && ctx.agent && typeof ctx.agent === "object"
+    ctx &&
+    typeof ctx === "object" &&
+    "agent" in ctx &&
+    ctx.agent &&
+    typeof ctx.agent === "object"
       ? (ctx.agent as Record<string, unknown>)
       : null;
   const agentAdapterConfig =
@@ -109,9 +133,12 @@ function normalizeHermesConfig<T extends { config?: unknown; agent?: unknown }>(
       : null;
 
   const configCommand =
-    typeof config?.command === "string" && config.command.length > 0 ? config.command : undefined;
+    typeof config?.command === "string" && config.command.length > 0
+      ? config.command
+      : undefined;
   const agentCommand =
-    typeof agentAdapterConfig?.command === "string" && agentAdapterConfig.command.length > 0
+    typeof agentAdapterConfig?.command === "string" &&
+    agentAdapterConfig.command.length > 0
       ? agentAdapterConfig.command
       : undefined;
 
@@ -203,6 +230,7 @@ const auggieLocalAdapter: ServerAdapterModule = {
   sessionCodec: auggieSessionCodec,
   sessionManagement: getAdapterSessionManagement("auggie_local") ?? undefined,
   models: auggieModels,
+  listModels: listAuggieModels,
   supportsLocalAgentJwt: true,
   supportsInstructionsBundle: true,
   instructionsPathKey: "instructionsFilePath",
@@ -258,7 +286,8 @@ const piLocalAdapter: ServerAdapterModule = {
 const hermesLocalAdapter: ServerAdapterModule = {
   type: "hermes_local",
   execute: (ctx) => hermesExecute(normalizeHermesConfig(ctx) as never),
-  testEnvironment: (ctx) => hermesTestEnvironment(normalizeHermesConfig(ctx) as never),
+  testEnvironment: (ctx) =>
+    hermesTestEnvironment(normalizeHermesConfig(ctx) as never),
   sessionCodec: hermesSessionCodec,
   listSkills: hermesListSkills,
   syncSkills: hermesSyncSkills,
@@ -334,13 +363,11 @@ const externalAdaptersReady: Promise<void> = (async () => {
           builtinFallbacks.set(externalAdapter.type, existing);
         }
       }
-      adaptersByType.set(
-        externalAdapter.type,
-        {
-          ...externalAdapter,
-          sessionManagement: getAdapterSessionManagement(externalAdapter.type) ?? undefined,
-        },
-      );
+      adaptersByType.set(externalAdapter.type, {
+        ...externalAdapter,
+        sessionManagement:
+          getAdapterSessionManagement(externalAdapter.type) ?? undefined,
+      });
     }
   } catch (err) {
     console.error("[paperclip] Failed to load external adapters:", err);
@@ -358,7 +385,10 @@ export function waitForExternalAdapters(): Promise<void> {
 }
 
 export function registerServerAdapter(adapter: ServerAdapterModule): void {
-  if (BUILTIN_ADAPTER_TYPES.has(adapter.type) && !builtinFallbacks.has(adapter.type)) {
+  if (
+    BUILTIN_ADAPTER_TYPES.has(adapter.type) &&
+    !builtinFallbacks.has(adapter.type)
+  ) {
     const existing = adaptersByType.get(adapter.type);
     if (existing) {
       builtinFallbacks.set(adapter.type, existing);
@@ -395,7 +425,9 @@ export function getServerAdapter(type: string): ServerAdapterModule {
   return findActiveServerAdapter(type) ?? processAdapter;
 }
 
-export async function listAdapterModels(type: string): Promise<{ id: string; label: string }[]> {
+export async function listAdapterModels(
+  type: string,
+): Promise<{ id: string; label: string }[]> {
   const adapter = findActiveServerAdapter(type);
   if (!adapter) return [];
   if (adapter.listModels) {
@@ -418,13 +450,18 @@ export function listEnabledServerAdapters(): ServerAdapterModule[] {
   const disabled = getDisabledAdapterTypesFromStore();
   const disabledSet = disabled.length > 0 ? new Set(disabled) : null;
   return disabledSet
-    ? Array.from(adaptersByType.values()).filter((a) => !disabledSet.has(a.type))
+    ? Array.from(adaptersByType.values()).filter(
+        (a) => !disabledSet.has(a.type),
+      )
     : Array.from(adaptersByType.values());
 }
 
-export async function detectAdapterModel(
-  type: string,
-): Promise<{ model: string; provider: string; source: string; candidates?: string[] } | null> {
+export async function detectAdapterModel(type: string): Promise<{
+  model: string;
+  provider: string;
+  source: string;
+  candidates?: string[];
+} | null> {
   const adapter = findActiveServerAdapter(type);
   if (!adapter?.detectModel) return null;
   const detected = await adapter.detectModel();
@@ -459,12 +496,16 @@ export function setOverridePaused(type: string, paused: boolean): boolean {
   const wasPaused = pausedOverrides.has(type);
   if (paused && !wasPaused) {
     pausedOverrides.add(type);
-    console.log(`[paperclip] Override paused for "${type}" — builtin adapter restored`);
+    console.log(
+      `[paperclip] Override paused for "${type}" — builtin adapter restored`,
+    );
     return true;
   }
   if (!paused && wasPaused) {
     pausedOverrides.delete(type);
-    console.log(`[paperclip] Override resumed for "${type}" — external adapter active`);
+    console.log(
+      `[paperclip] Override resumed for "${type}" — external adapter active`,
+    );
     return true;
   }
   return false;
@@ -484,7 +525,9 @@ export function findServerAdapter(type: string): ServerAdapterModule | null {
   return adaptersByType.get(type) ?? null;
 }
 
-export function findActiveServerAdapter(type: string): ServerAdapterModule | null {
+export function findActiveServerAdapter(
+  type: string,
+): ServerAdapterModule | null {
   if (pausedOverrides.has(type)) {
     const fallback = builtinFallbacks.get(type);
     if (fallback) return fallback;

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -36,6 +36,14 @@ import {
 } from "@paperclipai/adapter-gemini-local/server";
 import { agentConfigurationDoc as geminiAgentConfigurationDoc, models as geminiModels } from "@paperclipai/adapter-gemini-local";
 import {
+  execute as auggieExecute,
+  listAuggieSkills,
+  syncAuggieSkills,
+  testEnvironment as auggieTestEnvironment,
+  sessionCodec as auggieSessionCodec,
+} from "@paperclipai/adapter-auggie-local/server";
+import { agentConfigurationDoc as auggieAgentConfigurationDoc, models as auggieModels } from "@paperclipai/adapter-auggie-local";
+import {
   execute as openCodeExecute,
   listOpenCodeSkills,
   syncOpenCodeSkills,
@@ -186,6 +194,22 @@ const geminiLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: geminiAgentConfigurationDoc,
 };
 
+const auggieLocalAdapter: ServerAdapterModule = {
+  type: "auggie_local",
+  execute: auggieExecute,
+  testEnvironment: auggieTestEnvironment,
+  listSkills: listAuggieSkills,
+  syncSkills: syncAuggieSkills,
+  sessionCodec: auggieSessionCodec,
+  sessionManagement: getAdapterSessionManagement("auggie_local") ?? undefined,
+  models: auggieModels,
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: true,
+  agentConfigurationDoc: auggieAgentConfigurationDoc,
+};
+
 const openclawGatewayAdapter: ServerAdapterModule = {
   type: "openclaw_gateway",
   execute: openclawGatewayExecute,
@@ -265,6 +289,7 @@ function registerBuiltInAdapters() {
     piLocalAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,
+    auggieLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,
     processAdapter,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -94,6 +94,7 @@ export function agentRoutes(db: Db) {
     codex_local: "instructionsFilePath",
     droid_local: "instructionsFilePath",
     gemini_local: "instructionsFilePath",
+    auggie_local: "instructionsFilePath",
     hermes_local: "instructionsFilePath",
     opencode_local: "instructionsFilePath",
     cursor: "instructionsFilePath",
@@ -713,6 +714,7 @@ export function agentRoutes(db: Db) {
   const LEGACY_MATERIALIZED_SKILLS_SET = new Set([
     "cursor",
     "gemini_local",
+    "auggie_local",
     "opencode_local",
     "pi_local",
   ]);

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -603,6 +603,10 @@ const ADAPTER_DEFAULT_RULES_BY_TYPE: Record<string, Array<{ path: string[]; valu
     { path: ["timeoutSec"], value: 0 },
     { path: ["graceSec"], value: 15 },
   ],
+  auggie_local: [
+    { path: ["timeoutSec"], value: 0 },
+    { path: ["graceSec"], value: 15 },
+  ],
   opencode_local: [
     { path: ["timeoutSec"], value: 0 },
     { path: ["graceSec"], value: 15 },

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -137,6 +137,7 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "codex_local",
   "cursor",
   "gemini_local",
+  "auggie_local",
   "hermes_local",
   "opencode_local",
   "pi_local",

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@lexical/link": "0.35.0",
     "@mdxeditor/editor": "^3.52.4",
+    "@paperclipai/adapter-auggie-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -69,6 +69,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     description: "Local Gemini agent",
     icon: Gem,
   },
+  auggie_local: {
+    label: "Auggie",
+    description: "Local Augment Code CLI agent",
+    icon: Terminal,
+  },
   opencode_local: {
     label: "OpenCode",
     description: "Local multi-provider agent",

--- a/ui/src/adapters/auggie-local/config-fields.tsx
+++ b/ui/src/adapters/auggie-local/config-fields.tsx
@@ -1,0 +1,51 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  DraftInput,
+  Field,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Prepended to the Auggie prompt at runtime.";
+
+export function AuggieLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  hideInstructionsFile,
+}: AdapterConfigFieldsProps) {
+  if (hideInstructionsFile) return null;
+  return (
+    <>
+      <Field label="Agent instructions file" hint={instructionsFileHint}>
+        <div className="flex items-center gap-2">
+          <DraftInput
+            value={
+              isCreate
+                ? values!.instructionsFilePath ?? ""
+                : eff(
+                    "adapterConfig",
+                    "instructionsFilePath",
+                    String(config.instructionsFilePath ?? ""),
+                  )
+            }
+            onCommit={(v) =>
+              isCreate
+                ? set!({ instructionsFilePath: v })
+                : mark("adapterConfig", "instructionsFilePath", v || undefined)
+            }
+            immediate
+            className={inputClass}
+            placeholder="/absolute/path/to/AGENTS.md"
+          />
+          <ChoosePathButton />
+        </div>
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/auggie-local/index.ts
+++ b/ui/src/adapters/auggie-local/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseAuggieStdoutLine } from "@paperclipai/adapter-auggie-local/ui";
+import { AuggieLocalConfigFields } from "./config-fields";
+import { buildAuggieLocalConfig } from "@paperclipai/adapter-auggie-local/ui";
+
+export const auggieLocalUIAdapter: UIAdapterModule = {
+  type: "auggie_local",
+  label: "Auggie CLI (local)",
+  parseStdoutLine: parseAuggieStdoutLine,
+  ConfigFields: AuggieLocalConfigFields,
+  buildAdapterConfig: buildAuggieLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -3,6 +3,7 @@ import { claudeLocalUIAdapter } from "./claude-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
+import { auggieLocalUIAdapter } from "./auggie-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
@@ -50,6 +51,7 @@ function registerBuiltInUIAdapters() {
     claudeLocalUIAdapter,
     codexLocalUIAdapter,
     geminiLocalUIAdapter,
+    auggieLocalUIAdapter,
     hermesLocalUIAdapter,
     openCodeLocalUIAdapter,
     piLocalUIAdapter,

--- a/ui/src/adapters/use-adapter-capabilities.ts
+++ b/ui/src/adapters/use-adapter-capabilities.ts
@@ -19,6 +19,7 @@ const KNOWN_DEFAULTS: Record<string, AdapterCapabilities> = {
   codex_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false },
   cursor: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true },
   gemini_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true },
+  auggie_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true },
   opencode_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true },
   pi_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true },
   hermes_local: { supportsInstructionsBundle: false, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false },

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -221,6 +221,7 @@ export function OnboardingWizard() {
     claude_local: "claude",
     codex_local: "codex",
     gemini_local: "gemini",
+    auggie_local: "auggie",
     pi_local: "pi",
     cursor: "agent",
     opencode_local: "opencode",

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -23,6 +23,7 @@ const ENABLED_INVITE_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
   "gemini_local",
+  "auggie_local",
   "opencode_local",
   "pi_local",
   "cursor",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     projects: [
       "packages/db",
       "packages/adapter-utils",
+      "packages/adapters/auggie-local",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",
       "server",


### PR DESCRIPTION
Resolves #2150

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each agent type is wired in via a first-class "adapter" that knows how to spawn, stream, parse, and resume one CLI runtime
> - Augment Code ships an official CLI, `auggie`, with a stable JSON output mode (`--print --output-format json`) and a `--resume <sessionId>` flag — everything needed to run it as a Paperclip worker
> - But Paperclip had no `auggie_local` adapter, so operators could not hire Auggie as a worker without writing and maintaining their own external plugin
> - This pull request adds a built-in `@paperclipai/adapter-auggie-local` package and wires it through shared/server/ui/cli registries, including dynamic model discovery via `auggie models list --json`
> - The benefit is Auggie becomes a drop-in built-in adapter with the same ergonomics as `claude_local` / `codex_local`: session resume, skills materialization under `~/.augment/skills/`, auth-error detection, and a model dropdown populated from the operator's actual Auggie account

## What Changed

- New package `packages/adapters/auggie-local` implementing the full adapter surface:
  - `server/execute.ts` — spawns `auggie --print --output-format json`, adds `--resume <sessionId>` when the session's cwd matches, streams stdout
  - `server/parse.ts` — JSON result parser with preamble skip and auth-error detection
  - `server/skills.ts` — symlinks workspace skills into `~/.augment/skills/`
  - `server/test.ts` — env probe + `sessionCodec`
  - `cli/format-event.ts` — terminal formatter for stream events
  - `ui/parse-stdout.ts` + `ui/build-config.ts` — shared UI parser and config builder (with a React `config-fields` wrapper in `ui/src/adapters/auggie-local/`)
- Dynamic model discovery (commit 2):
  - `server/models.ts` shells out to `auggie models list --json` with a 20s timeout and a 5-minute in-memory TTL cache keyed on command + cwd + hashed env (matching the `pi-local` / `opencode-local` pattern)
  - `parseAuggieModelsJson` prepends the `auto` sentinel, sorts non-legacy entries by `modelGroupPriority` / `costTier`, appends legacy entries with a `(legacy)` suffix, and honors `displayName` / `shortName` fallbacks
  - Expands the static `models` export in `src/index.ts` to a useful fallback so offline/unauthenticated hosts still get a populated dropdown
  - Wires `listModels: listAuggieModels` into `server/src/adapters/registry.ts`
- Registry wiring (minimal, single-line insertions mirroring other built-in adapters):
  - `packages/shared/src/constants.ts` — `AGENT_ADAPTER_TYPES`
  - `server/src/adapters/{registry.ts, builtin-adapter-types.ts}`
  - `server/src/routes/agents.ts` — `instructionsPathKey` + `LEGACY_MATERIALIZED_SKILLS_SET`
  - `server/src/services/{heartbeat.ts, company-portability.ts}`
  - `cli/src/adapters/registry.ts`
  - `ui/src/adapters/{registry.ts, adapter-display-registry.ts, use-adapter-capabilities.ts}`
  - `ui/src/pages/InviteLanding.tsx`, `ui/src/components/OnboardingWizard.tsx`
  - `vitest.config.ts` — register the new test project
- Tests (all passing):
  - 13 parser tests (`src/server/parse.test.ts`)
  - 6 build-config tests (`src/ui/build-config.test.ts`)
  - Model-discovery tests for parsing, sort order, legacy suffixing, empty arrays, invalid JSON, and fail-soft (`[]`) fallback (`src/server/models.test.ts`)

## Verification

Commands run locally on this branch:

```sh
pnpm -r typecheck    # ✅ pass (all projects)
pnpm test:run        # 1796 passed / 1 skipped / 1 failed *
pnpm build           # ✅ pass (server, ui, cli)
```

\* The single failing test is `cli/src/__tests__/worktree.test.ts > seeds authenticated users into minimally cloned worktree instances` — a pre-existing drizzle-restore SQL syntax error also present on `master`. This branch does not touch `worktree.ts`, `worktree.test.ts`, or `backup-lib.ts`. Confirmed unrelated.

Manual verification (see screenshots below):

1. `pnpm dev`, open the board, click **New agent** → **I want advanced configuration myself**
2. The adapter-type grid shows a new **Auggie** tile (`Local Augment Code CLI agent`)
3. Selecting the tile opens the advanced form with `adapterType=auggie_local`
4. The **Model** dropdown is populated from a real `auggie models list --json` invocation on the host — the `auto` sentinel is first, non-legacy models are grouped ahead of legacy ones, and legacy entries are suffixed `(legacy)`

Observed model set (Auggie 0.24.0 on this host):

```
auto                           → Auto (account default)
gemini-3.1-pro-preview         → Gemini 3.1 Pro Preview
gpt5, gpt5.1, gpt5.2           → GPT-5 / 5.1 / 5.2  (legacy)
gpt5.4                         → GPT-5.4
haiku4.5                       → Haiku 4.5
kimi-k2.6                      → Kimi K2.6
opus4.5                        → Opus 4.5 (legacy)
opus4.6, opus4.6-500k, opus4.7 → Opus 4.6, Opus 4.6 (500K), Opus 4.7
sonnet4, sonnet4.5             → Sonnet 4 / 4.5  (legacy)
sonnet4.6, sonnet4.6-500k      → Sonnet 4.6, Sonnet 4.6 (500K)
```

### Screenshots

Auggie tile in the adapter-type picker: 

<img width="1440" height="900" alt="01-auggie-adapter-tile" src="https://github.com/user-attachments/assets/ca6574ee-a0b2-4573-91eb-849d763a9991" />


Full New-Agent form with `adapterType=auggie_local`:

<img width="1440" height="900" alt="02-new-agent-form" src="https://github.com/user-attachments/assets/68083479-9f7f-449a-b4d6-0742d23c1d01" />


Model dropdown populated from `auggie models list --json`, with `(legacy)` suffixes:

<img width="1440" height="900" alt="03-auggie-model-dropdown" src="https://github.com/user-attachments/assets/254acd61-78b3-43ab-89b5-dfa6f7cc7209" />

## Risks

- **Low-to-moderate.** The new package is self-contained; existing adapters are untouched.
- Model discovery shells out to `auggie`; failures are caught and fall back to the static list in `src/index.ts`, so a missing/unauthenticated CLI cannot brick hiring or the UI.
- Registry additions are single-line insertions mirroring existing adapters (`claude_local`, `codex_local`); behavior is additive.
- Skills materialization creates symlinks under `~/.augment/skills/`. A corresponding entry in `LEGACY_MATERIALIZED_SKILLS_SET` ensures cleanup on agent removal matches the pattern used by other adapters.
- The `auggie models list --json` call has a 20s timeout and a 5-minute TTL cache, so a slow CLI probe cannot block the UI repeatedly.

## Model Used

- **Provider / model:** Anthropic Claude Opus 4.7, via the Augment Agent tool harness
- **Context window:** ~200K tokens
- **Capabilities used:** extended thinking, tool use (shell, code edit, Playwright for UI verification)
- **Role:** scaffolded the `packages/adapters/auggie-local` package, wrote the unit tests, wired the registries, implemented dynamic model discovery, and captured the verification screenshots. Human-reviewed throughout.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (aligns with the "bring your own agent" / first-party adapter direction; no existing Auggie entry)
- [x] I have run tests locally and they pass (single unrelated pre-existing failure on master noted in Verification)
- [x] I have added or updated tests where applicable (19 new unit tests across parser, build-config, and model discovery)
- [x] If this change affects the UI, I have included before/after screenshots (new adapter tile + new model dropdown shown above)
- [x] I have updated relevant documentation to reflect my changes (no user-facing doc changes required; the adapter follows existing conventions)
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
