### PR TITLE
fix(heartbeat): prevent false auto-block after successful continuation retry

### DIFF
--- a/packages/db/src/migrations/0057_open_routine_origin_uniqueness.sql
+++ b/packages/db/src/migrations/0057_open_routine_origin_uniqueness.sql
@@ -1,0 +1,4 @@
+CREATE UNIQUE INDEX IF NOT EXISTS "issues_open_routine_origin_uq" ON "issues" USING btree ("company_id","origin_kind","origin_id") WHERE "issues"."origin_kind" = 'routine_execution'
+          and "issues"."origin_id" is not null
+          and "issues"."hidden_at" is null
+          and "issues"."status" in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked');

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1776084034244,
       "tag": "0056_spooky_ultragirl",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1776375450733,
+      "tag": "0057_open_routine_origin_uniqueness",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -90,5 +90,13 @@ export const issues = pgTable(
           and ${table.executionRunId} is not null
           and ${table.status} in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked')`,
       ),
+    openRoutineOriginIdx: uniqueIndex("issues_open_routine_origin_uq")
+      .on(table.companyId, table.originKind, table.originId)
+      .where(
+        sql`${table.originKind} = 'routine_execution'
+          and ${table.originId} is not null
+          and ${table.hiddenAt} is null
+          and ${table.status} in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked')`,
+      ),
   }),
 );

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -650,6 +650,30 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Latest retry failure: `process_lost` - run failed before issue advanced.");
   });
 
+  it("does not auto-block in-progress work when the latest continuation retry already succeeded", async () => {
+    const { issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.status).toBe("succeeded");
+  });
+
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {
     const { issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -349,6 +349,68 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues[0]?.id).toBe(previousIssue.id);
   });
 
+  it("repairs stale execution locks after duplicate-key conflicts and creates a fresh issue", async () => {
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const staleHeartbeatRunId = randomUUID();
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "todo",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: staleHeartbeatRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId: previousIssue.id },
+      startedAt: new Date("2026-03-20T12:01:00.000Z"),
+      finishedAt: new Date("2026-03-20T12:03:00.000Z"),
+    });
+
+    await db
+      .update(issues)
+      .set({
+        executionRunId: staleHeartbeatRunId,
+        executionLockedAt: new Date("2026-03-20T12:01:00.000Z"),
+      })
+      .where(eq(issues.id, previousIssue.id));
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+
+    expect(run.status).toBe("issue_created");
+    expect(run.linkedIssueId).toBeTruthy();
+    expect(run.linkedIssueId).not.toBe(previousIssue.id);
+
+    const refreshedPreviousIssue = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, previousIssue.id))
+      .then((rows) => rows[0] ?? null);
+
+    expect(refreshedPreviousIssue?.executionRunId).toBeNull();
+  });
+
   it("interpolates routine variables into the execution issue and stores resolved values", async () => {
     const { companyId, agentId, projectId, svc } = await seedFixture();
     const variableRoutine = await svc.create(

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -394,6 +394,25 @@ export function issueRoutes(
     throw unauthorized();
   }
 
+  function canCreateIssuesLegacy(agent: { permissions: Record<string, unknown> | null | undefined; role: string }) {
+    if (agent.role === "ceo") return true;
+    if (!agent.permissions || typeof agent.permissions !== "object") return false;
+    const permissions = agent.permissions as Record<string, unknown>;
+    return Boolean(permissions.canCreateIssues || permissions.canCreateAgents);
+  }
+
+  async function assertCanCreateIssues(req: Request, companyId: string) {
+    assertCompanyAccess(req, companyId);
+    if (req.actor.type === "board") return;
+    if (req.actor.type === "agent") {
+      if (!req.actor.agentId) throw forbidden("Agent authentication required");
+      const actorAgent = await agentsSvc.getById(req.actor.agentId);
+      if (actorAgent && actorAgent.companyId === companyId && canCreateIssuesLegacy(actorAgent)) return;
+      throw forbidden("Missing permission: issues:create");
+    }
+    throw unauthorized();
+  }
+
   function requireAgentRunId(req: Request, res: Response) {
     if (req.actor.type !== "agent") return null;
     const runId = req.actor.runId?.trim();
@@ -1329,6 +1348,7 @@ export function issueRoutes(
   router.post("/companies/:companyId/issues", validate(createIssueSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
+    await assertCanCreateIssues(req, companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
       await assertCanAssignTasks(req, companyId);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1347,7 +1347,6 @@ export function issueRoutes(
 
   router.post("/companies/:companyId/issues", validate(createIssueSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
     await assertCanCreateIssues(req, companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3083,6 +3083,11 @@ export function heartbeatService(db: Db) {
         continue;
       }
 
+      if (latestRun?.status === "succeeded") {
+        result.skipped += 1;
+        continue;
+      }
+
       if (latestRetryReason === "issue_continuation_needed") {
         const failureSummary = summarizeRunFailureForIssueComment(latestRun);
         const updated = await escalateStrandedAssignedIssue({

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -45,6 +45,7 @@ import { logActivity } from "./activity-log.js";
 
 const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
 const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running"];
+const TERMINAL_HEARTBEAT_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"];
 const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
 const MAX_CATCH_UP_RUNS = 25;
 const WEEKDAY_INDEX: Record<string, number> = {
@@ -58,6 +59,24 @@ const WEEKDAY_INDEX: Record<string, number> = {
 };
 
 type Actor = { agentId?: string | null; userId?: string | null };
+
+function isOpenRoutineExecutionConflict(error: unknown) {
+  const constraint =
+    !!error && typeof error === "object" && "constraint" in error
+      ? (error as { constraint?: string }).constraint
+      : undefined;
+  const constraintName =
+    !!error && typeof error === "object" && "constraint_name" in error
+      ? (error as { constraint_name?: string }).constraint_name
+      : undefined;
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code?: string }).code === "23505" &&
+    (constraint === "issues_open_routine_execution_uq" || constraintName === "issues_open_routine_execution_uq")
+  );
+}
 
 function assertTimeZone(timeZone: string) {
   try {
@@ -640,6 +659,55 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  async function clearStaleExecutionLockForRoutineIssue(routine: typeof routines.$inferSelect, executor: Db = db) {
+    const candidate = await executor
+      .select({
+        id: issues.id,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, "routine_execution"),
+          eq(issues.originId, routine.id),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+          isNotNull(issues.executionRunId),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!candidate?.executionRunId) return false;
+
+    const run = await executor
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.id, candidate.executionRunId), eq(heartbeatRuns.companyId, routine.companyId)))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    if (run && LIVE_HEARTBEAT_RUN_STATUSES.includes(run.status)) {
+      return false;
+    }
+    if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.includes(run.status)) {
+      return false;
+    }
+
+    await executor
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(issues.id, candidate.id), eq(issues.executionRunId, candidate.executionRunId)));
+
+    return true;
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -790,47 +858,80 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
             executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
           });
         } catch (error) {
-          const isOpenExecutionConflict =
-            !!error &&
-            typeof error === "object" &&
-            "code" in error &&
-            (error as { code?: string }).code === "23505" &&
-            "constraint" in error &&
-            (error as { constraint?: string }).constraint === "issues_open_routine_execution_uq";
+          const isOpenExecutionConflict = isOpenRoutineExecutionConflict(error);
           if (!isOpenExecutionConflict || input.routine.concurrencyPolicy === "always_enqueue") {
             throw error;
           }
 
           const existingIssue = await findLiveExecutionIssue(input.routine, txDb);
-          if (!existingIssue) throw error;
-          const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
-          const updated = await finalizeRun(createdRun.id, {
-            status,
-            linkedIssueId: existingIssue.id,
-            coalescedIntoRunId: existingIssue.originRunId,
-            completedAt: triggeredAt,
-          }, txDb);
-          await updateRoutineTouchedState({
-            routineId: input.routine.id,
-            triggerId: input.trigger?.id ?? null,
-            triggeredAt,
-            status,
-            issueId: existingIssue.id,
-            nextRunAt,
-          }, txDb);
-          return updated ?? createdRun;
+          if (existingIssue) {
+            const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
+            const updated = await finalizeRun(createdRun.id, {
+              status,
+              linkedIssueId: existingIssue.id,
+              coalescedIntoRunId: existingIssue.originRunId,
+              completedAt: triggeredAt,
+            }, txDb);
+            await updateRoutineTouchedState({
+              routineId: input.routine.id,
+              triggerId: input.trigger?.id ?? null,
+              triggeredAt,
+              status,
+              issueId: existingIssue.id,
+              nextRunAt,
+            }, txDb);
+            return updated ?? createdRun;
+          }
+
+          const repairedStaleLock = await clearStaleExecutionLockForRoutineIssue(input.routine, db);
+          if (!repairedStaleLock) throw error;
+
+          createdIssue = await issueSvc.create(input.routine.companyId, {
+            projectId,
+            goalId: input.routine.goalId,
+            parentId: input.routine.parentIssueId,
+            title,
+            description,
+            status: "todo",
+            priority: input.routine.priority,
+            assigneeAgentId,
+            originKind: "routine_execution",
+            originId: input.routine.id,
+            originRunId: createdRun.id,
+            executionWorkspaceId: input.executionWorkspaceId ?? null,
+            executionWorkspacePreference: input.executionWorkspacePreference ?? null,
+            executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
+          });
         }
 
         // Keep the dispatch lock until the issue is linked to a queued heartbeat run.
-        await queueIssueAssignmentWakeup({
-          heartbeat,
-          issue: createdIssue,
-          reason: "issue_assigned",
-          mutation: "create",
-          contextSource: "routine.dispatch",
-          requestedByActorType: input.source === "schedule" ? "system" : undefined,
-          rethrowOnError: true,
-        });
+        try {
+          await queueIssueAssignmentWakeup({
+            heartbeat,
+            issue: createdIssue,
+            reason: "issue_assigned",
+            mutation: "create",
+            contextSource: "routine.dispatch",
+            requestedByActorType: input.source === "schedule" ? "system" : undefined,
+            rethrowOnError: true,
+          });
+        } catch (error) {
+          const isOpenExecutionConflict = isOpenRoutineExecutionConflict(error);
+          if (!isOpenExecutionConflict || input.routine.concurrencyPolicy === "always_enqueue") {
+            throw error;
+          }
+          const repairedStaleLock = await clearStaleExecutionLockForRoutineIssue(input.routine, db);
+          if (!repairedStaleLock) throw error;
+          await queueIssueAssignmentWakeup({
+            heartbeat,
+            issue: createdIssue,
+            reason: "issue_assigned",
+            mutation: "create",
+            contextSource: "routine.dispatch",
+            requestedByActorType: input.source === "schedule" ? "system" : undefined,
+            rethrowOnError: true,
+          });
+        }
         const updated = await finalizeRun(createdRun.id, {
           status: "issue_created",
           linkedIssueId: createdIssue.id,

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -634,7 +634,7 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
       .then((rows) => rows[0]?.issues ?? null);
     if (executionBoundIssue) return executionBoundIssue;
 
-    return executor
+    const contextualIssue = await executor
       .select()
       .from(issues)
       .innerJoin(
@@ -657,6 +657,23 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
       .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
       .limit(1)
       .then((rows) => rows[0]?.issues ?? null);
+    if (contextualIssue) return contextualIssue;
+
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, "routine_execution"),
+          eq(issues.originId, routine.id),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
   }
 
   async function clearStaleExecutionLockForRoutineIssue(routine: typeof routines.$inferSelect, executor: Db = db) {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -74,7 +74,10 @@ function isOpenRoutineExecutionConflict(error: unknown) {
     typeof error === "object" &&
     "code" in error &&
     (error as { code?: string }).code === "23505" &&
-    (constraint === "issues_open_routine_execution_uq" || constraintName === "issues_open_routine_execution_uq")
+    (constraint === "issues_open_routine_execution_uq" ||
+      constraintName === "issues_open_routine_execution_uq" ||
+      constraint === "issues_open_routine_origin_uq" ||
+      constraintName === "issues_open_routine_origin_uq")
   );
 }
 


### PR DESCRIPTION
## Summary
- prevent stranded-work reconciliation from auto-blocking `in_progress` issues when the latest continuation retry already succeeded
- add regression test to lock the behavior

## Why
`reconcileStrandedAssignedIssues()` could escalate to `blocked` based only on a previous `retryReason=issue_continuation_needed`, even when the latest run had already succeeded. This caused false-positive auto-block churn in live issue lanes.

## Changes
- `server/src/services/heartbeat.ts`
  - add guard: if latest run status is `succeeded`, skip continuation escalation path
- `server/src/__tests__/heartbeat-process-recovery.test.ts`
  - new test: `does not auto-block in-progress work when the latest continuation retry already succeeded`

## Validation
- targeted test run:
  - `pnpm --filter server test -- heartbeat-process-recovery.test.ts` (pass)

## Operational context
This patch was applied in hotfix runtime and validated against recurrence conditions observed in IOS lane (IOS-601).