### PR TITLE
fix(windows): UTF-8 + cross-platform encoding robustness

### DIFF
--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -90,7 +90,7 @@ async function installSkillsForTarget(
         } catch (err) {
           await fs.unlink(target);
           try {
-            await fs.symlink(source, target);
+            await fs.symlink(source, target, process.platform === "win32" ? "junction" : undefined);
             summary.linked.push(entry.name);
             continue;
           } catch (linkErr) {
@@ -128,7 +128,7 @@ async function installSkillsForTarget(
     }
 
     try {
-      await fs.symlink(source, target);
+      await fs.symlink(source, target, process.platform === "win32" ? "junction" : undefined);
       summary.linked.push(entry.name);
     } catch (err) {
       summary.failed.push({

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1310,7 +1310,7 @@ export async function ensurePaperclipSkillSymlink(
   source: string,
   target: string,
   linkSkill: (source: string, target: string) => Promise<void> = (linkSource, linkTarget) =>
-    fs.symlink(linkSource, linkTarget),
+    fs.symlink(linkSource, linkTarget, process.platform === "win32" ? "junction" : undefined),
 ): Promise<"created" | "repaired" | "skipped"> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {
@@ -1439,6 +1439,20 @@ export async function runChildProcess(
       delete rawMerged[key];
     }
 
+    // Ensure child processes (and their descendants) use UTF-8 so non-ASCII
+    // characters (accented letters, CJK, emoji, etc.) are not corrupted.
+    // On Windows the default codepage (e.g. Windows-1252) causes every
+    // accented character to become U+FFFD when text passes through shells
+    // (cmd.exe, Git Bash) and tools (curl, git) spawned by the agent.
+    // LANG/LC_ALL propagate to all subprocesses in the tree, covering both
+    // the agent CLI itself and any shell commands it runs via tool calls.
+    rawMerged.LANG ??= "en_US.UTF-8";
+    rawMerged.LC_ALL ??= "en_US.UTF-8";
+    if (process.platform === "win32") {
+      rawMerged.PYTHONIOENCODING ??= "utf-8";
+      rawMerged.PYTHONUTF8 ??= "1";
+    }
+
     const mergedEnv = ensurePathInEnv(rawMerged);
     void resolveSpawnTarget(command, args, opts.cwd, mergedEnv, {
       remoteExecution: opts.remoteExecution ?? null,
@@ -1529,15 +1543,19 @@ export async function runChildProcess(
               }, opts.timeoutSec * 1000)
             : null;
 
-        child.stdout?.on("data", (chunk: unknown) => {
+        // Set encoding so Node's StringDecoder handles multi-byte UTF-8
+        // characters that may be split across data chunks (e.g. ç, ã, é).
+        child.stdout?.setEncoding("utf8");
+        child.stderr?.setEncoding("utf8");
+
+        child.stdout?.on("data", (chunk: string) => {
           const readable = child.stdout;
           if (!readable) return;
           readable.pause();
-          const text = String(chunk);
-          stdout = appendWithCap(stdout, text);
+          stdout = appendWithCap(stdout, chunk);
           maybeArmTerminalResultCleanup();
           logChain = logChain
-            .then(() => opts.onLog("stdout", text))
+            .then(() => opts.onLog("stdout", chunk))
             .catch((err) => onLogError(err, runId, "failed to append stdout log chunk"))
             .finally(() => {
               maybeArmTerminalResultCleanup();
@@ -1545,15 +1563,14 @@ export async function runChildProcess(
             });
         });
 
-        child.stderr?.on("data", (chunk: unknown) => {
+        child.stderr?.on("data", (chunk: string) => {
           const readable = child.stderr;
           if (!readable) return;
           readable.pause();
-          const text = String(chunk);
-          stderr = appendWithCap(stderr, text);
+          stderr = appendWithCap(stderr, chunk);
           maybeArmTerminalResultCleanup();
           logChain = logChain
-            .then(() => opts.onLog("stderr", text))
+            .then(() => opts.onLog("stderr", chunk))
             .catch((err) => onLogError(err, runId, "failed to append stderr log chunk"))
             .finally(() => {
               maybeArmTerminalResultCleanup();

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -46,7 +46,7 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {
     await ensureParentDir(target);
-    await fs.symlink(source, target);
+    await fs.symlink(source, target, process.platform === "win32" ? "junction" : undefined);
     return;
   }
 
@@ -61,7 +61,7 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   if (resolvedLinkedPath === source) return;
 
   await fs.unlink(target);
-  await fs.symlink(source, target);
+  await fs.symlink(source, target, process.platform === "win32" ? "junction" : undefined);
 }
 
 async function ensureCopiedFile(target: string, source: string): Promise<void> {

--- a/scripts/ensure-workspace-package-links.ts
+++ b/scripts/ensure-workspace-package-links.ts
@@ -101,7 +101,7 @@ async function ensureWorkspaceLinksCurrent(workspaceDir: string) {
     const linkPath = path.join(repoRoot, mismatch.workspaceDir, "node_modules", ...mismatch.packageName.split("/"));
     await fs.mkdir(path.dirname(linkPath), { recursive: true });
     await fs.rm(linkPath, { recursive: true, force: true });
-    await fs.symlink(mismatch.expectedPath, linkPath);
+    await fs.symlink(mismatch.expectedPath, linkPath, process.platform === "win32" ? "junction" : undefined);
   }
 
   const remainingMismatches = findWorkspaceLinkMismatches(workspaceDir);

--- a/server/src/adapters/plugin-loader.ts
+++ b/server/src/adapters/plugin-loader.ts
@@ -11,6 +11,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { ServerAdapterModule } from "./types.js";
 import { logger } from "../middleware/logger.js";
 
@@ -177,7 +178,7 @@ export async function loadExternalAdapterPackage(
 
   logger.info({ packageName, packageDir, entryPoint, modulePath, hasUiParser: !!uiParserSource }, "Loading external adapter package");
 
-  const mod = await import(modulePath);
+  const mod = await import(pathToFileURL(modulePath).href);
   const adapterModule = validateAdapterModule(mod, packageName);
 
   if (uiParserSource) {
@@ -212,7 +213,7 @@ export async function reloadExternalAdapter(
   const packageDir = resolvePackageDir(record);
   const entryPoint = resolvePackageEntryPoint(packageDir);
   const modulePath = path.resolve(packageDir, entryPoint);
-  const fileUrl = `file://${modulePath}`;
+  const fileUrl = pathToFileURL(modulePath).href;
 
   // Bust ESM module cache so re-import loads fresh code from disk.
   // Query-string trick (?t=...) works in Node; Bun may need the file:// URL

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,6 +8,7 @@ import type { StorageService } from "./storage/types.js";
 import { httpLogger, errorHandler } from "./middleware/index.js";
 import { actorMiddleware } from "./middleware/auth.js";
 import { boardMutationGuard } from "./middleware/board-mutation-guard.js";
+import { latin1BodyRepair } from "./middleware/latin1-body-repair.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "./middleware/private-hostname-guard.js";
 import { healthRoutes } from "./routes/health.js";
 import { companyRoutes } from "./routes/companies.js";
@@ -144,6 +145,10 @@ export async function createApp(
       (req as unknown as { rawBody: Buffer }).rawBody = buf;
     },
   }));
+  // Repair JSON bodies sent with Latin-1/CP-1252 encoding instead of UTF-8.
+  // Git-Bash's mingw64 curl on Windows silently transcodes UTF-8 args to the
+  // active OEM code page, corrupting accented characters (Portuguese, etc.).
+  app.use(latin1BodyRepair());
   app.use(httpLogger);
   const privateHostnameGateEnabled = shouldEnablePrivateHostnameGuard({
     deploymentMode: opts.deploymentMode,
@@ -345,7 +350,7 @@ export async function createApp(
         }
         res
           .status(200)
-          .set("Content-Type", "text/html")
+          .set("Content-Type", "text/html; charset=utf-8")
           .set("Cache-Control", "no-cache")
           .end(indexHtml);
       });
@@ -389,7 +394,7 @@ export async function createApp(
       }
       try {
         const html = await renderViteHtml.render(req.originalUrl);
-        res.status(200).set({ "Content-Type": "text/html" }).end(html);
+        res.status(200).set({ "Content-Type": "text/html; charset=utf-8" }).end(html);
       } catch (err) {
         next(err);
       }

--- a/server/src/middleware/latin1-body-repair.ts
+++ b/server/src/middleware/latin1-body-repair.ts
@@ -1,0 +1,37 @@
+import type { RequestHandler } from "express";
+
+/**
+ * Middleware that detects JSON request bodies encoded as Latin-1 / CP-1252
+ * (instead of UTF-8) and re-decodes them so downstream handlers see correct
+ * Unicode characters.
+ *
+ * This fixes a common issue on Windows where Git-Bash's mingw64 curl silently
+ * transcodes UTF-8 CLI arguments to the active OEM code page, corrupting
+ * accented characters (Portuguese, Spanish, French, etc.).
+ */
+export function latin1BodyRepair(): RequestHandler {
+  return (req, _res, next) => {
+    const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+    if (
+      rawBody &&
+      req.is("application/json") &&
+      req.body != null
+    ) {
+      // Check whether the raw bytes are valid UTF-8 by round-tripping.
+      // If they are, nothing to repair.
+      const utf8 = rawBody.toString("utf8");
+      if (Buffer.from(utf8, "utf8").equals(rawBody)) {
+        return next();
+      }
+
+      // Raw bytes are NOT valid UTF-8 — assume Latin-1 and re-parse.
+      try {
+        const repaired = rawBody.toString("latin1");
+        req.body = JSON.parse(repaired);
+      } catch {
+        // If re-parsing fails, leave body as-is and let downstream handle it.
+      }
+    }
+    next();
+  };
+}

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -29,7 +29,7 @@ import { readdir, readFile, rm, stat } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import type { Db } from "@paperclipai/db";
 import type {
@@ -51,6 +51,7 @@ import type { PluginLifecycleManager } from "./plugin-lifecycle.js";
 import { pluginDatabaseService } from "./plugin-database.js";
 
 const execFileAsync = promisify(execFile);
+const NPM_BIN = process.platform === "win32" ? "npm.cmd" : "npm";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // ---------------------------------------------------------------------------
@@ -838,9 +839,9 @@ export function pluginLoader(
         // --ignore-scripts prevents preinstall/install/postinstall hooks from
         // executing arbitrary code on the host before manifest validation.
         await execFileAsync(
-          "npm",
+          NPM_BIN,
           ["install", spec, "--prefix", targetInstallDir, "--save", "--ignore-scripts"],
-          { timeout: 120_000 }, // 2 minute timeout for npm install
+          { timeout: 120_000, shell: process.platform === "win32" }, // 2 minute timeout for npm install
         );
       } catch (err) {
         throw new Error(`npm install failed for ${spec}: ${String(err)}`);
@@ -932,7 +933,10 @@ export function pluginLoader(
 
     try {
       // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests
-      const mod = await import(manifestPath) as Record<string, unknown>;
+      const importSpecifier = path.isAbsolute(manifestPath)
+        ? pathToFileURL(manifestPath).href
+        : manifestPath;
+      const mod = await import(importSpecifier) as Record<string, unknown>;
       // The manifest may be the default export or the module itself
       raw = mod["default"] ?? mod;
     } catch (err) {
@@ -1404,9 +1408,9 @@ export function pluginLoader(
       if (existsSync(packageJsonPath)) {
         try {
           await execFileAsync(
-            "npm",
+            NPM_BIN,
             ["uninstall", plugin.packageName, "--prefix", localPluginDir, "--ignore-scripts"],
-            { timeout: 120_000 },
+            { timeout: 120_000, shell: process.platform === "win32" },
           );
         } catch (err) {
           log.warn(
@@ -1752,7 +1756,7 @@ export function pluginLoader(
       // (for example @paperclipai/shared exports). Run those workers through
       // the tsx loader so first-party example plugins work in development.
       if (plugin.packagePath && existsSync(DEV_TSX_LOADER_PATH)) {
-        workerOptions.execArgv = ["--import", DEV_TSX_LOADER_PATH];
+        workerOptions.execArgv = ["--import", pathToFileURL(DEV_TSX_LOADER_PATH).href];
       }
 
       await workerManager.startWorker(pluginId, workerOptions);

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -77,8 +77,38 @@ function createLocalFileRunLogStore(basePath: string): RunLogStore {
       stream.on("end", () => resolve());
     });
 
-    const content = Buffer.concat(chunks).toString("utf8");
-    const nextOffset = end + 1 < stat.size ? end + 1 : undefined;
+    const buf = Buffer.concat(chunks);
+
+    // Trim trailing bytes that form an incomplete UTF-8 multi-byte character
+    // so they are included in the next read instead of becoming U+FFFD.
+    let trimEnd = buf.length;
+    if (trimEnd > 0) {
+      // Walk backwards to find a valid UTF-8 boundary.
+      // A UTF-8 continuation byte has the pattern 10xxxxxx (0x80..0xBF).
+      // A leading byte tells how many continuation bytes follow:
+      //   110xxxxx = 2-byte, 1110xxxx = 3-byte, 11110xxx = 4-byte.
+      let trailingContinuation = 0;
+      while (trailingContinuation < 4 && trailingContinuation < trimEnd) {
+        const byte = buf[trimEnd - 1 - trailingContinuation]!;
+        if ((byte & 0xc0) !== 0x80) break; // not a continuation byte
+        trailingContinuation++;
+      }
+      if (trailingContinuation > 0 && trailingContinuation < trimEnd) {
+        const leadByte = buf[trimEnd - 1 - trailingContinuation]!;
+        let expectedContinuation = 0;
+        if ((leadByte & 0xe0) === 0xc0) expectedContinuation = 1;       // 2-byte sequence
+        else if ((leadByte & 0xf0) === 0xe0) expectedContinuation = 2;  // 3-byte sequence
+        else if ((leadByte & 0xf8) === 0xf0) expectedContinuation = 3;  // 4-byte sequence
+        if (trailingContinuation < expectedContinuation) {
+          // Incomplete character — exclude the partial bytes
+          trimEnd -= trailingContinuation + 1;
+        }
+      }
+    }
+
+    const content = buf.subarray(0, trimEnd).toString("utf8");
+    const bytesConsumed = start + trimEnd;
+    const nextOffset = bytesConsumed < stat.size ? bytesConsumed : undefined;
     return { content, nextOffset };
   }
 

--- a/server/src/services/workspace-operation-log-store.ts
+++ b/server/src/services/workspace-operation-log-store.ts
@@ -77,8 +77,33 @@ function createLocalFileWorkspaceOperationLogStore(basePath: string): WorkspaceO
       stream.on("end", () => resolve());
     });
 
-    const content = Buffer.concat(chunks).toString("utf8");
-    const nextOffset = end + 1 < stat.size ? end + 1 : undefined;
+    const buf = Buffer.concat(chunks);
+
+    // Trim trailing bytes that form an incomplete UTF-8 multi-byte character
+    // so they are included in the next read instead of becoming U+FFFD.
+    let trimEnd = buf.length;
+    if (trimEnd > 0) {
+      let trailingContinuation = 0;
+      while (trailingContinuation < 4 && trailingContinuation < trimEnd) {
+        const byte = buf[trimEnd - 1 - trailingContinuation]!;
+        if ((byte & 0xc0) !== 0x80) break;
+        trailingContinuation++;
+      }
+      if (trailingContinuation > 0 && trailingContinuation < trimEnd) {
+        const leadByte = buf[trimEnd - 1 - trailingContinuation]!;
+        let expectedContinuation = 0;
+        if ((leadByte & 0xe0) === 0xc0) expectedContinuation = 1;
+        else if ((leadByte & 0xf0) === 0xe0) expectedContinuation = 2;
+        else if ((leadByte & 0xf8) === 0xf0) expectedContinuation = 3;
+        if (trailingContinuation < expectedContinuation) {
+          trimEnd -= trailingContinuation + 1;
+        }
+      }
+    }
+
+    const content = buf.subarray(0, trimEnd).toString("utf8");
+    const bytesConsumed = start + trimEnd;
+    const nextOffset = bytesConsumed < stat.size ? bytesConsumed : undefined;
     return { content, nextOffset };
   }
 

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -266,7 +266,7 @@ export async function ensureServerWorkspaceLinksCurrent(
     const linkPath = path.join(workspaceRoot, "server", "node_modules", ...mismatch.packageName.split("/"));
     await fs.mkdir(path.dirname(linkPath), { recursive: true });
     await fs.rm(linkPath, { recursive: true, force: true });
-    await fs.symlink(mismatch.expectedPath, linkPath);
+    await fs.symlink(mismatch.expectedPath, linkPath, process.platform === "win32" ? "junction" : undefined);
   }
 
   const remainingMismatches = findServerWorkspaceLinkMismatches(workspaceRoot);
@@ -287,6 +287,16 @@ export function sanitizeRuntimeServiceBaseEnv(baseEnv: NodeJS.ProcessEnv): NodeJ
   delete env.DATABASE_URL;
   delete env.npm_config_tailscale_auth;
   delete env.npm_config_authenticated_private;
+
+  // Ensure child processes use UTF-8 so non-ASCII characters are not
+  // corrupted by the default Windows codepage (e.g. cp850).
+  env.LANG ??= "en_US.UTF-8";
+  env.LC_ALL ??= "en_US.UTF-8";
+  if (process.platform === "win32") {
+    env.PYTHONIOENCODING ??= "utf-8";
+    env.PYTHONUTF8 ??= "1";
+  }
+
   return env;
 }
 
@@ -484,11 +494,15 @@ async function executeProcess(input: {
     });
     const stdout = createProcessOutputCapture(input.maxStdoutBytes ?? DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES);
     const stderr = createProcessOutputCapture(input.maxStderrBytes ?? DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES);
-    child.stdout?.on("data", (chunk) => {
-      stdout.append(String(chunk));
+    // Use StringDecoder via setEncoding so multi-byte UTF-8 characters
+    // split across data chunks (e.g. ç, ã, é) are not corrupted.
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout.append(chunk);
     });
-    child.stderr?.on("data", (chunk) => {
-      stderr.append(String(chunk));
+    child.stderr?.on("data", (chunk: string) => {
+      stderr.append(chunk);
     });
     child.on("error", reject);
     child.on("close", (code) => resolve({ stdout, stderr, code }));
@@ -2049,15 +2063,17 @@ async function startLocalRuntimeService(input: {
   });
   let stderrExcerpt = "";
   let stdoutExcerpt = "";
-  child.stdout?.on("data", async (chunk) => {
-    const text = String(chunk);
-    stdoutExcerpt = (stdoutExcerpt + text).slice(-4096);
-    if (input.onLog) await input.onLog("stdout", `[service:${serviceName}] ${text}`);
+  // Use StringDecoder via setEncoding so multi-byte UTF-8 characters
+  // split across data chunks (e.g. ç, ã, é) are not corrupted.
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", async (chunk: string) => {
+    stdoutExcerpt = (stdoutExcerpt + chunk).slice(-4096);
+    if (input.onLog) await input.onLog("stdout", `[service:${serviceName}] ${chunk}`);
   });
-  child.stderr?.on("data", async (chunk) => {
-    const text = String(chunk);
-    stderrExcerpt = (stderrExcerpt + text).slice(-4096);
-    if (input.onLog) await input.onLog("stderr", `[service:${serviceName}] ${text}`);
+  child.stderr?.on("data", async (chunk: string) => {
+    stderrExcerpt = (stderrExcerpt + chunk).slice(-4096);
+    if (input.onLog) await input.onLog("stderr", `[service:${serviceName}] ${chunk}`);
   });
 
   try {


### PR DESCRIPTION
## Summary

Fixes accented-character corruption and symlink/npm failures when running Paperclip on Windows.

- Default symlinks to `junction` on Windows across adapters, CLI, scripts, and server runtime so workspace linking doesn't require admin privileges
- Propagate `LANG` / `LC_ALL` / `PYTHONIOENCODING` / `PYTHONUTF8` env vars to child processes so spawned tools don't corrupt accented characters via the default Windows codepage (cp850/cp1252)
- Set UTF-8 encoding on child stdout/stderr streams so multi-byte sequences split across data chunks don't become U+FFFD
- Trim trailing incomplete UTF-8 sequences at log chunk boundaries (`run-log-store`, `workspace-operation-log-store`) so partial bytes carry over to next read instead of corrupting
- Add `latin1-body-repair` middleware to re-decode JSON bodies that Git-Bash on Windows silently transcoded from UTF-8 to the active OEM codepage
- Force `text/html; charset=utf-8` on HTML responses
- Use `pathToFileURL` for dynamic ESM imports on Windows (absolute paths without file:// scheme fail on newer Node)
- Use `npm.cmd` shim + `shell: true` when spawning npm on Windows

## Test plan

- [ ] Run an agent with accented characters in prompts/comments on Windows — verify no `�` corruption in logs or chat
- [ ] Trigger a workspace relink on Windows without admin — verify junctions are created
- [ ] Install/uninstall a plugin via npm on Windows
- [ ] POST an issue with a Portuguese title via Git-Bash curl — verify accents survive