### PR TITLE
Implement workspace file REST endpoints (ANY-29)

### DIFF
--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -9,9 +9,10 @@ import {
 } from "@paperclipai/shared";
 import { trackProjectCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
-import { projectService, logActivity, secretService, workspaceOperationService } from "../services/index.js";
-import { conflict } from "../errors.js";
+import { projectService, logActivity, issueService, secretService, workspaceOperationService } from "../services/index.js";
+import { badRequest, conflict, unprocessable } from "../errors.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { listFiles, readFile, writeFile } from "../services/workspace-files.js";
 import { startRuntimeServicesForWorkspaceControl, stopRuntimeServicesForProjectWorkspace } from "../services/workspace-runtime.js";
 import { getTelemetryClient } from "../telemetry.js";
 
@@ -457,6 +458,169 @@ export function projectRoutes(db: Db) {
     });
 
     res.json(project);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Workspace file endpoints — operate on the project's primary workspace cwd
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Resolve the primary workspace `cwd` for a project, or respond with an
+   * appropriate error status and return `null`.
+   */
+  async function resolvePrimaryWorkspaceCwd(
+    req: Request,
+    res: import("express").Response,
+  ): Promise<{ project: NonNullable<Awaited<ReturnType<typeof svc.getById>>>; cwd: string } | null> {
+    const id = req.params.id as string;
+    const project = await svc.getById(id);
+    if (!project) {
+      res.status(404).json({ error: "Project not found" });
+      return null;
+    }
+    assertCompanyAccess(req, project.companyId);
+    const workspace = project.primaryWorkspace;
+    if (!workspace || !workspace.cwd) {
+      res.status(422).json({ error: "Project has no workspace with a local path" });
+      return null;
+    }
+    return { project, cwd: workspace.cwd };
+  }
+
+  // GET /projects/:id/workspace/files — list directory contents
+  router.get("/projects/:id/workspace/files", async (req, res) => {
+    const ctx = await resolvePrimaryWorkspaceCwd(req, res);
+    if (!ctx) return;
+
+    const requestedPath = typeof req.query.path === "string" ? req.query.path : ".";
+    const depth = Math.min(Math.max(parseInt(String(req.query.depth), 10) || 1, 1), 10);
+
+    try {
+      const entries = await listFiles(ctx.cwd, requestedPath, depth);
+      res.json({ entries });
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code;
+      if (code === "BAD_PATH") {
+        res.status(400).json({ error: (err as Error).message });
+        return;
+      }
+      throw err;
+    }
+  });
+
+  // GET /projects/:id/workspace/files/read — read a text file
+  router.get("/projects/:id/workspace/files/read", async (req, res) => {
+    const ctx = await resolvePrimaryWorkspaceCwd(req, res);
+    if (!ctx) return;
+
+    const requestedPath = typeof req.query.path === "string" ? req.query.path : "";
+    if (!requestedPath) {
+      res.status(400).json({ error: "Query parameter 'path' is required" });
+      return;
+    }
+
+    try {
+      const result = await readFile(ctx.cwd, requestedPath);
+
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: ctx.project.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "workspace.file.read",
+        entityType: "project",
+        entityId: ctx.project.id,
+        details: { path: result.path, size: result.size },
+      });
+
+      res.json(result);
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code;
+      if (code === "BAD_PATH") {
+        res.status(400).json({ error: (err as Error).message });
+        return;
+      }
+      if (code === "NOT_FOUND") {
+        res.status(404).json({ error: (err as Error).message });
+        return;
+      }
+      if (code === "NOT_FILE") {
+        res.status(400).json({ error: (err as Error).message });
+        return;
+      }
+      if (code === "BINARY") {
+        res.status(422).json({ error: (err as Error).message });
+        return;
+      }
+      if (code === "TOO_LARGE") {
+        res.status(413).json({ error: (err as Error).message });
+        return;
+      }
+      throw err;
+    }
+  });
+
+  // POST /projects/:id/workspace/files/write — write a text file
+  router.post("/projects/:id/workspace/files/write", async (req, res) => {
+    const ctx = await resolvePrimaryWorkspaceCwd(req, res);
+    if (!ctx) return;
+
+    const { path: filePath, content, issueId } = req.body as {
+      path?: string;
+      content?: string;
+      issueId?: string;
+    };
+
+    if (!filePath || typeof filePath !== "string") {
+      throw badRequest("Body field 'path' is required");
+    }
+    if (typeof content !== "string") {
+      throw badRequest("Body field 'content' is required and must be a string");
+    }
+
+    // Agent callers must include issueId; board callers: optional
+    const actor = getActorInfo(req);
+    if (actor.actorType === "agent") {
+      if (!issueId || typeof issueId !== "string") {
+        throw badRequest("Agent callers must include 'issueId' in the request body");
+      }
+      const issueSvc = issueService(db);
+      const issue = await issueSvc.getById(issueId);
+      if (!issue) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
+      }
+      assertCompanyAccess(req, issue.companyId);
+    }
+
+    try {
+      const result = await writeFile(ctx.cwd, filePath, content);
+
+      await logActivity(db, {
+        companyId: ctx.project.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "workspace.file.written",
+        entityType: "project",
+        entityId: ctx.project.id,
+        details: { path: result.path, size: result.size, issueId: issueId ?? null },
+      });
+
+      res.json(result);
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code;
+      if (code === "BAD_PATH") {
+        res.status(400).json({ error: (err as Error).message });
+        return;
+      }
+      if (code === "TOO_LARGE") {
+        res.status(413).json({ error: (err as Error).message });
+        return;
+      }
+      throw err;
+    }
   });
 
   return router;

--- a/server/src/services/workspace-files.ts
+++ b/server/src/services/workspace-files.ts
@@ -1,0 +1,205 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+const MAX_FILE_SIZE = 1_048_576; // 1 MB
+const MAX_LISTING_ENTRIES = 1000;
+const BINARY_CHECK_BYTES = 8192; // 8 KB
+const EXCLUDED_DIRS: ReadonlySet<string> = new Set([".git"]);
+
+// ---------------------------------------------------------------------------
+// Path sandboxing
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve `requestedPath` against `workspaceRoot` and assert the result stays
+ * inside the workspace.  Rejects null bytes and leading-slash escapes.
+ */
+export function resolveAndSandbox(workspaceRoot: string, requestedPath: string): string {
+  if (requestedPath.includes("\0")) {
+    throw Object.assign(new Error("Path contains null bytes"), { code: "BAD_PATH" });
+  }
+  const normalized = requestedPath.replace(/^\/+/, "");
+  const resolved = path.resolve(workspaceRoot, normalized);
+  if (resolved !== workspaceRoot && !resolved.startsWith(workspaceRoot + path.sep)) {
+    throw Object.assign(new Error("Path escapes workspace root"), { code: "BAD_PATH" });
+  }
+  return resolved;
+}
+
+/**
+ * Same as `resolveAndSandbox` but additionally follows symlinks via
+ * `fs.realpath` to prevent symlink-based escapes.
+ *
+ * For paths that do not yet exist (write targets) we walk up to the nearest
+ * existing ancestor and verify *that* is inside the workspace.
+ */
+async function resolveAndSandboxReal(workspaceRoot: string, requestedPath: string): Promise<string> {
+  const resolved = resolveAndSandbox(workspaceRoot, requestedPath);
+  const realRoot = await fs.realpath(workspaceRoot);
+
+  try {
+    const realResolved = await fs.realpath(resolved);
+    if (realResolved !== realRoot && !realResolved.startsWith(realRoot + path.sep)) {
+      throw Object.assign(new Error("Path escapes workspace root via symlink"), { code: "BAD_PATH" });
+    }
+    return resolved;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      // File does not exist yet — verify the nearest existing ancestor.
+      let ancestor = path.dirname(resolved);
+      while (ancestor !== path.dirname(ancestor)) {
+        try {
+          const realAncestor = await fs.realpath(ancestor);
+          if (realAncestor !== realRoot && !realAncestor.startsWith(realRoot + path.sep)) {
+            throw Object.assign(new Error("Path escapes workspace root via symlink"), { code: "BAD_PATH" });
+          }
+          return resolved;
+        } catch (innerErr: unknown) {
+          if ((innerErr as NodeJS.ErrnoException).code === "ENOENT") {
+            ancestor = path.dirname(ancestor);
+            continue;
+          }
+          throw innerErr;
+        }
+      }
+      return resolved;
+    }
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Binary detection
+// ---------------------------------------------------------------------------
+
+function isBinaryBuffer(buffer: Buffer): boolean {
+  const end = Math.min(buffer.length, BINARY_CHECK_BYTES);
+  for (let i = 0; i < end; i++) {
+    if (buffer[i] === 0) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface FileEntry {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+  size?: number;
+}
+
+/**
+ * List directory contents up to `depth` levels deep.
+ * Excludes `.git` directories.  Caps output at 1 000 entries.
+ */
+export async function listFiles(
+  workspaceRoot: string,
+  requestedPath: string,
+  depth: number = 1,
+): Promise<FileEntry[]> {
+  const resolved = await resolveAndSandboxReal(workspaceRoot, requestedPath);
+  const entries: FileEntry[] = [];
+
+  async function walk(dir: string, currentDepth: number) {
+    if (currentDepth > depth || entries.length >= MAX_LISTING_ENTRIES) return;
+
+    let dirEntries: import("node:fs").Dirent[];
+    try {
+      dirEntries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of dirEntries) {
+      if (entries.length >= MAX_LISTING_ENTRIES) break;
+      if (EXCLUDED_DIRS.has(entry.name)) continue;
+
+      const fullPath = path.join(dir, entry.name);
+      const relativePath = path.relative(workspaceRoot, fullPath);
+
+      if (entry.isDirectory()) {
+        entries.push({ name: entry.name, path: relativePath, type: "directory" });
+        if (currentDepth < depth) {
+          await walk(fullPath, currentDepth + 1);
+        }
+      } else if (entry.isFile()) {
+        try {
+          const stat = await fs.stat(fullPath);
+          entries.push({ name: entry.name, path: relativePath, type: "file", size: stat.size });
+        } catch {
+          // skip files we can't stat (permissions, etc.)
+        }
+      }
+    }
+  }
+
+  await walk(resolved, 1);
+  return entries;
+}
+
+/**
+ * Read a text file from the workspace.
+ * Rejects binary files (422) and files > 1 MB (413).
+ */
+export async function readFile(
+  workspaceRoot: string,
+  requestedPath: string,
+): Promise<{ content: string; size: number; path: string }> {
+  const resolved = await resolveAndSandboxReal(workspaceRoot, requestedPath);
+
+  let stat: import("node:fs").Stats;
+  try {
+    stat = await fs.stat(resolved);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw Object.assign(new Error("File not found"), { code: "NOT_FOUND" });
+    }
+    throw err;
+  }
+
+  if (!stat.isFile()) {
+    throw Object.assign(new Error("Path is not a file"), { code: "NOT_FILE" });
+  }
+  if (stat.size > MAX_FILE_SIZE) {
+    throw Object.assign(new Error(`File exceeds ${MAX_FILE_SIZE} byte limit`), { code: "TOO_LARGE" });
+  }
+
+  const buffer = await fs.readFile(resolved);
+  if (isBinaryBuffer(buffer)) {
+    throw Object.assign(new Error("File appears to be binary"), { code: "BINARY" });
+  }
+
+  return {
+    content: buffer.toString("utf-8"),
+    size: stat.size,
+    path: path.relative(workspaceRoot, resolved),
+  };
+}
+
+/**
+ * Write a UTF-8 text file into the workspace, creating parent directories as
+ * needed.  Rejects content > 1 MB (413).
+ */
+export async function writeFile(
+  workspaceRoot: string,
+  requestedPath: string,
+  contents: string,
+): Promise<{ path: string; size: number }> {
+  const resolved = await resolveAndSandboxReal(workspaceRoot, requestedPath);
+
+  const buf = Buffer.from(contents, "utf-8");
+  if (buf.length > MAX_FILE_SIZE) {
+    throw Object.assign(new Error(`Content exceeds ${MAX_FILE_SIZE} byte limit`), { code: "TOO_LARGE" });
+  }
+
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  await fs.writeFile(resolved, buf);
+
+  return {
+    path: path.relative(workspaceRoot, resolved),
+    size: buf.length,
+  };
+}


### PR DESCRIPTION
## Summary

- **Created** `server/src/services/workspace-files.ts` — service module with path sandboxing (`resolveAndSandbox`, `resolveAndSandboxReal`), directory listing, file reading (binary detection + size check), and file writing (mkdir -p)
- **Modified** `server/src/routes/projects.ts` — added 3 route handlers:
  - `GET /projects/:id/workspace/files` — list directory contents (query: `path`, `depth`)
  - `GET /projects/:id/workspace/files/read` — read text file (query: `path`)
  - `POST /projects/:id/workspace/files/write` — write text file (body: `path`, `content`, `issueId`)

## Security

- Path sandboxing: null byte rejection, leading-slash stripping, `fs.realpath` symlink escape prevention
- Binary detection via null-byte scan of first 8KB → 422
- Size limit: 1MB → 413
- Write auth: agent callers must provide valid `issueId` (same company). Board callers: optional
- `.git` directories excluded from listings
- Activity logging: `workspace.file.read` and `workspace.file.written`

## Test plan

- [ ] TypeScript compiles clean (verified)
- [ ] Manual test: list files on a project with workspace
- [ ] Manual test: read file, verify binary rejection
- [ ] Manual test: write file, verify path sandboxing
- [ ] Manual test: attempt symlink escape — should fail
- [ ] Manual test: attempt path traversal (`../../etc/passwd`) — should fail

Parent: ANY-28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>