### PR TITLE
WAT-1953 gate done on merged paperclip/main PR

### DIFF
--- a/server/src/__tests__/issue-done-pr-guardrail-routes.test.ts
+++ b/server/src/__tests__/issue-done-pr-guardrail-routes.test.ts
@@ -1,0 +1,240 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const issueId = "11111111-1111-4111-8111-111111111111";
+const companyId = "company-1";
+
+const mockIssueService = vi.hoisted(() => ({
+  addComment: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  getById: vi.fn(),
+  listComments: vi.fn(),
+  update: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+}));
+
+function registerModuleMocks() {
+  vi.doMock("@paperclipai/shared/telemetry", () => ({
+    trackAgentTaskCompleted: vi.fn(),
+    trackErrorHandlerCrash: vi.fn(),
+  }));
+
+  vi.doMock("../telemetry.js", () => ({
+    getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+  }));
+
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => ({
+      canUser: vi.fn(),
+      hasPermission: vi.fn(),
+    }),
+    agentService: () => ({
+      getById: vi.fn(),
+    }),
+    documentService: () => ({}),
+    executionWorkspaceService: () => ({}),
+    feedbackService: () => ({}),
+    goalService: () => ({}),
+    heartbeatService: () => ({
+      wakeup: vi.fn(async () => undefined),
+      reportRunActivity: vi.fn(async () => undefined),
+    }),
+    instanceSettingsService: () => ({}),
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: async () => undefined,
+      diffIssueReferenceSummary: () => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      }),
+      emptySummary: () => ({ outbound: [], inbound: [] }),
+      listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+      syncComment: async () => undefined,
+      syncDocument: async () => undefined,
+      syncIssue: async () => undefined,
+    }),
+    issueService: () => mockIssueService,
+    issueThreadInteractionService: () => ({
+      expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+      expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+    }),
+    logActivity: vi.fn(async () => undefined),
+    projectService: () => ({}),
+    routineService: () => ({
+      syncRunStatusForIssue: vi.fn(async () => undefined),
+    }),
+    workProductService: () => ({}),
+  }));
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: issueId,
+    companyId,
+    status: "in_review",
+    priority: "high",
+    projectId: null,
+    projectWorkspaceId: "workspace-1",
+    executionWorkspaceId: null,
+    assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+    assigneeUserId: null,
+    createdByUserId: "local-board",
+    identifier: "WAT-1953",
+    title: "Publish repo change",
+    description: null,
+    executionPolicy: null,
+    executionState: null,
+    hiddenAt: null,
+    ...overrides,
+  };
+}
+
+async function createApp() {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: [companyId],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue done paperclip/main PR guardrail", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@paperclipai/shared/telemetry");
+    vi.doUnmock("../telemetry.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.resetAllMocks();
+    mockIssueService.getById.mockResolvedValue(makeIssue());
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-new",
+      companyId,
+      issueId,
+      body: "closeout",
+      authorAgentId: null,
+      authorUserId: "local-board",
+      createdAt: new Date("2026-04-25T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-25T08:00:00.000Z"),
+    });
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.listComments.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue(),
+      ...patch,
+    }));
+  });
+
+  it("rejects done when paperclip/main PR evidence says the PR is still unmerged", async () => {
+    mockIssueService.listComments.mockResolvedValue([
+      {
+        id: "comment-1",
+        body:
+          "Implementation approved. Merge lane and PR: paperclip/main https://github.com/paperclipai/paperclip/pull/4437. paperclip/main merge: not merged; review required.",
+      },
+    ]);
+
+    const res = await request(await createApp()).patch(`/api/issues/${issueId}`).send({
+      status: "done",
+      comment: "Closing after QE review.",
+    });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("paperclip/main PR must be merged");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows done when the latest paperclip/main evidence says the PR merged", async () => {
+    mockIssueService.listComments.mockResolvedValue([
+      {
+        id: "comment-1",
+        body:
+          "Implementation approved. Merge lane and PR: paperclip/main https://github.com/paperclipai/paperclip/pull/4437. paperclip/main merge: not merged; review required.",
+      },
+    ]);
+
+    const res = await request(await createApp()).patch(`/api/issues/${issueId}`).send({
+      status: "done",
+      comment:
+        "Implementation status: approved. Merge lane and PR: paperclip/main https://github.com/paperclipai/paperclip/pull/4437. paperclip/main merge: merged and pushed as merge commit abc123.",
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "done" }),
+    );
+  });
+
+  it("allows done without PR evidence when the closeout gives an explicit non-repo reason", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      projectWorkspaceId: null,
+      title: "Clarify process policy",
+    }));
+
+    const res = await request(await createApp()).patch(`/api/issues/${issueId}`).send({
+      status: "done",
+      comment: "No publishable repo changes: this was an issue-thread policy clarification only.",
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "done" }),
+    );
+  });
+
+  it("rejects in_review for repo work without a pushed commit and primary PR link", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      status: "in_progress",
+    }));
+
+    const res = await request(await createApp()).patch(`/api/issues/${issueId}`).send({
+      status: "in_review",
+      comment: "Ready for review. Verified locally.",
+    });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("in_review requires pushed work");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows in_review for repo work when pushed commit and primary PR link are recorded", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      status: "in_progress",
+    }));
+
+    const res = await request(await createApp()).patch(`/api/issues/${issueId}`).send({
+      status: "in_review",
+      comment:
+        "Ready for review. Primary paperclip/main PR: https://github.com/paperclipai/paperclip/pull/4461. Pushed commit SHA: 35a3cc5c41628039cfa2a6cb0df0ad5a5b807a6a.",
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "in_review" }),
+    );
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -56,7 +56,7 @@ import {
   workProductService,
 } from "../services/index.js";
 import { logger } from "../middleware/logger.js";
-import { conflict, forbidden, HttpError, notFound, unauthorized } from "../errors.js";
+import { conflict, forbidden, HttpError, notFound, unauthorized, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import {
   assertNoAgentHostWorkspaceCommandMutation,
@@ -108,6 +108,145 @@ type ExecutionStageWakeContext = {
   lastDecisionOutcome: ParsedExecutionState["lastDecisionOutcome"];
   allowedActions: string[];
 };
+
+type DonePaperclipMainGuardrailSource = {
+  body: string | null | undefined;
+};
+
+type DonePaperclipMainGuardrailIssue = {
+  title: string;
+  description?: string | null;
+  projectWorkspaceId?: string | null;
+  executionWorkspaceId?: string | null;
+};
+
+const githubPullRequestUrlPattern = /https?:\/\/github\.com\/[^\s)]+\/pull\/\d+/i;
+const genericPullRequestReferencePattern = /\bPR\s*#?\d+\b|\bpull\/\d+\b/i;
+const publishableDoneSignalPattern =
+  /\b(?:paperclip\/main|origin\/dev|pull\/\d+|PR\s*#?\d+|publishable|repo|repository|branch|commit|merge|merged|code|data)\b/i;
+const explicitNonRepoDoneExceptionPattern =
+  /\b(?:non[- ]repo|no publishable repo changes|no repo changes|no code changes|no PR needed|PR not needed|paperclip\/main PR not needed)\b(?:\s*[:;-]\s*|\s+because\s+).{8,}/i;
+const pushedCommitEvidencePattern =
+  /\b(?:pushed commit(?: SHA)?|commit SHA|pushed SHA|branch tip|head commit)\b[^.\n]{0,80}\b[0-9a-f]{7,40}\b/i;
+const unmergedPaperclipMainPattern =
+  /\b(?:unmerged|not merged|mergedAt\s*[:=]\s*null|review[_ -]?required|review required|still open|open\/unmerged|draft|branch protection[^.\n]{0,100}requires|pending[^.\n]{0,100}(?:approval|review|merge))\b/i;
+const mergedPaperclipMainPattern =
+  /\b(?:merged and pushed|merge commit|paperclip\/main[^.\n]{0,200}(?:has merged|merged and pushed|merge commit|merged\s+(?:as|into|to))|(?:merged and pushed|merge commit)[^.\n]{0,200}paperclip\/main|mergedAt\s*[:=]\s*(?!null)\S+)\b/i;
+
+function paperclipMainPrStateFromText(text: string): {
+  mentioned: boolean;
+  state: "merged" | "unmerged" | null;
+  prUrl: string | null;
+} {
+  const mentionsPaperclipMain = /\bpaperclip\/main\b/i.test(text);
+  const prUrl = text.match(githubPullRequestUrlPattern)?.[0] ?? null;
+  const mentionsPr = Boolean(prUrl) || genericPullRequestReferencePattern.test(text);
+  if (!mentionsPaperclipMain || !mentionsPr) {
+    return { mentioned: false, state: null, prUrl };
+  }
+
+  if (unmergedPaperclipMainPattern.test(text)) {
+    return { mentioned: true, state: "unmerged", prUrl };
+  }
+  if (mergedPaperclipMainPattern.test(text)) {
+    return { mentioned: true, state: "merged", prUrl };
+  }
+  return { mentioned: true, state: null, prUrl };
+}
+
+function validateDonePaperclipMainGuardrail(input: {
+  issue: DonePaperclipMainGuardrailIssue;
+  previousComments: DonePaperclipMainGuardrailSource[];
+  currentCommentBody?: string | null;
+}) {
+  const sources = [
+    input.issue.title,
+    input.issue.description,
+    ...input.previousComments.map((comment) => comment.body),
+    input.currentCommentBody,
+  ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+  const combined = sources.join("\n\n");
+
+  if (explicitNonRepoDoneExceptionPattern.test(combined)) {
+    return;
+  }
+
+  const requiresMainPrEvidence =
+    Boolean(input.issue.projectWorkspaceId) ||
+    Boolean(input.issue.executionWorkspaceId) ||
+    publishableDoneSignalPattern.test(combined);
+  if (!requiresMainPrEvidence) {
+    return;
+  }
+
+  let sawPaperclipMainPr = false;
+  let latestState: "merged" | "unmerged" | null = null;
+  let latestPrUrl: string | null = null;
+  for (const source of sources) {
+    const evidence = paperclipMainPrStateFromText(source);
+    if (!evidence.mentioned) continue;
+    sawPaperclipMainPr = true;
+    latestState = evidence.state;
+    latestPrUrl = evidence.prUrl ?? latestPrUrl;
+  }
+
+  if (!sawPaperclipMainPr) {
+    throw unprocessable(
+      "Done transition for repo or publishable work requires a paperclip/main PR link with merged evidence, or an explicit non-repo reason.",
+      { guardrail: "paperclip_main_pr_done_gate" },
+    );
+  }
+
+  if (latestState !== "merged") {
+    throw unprocessable(
+      "paperclip/main PR must be merged before marking issue done.",
+      {
+        guardrail: "paperclip_main_pr_done_gate",
+        paperclipMainPr: latestPrUrl,
+        latestState: latestState ?? "missing_merged_evidence",
+      },
+    );
+  }
+}
+
+function validateInReviewPushedPrGuardrail(input: {
+  issue: DonePaperclipMainGuardrailIssue;
+  previousComments: DonePaperclipMainGuardrailSource[];
+  currentCommentBody?: string | null;
+}) {
+  const sources = [
+    input.issue.title,
+    input.issue.description,
+    ...input.previousComments.map((comment) => comment.body),
+    input.currentCommentBody,
+  ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+  const combined = sources.join("\n\n");
+
+  if (explicitNonRepoDoneExceptionPattern.test(combined)) {
+    return;
+  }
+
+  const requiresPushedPrEvidence =
+    Boolean(input.issue.projectWorkspaceId) ||
+    Boolean(input.issue.executionWorkspaceId) ||
+    publishableDoneSignalPattern.test(combined);
+  if (!requiresPushedPrEvidence) {
+    return;
+  }
+
+  const hasPrimaryPrLink = sources.some((source) => paperclipMainPrStateFromText(source).mentioned);
+  const hasPushedCommit = sources.some((source) => pushedCommitEvidencePattern.test(source));
+  if (!hasPrimaryPrLink || !hasPushedCommit) {
+    throw unprocessable(
+      "in_review requires pushed work with a primary paperclip/main PR link and pushed commit SHA recorded.",
+      {
+        guardrail: "paperclip_main_pr_in_review_gate",
+        hasPrimaryPrLink,
+        hasPushedCommit,
+      },
+    );
+  }
+}
 
 function executionPrincipalsEqual(
   left: ParsedExecutionState["currentParticipant"] | null,
@@ -2039,6 +2178,30 @@ export function issueRoutes(
       };
     }
     Object.assign(updateFields, transition.patch);
+
+    if (existing.status !== "done" && updateFields.status === "done") {
+      const listComments = (svc as { listComments?: typeof svc.listComments }).listComments;
+      const previousComments = typeof listComments === "function"
+        ? await listComments(existing.id, { order: "asc", limit: 500 })
+        : [];
+      validateDonePaperclipMainGuardrail({
+        issue: existing,
+        previousComments,
+        currentCommentBody: commentBody,
+      });
+    }
+    if (existing.status !== "in_review" && updateFields.status === "in_review") {
+      const listComments = (svc as { listComments?: typeof svc.listComments }).listComments;
+      const previousComments = typeof listComments === "function"
+        ? await listComments(existing.id, { order: "asc", limit: 500 })
+        : [];
+      validateInReviewPushedPrGuardrail({
+        issue: existing,
+        previousComments,
+        currentCommentBody: commentBody,
+      });
+    }
+
     if (reviewRequest !== undefined && transition.patch.executionState === undefined) {
       const existingExecutionState = parseIssueExecutionState(existing.executionState);
       if (!existingExecutionState || existingExecutionState.status !== "pending") {


### PR DESCRIPTION
## Summary
- add a server-side `done` transition guardrail that inspects issue metadata, previous comments, and the current closeout comment for `paperclip/main` PR evidence
- reject repo/publishable tickets moving to `done` when the latest `paperclip/main` PR evidence is unmerged, review-required, draft, or missing merged evidence
- add an `in_review` transition guardrail requiring pushed work evidence: primary `paperclip/main` PR link plus pushed commit SHA before repo/publishable work enters review
- allow explicit non-repo/no-publishable-change closeouts with a reason

## Tests
- pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-done-pr-guardrail-routes.test.ts
- pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-telemetry-routes.test.ts src/__tests__/issue-dependency-wakeups-routes.test.ts src/__tests__/issue-comment-reopen-routes.test.ts
- pnpm --filter @paperclipai/server typecheck
- git diff --check

## Notes
- Implemented for WAT-1953 after Will added the pushed-branch / PR-link stage rule. The branch is based on origin/master and excludes unrelated dirty work from the shared checkout.