### PR TITLE
fix(heartbeat): exempt standing rollup issues from auto-block

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -18,6 +18,7 @@ import {
   issueDocuments,
   issueRelations,
   issues,
+  routines,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -323,6 +324,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
+    await db.delete(routines);
     for (let attempt = 0; attempt < 5; attempt += 1) {
       await db.delete(agentRuntimeState);
       try {
@@ -758,6 +760,43 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("retried continuation");
+  });
+
+  it("does not block a standing rollup issue during terminal-run release when recovery also fails", async () => {
+    mockAdapterExecute.mockRejectedValueOnce(new Error("continuation recovery failed"));
+
+    const { agentId, companyId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: 999_999_999,
+      processLossRetryCount: 1,
+    });
+    await db.insert(routines).values({
+      id: randomUUID(),
+      companyId,
+      parentIssueId: issueId,
+      title: "Daily standing rollup",
+      assigneeAgentId: agentId,
+      status: "active",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const finalIssue = await waitForValue(async () => {
+      const rows = await db.select().from(issues).where(eq(issues.id, issueId));
+      const issue = rows[0] ?? null;
+      return issue && issue.executionRunId === null ? issue : null;
+    });
+    expect(finalIssue?.status).toBe("in_progress");
+    expect(finalIssue?.executionRunId).toBeNull();
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments.filter((c) => c.body.includes("Moving it to `blocked`"))).toHaveLength(0);
+
+    const auditEntries = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
+    expect(auditEntries.some((entry) => entry.action === "issue.auto_block_skipped_standing_rollup")).toBe(true);
   });
 
   it("schedules a bounded retry for codex transient upstream failures instead of blocking the issue immediately", async () => {
@@ -1211,6 +1250,91 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("retried continuation");
     expect(comments[0]?.body).toContain("Latest retry failure: `process_lost` - run failed before issue advanced.");
+  });
+
+  it("skips auto-block for standing rollup in-progress issues that parent an active routine", async () => {
+    const { agentId, companyId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db.insert(routines).values({
+      id: randomUUID(),
+      companyId,
+      parentIssueId: issueId,
+      title: "Daily standing rollup",
+      assigneeAgentId: agentId,
+      status: "active",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.standingRollupSkipped).toBe(1);
+    expect(result.issueIds).not.toContain(issueId);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+
+    const auditEntries = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(auditEntries.some((entry) => entry.action === "issue.auto_block_skipped_standing_rollup")).toBe(true);
+  });
+
+  it("skips auto-block for standing rollup todo issues that parent an active routine", async () => {
+    const { agentId, companyId, issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+    });
+    await db.insert(routines).values({
+      id: randomUUID(),
+      companyId,
+      parentIssueId: issueId,
+      title: "Daily standing rollup",
+      assigneeAgentId: agentId,
+      status: "active",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.standingRollupSkipped).toBe(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
+
+  it("still blocks stranded work when the only matching routine is paused", async () => {
+    const { agentId, companyId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db.insert(routines).values({
+      id: randomUUID(),
+      companyId,
+      parentIssueId: issueId,
+      title: "Paused rollup",
+      assigneeAgentId: agentId,
+      status: "paused",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.standingRollupSkipped).toBe(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
   });
 
   it("re-enqueues continuation when the latest automatic continuation succeeded without closing the issue", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -38,6 +38,7 @@ import {
   issueWorkProducts,
   projects,
   projectWorkspaces,
+  routines,
   workspaceOperations,
 } from "@paperclipai/db";
 import { conflict, HttpError, notFound } from "../errors.js";
@@ -4031,6 +4032,16 @@ export function heartbeatService(db: Db) {
       .then((rows) => rows[0] ?? null);
   }
 
+  async function isStandingRollupIssue(issueId: string) {
+    const row = await db
+      .select({ id: routines.id })
+      .from(routines)
+      .where(and(eq(routines.parentIssueId, issueId), eq(routines.status, "active")))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    return Boolean(row);
+  }
+
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
     const [run, deferredWake] = await Promise.all([
       db
@@ -4246,6 +4257,33 @@ export function heartbeatService(db: Db) {
     return { assigned, skipped, issueIds };
   }
 
+  async function recordStandingRollupAutoBlockSkip(input: {
+    issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "identifier">;
+    previousStatus: "todo" | "in_progress";
+    latestRun: Pick<typeof heartbeatRuns.$inferSelect, "id" | "status" | "errorCode"> | null;
+    source: string;
+  }) {
+    await logActivity(db, {
+      companyId: input.issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: null,
+      action: "issue.auto_block_skipped_standing_rollup",
+      entityType: "issue",
+      entityId: input.issue.id,
+      details: {
+        identifier: input.issue.identifier,
+        previousStatus: input.previousStatus,
+        source: input.source,
+        reason: "standing_rollup_issue",
+        latestRunId: input.latestRun?.id ?? null,
+        latestRunStatus: input.latestRun?.status ?? null,
+        latestRunErrorCode: input.latestRun?.errorCode ?? null,
+      },
+    });
+  }
+
   async function escalateStrandedAssignedIssue(input: {
     issue: typeof issues.$inferSelect;
     previousStatus: "todo" | "in_progress";
@@ -4303,6 +4341,7 @@ export function heartbeatService(db: Db) {
       orphanBlockersAssigned: 0,
       escalated: 0,
       skipped: 0,
+      standingRollupSkipped: 0,
       issueIds: [] as string[],
     };
 
@@ -4336,6 +4375,16 @@ export function heartbeatService(db: Db) {
         }
 
         if (didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
+          if (await isStandingRollupIssue(issue.id)) {
+            await recordStandingRollupAutoBlockSkip({
+              issue,
+              previousStatus: "todo",
+              latestRun,
+              source: "heartbeat.reconcile_stranded_assigned_issue",
+            });
+            result.standingRollupSkipped += 1;
+            continue;
+          }
           const failureSummary = summarizeRunFailureForIssueComment(latestRun);
           const updated = await escalateStrandedAssignedIssue({
             issue,
@@ -4377,6 +4426,16 @@ export function heartbeatService(db: Db) {
         continue;
       }
       if (didAutomaticRecoveryFail(latestRun, "issue_continuation_needed")) {
+        if (await isStandingRollupIssue(issue.id)) {
+          await recordStandingRollupAutoBlockSkip({
+            issue,
+            previousStatus: "in_progress",
+            latestRun,
+            source: "heartbeat.reconcile_stranded_assigned_issue",
+          });
+          result.standingRollupSkipped += 1;
+          continue;
+        }
         const failureSummary = summarizeRunFailureForIssueComment(latestRun);
         const updated = await escalateStrandedAssignedIssue({
           issue,
@@ -6415,6 +6474,21 @@ export function heartbeatService(db: Db) {
         !recoveryAgent ||
         didAutomaticRecoveryFail(run, issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed");
       if (shouldBlockImmediately) {
+        const standingRollup = await tx
+          .select({ id: routines.id })
+          .from(routines)
+          .where(and(eq(routines.parentIssueId, issue.id), eq(routines.status, "active")))
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (standingRollup) {
+          return {
+            kind: "released_standing_rollup" as const,
+            issueId: issue.id,
+            issueIdentifier: issue.identifier,
+            previousStatus: issue.status as "todo" | "in_progress",
+            latestRun: run,
+          };
+        }
         const comment = buildImmediateExecutionPathRecoveryComment({
           status: issue.status as "todo" | "in_progress",
           latestRun: run,
@@ -6528,6 +6602,20 @@ export function heartbeatService(db: Db) {
           latestRunStatus: run.status,
           latestRunErrorCode: run.errorCode ?? null,
         },
+      });
+      return;
+    }
+
+    if (promotionResult?.kind === "released_standing_rollup") {
+      await recordStandingRollupAutoBlockSkip({
+        issue: {
+          id: promotionResult.issueId,
+          companyId: run.companyId,
+          identifier: promotionResult.issueIdentifier,
+        },
+        previousStatus: promotionResult.previousStatus,
+        latestRun: promotionResult.latestRun,
+        source: "heartbeat.release_issue_execution_and_promote",
       });
       return;
     }


### PR DESCRIPTION
## Summary

Fix for TEL-59 — the 6-hour blocker sweep was auto-moving standing rollup issues (routine parent log issues) to `blocked` every cycle because their assigned agent has no live execution path between routine fires. Each cycle required a manual CEO clear + restart-note comment.

An issue is now treated as a standing rollup when it is the `parentIssueId` of an `active` routine. In both paths that escalate stranded assigned issues to `blocked`:

1. `reconcileStrandedAssignedIssues` (the periodic sweep)
2. `releaseIssueExecutionAndPromote` (the terminal-run release path)

…the exemption short-circuits the block, leaves the issue in its current `todo`/`in_progress` state, and records an audit entry under `issue.auto_block_skipped_standing_rollup` for observability. Paused or deleted routines don't trigger the exemption.

The sweep result object now exposes a `standingRollupSkipped` counter for heartbeat telemetry.

## Why routine-parent (not labels)

Label-based allowlist was the cheapest-ship option flagged in the ticket, but routine-parent is zero-config and matches the observed failure exactly (TEL-30, the parent of the `Daily skill usage audit` routine). No migration, no label naming debate, no "I forgot the label" re-occurrences. If we later need exemption for hand-rolled rollup issues without a routine, adding a label check on top is additive.

## Test plan

- [x] `server/src/__tests__/heartbeat-process-recovery.test.ts` — 3 new positive tests (sweep `in_progress`, sweep `todo`, release path) and 1 negative test (paused routine still blocks)
- [x] Full file still passes: `npx vitest run src/__tests__/heartbeat-process-recovery.test.ts` → 22/22