### PR TITLE
fix: harden legacy issue-list encoding handling

### DIFF
--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -1,9 +1,11 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
 import postgres from "postgres";
 import {
   applyPendingMigrations,
+  createDb,
   inspectMigrations,
 } from "./client.js";
 import {
@@ -43,6 +45,15 @@ if (!embeddedPostgresSupport.supported) {
 }
 
 describeEmbeddedPostgres("applyPendingMigrations", () => {
+  it("forces UTF8 client encoding for Drizzle connections", async () => {
+    const connectionString = await createTempDatabase();
+    const db = createDb(connectionString);
+
+    const rows = await db.execute<{ client_encoding: string }>(sql.raw(`SHOW client_encoding`));
+
+    expect(rows[0]?.client_encoding).toBe("UTF8");
+  });
+
   it(
     "applies an inserted earlier migration without replaying later legacy migrations",
     async () => {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -11,7 +11,7 @@ const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
 const MIGRATIONS_JOURNAL_JSON = fileURLToPath(new URL("./migrations/meta/_journal.json", import.meta.url));
 
 function createUtilitySql(url: string) {
-  return postgres(url, { max: 1, onnotice: () => {} });
+  return postgres(url, { max: 1, onnotice: () => {}, connection: { client_encoding: "UTF8" } });
 }
 
 function isSafeIdentifier(value: string): boolean {
@@ -46,7 +46,7 @@ export type MigrationState =
     };
 
 export function createDb(url: string) {
-  const sql = postgres(url);
+  const sql = postgres(url, { connection: { client_encoding: "UTF8" } });
   return drizzlePg(sql, { schema });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,6 +586,9 @@ importers:
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
+      postgres:
+        specifier: ^3.4.8
+        version: 3.4.8
       supertest:
         specifier: ^7.0.0
         version: 7.2.2

--- a/server/package.json
+++ b/server/package.json
@@ -86,6 +86,7 @@
     "@types/supertest": "^6.0.2",
     "@types/ws": "^8.18.1",
     "cross-env": "^10.1.0",
+    "postgres": "^3.4.8",
     "supertest": "^7.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -118,17 +118,18 @@ describeEmbeddedPostgres("issueService.list legacy SQL_ASCII descriptions", () =
       requireBoardApprovalForNewAgents: false,
     });
 
-    await sqlAscii.unsafe(`
-      INSERT INTO "issues" ("id", "company_id", "title", "description", "status", "priority")
-      VALUES (
-        '${issueId}',
-        '${companyId}',
-        'Legacy description bytes',
-        convert_from(E'\\xe2'::bytea, 'SQL_ASCII'),
-        'todo',
-        'medium'
-      )
-    `);
+    await sqlAscii.unsafe(
+      `INSERT INTO "issues" ("id", "company_id", "title", "description", "status", "priority")
+       VALUES (
+         $1,
+         $2,
+         'Legacy description bytes',
+         convert_from(E'\\xe2'::bytea, 'SQL_ASCII'),
+         'todo',
+         'medium'
+       )`,
+      [issueId, companyId],
+    );
 
     const result = await svc.list(companyId);
 

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2,9 +2,11 @@ import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { sql } from "drizzle-orm";
+import postgres from "postgres";
 import {
   activityLog,
   agents,
+  applyPendingMigrations,
   companies,
   createDb,
   executionWorkspaces,
@@ -57,6 +59,87 @@ if (!embeddedPostgresSupport.supported) {
     `Skipping embedded Postgres issue service tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
   );
 }
+
+describeEmbeddedPostgres("issueService.list legacy SQL_ASCII descriptions", () => {
+  let adminSql!: ReturnType<typeof postgres>;
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let sqlAscii!: ReturnType<typeof postgres>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-sql-ascii-");
+    const adminUrl = new URL(tempDb.connectionString);
+    adminUrl.pathname = "/postgres";
+    adminSql = postgres(adminUrl.toString(), { connection: { client_encoding: "UTF8" } });
+
+    const legacyDbName = `paperclip_legacy_${randomUUID().replace(/-/g, "")}`;
+    await adminSql.unsafe(`CREATE DATABASE "${legacyDbName}" WITH TEMPLATE template0 ENCODING 'SQL_ASCII' LC_COLLATE 'C' LC_CTYPE 'C'`);
+
+    const legacyUrl = new URL(tempDb.connectionString);
+    legacyUrl.pathname = `/${legacyDbName}`;
+    await applyPendingMigrations(legacyUrl.toString());
+
+    db = createDb(legacyUrl.toString());
+    svc = issueService(db);
+    sqlAscii = postgres(legacyUrl.toString(), { connection: { client_encoding: "SQL_ASCII" } });
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await sqlAscii.end();
+    await adminSql.end();
+    await tempDb?.cleanup();
+  });
+
+  it("returns list rows instead of throwing when a description contains legacy non-UTF8 bytes", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await sqlAscii.unsafe(`
+      INSERT INTO "issues" ("id", "company_id", "title", "description", "status", "priority")
+      VALUES (
+        '${issueId}',
+        '${companyId}',
+        'Legacy description bytes',
+        convert_from(E'\\xe2'::bytea, 'SQL_ASCII'),
+        'todo',
+        'medium'
+      )
+    `);
+
+    const result = await svc.list(companyId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(expect.objectContaining({
+      id: issueId,
+      title: "Legacy description bytes",
+      description: "�",
+    }));
+  });
+});
 
 describeEmbeddedPostgres("issueService.list participantAgentId", () => {
   let db!: ReturnType<typeof createDb>;

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -103,6 +103,7 @@ describeEmbeddedPostgres("issueService.list legacy SQL_ASCII descriptions", () =
 
   afterAll(async () => {
     await sqlAscii.end();
+    await db.$client.end();
     await adminSql.end();
     await tempDb?.cleanup();
   });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, so core task surfaces like the issues list have to stay readable even when an older install carries forward messy historical state.
> - This bug sits in the database/client boundary for the issues list path, where Paperclip reads issue rows out of PostgreSQL and returns a trimmed preview to the board.
> - Issue `#3893` reports `22021 / invalid byte sequence for encoding UTF8` on `GET /api/companies/:id/issues` after upgrading an existing embedded database.
> - The failure mode points to legacy non-UTF-8 bytes surviving in older databases, while the current server path needs to keep reading safely under a UTF-8 client connection.
> - This pull request hardens the DB client encoding settings and adds a regression test that creates a migrated `SQL_ASCII` database, inserts a legacy bad description byte, and proves `issueService.list()` still returns a usable row.
> - The benefit is a stable issues list for upgraded installs with legacy encoding history, plus direct coverage for the exact compatibility path that regressed in the issue.

## What Changed

- Forces `postgres` utility and Drizzle clients to connect with `client_encoding = UTF8` in `packages/db/src/client.ts`.
- Adds a DB client regression test in `packages/db/src/client.test.ts` that asserts Drizzle sessions negotiate `UTF8`.
- Adds `postgres` as a server dev dependency for the encoding regression harness.
- Adds a server regression test in `server/src/__tests__/issues-service.test.ts` that creates a migrated `SQL_ASCII` database, inserts a legacy invalid description byte, and verifies `issueService.list()` returns a replacement-character preview instead of throwing.

## Verification

- `pnpm exec vitest run packages/db/src/client.test.ts server/src/__tests__/issues-service.test.ts`
- `pnpm -r typecheck`
- `pnpm build`
- `pnpm test:run` currently still has unrelated existing failures in `costs-service.test.ts`, `heartbeat-process-recovery.test.ts`, `workspace-runtime.test.ts`, `network-bind.test.ts`, and `onboard.test.ts`

## Risks

- Low risk: runtime code change is limited to explicitly pinning PostgreSQL client encoding to UTF-8.
- Test risk is moderate only in that the new regression harness creates and migrates a dedicated `SQL_ASCII` database during the suite, which adds setup work but keeps the repro faithful to the reported upgrade path.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI with a GPT-5-based coding agent runtime, shell/code execution enabled; exact hosted model build and context window are not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
