### PR TITLE
ANGA-640: Remove jq/python deps from heartbeat workflows

### DIFF
--- a/doc/OPENCLAW_ONBOARDING.md
+++ b/doc/OPENCLAW_ONBOARDING.md
@@ -7,7 +7,7 @@ pnpm dev --bind lan
 ```
 Then verify:
 ```bash
-curl -sS http://127.0.0.1:3100/api/health | jq
+curl -sS http://127.0.0.1:3100/api/health | node -e "console.log(JSON.stringify(JSON.parse(require('fs').readFileSync(0,'utf-8')),null,2))"
 ```
 
 2. Start a clean/stock OpenClaw Docker.
@@ -43,7 +43,20 @@ Security/control note:
 - If you can run API checks with board auth:
 ```bash
 AGENT_ID="<newly-created-agent-id>"
-curl -sS -H "Cookie: $PAPERCLIP_COOKIE" "http://127.0.0.1:3100/api/agents/$AGENT_ID" | jq '{adapterType,adapterConfig:{url:.adapterConfig.url,tokenLen:(.adapterConfig.headers["x-openclaw-token"] // .adapterConfig.headers["x-openclaw-auth"] // "" | length),disableDeviceAuth:(.adapterConfig.disableDeviceAuth // false),hasDeviceKey:(.adapterConfig.devicePrivateKeyPem // "" | length > 0)}}'
+curl -sS -H "Cookie: $PAPERCLIP_COOKIE" "http://127.0.0.1:3100/api/agents/$AGENT_ID" | node -e "
+const data = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const token = data.adapterConfig?.headers?.['x-openclaw-token'] || data.adapterConfig?.headers?.['x-openclaw-auth'] || '';
+const deviceKey = data.adapterConfig?.devicePrivateKeyPem || '';
+console.log(JSON.stringify({
+  adapterType: data.adapterType,
+  adapterConfig: {
+    url: data.adapterConfig?.url,
+    tokenLen: token.length,
+    disableDeviceAuth: data.adapterConfig?.disableDeviceAuth || false,
+    hasDeviceKey: deviceKey.length > 0
+  }
+}, null, 2));
+"
 ```
 - Expected: `adapterType=openclaw_gateway`, `tokenLen >= 16`, `hasDeviceKey=true`, and `disableDeviceAuth=false`.
 

--- a/scripts/paperclip-issue-update.sh
+++ b/scripts/paperclip-issue-update.sh
@@ -80,16 +80,17 @@ elif [[ ! -t 0 ]]; then
   comment="$(cat)"
 fi
 
-require_command jq
+require_command node
 
 payload="$(
-  jq -nc \
-    --arg status "$status" \
-    --arg comment "$comment" \
-    '
-      (if $status == "" then {} else {status: $status} end) +
-      (if $comment == "" then {} else {comment: $comment} end)
-    '
+  node -e "
+    const status = process.argv[1];
+    const comment = process.argv[2];
+    const payload = {};
+    if (status) payload.status = status;
+    if (comment) payload.comment = comment;
+    console.log(JSON.stringify(payload));
+  " "$status" "$comment"
 )"
 
 if [[ "$dry_run" == "1" ]]; then

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -103,7 +103,7 @@ Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 { "status": "done", "comment": "What was done and why." }
 ```
 
-For multiline markdown comments, do **not** hand-inline the markdown into a one-line JSON string — that is how comments get "smooshed" together. Use the helper below (or an equivalent `jq --arg` pattern reading from a heredoc/file) so literal newlines survive JSON encoding:
+For multiline markdown comments, do **not** hand-inline the markdown into a one-line JSON string. That is how comments get "smooshed" together. Use the helper below or an equivalent Node.js pattern so literal newlines survive JSON encoding:
 
 ```bash
 scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done <<'MD'
@@ -259,7 +259,19 @@ Never leave bare ticket ids in issue descriptions or comments when a clickable i
 
 Do NOT use unprefixed paths like `/issues/PAP-123` or `/agents/cto` — always include the company prefix.
 
-**Preserve markdown line breaks (required):** build multiline JSON bodies from heredoc/file input (via the helper in Step 8 or `jq -n --arg comment "$comment"`). Never manually compress markdown into a one-line JSON `comment` string unless you intentionally want a single paragraph.
+**Preserve markdown line breaks (required):** When posting comments through shell commands, build the JSON payload from multiline stdin or another multiline source. Do not flatten a list or multi-paragraph update into a single quoted JSON line. Preferred helper:
+
+```bash
+scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status in_progress <<'MD'
+Investigating comment formatting
+
+- Pulled the raw stored comment body
+- Compared it with the run's final assistant message
+- Traced whether the flattening happened before or after the API call
+MD
+```
+
+If you cannot use the helper, use Node.js to build JSON with proper escaping. Example: `node -e "console.log(JSON.stringify({comment: process.argv[1]}))" "$comment"` with `comment` read from a heredoc or file. Never manually compress markdown into a one-line JSON `comment` string unless you intentionally want a single paragraph.
 
 Example:
 


### PR DESCRIPTION
## Summary
Eliminates jq and python dependencies from Paperclip heartbeat coordination paths, enabling workflows to run reliably on baseline runtime (curl + node/POSIX tools only).

## Changes
- **scripts/paperclip-issue-update.sh**: Replaced `jq -nc --arg` with `node -e` for JSON building
- **skills/paperclip/SKILL.md**: Updated documentation to show Node.js patterns instead of jq
- **doc/OPENCLAW_ONBOARDING.md**: Replaced jq with node for API health checks and verification

## Before/After Example

**Before** (requires jq):
```bash
jq -nc --arg status "done" --arg comment "Task complete" \
  '(if $status == "" then {} else {status: $status} end) +
   (if $comment == "" then {} else {comment: $comment} end)'
```

**After** (uses node):
```bash
node -e "
  const status = process.argv[1];
  const comment = process.argv[2];
  const payload = {};
  if (status) payload.status = status;
  if (comment) payload.comment = comment;
  console.log(JSON.stringify(payload));
" "done" "Task complete"
```

## Test Plan
- [x] Verified `scripts/paperclip-issue-update.sh` works with `--dry-run` flag
- [x] Tested multiline comment preservation with node-based JSON encoding
- [x] All modified examples use only baseline tools (curl + node)

## Context
During CTO heartbeat run 346394a7, jq and python were unavailable in runtime, causing avoidable retries before switching to node-based parsing. This PR systematically removes those dependencies from the critical heartbeat path.

Fixes ANGA-640

🤖 Generated with [Claude Code](https://claude.com/claude-code)