### PR TITLE
Fix Dashboard Agents widget showing duplicate CEO cards (#4457)

### DIFF
--- a/ui/src/components/ActiveAgentsPanel.test.tsx
+++ b/ui/src/components/ActiveAgentsPanel.test.tsx
@@ -14,6 +14,10 @@ const mockIssuesApi = vi.hoisted(() => ({
   list: vi.fn(),
 }));
 
+const mockAgentsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
 vi.mock("@/lib/router", () => ({
   Link: ({ to, children, ...props }: { to: string; children: ReactNode }) => (
     <a href={to} {...props}>
@@ -30,8 +34,16 @@ vi.mock("../api/issues", () => ({
   issuesApi: mockIssuesApi,
 }));
 
+vi.mock("../api/agents", () => ({
+  agentsApi: mockAgentsApi,
+}));
+
 vi.mock("./Identity", () => ({
   Identity: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+vi.mock("./AgentIconPicker", () => ({
+  AgentIcon: () => <span data-testid="agent-icon" />,
 }));
 
 vi.mock("./RunChatSurface", () => ({
@@ -71,6 +83,56 @@ function createRun(index: number) {
   };
 }
 
+function createRunForAgent(overrides: {
+  id: string;
+  agentId: string;
+  agentName: string;
+  status?: string;
+  createdAt?: string;
+  finishedAt?: string | null;
+}) {
+  return {
+    id: overrides.id,
+    status: overrides.status ?? "running",
+    invocationSource: "assignment",
+    triggerDetail: null,
+    startedAt: "2026-04-24T12:00:00.000Z",
+    finishedAt: overrides.finishedAt ?? null,
+    createdAt: overrides.createdAt ?? "2026-04-24T12:00:00.000Z",
+    agentId: overrides.agentId,
+    agentName: overrides.agentName,
+    adapterType: "codex_local",
+    issueId: null,
+  };
+}
+
+function createAgent(overrides: { id: string; name: string; role?: string; status?: string }) {
+  return {
+    id: overrides.id,
+    companyId: "company-1",
+    name: overrides.name,
+    urlKey: overrides.name.toLowerCase(),
+    role: overrides.role ?? "general",
+    title: null,
+    icon: null,
+    status: overrides.status ?? "idle",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "codex_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    pauseReason: null,
+    pausedAt: null,
+    permissions: {},
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
 describe("ActiveAgentsPanel", () => {
   let container: HTMLDivElement;
 
@@ -79,6 +141,7 @@ describe("ActiveAgentsPanel", () => {
     document.body.appendChild(container);
     mockHeartbeatsApi.liveRunsForCompany.mockResolvedValue([1, 2, 3, 4, 5].map(createRun));
     mockIssuesApi.list.mockResolvedValue([]);
+    mockAgentsApi.list.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -144,6 +207,53 @@ describe("ActiveAgentsPanel", () => {
       limit: 50,
     });
     expect(container.textContent).not.toContain("more active/recent");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("renders one card per agent in agents mode, not one per run (regression: #4457)", async () => {
+    mockAgentsApi.list.mockResolvedValue([
+      createAgent({ id: "agent-ceo", name: "CEO", role: "ceo" }),
+      createAgent({ id: "agent-cto", name: "CTO", role: "cto" }),
+    ]);
+    mockHeartbeatsApi.liveRunsForCompany.mockResolvedValue([
+      createRunForAgent({
+        id: "run-ceo-1",
+        agentId: "agent-ceo",
+        agentName: "CEO",
+        status: "running",
+        createdAt: "2026-04-24T12:00:01.000Z",
+      }),
+      createRunForAgent({
+        id: "run-ceo-2",
+        agentId: "agent-ceo",
+        agentName: "CEO",
+        status: "completed",
+        createdAt: "2026-04-24T12:00:00.000Z",
+        finishedAt: "2026-04-24T12:01:00.000Z",
+      }),
+    ]);
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ActiveAgentsPanel companyId="company-1" displayMode="agents" />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    const ceoMatches = container.textContent?.match(/CEO/g) ?? [];
+    expect(ceoMatches.length).toBe(1);
+    expect(container.textContent).toContain("CTO");
+    expect(container.textContent).toContain("Idle");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -1,13 +1,15 @@
 import { memo, useMemo } from "react";
 import { Link } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
-import type { Issue } from "@paperclipai/shared";
+import type { Agent, Issue } from "@paperclipai/shared";
+import { agentsApi } from "../api/agents";
 import { heartbeatsApi, type LiveRunForIssue } from "../api/heartbeats";
 import type { TranscriptEntry } from "../adapters";
 import { issuesApi } from "../api/issues";
 import { queryKeys } from "../lib/queryKeys";
-import { cn, relativeTime } from "../lib/utils";
+import { cn, agentUrl, relativeTime } from "../lib/utils";
 import { ExternalLink } from "lucide-react";
+import { AgentIcon } from "./AgentIconPicker";
 import { Identity } from "./Identity";
 import { RunChatSurface } from "./RunChatSurface";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
@@ -23,6 +25,8 @@ function isRunActive(run: LiveRunForIssue): boolean {
   return run.status === "queued" || run.status === "running";
 }
 
+type DisplayMode = "runs" | "agents";
+
 interface ActiveAgentsPanelProps {
   companyId: string;
   title?: string;
@@ -34,6 +38,7 @@ interface ActiveAgentsPanelProps {
   emptyMessage?: string;
   queryScope?: string;
   showMoreLink?: boolean;
+  displayMode?: DisplayMode;
 }
 
 export function ActiveAgentsPanel({
@@ -47,15 +52,35 @@ export function ActiveAgentsPanel({
   emptyMessage = "No recent agent runs.",
   queryScope = "dashboard",
   showMoreLink = true,
+  displayMode = "runs",
 }: ActiveAgentsPanelProps) {
   const { data: liveRuns } = useQuery({
     queryKey: [...queryKeys.liveRuns(companyId), queryScope, { minRunCount, fetchLimit }],
     queryFn: () => heartbeatsApi.liveRunsForCompany(companyId, { minCount: minRunCount, limit: fetchLimit }),
   });
 
+  const { data: agents } = useQuery({
+    queryKey: queryKeys.agents.list(companyId),
+    queryFn: () => agentsApi.list(companyId),
+    enabled: displayMode === "agents",
+  });
+
   const runs = liveRuns ?? [];
-  const visibleRuns = useMemo(() => runs.slice(0, cardLimit), [cardLimit, runs]);
-  const hiddenRunCount = Math.max(0, runs.length - visibleRuns.length);
+
+  const cards = useMemo<DashboardCard[]>(() => {
+    if (displayMode === "agents") {
+      return buildAgentCards(agents ?? [], runs);
+    }
+    return runs.map((run): DashboardCard => ({ kind: "run", id: run.id, run }));
+  }, [agents, displayMode, runs]);
+
+  const visibleCards = useMemo(() => cards.slice(0, cardLimit), [cardLimit, cards]);
+  const hiddenCardCount = Math.max(0, cards.length - visibleCards.length);
+
+  const visibleRuns = useMemo(
+    () => visibleCards.map((card) => card.run).filter((run): run is LiveRunForIssue => run !== undefined),
+    [visibleCards],
+  );
   const { data: issues } = useQuery({
     queryKey: [...queryKeys.issues.list(companyId), "with-routine-executions"],
     queryFn: () => issuesApi.list(companyId, { includeRoutineExecutions: true }),
@@ -84,35 +109,87 @@ export function ActiveAgentsPanel({
       <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
         {title}
       </h3>
-      {runs.length === 0 ? (
+      {visibleCards.length === 0 ? (
         <div className="rounded-xl border border-border p-4">
           <p className="text-sm text-muted-foreground">{emptyMessage}</p>
         </div>
       ) : (
         <div className={cn("grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-4 xl:grid-cols-4", gridClassName)}>
-          {visibleRuns.map((run) => (
-            <AgentRunCard
-              key={run.id}
-              companyId={companyId}
-              run={run}
-              issue={run.issueId ? issueById.get(run.issueId) : undefined}
-              transcript={transcriptByRun.get(run.id) ?? EMPTY_TRANSCRIPT}
-              hasOutput={hasOutputForRun(run.id)}
-              isActive={isRunActive(run)}
-              className={cardClassName}
-            />
-          ))}
+          {visibleCards.map((card) => {
+            const cardRun = card.run;
+            if (cardRun) {
+              return (
+                <AgentRunCard
+                  key={card.id}
+                  companyId={companyId}
+                  run={cardRun}
+                  issue={cardRun.issueId ? issueById.get(cardRun.issueId) : undefined}
+                  transcript={transcriptByRun.get(cardRun.id) ?? EMPTY_TRANSCRIPT}
+                  hasOutput={hasOutputForRun(cardRun.id)}
+                  isActive={isRunActive(cardRun)}
+                  className={cardClassName}
+                />
+              );
+            }
+            if (card.kind === "agent") {
+              return <AgentIdleCard key={card.id} agent={card.agent} className={cardClassName} />;
+            }
+            return null;
+          })}
         </div>
       )}
-      {showMoreLink && hiddenRunCount > 0 && (
+      {showMoreLink && hiddenCardCount > 0 && (
         <div className="mt-3 flex justify-end text-xs text-muted-foreground">
           <Link to="/dashboard/live" className="hover:text-foreground hover:underline">
-            {hiddenRunCount} more active/recent run{hiddenRunCount === 1 ? "" : "s"}
+            {hiddenCardCount} more {displayMode === "agents" ? "agent" : "active/recent run"}
+            {hiddenCardCount === 1 ? "" : "s"}
           </Link>
         </div>
       )}
     </div>
   );
+}
+
+type DashboardCard =
+  | { kind: "run"; id: string; run: LiveRunForIssue; agent?: undefined }
+  | { kind: "agent"; id: string; agent: Agent; run: LiveRunForIssue | undefined };
+
+function buildAgentCards(agents: Agent[], runs: LiveRunForIssue[]): DashboardCard[] {
+  const visibleAgents = agents.filter((agent) => agent.status !== "terminated");
+  const latestRunByAgent = new Map<string, LiveRunForIssue>();
+  for (const run of runs) {
+    const existing = latestRunByAgent.get(run.agentId);
+    if (!existing) {
+      latestRunByAgent.set(run.agentId, run);
+      continue;
+    }
+    if (isRunActive(run) && !isRunActive(existing)) {
+      latestRunByAgent.set(run.agentId, run);
+      continue;
+    }
+    if (isRunActive(run) === isRunActive(existing) && run.createdAt > existing.createdAt) {
+      latestRunByAgent.set(run.agentId, run);
+    }
+  }
+  const cards = visibleAgents.map<DashboardCard>((agent) => ({
+    kind: "agent",
+    id: agent.id,
+    agent,
+    run: latestRunByAgent.get(agent.id),
+  }));
+  cards.sort((a, b) => {
+    const aActive = a.run && isRunActive(a.run) ? 1 : 0;
+    const bActive = b.run && isRunActive(b.run) ? 1 : 0;
+    if (aActive !== bActive) return bActive - aActive;
+    const aHasRun = a.run ? 1 : 0;
+    const bHasRun = b.run ? 1 : 0;
+    if (aHasRun !== bHasRun) return bHasRun - aHasRun;
+    if (a.run && b.run && a.run.createdAt !== b.run.createdAt) {
+      return a.run.createdAt < b.run.createdAt ? 1 : -1;
+    }
+    return (a.agent?.name ?? "").localeCompare(b.agent?.name ?? "");
+  });
+  return cards;
 }
 
 const AgentRunCard = memo(function AgentRunCard({
@@ -191,6 +268,52 @@ const AgentRunCard = memo(function AgentRunCard({
           hasOutput={hasOutput}
           companyId={companyId}
         />
+      </div>
+    </div>
+  );
+});
+
+const AgentIdleCard = memo(function AgentIdleCard({
+  agent,
+  className,
+}: {
+  agent: Agent;
+  className?: string;
+}) {
+  const idleLabel = agent.lastHeartbeatAt
+    ? `Last heartbeat ${relativeTime(agent.lastHeartbeatAt)}`
+    : "No recent activity";
+  return (
+    <div
+      className={cn(
+        "flex h-[320px] flex-col overflow-hidden rounded-xl border border-border bg-background/70 shadow-sm",
+        className,
+      )}
+    >
+      <div className="border-b border-border/60 px-3 py-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="inline-flex h-2.5 w-2.5 rounded-full bg-muted-foreground/35" />
+              <Identity name={agent.name} size="sm" className="[&>span:last-child]:!text-[11px]" />
+            </div>
+            <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+              <span>{idleLabel}</span>
+            </div>
+          </div>
+          <Link
+            to={agentUrl(agent)}
+            className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-background/70 px-2 py-1 text-[10px] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ExternalLink className="h-2.5 w-2.5" />
+          </Link>
+        </div>
+      </div>
+      <div className="flex min-h-0 flex-1 items-center justify-center p-3">
+        <div className="flex flex-col items-center gap-2 text-center text-xs text-muted-foreground">
+          <AgentIcon icon={agent.icon} className="h-6 w-6 text-muted-foreground/60" />
+          <span>Idle — no run in progress.</span>
+        </div>
       </div>
     </div>
   );

--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -104,15 +104,19 @@ export function ActiveAgentsPanel({
     enableRealtimeUpdates: false,
   });
 
+  const isAgentsLoading = displayMode === "agents" && agents === undefined;
+
   return (
     <div>
       <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
         {title}
       </h3>
       {visibleCards.length === 0 ? (
-        <div className="rounded-xl border border-border p-4">
-          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
-        </div>
+        isAgentsLoading ? null : (
+          <div className="rounded-xl border border-border p-4">
+            <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+          </div>
+        )
       ) : (
         <div className={cn("grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-4 xl:grid-cols-4", gridClassName)}>
           {visibleCards.map((card) => {

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -214,7 +214,11 @@ export function Dashboard() {
         </div>
       )}
 
-      <ActiveAgentsPanel companyId={selectedCompanyId!} />
+      <ActiveAgentsPanel
+        companyId={selectedCompanyId!}
+        displayMode="agents"
+        emptyMessage="No agents yet."
+      />
 
       {data && (
         <>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The Dashboard's "Agents" widget is the first surface a new operator sees after onboarding — it's the proof that "the agents are doing the thing"
> - That widget is implemented by `ActiveAgentsPanel`, which renders one card per heartbeat run rather than one card per agent
> - Right after the CEO's default first task ("Hire your first engineer") finishes, the CEO has multiple recent runs (the active hire run + finished continuations / server-side backfill) while the freshly-hired CTO has zero runs (the hire flow leaves CTO `idle` with no enqueued run)
> - So the widget renders two cards both labelled "CEO" instead of one card per agent — exactly what #4457 reports, and what new operators see on the very first dashboard view
> - This pull request adds an explicit `displayMode="agents"` mode to `ActiveAgentsPanel` that joins agents → latest live run, renders an idle card for agents without runs, and is opt-in (the run-centric `DashboardLive` page keeps its old behaviour)
> - The benefit is the dashboard widget matches its label ("Agents") and gives operators the correct "one row per agent" mental model

## What Changed

- `ui/src/components/ActiveAgentsPanel.tsx` — new `displayMode: "runs" | "agents"` prop (default `"runs"` so all existing callers are unaffected). In `"agents"` mode the panel additionally fetches `agentsApi.list(companyId)`, joins each non-terminated agent to their latest live run via `buildAgentCards`, and renders a new `AgentIdleCard` for agents with no run. Sort: active runs → finished runs (recency desc) → idle agents (alphabetical).
- `ui/src/pages/Dashboard.tsx` — passes `displayMode="agents"` and a context-appropriate `emptyMessage="No agents yet."` to the dashboard-widget instance only. `DashboardLive` is unchanged.
- `ui/src/components/ActiveAgentsPanel.test.tsx` — adds `agentsApi`/`AgentIcon` mocks and a regression test that asserts CEO renders exactly once + CTO + "Idle" appear when CEO has 2 runs and CTO has 0 (fails on master without the fix).
- Loading-flash fix (after Greptile review): suppress the `"No agents yet."` empty-state until the agents query has settled (`agents !== undefined`), so a loaded company with agents does not briefly flash an empty card on every dashboard mount.

## Verification

- `pnpm exec vitest run` → **623/623 tests pass**, including the new regression test (which fails on master).
- `pnpm typecheck` → clean.
- Manual browser test 
**Before** (master — two CEO cards):
<img width="1280" height="800" alt="dashboard-before-fix" src="https://github.com/user-attachments/assets/c62f69f0-6d0c-4de5-be0c-345acd3aa532" />

**After** (this PR — CEO + idle CTO):
<img width="1280" height="800" alt="dashboard-after-fix" src="https://github.com/user-attachments/assets/c45348fe-cb6f-4f4b-a82d-3a473a249e14" />

## Risks

- **Low risk.** The new code path is gated on the explicit `displayMode="agents"` opt-in. Every other `ActiveAgentsPanel` caller (DashboardLive, etc.) keeps the run-centric default — no behaviour change for them.
- The agents-mode card list filters `status !== "terminated"`, so `pending_approval` agents will appear on the dashboard. Consistent with `SidebarAgents`, which uses the same filter.
- The "X more agents" overflow link in agents mode still points to `/dashboard/live` (the run-centric view). Acceptable since the full agents list is one sidebar click away, but a maintainer may prefer a different target.
- *Why* the CEO had ≥2 runs to begin with is not confirmed in this PR — could be the server-side fallback at `agents.ts:2587-2602` that backfills with finished runs, or concurrent liveness continuations from #4083. The fix handles both. If it turns out to be concurrent live runs (two simultaneous queued/running rows for one agent), that is a separate orchestration concern worth a follow-up.

## Model Used

- Provider: Anthropic
- Model: Claude (`claude-opus-4-7`)
- Context window: 1M
- Capabilities: standard tool use (file edits, sandboxed shell, Chrome DevTools MCP for browser verification, GitHub CLI). Iterative reasoning ("ultrathink") was applied during root-cause analysis.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — captured locally; will attach as a comment on request (see Verification)
- [x] I have updated relevant documentation to reflect my changes (no docs needed for an internal widget mode)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #4457.