### PR TITLE
feat(permissions): add scoped agents:skills:sync permission for skill-sync delegation

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -487,6 +487,7 @@ export const PERMISSION_KEYS = [
   "tasks:manage_active_checkouts",
   "joins:approve",
   "environments:manage",
+  "agents:skills:sync",
 ] as const;
 export type PermissionKey = (typeof PERMISSION_KEYS)[number];
 

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -131,6 +131,7 @@ export type TestAdapterEnvironment = z.infer<typeof testAdapterEnvironmentSchema
 export const updateAgentPermissionsSchema = z.object({
   canCreateAgents: z.boolean(),
   canAssignTasks: z.boolean(),
+  canSyncOtherAgentSkills: z.boolean().optional().default(false),
 });
 
 export type UpdateAgentPermissions = z.infer<typeof updateAgentPermissionsSchema>;

--- a/server/src/__tests__/agent-skills-sync-permission.test.ts
+++ b/server/src/__tests__/agent-skills-sync-permission.test.ts
@@ -1,0 +1,555 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const TARGET_AGENT_ID = "11111111-1111-4111-8111-111111111111";
+const ACTOR_AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const COMPANY_ID = "33333333-3333-4333-8333-333333333333";
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  list: vi.fn(),
+  update: vi.fn(),
+  create: vi.fn(),
+  updatePermissions: vi.fn(),
+  rollbackConfigRevision: vi.fn(),
+  resolveByReference: vi.fn(),
+  getChainOfCommand: vi.fn(),
+  activatePendingApproval: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+  getMembership: vi.fn(),
+  listPrincipalGrants: vi.fn(),
+  ensureMembership: vi.fn(),
+  setPrincipalPermission: vi.fn(),
+}));
+
+const mockApprovalService = vi.hoisted(() => ({ create: vi.fn(), getById: vi.fn() }));
+const mockBudgetService = vi.hoisted(() => ({ upsertPolicy: vi.fn() }));
+const mockEnvironmentService = vi.hoisted(() => ({ getById: vi.fn() }));
+const mockHeartbeatService = vi.hoisted(() => ({
+  listTaskSessions: vi.fn(),
+  resetRuntimeSession: vi.fn(),
+  getRun: vi.fn(),
+  cancelRun: vi.fn(),
+}));
+const mockIssueApprovalService = vi.hoisted(() => ({ linkManyForApproval: vi.fn() }));
+const mockIssueService = vi.hoisted(() => ({ list: vi.fn() }));
+const mockSecretService = vi.hoisted(() => ({
+  normalizeAdapterConfigForPersistence: vi.fn(),
+  resolveAdapterConfigForRuntime: vi.fn(),
+}));
+const mockAgentInstructionsService = vi.hoisted(() => ({
+  materializeManagedBundle: vi.fn(),
+}));
+const mockCompanySkillService = vi.hoisted(() => ({
+  listRuntimeSkillEntries: vi.fn(),
+  resolveRequestedSkillKeys: vi.fn(),
+}));
+const mockWorkspaceOperationService = vi.hoisted(() => ({}));
+const mockInstanceSettingsService = vi.hoisted(() => ({ getGeneral: vi.fn() }));
+const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockTrackAgentCreated = vi.hoisted(() => vi.fn());
+const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
+const mockSyncInstructionsBundleConfigFromFilePath = vi.hoisted(() => vi.fn());
+const mockEnsureOpenCodeModelConfiguredAndAvailable = vi.hoisted(() => vi.fn());
+
+const mockAdapter = vi.hoisted(() => ({
+  listSkills: vi.fn(),
+  syncSkills: vi.fn(),
+}));
+
+function registerModuleMocks() {
+  vi.doMock("../routes/agents.js", async () => vi.importActual("../routes/agents.js"));
+  vi.doMock("../routes/authz.js", async () => vi.importActual("../routes/authz.js"));
+  vi.doMock("../middleware/index.js", async () => vi.importActual("../middleware/index.js"));
+  vi.doMock("@paperclipai/adapter-opencode-local/server", async () => {
+    const actual = await vi.importActual<typeof import("@paperclipai/adapter-opencode-local/server")>(
+      "@paperclipai/adapter-opencode-local/server",
+    );
+    return {
+      ...actual,
+      ensureOpenCodeModelConfiguredAndAvailable: mockEnsureOpenCodeModelConfiguredAndAvailable,
+    };
+  });
+
+  vi.doMock("@paperclipai/shared/telemetry", () => ({
+    trackAgentCreated: mockTrackAgentCreated,
+    trackErrorHandlerCrash: vi.fn(),
+  }));
+  vi.doMock("../telemetry.js", () => ({
+    getTelemetryClient: mockGetTelemetryClient,
+  }));
+  vi.doMock("../adapters/index.js", () => ({
+    findServerAdapter: vi.fn(() => mockAdapter),
+    findActiveServerAdapter: vi.fn(() => mockAdapter),
+    listAdapterModels: vi.fn(),
+    detectAdapterModel: vi.fn(),
+  }));
+  vi.doMock("../services/index.js", () => ({
+    agentService: () => mockAgentService,
+    agentInstructionsService: () => mockAgentInstructionsService,
+    accessService: () => mockAccessService,
+    approvalService: () => mockApprovalService,
+    budgetService: () => mockBudgetService,
+    companySkillService: () => mockCompanySkillService,
+    environmentService: () => mockEnvironmentService,
+    heartbeatService: () => mockHeartbeatService,
+    issueApprovalService: () => mockIssueApprovalService,
+    issueService: () => mockIssueService,
+    ISSUE_LIST_DEFAULT_LIMIT: 500,
+    logActivity: mockLogActivity,
+    secretService: () => mockSecretService,
+    syncInstructionsBundleConfigFromFilePath: mockSyncInstructionsBundleConfigFromFilePath,
+    workspaceOperationService: () => mockWorkspaceOperationService,
+  }));
+  vi.doMock("../services/instance-settings.js", () => ({
+    instanceSettingsService: () => mockInstanceSettingsService,
+  }));
+}
+
+function createDb() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => [
+          { id: COMPANY_ID, requireBoardApprovalForNewAgents: false },
+        ]),
+      })),
+    })),
+  };
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ agentRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/agents.js"),
+    import("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", agentRoutes(createDb() as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeAgent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TARGET_AGENT_ID,
+    companyId: COMPANY_ID,
+    name: "Target",
+    urlKey: "target",
+    role: "engineer",
+    title: "Target",
+    icon: null,
+    status: "idle",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "claude_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    defaultEnvironmentId: null,
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    pauseReason: null,
+    pausedAt: null,
+    permissions: { canCreateAgents: false },
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date("2026-04-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeActorAgent(overrides: Record<string, unknown> = {}) {
+  return makeAgent({
+    id: ACTOR_AGENT_ID,
+    urlKey: "actor",
+    name: "Actor",
+    title: "Actor",
+    ...overrides,
+  });
+}
+
+describe.sequential("POST /agents/:id/skills/sync — narrow grant fall-through", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@paperclipai/shared/telemetry");
+    vi.doUnmock("../telemetry.js");
+    vi.doUnmock("../adapters/index.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../services/instance-settings.js");
+    vi.doUnmock("../routes/agents.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.doUnmock("@paperclipai/adapter-opencode-local/server");
+    registerModuleMocks();
+    vi.resetAllMocks();
+
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === TARGET_AGENT_ID) return makeAgent();
+      if (id === ACTOR_AGENT_ID) return makeActorAgent();
+      return null;
+    });
+    mockAgentService.list.mockResolvedValue([]);
+    mockAgentService.getChainOfCommand.mockResolvedValue([]);
+    mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: makeAgent() });
+    mockAgentService.update.mockImplementation(
+      async (_id: string, patch: Record<string, unknown>) => ({
+        ...makeAgent(),
+        adapterConfig: patch.adapterConfig ?? {},
+      }),
+    );
+    mockAgentService.updatePermissions.mockResolvedValue(makeAgent());
+    mockAgentService.rollbackConfigRevision.mockResolvedValue(makeAgent());
+    mockAgentService.activatePendingApproval.mockResolvedValue({
+      agent: makeAgent(),
+      activated: false,
+    });
+
+    mockAccessService.canUser.mockResolvedValue(false);
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAccessService.getMembership.mockResolvedValue(null);
+    mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+    mockAccessService.ensureMembership.mockResolvedValue(undefined);
+    mockAccessService.setPrincipalPermission.mockResolvedValue(undefined);
+
+    mockSecretService.normalizeAdapterConfigForPersistence.mockImplementation(
+      async (_companyId: string, config: Record<string, unknown>) => config,
+    );
+    mockSecretService.resolveAdapterConfigForRuntime.mockResolvedValue({ config: { env: {} } });
+
+    mockCompanySkillService.listRuntimeSkillEntries.mockResolvedValue([]);
+    mockCompanySkillService.resolveRequestedSkillKeys.mockImplementation(
+      async (_companyId: string, requested: string[]) => requested,
+    );
+
+    mockAdapter.listSkills.mockResolvedValue({
+      adapterType: "claude_local",
+      supported: true,
+      mode: "ephemeral",
+      desiredSkills: [],
+      entries: [],
+      warnings: [],
+    });
+    mockAdapter.syncSkills.mockResolvedValue({
+      adapterType: "claude_local",
+      supported: true,
+      mode: "ephemeral",
+      desiredSkills: [],
+      entries: [],
+      warnings: [],
+    });
+
+    mockAgentInstructionsService.materializeManagedBundle.mockImplementation(
+      async (agent: Record<string, unknown>, files: Record<string, string>) => ({
+        bundle: null,
+        adapterConfig: {
+          ...((agent.adapterConfig as Record<string, unknown> | undefined) ?? {}),
+          promptTemplate: files["AGENTS.md"] ?? "",
+        },
+      }),
+    );
+
+    mockInstanceSettingsService.getGeneral.mockResolvedValue({ censorUsernameInLogs: false });
+    mockGetTelemetryClient.mockReturnValue({ track: vi.fn() });
+    mockSyncInstructionsBundleConfigFromFilePath.mockImplementation((_agent, config) => config);
+    mockEnsureOpenCodeModelConfiguredAndAvailable.mockResolvedValue([]);
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  function actorAgentCaller() {
+    return {
+      type: "agent" as const,
+      agentId: ACTOR_AGENT_ID,
+      companyId: COMPANY_ID,
+      source: "agent_key" as const,
+      runId: "run-1",
+      companyIds: [COMPANY_ID],
+    };
+  }
+
+  it("403s when actor is an agent without agents:create or agents:skills:sync", async () => {
+    mockAccessService.hasPermission.mockResolvedValue(false);
+
+    const app = await createApp(actorAgentCaller());
+
+    const res = await request(app)
+      .post(`/api/agents/${TARGET_AGENT_ID}/skills/sync`)
+      .send({ desiredSkills: [] });
+
+    expect(res.status).toBe(403);
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+  });
+
+  it("200s when actor holds agents:skills:sync and does NOT hold agents:create", async () => {
+    mockAccessService.hasPermission.mockImplementation(
+      async (
+        _companyId: string,
+        _principalType: string,
+        _principalId: string,
+        permissionKey: string,
+      ) => permissionKey === "agents:skills:sync",
+    );
+
+    const app = await createApp(actorAgentCaller());
+
+    const res = await request(app)
+      .post(`/api/agents/${TARGET_AGENT_ID}/skills/sync`)
+      .send({ desiredSkills: [] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      TARGET_AGENT_ID,
+      expect.any(Object),
+      expect.objectContaining({
+        recordRevision: expect.objectContaining({
+          source: "skill-sync",
+          createdByAgentId: ACTOR_AGENT_ID,
+        }),
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.skills_synced",
+        agentId: ACTOR_AGENT_ID,
+        entityId: TARGET_AGENT_ID,
+      }),
+    );
+  });
+
+  it("does NOT leak into PATCH /agents/:id when only agents:skills:sync is granted", async () => {
+    mockAccessService.hasPermission.mockImplementation(
+      async (
+        _companyId: string,
+        _principalType: string,
+        _principalId: string,
+        permissionKey: string,
+      ) => permissionKey === "agents:skills:sync",
+    );
+
+    const app = await createApp(actorAgentCaller());
+
+    const res = await request(app)
+      .patch(`/api/agents/${TARGET_AGENT_ID}`)
+      .send({ title: "renamed" });
+
+    expect(res.status).toBe(403);
+    expect(mockAgentService.update).not.toHaveBeenCalledWith(
+      TARGET_AGENT_ID,
+      expect.objectContaining({ title: "renamed" }),
+      expect.anything(),
+    );
+  });
+
+  it("does NOT leak into POST /agents/:id/config-revisions/:revisionId/rollback when only agents:skills:sync is granted", async () => {
+    mockAccessService.hasPermission.mockImplementation(
+      async (
+        _companyId: string,
+        _principalType: string,
+        _principalId: string,
+        permissionKey: string,
+      ) => permissionKey === "agents:skills:sync",
+    );
+
+    const app = await createApp(actorAgentCaller());
+
+    const res = await request(app)
+      .post(`/api/agents/${TARGET_AGENT_ID}/config-revisions/rev-1/rollback`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(mockAgentService.rollbackConfigRevision).not.toHaveBeenCalled();
+  });
+
+  it("still 200s for self-sync without any narrow grant (fall-through to assertCanUpdateAgent)", async () => {
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAgentService.getById.mockImplementation(async (id: string) =>
+      id === TARGET_AGENT_ID ? makeAgent() : makeAgent({ id }),
+    );
+
+    const app = await createApp({
+      type: "agent",
+      agentId: TARGET_AGENT_ID,
+      companyId: COMPANY_ID,
+      source: "agent_key",
+      runId: "run-1",
+      companyIds: [COMPANY_ID],
+    });
+
+    const res = await request(app)
+      .post(`/api/agents/${TARGET_AGENT_ID}/skills/sync`)
+      .send({ desiredSkills: [] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+  });
+
+  it("still 200s for CEO actor without any narrow grant", async () => {
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    const ceoAgent = makeActorAgent({ role: "ceo" });
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === TARGET_AGENT_ID) return makeAgent();
+      if (id === ACTOR_AGENT_ID) return ceoAgent;
+      return null;
+    });
+
+    const app = await createApp(actorAgentCaller());
+
+    const res = await request(app)
+      .post(`/api/agents/${TARGET_AGENT_ID}/skills/sync`)
+      .send({ desiredSkills: [] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+  });
+});
+
+describe.sequential("PATCH /agents/:id/permissions — canSyncOtherAgentSkills mirror", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@paperclipai/shared/telemetry");
+    vi.doUnmock("../telemetry.js");
+    vi.doUnmock("../adapters/index.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../services/instance-settings.js");
+    vi.doUnmock("../routes/agents.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.doUnmock("@paperclipai/adapter-opencode-local/server");
+    registerModuleMocks();
+    vi.resetAllMocks();
+
+    mockAgentService.getById.mockResolvedValue(makeAgent());
+    mockAgentService.list.mockResolvedValue([]);
+    mockAgentService.getChainOfCommand.mockResolvedValue([]);
+    mockAgentService.updatePermissions.mockResolvedValue(makeAgent());
+    mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: makeAgent() });
+
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAccessService.getMembership.mockResolvedValue(null);
+    mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+    mockAccessService.ensureMembership.mockResolvedValue(undefined);
+    mockAccessService.setPrincipalPermission.mockResolvedValue(undefined);
+
+    mockInstanceSettingsService.getGeneral.mockResolvedValue({ censorUsernameInLogs: false });
+    mockGetTelemetryClient.mockReturnValue({ track: vi.fn() });
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("mirrors canSyncOtherAgentSkills=true into the agents:skills:sync principal grant", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [COMPANY_ID],
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${TARGET_AGENT_ID}/permissions`)
+      .send({ canCreateAgents: false, canAssignTasks: false, canSyncOtherAgentSkills: true });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      COMPANY_ID,
+      "agent",
+      TARGET_AGENT_ID,
+      "agents:skills:sync",
+      true,
+      "board-user",
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.permissions_updated",
+        details: expect.objectContaining({
+          canSyncOtherAgentSkills: true,
+        }),
+      }),
+    );
+  });
+
+  it("clears agents:skills:sync grant when canSyncOtherAgentSkills is false and no implicit coupling", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [COMPANY_ID],
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${TARGET_AGENT_ID}/permissions`)
+      .send({ canCreateAgents: false, canAssignTasks: false, canSyncOtherAgentSkills: false });
+
+    expect(res.status).toBe(200);
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      COMPANY_ID,
+      "agent",
+      TARGET_AGENT_ID,
+      "agents:skills:sync",
+      false,
+      "board-user",
+    );
+  });
+
+  it("keeps agents:skills:sync grant enabled when agent has canCreateAgents (implicit coupling)", async () => {
+    mockAgentService.updatePermissions.mockResolvedValue(
+      makeAgent({ permissions: { canCreateAgents: true } }),
+    );
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [COMPANY_ID],
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${TARGET_AGENT_ID}/permissions`)
+      .send({ canCreateAgents: true, canAssignTasks: false, canSyncOtherAgentSkills: false });
+
+    expect(res.status).toBe(200);
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      COMPANY_ID,
+      "agent",
+      TARGET_AGENT_ID,
+      "agents:skills:sync",
+      true,
+      "board-user",
+    );
+  });
+
+  it("defaults canSyncOtherAgentSkills to false when omitted (backwards compatible payload)", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [COMPANY_ID],
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${TARGET_AGENT_ID}/permissions`)
+      .send({ canCreateAgents: false, canAssignTasks: false });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      COMPANY_ID,
+      "agent",
+      TARGET_AGENT_ID,
+      "agents:skills:sync",
+      false,
+      "board-user",
+    );
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -970,7 +970,29 @@ export function agentRoutes(db: Db) {
         res.status(404).json({ error: "Agent not found" });
         return;
       }
-      await assertCanUpdateAgent(req, agent);
+
+      // Narrow grant fall-through: an agent holding agents:skills:sync in the
+      // same company can sync any agent's skills without being granted the
+      // broader agents:create surface. Self-sync, CEO, and agents:create
+      // holders still fall through to assertCanUpdateAgent unchanged.
+      let allowedByNarrowGrant = false;
+      if (req.actor.type === "agent" && req.actor.agentId) {
+        assertCompanyAccess(req, agent.companyId);
+        const actorAgent = await svc.getById(req.actor.agentId);
+        if (!actorAgent || actorAgent.companyId !== agent.companyId) {
+          throw forbidden("Agent key cannot access another company");
+        }
+        allowedByNarrowGrant = await access.hasPermission(
+          agent.companyId,
+          "agent",
+          actorAgent.id,
+          "agents:skills:sync",
+        );
+      }
+
+      if (!allowedByNarrowGrant) {
+        await assertCanUpdateAgent(req, agent);
+      }
 
       const requestedSkills = Array.from(
         new Set(
@@ -1713,6 +1735,10 @@ export function agentRoutes(db: Db) {
 
     const effectiveCanAssignTasks =
       agent.role === "ceo" || Boolean(agent.permissions?.canCreateAgents) || req.body.canAssignTasks;
+    const effectiveCanSyncSkills =
+      agent.role === "ceo"
+      || Boolean(agent.permissions?.canCreateAgents)
+      || Boolean(req.body.canSyncOtherAgentSkills);
     await access.ensureMembership(agent.companyId, "agent", agent.id, "member", "active");
     await access.setPrincipalPermission(
       agent.companyId,
@@ -1720,6 +1746,14 @@ export function agentRoutes(db: Db) {
       agent.id,
       "tasks:assign",
       effectiveCanAssignTasks,
+      req.actor.type === "board" ? (req.actor.userId ?? null) : null,
+    );
+    await access.setPrincipalPermission(
+      agent.companyId,
+      "agent",
+      agent.id,
+      "agents:skills:sync",
+      effectiveCanSyncSkills,
       req.actor.type === "board" ? (req.actor.userId ?? null) : null,
     );
 
@@ -1736,6 +1770,7 @@ export function agentRoutes(db: Db) {
       details: {
         canCreateAgents: agent.permissions?.canCreateAgents ?? false,
         canAssignTasks: effectiveCanAssignTasks,
+        canSyncOtherAgentSkills: effectiveCanSyncSkills,
       },
     });
 

--- a/skills/paperclip/references/company-skills.md
+++ b/skills/paperclip/references/company-skills.md
@@ -18,7 +18,7 @@ The canonical model is:
 
 - Company skill reads: any same-company actor
 - Company skill mutations: board, CEO, or an agent with the effective `agents:create` capability
-- Agent skill assignment: same permission model as updating that agent
+- Agent skill assignment: CEO, the target agent itself, any agent with `agents:create` (broad), **or any agent with `agents:skills:sync`** (narrow, scoped exclusively to `POST /api/agents/:agentId/skills/sync`)
 
 ## Core Endpoints
 
@@ -139,6 +139,25 @@ If you need the current state first:
 curl -sS "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills" \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY"
 ```
+
+### Scoped delegation: the `agents:skills:sync` permission
+
+CEO can designate a "skill manager" agent without granting it full agent-mutation powers. Use the existing CEO-only permissions endpoint:
+
+```sh
+curl -sS -X PATCH "$PAPERCLIP_API_URL/api/agents/<skill-manager-agent-id>/permissions" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "canCreateAgents": false,
+    "canAssignTasks": true,
+    "canSyncOtherAgentSkills": true
+  }'
+```
+
+The designated agent can now call `POST /api/agents/:agentId/skills/sync` against any other agent in the same company. It **cannot** `PATCH` other agents or roll back their config revisions — those still require `agents:create` or CEO.
+
+All syncs continue to record the acting agent id in `agent_revisions` (`source="skill-sync"`) and `activity_log` (`action="agent.skills_synced"`), so the audit trail is unchanged from the CEO-run path.
 
 ## Include Skills During Hire Or Create
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agent configuration (skills, role, adapter config, instructions) is mutated through `server/src/routes/agents.ts`
> - Several strictly-broader surfaces (`PATCH /agents/:id`, `POST /agents/:id/config-revisions/:revisionId/rollback`) share one access gate — `assertCanUpdateAgent` — with the narrow skills-bookkeeping surface (`POST /agents/:id/skills/sync`)
> - A company that wants to delegate daily skill-sync audits to a dedicated agent has to grant it `agents:create`, which also hands it full write access to every other agent's role, adapter config, and instructions — way too broad for "skill bookkeeper"
> - This pull request adds a narrow, additive `agents:skills:sync` permission that unlocks only `/skills/sync` and nothing else, exposed through the existing CEO-only `PATCH /agents/:id/permissions` endpoint (no new route, no new role, no migration)
> - The benefit is that real Paperclip users (e.g. Telos's `SkillManager` agent) can run scheduled skill audits without CEO on the critical path, while `assertCanUpdateAgent` remains the single gate for everything else

## Summary

Introduces a narrow `agents:skills:sync` permission so a designated agent can call `POST /api/agents/:id/skills/sync` on other agents without being granted the full "modify any agent" surface (`agents:create` + `canCreateAgents`, which also gate `PATCH /agents/:id` and config-revision rollback).

**Current behavior:** only CEO, the agent itself, or an `agents:create` holder can sync another agent's skills. That forces every daily skill-sync audit through CEO or over-privileges the auditor.

**New behavior:** CEO can flip `canSyncOtherAgentSkills` on any agent via the existing `PATCH /agents/:id/permissions` endpoint. That agent can then call `/skills/sync` on any same-company agent. All other agent-mutation routes are unchanged.

## Motivation

Downstream background: Telos's `SkillManager` agent runs a daily audit that keeps every agent's installed skill set aligned with a declared keep-list. It hits 403 Forbidden today, forcing CEO to manually run the sync. Granting `agents:create` would unblock the audit but also hand the agent free write access to every other agent's config, role, and instructions — which defeats the point of having a scoped "skill bookkeeper" role.

## What Changed

- **`packages/shared/src/constants.ts`** — add `"agents:skills:sync"` to `PERMISSION_KEYS`. `updateMemberPermissionsSchema` (uses `z.enum(PERMISSION_KEYS)`) and `validPermissionKeys` (built from the same constant) pick it up automatically.
- **`packages/shared/src/validators/agent.ts`** — extend `updateAgentPermissionsSchema` with `canSyncOtherAgentSkills: z.boolean().optional().default(false)`. Additive; existing payloads `{canCreateAgents, canAssignTasks}` continue to work.
- **`server/src/routes/agents.ts`** — `POST /agents/:id/skills/sync`: branch on the narrow grant before `assertCanUpdateAgent`. If the actor is an agent in the same company holding `agents:skills:sync`, allow the call; otherwise fall through (preserving CEO / self / `agents:create` paths). Same-company guard is duplicated on the narrow path so cross-tenant access can never slip through.
- **`server/src/routes/agents.ts`** — `PATCH /agents/:id/permissions`: compute `effectiveCanSyncSkills` (implicitly coupled to `role === "ceo"` and `canCreateAgents`, mirroring how `canAssignTasks` is coupled today), mirror it into `principal_permission_grants` via `access.setPrincipalPermission(..., "agents:skills:sync", ...)`, and include `canSyncOtherAgentSkills` in the `agent.permissions_updated` activity-log entry.
- **`server/src/__tests__/agent-skills-sync-permission.test.ts`** — new regression suite (10 tests):
  - narrow grant → 200 on `/skills/sync`, 403 on `PATCH /agents/:id`, 403 on `config-revisions/rollback`
  - fall-through preserved for CEO and self-sync without the narrow grant
  - audit trail unchanged: `agent_revisions.source="skill-sync"` and `activity_log.action="agent.skills_synced"` continue to record the grant holder's `agentId`
  - `PATCH /agents/:id/permissions` mirror: sets grant true/false as directed, keeps it true when `canCreateAgents` is on (implicit coupling), and defaults to `false` when omitted from the payload
- **`skills/paperclip/references/company-skills.md`** — Permission Model updated to list `agents:skills:sync`, plus a new "Scoped delegation" subsection with the CEO-side grant recipe.

## What's out of scope

- No new REST endpoint. Grant flips go through the existing CEO-only `PATCH /agents/:id/permissions`.
- No new role. No new agent record column. The grant is stored exclusively in the existing `principal_permission_grants` table.
- No change to `assertCanUpdateAgent` — broader mutation paths keep their existing gate.

## Verification

```bash
pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-skills-sync-permission.test.ts
pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-skills-routes.test.ts src/__tests__/agent-permissions-routes.test.ts src/__tests__/agent-cross-tenant-authz-routes.test.ts src/__tests__/access-service.test.ts src/__tests__/access-validators.test.ts src/__tests__/authz-company-access.test.ts src/__tests__/invite-join-grants.test.ts
pnpm --filter @paperclipai/shared typecheck
pnpm --filter @paperclipai/server typecheck
```

All targeted suites pass locally (71 tests green), and typecheck is clean on both `@paperclipai/shared` and `@paperclipai/server`.

Smoke test (manual, against a local instance):
1. Create two agents A (target) and B (actor), both non-CEO.
2. As CEO: `PATCH /api/agents/<B>/permissions` with `{canCreateAgents: false, canAssignTasks: true, canSyncOtherAgentSkills: true}`.
3. As B: `POST /api/agents/<A>/skills/sync` → expect 200.
4. As B: `PATCH /api/agents/<A>` → expect 403.
5. `activity_log` now has a row with `action="agent.skills_synced"` and `actorAgentId=<B>` (not CEO).

## Risks

- **Low.** Additive change only; no schema migration and no route whose 200 response becomes a 403. The narrow grant runs *before* `assertCanUpdateAgent`, never in place of it, so every existing path (CEO, self, `agents:create` holder) still works identically. Cross-tenant risk is bounded by the duplicated same-company guard on the narrow path.
- One behavioral shift: `PATCH /agents/:id/permissions` now always writes a `agents:skills:sync` grant row (true or false). Callers sending the legacy `{canCreateAgents, canAssignTasks}` payload will get `canSyncOtherAgentSkills=false` written, which matches the prior implicit behavior (the grant simply did not exist).

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Provider: Anthropic Claude
- Model: `claude-opus-4-7` (Claude Opus 4.7) with 1M-token extended context
- Mode: tool-use / code execution; extended thinking via Paperclip agent harness
- Role: drafted spec + code + tests + docs; human (Telos CEO) reviewed the spec before work started ([TEL-32](https://github.com/paperclipai/paperclip/issues))

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — *N/A, server-only*
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
