### PR TITLE
[codex] Fix issue detail mount refetch

### DIFF
--- a/ui/src/lib/issueDetailCache.test.ts
+++ b/ui/src/lib/issueDetailCache.test.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import type { Issue } from "@paperclipai/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { issuesApi } from "@/api/issues";
@@ -103,5 +103,31 @@ describe("issueDetailCache", () => {
     expect(result).toEqual(issue);
     expect(queryClient.getQueryData(queryKeys.issues.detail(issue.identifier!))).toEqual(issue);
     expect(queryClient.getQueryData(queryKeys.issues.detail(issue.id))).toEqual(issue);
+  });
+
+  it("refetches the authoritative issue detail on mount even when a prefetched snapshot exists", async () => {
+    const prefetchedIssue = createIssue({ title: "Prefetched snapshot" });
+    const refreshedIssue = createIssue({ title: "Fresh detail payload" });
+    await prefetchIssueDetail(queryClient, prefetchedIssue.identifier!, { issue: prefetchedIssue });
+    vi.mocked(issuesApi.get).mockResolvedValue(refreshedIssue);
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: queryKeys.issues.detail(prefetchedIssue.identifier!),
+      queryFn: () => fetchIssueDetail(queryClient, prefetchedIssue.identifier!),
+      initialData: () => getCachedIssueDetail(queryClient, prefetchedIssue.identifier!, prefetchedIssue),
+      staleTime: 30_000,
+      refetchOnMount: "always",
+    });
+
+    const unsubscribe = observer.subscribe(() => {});
+
+    await vi.waitFor(() => {
+      expect(issuesApi.get).toHaveBeenCalledWith(prefetchedIssue.identifier!);
+    });
+
+    expect(queryClient.getQueryData(queryKeys.issues.detail(prefetchedIssue.identifier!))).toEqual(refreshedIssue);
+    expect(queryClient.getQueryData(queryKeys.issues.detail(prefetchedIssue.id))).toEqual(refreshedIssue);
+
+    unsubscribe();
   });
 });

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -898,6 +898,7 @@ export function IssueDetail() {
     queryFn: () => fetchIssueDetail(queryClient, issueId!),
     enabled: !!issueId,
     initialData: () => cachedIssue,
+    refetchOnMount: "always",
   });
   const resolvedCompanyId = issue?.companyId ?? selectedCompanyId;
   const commentComposerDisabledReason = useMemo(() => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane UI for operating agent companies and issue detail is one of the primary operator workflows.
> - The affected subsystem is the board frontend issue detail screen, which mixes cached navigation state with live API-backed issue data.
> - Issue links and quicklook prefetch seed the React Query cache before the detail page mounts.
> - The UI QueryClient defaults to a 30 second stale window, so the mounted issue detail query could treat the prefetched snapshot as fresh and skip `GET /api/issues/:id` entirely.
> - That behavior leaves the screen dependent on opportunistic cache state instead of always hydrating the authoritative issue payload when a user opens the page.
> - This pull request forces a mount-time refetch for the issue detail query while preserving the instant cached render, and adds a regression test for the prefetched-cache path.
> - The benefit is that frontend navigation remains fast, but opening an issue now reliably calls the API and refreshes the page state.

## What Changed

- Set the issue detail page query to `refetchOnMount: "always"` so opening an issue always fetches the authoritative `/api/issues/:id` payload even when cache was seeded by prefetch.
- Added a regression test that starts from a prefetched issue snapshot and verifies the detail query still performs the API refetch on mount.

## Verification

- `pnpm vitest run ui/src/lib/issueDetailCache.test.ts`
- `pnpm --filter @paperclipai/ui exec tsc --noEmit`
- `pnpm --filter @paperclipai/ui build`
- No before/after screenshots: this is a mount/refetch behavior fix with no visual UI delta.

## Risks

- Low risk. The change is scoped to the issue detail query and only adds the expected authoritative fetch on mount; the main tradeoff is one additional issue-detail GET when opening the page from a warm prefetched cache.

## Model Used

- OpenAI Codex, GPT-5-based coding agent in the Codex environment with terminal command execution, patch application, and repo inspection tools. Exact deployment model ID is not exposed in-session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
