### PR TITLE
fix(server): forward pluginDbId through the plugin tool dispatcher

### DIFF
--- a/server/src/__tests__/plugin-tool-dispatcher.test.ts
+++ b/server/src/__tests__/plugin-tool-dispatcher.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { createPluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const PLUGIN_KEY = "acme.linear";
+const PLUGIN_DB_ID = "00000000-0000-0000-0000-0000000000aa";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_KEY,
+  apiVersion: 1,
+  version: "1.0.0",
+  displayName: "Acme Linear",
+  description: "Test manifest for plugin-tool-dispatcher regression tests.",
+  author: "Paperclip Tests",
+  categories: ["connector"],
+  capabilities: ["agent.tools.register"],
+  entrypoints: {
+    worker: "worker.js",
+  },
+  tools: [
+    {
+      name: "search-issues",
+      displayName: "Search issues",
+      description: "Search Linear issues.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+      },
+    },
+  ],
+};
+
+function makeWorkerManagerStub(runningDbIds: ReadonlySet<string>): PluginWorkerManager {
+  const call = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+  const isRunning = vi.fn((pluginId: string) => runningDbIds.has(pluginId));
+
+  return {
+    startWorker: vi.fn(),
+    stopWorker: vi.fn(),
+    getWorker: vi.fn(),
+    isRunning,
+    stopAll: vi.fn(),
+    diagnostics: vi.fn().mockReturnValue([]),
+    call,
+  } as unknown as PluginWorkerManager;
+}
+
+// ---------------------------------------------------------------------------
+// Regression: registerPluginTools must forward pluginDbId
+// ---------------------------------------------------------------------------
+
+describe("plugin-tool-dispatcher — pluginDbId routing", () => {
+  it("routes executeTool to the DB UUID when registerPluginTools was called with pluginDbId", async () => {
+    // Worker is "running" under the DB UUID only.
+    const workerManager = makeWorkerManagerStub(new Set([PLUGIN_DB_ID]));
+
+    const dispatcher = createPluginToolDispatcher({ workerManager });
+    dispatcher.registerPluginTools(PLUGIN_KEY, manifest, PLUGIN_DB_ID);
+
+    const result = await dispatcher.executeTool(
+      `${PLUGIN_KEY}:search-issues`,
+      { query: "auth bug" },
+      { agentId: "a1", runId: "r1", companyId: "c1", projectId: "p1" },
+    );
+
+    expect(result.pluginId).toBe(PLUGIN_KEY);
+    expect(workerManager.isRunning).toHaveBeenCalledWith(PLUGIN_DB_ID);
+    expect(workerManager.isRunning).not.toHaveBeenCalledWith(PLUGIN_KEY);
+    expect(workerManager.call).toHaveBeenCalledWith(
+      PLUGIN_DB_ID,
+      "executeTool",
+      expect.objectContaining({ toolName: "search-issues" }),
+    );
+  });
+
+  it("fails with 'worker is not running' when pluginDbId is omitted and worker is keyed by DB UUID", async () => {
+    // Regression guard: the old bug was that plugin-loader forgot to pass
+    // the DB UUID, so the registry fell back to pluginId (= manifest key)
+    // and isRunning(...) always missed.
+    const workerManager = makeWorkerManagerStub(new Set([PLUGIN_DB_ID]));
+
+    const dispatcher = createPluginToolDispatcher({ workerManager });
+    // Intentionally omit the 3rd arg — reproduces the bug shape.
+    dispatcher.registerPluginTools(PLUGIN_KEY, manifest);
+
+    await expect(
+      dispatcher.executeTool(
+        `${PLUGIN_KEY}:search-issues`,
+        { query: "auth bug" },
+        { agentId: "a1", runId: "r1", companyId: "c1", projectId: "p1" },
+      ),
+    ).rejects.toThrow(/worker for plugin .* is not running/);
+
+    expect(workerManager.isRunning).toHaveBeenCalledWith(PLUGIN_KEY);
+    expect(workerManager.call).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1826,7 +1826,10 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        // Pass `pluginId` (the DB UUID) as the 3rd arg so the registry can
+        // route tool execution to the correct worker. The worker manager keys
+        // running workers by DB UUID, not by the namespaced manifest id.
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,20 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin's namespaced identifier (manifest `id`, used
+   *   for tool namespacing)
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - The plugin's database UUID, used by the registry to
+   *   route tool execution to the correct worker via the PluginWorkerManager.
+   *   When omitted, the registry falls back to `pluginId`, which will cause
+   *   `workerManager.isRunning(...)` lookups to miss (workers are keyed by DB
+   *   UUID), so callers in the normal plugin lifecycle should always pass
+   *   this.
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +437,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Plugins extend the host by registering agent-callable tools; the runtime surface for agents is `POST /api/plugins/tools/execute`, routed by the `PluginToolDispatcher` to a per-plugin worker managed by the `PluginWorkerManager`
> - A plugin's worker is keyed in the worker manager by its **database UUID**, not by its namespaced manifest id — `workerManager.startWorker(plugin.id, ...)` at `plugin-loader.ts` and `workerManager.isRunning(dbId)` at `plugin-tool-registry.ts` both use the UUID
> - But the call chain `plugin-loader.ts` → `PluginToolDispatcher.registerPluginTools` → `PluginToolRegistry.registerPlugin` silently dropped the DB UUID at the dispatcher layer, so every registered tool ended up with `tool.pluginDbId` equal to the manifest key (e.g. `"acme.linear"`); `workerManager.isRunning("acme.linear")` returns `false` because the worker is registered under its UUID, and execution throws `worker for plugin "…" is not running.`
> - Symptom in the wild: every `POST /api/plugins/tools/execute` returns 502 with that exact message even when the worker is visibly alive and `worker status change starting → running` appears in the log for that DB UUID
> - This PR restores the routing invariant by forwarding `pluginDbId` through the dispatcher and passing it from the loader
> - The benefit is `/api/plugins/tools/execute` becomes functional again, unblocking every plugin that registers tools

## What Changed

- `server/src/services/plugin-tool-dispatcher.ts`: widen both the `PluginToolDispatcher.registerPluginTools` interface and the factory implementation to accept an optional `pluginDbId?: string` and forward it to `registry.registerPlugin`. Added a doc comment explaining why the worker-manager lookup misses when it is omitted.
- `server/src/services/plugin-loader.ts`: at the single call site in `activatePlugin` (the `agent.tools.register` branch), pass the plugin's DB UUID (`pluginId` in that scope — bound from `plugin.id` a few lines up) as the third argument to `toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId)`.
- `server/src/__tests__/plugin-tool-dispatcher.test.ts` (new): vitest regression with two cases:
  1. `registerPluginTools(pluginKey, manifest, pluginDbId)` — asserts `workerManager.isRunning` and `.call` are both invoked with the DB UUID, never the namespaced manifest key.
  2. Omitting the third arg — asserts `executeTool` throws the exact `worker for plugin "…" is not running` shape, i.e. reproduces the bug that motivated this PR.

No other call sites touch `registerPluginTools`; `unregisterPluginTools` already took `pluginId` (the namespaced key, which matches the registry's primary index) so it is unchanged.

## Verification

Upstream CI: `pnpm --filter @paperclipai/server test run` will exercise the new `plugin-tool-dispatcher.test.ts` on this PR.

Manually reproduced on a live instance (`@paperclipai/server@2026.416.0` on Windows / Node 22):

1. Install any plugin that declares `capabilities: ["agent.tools.register"]` and at least one `tools[]` entry (I used `quell.farcaster` v0.2.0).
2. `POST /api/plugins/tools/execute` with `{ tool: "quell.farcaster:search_casts", parameters: { query: "quell", limit: 1 }, runContext: { … } }` as a board user.

Before (`dist/services/plugin-loader.js:1085` missing the DB UUID):

```
502 — worker for plugin "quell.farcaster" is not running.
```

After manually hotfixing the two dist files to match this PR's source changes and restarting the service, the same request completes successfully; the server log shows `dispatching tool execution` followed by `tool execution completed` instead of the synchronous throw.

## Risks

Low. The change is additive on the public dispatcher API (optional third argument, no caller must supply it) and the loader change is the one call site that already knows the DB UUID from its own scope. Non-test behavioural difference: previously-broken `executeTool` paths now actually reach the worker instead of throwing; there is no code path where forwarding the DB UUID degrades an existing correct flow, since the registry already accepts `pluginDbId?: string` and falls back to `pluginId` when absent.

Backwards compatibility: existing callers that pass only two arguments still compile and behave as today (they would hit the pre-existing `dbId = pluginDbId ?? pluginId` fallback in `plugin-tool-registry.ts`, which was already the pre-fix behaviour and still produces the same "worker not running" failure mode — this PR fixes the one in-tree call site that was supposed to pass the UUID).

## Model Used

- Claude Opus 4.7 (claude-opus-4-7) with 1M-context mode, extended reasoning enabled, tool use + code execution via Claude Code harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have listed concrete changes
- [x] I have described how reviewers can verify this works
- [x] I have called out risks
- [x] I have disclosed the AI model used

---

Filed as the upstream follow-up to an internal ticket (QUE-42). Attaches cleanly on top of current `master` (e4995bb).
