### PR TITLE
security: redact envs with generic *_TOKEN suffix (TELEGRAM_BOT_TOKEN etc)

### DIFF
--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -63,4 +63,26 @@ describe("redaction", () => {
       safe: "value",
     });
   });
+
+  it("redacts generic token bindings such as TELEGRAM_BOT_TOKEN", () => {
+    const input = {
+      env: {
+        TELEGRAM_BOT_TOKEN: {
+          type: "plain",
+          value: "telegram-secret",
+        },
+        PAPERCLIP_API_URL: "http://localhost:3100",
+      },
+    };
+
+    const result = sanitizeRecord(input);
+
+    expect(result.env).toEqual({
+      TELEGRAM_BOT_TOKEN: {
+        type: "plain",
+        value: REDACTED_EVENT_VALUE,
+      },
+      PAPERCLIP_API_URL: "http://localhost:3100",
+    });
+  });
 });

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1,5 +1,5 @@
 const SECRET_PAYLOAD_KEY_RE =
-  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)/i;
+  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring|(?:^|[-_])token(?:$|[-_]))/i;
 const JWT_VALUE_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)?$/;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
 


### PR DESCRIPTION
## Summary

Extends `SECRET_PAYLOAD_KEY_RE` so that env var names with a generic `_TOKEN` suffix (bounded by `-`/`_`/start/end) are redacted, not only names already matching `api[-_]?key|secret|auth[-_]?token|bearer|jwt|...`.

Before this change, agents that declare env vars like `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, or `SLACK_APP_TOKEN` leaked raw values into heartbeat/event logs because the redaction regex did not match a generic `_TOKEN` suffix.

## Change

- `server/src/redaction.ts`: add alternation `(?:^|[-_])token(?:$|[-_])` to `SECRET_PAYLOAD_KEY_RE`
- `server/src/__tests__/redaction.test.ts`: add regression test "redacts generic token bindings such as TELEGRAM_BOT_TOKEN" — covers the new pattern, ensures unrelated keys like `PAPERCLIP_API_URL` are not over-matched.

## Test plan

- [x] Existing tests still pass
- [x] New regression test passes: `TELEGRAM_BOT_TOKEN.value` redacted, `PAPERCLIP_API_URL` untouched
- [x] Verified in production heartbeat logs (self-hosted deployment) — Telegram bot token no longer appears in event stream

Caught in a downstream self-hosted deployment running Paperclip agents with Telegram notification bots.