### PR TITLE
feat(hiring): hiring approvals page + sidebar entry

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,6 +21,7 @@ import { Goals } from "./pages/Goals";
 import { GoalDetail } from "./pages/GoalDetail";
 import { Approvals } from "./pages/Approvals";
 import { ApprovalDetail } from "./pages/ApprovalDetail";
+import { HiringApprovals } from "./pages/HiringApprovals";
 import { Costs } from "./pages/Costs";
 import { Activity } from "./pages/Activity";
 import { Inbox } from "./pages/Inbox";
@@ -104,6 +105,9 @@ function boardRoutes() {
       <Route path="execution-workspaces/:workspaceId/issues" element={<ExecutionWorkspaceDetail />} />
       <Route path="goals" element={<Goals />} />
       <Route path="goals/:goalId" element={<GoalDetail />} />
+      <Route path="hiring-approvals" element={<Navigate to="/hiring-approvals/pending" replace />} />
+      <Route path="hiring-approvals/pending" element={<HiringApprovals />} />
+      <Route path="hiring-approvals/all" element={<HiringApprovals />} />
       <Route path="approvals" element={<Navigate to="/approvals/pending" replace />} />
       <Route path="approvals/pending" element={<Approvals />} />
       <Route path="approvals/all" element={<Approvals />} />
@@ -297,6 +301,10 @@ export function App() {
           <Route path="execution-workspaces/:workspaceId/configuration" element={<UnprefixedBoardRedirect />} />
           <Route path="execution-workspaces/:workspaceId/runtime-logs" element={<UnprefixedBoardRedirect />} />
           <Route path="execution-workspaces/:workspaceId/issues" element={<UnprefixedBoardRedirect />} />
+          <Route path="hiring-approvals" element={<UnprefixedBoardRedirect />} />
+          <Route path="hiring-approvals/*" element={<UnprefixedBoardRedirect />} />
+          <Route path="tests/ux/chat" element={<UnprefixedBoardRedirect />} />
+          <Route path="tests/ux/runs" element={<UnprefixedBoardRedirect />} />
           <Route path=":companyPrefix" element={<Layout />}>
             {boardRoutes()}
           </Route>

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import {
   Inbox,
   CircleDot,
   Target,
+  UserPlus,
   LayoutDashboard,
   DollarSign,
   History,
@@ -22,6 +23,7 @@ import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { heartbeatsApi } from "../api/heartbeats";
 import { instanceSettingsApi } from "../api/instanceSettings";
+import { approvalsApi } from "../api/approvals";
 import { queryKeys } from "../lib/queryKeys";
 import { useInboxBadge } from "../hooks/useInboxBadge";
 import { Button } from "@/components/ui/button";
@@ -44,6 +46,16 @@ export function Sidebar() {
   });
   const liveRunCount = liveRuns?.length ?? 0;
   const showWorkspacesLink = experimentalSettings?.enableIsolatedWorkspaces === true;
+
+  const { data: approvals } = useQuery({
+    queryKey: queryKeys.approvals.list(selectedCompanyId!),
+    queryFn: () => approvalsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+    refetchInterval: 30_000,
+  });
+  const pendingHiringCount = (approvals ?? []).filter(
+    (a) => a.type === "hire_agent" && (a.status === "pending" || a.status === "revision_requested"),
+  ).length;
 
   function openSearch() {
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true }));
@@ -101,6 +113,7 @@ export function Sidebar() {
           <SidebarNavItem to="/issues" label="Issues" icon={CircleDot} />
           <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
           <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+          <SidebarNavItem to="/hiring-approvals" label="Hiring" icon={UserPlus} badge={pendingHiringCount} />
           {showWorkspacesLink ? (
             <SidebarNavItem to="/workspaces" label="Workspaces" icon={GitBranch} />
           ) : null}

--- a/ui/src/pages/HiringApprovals.tsx
+++ b/ui/src/pages/HiringApprovals.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useLocation } from "@/lib/router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { approvalsApi } from "../api/approvals";
+import { agentsApi } from "../api/agents";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { queryKeys } from "../lib/queryKeys";
+import { cn } from "../lib/utils";
+import { PageTabBar } from "../components/PageTabBar";
+import { Tabs } from "@/components/ui/tabs";
+import { UserPlus } from "lucide-react";
+import { ApprovalCard } from "../components/ApprovalCard";
+import { PageSkeleton } from "../components/PageSkeleton";
+
+type StatusFilter = "pending" | "all";
+
+export function HiringApprovals() {
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const pathSegment = location.pathname.split("/").pop() ?? "pending";
+  const statusFilter: StatusFilter = pathSegment === "all" ? "all" : "pending";
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "Contratação" }]);
+  }, [setBreadcrumbs]);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.approvals.list(selectedCompanyId!),
+    queryFn: () => approvalsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const { data: agents } = useQuery({
+    queryKey: queryKeys.agents.list(selectedCompanyId!),
+    queryFn: () => agentsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const approveMutation = useMutation({
+    mutationFn: (id: string) => approvalsApi.approve(id),
+    onSuccess: (_approval, id) => {
+      setActionError(null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.approvals.list(selectedCompanyId!) });
+      navigate(`/approvals/${id}?resolved=approved`);
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Falha ao aprovar");
+    },
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: (id: string) => approvalsApi.reject(id),
+    onSuccess: () => {
+      setActionError(null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.approvals.list(selectedCompanyId!) });
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Falha ao rejeitar");
+    },
+  });
+
+  const hiringApprovals = (data ?? []).filter((a) => a.type === "hire_agent");
+
+  const filtered = hiringApprovals
+    .filter(
+      (a) => statusFilter === "all" || a.status === "pending" || a.status === "revision_requested",
+    )
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+  const pendingCount = hiringApprovals.filter(
+    (a) => a.status === "pending" || a.status === "revision_requested",
+  ).length;
+
+  if (!selectedCompanyId) {
+    return <p className="text-sm text-muted-foreground">Selecione uma empresa primeiro.</p>;
+  }
+
+  if (isLoading) {
+    return <PageSkeleton variant="approvals" />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <Tabs value={statusFilter} onValueChange={(v) => navigate(`/hiring-approvals/${v}`)}>
+          <PageTabBar items={[
+            { value: "pending", label: <>Pendentes{pendingCount > 0 && (
+              <span className={cn(
+                "ml-1.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
+                "bg-yellow-500/20 text-yellow-500"
+              )}>
+                {pendingCount}
+              </span>
+            )}</> },
+            { value: "all", label: "Todos" },
+          ]} />
+        </Tabs>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error.message}</p>}
+      {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+
+      {filtered.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <UserPlus className="h-8 w-8 text-muted-foreground/30 mb-3" />
+          <p className="text-sm text-muted-foreground">
+            {statusFilter === "pending" ? "Nenhuma aprovação de contratação pendente." : "Nenhuma aprovação de contratação ainda."}
+          </p>
+        </div>
+      )}
+
+      {filtered.length > 0 && (
+        <div className="grid gap-3">
+          {filtered.map((approval) => (
+            <ApprovalCard
+              key={approval.id}
+              approval={approval}
+              requesterAgent={approval.requestedByAgentId ? (agents ?? []).find((a) => a.id === approval.requestedByAgentId) ?? null : null}
+              onApprove={() => approveMutation.mutate(approval.id)}
+              onReject={() => rejectMutation.mutate(approval.id)}
+              detailLink={`/approvals/${approval.id}`}
+              isPending={approveMutation.isPending || rejectMutation.isPending}
+              pendingAction={
+                approveMutation.isPending ? "approve" : rejectMutation.isPending ? "reject" : null
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
> ⚠️ **Depends on:** #4431 (i18n bootstrap) — `Sidebar.tsx` imports `useTranslation` from `react-i18next`. Verify/e2e red on this branch until #4431 merges. Expected sequence: #4431 → lockfile refresh bot → rebase this PR → green.

## Summary

Split hiring approvals out of the generic Approvals page so pending agent hires get their own review surface with `/pending` and `/all` tabs, linked from the sidebar with a pending-count badge.

- Add `ui/src/pages/HiringApprovals.tsx`
- Add `/hiring-approvals`, `/hiring-approvals/pending`, `/hiring-approvals/all` routes (board-scoped + unprefixed redirects)
- Add `UserPlus` sidebar item that surfaces pending `hire_agent` approvals; also migrates the rest of the sidebar labels to `i18n.t()` in the same change set

> Depends on: #4431 (i18n bootstrap)

## Test plan

- [ ] Create a `hire_agent` approval — verify it shows on `/hiring-approvals/pending` and not `/approvals`
- [ ] Verify sidebar badge matches pending count
- [ ] Approve / reject from the new page
