### PR TITLE
[WAT-1777] Guard Paperclip worktree cleanup lifecycle

### DIFF
--- a/doc/experimental/issue-worktree-support.md
+++ b/doc/experimental/issue-worktree-support.md
@@ -22,6 +22,45 @@ We are intentionally not shipping the UI for this yet. The runtime code remains 
 - seeded worktree instances can keep local-encrypted secrets working
 - seeded worktree instances can rebind same-repo project workspace paths onto the current git worktree
 
+## Large-repo Worktree Lifecycle Policy
+
+Paperclip-owned issue and review worktrees are execution workspaces, not agent-owned scratch directories. The execution workspace record is the source of truth for:
+
+- owner: the Paperclip company/project plus the issue linked through `sourceIssueId` and `issues.executionWorkspaceId`
+- linked work: the issue identifier, branch name, base ref, project workspace, and any PR link carried in the issue thread
+- creation and use time: `openedAt`, `createdAt`, and `lastUsedAt`
+- cleanup eligibility: `closedAt`, `cleanupEligibleAt`, `cleanupReason`, and workspace `status`
+- provider ownership: `providerType: "git_worktree"` plus `metadata.createdByRuntime: true` means Paperclip may remove the derived worktree after close-readiness passes
+
+Retention defaults for large local worktrees:
+
+- active or linked to open issue: keep; report size and readiness only
+- clean, idle, Paperclip-created issue worktree: eligible for cleanup after 24 hours
+- in review: keep for 7 days unless a reviewer explicitly archives the workspace earlier
+- `cleanup_failed`: keep until an operator resolves the reported reason
+- shared/project-primary workspace: never delete the underlying project checkout; archive only the execution workspace record
+
+Close and cleanup must use the execution workspace close-readiness report before deleting anything. The report includes linked open issues, runtime services, git dirty state, untracked files, ahead/behind counts, merge status, and planned cleanup actions. Destructive archive is blocked for isolated git worktrees when:
+
+- the workspace is linked to any non-terminal issue
+- tracked files are modified
+- untracked files are present
+- commits are ahead of the base ref and not merged
+- git status cannot be inspected
+
+The lower-level cleanup helper also refuses to remove a git worktree when `git status --porcelain --untracked-files=all` is non-empty, so direct callers report dirty worktrees instead of deleting them. If a worktree is clean and Paperclip owns it, cleanup removes the git worktree and then attempts to delete the runtime-created branch with `git branch -d`; unmerged branches are reported and kept.
+
+Safe stale-worktree reporting should list, but not delete, candidate `/tmp` worktrees matching all of:
+
+- provider is `git_worktree`
+- workspace path resolves under `/tmp` or the platform temp directory
+- status is `idle`, `in_review`, or `cleanup_failed`, or `lastUsedAt` is older than the retention window
+- close-readiness is not `ready`
+
+Each row should include workspace id, issue identifier, owner agent if known, path, branch, base ref, opened/last-used time, approximate path size, readiness state, blocking reasons, and planned actions. Deletion is only allowed by the archive/close path after readiness returns `ready` or `ready_with_warnings`; blocked rows remain report-only.
+
+Successful release/completion behavior: when a Paperclip-owned isolated worktree is closed, the server archives the execution workspace record, stops attached runtime services, runs configured cleanup/teardown commands, removes the clean git worktree, and records any cleanup warning in `cleanupReason`. If release/completion does not explicitly archive the workspace, the stale-worktree report is the follow-up mechanism that makes the retention breach visible before manual or scheduled archive.
+
 ## Hidden UI entrypoints
 
 These are the current user-facing UI surfaces for the feature, now intentionally disabled:

--- a/doc/experimental/issue-worktree-support.md
+++ b/doc/experimental/issue-worktree-support.md
@@ -24,13 +24,23 @@ We are intentionally not shipping the UI for this yet. The runtime code remains 
 
 ## Large-repo Worktree Lifecycle Policy
 
-Paperclip-owned issue and review worktrees are execution workspaces, not agent-owned scratch directories. The execution workspace record is the source of truth for:
+Paperclip-owned issue and review worktrees should be execution workspaces, not agent-owned scratch directories. For worktrees created through the execution workspace runtime, the execution workspace record is the source of truth for:
 
 - owner: the Paperclip company/project plus the issue linked through `sourceIssueId` and `issues.executionWorkspaceId`
 - linked work: the issue identifier, branch name, base ref, project workspace, and any PR link carried in the issue thread
 - creation and use time: `openedAt`, `createdAt`, and `lastUsedAt`
 - cleanup eligibility: `closedAt`, `cleanupEligibleAt`, `cleanupReason`, and workspace `status`
 - provider ownership: `providerType: "git_worktree"` plus `metadata.createdByRuntime: true` means Paperclip may remove the derived worktree after close-readiness passes
+
+Some existing large-repo worktrees were created by local agent workflows before execution workspace records covered every path. Examples include superpowers or agent-created worktrees under `/tmp` with names derived from issue branches. Those worktrees are still in scope for stale-worktree prevention, but they are not automatically safe to delete. Until they are adopted into execution workspace records or carry explicit Paperclip ownership metadata, they use a report-only lifecycle:
+
+- owner discovery: infer the repository from `git rev-parse --show-toplevel`, the branch or detached commit from `git status --branch --porcelain=v2`, and the creating workflow from path markers such as `/tmp`, `.paperclip/worktrees`, `paperclip/`, `wat-`, or adapter-specific worktree roots
+- linked work discovery: parse `WAT-\d+` or project issue keys from the branch name, worktree basename, PR branch, or recent commit subjects, then query matching Paperclip issues and PR links
+- active-work guardrail: if any inferred linked issue is non-terminal, the row remains active and report-only regardless of age
+- missing-link guardrail: if no issue or PR can be inferred, the row is reported as orphaned but not deleted
+- retention: clean, linked, terminal non-execution worktrees are stale after 24 hours; review-shaped worktrees are stale after 7 days; unknown-owner rows stay report-only until an operator records ownership or removes them manually
+- dirty-work guardrails: dirty tracked files, untracked files, unpushed commits, detached heads, unresolved merges, inaccessible git status, missing upstream/base refs, or running processes with `cwd` inside the worktree all block deletion
+- deletion policy: non-execution worktrees are never deleted by the automatic release/completion cleanup path. A later cleanup implementation may delete them only after adopting them into an execution workspace record or recording equivalent owner, issue, creation time, and Paperclip-created metadata.
 
 Retention defaults for large local worktrees:
 
@@ -39,6 +49,7 @@ Retention defaults for large local worktrees:
 - in review: keep for 7 days unless a reviewer explicitly archives the workspace earlier
 - `cleanup_failed`: keep until an operator resolves the reported reason
 - shared/project-primary workspace: never delete the underlying project checkout; archive only the execution workspace record
+- non-execution Paperclip/agent worktree: report when stale by the windows above, but do not delete until ownership metadata is explicit
 
 Close and cleanup must use the execution workspace close-readiness report before deleting anything. The report includes linked open issues, runtime services, git dirty state, untracked files, ahead/behind counts, merge status, and planned cleanup actions. Destructive archive is blocked for isolated git worktrees when:
 
@@ -50,7 +61,7 @@ Close and cleanup must use the execution workspace close-readiness report before
 
 The lower-level cleanup helper also refuses to remove a git worktree when `git status --porcelain --untracked-files=all` is non-empty, so direct callers report dirty worktrees instead of deleting them. If a worktree is clean and Paperclip owns it, cleanup removes the git worktree and then attempts to delete the runtime-created branch with `git branch -d`; unmerged branches are reported and kept.
 
-Safe stale-worktree reporting should list, but not delete, candidate `/tmp` worktrees matching all of:
+Safe stale-worktree reporting should list, but not delete, execution-workspace candidate `/tmp` worktrees matching all of:
 
 - provider is `git_worktree`
 - workspace path resolves under `/tmp` or the platform temp directory
@@ -58,6 +69,8 @@ Safe stale-worktree reporting should list, but not delete, candidate `/tmp` work
 - close-readiness is not `ready`
 
 Each row should include workspace id, issue identifier, owner agent if known, path, branch, base ref, opened/last-used time, approximate path size, readiness state, blocking reasons, and planned actions. Deletion is only allowed by the archive/close path after readiness returns `ready` or `ready_with_warnings`; blocked rows remain report-only.
+
+The same stale report should also scan registered large-repo roots and platform temp worktree roots for non-execution git worktrees. These rows should include source `non_execution_git_worktree`, inferred repository, inferred issue or PR, owner agent if known, path, branch or detached commit, upstream/base ref, last filesystem activity, approximate path size, git cleanliness, ahead/unpushed status, active process hints, and why the row is report-only. They are stale signals for operators and future adoption work, not deletion candidates.
 
 Successful release/completion behavior: when a Paperclip-owned isolated worktree is closed, the server archives the execution workspace record, stops attached runtime services, runs configured cleanup/teardown commands, removes the clean git worktree, and records any cleanup warning in `cleanupReason`. If release/completion does not explicitly archive the workspace, the stale-worktree report is the follow-up mechanism that makes the retention breach visible before manual or scheduled archive.
 

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -343,7 +343,7 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(readExecutionWorkspaceConfig(byId.get(untouchedWorkspaceId) ?? null)).toBeNull();
   });
 
-  it("warns about dirty and unmerged git worktrees and reports cleanup actions", async () => {
+  it("blocks destructive close for dirty and unmerged git worktrees", async () => {
     const repoRoot = await createTempRepo();
     tempDirs.add(repoRoot);
     const worktreePath = path.join(path.dirname(repoRoot), `paperclip-worktree-${randomUUID()}`);
@@ -416,10 +416,10 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
 
     expect(readiness).toMatchObject({
       workspaceId: executionWorkspaceId,
-      state: "ready_with_warnings",
+      state: "blocked",
       isSharedWorkspace: false,
       isProjectPrimaryWorkspace: false,
-      isDestructiveCloseAllowed: true,
+      isDestructiveCloseAllowed: false,
       git: {
         workspacePath: worktreePath,
         branchName: "paperclip-close-check",
@@ -432,6 +432,10 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
         isMergedIntoBase: false,
       },
     });
+    expect(readiness?.blockingReasons).toEqual(expect.arrayContaining([
+      "This git worktree has 1 untracked file; archive it after committing, stashing, or removing the file.",
+      "This git worktree has 1 unmerged commit ahead of main; push or merge it before archive cleanup.",
+    ]));
     expect(readiness?.warnings).toEqual(expect.arrayContaining([
       "The workspace has 1 untracked file.",
       "This workspace is 1 commit ahead of main and is not merged.",

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1976,6 +1976,67 @@ describe("realizeExecutionWorkspace", () => {
     });
   }, 10_000);
 
+  it("reports dirty git worktrees instead of removing them during cleanup", async () => {
+    const repoRoot = await createTempRepo();
+
+    const workspace = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-452",
+        title: "Keep dirty worktree",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    await fs.writeFile(path.join(workspace.cwd, "scratch.txt"), "still here\n", "utf8");
+
+    const cleanup = await cleanupExecutionWorkspaceArtifacts({
+      workspace: {
+        id: "execution-workspace-1",
+        cwd: workspace.cwd,
+        providerType: "git_worktree",
+        providerRef: workspace.worktreePath,
+        branchName: workspace.branchName,
+        repoUrl: workspace.repoUrl,
+        baseRef: workspace.repoRef,
+        projectId: workspace.projectId,
+        projectWorkspaceId: workspace.workspaceId,
+        sourceIssueId: "issue-1",
+        metadata: {
+          createdByRuntime: true,
+        },
+      },
+      projectWorkspace: {
+        cwd: repoRoot,
+        cleanupCommand: null,
+      },
+    });
+
+    expect(cleanup.cleaned).toBe(false);
+    expect(cleanup.warnings).toEqual(expect.arrayContaining([
+      `Skipped removing git worktree "${workspace.cwd}" because it has uncommitted or untracked files.`,
+    ]));
+    await expect(fs.stat(path.join(workspace.cwd, "scratch.txt"))).resolves.toBeTruthy();
+  });
+
   it("records teardown and cleanup operations when a recorder is provided", async () => {
     const repoRoot = await createTempRepo();
     const { recorder, operations } = createWorkspaceOperationRecorderDouble();

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -2031,9 +2031,9 @@ describe("realizeExecutionWorkspace", () => {
     });
 
     expect(cleanup.cleaned).toBe(false);
-    expect(cleanup.warnings).toEqual(expect.arrayContaining([
+    expect(cleanup.warnings).toEqual([
       `Skipped removing git worktree "${workspace.cwd}" because it has uncommitted or untracked files.`,
-    ]));
+    ]);
     await expect(fs.stat(path.join(workspace.cwd, "scratch.txt"))).resolves.toBeTruthy();
   });
 

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -591,6 +591,13 @@ export function executionWorkspaceService(db: Db) {
             ? "The workspace has 1 modified tracked file."
             : `The workspace has ${git.dirtyEntryCount} modified tracked files.`,
         );
+        if (!isSharedWorkspace && executionWorkspace.providerType === "git_worktree") {
+          blockingReasons.push(
+            git.dirtyEntryCount === 1
+              ? "This git worktree has 1 modified tracked file; archive it after committing, stashing, or reverting the file."
+              : `This git worktree has ${git.dirtyEntryCount} modified tracked files; archive it after committing, stashing, or reverting the files.`,
+          );
+        }
       }
       if (git?.hasUntrackedFiles) {
         warnings.push(
@@ -598,6 +605,13 @@ export function executionWorkspaceService(db: Db) {
             ? "The workspace has 1 untracked file."
             : `The workspace has ${git.untrackedEntryCount} untracked files.`,
         );
+        if (!isSharedWorkspace && executionWorkspace.providerType === "git_worktree") {
+          blockingReasons.push(
+            git.untrackedEntryCount === 1
+              ? "This git worktree has 1 untracked file; archive it after committing, stashing, or removing the file."
+              : `This git worktree has ${git.untrackedEntryCount} untracked files; archive it after committing, stashing, or removing the files.`,
+          );
+        }
       }
       if (git?.aheadCount && git.aheadCount > 0 && git.isMergedIntoBase === false) {
         warnings.push(
@@ -605,6 +619,13 @@ export function executionWorkspaceService(db: Db) {
             ? `This workspace is 1 commit ahead of ${git.baseRef ?? "the base ref"} and is not merged.`
             : `This workspace is ${git.aheadCount} commits ahead of ${git.baseRef ?? "the base ref"} and is not merged.`,
         );
+        if (!isSharedWorkspace && executionWorkspace.providerType === "git_worktree") {
+          blockingReasons.push(
+            git.aheadCount === 1
+              ? `This git worktree has 1 unmerged commit ahead of ${git.baseRef ?? "the base ref"}; push or merge it before archive cleanup.`
+              : `This git worktree has ${git.aheadCount} unmerged commits ahead of ${git.baseRef ?? "the base ref"}; push or merge them before archive cleanup.`,
+          );
+        }
       }
       if (git?.behindCount && git.behindCount > 0) {
         warnings.push(

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1377,22 +1377,37 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
       if (!repoRoot) {
         warnings.push(`Could not resolve git repo root for "${workspacePath}".`);
       } else {
+        let gitStatus: string | null = null;
         try {
-          await recordGitOperation(input.recorder, {
-            phase: "worktree_cleanup",
-            args: ["worktree", "remove", "--force", workspacePath],
-            cwd: repoRoot,
-            metadata: {
-              workspaceId: input.workspace.id,
-              workspacePath,
-              branchName: input.workspace.branchName,
-              cleanupAction: "worktree_remove",
-            },
-            successMessage: `Removed git worktree ${workspacePath}\n`,
-            failureLabel: `git worktree remove ${workspacePath}`,
-          });
+          gitStatus = await runGit(["status", "--porcelain=v1", "--untracked-files=all"], workspacePath);
         } catch (err) {
-          warnings.push(err instanceof Error ? err.message : String(err));
+          warnings.push(
+            `Skipped removing git worktree "${workspacePath}" because Paperclip could not inspect git status: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+
+        if (gitStatus && gitStatus.length > 0) {
+          warnings.push(`Skipped removing git worktree "${workspacePath}" because it has uncommitted or untracked files.`);
+        } else if (gitStatus === "") {
+          try {
+            await recordGitOperation(input.recorder, {
+              phase: "worktree_cleanup",
+              args: ["worktree", "remove", "--force", workspacePath],
+              cwd: repoRoot,
+              metadata: {
+                workspaceId: input.workspace.id,
+                workspacePath,
+                branchName: input.workspace.branchName,
+                cleanupAction: "worktree_remove",
+              },
+              successMessage: `Removed git worktree ${workspacePath}\n`,
+              failureLabel: `git worktree remove ${workspacePath}`,
+            });
+          } catch (err) {
+            warnings.push(err instanceof Error ? err.message : String(err));
+          }
         }
       }
     }

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1372,6 +1372,7 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
   }
 
   if (input.workspace.providerType === "git_worktree" && workspacePath) {
+    let worktreeWasRemoved = false;
     const worktreeExists = await directoryExists(workspacePath);
     if (worktreeExists) {
       if (!repoRoot) {
@@ -1405,13 +1406,14 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
               successMessage: `Removed git worktree ${workspacePath}\n`,
               failureLabel: `git worktree remove ${workspacePath}`,
             });
+            worktreeWasRemoved = true;
           } catch (err) {
             warnings.push(err instanceof Error ? err.message : String(err));
           }
         }
       }
     }
-    if (createdByRuntime && input.workspace.branchName) {
+    if (createdByRuntime && input.workspace.branchName && worktreeWasRemoved) {
       if (!repoRoot) {
         warnings.push(`Could not resolve git repo root to delete branch "${input.workspace.branchName}".`);
       } else {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Paperclip issue execution can create isolated git worktrees so agents can work without mutating the primary checkout.
> - Large repositories make worktree lifecycle policy important because stale or unsafe deletion can consume disk or destroy active work.
> - Existing cleanup paths removed runtime-created worktrees, but did not fully report why unsafe worktrees should be left in place.
> - This pull request documents the lifecycle policy and makes close/cleanup report dirty, untracked, unmerged, or active worktrees instead of deleting them.
> - A Greptile follow-up tightened branch cleanup so branches are deleted only after the git worktree removal actually succeeds.
> - The benefit is safer Paperclip workspace cleanup with clearer operator evidence for large-repo workspaces.

## What Changed

- Documented large-repo worktree lifecycle policy for Paperclip issue/review workspaces.
- Added close-readiness blocking reasons for dirty, untracked, or unmerged isolated git worktrees.
- Made runtime cleanup report dirty/uninspectable git worktrees instead of deleting them.
- Gated runtime-created branch deletion so it only runs after the associated git worktree was actually removed.
- Added regression coverage for blocked close behavior, cleanup reporting, and the dirty-worktree branch-deletion warning case.

## Verification

- `pnpm vitest run server/src/__tests__/execution-workspaces-service.test.ts server/src/__tests__/workspace-runtime.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check origin/master...HEAD`
- Red/green regression check: `pnpm vitest run server/src/__tests__/workspace-runtime.test.ts -t "reports dirty git worktrees instead of removing them during cleanup"` failed before the branch-deletion gate and passed after the fix.

## Risks

- Low risk: the cleanup behavior is more conservative for git worktrees and only suppresses branch deletion when worktree removal did not happen.
- Unmerged runtime-created branches are still preserved and reported through the existing `git branch -d` warning path after a successful worktree removal.
- No schema, API, or UI changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex based on GPT-5 via the Paperclip local agent adapter, with shell/git/GitHub CLI tool use and medium reasoning effort.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

## Paperclip

- WAT-1777
- WAT-1842
