### PR TITLE
Normalize plugin SQL helper naming

### DIFF
--- a/server/src/services/plugin-database.ts
+++ b/server/src/services/plugin-database.ts
@@ -117,7 +117,7 @@ function stripSqlForKeywordScan(input: string): string {
     .replace(/\/\*[\s\S]*?\*\//g, "");
 }
 
-function normaliseSql(input: string): string {
+function normalizeSql(input: string): string {
   return stripSqlForKeywordScan(input).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
@@ -150,7 +150,7 @@ function assertAllowedPublicRead(
 }
 
 function assertNoBannedSql(statement: string): void {
-  const normalized = normaliseSql(statement);
+  const normalized = normalizeSql(statement);
   const banned = [
     /\bcreate\s+extension\b/,
     /\bcreate\s+(?:event\s+)?trigger\b/,
@@ -177,7 +177,7 @@ export function validatePluginMigrationStatement(
   assertIdentifier(namespace, "namespace");
   assertNoBannedSql(statement);
 
-  const normalized = normaliseSql(statement);
+  const normalized = normalizeSql(statement);
   if (/^\s*(drop|truncate)\b/.test(normalized)) {
     throw new Error("Destructive plugin migrations are not allowed in Phase 1");
   }
@@ -214,7 +214,7 @@ export function validatePluginRuntimeQuery(
   }
   const statement = statements[0]!;
   assertNoBannedSql(statement);
-  const normalized = normaliseSql(statement);
+  const normalized = normalizeSql(statement);
   if (!normalized.startsWith("select ") && !normalized.startsWith("with ")) {
     throw new Error("ctx.db.query only allows SELECT statements");
   }
@@ -240,7 +240,7 @@ export function validatePluginRuntimeExecute(query: string, namespace: string): 
   }
   const statement = statements[0]!;
   assertNoBannedSql(statement);
-  const normalized = normaliseSql(statement);
+  const normalized = normalizeSql(statement);
   if (!/^(insert\s+into|update|delete\s+from)\b/.test(normalized)) {
     throw new Error("ctx.db.execute only allows INSERT, UPDATE, or DELETE");
   }


### PR DESCRIPTION
## Summary
Renames one British-English identifier in plugin SQL validation helpers from `normaliseSql` to `normalizeSql` and updates local call sites so naming is consistent with the file's existing American-English convention.

**Jira:** [PAT-10](https://growtherapy.atlassian.net/browse/PAT-10)

## Diffstats
- `server/src/services/plugin-database.ts`: 5 insertions, 5 deletions

## Test plan
- `pnpm run preflight:workspace-links && pnpm exec vitest run server/src/__tests__/plugin-database.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- Change is non-visual; no QA visual validation required.

## QA
No UI or user-visible surface changed, so no QA child issue was created.

## Thinking Path
> - Paperclip enforces clear naming conventions across shared server code.
> - `plugin-database.ts` is the SQL validation layer for plugin migration/runtime guards.
> - The module already uses American-English naming (`normalized`).
> - A single helper remained in British spelling (`normaliseSql`), creating inconsistent nomenclature.
> - This pull request aligns that helper to American spelling and updates its local call sites.
> - The benefit is clearer, consistent naming with zero behavioral change.

## What Changed
- Renamed `normaliseSql` to `normalizeSql` in `server/src/services/plugin-database.ts`.
- Updated the four internal call sites that referenced the old helper name.
- Left logic untouched; this is a naming-only consistency fix.

## Verification
- `pnpm run preflight:workspace-links && pnpm exec vitest run server/src/__tests__/plugin-database.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks
- Low risk: mechanical rename in one module; all local references updated and validated via tests/typecheck.

## Model Used
- OpenAI Codex 5.3 via Cursor CLI with tool-assisted code editing, git operations, and local test execution.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

[_~PatBot_](https://github.com/search?q=PatBot+is%3Apr+owner%3AGrow-Therapy-Team&type=pullrequests)