### PR TITLE
fix: cancel heartbeat run on CLI timeout

### DIFF
--- a/cli/src/commands/heartbeat-run.ts
+++ b/cli/src/commands/heartbeat-run.ts
@@ -250,6 +250,13 @@ export async function heartbeatRun(opts: HeartbeatRunOptions): Promise<void> {
       finalError = `CLI timed out after ${timeoutMs}ms`;
       finalStatus = "timed_out";
       console.error(pc.yellow(finalError));
+      try {
+        await api.post(`/api/heartbeat-runs/${activeRunId}/cancel`, {});
+        console.error(pc.yellow(`Cancelled heartbeat run ${activeRunId} after CLI timeout.`));
+      } catch (err) {
+        const reason = asErrorText(err) || (err instanceof Error ? err.message : String(err));
+        console.error(pc.yellow(`Failed to cancel heartbeat run ${activeRunId} after CLI timeout: ${reason}`));
+      }
       break;
     }
 

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -485,7 +485,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     resolvedCommand,
   });
 
-  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const timeoutSec = asNumber(config.timeoutSec, 15 * 60);
   const graceSec = asNumber(config.graceSec, 20);
 
   const runtimeSessionParams = parseObject(runtime.sessionParams);

--- a/packages/adapters/codex-local/src/ui/build-config.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.ts
@@ -74,7 +74,7 @@ export function buildCodexLocalConfig(v: CreateConfigValues): Record<string, unk
   if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
   ac.model = v.model || DEFAULT_CODEX_LOCAL_MODEL;
   if (v.thinkingEffort) ac.modelReasoningEffort = v.thinkingEffort;
-  ac.timeoutSec = 0;
+  ac.timeoutSec = 15 * 60;
   ac.graceSec = 15;
   const env = parseEnvBindings(v.envBindings);
   const legacy = parseEnvVars(v.envVars);

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -246,7 +246,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       });
     }
 
-    const timeoutSec = asNumber(config.timeoutSec, 0);
+    const timeoutSec = asNumber(config.timeoutSec, 15 * 60);
     const graceSec = asNumber(config.graceSec, 20);
     const extraArgs = (() => {
       const fromExtraArgs = asStringArray(config.extraArgs);

--- a/packages/adapters/opencode-local/src/ui/build-config.test.ts
+++ b/packages/adapters/opencode-local/src/ui/build-config.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { buildCodexLocalConfig } from "./build-config.js";
 import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { buildOpenCodeLocalConfig } from "./build-config.js";
 
 function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
   return {
-    adapterType: "codex_local",
+    adapterType: "opencode_local",
     cwd: "",
     instructionsFilePath: "",
     promptTemplate: "",
-    model: "gpt-5.4",
+    model: "opencode-go/minimax-m2.7",
     thinkingEffort: "",
     chrome: false,
     dangerouslySkipPermissions: true,
@@ -35,22 +35,15 @@ function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigVa
   };
 }
 
-describe("buildCodexLocalConfig", () => {
-  it("persists the fastMode toggle into adapter config", () => {
-    const config = buildCodexLocalConfig(
-      makeValues({
-        search: true,
-        fastMode: true,
-      }),
-    );
+describe("buildOpenCodeLocalConfig", () => {
+  it("enables a finite adapter timeout by default", () => {
+    const config = buildOpenCodeLocalConfig(makeValues());
 
     expect(config).toMatchObject({
-      model: "gpt-5.4",
-      search: true,
-      fastMode: true,
+      model: "opencode-go/minimax-m2.7",
       timeoutSec: 15 * 60,
-      graceSec: 15,
-      dangerouslyBypassApprovalsAndSandbox: true,
+      graceSec: 20,
+      dangerouslySkipPermissions: true,
     });
   });
 });

--- a/packages/adapters/opencode-local/src/ui/build-config.ts
+++ b/packages/adapters/opencode-local/src/ui/build-config.ts
@@ -59,9 +59,7 @@ export function buildOpenCodeLocalConfig(v: CreateConfigValues): Record<string, 
   if (v.model) ac.model = v.model;
   if (v.thinkingEffort) ac.variant = v.thinkingEffort;
   ac.dangerouslySkipPermissions = v.dangerouslySkipPermissions;
-  // OpenCode sessions can run until the CLI exits naturally; keep timeout disabled (0)
-  // and rely on graceSec for termination handling when a timeout is configured elsewhere.
-  ac.timeoutSec = 0;
+  ac.timeoutSec = 15 * 60;
   ac.graceSec = 20;
   const env = parseEnvBindings(v.envBindings);
   const legacy = parseEnvVars(v.envVars);


### PR DESCRIPTION
## Summary

- cancel the server-side heartbeat run when `paperclipai heartbeat run --timeout-ms` expires
- give `codex_local` and `opencode_local` finite default adapter timeouts instead of leaving runs unbounded
- persist the same finite timeout from the local adapter UI config builders
- add/update UI config tests for Codex and OpenCode timeout defaults

## Related work

Related to #4362, but intentionally narrower and complementary. #4362 hardens heartbeat wakeup/runaway cascades in the server lifecycle. This PR covers the client-side timeout path where the CLI gives up waiting but the server-side heartbeat run and child local adapter process can continue running.

## Why

Before this change, the CLI could time out locally while the server-side run and child agent process continued running. In practice this can leave long-running local adapter processes alive after the caller has already given up.

## Testing

- `pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `pnpm --filter @paperclipai/adapter-opencode-local typecheck`
- `pnpm --filter @paperclipai/plugin-sdk build && pnpm --filter paperclipai typecheck`
- `pnpm exec vitest run packages/adapters/codex-local/src/ui/build-config.test.ts packages/adapters/opencode-local/src/ui/build-config.test.ts`

Also smoke-tested on a private Paperclip instance with a temporary `process` adapter agent running `sleep 60`: invoking `heartbeat run --timeout-ms 2000` now cancels the server run and leaves no child process behind.
