### PR TITLE
feat(plugin-events): enrich agent.run.* payload with issue context + result

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2590,30 +2590,82 @@ export function heartbeatService(db: Db) {
               ? "agent.run.cancelled"
               : null;
     if (!eventType) return;
-    publishPluginDomainEvent({
-      eventId: randomUUID(),
-      eventType,
-      occurredAt: new Date().toISOString(),
-      actorId: run.agentId,
-      actorType: "agent",
-      entityId: run.id,
-      entityType: "heartbeat_run",
-      companyId: run.companyId,
-      payload: {
-        runId: run.id,
-        agentId: run.agentId,
-        status: run.status,
-        invocationSource: run.invocationSource,
-        triggerDetail: run.triggerDetail,
-        error: run.error ?? null,
-        errorCode: run.errorCode ?? null,
-        issueId: typeof run.contextSnapshot === "object" && run.contextSnapshot !== null
-          ? (run.contextSnapshot as Record<string, unknown>).issueId ?? null
-          : null,
-        startedAt: run.startedAt ? new Date(run.startedAt).toISOString() : null,
-        finishedAt: run.finishedAt ? new Date(run.finishedAt).toISOString() : null,
-      },
-    });
+    // Enrich payload with issueTitle / issueDescription / result so plugins
+    // (e.g. hindsight-paperclip) that expect these canonical fields can build
+    // queries on `agent.run.started` and store content on `agent.run.finished`
+    // without making a follow-up HTTP call. Looked up asynchronously so the
+    // main state transition path is not slowed down — the emit is fire-and-
+    // forget by design.
+    const ctxSnapshot =
+      typeof run.contextSnapshot === "object" && run.contextSnapshot !== null
+        ? (run.contextSnapshot as Record<string, unknown>)
+        : {};
+    const issueIdRaw = ctxSnapshot.issueId;
+    const issueId = typeof issueIdRaw === "string" && issueIdRaw.length > 0 ? issueIdRaw : null;
+    const resultJson = (run as unknown as { resultJson?: unknown }).resultJson;
+    const resultObj =
+      typeof resultJson === "object" && resultJson !== null
+        ? (resultJson as Record<string, unknown>)
+        : {};
+    const maybeString = (v: unknown): string | undefined =>
+      typeof v === "string" && v.length > 0 ? v : undefined;
+    const directResult =
+      maybeString(resultObj.output) ??
+      maybeString(resultObj.result) ??
+      maybeString(resultObj.summary) ??
+      (typeof resultJson === "string" && resultJson.length > 0
+        ? (resultJson as string)
+        : undefined);
+
+    void (async () => {
+      let issueTitle: string | null = null;
+      let issueDescription: string | null = null;
+      if (issueId) {
+        try {
+          const row = await db
+            .select({
+              title: issues.title,
+              description: issues.description,
+            })
+            .from(issues)
+            .where(eq(issues.id, issueId))
+            .limit(1)
+            .then((rows) => rows[0] ?? null);
+          if (row) {
+            issueTitle = row.title ?? null;
+            issueDescription = row.description ?? null;
+          }
+        } catch {
+          // Non-fatal — emit the event even if the enrichment lookup fails.
+        }
+      }
+      publishPluginDomainEvent({
+        eventId: randomUUID(),
+        eventType,
+        occurredAt: new Date().toISOString(),
+        actorId: run.agentId,
+        actorType: "agent",
+        entityId: run.id,
+        entityType: "heartbeat_run",
+        companyId: run.companyId,
+        payload: {
+          runId: run.id,
+          agentId: run.agentId,
+          status: run.status,
+          invocationSource: run.invocationSource,
+          triggerDetail: run.triggerDetail,
+          error: run.error ?? null,
+          errorCode: run.errorCode ?? null,
+          issueId,
+          issueTitle,
+          issueDescription,
+          result: directResult ?? null,
+          output: directResult ?? null,
+          startedAt: run.startedAt ? new Date(run.startedAt).toISOString() : null,
+          finishedAt: run.finishedAt ? new Date(run.finishedAt).toISOString() : null,
+        },
+      });
+    })().catch(() => {});
   }
 
   async function setWakeupStatus(


### PR DESCRIPTION
### Problem

`publishRunLifecyclePluginEvent` emits only run lifecycle metadata (`status`, `startedAt`, `finishedAt`, `issueId`, `error`…). Plugin consumers that want to react to the actual run content have to make a follow-up HTTP call to fetch the issue (`issueTitle` / `issueDescription`) and the produced output (`resultJson`), which:

- defeats much of the value of a first-class event bus,
- silently breaks every plugin that reads those canonical fields from the payload.

Typical example: [`@vectorize-io/hindsight-paperclip`](https://www.npmjs.com/package/@vectorize-io/hindsight-paperclip) subscribes to both `agent.run.started` and `agent.run.finished` and reads `issueTitle`, `issueDescription`, `output`, `result` from the payload to build a recall query and retain the run output:

```ts
// node_modules/@vectorize-io/hindsight-paperclip/dist/worker.js
ctx.events.on("agent.run.started", async (event) => {
  const { agentId, runId, issueTitle, issueDescription } = event.payload;
  const query = [issueTitle, issueDescription].filter(Boolean).join("\n");
  if (!query.trim()) return;          // ← bail: fields never present
  ...
});

ctx.events.on("agent.run.finished", async (event) => {
  const { output, result } = event.payload;
  const content = output ?? result;
  if (!content?.trim()) return;       // ← bail: fields never present
  ...
});
```

With the current envelope none of those fields exist, so both handlers return immediately and the auto-retain + auto-recall advertised in the plugin's README are effectively dead code — even though every other layer (bus subscription, host→worker IPC, handleOnEvent dispatch) works correctly.

### Fix

Populate the payload with four additional fields:

| Field | Source | Notes |
|---|---|---|
| `issueTitle` | `issues.title` via `db.select(...).where(eq(issues.id, issueId))` | `null` when no `issueId` on the run |
| `issueDescription` | `issues.description` | same fallback |
| `result` | `run.resultJson.output ?? run.resultJson.result ?? run.resultJson.summary ?? stringified resultJson` | `null` until the run terminates |
| `output` | same as `result` (mirrored for plugins that read either key) | |

The lookup is performed inside a `void (async () => {...})().catch(() => {})` so:

- the main state-transition path in `setRunStatus` / `claim*` is never slowed down by the DB round-trip,
- a missing row, a dropped connection or a malformed `resultJson` can never break the run that triggered the event.

### Backward compatibility

100% additive. No existing field is renamed or removed. Plugins that only read the pre-existing keys (`runId`, `agentId`, `status`, `startedAt`, …) are unaffected.

### Test plan

- [ ] Install `@vectorize-io/hindsight-paperclip` (or any plugin reading `issueTitle`/`output` from an `agent.run.*` payload).
- [ ] Run a heartbeat that processes an issue.
- [ ] Verify the plugin now reacts on both `run.started` (should query Hindsight with the issue title/description) and `run.finished` (should retain the run output).
- [ ] Verify runs that have no `issueId` still emit the event, with `issueTitle` / `issueDescription` = `null`.
- [ ] Verify `run.resultJson` is a string, not a structured object: the fallback stringification path is exercised.

### Verified against

- Paperclip `2026.416.x` (this branch).
- `@vectorize-io/hindsight-paperclip@0.2.1`.
- Self-hosted Hindsight `ghcr.io/vectorize-io/hindsight:latest` with Anthropic `claude-haiku-4-5`.
- End-to-end: a heartbeat that previously produced zero Hindsight activity now yields `CONSOLIDATION ... created=3` for the agent's bank.
