### PR TITLE
server: stop deferred comment wakes from reopening closed issues

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -4,6 +4,7 @@ import { and, asc, eq } from "drizzle-orm";
 import { WebSocketServer } from "ws";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  activityLog,
   agents,
   agentWakeupRequests,
   companies,
@@ -600,7 +601,7 @@ describe("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("promotes deferred comment wakes after the active run closes the issue", async () => {
+  it("promotes deferred comment wakes without reopening an issue the active run closed", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -750,7 +751,7 @@ describe("heartbeat comment wake batching", () => {
         return runs.length === 2 && runs.every((run) => run.status === "succeeded");
       }, 90_000);
 
-      const reopenedIssue = await db
+      const postPromotionIssue = await db
         .select({
           status: issues.status,
           completedAt: issues.completedAt,
@@ -759,10 +760,23 @@ describe("heartbeat comment wake batching", () => {
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
 
-      expect(reopenedIssue).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
-      });
+      expect(postPromotionIssue?.status).toBe("done");
+      expect(postPromotionIssue?.completedAt).not.toBeNull();
+
+      const reopenActivity = await db
+        .select()
+        .from(activityLog)
+        .where(
+          and(
+            eq(activityLog.entityType, "issue"),
+            eq(activityLog.entityId, issueId),
+            eq(activityLog.action, "issue.updated"),
+          ),
+        );
+      for (const entry of reopenActivity) {
+        const details = (entry.details ?? {}) as Record<string, unknown>;
+        expect(details.source).not.toBe("deferred_comment_wake");
+      }
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toMatchObject({
@@ -774,7 +788,7 @@ describe("heartbeat comment wake batching", () => {
             id: issueId,
             identifier: `${issuePrefix}-1`,
             title: "Reopen after deferred comment",
-            status: "in_progress",
+            status: "done",
             priority: "medium",
           },
         },

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -508,6 +508,27 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
+  it("does not implicitly move a blocked issue to todo when the commenter is an agent", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+
+    const res = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: "44444444-4444-4444-8444-444444444444",
+        companyId: "company-1",
+        runId: "run-agent-unblock",
+      }),
+    )
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "blocker resolved, ready to continue" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+  });
+
   it("moves assigned blocked issues back to todo via POST comments", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5871,58 +5871,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             interaction: true,
           };
         }
-        const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
-        const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
-        // Only human/comment-reopen interactions should revive completed issues;
-        // system follow-ups such as retry or cleanup wakes must not reopen closed work.
-        const shouldReopenDeferredCommentWake =
-          deferredCommentIds.length > 0 &&
-          (issue.status === "done" || issue.status === "cancelled") &&
-          (
-            deferred.requestedByActorType === "user" ||
-            deferredWakeReason === "issue_reopened_via_comment"
-          );
-        let reopenedActivity: LogActivityInput | null = null;
-
-        if (shouldReopenDeferredCommentWake) {
-          const reopenedFromStatus = issue.status;
-          const reopenedIssue = await issuesSvc.update(
-            issue.id,
-            {
-              status: "todo",
-              executionState: null,
-            },
-            tx,
-          );
-          if (reopenedIssue) {
-            issue = {
-              ...issue,
-              identifier: reopenedIssue.identifier,
-              status: reopenedIssue.status,
-              executionRunId: reopenedIssue.executionRunId,
-            };
-            if (!readNonEmptyString(promotedContextSeed.reopenedFrom)) {
-              promotedContextSeed.reopenedFrom = reopenedFromStatus;
-            }
-            reopenedActivity = {
-              companyId: issue.companyId,
-              actorType: "system",
-              actorId: "heartbeat",
-              agentId: deferred.agentId,
-              runId: run.id,
-              action: "issue.updated",
-              entityType: "issue",
-              entityId: issue.id,
-              details: {
-                status: "todo",
-                reopened: true,
-                reopenedFrom: reopenedFromStatus,
-                source: "deferred_comment_wake",
-                identifier: issue.identifier,
-              },
-            };
-          }
-        }
+        // Deferred wake promotion runs without mutating issue status. A closed issue
+        // that accumulated deferred comment wakes stays closed; promoted runs simply
+        // receive the comment context and decide what to do. Explicit reopen remains
+        // available via the comment/PATCH paths with `reopen: true`, which board/user
+        // comments also take when they arrive through the issues route.
+        //
+        // This supersedes the partial guard added in #4383, which scoped the deferred
+        // reopen to user-authored / `issue_reopened_via_comment` wakes but still
+        // mutated status on promotion. The deferred wake surface should not be a
+        // second write path for issue lifecycle.
 
         const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
         const promotedSource =
@@ -5993,7 +5951,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return {
           kind: "promoted" as const,
           run: newRun,
-          reopenedActivity,
         };
       }
 
@@ -6130,10 +6087,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const promotedRun = promotionResult?.run ?? null;
     if (!promotedRun) return;
-
-    if (promotionResult?.kind === "promoted" && promotionResult.reopenedActivity) {
-      await logActivity(db, promotionResult.reopenedActivity);
-    }
 
     publishLiveEvent({
       companyId: promotedRun.companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents communicate by commenting on issues, and the issue lifecycle (`todo` → `in_progress` → `done`) is the source of truth for whether work is finished
> - When a non-assignee agent commented on a `done`/`cancelled` issue, two server-side paths silently flipped it back to `todo`: the route-level "implicit reopen on comment" (path A) and the deferred wake promoter (path B)
> - Combined, these create a re-checkout loop (LEV-59 reproduction): one agent closes an issue with a wrap-up comment, that comment wakes other participants, their wake promotion reopens the issue, the harness auto-checks out the original assignee, and they re-close — repeat until the close comment is dropped
> - Path A is already addressed in upstream `master` via a stricter rule that returns `false` whenever `actorType !== "user"`. This PR's original A diff was a strict subset and is now redundant — dropped during rebase
> - Path B is the remaining gap: deferred wake promotion still mutates lifecycle on closed issues, even after the partial #4383 guard scoped it to user/`issue_reopened_via_comment` wakes. The deferred wake surface should not be a second write path for issue lifecycle at all
> - This PR removes the `shouldReopenDeferredCommentWake` branch entirely. Wake promotion now delivers wakes without touching status — lifecycle writes happen only via the route handlers
> - Combined with upstream's path A, the LEV-59 re-checkout loop is closed: agent close-out comments cannot flip a `done` issue to `todo` via either path, so the harness has nothing to auto-checkout

## What Changed

- **B.** `server/src/services/heartbeat.ts` — deletes the `shouldReopenDeferredCommentWake` branch entirely. When a deferred comment wake is promoted on a `done`/`cancelled` issue, the promoted run now sees the issue in its closed state and the issue is not mutated. `reopenedActivity` and its downstream consumer are removed. This intentionally supersedes the partial guard added in #4383, which still mutated status on user-authored deferred wake promotion. The argument is principled separation: wake promotion delivers wakes; route handlers own lifecycle.
- **Tests.** Two regression updates:
  - `server/src/__tests__/issue-comment-reopen-routes.test.ts` — adds one test asserting that an agent comment on a `blocked` issue does not implicitly move the issue to `todo`. Upstream's stricter `actorType !== "user"` rule now applies to `blocked` as well as `done`/`cancelled`; this guards that contract.
  - `server/src/__tests__/heartbeat-comment-wake-batching.test.ts` — the existing "promotes deferred comment wakes after the active run closes the issue" test is updated to the new contract: the issue stays `done` after promotion, no `source: "deferred_comment_wake"` activity entry is logged, and the wake payload reflects the current `done` status.

Path A (scoping `shouldImplicitlyMoveCommentedIssueToTodo` so agent comments do not implicitly reopen closed issues) is **already in upstream `master`** via a stricter form. No code change is needed in `routes/issues.ts` for that path; the rebase confirmed the original A diff is redundant.

## Verification

```
pnpm exec vitest run --project @paperclipai/server \
  server/src/__tests__/issue-comment-reopen-routes.test.ts \
  server/src/__tests__/heartbeat-comment-wake-batching.test.ts \
  server/src/__tests__/heartbeat-dependency-scheduling.test.ts \
  server/src/__tests__/heartbeat-retry-scheduling.test.ts \
  server/src/__tests__/heartbeat-process-recovery.test.ts \
  server/src/__tests__/issue-comment-cancel-routes.test.ts \
  server/src/__tests__/issue-thread-interaction-routes.test.ts
# 81/81 passed
```

Manual reproduction against a patched build: agent A PATCHes a `done` issue with a non-empty comment; agent B (a non-assignee participant) receives the `issue_commented` wake and runs a heartbeat; verify the issue's status remains `done` and `activityLog` has no entry with `source: "deferred_comment_wake"`. Board/user comments on the same `done` issue continue to implicitly reopen via the routes path (upstream A behavior, unchanged).

## Risks

- This expands #4383's recent partial guard (user-actor branch on deferred wake) into a full removal. If reviewers prefer to keep user-authored deferred wakes capable of reopening, push back — upstream's path A in `routes/issues.ts` already covers the LEV-59 loop for agent-authored comments. The argument for the full removal is principled separation, not loop-prevention.
- Removing the `executionState: null` side effect on wake promotion: no consumers found in the skill/harness, but please check your own forks before merging.
- Behavioral surface is internal to the deferred wake promotion code path. Agents that need to reopen closed issues continue to do so via the explicit `reopen: true` flag on the routes path (already supported).

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7, 1M context window (model ID `claude-opus-4-7[1m]`)
- Capabilities used: tool use (file edit, shell, gh CLI), extended-context reasoning over the bundled `@paperclipai/server` source for root-cause analysis
- Harness: Claude Code SDK running inside the Paperclip heartbeat runner (agent role: Hardison, internal id `0837f706-2660-4ce6-be30-bd2740d8948f`)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only change
- [ ] I have updated relevant documentation to reflect my changes — no doc changes required; behavior change is captured in the PR body and risks
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

## Origin

Internal tracking: LEV-73 (RCA), LEV-74 (this implementation), board approval 1ae21a18. PR was rebased onto upstream `master` after upstream landed path A independently — original commit 30521174 reduced to e7465c2e (path B + tests).