### PR TITLE
chore(deps): pin embedded-postgres to beta.15

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -51,7 +51,7 @@
     "drizzle-orm": "0.38.4",
     "dotenv": "^17.0.1",
     "commander": "^13.1.0",
-    "embedded-postgres": "^18.1.0-beta.16",
+    "embedded-postgres": "18.1.0-beta.15",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -56,9 +56,17 @@
   "packageManager": "pnpm@9.15.4",
   "pnpm": {
     "patchedDependencies": {
-      "embedded-postgres@18.1.0-beta.16": "patches/embedded-postgres@18.1.0-beta.16.patch"
+      "embedded-postgres@18.1.0-beta.15": "patches/embedded-postgres@18.1.0-beta.15.patch"
     },
     "overrides": {
+      "@embedded-postgres/darwin-arm64": "18.1.0-beta.15",
+      "@embedded-postgres/darwin-x64": "18.1.0-beta.15",
+      "@embedded-postgres/linux-arm": "18.1.0-beta.15",
+      "@embedded-postgres/linux-arm64": "18.1.0-beta.15",
+      "@embedded-postgres/linux-ia32": "18.1.0-beta.15",
+      "@embedded-postgres/linux-ppc64": "18.1.0-beta.15",
+      "@embedded-postgres/linux-x64": "18.1.0-beta.15",
+      "@embedded-postgres/windows-x64": "18.1.0-beta.15",
       "rollup": ">=4.59.0"
     }
   }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@paperclipai/shared": "workspace:*",
     "drizzle-orm": "^0.38.4",
-    "embedded-postgres": "^18.1.0-beta.16",
+    "embedded-postgres": "18.1.0-beta.15",
     "postgres": "^3.4.5"
   },
   "devDependencies": {

--- a/patches/embedded-postgres@18.1.0-beta.15.patch
+++ b/patches/embedded-postgres@18.1.0-beta.15.patch
@@ -10,7 +10,7 @@ diff --git a/dist/index.js b/dist/index.js
  // The default configuration options for the class
  const defaults = {
      databaseDir: path.join(process.cwd(), 'data', 'db'),
-@@ -133,7 +133,7 @@
+@@ -121,7 +121,7 @@
                      `--pwfile=${passwordFile}`,
                      `--lc-messages=${LC_MESSAGES_LOCALE}`,
                      ...this.options.initdbFlags,
@@ -19,7 +19,7 @@ diff --git a/dist/index.js b/dist/index.js
                  // Connect to stderr, as that is where the messages get sent
                  (_a = process.stdout) === null || _a === void 0 ? void 0 : _a.on('data', (chunk) => {
                      // Parse the data as a string and log it
-@@ -177,7 +177,7 @@
+@@ -165,7 +165,7 @@
                      '-p',
                      this.options.port.toString(),
                      ...this.options.postgresFlags,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,20 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@embedded-postgres/darwin-arm64': 18.1.0-beta.15
+  '@embedded-postgres/darwin-x64': 18.1.0-beta.15
+  '@embedded-postgres/linux-arm': 18.1.0-beta.15
+  '@embedded-postgres/linux-arm64': 18.1.0-beta.15
+  '@embedded-postgres/linux-ia32': 18.1.0-beta.15
+  '@embedded-postgres/linux-ppc64': 18.1.0-beta.15
+  '@embedded-postgres/linux-x64': 18.1.0-beta.15
+  '@embedded-postgres/windows-x64': 18.1.0-beta.15
   rollup: '>=4.59.0'
 
 patchedDependencies:
-  embedded-postgres@18.1.0-beta.16:
-    hash: 55uhvnotpqyiy37rn3pqpukhei
-    path: patches/embedded-postgres@18.1.0-beta.16.patch
+  embedded-postgres@18.1.0-beta.15:
+    hash: nilquonpsejtfgoc4xkqg7mgk4
+    path: patches/embedded-postgres@18.1.0-beta.15.patch
 
 importers:
 
@@ -80,8 +88,8 @@ importers:
         specifier: 0.38.4
         version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
-        specifier: ^18.1.0-beta.16
-        version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
+        specifier: 18.1.0-beta.15
+        version: 18.1.0-beta.15(patch_hash=nilquonpsejtfgoc4xkqg7mgk4)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -232,8 +240,8 @@ importers:
         specifier: ^0.38.4
         version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
-        specifier: ^18.1.0-beta.16
-        version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
+        specifier: 18.1.0-beta.15
+        version: 18.1.0-beta.15(patch_hash=nilquonpsejtfgoc4xkqg7mgk4)
       postgres:
         specifier: ^3.4.5
         version: 3.4.8
@@ -539,8 +547,8 @@ importers:
         specifier: ^0.38.4
         version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
-        specifier: ^18.1.0-beta.16
-        version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
+        specifier: 18.1.0-beta.15
+        version: 18.1.0-beta.15(patch_hash=nilquonpsejtfgoc4xkqg7mgk4)
       express:
         specifier: ^5.1.0
         version: 5.2.1
@@ -1303,50 +1311,50 @@ packages:
   '@electric-sql/pglite@0.3.15':
     resolution: {integrity: sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==}
 
-  '@embedded-postgres/darwin-arm64@18.1.0-beta.16':
-    resolution: {integrity: sha512-tU/syLOamFZdXMC+p7AYczmFKIiolFlZ8y3Qb7KonX37O07ezc/OSDiQ641sheV3X0WPf9V10qyK8c81rleDdw==}
+  '@embedded-postgres/darwin-arm64@18.1.0-beta.15':
+    resolution: {integrity: sha512-pdCU/y07Ebdz8cBP8DRSBa3ORqUjEdLIlNE4qLB0cXHbRR8QSUwJA/U809qMm9rJ1ZDG2WjGgVvNniXDGbRSEA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@embedded-postgres/darwin-x64@18.1.0-beta.16':
-    resolution: {integrity: sha512-4zHNCscGJt/3pmkpLCuU/IpMJzwENM6OqSHE+WWkOoNqYid49ZnmgB1ltOelgZgRoPRIy/HDEnrMeuVxQHBhEw==}
+  '@embedded-postgres/darwin-x64@18.1.0-beta.15':
+    resolution: {integrity: sha512-eGxygBRTc4RSr4z+Itg5C/Rkuzt1x1ef3MCARVwvfaJjBLt/zx7HV5TCFaAiEQo+U2DuNfena1izSFCI48pTKA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@embedded-postgres/linux-arm64@18.1.0-beta.16':
-    resolution: {integrity: sha512-G0f/reVFc7svqncDQL7blwKulzYIYsz+o/3TEtAJOaGMXYkD8Swzv9RFKfEJOr9+IVRwCmoFFppMeBnUwMoGZg==}
+  '@embedded-postgres/linux-arm64@18.1.0-beta.15':
+    resolution: {integrity: sha512-a1AIFKpQpg/B5xKGKt+/+040X3QfHCHnf3jb9AiHzK9D9TADT07LFNt9A1nr8MXywazZ4gfGv1RBX39WHmpIgg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@embedded-postgres/linux-arm@18.1.0-beta.16':
-    resolution: {integrity: sha512-aB1t95YGnqay8swh70s7zo587Nog90UL9yUYrzMMNMq40Qfrq9aWiBn0+6vCxp1rSFaPyJMPvW62/rIKLFBkKg==}
+  '@embedded-postgres/linux-arm@18.1.0-beta.15':
+    resolution: {integrity: sha512-VCAANozQXOI1oe6YJ6JgNcWIWQBQvmv/iQvgXZJqY0vqVMFoVLjYiQ1zJ+Ayv9lYPo7Ncswwsrqx/Sk7ock4mQ==}
     engines: {node: '>=16'}
     cpu: [arm]
     os: [linux]
 
-  '@embedded-postgres/linux-ia32@18.1.0-beta.16':
-    resolution: {integrity: sha512-gMTIryUMnwyLancs34gXqaiuXIFMgn8RGYZ2wJZEuXpW0SQ/cE07kFINmoQO1sN+5T/IR0KvMXPzxo867wO3ew==}
+  '@embedded-postgres/linux-ia32@18.1.0-beta.15':
+    resolution: {integrity: sha512-DxXmvpN6rVNqiuRJ6fpuFPcmYiq6lp+QBAnZS5cLJswKEUpyC23q4dfDo/mpP/iYdvUUZGgv2S5YPFNNzvp7pQ==}
     engines: {node: '>=16'}
     cpu: [ia32]
     os: [linux]
 
-  '@embedded-postgres/linux-ppc64@18.1.0-beta.16':
-    resolution: {integrity: sha512-wTglX0bZVBretiUJrZUO/EmEP8w7jC+i8ZAEKesHHIqIDXEV2F9l+6aTjWt2wRu5SAJ6gpe2RbcKvJ6x+6m1Qw==}
+  '@embedded-postgres/linux-ppc64@18.1.0-beta.15':
+    resolution: {integrity: sha512-PlNW4/WCD/cMrL28H7iCN+HqWHvP1yl9wRId2cO9DNlW8QiTOwGs72irA3msuoBqoClsOWQHpQLnn3v7D6TJ5w==}
     engines: {node: '>=16'}
     cpu: [ppc64]
     os: [linux]
 
-  '@embedded-postgres/linux-x64@18.1.0-beta.16':
-    resolution: {integrity: sha512-+GIabpHh7QV2AcYBuzyQC41AYczSFphxfHy4ccTPIPrp6OSthZXH+A9fymjQzOiDHg9+1UeYET00Aj7sScjXrg==}
+  '@embedded-postgres/linux-x64@18.1.0-beta.15':
+    resolution: {integrity: sha512-AvFLqFLBdaAJIBjgyH7ejVVtgMss/DqAuE05FGyaoxmwuMQtr7c5rIm3kUbM+RzOzDFZZY9EzU67OQt5wlmxCA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@embedded-postgres/windows-x64@18.1.0-beta.16':
-    resolution: {integrity: sha512-v6AXH1zi6YyoqPM6U7mX08prJ33yD9gqsbo3YdtPi8FDx0C/y9sYa3aQVf/3blPJvHyERYbY8fZnYXbb79Lo0Q==}
+  '@embedded-postgres/windows-x64@18.1.0-beta.15':
+    resolution: {integrity: sha512-xLIAuYqkUK1Hk93Bsn1eGAbpEEDgt4UHpg/fA1Vgj66rOJTDf1Q783rWNIBZ7kZP9FtgSnAk4gJhLRMNgkakMg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -4546,8 +4554,8 @@ packages:
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
 
-  embedded-postgres@18.1.0-beta.16:
-    resolution: {integrity: sha512-TDp7Ld0h84x5fzIIZFyreYWqZrxUNjuXB6OxqJCmV6PodB2vzQ+1hlL6n4uK1de7bIAxYt5OkDykwcuIONQdQg==}
+  embedded-postgres@18.1.0-beta.15:
+    resolution: {integrity: sha512-JZZuPouEAk4vNaYODGGNIPYTMO/Al09Y8L2WvcqGdO3+fPFzJl4lhxJm8EfMOpJpi/x9tH1Ba47ZGE4/TTJjtA==}
     engines: {node: '>=16'}
 
   empathic@2.0.0:
@@ -7562,28 +7570,28 @@ snapshots:
   '@electric-sql/pglite@0.3.15':
     optional: true
 
-  '@embedded-postgres/darwin-arm64@18.1.0-beta.16':
+  '@embedded-postgres/darwin-arm64@18.1.0-beta.15':
     optional: true
 
-  '@embedded-postgres/darwin-x64@18.1.0-beta.16':
+  '@embedded-postgres/darwin-x64@18.1.0-beta.15':
     optional: true
 
-  '@embedded-postgres/linux-arm64@18.1.0-beta.16':
+  '@embedded-postgres/linux-arm64@18.1.0-beta.15':
     optional: true
 
-  '@embedded-postgres/linux-arm@18.1.0-beta.16':
+  '@embedded-postgres/linux-arm@18.1.0-beta.15':
     optional: true
 
-  '@embedded-postgres/linux-ia32@18.1.0-beta.16':
+  '@embedded-postgres/linux-ia32@18.1.0-beta.15':
     optional: true
 
-  '@embedded-postgres/linux-ppc64@18.1.0-beta.16':
+  '@embedded-postgres/linux-ppc64@18.1.0-beta.15':
     optional: true
 
-  '@embedded-postgres/linux-x64@18.1.0-beta.16':
+  '@embedded-postgres/linux-x64@18.1.0-beta.15':
     optional: true
 
-  '@embedded-postgres/windows-x64@18.1.0-beta.16':
+  '@embedded-postgres/windows-x64@18.1.0-beta.15':
     optional: true
 
   '@emnapi/runtime@1.9.1':
@@ -10767,19 +10775,19 @@ snapshots:
 
   electron-to-chromium@1.5.286: {}
 
-  embedded-postgres@18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei):
+  embedded-postgres@18.1.0-beta.15(patch_hash=nilquonpsejtfgoc4xkqg7mgk4):
     dependencies:
       async-exit-hook: 2.0.1
       pg: 8.18.0
     optionalDependencies:
-      '@embedded-postgres/darwin-arm64': 18.1.0-beta.16
-      '@embedded-postgres/darwin-x64': 18.1.0-beta.16
-      '@embedded-postgres/linux-arm': 18.1.0-beta.16
-      '@embedded-postgres/linux-arm64': 18.1.0-beta.16
-      '@embedded-postgres/linux-ia32': 18.1.0-beta.16
-      '@embedded-postgres/linux-ppc64': 18.1.0-beta.16
-      '@embedded-postgres/linux-x64': 18.1.0-beta.16
-      '@embedded-postgres/windows-x64': 18.1.0-beta.16
+      '@embedded-postgres/darwin-arm64': 18.1.0-beta.15
+      '@embedded-postgres/darwin-x64': 18.1.0-beta.15
+      '@embedded-postgres/linux-arm': 18.1.0-beta.15
+      '@embedded-postgres/linux-arm64': 18.1.0-beta.15
+      '@embedded-postgres/linux-ia32': 18.1.0-beta.15
+      '@embedded-postgres/linux-ppc64': 18.1.0-beta.15
+      '@embedded-postgres/linux-x64': 18.1.0-beta.15
+      '@embedded-postgres/windows-x64': 18.1.0-beta.15
     transitivePeerDependencies:
       - pg-native
 

--- a/server/package.json
+++ b/server/package.json
@@ -63,7 +63,7 @@
     "dompurify": "^3.3.2",
     "dotenv": "^17.0.1",
     "drizzle-orm": "^0.38.4",
-    "embedded-postgres": "^18.1.0-beta.16",
+    "embedded-postgres": "18.1.0-beta.15",
     "express": "^5.1.0",
     "hermes-paperclip-adapter": "^0.2.0",
     "jsdom": "^28.1.0",


### PR DESCRIPTION
## Thinking Path

> - Paperclip relies on embedded PostgreSQL for local/runtime database flows, so the `embedded-postgres` package and its platform binaries need to resolve as one coherent version set.
> - PR #4102 tried to pin `embedded-postgres` to beta.15, but the branch name failed the lockfile policy and pnpm still resolved `@embedded-postgres/*` platform packages to beta.16 through upstream optional dependency ranges.
> - The replacement path needs to use the one policy-approved branch name for lockfile changes and explicitly pin the platform packages so Linux installs do not drift back to beta.16.
> - Keeping the existing package patch aligned with beta.15 preserves the LC_MESSAGES environment behavior while making the lockfile and package metadata agree.

## What Changed

- Pinned direct `embedded-postgres` dependencies in `cli`, `packages/db`, and `server` to exact `18.1.0-beta.15`.
- Moved the patched dependency entry and patch filename from `embedded-postgres@18.1.0-beta.16` to `embedded-postgres@18.1.0-beta.15`.
- Added root `pnpm.overrides` for every `@embedded-postgres/*` optional platform package so pnpm resolves all platform binaries to `18.1.0-beta.15` instead of beta.16.
- Refreshed `pnpm-lock.yaml` on the policy-approved `chore/refresh-lockfile` branch.
- Confirmed no `18.1.0-beta.16` references remain in dependency files, lockfile, or patches.

## Verification

- Local port of PR policy check: branch name allows `pnpm-lock.yaml`; Dockerfile deps stage check passed; lockfile-only install passed.
- `env -u NODE_ENV CI=true pnpm install --frozen-lockfile`
- `env -u NODE_ENV pnpm -r typecheck`
- `env -u NODE_ENV -u DATABASE_URL pnpm test:run` (first run inherited a local `DATABASE_URL` and failed that env-sensitive runtime-config assertion; rerun with `DATABASE_URL` unset passed)
- `env -u NODE_ENV -u DATABASE_URL pnpm build`
- `env -u NODE_ENV -u DATABASE_URL npx playwright install chromium`
- `env -u NODE_ENV -u DATABASE_URL PAPERCLIP_E2E_SKIP_LLM=true pnpm run test:e2e`
- Disposable clone canary dry-run: `./scripts/release.sh canary --skip-verify --dry-run` passed after `env -u NODE_ENV CI=true pnpm install --frozen-lockfile` installed dependencies in the clone. The first dry-run attempt only failed because the disposable clone had no `node_modules`.

## Risks

- Low dependency hygiene risk: the direct package and all platform optional packages are now explicitly pinned to beta.15, so the remaining risk is upstream package metadata changing in a future release.
- The lockfile exception depends on the branch name staying exactly `chore/refresh-lockfile`; this PR uses that branch name from the fork head.

## Model Used

- OpenAI Codex
- Model ID: GPT-5.5
- Reasoning effort: xhigh
- Capabilities used: terminal tool execution, GitHub CLI, GitHub connector, local test/build/release verification

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable; dependency-only change)
- [x] I have updated relevant documentation to reflect my changes (not applicable; dependency-only change)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
