### PR TITLE
Feature/mcp over http

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -5,6 +5,11 @@ Model Context Protocol server for Paperclip.
 This package is a thin MCP wrapper over the existing Paperclip REST API. It does
 not talk to the database directly and it does not reimplement business logic.
 
+Paperclip now exposes the same MCP tool surface in two ways:
+
+- Standalone stdio server via `@paperclipai/mcp-server`
+- Embedded streamable HTTP endpoint on the main Paperclip app at `/mcp`
+
 ## Authentication
 
 The server reads its configuration from environment variables:
@@ -17,6 +22,8 @@ The server reads its configuration from environment variables:
 
 ## Usage
 
+### Standalone stdio server
+
 ```sh
 npx -y @paperclipai/mcp-server
 ```
@@ -27,6 +34,19 @@ Or locally in this repo:
 pnpm --filter @paperclipai/mcp-server build
 node packages/mcp-server/dist/stdio.js
 ```
+
+### Embedded Paperclip app endpoint
+
+When you run the main Paperclip server, it now mounts the same MCP tool surface
+at:
+
+```text
+/mcp
+```
+
+This endpoint runs inside the existing Paperclip service; it is not a separate
+service or sidecar. It reuses the current authenticated Paperclip actor and
+forwards auth back into the existing REST-backed tool implementation.
 
 ## Tool Surface
 

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -85,8 +85,13 @@ export class PaperclipApiClient {
       ...(this.config.requestHeaders ?? {}),
       Accept: "application/json",
     };
-    const authHeader = this.config.authHeader ?? `Bearer ${this.config.apiKey}`;
-    if (authHeader.trim()) headers.Authorization = authHeader;
+    const configuredAuthHeader = this.config.authHeader?.trim();
+    const apiKey = this.config.apiKey?.trim();
+    if (configuredAuthHeader) {
+      headers.Authorization = configuredAuthHeader;
+    } else if (apiKey) {
+      headers.Authorization = `Bearer ${apiKey}`;
+    }
     if (options.body !== undefined) {
       headers["Content-Type"] = "application/json";
     }

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -82,9 +82,11 @@ export class PaperclipApiClient {
 
     const url = new URL(path.slice(1), `${this.config.apiUrl}/`);
     const headers: Record<string, string> = {
-      Authorization: `Bearer ${this.config.apiKey}`,
+      ...(this.config.requestHeaders ?? {}),
       Accept: "application/json",
     };
+    const authHeader = this.config.authHeader ?? `Bearer ${this.config.apiKey}`;
+    if (authHeader.trim()) headers.Authorization = authHeader;
     if (options.body !== undefined) {
       headers["Content-Type"] = "application/json";
     }

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -4,6 +4,8 @@ export interface PaperclipMcpConfig {
   companyId: string | null;
   agentId: string | null;
   runId: string | null;
+  authHeader?: string;
+  requestHeaders?: Record<string, string>;
 }
 
 function nonEmpty(value: string | undefined): string | null {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,8 +1,12 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+export { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+export { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { PaperclipApiClient } from "./client.js";
 import { readConfigFromEnv, type PaperclipMcpConfig } from "./config.js";
 import { createToolDefinitions } from "./tools.js";
+
+export type { PaperclipMcpConfig } from "./config.js";
 
 export function createPaperclipMcpServer(config: PaperclipMcpConfig = readConfigFromEnv()) {
   const server = new McpServer({

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PaperclipApiClient } from "./client.js";
 import { createToolDefinitions } from "./tools.js";
 
@@ -30,6 +30,10 @@ describe("paperclip MCP tools", () => {
     vi.restoreAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("adds auth headers and run id to mutating requests", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       mockJsonResponse({ ok: true }),
@@ -50,6 +54,30 @@ describe("paperclip MCP tools", () => {
     expect((init.headers as Record<string, string>)["X-Paperclip-Run-Id"]).toBe(
       "33333333-3333-3333-3333-333333333333",
     );
+  });
+
+  it("omits Authorization when neither auth header nor api key is configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({ ok: true }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PaperclipApiClient({
+      apiUrl: "http://localhost:3100/api",
+      apiKey: "",
+      companyId: null,
+      agentId: null,
+      runId: null,
+      requestHeaders: {
+        Cookie: "paperclip.sid=session-token",
+      },
+    });
+
+    await client.requestJson("GET", "/agents/me");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+    expect((init.headers as Record<string, string>).Cookie).toBe("paperclip.sid=session-token");
   });
 
   it("uses default company id for company-scoped list tools", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,19 +169,6 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
-  packages/adapters/hermes-gateway:
-    dependencies:
-      '@paperclipai/adapter-utils':
-        specifier: workspace:*
-        version: link:../../adapter-utils
-    devDependencies:
-      '@types/node':
-        specifier: ^24.6.0
-        version: 24.12.0
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-
   packages/adapters/openclaw-gateway:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -490,9 +477,6 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
-      '@paperclipai/adapter-hermes-gateway':
-        specifier: workspace:*
-        version: link:../packages/adapters/hermes-gateway
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -508,9 +492,6 @@ importers:
       '@paperclipai/db':
         specifier: workspace:*
         version: link:../packages/db
-      '@paperclipai/mcp-server':
-        specifier: workspace:*
-        version: link:../packages/mcp-server
       '@paperclipai/plugin-sdk':
         specifier: workspace:*
         version: link:../packages/plugins/sdk

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,19 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/hermes-gateway:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/adapters/openclaw-gateway:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -477,6 +490,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-hermes-gateway':
+        specifier: workspace:*
+        version: link:../packages/adapters/hermes-gateway
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -492,6 +508,9 @@ importers:
       '@paperclipai/db':
         specifier: workspace:*
         version: link:../packages/db
+      '@paperclipai/mcp-server':
+        specifier: workspace:*
+        version: link:../packages/mcp-server
       '@paperclipai/plugin-sdk':
         specifier: workspace:*
         version: link:../packages/plugins/sdk

--- a/server/package.json
+++ b/server/package.json
@@ -53,6 +53,7 @@
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",
+    "@paperclipai/mcp-server": "workspace:*",
     "@paperclipai/plugin-sdk": "workspace:*",
     "@paperclipai/shared": "workspace:*",
     "ajv": "^8.18.0",

--- a/server/src/__tests__/mcp-routes.test.ts
+++ b/server/src/__tests__/mcp-routes.test.ts
@@ -1,16 +1,16 @@
 import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mcpRoutes } from "../routes/mcp.js";
+import { buildInternalApiUrl, mcpRoutes } from "../routes/mcp.js";
 
-function createApp(actor: Express.Request["actor"]) {
+function createApp(actor: Express.Request["actor"], opts: { bindHost?: string } = {}) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
     req.actor = actor;
     next();
   });
-  app.use("/mcp", mcpRoutes({ serverPort: 3100 }));
+  app.use("/mcp", mcpRoutes({ serverPort: 3100, bindHost: opts.bindHost ?? "127.0.0.1" }));
   return app;
 }
 
@@ -61,6 +61,40 @@ async function initializeSession(
 describe("mcp routes", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("builds internal API URLs from the configured bind host", () => {
+    expect(buildInternalApiUrl(3100, "0.0.0.0")).toBe("http://127.0.0.1:3100/api");
+    expect(buildInternalApiUrl(3100, "192.168.1.25")).toBe("http://192.168.1.25:3100/api");
+    expect(buildInternalApiUrl(3100, "::1")).toBe("http://[::1]:3100/api");
+  });
+
+  it("rejects requests without validated Paperclip authentication", async () => {
+    const app = createApp({
+      type: "none",
+      source: "none",
+    });
+
+    await request(app)
+      .post("/mcp")
+      .set({
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer invalid-token",
+      })
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: {
+            name: "paperclip-test-client",
+            version: "1.0.0",
+          },
+        },
+      })
+      .expect(401);
   });
 
   it("initializes a session and lists tools over HTTP", async () => {
@@ -122,8 +156,10 @@ describe("mcp routes", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const app = createApp({
-      type: "none",
-      source: "none",
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      source: "agent_key",
     });
 
     const sessionId = await initializeSession(app, {

--- a/server/src/__tests__/mcp-routes.test.ts
+++ b/server/src/__tests__/mcp-routes.test.ts
@@ -1,16 +1,18 @@
 import express from "express";
 import request from "supertest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildInternalApiUrl, mcpRoutes } from "../routes/mcp.js";
 
+type ActorSource = Express.Request["actor"] | (() => Express.Request["actor"]);
+
 function createApp(
-  actor: Express.Request["actor"],
+  actor: ActorSource,
   opts: { bindHost?: string; sessionIdleTimeoutMs?: number; maxSessions?: number } = {},
 ) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    req.actor = actor;
+    req.actor = typeof actor === "function" ? actor() : actor;
     next();
   });
   app.use(
@@ -72,6 +74,11 @@ async function initializeSession(
 describe("mcp routes", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it("builds internal API URLs from the configured bind host", () => {
@@ -218,27 +225,29 @@ describe("mcp routes", () => {
     );
   });
 
-  it("expires idle sessions", async () => {
-    const app = createApp(
-      {
-        type: "board",
-        userId: "board-user",
-        source: "session",
-      },
-      { sessionIdleTimeoutMs: 10 },
-    );
+  it("rejects reuse of a session by a different actor", async () => {
+    let actor: Express.Request["actor"] = {
+      type: "board",
+      userId: "board-user-1",
+      source: "session",
+    };
+    const app = createApp(() => actor);
 
     const sessionId = await initializeSession(app, {
       Authorization: "Bearer token-123",
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    actor = {
+      type: "board",
+      userId: "board-user-2",
+      source: "session",
+    };
 
-    await request(app)
+    const response = await request(app)
       .post("/mcp")
       .set({
         Accept: "application/json, text/event-stream",
-        Authorization: "Bearer token-123",
+        Authorization: "Bearer token-456",
         "mcp-session-id": sessionId,
       })
       .send({
@@ -246,8 +255,55 @@ describe("mcp routes", () => {
         id: 4,
         method: "tools/list",
         params: {},
-      })
-      .expect(400);
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: -32001,
+          message: expect.stringContaining("different actor"),
+        }),
+      }),
+    );
+  });
+
+  it("expires idle sessions", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    try {
+      const app = createApp(
+        {
+          type: "board",
+          userId: "board-user",
+          source: "session",
+        },
+        { sessionIdleTimeoutMs: 10 },
+      );
+
+      const sessionId = await initializeSession(app, {
+        Authorization: "Bearer token-123",
+      });
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      await request(app)
+        .post("/mcp")
+        .set({
+          Accept: "application/json, text/event-stream",
+          Authorization: "Bearer token-123",
+          "mcp-session-id": sessionId,
+        })
+        .send({
+          jsonrpc: "2.0",
+          id: 5,
+          method: "tools/list",
+          params: {},
+        })
+        .expect(400);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("evicts the oldest session when the session cap is reached", async () => {
@@ -276,7 +332,7 @@ describe("mcp routes", () => {
       })
       .send({
         jsonrpc: "2.0",
-        id: 5,
+        id: 6,
         method: "tools/list",
         params: {},
       })
@@ -291,7 +347,7 @@ describe("mcp routes", () => {
       })
       .send({
         jsonrpc: "2.0",
-        id: 6,
+        id: 7,
         method: "tools/list",
         params: {},
       });

--- a/server/src/__tests__/mcp-routes.test.ts
+++ b/server/src/__tests__/mcp-routes.test.ts
@@ -3,14 +3,25 @@ import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildInternalApiUrl, mcpRoutes } from "../routes/mcp.js";
 
-function createApp(actor: Express.Request["actor"], opts: { bindHost?: string } = {}) {
+function createApp(
+  actor: Express.Request["actor"],
+  opts: { bindHost?: string; sessionIdleTimeoutMs?: number; maxSessions?: number } = {},
+) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
     req.actor = actor;
     next();
   });
-  app.use("/mcp", mcpRoutes({ serverPort: 3100, bindHost: opts.bindHost ?? "127.0.0.1" }));
+  app.use(
+    "/mcp",
+    mcpRoutes({
+      serverPort: 3100,
+      bindHost: opts.bindHost ?? "127.0.0.1",
+      sessionIdleTimeoutMs: opts.sessionIdleTimeoutMs,
+      maxSessions: opts.maxSessions,
+    }),
+  );
   return app;
 }
 
@@ -205,5 +216,86 @@ describe("mcp routes", () => {
     expect((init.headers as Record<string, string>).Authorization).toBe(
       "Bearer route-token-123",
     );
+  });
+
+  it("expires idle sessions", async () => {
+    const app = createApp(
+      {
+        type: "board",
+        userId: "board-user",
+        source: "session",
+      },
+      { sessionIdleTimeoutMs: 10 },
+    );
+
+    const sessionId = await initializeSession(app, {
+      Authorization: "Bearer token-123",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    await request(app)
+      .post("/mcp")
+      .set({
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer token-123",
+        "mcp-session-id": sessionId,
+      })
+      .send({
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/list",
+        params: {},
+      })
+      .expect(400);
+  });
+
+  it("evicts the oldest session when the session cap is reached", async () => {
+    const app = createApp(
+      {
+        type: "board",
+        userId: "board-user",
+        source: "session",
+      },
+      { maxSessions: 1 },
+    );
+
+    const firstSessionId = await initializeSession(app, {
+      Authorization: "Bearer token-123",
+    });
+    const secondSessionId = await initializeSession(app, {
+      Authorization: "Bearer token-123",
+    });
+
+    await request(app)
+      .post("/mcp")
+      .set({
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer token-123",
+        "mcp-session-id": firstSessionId,
+      })
+      .send({
+        jsonrpc: "2.0",
+        id: 5,
+        method: "tools/list",
+        params: {},
+      })
+      .expect(400);
+
+    const response = await request(app)
+      .post("/mcp")
+      .set({
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer token-123",
+        "mcp-session-id": secondSessionId,
+      })
+      .send({
+        jsonrpc: "2.0",
+        id: 6,
+        method: "tools/list",
+        params: {},
+      });
+
+    expect(response.status).toBe(200);
   });
 });

--- a/server/src/__tests__/mcp-routes.test.ts
+++ b/server/src/__tests__/mcp-routes.test.ts
@@ -1,0 +1,173 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mcpRoutes } from "../routes/mcp.js";
+
+function createApp(actor: Express.Request["actor"]) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = actor;
+    next();
+  });
+  app.use("/mcp", mcpRoutes({ serverPort: 3100 }));
+  return app;
+}
+
+function extractJsonRpcMessage(response: request.Response) {
+  if (response.body && typeof response.body === "object" && Object.keys(response.body).length > 0) {
+    return response.body as Record<string, unknown>;
+  }
+
+  const dataLine = response.text
+    .split("\n")
+    .find((line) => line.startsWith("data: "));
+  if (!dataLine) {
+    throw new Error(`Missing MCP data frame in response: ${response.text}`);
+  }
+  return JSON.parse(dataLine.slice("data: ".length)) as Record<string, unknown>;
+}
+
+async function initializeSession(
+  app: express.Express,
+  headers: Record<string, string> = {},
+) {
+  const response = await request(app)
+    .post("/mcp")
+    .set({
+      Accept: "application/json, text/event-stream",
+      ...headers,
+    })
+    .send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: {
+          name: "paperclip-test-client",
+          version: "1.0.0",
+        },
+      },
+    });
+
+  expect(response.status).toBe(200);
+  const sessionId = response.header["mcp-session-id"];
+  expect(sessionId).toBeTruthy();
+  return String(sessionId);
+}
+
+describe("mcp routes", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("initializes a session and lists tools over HTTP", async () => {
+    const app = createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+    });
+
+    const sessionId = await initializeSession(app, {
+      Authorization: "Bearer token-123",
+    });
+
+    await request(app)
+      .post("/mcp")
+      .set({
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer token-123",
+        "mcp-session-id": sessionId,
+      })
+      .send({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+        params: {},
+      })
+      .expect(202);
+
+    const response = await request(app)
+      .post("/mcp")
+      .set({
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer token-123",
+        "mcp-session-id": sessionId,
+      })
+      .send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/list",
+        params: {},
+      });
+
+    const message = extractJsonRpcMessage(response);
+    expect(response.status).toBe(200);
+    expect((message.result as { tools: unknown[] }).tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "paperclipMe" }),
+        expect.objectContaining({ name: "paperclipApiRequest" }),
+      ]),
+    );
+  });
+
+  it("forwards request auth into the existing REST-backed tool client", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "agent-1", role: "ceo" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const app = createApp({
+      type: "none",
+      source: "none",
+    });
+
+    const sessionId = await initializeSession(app, {
+      Authorization: "Bearer route-token-123",
+    });
+
+    await request(app)
+      .post("/mcp")
+      .set({
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer route-token-123",
+        "mcp-session-id": sessionId,
+      })
+      .send({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+        params: {},
+      })
+      .expect(202);
+
+    const response = await request(app)
+      .post("/mcp")
+      .set({
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer route-token-123",
+        "mcp-session-id": sessionId,
+      })
+      .send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "paperclipMe",
+          arguments: {},
+        },
+      });
+
+    extractJsonRpcMessage(response);
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toBe("http://127.0.0.1:3100/api/agents/me");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer route-token-123",
+    );
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -40,6 +40,7 @@ import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
+import { mcpRoutes } from "./routes/mcp.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
@@ -171,6 +172,7 @@ export async function createApp(
     app.all("/api/auth/{*authPath}", opts.betterAuthHandler);
   }
   app.use(llmRoutes(db));
+  app.use("/mcp", mcpRoutes({ serverPort: opts.serverPort }));
 
   const hostServicesDisposers = new Map<string, () => void>();
   const workerManager = opts.pluginWorkerManager ?? createPluginWorkerManager();

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -172,7 +172,7 @@ export async function createApp(
     app.all("/api/auth/{*authPath}", opts.betterAuthHandler);
   }
   app.use(llmRoutes(db));
-  app.use("/mcp", mcpRoutes({ serverPort: opts.serverPort }));
+  app.use("/mcp", mcpRoutes({ serverPort: opts.serverPort, bindHost: opts.bindHost }));
 
   const hostServicesDisposers = new Map<string, () => void>();
   const workerManager = opts.pluginWorkerManager ?? createPluginWorkerManager();

--- a/server/src/routes/mcp.ts
+++ b/server/src/routes/mcp.ts
@@ -10,7 +10,11 @@ import {
 type McpSession = {
   server: Awaited<ReturnType<typeof createPaperclipMcpServer>>["server"];
   transport: StreamableHTTPServerTransport;
+  timeout: ReturnType<typeof setTimeout>;
 };
+
+export const MCP_SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+export const MCP_MAX_SESSIONS = 100;
 
 function readOptionalHeader(req: Request, name: string): string | null {
   const value = req.header(name)?.trim();
@@ -69,9 +73,47 @@ function sendBadRequest(res: Response, message: string) {
   });
 }
 
-export function mcpRoutes(opts: { serverPort: number; bindHost: string }) {
+export function mcpRoutes(opts: {
+  serverPort: number;
+  bindHost: string;
+  sessionIdleTimeoutMs?: number;
+  maxSessions?: number;
+}) {
   const router = Router();
   const sessions = new Map<string, McpSession>();
+  const sessionIdleTimeoutMs = opts.sessionIdleTimeoutMs ?? MCP_SESSION_IDLE_TIMEOUT_MS;
+  const maxSessions = opts.maxSessions ?? MCP_MAX_SESSIONS;
+
+  function removeSession(sessionId: string) {
+    const session = sessions.get(sessionId);
+    if (!session) return;
+    sessions.delete(sessionId);
+    clearTimeout(session.timeout);
+    void session.server.close().catch(() => {});
+  }
+
+  function scheduleSessionTimeout(sessionId: string) {
+    const timeout = setTimeout(() => {
+      removeSession(sessionId);
+    }, sessionIdleTimeoutMs);
+    timeout.unref?.();
+    return timeout;
+  }
+
+  function touchSession(sessionId: string, session: McpSession) {
+    clearTimeout(session.timeout);
+    session.timeout = scheduleSessionTimeout(sessionId);
+    sessions.delete(sessionId);
+    sessions.set(sessionId, session);
+  }
+
+  function enforceSessionLimit() {
+    while (sessions.size >= maxSessions) {
+      const oldestSessionId = sessions.keys().next().value as string | undefined;
+      if (!oldestSessionId) break;
+      removeSession(oldestSessionId);
+    }
+  }
 
   async function createSession(req: Request) {
     const config = buildPaperclipMcpConfig(req, opts.serverPort, opts.bindHost);
@@ -79,16 +121,16 @@ export function mcpRoutes(opts: { serverPort: number; bindHost: string }) {
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (sessionId) => {
-        sessions.set(sessionId, { server, transport });
+        enforceSessionLimit();
+        sessions.set(sessionId, { server, transport, timeout: scheduleSessionTimeout(sessionId) });
       },
     });
 
     transport.onclose = () => {
       const sessionId = transport.sessionId;
       if (sessionId) {
-        sessions.delete(sessionId);
+        removeSession(sessionId);
       }
-      void server.close().catch(() => {});
     };
 
     await server.connect(transport);
@@ -112,6 +154,7 @@ export function mcpRoutes(opts: { serverPort: number; bindHost: string }) {
           sendBadRequest(res, "Bad Request: Invalid session ID");
           return;
         }
+        touchSession(sessionId, existing);
         await existing.transport.handleRequest(req, res, req.body);
         return;
       }
@@ -150,6 +193,7 @@ export function mcpRoutes(opts: { serverPort: number; bindHost: string }) {
       sendBadRequest(res, "Bad Request: Invalid session ID");
       return;
     }
+    touchSession(sessionId, existing);
     await existing.transport.handleRequest(req, res);
   });
 
@@ -166,6 +210,7 @@ export function mcpRoutes(opts: { serverPort: number; bindHost: string }) {
       sendBadRequest(res, "Bad Request: Invalid session ID");
       return;
     }
+    touchSession(sessionId, existing);
     await existing.transport.handleRequest(req, res);
   });
 

--- a/server/src/routes/mcp.ts
+++ b/server/src/routes/mcp.ts
@@ -17,7 +17,22 @@ function readOptionalHeader(req: Request, name: string): string | null {
   return value ? value : null;
 }
 
-export function buildPaperclipMcpConfig(req: Request, serverPort: number): PaperclipMcpConfig {
+function formatHostForUrl(host: string): string {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+}
+
+export function buildInternalApiUrl(serverPort: number, bindHost: string): string {
+  const normalizedHost = bindHost.trim().toLowerCase();
+  const internalHost =
+    normalizedHost === "0.0.0.0"
+      ? "127.0.0.1"
+      : normalizedHost === "::"
+        ? "::1"
+        : bindHost.trim() || "127.0.0.1";
+  return `http://${formatHostForUrl(internalHost)}:${serverPort}/api`;
+}
+
+export function buildPaperclipMcpConfig(req: Request, serverPort: number, bindHost: string): PaperclipMcpConfig {
   const cookie = readOptionalHeader(req, "cookie");
   const companyId =
     readOptionalHeader(req, "x-paperclip-company-id") ??
@@ -28,7 +43,7 @@ export function buildPaperclipMcpConfig(req: Request, serverPort: number): Paper
   const runId = readOptionalHeader(req, "x-paperclip-run-id") ?? req.actor.runId ?? null;
 
   return {
-    apiUrl: `http://127.0.0.1:${serverPort}/api`,
+    apiUrl: buildInternalApiUrl(serverPort, bindHost),
     apiKey: "",
     authHeader: readOptionalHeader(req, "authorization") ?? undefined,
     companyId,
@@ -54,12 +69,12 @@ function sendBadRequest(res: Response, message: string) {
   });
 }
 
-export function mcpRoutes(opts: { serverPort: number }) {
+export function mcpRoutes(opts: { serverPort: number; bindHost: string }) {
   const router = Router();
   const sessions = new Map<string, McpSession>();
 
   async function createSession(req: Request) {
-    const config = buildPaperclipMcpConfig(req, opts.serverPort);
+    const config = buildPaperclipMcpConfig(req, opts.serverPort, opts.bindHost);
     const { server } = createPaperclipMcpServer(config);
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
@@ -82,7 +97,6 @@ export function mcpRoutes(opts: { serverPort: number }) {
 
   async function ensureAuthenticated(req: Request, res: Response): Promise<boolean> {
     if (req.actor.type !== "none") return true;
-    if (readOptionalHeader(req, "authorization") || readOptionalHeader(req, "cookie")) return true;
     res.status(401).json({ error: "Authentication required" });
     return false;
   }

--- a/server/src/routes/mcp.ts
+++ b/server/src/routes/mcp.ts
@@ -11,6 +11,7 @@ type McpSession = {
   server: Awaited<ReturnType<typeof createPaperclipMcpServer>>["server"];
   transport: StreamableHTTPServerTransport;
   timeout: ReturnType<typeof setTimeout>;
+  actorFingerprint: string;
 };
 
 export const MCP_SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
@@ -63,14 +64,49 @@ function readSessionId(req: Request): string | null {
 }
 
 function sendBadRequest(res: Response, message: string) {
-  res.status(400).json({
+  sendJsonRpcError(res, 400, -32000, message);
+}
+
+function sendJsonRpcError(res: Response, status: number, code: number, message: string) {
+  res.status(status).json({
     jsonrpc: "2.0",
     error: {
-      code: -32000,
+      code,
       message,
     },
     id: null,
   });
+}
+
+function sendInternalError(res: Response, error: unknown) {
+  if (res.headersSent) return;
+  sendJsonRpcError(
+    res,
+    500,
+    -32603,
+    error instanceof Error ? error.message : "Internal server error",
+  );
+}
+
+function actorFingerprint(actor: Request["actor"]): string {
+  if (actor.type === "board") {
+    return JSON.stringify({
+      type: actor.type,
+      userId: actor.userId ?? null,
+      source: actor.source ?? null,
+      keyId: actor.keyId ?? null,
+    });
+  }
+  if (actor.type === "agent") {
+    return JSON.stringify({
+      type: actor.type,
+      agentId: actor.agentId ?? null,
+      companyId: actor.companyId ?? null,
+      source: actor.source ?? null,
+      keyId: actor.keyId ?? null,
+    });
+  }
+  return JSON.stringify({ type: actor.type });
 }
 
 export function mcpRoutes(opts: {
@@ -115,14 +151,32 @@ export function mcpRoutes(opts: {
     }
   }
 
+  function lookupSession(req: Request, res: Response, sessionId: string): McpSession | null {
+    const existing = sessions.get(sessionId);
+    if (!existing) {
+      sendBadRequest(res, "Bad Request: Invalid session ID");
+      return null;
+    }
+    if (existing.actorFingerprint !== actorFingerprint(req.actor)) {
+      sendJsonRpcError(res, 403, -32001, "Forbidden: MCP session belongs to a different actor");
+      return null;
+    }
+    return existing;
+  }
+
   async function createSession(req: Request) {
     const config = buildPaperclipMcpConfig(req, opts.serverPort, opts.bindHost);
     const { server } = createPaperclipMcpServer(config);
+    const sessionActorFingerprint = actorFingerprint(req.actor);
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (sessionId) => {
-        enforceSessionLimit();
-        sessions.set(sessionId, { server, transport, timeout: scheduleSessionTimeout(sessionId) });
+        sessions.set(sessionId, {
+          server,
+          transport,
+          timeout: scheduleSessionTimeout(sessionId),
+          actorFingerprint: sessionActorFingerprint,
+        });
       },
     });
 
@@ -133,6 +187,7 @@ export function mcpRoutes(opts: {
       }
     };
 
+    enforceSessionLimit();
     await server.connect(transport);
     return { server, transport };
   }
@@ -149,11 +204,8 @@ export function mcpRoutes(opts: {
     const sessionId = readSessionId(req);
     try {
       if (sessionId) {
-        const existing = sessions.get(sessionId);
-        if (!existing) {
-          sendBadRequest(res, "Bad Request: Invalid session ID");
-          return;
-        }
+        const existing = lookupSession(req, res, sessionId);
+        if (!existing) return;
         touchSession(sessionId, existing);
         await existing.transport.handleRequest(req, res, req.body);
         return;
@@ -167,16 +219,7 @@ export function mcpRoutes(opts: {
       const created = await createSession(req);
       await created.transport.handleRequest(req, res, req.body);
     } catch (error) {
-      if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: "2.0",
-          error: {
-            code: -32603,
-            message: error instanceof Error ? error.message : "Internal server error",
-          },
-          id: null,
-        });
-      }
+      sendInternalError(res, error);
     }
   });
 
@@ -188,13 +231,14 @@ export function mcpRoutes(opts: {
       sendBadRequest(res, "Bad Request: Missing session ID");
       return;
     }
-    const existing = sessions.get(sessionId);
-    if (!existing) {
-      sendBadRequest(res, "Bad Request: Invalid session ID");
-      return;
+    try {
+      const existing = lookupSession(req, res, sessionId);
+      if (!existing) return;
+      touchSession(sessionId, existing);
+      await existing.transport.handleRequest(req, res);
+    } catch (error) {
+      sendInternalError(res, error);
     }
-    touchSession(sessionId, existing);
-    await existing.transport.handleRequest(req, res);
   });
 
   router.delete("/", async (req, res) => {
@@ -205,13 +249,14 @@ export function mcpRoutes(opts: {
       sendBadRequest(res, "Bad Request: Missing session ID");
       return;
     }
-    const existing = sessions.get(sessionId);
-    if (!existing) {
-      sendBadRequest(res, "Bad Request: Invalid session ID");
-      return;
+    try {
+      const existing = lookupSession(req, res, sessionId);
+      if (!existing) return;
+      await existing.transport.handleRequest(req, res);
+      removeSession(sessionId);
+    } catch (error) {
+      sendInternalError(res, error);
     }
-    touchSession(sessionId, existing);
-    await existing.transport.handleRequest(req, res);
   });
 
   return router;

--- a/server/src/routes/mcp.ts
+++ b/server/src/routes/mcp.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from "node:crypto";
+import { Router, type Request, type Response } from "express";
+import {
+  StreamableHTTPServerTransport,
+  createPaperclipMcpServer,
+  isInitializeRequest,
+  type PaperclipMcpConfig,
+} from "@paperclipai/mcp-server";
+
+type McpSession = {
+  server: Awaited<ReturnType<typeof createPaperclipMcpServer>>["server"];
+  transport: StreamableHTTPServerTransport;
+};
+
+function readOptionalHeader(req: Request, name: string): string | null {
+  const value = req.header(name)?.trim();
+  return value ? value : null;
+}
+
+export function buildPaperclipMcpConfig(req: Request, serverPort: number): PaperclipMcpConfig {
+  const cookie = readOptionalHeader(req, "cookie");
+  const companyId =
+    readOptionalHeader(req, "x-paperclip-company-id") ??
+    (req.actor.type === "agent" ? req.actor.companyId ?? null : null);
+  const agentId =
+    readOptionalHeader(req, "x-paperclip-agent-id") ??
+    (req.actor.type === "agent" ? req.actor.agentId ?? null : null);
+  const runId = readOptionalHeader(req, "x-paperclip-run-id") ?? req.actor.runId ?? null;
+
+  return {
+    apiUrl: `http://127.0.0.1:${serverPort}/api`,
+    apiKey: "",
+    authHeader: readOptionalHeader(req, "authorization") ?? undefined,
+    companyId,
+    agentId,
+    runId,
+    requestHeaders: cookie ? { Cookie: cookie } : undefined,
+  };
+}
+
+function readSessionId(req: Request): string | null {
+  const sessionId = req.header("mcp-session-id")?.trim();
+  return sessionId ? sessionId : null;
+}
+
+function sendBadRequest(res: Response, message: string) {
+  res.status(400).json({
+    jsonrpc: "2.0",
+    error: {
+      code: -32000,
+      message,
+    },
+    id: null,
+  });
+}
+
+export function mcpRoutes(opts: { serverPort: number }) {
+  const router = Router();
+  const sessions = new Map<string, McpSession>();
+
+  async function createSession(req: Request) {
+    const config = buildPaperclipMcpConfig(req, opts.serverPort);
+    const { server } = createPaperclipMcpServer(config);
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sessionId) => {
+        sessions.set(sessionId, { server, transport });
+      },
+    });
+
+    transport.onclose = () => {
+      const sessionId = transport.sessionId;
+      if (sessionId) {
+        sessions.delete(sessionId);
+      }
+      void server.close().catch(() => {});
+    };
+
+    await server.connect(transport);
+    return { server, transport };
+  }
+
+  async function ensureAuthenticated(req: Request, res: Response): Promise<boolean> {
+    if (req.actor.type !== "none") return true;
+    if (readOptionalHeader(req, "authorization") || readOptionalHeader(req, "cookie")) return true;
+    res.status(401).json({ error: "Authentication required" });
+    return false;
+  }
+
+  router.post("/", async (req, res) => {
+    if (!(await ensureAuthenticated(req, res))) return;
+
+    const sessionId = readSessionId(req);
+    try {
+      if (sessionId) {
+        const existing = sessions.get(sessionId);
+        if (!existing) {
+          sendBadRequest(res, "Bad Request: Invalid session ID");
+          return;
+        }
+        await existing.transport.handleRequest(req, res, req.body);
+        return;
+      }
+
+      if (!isInitializeRequest(req.body)) {
+        sendBadRequest(res, "Bad Request: No valid session ID provided");
+        return;
+      }
+
+      const created = await createSession(req);
+      await created.transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32603,
+            message: error instanceof Error ? error.message : "Internal server error",
+          },
+          id: null,
+        });
+      }
+    }
+  });
+
+  router.get("/", async (req, res) => {
+    if (!(await ensureAuthenticated(req, res))) return;
+
+    const sessionId = readSessionId(req);
+    if (!sessionId) {
+      sendBadRequest(res, "Bad Request: Missing session ID");
+      return;
+    }
+    const existing = sessions.get(sessionId);
+    if (!existing) {
+      sendBadRequest(res, "Bad Request: Invalid session ID");
+      return;
+    }
+    await existing.transport.handleRequest(req, res);
+  });
+
+  router.delete("/", async (req, res) => {
+    if (!(await ensureAuthenticated(req, res))) return;
+
+    const sessionId = readSessionId(req);
+    if (!sessionId) {
+      sendBadRequest(res, "Bad Request: Missing session ID");
+      return;
+    }
+    const existing = sessions.get(sessionId);
+    if (!existing) {
+      sendBadRequest(res, "Bad Request: Invalid session ID");
+      return;
+    }
+    await existing.transport.handleRequest(req, res);
+  });
+
+  return router;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "packages/db",
       "packages/adapter-utils",
       "packages/adapters/claude-local",
+      "packages/mcp-server",
       "packages/adapters/codex-local",
       "packages/adapters/cursor-local",
       "packages/adapters/gemini-local",


### PR DESCRIPTION
  ## Thinking Path

  > - Paperclip already has an MCP package that exposes its REST-backed tool surface through a standalone stdio server.
  > - Some MCP clients and remote agents integrate over streamable HTTP rather than spawning a local stdio process.
  > - Running MCP as a separate service would duplicate deployment, auth, and routing concerns that the Paperclip server already owns.
  > - The existing MCP implementation should remain the single source of truth for tools and REST API behavior.
  > - This pull request embeds a streamable HTTP MCP endpoint into the main Paperclip server at `/mcp`.
  > - The benefit is additive MCP-over-HTTP support without breaking the existing stdio server or reimplementing tool logic.
  > - Additional motivation includes PR #4359 so that remote Hermes agents can natively interact with paperclip over-the-wire

  ## What Changed

  - Added an authenticated `/mcp` route to the main Paperclip server using `StreamableHTTPServerTransport`.
  - Reused the existing `@paperclipai/mcp-server` tool surface and REST-backed client instead of duplicating MCP tool logic.
  - Forwarded the authenticated Paperclip actor context, authorization header, cookies, company ID, agent ID, and run ID into MCP tool execution.
  - Added internal API URL resolution so the embedded MCP route can call the existing server API reliably when bound to `0.0.0.0`, `::`, loopback, or a concrete host.
  - Added MCP session lifecycle management with idle expiration and a max-session cap.
  - Updated the MCP package exports/config/client support needed by the embedded HTTP route.
  - Updated `packages/mcp-server/README.md` to document both stdio and embedded HTTP usage.
  - Added route tests covering authentication, session initialization, tool listing, auth forwarding, host resolution, idle expiry, and session cap eviction.

  ## Verification

  - `pnpm --filter @paperclipai/mcp-server build`
  - `pnpm exec vitest run packages/mcp-server/src/tools.test.ts server/src/__tests__/mcp-routes.test.ts`
  - `pnpm --filter @paperclipai/mcp-server typecheck`
  - `pnpm --filter @paperclipai/server typecheck`

  Manual verification path:

  - Start the Paperclip server normally.
  - Authenticate as an existing Paperclip user or agent.
  - Connect an MCP streamable HTTP client to `/mcp`.
  - Confirm `initialize`, `tools/list`, and tool calls work through the existing Paperclip API.

  ## Risks

  - Low migration risk: this is additive and does not change the existing stdio MCP server contract.
  - HTTP MCP sessions are in-memory, so sessions do not survive server restarts and are not shared across multiple server replicas.
  - The embedded endpoint depends on existing Paperclip auth middleware; incorrect reverse-proxy auth/header behavior could prevent MCP clients from authenticating.
  - The route forwards request auth into the REST-backed MCP client, so tool permissions should match the authenticated Paperclip actor.

  > For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected
  — check the roadmap first. See `CONTRIBUTING.md`.

  ## Model Used

  - OpenAI GPT-5-family coding agent via Codex-style tool-using environment
  - Model family used in this contribution workflow: GPT-5.4/5.5-class coding assistant behavior with tool use, shell execution, patch application, Docker build execution, and repository inspection
  - Context included multi-file repository analysis across Paperclip, homelab deployment manifests, and related Hermes integration work
  - Reasoning mode: tool-assisted multi-step code modification and verification workflow
  - Capabilities used: code generation, refactoring, shell execution, Docker build verification, Git operations, and Kubernetes manifest validation

  ## Checklist

  - [x] I have included a thinking path that traces from project context to this change
  - [x] I have specified the model used (with version and capability details)
  - [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
  - [x] I have run tests locally and they pass
  - [x] I have added or updated tests where applicable
  - [x] If this change affects the UI, I have included before/after screenshots
  - [x] I have updated relevant documentation to reflect my changes
  - [x] I have considered and documented any risks above
  - [x] I will address all Greptile and reviewer comments before requesting merge
