### PR TITLE
fix(plugins): forward plugin DB UUID to tool dispatcher for worker lookup

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1826,7 +1826,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,16 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin's unique identifier (typically `pluginKey`)
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - The DB UUID of the plugin. Required for worker lookup
+   *   during tool dispatch; if omitted, `pluginId` is used and worker dispatch
+   *   will fail because workers are indexed by DB UUID, not pluginKey.
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +433,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, where each agent's plugin-contributed tools are executed inside a per-plugin worker process.
> - Agent tools can be contributed by first-party plugins (loaded at startup by `dispatcher.initialize()`) or by external plugins installed at runtime via `POST /api/plugins/install` (which goes through `plugin-loader.ts`).
> - Tool dispatch flows: `PluginToolDispatcher.registerPluginTools` → `registry.registerPlugin` → at execute time, `workerManager.isRunning(tool.pluginDbId)` looks up the workers `Map`, which is keyed by the plugin's DB UUID.
> - Externally-installed plugins (e.g. `paperclip-plugin-acp`) transitioned to `ready`, the worker spawned, 7 tools registered, and `bridge/data` / `bridge/action` endpoints worked — but every call to `/api/plugins/tools/execute` returned `502 "worker for plugin … is not running"`.
> - Root cause: `plugin-loader.ts` called `registerPluginTools(pluginKey, manifest)` without forwarding the DB UUID, so `registry.registerPlugin` defaulted `pluginDbId` to `pluginKey` (a string). `workerManager.isRunning` was then handed a key that does not exist in the workers `Map` and always returned `false`.
> - First-party plugins were unaffected because `dispatcher.initialize()` registered them with `plugin.id` directly — but `plugin-loader` then re-registered them with the buggy call and overwrote the correct entry, masking the bug only because startup ordering happens to leave first-party plugins re-keyed identically to themselves in some cases.
> - This pull request threads an optional `pluginDbId` argument through the full register chain so the registry stores the same UUID the worker manager uses for lookup.
> - The benefit is that runtime-installed agent-tool plugins can finally execute their tools end-to-end, unblocking the ACP plugin and any future external plugin that ships agent tools.

## What Changed

- Added an optional `pluginDbId` parameter to `PluginToolDispatcher.registerPluginTools` (interface + implementation) in `server/src/services/plugin-tool-dispatcher.ts`.
- Forwarded `pluginDbId` to `registry.registerPlugin` inside the dispatcher implementation.
- Passed `pluginId` (the plugin row's DB UUID) as the third argument at the single call site in `server/src/services/plugin-loader.ts`.

## Verification

Repro before the fix:

```bash
curl -X POST /api/plugins/install -d '{"packageName":"paperclip-plugin-acp"}'
# → plugin reaches `ready`, worker spawns, 7 tools registered

curl -X POST /api/plugins/tools/execute \
  -d '{"tool":"paperclip-plugin-acp:acp_status","parameters":{},"runContext":{...}}'
# → {"error":"Cannot execute tool \"paperclip-plugin-acp:acp_status\" — worker for plugin \"paperclip-plugin-acp\" is not running."}
```

After the fix, the same call returns:

```json
{"result":{"data":{"activeSessions":0,"sessions":[]}}}
```

Manual checks:

- [x] Install an external agent-tool plugin (`paperclip-plugin-acp`) via `/api/plugins/install`.
- [x] `/api/plugins/tools/execute` routes the call to the worker and returns the tool result.
- [x] First-party plugins (loaded at startup via `dispatcher.initialize()`) continue to work.
- [x] `bridge/data` and `bridge/action` endpoints are unchanged.
- [x] End-to-end ACP flow validated: `acp_spawn` → active session → `acp_status` → `acp_close`.

## Risks

- **Low risk.** The new parameter is optional, so existing callers that omit it keep their previous behavior. The change is a two-line forwarding of an argument through one register chain — no logic added, no schema change, no migration. The only behavioral difference is that `registry.registerPlugin` now receives the correct `pluginDbId` for runtime-installed plugins, which is exactly the fix.

> Verified against Paperclip v2026.416.0 in authenticated mode and `paperclip-plugin-acp@0.3.0` (Claude Code CLI spawn, oneshot mode).

## Model Used

- **Claude Opus 4.7** (model ID: `claude-opus-4-7`), 1M context window, used via Claude Code CLI for code search, root-cause analysis, and the final patch. No extended thinking mode; standard tool use (Read / Grep / Edit / Bash).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable <!-- N/A: no existing test covers the runtime-install + dispatch path; happy to add one if maintainers prefer -->
- [x] If this change affects the UI, I have included before/after screenshots <!-- N/A: server-only change -->
- [x] I have updated relevant documentation to reflect my changes <!-- N/A: internal forwarding, no public-facing doc -->
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
