### PR TITLE
feat(server): run-scoped proxy auth tokens (APE-1712)

### DIFF
--- a/server/src/__tests__/proxy-token-routes.test.ts
+++ b/server/src/__tests__/proxy-token-routes.test.ts
@@ -1,0 +1,177 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be hoisted so vi.doMock sees them before imports
+// ---------------------------------------------------------------------------
+const mockVerifyLocalAgentJwt = vi.hoisted(() => vi.fn());
+
+const mockDbSelect = vi.hoisted(() => vi.fn());
+
+function registerMocks() {
+  vi.doMock("../agent-auth-jwt.js", () => ({
+    verifyLocalAgentJwt: mockVerifyLocalAgentJwt,
+  }));
+
+  // Minimal Drizzle-compatible db stub that returns what mockDbSelect resolves to.
+  // The route calls: db.select({...}).from(heartbeatRuns).where(...).then(rows => rows[0] ?? null)
+  vi.doMock("@paperclipai/db", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@paperclipai/db")>();
+    return {
+      ...actual,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// App factory — re-imported after mocks are registered
+// ---------------------------------------------------------------------------
+async function createApp(db: unknown) {
+  const [{ proxyRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/proxy.js"),
+    import("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use("/api", proxyRoutes(db as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeDb(runRow: Record<string, unknown> | null) {
+  const chain = {
+    from: () => chain,
+    where: () => chain,
+    then: (fn: (rows: unknown[]) => unknown) =>
+      Promise.resolve(fn(runRow ? [runRow] : [])),
+  };
+  return {
+    select: () => chain,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("proxy token validation routes", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    registerMocks();
+  });
+
+  it("returns 400 when token is missing", async () => {
+    const app = await createApp(makeDb(null));
+    const res = await request(app).post("/api/proxy/validate-run-token").send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ valid: false, reason: "missing_token" });
+  });
+
+  it("returns 401 when JWT is invalid", async () => {
+    mockVerifyLocalAgentJwt.mockReturnValue(null);
+    const app = await createApp(makeDb(null));
+    const res = await request(app)
+      .post("/api/proxy/validate-run-token")
+      .send({ token: "bad-token" });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ valid: false, reason: "invalid_token" });
+  });
+
+  it("returns 401 when run is not found", async () => {
+    mockVerifyLocalAgentJwt.mockReturnValue({
+      sub: "agent-1",
+      company_id: "company-1",
+      run_id: "run-999",
+      adapter_type: "claude_local",
+      iat: 1000,
+      exp: 9999999999,
+    });
+    const app = await createApp(makeDb(null)); // null = run not found
+    const res = await request(app)
+      .post("/api/proxy/validate-run-token")
+      .send({ token: "valid-but-run-gone" });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ valid: false, reason: "run_not_found" });
+  });
+
+  it("returns 401 when run has finished (token implicitly revoked)", async () => {
+    mockVerifyLocalAgentJwt.mockReturnValue({
+      sub: "agent-1",
+      company_id: "company-1",
+      run_id: "run-1",
+      adapter_type: "claude_local",
+      iat: 1000,
+      exp: 9999999999,
+    });
+    const app = await createApp(
+      makeDb({
+        id: "run-1",
+        agentId: "agent-1",
+        companyId: "company-1",
+        status: "done",
+        finishedAt: new Date("2026-04-10T05:00:00Z"), // run completed
+      }),
+    );
+    const res = await request(app)
+      .post("/api/proxy/validate-run-token")
+      .send({ token: "token-for-completed-run" });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ valid: false, reason: "run_finished" });
+  });
+
+  it("returns 401 when token agent does not match run agent", async () => {
+    mockVerifyLocalAgentJwt.mockReturnValue({
+      sub: "agent-WRONG",
+      company_id: "company-1",
+      run_id: "run-1",
+      adapter_type: "claude_local",
+      iat: 1000,
+      exp: 9999999999,
+    });
+    const app = await createApp(
+      makeDb({
+        id: "run-1",
+        agentId: "agent-1", // different agent
+        companyId: "company-1",
+        status: "running",
+        finishedAt: null,
+      }),
+    );
+    const res = await request(app)
+      .post("/api/proxy/validate-run-token")
+      .send({ token: "mismatched-agent-token" });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ valid: false, reason: "token_agent_mismatch" });
+  });
+
+  it("returns 200 with agent info for a valid token on an active run", async () => {
+    mockVerifyLocalAgentJwt.mockReturnValue({
+      sub: "agent-1",
+      company_id: "company-1",
+      run_id: "run-1",
+      adapter_type: "claude_local",
+      iat: 1000,
+      exp: 9999999999,
+    });
+    const app = await createApp(
+      makeDb({
+        id: "run-1",
+        agentId: "agent-1",
+        companyId: "company-1",
+        status: "running",
+        finishedAt: null, // run still active
+      }),
+    );
+    const res = await request(app)
+      .post("/api/proxy/validate-run-token")
+      .send({ token: "valid-active-token" });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      valid: true,
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+    });
+  });
+});

--- a/server/src/__tests__/proxy-token-routes.test.ts
+++ b/server/src/__tests__/proxy-token-routes.test.ts
@@ -120,6 +120,56 @@ describe("proxy token validation routes", () => {
     expect(res.body).toMatchObject({ valid: false, reason: "run_finished" });
   });
 
+  it("rejects a run in terminal status with no finishedAt (crash path)", async () => {
+    mockVerifyLocalAgentJwt.mockReturnValue({
+      sub: "agent-1",
+      company_id: "company-1",
+      run_id: "run-1",
+      adapter_type: "claude_local",
+      iat: 1000,
+      exp: 9999999999,
+    });
+    const app = await createApp(
+      makeDb({
+        id: "run-1",
+        agentId: "agent-1",
+        companyId: "company-1",
+        status: "error",
+        finishedAt: null, // crashed — no finishedAt
+      }),
+    );
+    const res = await request(app)
+      .post("/api/proxy/validate-run-token")
+      .send({ token: "token-for-crashed-run" });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ valid: false, reason: "run_finished" });
+  });
+
+  it("rejects a cancelled run with no finishedAt (crash path)", async () => {
+    mockVerifyLocalAgentJwt.mockReturnValue({
+      sub: "agent-1",
+      company_id: "company-1",
+      run_id: "run-1",
+      adapter_type: "claude_local",
+      iat: 1000,
+      exp: 9999999999,
+    });
+    const app = await createApp(
+      makeDb({
+        id: "run-1",
+        agentId: "agent-1",
+        companyId: "company-1",
+        status: "cancelled",
+        finishedAt: null,
+      }),
+    );
+    const res = await request(app)
+      .post("/api/proxy/validate-run-token")
+      .send({ token: "token-for-cancelled-run" });
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ valid: false, reason: "run_finished" });
+  });
+
   it("returns 401 when token agent does not match run agent", async () => {
     mockVerifyLocalAgentJwt.mockReturnValue({
       sub: "agent-WRONG",

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -31,7 +31,7 @@ function jwtConfig() {
 
   return {
     secret,
-    ttlSeconds: parseNumber(process.env.PAPERCLIP_AGENT_JWT_TTL_SECONDS, 60 * 60 * 48),
+    ttlSeconds: parseNumber(process.env.PAPERCLIP_AGENT_JWT_TTL_SECONDS, 60 * 60 * 4),
     issuer: process.env.PAPERCLIP_AGENT_JWT_ISSUER ?? "paperclip",
     audience: process.env.PAPERCLIP_AGENT_JWT_AUDIENCE ?? "paperclip-api",
   };

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -40,6 +40,7 @@ import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
+import { proxyRoutes } from "./routes/proxy.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
@@ -282,6 +283,7 @@ export async function createApp(
     ),
   );
   api.use(adapterRoutes());
+  api.use(proxyRoutes(db));
   api.use(
     accessRoutes(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -54,7 +54,8 @@ export function proxyRoutes(db: Db): Router {
       return res.status(401).json({ valid: false, reason: "run_not_found" });
     }
 
-    if (run.finishedAt !== null) {
+    const TERMINAL_STATUSES = new Set(["done", "cancelled", "failed", "error"]);
+    if (run.finishedAt !== null || TERMINAL_STATUSES.has(run.status)) {
       return res.status(401).json({ valid: false, reason: "run_finished" });
     }
 

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -1,0 +1,75 @@
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRuns } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
+import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
+
+/**
+ * Routes for execution-proxy token validation.
+ *
+ * The execution proxy (running on a workstation) calls these endpoints to
+ * validate short-lived run-scoped bearer tokens before executing commands on
+ * behalf of an agent heartbeat. Tokens are minted by the Paperclip harness at
+ * run start (via createLocalAgentJwt) and are implicitly revoked when the run
+ * finishes (finishedAt is set).
+ *
+ * POST /api/proxy/validate-run-token
+ *   Body:  { token: string }
+ *   200:   { valid: true,  agentId, companyId, runId }
+ *   401:   { valid: false, reason }
+ *
+ * This endpoint is intentionally unauthenticated — the proxy has no API key of
+ * its own; the token-under-validation IS the credential being evaluated.
+ */
+export function proxyRoutes(db: Db): Router {
+  const router = Router();
+
+  router.post("/proxy/validate-run-token", async (req, res) => {
+    const { token } = req.body ?? {};
+    if (typeof token !== "string" || !token) {
+      return res.status(400).json({ valid: false, reason: "missing_token" });
+    }
+
+    // 1. Verify JWT signature and static claims (signature, expiry, issuer, audience).
+    const claims = verifyLocalAgentJwt(token);
+    if (!claims) {
+      return res.status(401).json({ valid: false, reason: "invalid_token" });
+    }
+
+    // 2. Check the referenced run is still active (finishedAt IS NULL).
+    //    This is the "run-scoped" constraint: token is useless after the run ends.
+    const run = await db
+      .select({
+        id: heartbeatRuns.id,
+        agentId: heartbeatRuns.agentId,
+        companyId: heartbeatRuns.companyId,
+        status: heartbeatRuns.status,
+        finishedAt: heartbeatRuns.finishedAt,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, claims.run_id))
+      .then((rows) => rows[0] ?? null);
+
+    if (!run) {
+      return res.status(401).json({ valid: false, reason: "run_not_found" });
+    }
+
+    if (run.finishedAt !== null) {
+      return res.status(401).json({ valid: false, reason: "run_finished" });
+    }
+
+    // 3. Sanity-check: JWT sub must match the run's agent.
+    if (run.agentId !== claims.sub || run.companyId !== claims.company_id) {
+      return res.status(401).json({ valid: false, reason: "token_agent_mismatch" });
+    }
+
+    return res.status(200).json({
+      valid: true,
+      agentId: run.agentId,
+      companyId: run.companyId,
+      runId: run.id,
+    });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

Run-scoped proxy authentication tokens for APE-1712.

Pushed by CTO from mst001 to unblock APE-1782.

## Related Issues
- APE-1712: Original implementation
- APE-1782: Push blocker (resolved)
- APE-1717: Downstream dependency