### PR TITLE
feat(harness): monitoring-label exemption from status auto-transitions

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -86,7 +86,7 @@ import {
   type RealizedExecutionWorkspace,
   sanitizeRuntimeServiceBaseEnv,
 } from "./workspace-runtime.js";
-import { issueService } from "./issues.js";
+import { issueHasLabel, issueService, MONITORING_LABEL_NAME } from "./issues.js";
 import {
   ISSUE_TREE_CONTROL_INTERACTION_WAKE_REASONS,
   issueTreeControlService,
@@ -4328,6 +4328,15 @@ export function heartbeatService(db: Db) {
         continue;
       }
 
+      // Monitoring-label exemption: parent/monitor tickets (feature epics,
+      // phase parents, standing inboxes, governance umbrellas, cleanup plan
+      // parents) are intentionally owned-active without a live executor. Skip
+      // stranded-issue reconciliation entirely for them. See upstream issue #4395.
+      if (await issueHasLabel(db, issue.id, MONITORING_LABEL_NAME)) {
+        result.skipped += 1;
+        continue;
+      }
+
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
       if (issue.status === "todo") {
         if (!latestRun || latestRun.status === "succeeded") {
@@ -4648,6 +4657,13 @@ export function heartbeatService(db: Db) {
       .where(eq(issues.id, input.finding.issueId))
       .then((rows) => rows[0] ?? null);
     if (!issue || issue.companyId !== input.finding.companyId) return { kind: "skipped" as const };
+
+    // Monitoring-label exemption: do not open liveness escalations against
+    // parent/monitor tickets that are owned-active without an executor. See
+    // upstream issue #4395.
+    if (await issueHasLabel(db, issue.id, MONITORING_LABEL_NAME)) {
+      return { kind: "skipped" as const };
+    }
 
     const existing = await findOpenLivenessEscalation(issue.companyId, input.finding.incidentKey);
     if (existing) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -49,6 +49,16 @@ export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
 const ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE = 500;
 export const MAX_CHILD_ISSUES_CREATED_BY_HELPER = 25;
+
+/**
+ * Label name that exempts an issue from harness-driven status auto-transitions
+ * (both `in_progress → blocked` on executor loss and `blocked → in_progress`
+ * on checkout). Applied to parent/monitor tickets that are owned-active
+ * without an attached executor — feature epics, phase parents, standing
+ * inboxes, governance umbrellas, cleanup plan parents. See upstream issue
+ * #4395.
+ */
+export const MONITORING_LABEL_NAME = "monitoring";
 const MAX_CHILD_COMPLETION_SUMMARIES = 20;
 const CHILD_COMPLETION_SUMMARY_BODY_MAX_CHARS = 500;
 function assertTransition(from: string, to: string) {
@@ -651,6 +661,20 @@ async function labelMapForIssues(dbOrTx: any, issueIds: string[]): Promise<Map<s
     }
   }
   return map;
+}
+
+export async function issueHasLabel(
+  dbOrTx: any,
+  issueId: string,
+  labelName: string,
+): Promise<boolean> {
+  const rows = await dbOrTx
+    .select({ issueId: issueLabels.issueId })
+    .from(issueLabels)
+    .innerJoin(labels, eq(issueLabels.labelId, labels.id))
+    .where(and(eq(issueLabels.issueId, issueId), eq(labels.name, labelName)))
+    .limit(1);
+  return rows.length > 0;
 }
 
 async function withIssueLabels(dbOrTx: any, rows: IssueRow[]): Promise<IssueWithLabels[]> {
@@ -2297,6 +2321,19 @@ export function issueService(db: Db) {
       const executionLockCondition = checkoutRunId
         ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId))
         : isNull(issues.executionRunId);
+
+      // Monitoring-label exemption: if the issue is currently `blocked` and
+      // carries the `monitoring` label, preserve the blocked status rather than
+      // auto-flipping to `in_progress` on checkout. See upstream issue #4395.
+      const preCheckoutStatus = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(eq(issues.id, id))
+        .then((rows) => rows[0]?.status ?? null);
+      const preserveBlockedForMonitoring =
+        preCheckoutStatus === "blocked" &&
+        (await issueHasLabel(db, id, MONITORING_LABEL_NAME));
+
       const updated = await db
         .update(issues)
         .set({
@@ -2304,8 +2341,7 @@ export function issueService(db: Db) {
           assigneeUserId: null,
           checkoutRunId,
           executionRunId: checkoutRunId,
-          status: "in_progress",
-          startedAt: now,
+          ...(preserveBlockedForMonitoring ? {} : { status: "in_progress" as const, startedAt: now }),
           updatedAt: now,
         })
         .where(


### PR DESCRIPTION
Draft PR for design feedback. Refs #4395.

## Summary

Introduces a `monitoring` label that exempts parent/monitor tickets from the two harness-driven status auto-transitions that currently thrash on them:

1. **`in_progress → blocked`** — on stranded-issue reconciliation (`heartbeatService::reconcileStrandedAssignedIssues`) and liveness escalation (`heartbeatService::createIssueGraphLivenessEscalation`), when no executor is attached.
2. **`blocked → in_progress`** — on checkout (`issueService::checkout`). Status is preserved rather than force-flipped to `in_progress`; execution lock fields (`checkoutRunId`, `executionRunId`) still update so the run proceeds normally.

Full rationale in #4395 (including alternatives considered and why the explicit-label design wins over heuristics and a new status type).

## Change surface

Two files, ~55 LOC, no schema changes (uses the existing `labels` / `issue_labels` tables).

- `server/src/services/issues.ts`
  - Exported constant: `MONITORING_LABEL_NAME = \"monitoring\"`
  - Exported helper: `issueHasLabel(dbOrTx, issueId, labelName): Promise<boolean>` (single-row lookup via `issueLabels ⋈ labels`)
  - `checkout()` now pre-fetches current status; when it is `blocked` and the issue carries the monitoring label, the status/`startedAt` fields are omitted from the update so the pre-existing `blocked` state is preserved.
- `server/src/services/heartbeat.ts`
  - `reconcileStrandedAssignedIssues`: early-skip for monitoring-labeled issues (placed after the existing `hasActiveExecutionPath` guard so the cost profile is comparable to the other guards).
  - `createIssueGraphLivenessEscalation`: early-return for monitoring-labeled issues (does not open a liveness escalation incident, which would otherwise cascade into `ensureIssueBlockedByEscalation`).

## Backwards compatibility

- Leaf tickets without the label see **zero behavioural change** — the guards short-circuit only when the label is present.
- The label is opt-in; no retroactive labelling is implied by this PR.
- The `blocked → in_progress` checkout guard only preserves status when the pre-state is `blocked`. Checkouts from `todo`/`in_progress` are unaffected.

## Tests

**Gap — tests not included in this draft.** I'd like maintainer guidance on the preferred location / setup before writing them, since I'm not a regular contributor here and want the harness on the right side of your conventions. Candidate test cases:

1. Issue with `monitoring` label is skipped by `reconcileStrandedAssignedIssues` and does not transition to `blocked` even when recovery has failed (extend `server/src/__tests__/heartbeat-dependency-scheduling.test.ts` or `heartbeat-issue-liveness-escalation.test.ts`).
2. `createIssueGraphLivenessEscalation` returns `{ kind: \"skipped\" }` for a monitoring-labeled issue and does not create an escalation issue.
3. `checkout` on a `blocked` issue carrying `monitoring` preserves status = `blocked` while still setting `checkoutRunId` / `executionRunId`.
4. `checkout` on a `blocked` issue **without** the label still flips to `in_progress` (regression protection for the existing behaviour).

Happy to add these in a follow-up commit once you confirm the approach and test harness location.

## Downstream context

Tracked at Knaisoma as MRG-133. Internal ADR GDEC-011 is `Accepted` and explicitly commits us to the upstream design — we will adopt maintainer preferences (including a different design such as a `monitoring` status type) rather than ship a local fork.

Escalation date on our side: 2026-05-08 (10 business days from approval). If that's too tight for upstream review cadence, a signal here is all we need and I'll push it out.