### PR TITLE
feat(cost): impute API-equivalent cost for subscription-included runs

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1041,8 +1041,54 @@ function resolveLedgerBiller(result: AdapterExecutionResult): string {
   return readNonEmptyString(result.biller) ?? readNonEmptyString(result.provider) ?? "unknown";
 }
 
-function normalizeBilledCostCents(costUsd: number | null | undefined, billingType: BillingType): number {
-  if (billingType === "subscription_included") return 0;
+/**
+ * Anthropic API-equivalent pricing per million tokens (USD).
+ * Used to impute a dollar cost for subscription-included runs so the UI
+ * shows what the usage *would* cost at standard API rates.
+ */
+const ANTHROPIC_PRICING_PER_MTOK: Record<string, { input: number; cachedInput: number; output: number }> = {
+  "claude-opus-4-6":           { input: 15,  cachedInput: 1.50, output: 75 },
+  "claude-sonnet-4-6":         { input: 3,   cachedInput: 0.30, output: 15 },
+  "claude-haiku-4-6":          { input: 0.80, cachedInput: 0.08, output: 4 },
+  "claude-sonnet-4-5-20250929": { input: 3,   cachedInput: 0.30, output: 15 },
+  "claude-haiku-4-5-20251001":  { input: 0.80, cachedInput: 0.08, output: 4 },
+};
+
+function estimateCostCentsFromTokens(
+  model: string,
+  inputTokens: number,
+  cachedInputTokens: number,
+  outputTokens: number,
+): number {
+  const pricing = ANTHROPIC_PRICING_PER_MTOK[model];
+  if (!pricing) {
+    logger.warn({ model }, "no pricing entry for model; cost will be reported as 0");
+    return 0;
+  }
+  const cost =
+    (inputTokens / 1_000_000) * pricing.input +
+    (cachedInputTokens / 1_000_000) * pricing.cachedInput +
+    (outputTokens / 1_000_000) * pricing.output;
+  return Math.max(0, Math.round(cost * 100));
+}
+
+function normalizeBilledCostCents(
+  costUsd: number | null | undefined,
+  billingType: BillingType,
+  tokenEstimate?: { model: string; inputTokens: number; cachedInputTokens: number; outputTokens: number },
+): number {
+  if (billingType === "subscription_included") {
+    // Impute API-equivalent cost from token counts so the UI shows real usage cost
+    if (tokenEstimate) {
+      return estimateCostCentsFromTokens(
+        tokenEstimate.model,
+        tokenEstimate.inputTokens,
+        tokenEstimate.cachedInputTokens,
+        tokenEstimate.outputTokens,
+      );
+    }
+    return 0;
+  }
   if (typeof costUsd !== "number" || !Number.isFinite(costUsd)) return 0;
   return Math.max(0, Math.round(costUsd * 100));
 }


### PR DESCRIPTION
## Summary

Runs billed as `subscription_included` used to be recorded as \$0 cost because the provider never returns a per-run dollar amount. This makes usage invisible on the cost dashboard, even when a subscription seat is effectively consuming real API-equivalent usage.

- Add `ANTHROPIC_PRICING_PER_MTOK` table for current models (Opus 4.6, Sonnet 4.6, Haiku 4.6, Sonnet 4.5, Haiku 4.5)
- Add `estimateCostCentsFromTokens()` that converts input / cachedInput / output token counts to cents at standard API prices
- Extend `normalizeBilledCostCents()` to accept an optional `tokenEstimate`; when `billingType` is `subscription_included` and tokens are provided, impute the cost at API rates instead of returning 0

## Test plan

- [ ] Run an agent on a Claude subscription — verify cost dashboard shows imputed dollars, not \$0
- [ ] Run an agent with an unknown model — verify it logs a `no pricing entry` warning and falls back to 0