### PR TITLE
fix(routines): reject triggers[] on POST/PATCH with HTTP 400 (AKS-2872)

### DIFF
--- a/docs/api/routines.md
+++ b/docs/api/routines.md
@@ -40,6 +40,8 @@ POST /api/companies/{companyId}/routines
 
 **Agents can only create routines assigned to themselves.** Board operators can assign to any agent.
 
+> **Note:** `triggers[]` is not accepted on this endpoint. Requests containing that key return HTTP 400. Create triggers via `POST /routines/{id}/triggers`.
+
 Fields:
 
 | Field | Required | Description |
@@ -80,6 +82,8 @@ PATCH /api/routines/{routineId}
 ```
 
 All fields from create are updatable. **Agents can only update routines assigned to themselves and cannot reassign a routine to another agent.**
+
+> **Note:** `triggers[]` is not accepted on this endpoint. Requests containing that key return HTTP 400. Create triggers via `POST /routines/{id}/triggers`.
 
 ## Add Trigger
 

--- a/packages/shared/src/validators/routine.ts
+++ b/packages/shared/src/validators/routine.ts
@@ -47,7 +47,7 @@ export const routineVariableSchema = z.object({
   }
 });
 
-export const createRoutineSchema = z.object({
+const _routineBaseObjectSchema = z.object({
   projectId: z.string().uuid().optional().nullable(),
   goalId: z.string().uuid().optional().nullable(),
   parentIssueId: z.string().uuid().optional().nullable(),
@@ -59,11 +59,24 @@ export const createRoutineSchema = z.object({
   concurrencyPolicy: z.enum(ROUTINE_CONCURRENCY_POLICIES).optional().default("coalesce_if_active"),
   catchUpPolicy: z.enum(ROUTINE_CATCH_UP_POLICIES).optional().default("skip_missed"),
   variables: z.array(routineVariableSchema).optional().default([]),
+  triggers: z.unknown().optional(),
 });
 
+function _rejectTriggers(value: { triggers?: unknown }, ctx: z.RefinementCtx) {
+  if (value.triggers !== undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["triggers"],
+      message:
+        "triggers cannot be set on this endpoint — use POST /routines/{id}/triggers to create a trigger",
+    });
+  }
+}
+
+export const createRoutineSchema = _routineBaseObjectSchema.superRefine(_rejectTriggers);
 export type CreateRoutine = z.infer<typeof createRoutineSchema>;
 
-export const updateRoutineSchema = createRoutineSchema.partial();
+export const updateRoutineSchema = _routineBaseObjectSchema.partial().superRefine(_rejectTriggers);
 export type UpdateRoutine = z.infer<typeof updateRoutineSchema>;
 
 const baseTriggerSchema = z.object({

--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -281,6 +281,66 @@ describe("routine routes", () => {
     expect(mockRoutineService.runRoutine).not.toHaveBeenCalled();
   });
 
+  it("rejects POST /companies/:companyId/routines with triggers[] with 400", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Daily routine",
+        assigneeAgentId: agentId,
+        triggers: [{ kind: "schedule", cronExpression: "0 * * * *", timezone: "UTC" }],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Validation error");
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ["triggers"],
+          message: expect.stringContaining("POST /routines/{id}/triggers"),
+        }),
+      ]),
+    );
+    expect(mockRoutineService.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects PATCH /routines/:id with triggers[] with 400", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      source: "api_key",
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .patch(`/api/routines/${routineId}`)
+      .send({
+        triggers: [{ kind: "schedule", cronExpression: "0 * * * *", timezone: "UTC" }],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Validation error");
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ["triggers"],
+          message: expect.stringContaining("POST /routines/{id}/triggers"),
+        }),
+      ]),
+    );
+    expect(mockRoutineService.update).not.toHaveBeenCalled();
+  });
+
   it("allows routine creation when the board user has tasks:assign", async () => {
     mockAccessService.canUser.mockResolvedValue(true);
     const app = await createApp({


### PR DESCRIPTION
## Summary

- Adds `triggers: z.unknown().optional()` to the base routine object schema so the key survives Zod's strip-unknown step
- Adds a `superRefine` to both `createRoutineSchema` and `updateRoutineSchema` that rejects any request body containing a `triggers` key with a 400 Validation error, directing callers to `POST /routines/{id}/triggers`
- Two new tests: POST with `triggers[]` → 400, PATCH with `triggers[]` → 400 (both assert service not called)
- Docs updated for Create Routine and Update Routine with a note about the restriction

## Test plan

- [x] `pnpm --filter @paperclipai/shared typecheck` — passes
- [x] `pnpm -r typecheck` — passes (all packages)
- [x] `vitest run src/__tests__/routines-routes.test.ts` — 9/9 tests pass (includes 2 new trigger-rejection tests)

Refs: AKS-2872, AKS-2761

🤖 Generated with [Claude Code](https://claude.com/claude-code)