### PR TITLE
Stop chat bubble flicker while session query resolves

### DIFF
--- a/ui/src/components/IssueChatThread.test.tsx
+++ b/ui/src/components/IssueChatThread.test.tsx
@@ -1584,4 +1584,77 @@ describe("IssueChatThread", () => {
       avatarUrl: "/avatars/alice.png",
     });
   });
+
+  it("treats a viewer-authored comment as the current user while the session is still resolving", () => {
+    // Regression guard: when currentUserId is undefined (the session query
+    // has not resolved yet), an authorUserId-bearing comment must not flip
+    // to the wrong side. Previously this returned isCurrentUser=false,
+    // causing the viewer's own bubbles to render on the left until the
+    // session loaded a moment later — the visible "color flicker".
+    expect(resolveIssueChatHumanAuthor({
+      authorName: null,
+      authorUserId: "user-1",
+      currentUserId: undefined,
+    })).toMatchObject({ isCurrentUser: true });
+  });
+
+  it("does not treat an authorless comment as the current user while the session is resolving", () => {
+    expect(resolveIssueChatHumanAuthor({
+      authorName: null,
+      authorUserId: null,
+      currentUserId: undefined,
+    })).toMatchObject({ isCurrentUser: false });
+  });
+
+  it("treats null currentUserId as resolved-anonymous, not loading", () => {
+    // When the session resolves and the viewer is genuinely anonymous, we
+    // must not classify any human-authored comment as the current user.
+    expect(resolveIssueChatHumanAuthor({
+      authorName: "Alice",
+      authorUserId: "user-2",
+      currentUserId: null,
+    })).toMatchObject({ isCurrentUser: false });
+  });
+
+  it("renders a viewer-authored comment on the right side while the session is still resolving", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <IssueChatThread
+            comments={[{
+              id: "comment-1",
+              companyId: "company-1",
+              issueId: "issue-1",
+              authorAgentId: null,
+              authorUserId: "user-1",
+              body: "My own comment.",
+              createdAt: new Date("2026-04-06T12:00:00.000Z"),
+              updatedAt: new Date("2026-04-06T12:00:00.000Z"),
+            }]}
+            linkedRuns={[]}
+            timelineEvents={[]}
+            liveRuns={[]}
+            currentUserId={undefined}
+            onAdd={async () => {}}
+            showComposer={false}
+            enableLiveTranscriptPolling={false}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    // The viewer's own comment row should already use the right-side
+    // layout (justify-end) before the session query resolves, so the
+    // bubble does not visibly snap across the page.
+    const rightAlignedRows = container.querySelectorAll(
+      'div.flex.items-start.gap-2\\.5.justify-end',
+    );
+    expect(rightAlignedRows.length).toBe(1);
+
+    act(() => {
+      root.unmount();
+    });
+  });
 });

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -673,7 +673,15 @@ export function resolveIssueChatHumanAuthor(args: {
 }) {
   const { authorName, authorUserId, currentUserId, userProfileMap } = args;
   const profile = authorUserId ? userProfileMap?.get(authorUserId) ?? null : null;
-  const isCurrentUser = Boolean(authorUserId && currentUserId && authorUserId === currentUserId);
+  // currentUserId === undefined means the session query has not resolved yet.
+  // In that window we optimistically treat any human-authored comment as the
+  // viewer's own; otherwise the viewer's own bubbles flip to the wrong side
+  // until the session loads, producing a visible color/layout flicker.
+  // currentUserId === null means the session resolved and the viewer is
+  // anonymous, so the strict equality check applies.
+  const isCurrentUser = currentUserId === undefined
+    ? Boolean(authorUserId)
+    : Boolean(authorUserId && currentUserId && authorUserId === currentUserId);
   const resolvedAuthorName = profile?.label?.trim()
     || authorName?.trim()
     || (authorUserId === "local-board" ? "Board" : (isCurrentUser ? "You" : "User"));

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -560,7 +560,10 @@ type IssueDetailChatTabProps = {
   feedbackDataSharingPreference: "allowed" | "not_allowed" | "prompt";
   feedbackTermsUrl: string | null;
   agentMap: Map<string, Agent>;
-  currentUserId: string | null;
+  // `undefined` means the session query is still resolving; chat-bubble
+  // alignment uses this to avoid flickering the viewer's own messages to
+  // the wrong side before the session lands.
+  currentUserId: string | null | undefined;
   userLabelMap: ReadonlyMap<string, string> | null;
   userProfileMap: ReadonlyMap<string, import("../lib/company-members").CompanyUserProfile> | null;
   draftKey: string;
@@ -1184,7 +1187,13 @@ export function IssueDetail() {
     queryFn: () => projectsApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId,
   });
-  const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
+  // While the session query is loading, pass `undefined` so chat-bubble
+  // alignment can hold an optimistic "this is the viewer" assumption and
+  // not flicker the viewer's own messages to the wrong side. After the
+  // query resolves, fall back to `null` for genuinely anonymous sessions.
+  const currentUserId = session === undefined
+    ? undefined
+    : (session?.user?.id ?? session?.session?.userId ?? null);
   const { data: boardAccess } = useQuery({
     queryKey: queryKeys.access.currentBoardAccess,
     queryFn: () => accessApi.getCurrentBoardAccess(),
@@ -1665,7 +1674,7 @@ export function IssueDetail() {
             companyId: issue.companyId,
             issueId: issue.id,
             body,
-            authorUserId: currentUserId,
+            authorUserId: currentUserId ?? null,
             clientStatus: queuedComment ? "queued" : "pending",
             queueTargetRunId: queuedComment?.id ?? null,
           })
@@ -1866,7 +1875,7 @@ export function IssueDetail() {
             companyId: issue.companyId,
             issueId: issue.id,
             body,
-            authorUserId: currentUserId,
+            authorUserId: currentUserId ?? null,
             clientStatus: queuedComment ? "queued" : "pending",
             queueTargetRunId: queuedComment?.id ?? null,
           })
@@ -2120,7 +2129,7 @@ export function IssueDetail() {
             vote: variables.vote,
             reason: variables.reason,
           },
-          currentUserId,
+          currentUserId ?? null,
         ),
       );
       return { previousVotes };
@@ -3418,7 +3427,7 @@ export function IssueDetail() {
               childIssues={childIssues}
               agentMap={agentMap}
               hasLiveRuns={hasLiveRuns}
-              currentUserId={currentUserId}
+              currentUserId={currentUserId ?? null}
               userProfileMap={userProfileMap}
               pendingApprovalAction={pendingApprovalAction}
               handoffFocusSignal={handoffFocusSignal}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, with humans overseeing them through an issue board UI
> - The issue chat thread is the main place humans review and reply to agent activity, with the viewer's own messages aligned right and other authors aligned left
> - Bubble alignment is decided by `resolveIssueChatHumanAuthor`, which compares `authorUserId` to `currentUserId` from the session
> - On cold loads, the comments query and the session query resolve independently, and comments often arrive before the session
> - During that window `currentUserId` is `null`, so the viewer's own bubbles render on the *wrong* side (avatar-left, `justify-start`, "User" label) and then snap to the right when the session lands a moment later — a visible color/layout flicker
> - This pull request distinguishes "session loading" from "session loaded but anonymous" so chat-bubble alignment is stable from the first render
> - The benefit is that returning to an issue (or opening one with a cold session) no longer flashes your own messages across the page before settling

## What Changed

- `resolveIssueChatHumanAuthor` now branches on `currentUserId === undefined` (loading — optimistically classify any human-authored comment as the viewer's) vs `currentUserId === null` (resolved-anonymous — strict equality check, unchanged from before).
- `IssueDetail` passes `currentUserId = undefined` while the `useQuery` for `auth.session` is in flight, falling back to the existing `null`/string resolution after it resolves.
- Widened `IssueDetailChatTabProps.currentUserId` to `string | null | undefined` so the loading signal can travel to `IssueChatThread` without losing the distinction.
- Coerced `currentUserId ?? null` at the four sites that don't care about loading vs. anonymous: optimistic comment creation in both `addComment` / update mutations, optimistic feedback-vote merging, and the `IssueDetailActivityTab` prop.
- Added 4 tests in `IssueChatThread.test.tsx`: 3 unit tests covering `resolveIssueChatHumanAuthor` (loading-with-author, loading-without-author, resolved-anonymous), and 1 integration test that renders `IssueChatThread` with `currentUserId={undefined}` and asserts the viewer's bubble row uses `justify-end` from the first frame.

## Verification

```sh
pnpm install
cd ui
pnpm exec vitest run src/components/IssueChatThread.test.tsx   # 35/35 pass (4 new + 31 existing)
pnpm exec vitest run                                            # 626/626 pass
pnpm typecheck                                                  # clean
pnpm build                                                      # clean (only pre-existing chunk-size warnings)
```

Repo-wide `pnpm -r typecheck` also clean.

Manual repro (before fix):
1. Hard refresh into an issue you've previously commented on, ideally with the session endpoint slow / cache cold.
2. Watch your own past comments render with avatar-left and "User" label.
3. ~200–500 ms later the bubbles snap right; name flips to "You".

After fix: bubbles render in the correct position from the first paint regardless of how slow the session endpoint is.

## Risks

Low. The strict equality path is unchanged, so `resolved-anonymous` and `resolved-with-different-user` cases behave exactly as before. The only behavioral change is during the loading window, where the viewer's own messages are now correctly placed and other users' messages may briefly appear on the right before snapping to the left in multi-user companies — a less jarring trade than the original flicker, and only for the duration of the session query.

The same loading-flicker pattern technically also affects two activity-row inline `isCurrentUser` checks at `IssueChatThread.tsx:1836` (`ExpiredRequestConfirmationActivity`) and `:1964` (timeline event rows). They render small one-line entries rather than chat bubbles, so I kept this PR scoped to the visible chat-bubble bug (CONTRIBUTING.md "Path 1"). Happy to follow up on those in a separate PR if you'd like consistency there.

## Model Used

- Claude Opus 4.7 (Anthropic), exact model ID `claude-opus-4-7`, 1M-token context window. Used via Claude Code CLI for code reading, hypothesis formation, test-first authoring, and implementation. Fix and tests reviewed and run locally before pushing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have described what changed in concrete bullets
- [x] I have explained how to verify the change works
- [x] I have called out the risks (or noted Low risk with justification)
- [x] I have specified the AI model used (or noted "None — human-authored")
- [x] Tests pass locally (`pnpm test:run`)
- [x] Typecheck passes locally (`pnpm -r typecheck`)
- [x] Build passes locally (`pnpm build`)