### PR TITLE
fix(api): support status query on company agent list

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -11,7 +11,7 @@ Manage AI agents (employees) within a company.
 GET /api/companies/{companyId}/agents
 ```
 
-Returns all agents in the company.
+Returns all non-terminated agents in the company by default.
 
 Use the optional `status` query filter to return agents in one or more states. Pass statuses as a
 comma-separated list, repeat the parameter, or combine both forms:

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -21,9 +21,10 @@ GET /api/companies/{companyId}/agents?status=idle,running
 GET /api/companies/{companyId}/agents?status=idle&status=running,terminated
 ```
 
-Allowed values are `pending_approval`, `idle`, `running`, `paused`, `error`, and `terminated`.
-Requesting `terminated` includes terminated agents in the candidate list before applying the filter;
-without it, terminated agents remain excluded. Invalid status values and unsupported query parameters
+Allowed values are `active`, `pending_approval`, `idle`, `running`, `paused`, `error`, and
+`terminated`. If `status` is omitted, the endpoint preserves the existing unfiltered list behavior
+and excludes terminated agents by default. Requesting `terminated` includes terminated agents in the
+candidate list before applying the filter. Invalid status values and unsupported query parameters
 return `400`.
 
 ## Get Agent

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -13,7 +13,18 @@ GET /api/companies/{companyId}/agents
 
 Returns all agents in the company.
 
-This route does not accept query filters. Unsupported query parameters return `400`.
+Use the optional `status` query filter to return agents in one or more states. Pass statuses as a
+comma-separated list, repeat the parameter, or combine both forms:
+
+```
+GET /api/companies/{companyId}/agents?status=idle,running
+GET /api/companies/{companyId}/agents?status=idle&status=running,terminated
+```
+
+Allowed values are `pending_approval`, `idle`, `running`, `paused`, `error`, and `terminated`.
+Requesting `terminated` includes terminated agents in the candidate list before applying the filter;
+without it, terminated agents remain excluded. Invalid status values and unsupported query parameters
+return `400`.
 
 ## Get Agent
 

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -694,6 +694,106 @@ describe.sequential("agent permission routes", () => {
     );
   }, 15_000);
 
+  it("supports status query parameter on the agent list route", async () => {
+    mockAgentService.list.mockResolvedValue([
+      baseAgent,
+      {
+        ...baseAgent,
+        id: "33333333-3333-4333-8333-333333333333",
+        name: "Busy",
+        status: "running",
+      },
+      {
+        ...baseAgent,
+        id: "44444444-4444-4444-8444-444444444444",
+        name: "Retired",
+        status: "terminated",
+      },
+    ]);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/agents`)
+      .query({ status: "idle,running" });
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.list).toHaveBeenCalledWith(companyId, { includeTerminated: false });
+    expect(res.body).toHaveLength(2);
+    expect(res.body.map((agent: { status: string }) => agent.status).sort()).toEqual(["idle", "running"]);
+  });
+
+  it("includes terminated rows when status filter requests terminated", async () => {
+    mockAgentService.list.mockResolvedValue([
+      { ...baseAgent, status: "idle" },
+      {
+        ...baseAgent,
+        id: "44444444-4444-4444-8444-444444444444",
+        name: "Retired",
+        status: "terminated",
+      },
+    ]);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/agents`)
+      .query({ status: "terminated" });
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.list).toHaveBeenCalledWith(companyId, { includeTerminated: true });
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].status).toBe("terminated");
+  });
+
+  it("rejects invalid status values on the agent list route", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/agents`)
+      .query({ status: "idle,banana" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("banana");
+    expect(mockAgentService.list).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty status filter values on the agent list route", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/agents`)
+      .query({ status: "" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("comma-separated statuses");
+    expect(mockAgentService.list).not.toHaveBeenCalled();
+  });
+
   it("rejects unsupported query parameters on the agent list route", async () => {
     const app = await createApp({
       type: "board",

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -940,6 +940,143 @@ describe.sequential("agent permission routes", () => {
     );
   }, 15_000);
 
+  it("supports status query parameter on the agent list route", async () => {
+    mockAgentService.list.mockResolvedValue([
+      baseAgent,
+      {
+        ...baseAgent,
+        id: "33333333-3333-4333-8333-333333333333",
+        name: "Busy",
+        status: "running",
+      },
+      {
+        ...baseAgent,
+        id: "44444444-4444-4444-8444-444444444444",
+        name: "Retired",
+        status: "terminated",
+      },
+    ]);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/agents`)
+      .query({ status: "idle,running" });
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.list).toHaveBeenCalledWith(companyId, { includeTerminated: false });
+    expect(res.body).toHaveLength(2);
+    expect(res.body.map((agent: { status: string }) => agent.status).sort()).toEqual(["idle", "running"]);
+  });
+
+  it("supports repeated and comma-separated status query values together", async () => {
+    mockAgentService.list.mockResolvedValue([
+      baseAgent,
+      {
+        ...baseAgent,
+        id: "33333333-3333-4333-8333-333333333333",
+        name: "Busy",
+        status: "running",
+      },
+      {
+        ...baseAgent,
+        id: "44444444-4444-4444-8444-444444444444",
+        name: "Retired",
+        status: "terminated",
+      },
+    ]);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/agents?status=idle&status=running,terminated`);
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.list).toHaveBeenCalledWith(companyId, { includeTerminated: true });
+    expect(res.body.map((agent: { status: string }) => agent.status).sort()).toEqual([
+      "idle",
+      "running",
+      "terminated",
+    ]);
+  });
+
+  it("includes terminated rows when status filter requests terminated", async () => {
+    mockAgentService.list.mockResolvedValue([
+      { ...baseAgent, status: "idle" },
+      {
+        ...baseAgent,
+        id: "44444444-4444-4444-8444-444444444444",
+        name: "Retired",
+        status: "terminated",
+      },
+    ]);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/agents`)
+      .query({ status: "terminated" });
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.list).toHaveBeenCalledWith(companyId, { includeTerminated: true });
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].status).toBe("terminated");
+  });
+
+  it("rejects invalid status values on the agent list route", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/agents`)
+      .query({ status: "idle,banana" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("banana");
+    expect(mockAgentService.list).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty status filter values on the agent list route", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/agents`)
+      .query({ status: "" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("comma-separated statuses");
+    expect(mockAgentService.list).not.toHaveBeenCalled();
+  });
+
   it("rejects unsupported query parameters on the agent list route", async () => {
     const app = await createApp({
       type: "board",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -5,6 +5,7 @@ import type { Db } from "@paperclipai/db";
 import { agents as agentsTable, companies, heartbeatRuns, issues as issuesTable } from "@paperclipai/db";
 import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
 import {
+  AGENT_STATUSES,
   agentSkillSyncSchema,
   agentMineInboxQuerySchema,
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -16,6 +17,7 @@ import {
   resetAgentSessionSchema,
   testAdapterEnvironmentSchema,
   type AgentSkillSnapshot,
+  type AgentStatus,
   type InstanceSchedulerHeartbeatAgent,
   upsertAgentInstructionsFileSchema,
   updateAgentInstructionsBundleSchema,
@@ -1114,20 +1116,61 @@ export function agentRoutes(
   router.get("/companies/:companyId/agents", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    const unsupportedQueryParams = Object.keys(req.query).sort();
+
+    const supportedQueryParams = new Set(["status"]);
+    const unsupportedQueryParams = Object.keys(req.query)
+      .filter((key) => !supportedQueryParams.has(key))
+      .sort();
     if (unsupportedQueryParams.length > 0) {
       res.status(400).json({
         error: `Unsupported query parameter${unsupportedQueryParams.length === 1 ? "" : "s"}: ${unsupportedQueryParams.join(", ")}`,
       });
       return;
     }
-    const result = await svc.list(companyId);
-    const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
-    if (canReadConfigs) {
-      res.json(result);
+
+    const requestedStatuses: AgentStatus[] = [];
+    const rawStatusQuery = req.query.status;
+    const statusQueryProvided = rawStatusQuery !== undefined;
+    const statusEntries = Array.isArray(rawStatusQuery) ? rawStatusQuery : rawStatusQuery ? [rawStatusQuery] : [];
+    for (const entry of statusEntries) {
+      if (typeof entry !== "string") continue;
+      for (const value of entry.split(",")) {
+        const trimmed = value.trim();
+        if (trimmed.length > 0) {
+          requestedStatuses.push(trimmed as AgentStatus);
+        }
+      }
+    }
+
+    if (statusQueryProvided && requestedStatuses.length === 0) {
+      res.status(400).json({
+        error: "Invalid status query parameter value: expected one or more comma-separated statuses",
+      });
       return;
     }
-    res.json(result.map((agent) => redactForRestrictedAgentView(agent)));
+
+    const invalidStatuses = requestedStatuses.filter((status) => !AGENT_STATUSES.includes(status));
+    if (invalidStatuses.length > 0) {
+      res.status(400).json({
+        error: `Invalid status query parameter value${invalidStatuses.length === 1 ? "" : "s"}: ${invalidStatuses.join(", ")}. Allowed: ${AGENT_STATUSES.join(", ")}`,
+      });
+      return;
+    }
+
+    const statusFilter = new Set(requestedStatuses);
+    const includeTerminated = statusFilter.has("terminated");
+    const result = await svc.list(companyId, { includeTerminated });
+    const filtered =
+      statusFilter.size > 0
+        ? result.filter((agent) => statusFilter.has(agent.status as AgentStatus))
+        : result;
+
+    const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
+    if (canReadConfigs) {
+      res.json(filtered);
+      return;
+    }
+    res.json(filtered.map((agent) => redactForRestrictedAgentView(agent)));
   });
 
   router.get("/instance/scheduler-heartbeats", async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -5,6 +5,7 @@ import type { Db } from "@paperclipai/db";
 import { agents as agentsTable, companies, heartbeatRuns, issues as issuesTable, projects as projectsTable } from "@paperclipai/db";
 import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
 import {
+  AGENT_STATUSES,
   agentSkillSyncSchema,
   agentMineInboxQuerySchema,
   ADAPTER_AGNOSTIC_KEYS,
@@ -20,6 +21,7 @@ import {
   type AgentDesiredSkillEntry,
   type AgentSkillAssignmentMode,
   type AgentSkillSnapshot,
+  type AgentStatus,
   type InstanceSchedulerHeartbeatAgent,
   upsertAgentInstructionsFileSchema,
   updateAgentInstructionsBundleSchema,
@@ -2144,20 +2146,63 @@ export function agentRoutes(
   router.get("/companies/:companyId/agents", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    const unsupportedQueryParams = Object.keys(req.query).sort();
+
+    const supportedQueryParams = new Set(["status"]);
+    const unsupportedQueryParams = Object.keys(req.query)
+      .filter((key) => !supportedQueryParams.has(key))
+      .sort();
     if (unsupportedQueryParams.length > 0) {
       res.status(400).json({
         error: `Unsupported query parameter${unsupportedQueryParams.length === 1 ? "" : "s"}: ${unsupportedQueryParams.join(", ")}`,
       });
       return;
     }
-    const result = await filterAgentsForActor(req, await svc.list(companyId));
-    const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
-    if (canReadConfigs) {
-      res.json(result);
+    const requestedStatuses: AgentStatus[] = [];
+    const rawStatusQuery = req.query.status;
+    const statusQueryProvided = rawStatusQuery !== undefined;
+    const statusEntries = Array.isArray(rawStatusQuery) ? rawStatusQuery : rawStatusQuery ? [rawStatusQuery] : [];
+    for (const entry of statusEntries) {
+      if (typeof entry !== "string") continue;
+      for (const value of entry.split(",")) {
+        const trimmed = value.trim();
+        if (trimmed.length > 0) {
+          requestedStatuses.push(trimmed as AgentStatus);
+        }
+      }
+    }
+
+    if (statusQueryProvided && requestedStatuses.length === 0) {
+      res.status(400).json({
+        error: "Invalid status query parameter value: expected one or more comma-separated statuses",
+      });
       return;
     }
-    res.json(result.map((agent) => redactForRestrictedAgentView(agent)));
+
+    const invalidStatuses = requestedStatuses.filter((status) => !AGENT_STATUSES.includes(status));
+    if (invalidStatuses.length > 0) {
+      res.status(400).json({
+        error: `Invalid status query parameter value${invalidStatuses.length === 1 ? "" : "s"}: ${invalidStatuses.join(", ")}. Allowed: ${AGENT_STATUSES.join(", ")}`,
+      });
+      return;
+    }
+
+    const statusFilter = new Set(requestedStatuses);
+    const includeTerminated = statusFilter.has("terminated");
+    const listedAgents = statusQueryProvided
+      ? await svc.list(companyId, { includeTerminated })
+      : await svc.list(companyId);
+    const result = await filterAgentsForActor(req, listedAgents);
+    const filtered =
+      statusFilter.size > 0
+        ? result.filter((agent) => statusFilter.has(agent.status as AgentStatus))
+        : result;
+
+    const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
+    if (canReadConfigs) {
+      res.json(filtered);
+      return;
+    }
+    res.json(filtered.map((agent) => redactForRestrictedAgentView(agent)));
   });
 
   router.get("/instance/scheduler-heartbeats", async (req, res) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for company workflows where automation logic depends on predictable API contracts.
> - The agent-list API (`GET /api/companies/:companyId/agents`) is part of that control-plane contract used by skills/templates to find available assignees.
> - Many shipped templates/skills call this route with `?status=idle` for auto-assignment and backlog triage flows.
> - The current route rejects all query parameters, returning `400 Unsupported query parameter: status`, which breaks those workflows despite `idle` being a valid agent status.
> - This creates a mismatch: issue-list routes support status filtering, but agent-list does not, causing avoidable runtime failures in generated company routines.
> - This pull request adds explicit, validated `status` filtering support on the company agent-list route while keeping strict rejection for unknown query params.
> - The benefit is that existing templates/skills work as documented and operator workflows can reliably fetch idle/active agent subsets from the API.

## Linked Issues or Issue Description

No public GitHub issue is linked. A search of open and closed pull requests found no duplicate implementation. PR #10951 is related because it enforces strict query validation on other list endpoints, but it does not add agent status filtering.

**What happened?**

`GET /api/companies/:companyId/agents?status=idle` returns `400 Unsupported query parameter: status`. Shipped workflows use this filter to find agents that can accept work.

**Expected behavior**

The endpoint should accept valid agent statuses, return only matching agents, and continue to reject unsupported query parameters and invalid status values.

**Steps to reproduce**

1. Start Paperclip from `master`.
2. Send `GET /api/companies/:companyId/agents?status=idle` with access to the company.
3. Observe the `400 Unsupported query parameter: status` response instead of a filtered agent list.

## What Changed

- Added support for `status` query param on `GET /api/companies/:companyId/agents`.
- Preserved strict query validation for unknown params (still returns 400 for unsupported keys).
- Implemented status parsing for comma-separated values (e.g. `status=idle,running`) and repeated params.
- Added validation against `AGENT_STATUSES`; invalid/empty status filters now return clear 400 errors.
- When `terminated` is requested, the route now loads with `includeTerminated: true` and then applies status filtering.
- Added/updated route tests in `server/src/__tests__/agent-permissions-routes.test.ts` for:
  - accepted status filtering,
  - terminated inclusion behavior,
  - invalid status rejection,
  - empty status rejection,
  - unsupported param rejection.

## Verification

- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-permissions-routes.test.ts`

## Risks

- Low risk: behavior change is scoped to one GET route and guarded by explicit validation.
- Potential compatibility note: requests like `?status=` now fail fast with 400 instead of silently returning an unfiltered list.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI `gpt-5.3-codex` via Hermes Agent (tool-assisted code editing, tests, git/gh workflow).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
