### PR TITLE
feat(server): inbox-lite assignmentOutcome + timer PAPERCLIP_ASSIGNMENT_OUTCOME_JSON (GST-84)

### DIFF
--- a/server/src/lib/wake-assignment-outcome.test.ts
+++ b/server/src/lib/wake-assignment-outcome.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  ASSIGNMENT_OUTCOME_SCHEMA_VERSION,
+  computeSharedInboxLiteAssignmentOutcome,
+  enforceNonEmptyRetryWakeResult,
+  evaluateWakeAssignment,
+  issuesToWakeCandidates,
+  parseWakeGuardrailResultJson,
+  serializeWakeGuardrailResult,
+} from "./wake-assignment-outcome.js";
+
+describe("wake-assignment-outcome", () => {
+  it("serializes and parses roundtrip", () => {
+    const original = evaluateWakeAssignment({
+      retryAttempt: 0,
+      maxRetries: 2,
+      candidates: [{ issueId: "a", assigneeAgentId: "agent-1" }],
+    });
+    const json = serializeWakeGuardrailResult(original);
+    expect(parseWakeGuardrailResultJson(json)).toEqual(original);
+  });
+
+  it("computes shared inbox outcome with deterministic ordering", () => {
+    const dep = new Map([
+      ["i1", { unresolvedBlockerIssueIds: [] as string[] }],
+      ["i2", { unresolvedBlockerIssueIds: [] as string[] }],
+    ]);
+    const outcome = computeSharedInboxLiteAssignmentOutcome({
+      rows: [
+        { id: "i2", status: "todo", assigneeAgentId: "a2" },
+        { id: "i1", status: "todo", assigneeAgentId: "a1" },
+      ],
+      dependencyReadiness: dep,
+      blockerAssigneeByIssueId: new Map(),
+      retryAttempt: 0,
+      maxRetries: 3,
+    });
+    expect(outcome.kind).toBe("issue_assigned");
+    if (outcome.kind === "issue_assigned") {
+      expect(outcome.issueId).toBe("i1");
+      expect(outcome.assigneeAgentId).toBe("a1");
+    }
+  });
+
+  it("maps blocked issues to blockedByOwnerId from dependency owners", () => {
+    const dep = new Map([["blocked-1", { unresolvedBlockerIssueIds: ["blocker-x"] }]]);
+    const candidates = issuesToWakeCandidates(
+      [{ id: "blocked-1", status: "blocked", assigneeAgentId: null }],
+      dep,
+      new Map([["blocker-x", "owner-agent"]]),
+    );
+    expect(candidates[0]?.blockedByOwnerId).toBe("owner-agent");
+    const outcome = evaluateWakeAssignment({
+      retryAttempt: 0,
+      maxRetries: 1,
+      candidates,
+    });
+    expect(outcome.kind).toBe("blocked_with_owner");
+  });
+
+  it("enforceNonEmptyRetryWakeResult covers null", () => {
+    const r = enforceNonEmptyRetryWakeResult(null, 2);
+    expect(r.schemaVersion).toBe(ASSIGNMENT_OUTCOME_SCHEMA_VERSION);
+    expect(r.kind).toBe("idle_with_reason");
+  });
+});

--- a/server/src/lib/wake-assignment-outcome.ts
+++ b/server/src/lib/wake-assignment-outcome.ts
@@ -1,0 +1,371 @@
+/**
+ * Wake assignment guardrail parity with Meetery `wakeGuardrail` (GST-77 / GST-80 / GST-84).
+ * Used for inbox-lite `assignmentOutcome` and `PAPERCLIP_ASSIGNMENT_OUTCOME_JSON` on timer wakes.
+ */
+import { and, eq, inArray } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { issues } from "@paperclipai/db";
+
+export const ASSIGNMENT_OUTCOME_SCHEMA_VERSION = 1 as const;
+
+export type CharterParentRef = {
+  id: string;
+  identifier: string;
+  title: string;
+};
+
+export type RoutineProjectionInput = {
+  nextRunAt: string;
+  routineId?: string;
+};
+
+export type WakeAssignmentCandidate = {
+  issueId: string;
+  assigneeAgentId?: string | null;
+  blockedByOwnerId?: string | null;
+  blockedReason?: string | null;
+};
+
+export type WakePolicyInput = {
+  retryAttempt: number;
+  maxRetries: number;
+  candidates: WakeAssignmentCandidate[];
+  routine?: RoutineProjectionInput | null;
+  charterParent?: CharterParentRef | null;
+};
+
+export type WakeGuardrailResult =
+  | {
+      schemaVersion: typeof ASSIGNMENT_OUTCOME_SCHEMA_VERSION;
+      kind: "issue_assigned";
+      issueId: string;
+      assigneeAgentId: string;
+      reason: string;
+      userVisible: string;
+    }
+  | {
+      schemaVersion: typeof ASSIGNMENT_OUTCOME_SCHEMA_VERSION;
+      kind: "blocked_with_owner";
+      issueId: string;
+      blockedByOwnerId: string;
+      reason: string;
+      userVisible: string;
+    }
+  | {
+      schemaVersion: typeof ASSIGNMENT_OUTCOME_SCHEMA_VERSION;
+      kind: "idle_with_reason";
+      reason: string;
+      userVisible: string;
+      nextRoutineAt?: string;
+      routineId?: string;
+      charterParent?: CharterParentRef;
+    };
+
+export type EnforceRetryWakeOptions = {
+  routine?: RoutineProjectionInput | null;
+  charterParent?: CharterParentRef | null;
+};
+
+function normalizeReason(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isViableCandidate(candidate: WakeAssignmentCandidate): boolean {
+  return Boolean(candidate.assigneeAgentId) || Boolean(candidate.blockedByOwnerId);
+}
+
+function selectDeterministicCandidate(
+  candidates: WakeAssignmentCandidate[],
+): WakeAssignmentCandidate | null {
+  const viable = candidates.filter(isViableCandidate);
+  if (viable.length === 0) return null;
+  const ordered = [...viable].sort((a, b) => a.issueId.localeCompare(b.issueId));
+  return ordered[0] ?? null;
+}
+
+function charterSentence(parent: CharterParentRef): string {
+  return `Parent charter: ${parent.identifier} — ${parent.title}.`;
+}
+
+function buildIdleUserVisible(params: {
+  idleKind: "empty_inbox" | "retry_exhausted" | "integrity";
+  retryAttempt?: number;
+  routine?: RoutineProjectionInput | null;
+  charterParent?: CharterParentRef | null;
+}): string {
+  const { idleKind, retryAttempt, routine, charterParent } = params;
+  const sentences: string[] = [];
+
+  if (idleKind === "integrity") {
+    sentences.push(
+      "Recovered an empty wake assignment from the guardrail integrity path. If this repeats across heartbeats, capture logs and escalate to support.",
+    );
+    if (typeof retryAttempt === "number") {
+      sentences.push(`Retry attempt index: ${retryAttempt}.`);
+    }
+  } else if (idleKind === "retry_exhausted") {
+    sentences.push(
+      "No assignable issue remained after exhausting the empty-inbox retry budget for this wake.",
+    );
+  } else {
+    sentences.push(
+      "No open assigned issues are available in this heartbeat's inbox candidate list.",
+    );
+  }
+
+  if (routine?.nextRunAt) {
+    sentences.push(`Next routine heartbeat is scheduled for ${routine.nextRunAt} (UTC).`);
+  } else if (idleKind !== "integrity") {
+    sentences.push(
+      "No routine enqueue time is on record for this agent (intentional idle until configuration changes).",
+    );
+  }
+
+  if (charterParent) {
+    sentences.push(charterSentence(charterParent));
+  }
+
+  return sentences.join(" ");
+}
+
+export function evaluateWakeAssignment(input: WakePolicyInput): WakeGuardrailResult {
+  const candidate = selectDeterministicCandidate(input.candidates);
+  if (candidate?.assigneeAgentId) {
+    const issueId = candidate.issueId;
+    return {
+      schemaVersion: ASSIGNMENT_OUTCOME_SCHEMA_VERSION,
+      kind: "issue_assigned",
+      issueId,
+      assigneeAgentId: candidate.assigneeAgentId,
+      reason: "candidate contains an assigned agent",
+      userVisible: `Assigned issue ${issueId} is the next unit of work to execute for this agent.`,
+    };
+  }
+
+  if (candidate?.blockedByOwnerId) {
+    const human =
+      normalizeReason(candidate.blockedReason) ??
+      "candidate is blocked and has an explicit owner";
+    return {
+      schemaVersion: ASSIGNMENT_OUTCOME_SCHEMA_VERSION,
+      kind: "blocked_with_owner",
+      issueId: candidate.issueId,
+      blockedByOwnerId: candidate.blockedByOwnerId,
+      reason: human,
+      userVisible: `Issue ${candidate.issueId} is blocked; unblock owner is ${candidate.blockedByOwnerId}. ${human}`,
+    };
+  }
+
+  const saturatedRetries = input.retryAttempt >= input.maxRetries;
+  const reason = saturatedRetries
+    ? "retry budget exhausted without assignable or owned-blocked work"
+    : "no assignable issues in this retry cycle";
+
+  const userVisible = buildIdleUserVisible({
+    idleKind: saturatedRetries ? "retry_exhausted" : "empty_inbox",
+    routine: input.routine,
+    charterParent: input.charterParent,
+  });
+
+  return {
+    schemaVersion: ASSIGNMENT_OUTCOME_SCHEMA_VERSION,
+    kind: "idle_with_reason",
+    reason,
+    userVisible,
+    ...(input.routine?.nextRunAt
+      ? {
+          nextRoutineAt: input.routine.nextRunAt,
+          ...(input.routine.routineId ? { routineId: input.routine.routineId } : {}),
+        }
+      : {}),
+    ...(input.charterParent ? { charterParent: input.charterParent } : {}),
+  };
+}
+
+export function enforceNonEmptyRetryWakeResult(
+  maybeResult: WakeGuardrailResult | null | undefined,
+  retryAttempt: number,
+  options?: EnforceRetryWakeOptions,
+): WakeGuardrailResult {
+  if (maybeResult) return maybeResult;
+  const reason = `integrity guard: empty wake result recovered at retry ${retryAttempt}`;
+  return {
+    schemaVersion: ASSIGNMENT_OUTCOME_SCHEMA_VERSION,
+    kind: "idle_with_reason",
+    reason,
+    userVisible: buildIdleUserVisible({
+      idleKind: "integrity",
+      retryAttempt,
+      routine: options?.routine,
+      charterParent: options?.charterParent,
+    }),
+    ...(options?.routine?.nextRunAt
+      ? {
+          nextRoutineAt: options.routine.nextRunAt,
+          ...(options.routine.routineId ? { routineId: options.routine.routineId } : {}),
+        }
+      : {}),
+    ...(options?.charterParent ? { charterParent: options.charterParent } : {}),
+  };
+}
+
+export function serializeWakeGuardrailResult(result: WakeGuardrailResult): string {
+  return JSON.stringify(result);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseWakeGuardrailResultJson(raw: string): WakeGuardrailResult | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    if (parsed.schemaVersion !== ASSIGNMENT_OUTCOME_SCHEMA_VERSION) return null;
+    const kind = parsed.kind;
+    if (kind === "issue_assigned") {
+      if (
+        typeof parsed.issueId === "string" &&
+        typeof parsed.assigneeAgentId === "string" &&
+        typeof parsed.reason === "string" &&
+        typeof parsed.userVisible === "string"
+      ) {
+        return parsed as WakeGuardrailResult;
+      }
+      return null;
+    }
+    if (kind === "blocked_with_owner") {
+      if (
+        typeof parsed.issueId === "string" &&
+        typeof parsed.blockedByOwnerId === "string" &&
+        typeof parsed.reason === "string" &&
+        typeof parsed.userVisible === "string"
+      ) {
+        return parsed as WakeGuardrailResult;
+      }
+      return null;
+    }
+    if (kind === "idle_with_reason") {
+      if (typeof parsed.reason === "string" && typeof parsed.userVisible === "string") {
+        return parsed as WakeGuardrailResult;
+      }
+      return null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export type InboxLiteIssueRow = {
+  id: string;
+  status: string;
+  assigneeAgentId: string | null;
+};
+
+export type IssueDependencyReadinessLite = {
+  unresolvedBlockerIssueIds?: string[];
+};
+
+export function issuesToWakeCandidates(
+  rows: InboxLiteIssueRow[],
+  dependencyReadiness: Map<string, IssueDependencyReadinessLite>,
+  blockerAssigneeByIssueId: ReadonlyMap<string, string | null>,
+): WakeAssignmentCandidate[] {
+  return rows.map((row) => {
+    const dep = dependencyReadiness.get(row.id);
+    const blockerIds = dep?.unresolvedBlockerIssueIds ?? [];
+    let blockedByOwnerId: string | null = null;
+    let blockedReason: string | null = null;
+    if (row.status === "blocked" && blockerIds.length > 0) {
+      const ordered = [...blockerIds].sort((a, b) => a.localeCompare(b));
+      for (const bid of ordered) {
+        const owner = blockerAssigneeByIssueId.get(bid) ?? null;
+        if (owner) {
+          blockedByOwnerId = owner;
+          blockedReason = "blocked by unresolved dependency with assignee owner";
+          break;
+        }
+      }
+    }
+    return {
+      issueId: row.id,
+      assigneeAgentId: row.assigneeAgentId,
+      blockedByOwnerId,
+      blockedReason,
+    };
+  });
+}
+
+export function defaultInboxLiteRetryWindow(): { retryAttempt: number; maxRetries: number } {
+  return { retryAttempt: 0, maxRetries: 3 };
+}
+
+export function resolveRetryWindowFromWakeContext(context: Record<string, unknown>): {
+  retryAttempt: number;
+  maxRetries: number;
+} {
+  const def = defaultInboxLiteRetryWindow();
+  const attemptRaw = context.emptyInboxWakeRetryAttempt ?? context.retryAttempt;
+  const maxRaw = context.emptyInboxWakeRetryMax ?? context.maxRetries;
+  const retryAttempt =
+    typeof attemptRaw === "number" && Number.isFinite(attemptRaw)
+      ? Math.max(0, Math.trunc(attemptRaw))
+      : def.retryAttempt;
+  const maxRetries =
+    typeof maxRaw === "number" && Number.isFinite(maxRaw) ? Math.max(0, Math.trunc(maxRaw)) : def.maxRetries;
+  return { retryAttempt, maxRetries };
+}
+
+export async function fetchAssigneesForIssueIds(
+  db: Db,
+  companyId: string,
+  ids: string[],
+): Promise<Map<string, string | null>> {
+  const map = new Map<string, string | null>();
+  if (ids.length === 0) return map;
+  const rows = await db
+    .select({ id: issues.id, assigneeAgentId: issues.assigneeAgentId })
+    .from(issues)
+    .where(and(eq(issues.companyId, companyId), inArray(issues.id, ids)));
+  for (const row of rows) {
+    map.set(row.id, row.assigneeAgentId);
+  }
+  return map;
+}
+
+export function collectUnresolvedBlockerIds(
+  dependencyReadiness: Map<string, IssueDependencyReadinessLite>,
+): string[] {
+  const out = new Set<string>();
+  for (const dep of dependencyReadiness.values()) {
+    for (const id of dep.unresolvedBlockerIssueIds ?? []) {
+      out.add(id);
+    }
+  }
+  return [...out];
+}
+
+export function computeSharedInboxLiteAssignmentOutcome(input: {
+  rows: InboxLiteIssueRow[];
+  dependencyReadiness: Map<string, IssueDependencyReadinessLite>;
+  blockerAssigneeByIssueId: ReadonlyMap<string, string | null>;
+  retryAttempt: number;
+  maxRetries: number;
+}): WakeGuardrailResult {
+  const candidates = issuesToWakeCandidates(
+    input.rows,
+    input.dependencyReadiness,
+    input.blockerAssigneeByIssueId,
+  );
+  return enforceNonEmptyRetryWakeResult(
+    evaluateWakeAssignment({
+      retryAttempt: input.retryAttempt,
+      maxRetries: input.maxRetries,
+      candidates,
+    }),
+    input.retryAttempt,
+  );
+}

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -79,6 +79,11 @@ import {
   resolveDefaultAgentInstructionsBundleRole,
 } from "../services/default-agent-instructions.js";
 import { getTelemetryClient } from "../telemetry.js";
+import {
+  collectUnresolvedBlockerIds,
+  computeSharedInboxLiteAssignmentOutcome,
+  fetchAssigneesForIssueIds,
+} from "../lib/wake-assignment-outcome.js";
 import { assertEnvironmentSelectionForCompany } from "./environment-selection.js";
 
 const RUN_LOG_DEFAULT_LIMIT_BYTES = 256_000;
@@ -1213,6 +1218,21 @@ export function agentRoutes(db: Db) {
       rows.map((issue) => issue.id),
     );
 
+    const blockerIds = collectUnresolvedBlockerIds(dependencyReadiness);
+    const blockerAssignees = await fetchAssigneesForIssueIds(db, req.actor.companyId, blockerIds);
+    const rowLite = rows.map((issue) => ({
+      id: issue.id,
+      status: issue.status,
+      assigneeAgentId: issue.assigneeAgentId,
+    }));
+    const assignmentOutcome = computeSharedInboxLiteAssignmentOutcome({
+      rows: rowLite,
+      dependencyReadiness,
+      blockerAssigneeByIssueId: blockerAssignees,
+      retryAttempt: 0,
+      maxRetries: 3,
+    });
+
     res.json(
       rows.map((issue) => ({
         id: issue.id,
@@ -1228,6 +1248,7 @@ export function agentRoutes(db: Db) {
         dependencyReady: dependencyReadiness.get(issue.id)?.isDependencyReady ?? true,
         unresolvedBlockerCount: dependencyReadiness.get(issue.id)?.unresolvedBlockerCount ?? 0,
         unresolvedBlockerIssueIds: dependencyReadiness.get(issue.id)?.unresolvedBlockerIssueIds ?? [],
+        assignmentOutcome,
       })),
     );
   });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -86,7 +86,14 @@ import {
   type RealizedExecutionWorkspace,
   sanitizeRuntimeServiceBaseEnv,
 } from "./workspace-runtime.js";
-import { issueService } from "./issues.js";
+import {
+  collectUnresolvedBlockerIds,
+  computeSharedInboxLiteAssignmentOutcome,
+  fetchAssigneesForIssueIds,
+  resolveRetryWindowFromWakeContext,
+  serializeWakeGuardrailResult,
+} from "../lib/wake-assignment-outcome.js";
+import { issueService, ISSUE_LIST_DEFAULT_LIMIT } from "./issues.js";
 import {
   ISSUE_TREE_CONTROL_INTERACTION_WAKE_REASONS,
   issueTreeControlService,
@@ -5713,6 +5720,47 @@ export function heartbeatService(db: Db) {
           (entry): entry is [string, string] => typeof entry[0] === "string" && typeof entry[1] === "string",
         ),
       );
+      const wakeReasonForOutcome = readNonEmptyString(context.wakeReason);
+      if (wakeReasonForOutcome === "heartbeat_timer") {
+        try {
+          const { retryAttempt, maxRetries } = resolveRetryWindowFromWakeContext(context);
+          const inboxRows = await issuesSvc.list(agent.companyId, {
+            assigneeAgentId: agent.id,
+            status: "todo,in_progress,blocked",
+            includeRoutineExecutions: true,
+            limit: ISSUE_LIST_DEFAULT_LIMIT,
+          });
+          const rowLite = inboxRows.map((row) => ({
+            id: row.id,
+            status: row.status,
+            assigneeAgentId: row.assigneeAgentId,
+          }));
+          const depMap = await issuesSvc.listDependencyReadiness(
+            agent.companyId,
+            rowLite.map((r) => r.id),
+          );
+          const blockerIds = collectUnresolvedBlockerIds(depMap);
+          const blockerAssignees = await fetchAssigneesForIssueIds(db, agent.companyId, blockerIds);
+          const outcome = computeSharedInboxLiteAssignmentOutcome({
+            rows: rowLite,
+            dependencyReadiness: depMap,
+            blockerAssigneeByIssueId: blockerAssignees,
+            retryAttempt,
+            maxRetries,
+          });
+          adapterEnv.PAPERCLIP_ASSIGNMENT_OUTCOME_JSON = serializeWakeGuardrailResult(outcome);
+        } catch (err) {
+          logger.warn(
+            {
+              err,
+              runId: run.id,
+              agentId: agent.id,
+              companyId: agent.companyId,
+            },
+            "failed to compute PAPERCLIP_ASSIGNMENT_OUTCOME_JSON for heartbeat_timer",
+          );
+        }
+      }
       const runtimeServices = await ensureRuntimeServicesForRun({
         db,
         runId: run.id,


### PR DESCRIPTION
## Summary

Implements the **GST-84** platform slice for GST-77: wake guardrail parity with the Meetery client contract, inbox-lite visibility, and adapter env wiring for scheduled timer wakes.

### Changes
- **`server/src/lib/wake-assignment-outcome.ts`**: `evaluateWakeAssignment`, `serializeWakeGuardrailResult` / `parseWakeGuardrailResultJson`, `issuesToWakeCandidates`, dependency-blocker assignee lookup, retry window helpers.
- **`GET /api/agents/me/inbox-lite`**: each row includes additive **`assignmentOutcome`** (one shared evaluation from the full inbox candidate list; same filters as today).
- **`heartbeat_timer`**: after base adapter env is built from config and **before** `ensureRuntimeServicesForRun`, lists the same inbox slice and sets **`PAPERCLIP_ASSIGNMENT_OUTCOME_JSON`**. Failures are logged and do not fail the run.
- **Tests**: `server/src/lib/wake-assignment-outcome.test.ts` (Vitest).

### Verification
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run server/src/lib/wake-assignment-outcome.test.ts`

### Paperclip / Meetery refs
- Parent narrative: **GST-84** / **GST-88** (release publish path)
- Acceptance umbrella: **GST-77** (QA on live timer wake + field)

cc @paperclipai/maintainers — upstream push for `meetery-company` was not permitted; this PR is from fork **`meetery-company/paperclip`**, branch `release/gst-84-inbox-assignment-outcome`.

Made with [Cursor](https://cursor.com)