### PR TITLE
Fix stranded reaper false-positive for delegated parents with active children

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -195,6 +195,7 @@ Recovery rule:
 
 - if the latest issue-linked run failed/timed out/cancelled and no live execution path remains, Paperclip queues one automatic assignment recovery wake
 - if that recovery wake also finishes and the issue is still stranded, Paperclip moves the issue to `blocked` and posts a visible comment
+- delegated parent exception: if the parent issue has at least one child in a non-terminal state (`todo`, `in_progress`, `in_review`, `blocked`), Paperclip does not apply stranded escalation to the parent yet
 
 This is a dispatch recovery, not a continuation recovery.
 
@@ -211,6 +212,7 @@ Recovery rule:
 
 - Paperclip queues one automatic continuation wake
 - if that continuation wake also finishes and the issue is still stranded, Paperclip moves the issue to `blocked` and posts a visible comment
+- delegated parent exception: if the parent issue has at least one child in a non-terminal state (`todo`, `in_progress`, `in_review`, `blocked`), Paperclip does not apply stranded escalation to the parent yet
 
 This is an active-work continuity recovery.
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -908,7 +908,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Latest retry failure: `process_lost` - run failed before issue advanced.");
   });
 
-  it("skips stranded escalation for delegated parent work when a child issue is still active", async () => {
+  it("skips stranded escalation for delegated parent work when a child issue is blocked", async () => {
     const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
       status: "todo",
       runStatus: "failed",
@@ -918,8 +918,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.insert(issues).values({
       id: randomUUID(),
       companyId,
-      title: "Active delegated child",
-      status: "in_progress",
+      title: "Blocked delegated child",
+      status: "blocked",
       priority: "medium",
       parentId: issueId,
       issueNumber: 2,

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -908,6 +908,70 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Latest retry failure: `process_lost` - run failed before issue advanced.");
   });
 
+  it("skips stranded escalation for delegated parent work when a child issue is still active", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+    });
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(issues).values({
+      id: randomUUID(),
+      companyId,
+      title: "Active delegated child",
+      status: "in_progress",
+      priority: "medium",
+      parentId: issueId,
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+  });
+
+  it("keeps stranded escalation enabled when delegated children are terminal", async () => {
+    const { companyId, issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+    });
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(issues).values({
+      id: randomUUID(),
+      companyId,
+      title: "Completed delegated child",
+      status: "done",
+      priority: "medium",
+      parentId: issueId,
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+  });
+
   it("assigns open unassigned blockers back to their creator agent", async () => {
     const companyId = randomUUID();
     const creatorAgentId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4293,6 +4293,9 @@ export function heartbeatService(db: Db) {
         and(
           eq(issues.companyId, companyId),
           eq(issues.parentId, issueId),
+          // Keep parent stranded recovery suppressed while any delegated child
+          // is still non-terminal, including blocked child work that still
+          // requires explicit intervention before the parent can complete.
           inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
         ),
       )

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4285,6 +4285,22 @@ export function heartbeatService(db: Db) {
     return updated;
   }
 
+  async function hasActiveNonTerminalChildIssue(companyId: string, issueId: string) {
+    const child = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.parentId, issueId),
+          inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    return child !== null;
+  }
+
   async function reconcileStrandedAssignedIssues() {
     const candidates = await db
       .select()
@@ -4319,6 +4335,11 @@ export function heartbeatService(db: Db) {
         continue;
       }
       if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await hasActiveNonTerminalChildIssue(issue.companyId, issue.id)) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and keeps issue execution state honest through heartbeat-run recovery loops.
> - The stranded-assigned-work reconciler in `server/src/services/heartbeat.ts` is responsible for recovering or escalating agent-owned `todo`/`in_progress` issues that lose live execution.
> - Parent issues that delegate work to child issues can legitimately have no direct live execution while children are still active.
> - The existing reconciler treated those delegated parents as stranded and could escalate them to `blocked` with a no-live-execution message.
> - This pull request adds an explicit child-activity guard so delegated parents are not falsely escalated while any child is still non-terminal.
> - The benefit is fewer false-positive escalations and a clearer execution contract for delegated issue trees.

## What Changed

- Added `hasActiveNonTerminalChildIssue(...)` in `server/src/services/heartbeat.ts` and used it in `reconcileStrandedAssignedIssues()` to skip parent stranded-recovery handling when at least one child is in `todo`, `in_progress`, `in_review`, or `blocked`.
- Added an inline code comment clarifying why `blocked` children intentionally keep parent suppression active until explicit intervention.
- Added regression coverage in `server/src/__tests__/heartbeat-process-recovery.test.ts`:
  - delegated parent + blocked child => no requeue/escalation for the parent.
  - delegated parent + terminal child => existing escalation behavior still applies.
- Updated `doc/execution-semantics.md` in both stranded `todo` and stranded `in_progress` sections to document the delegated-parent exception.

## Verification

- `pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`
- Confirmed all tests in that file pass (20/20), including the new delegated-parent regression cases.

## Risks

- Low risk: change is scoped to stranded-assigned reconciliation and only adds a skip condition for parent issues with active children.
- Behavioral risk: parent issues with blocked children will not auto-escalate via this loop; this is intentional and now explicitly documented in code and docs.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 (Codex coding agent runtime, tool-enabled CLI execution and patching workflow).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
