### PR TITLE
fix(heartbeat): honor maxConcurrentRuns < default instead of clamping to floor

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -837,7 +837,7 @@ export function compactRunLogChunk(chunk: string, maxChars = MAX_PERSISTED_LOG_C
 function normalizeMaxConcurrentRuns(value: unknown) {
   const parsed = Math.floor(asNumber(value, HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT));
   if (!Number.isFinite(parsed)) return HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT;
-  return Math.max(HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
+  return Math.max(1, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
 }
 
 async function withAgentStartLock<T>(agentId: string, fn: () => Promise<T>) {


### PR DESCRIPTION
## Summary

`normalizeMaxConcurrentRuns()` in `server/src/services/heartbeat.ts` uses `Math.max(HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT, ...)` as the lower bound, which silently raises any user-configured value below the default (5) up to 5. Setting an agent's `maxConcurrentRuns` to `1` is treated as `5`, allowing up to 5 parallel runs.

## Reproduction

Configure an agent with `runtimeConfig.heartbeat.maxConcurrentRuns = 1` and trigger several wakeups. Observe `heartbeat_runs.status = 'running'` count exceed 1 for that agent.

**Observed downstream:** an agent (`teamleader`) configured with `maxConcurrentRuns: 1` ran up to **4 concurrent heartbeat runs** in past 24h.

## Fix

Change the lower bound from `HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT` to `1` so values 1..10 are honored as configured:

\`\`\`diff
- return Math.max(HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
+ return Math.max(1, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
\`\`\`

The default-when-unset behavior is unchanged: `asNumber(value, DEFAULT)` returns `DEFAULT` when `value` is missing/invalid, and the early `Number.isFinite` check returns `DEFAULT` for non-finite results. Only legitimate small finite values are now honored instead of clamped.

## Test plan

- [x] Server typecheck passes
- [ ] Verify in a running instance: configure an agent with `maxConcurrentRuns: 1`, trigger multiple wakeups, confirm only 1 runs at a time and the rest queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)