### PR TITLE
feat(issues): add executor tracking fields

### DIFF
--- a/packages/db/src/migrations/0071_executor_tracking.sql
+++ b/packages/db/src/migrations/0071_executor_tracking.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "executor_agent_id" uuid;--> statement-breakpoint
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "checkout_history" jsonb DEFAULT '[]'::jsonb;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "issues" ADD CONSTRAINT "issues_executor_agent_id_agents_id_fk" FOREIGN KEY ("executor_agent_id") REFERENCES "public"."agents"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -498,6 +498,13 @@
       "when": 1776780004000,
       "tag": "0070_active_run_output_watchdog",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1777334400000,
+      "tag": "0071_executor_tracking",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -54,6 +54,8 @@ export const issues = pgTable(
       .references((): AnyPgColumn => executionWorkspaces.id, { onDelete: "set null" }),
     executionWorkspacePreference: text("execution_workspace_preference"),
     executionWorkspaceSettings: jsonb("execution_workspace_settings").$type<Record<string, unknown>>(),
+    executorAgentId: uuid("executor_agent_id").references(() => agents.id),
+    checkoutHistory: jsonb("checkout_history").$type<Array<{ agentId: string; runId: string | null; checkedOutAt: string; releasedAt: string | null }>>().default([]),
     startedAt: timestamp("started_at", { withTimezone: true }),
     completedAt: timestamp("completed_at", { withTimezone: true }),
     cancelledAt: timestamp("cancelled_at", { withTimezone: true }),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1153,6 +1153,8 @@ const issueListSelect = {
   executionWorkspaceId: issues.executionWorkspaceId,
   executionWorkspacePreference: issues.executionWorkspacePreference,
   executionWorkspaceSettings: sql<null>`null`,
+  executorAgentId: issues.executorAgentId,
+  checkoutHistory: issues.checkoutHistory,
   startedAt: issues.startedAt,
   completedAt: issues.completedAt,
   cancelledAt: issues.cancelledAt,
@@ -1666,12 +1668,15 @@ export function issueService(db: Db) {
     if (!stale) return null;
 
     const now = new Date();
+    const checkoutEntry = { agentId: input.actorAgentId, runId: input.actorRunId, checkedOutAt: now.toISOString(), releasedAt: null };
     const adopted = await db
       .update(issues)
       .set({
         checkoutRunId: input.actorRunId,
         executionRunId: input.actorRunId,
         executionLockedAt: now,
+        executorAgentId: sql`COALESCE(${issues.executorAgentId}, ${input.actorAgentId})`,
+        checkoutHistory: sql`COALESCE(${issues.checkoutHistory}, '[]'::jsonb) || ${JSON.stringify(checkoutEntry)}::jsonb`,
         updatedAt: now,
       })
       .where(
@@ -1700,12 +1705,15 @@ export function issueService(db: Db) {
     actorRunId: string;
   }) {
     const now = new Date();
+    const checkoutEntry = { agentId: input.actorAgentId, runId: input.actorRunId, checkedOutAt: now.toISOString(), releasedAt: null };
     const adopted = await db
       .update(issues)
       .set({
         checkoutRunId: input.actorRunId,
         executionRunId: input.actorRunId,
         executionLockedAt: now,
+        executorAgentId: sql`COALESCE(${issues.executorAgentId}, ${input.actorAgentId})`,
+        checkoutHistory: sql`COALESCE(${issues.checkoutHistory}, '[]'::jsonb) || ${JSON.stringify(checkoutEntry)}::jsonb`,
         updatedAt: now,
       })
       .where(
@@ -2733,6 +2741,7 @@ export function issueService(db: Db) {
       const executionLockCondition = checkoutRunId
         ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId))
         : isNull(issues.executionRunId);
+      const checkoutEntry = { agentId, runId: checkoutRunId, checkedOutAt: now.toISOString(), releasedAt: null };
       const updated = await db
         .update(issues)
         .set({
@@ -2740,6 +2749,8 @@ export function issueService(db: Db) {
           assigneeUserId: null,
           checkoutRunId,
           executionRunId: checkoutRunId,
+          executorAgentId: sql`COALESCE(${issues.executorAgentId}, ${agentId})`,
+          checkoutHistory: sql`COALESCE(${issues.checkoutHistory}, '[]'::jsonb) || ${JSON.stringify(checkoutEntry)}::jsonb`,
           status: "in_progress",
           startedAt: now,
           updatedAt: now,
@@ -2781,11 +2792,14 @@ export function issueService(db: Db) {
         (current.executionRunId == null || current.executionRunId === checkoutRunId) &&
         checkoutRunId
       ) {
+        const reCheckoutEntry = { agentId, runId: checkoutRunId, checkedOutAt: new Date().toISOString(), releasedAt: null };
         const adopted = await db
           .update(issues)
           .set({
             checkoutRunId,
             executionRunId: checkoutRunId,
+            executorAgentId: sql`COALESCE(${issues.executorAgentId}, ${agentId})`,
+            checkoutHistory: sql`COALESCE(${issues.checkoutHistory}, '[]'::jsonb) || ${JSON.stringify(reCheckoutEntry)}::jsonb`,
             updatedAt: new Date(),
           })
           .where(
@@ -2952,6 +2966,7 @@ export function issueService(db: Db) {
         }
       }
 
+      const releaseNow = new Date();
       const updated = await db
         .update(issues)
         .set({
@@ -2961,7 +2976,16 @@ export function issueService(db: Db) {
           executionRunId: null,
           executionAgentNameKey: null,
           executionLockedAt: null,
-          updatedAt: new Date(),
+          checkoutHistory: sql`CASE
+            WHEN jsonb_array_length(COALESCE(${issues.checkoutHistory}, '[]'::jsonb)) > 0
+            THEN jsonb_set(
+              ${issues.checkoutHistory},
+              ARRAY[(jsonb_array_length(${issues.checkoutHistory}) - 1)::text, 'releasedAt'],
+              to_jsonb(${releaseNow.toISOString()}::text)
+            )
+            ELSE COALESCE(${issues.checkoutHistory}, '[]'::jsonb)
+          END`,
+          updatedAt: releaseNow,
         })
         .where(eq(issues.id, id))
         .returning()


### PR DESCRIPTION
## Summary

- Adds `executorAgentId` to the issue model — set on first checkout via `COALESCE`, immutable through review reassignments. Answers "who did the work?" unambiguously.
- Adds `checkoutHistory` (jsonb, append-only) — records every checkout with `agentId`, `runId`, `checkedOutAt`, and `releasedAt` for full work attribution audit trail.
- Both fields exposed in issue list and detail API responses.
- `executorAgentId` intentionally NOT cleared on reassignment or status change — this is the core design point.

## Files changed

- `packages/db/src/schema/issues.ts` — schema columns
- `packages/db/src/migrations/0071_executor_tracking.sql` — additive-only migration (no data loss risk)
- `server/src/services/issues.ts` — checkout, adopt, re-checkout, and release paths

## Test plan

- [ ] Verify migration runs cleanly on fresh DB and existing DB with data
- [ ] Checkout an issue → confirm `executorAgentId` set to checking-out agent
- [ ] Reassign issue for review → confirm `executorAgentId` unchanged
- [ ] Second checkout by different agent → confirm `executorAgentId` still shows first executor
- [ ] Release issue → confirm last `checkoutHistory` entry has `releasedAt` stamped
- [ ] GET /api/issues/:id returns both new fields
- [ ] Existing issues show `null`/`[]` for the new fields (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)