### PR TITLE
feat(claude-local,server): granular quota/rate/5xx error classification (PMSA-15)

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import type {
+  AdapterExecutionContext,
+  AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
 import {
   adapterExecutionTargetIsRemote,
@@ -39,9 +42,8 @@ import {
   parseClaudeStreamJson,
   describeClaudeFailure,
   detectClaudeLoginRequired,
-  extractClaudeRetryNotBefore,
+  classifyClaudeFailure,
   isClaudeMaxTurnsResult,
-  isClaudeTransientUpstreamError,
   isClaudeUnknownSessionError,
 } from "./parse.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
@@ -87,7 +89,10 @@ function buildLoginResult(input: {
   };
 }
 
-function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
+function hasNonEmptyEnvValue(
+  env: Record<string, string>,
+  key: string,
+): boolean {
   const raw = env[key];
   return typeof raw === "string" && raw.trim().length > 0;
 }
@@ -100,12 +105,16 @@ function isBedrockAuth(env: Record<string, string>): boolean {
   );
 }
 
-function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
+function resolveClaudeBillingType(
+  env: Record<string, string>,
+): "api" | "subscription" | "metered_api" {
   if (isBedrockAuth(env)) return "metered_api";
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
 }
 
-async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {
+async function buildClaudeRuntimeConfig(
+  input: ClaudeExecutionInput,
+): Promise<ClaudeRuntimeConfig> {
   const { runId, agent, config, context, executionTarget, authToken } = input;
 
   const command = asString(config.command, "claude");
@@ -117,58 +126,82 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "") || null;
   const workspaceRepoRef = asString(workspaceContext.repoRef, "") || null;
   const workspaceBranch = asString(workspaceContext.branchName, "") || null;
-  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "") || null;
+  const workspaceWorktreePath =
+    asString(workspaceContext.worktreePath, "") || null;
   const agentHome = asString(workspaceContext.agentHome, "") || null;
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
-        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+        (value): value is Record<string, unknown> =>
+          typeof value === "object" && value !== null,
       )
     : [];
-  const runtimeServiceIntents = Array.isArray(context.paperclipRuntimeServiceIntents)
+  const runtimeServiceIntents = Array.isArray(
+    context.paperclipRuntimeServiceIntents,
+  )
     ? context.paperclipRuntimeServiceIntents.filter(
-        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+        (value): value is Record<string, unknown> =>
+          typeof value === "object" && value !== null,
       )
     : [];
   const runtimeServices = Array.isArray(context.paperclipRuntimeServices)
     ? context.paperclipRuntimeServices.filter(
-        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+        (value): value is Record<string, unknown> =>
+          typeof value === "object" && value !== null,
       )
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const useConfiguredInsteadOfAgentHome =
+    workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome
+    ? ""
+    : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
 
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
-    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+    typeof envConfig.PAPERCLIP_API_KEY === "string" &&
+    envConfig.PAPERCLIP_API_KEY.trim().length > 0;
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
   env.PAPERCLIP_RUN_ID = runId;
 
   const wakeTaskId =
-    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
-    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    (typeof context.taskId === "string" &&
+      context.taskId.trim().length > 0 &&
+      context.taskId.trim()) ||
+    (typeof context.issueId === "string" &&
+      context.issueId.trim().length > 0 &&
+      context.issueId.trim()) ||
     null;
   const wakeReason =
-    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+    typeof context.wakeReason === "string" &&
+    context.wakeReason.trim().length > 0
       ? context.wakeReason.trim()
       : null;
   const wakeCommentId =
-    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
-    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    (typeof context.wakeCommentId === "string" &&
+      context.wakeCommentId.trim().length > 0 &&
+      context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" &&
+      context.commentId.trim().length > 0 &&
+      context.commentId.trim()) ||
     null;
   const approvalId =
-    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+    typeof context.approvalId === "string" &&
+    context.approvalId.trim().length > 0
       ? context.approvalId.trim()
       : null;
   const approvalStatus =
-    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+    typeof context.approvalStatus === "string" &&
+    context.approvalStatus.trim().length > 0
       ? context.approvalStatus.trim()
       : null;
   const linkedIssueIds = Array.isArray(context.issueIds)
-    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    ? context.issueIds.filter(
+        (value): value is string =>
+          typeof value === "string" && value.trim().length > 0,
+      )
     : [];
   const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
 
@@ -224,7 +257,9 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
   }
   if (runtimeServiceIntents.length > 0) {
-    env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(runtimeServiceIntents);
+    env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(
+      runtimeServiceIntents,
+    );
   }
   if (runtimeServices.length > 0) {
     env.PAPERCLIP_RUNTIME_SERVICES_JSON = JSON.stringify(runtimeServices);
@@ -232,7 +267,8 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   if (runtimePrimaryUrl) {
     env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
   }
-  const targetPaperclipApiUrl = adapterExecutionTargetPaperclipApiUrl(executionTarget);
+  const targetPaperclipApiUrl =
+    adapterExecutionTargetPaperclipApiUrl(executionTarget);
   if (targetPaperclipApiUrl) {
     env.PAPERCLIP_API_URL = targetPaperclipApiUrl;
   }
@@ -246,8 +282,18 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   }
 
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
-  await ensureAdapterExecutionTargetCommandResolvable(command, executionTarget, cwd, runtimeEnv);
-  const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(command, executionTarget, cwd, runtimeEnv);
+  await ensureAdapterExecutionTargetCommandResolvable(
+    command,
+    executionTarget,
+    cwd,
+    runtimeEnv,
+  );
+  const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(
+    command,
+    executionTarget,
+    cwd,
+    runtimeEnv,
+  );
   const loggedEnv = buildInvocationEnvForLogs(env, {
     runtimeEnv,
     includeRuntimeKeys: ["HOME", "CLAUDE_CONFIG_DIR"],
@@ -294,13 +340,19 @@ export async function runClaudeLogin(input: {
     authToken: input.authToken,
   });
 
-  const proc = await runAdapterExecutionTargetProcess(input.runId, null, runtime.command, ["login"], {
-    cwd: runtime.cwd,
-    env: runtime.env,
-    timeoutSec: runtime.timeoutSec,
-    graceSec: runtime.graceSec,
-    onLog,
-  });
+  const proc = await runAdapterExecutionTargetProcess(
+    input.runId,
+    null,
+    runtime.command,
+    ["login"],
+    {
+      cwd: runtime.cwd,
+      env: runtime.env,
+      timeoutSec: runtime.timeoutSec,
+      graceSec: runtime.graceSec,
+      onLog,
+    },
+  );
 
   const loginMeta = detectClaudeLoginRequired({
     parsed: null,
@@ -314,13 +366,26 @@ export async function runClaudeLogin(input: {
   });
 }
 
-export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+export async function execute(
+  ctx: AdapterExecutionContext,
+): Promise<AdapterExecutionResult> {
+  const {
+    runId,
+    agent,
+    runtime,
+    config,
+    context,
+    onLog,
+    onMeta,
+    onSpawn,
+    authToken,
+  } = ctx;
   const executionTarget = readAdapterExecutionTarget({
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
   });
-  const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
+  const executionTargetIsRemote =
+    adapterExecutionTargetIsRemote(executionTarget);
 
   const promptTemplate = asString(
     config.promptTemplate,
@@ -330,9 +395,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effort = asString(config.effort, "");
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
-  const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+  const dangerouslySkipPermissions = asBoolean(
+    config.dangerouslySkipPermissions,
+    true,
+  );
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
-  const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  const instructionsFileDir = instructionsFilePath
+    ? `${path.dirname(instructionsFilePath)}/`
+    : "";
   const runtimeConfig = await buildClaudeRuntimeConfig({
     runId,
     agent,
@@ -354,7 +424,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     graceSec,
     extraArgs,
   } = runtimeConfig;
-  const effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
+  const effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(
+    executionTarget,
+    cwd,
+  );
   const terminalResultCleanupGraceMs = Math.max(
     0,
     asNumber(config.terminalResultCleanupGraceMs, 5_000),
@@ -365,15 +438,23 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     ),
   );
   const billingType = resolveClaudeBillingType(effectiveEnv);
-  const claudeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
-  const desiredSkillNames = new Set(resolveClaudeDesiredSkillNames(config, claudeSkillEntries));
+  const claudeSkillEntries = await readPaperclipRuntimeSkillEntries(
+    config,
+    __moduleDir,
+  );
+  const desiredSkillNames = new Set(
+    resolveClaudeDesiredSkillNames(config, claudeSkillEntries),
+  );
   // When instructionsFilePath is configured, build a stable content-addressed
   // file that includes both the file content and the path directive, so we only
   // need --append-system-prompt-file (Claude CLI forbids using both flags together).
   let combinedInstructionsContents: string | null = null;
   if (instructionsFilePath) {
     try {
-      const instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
+      const instructionsContent = await fs.readFile(
+        instructionsFilePath,
+        "utf-8",
+      );
       const pathDirective =
         `\nThe above agent instructions were loaded from ${instructionsFilePath}. ` +
         `Resolve any relative file references from ${instructionsFileDir}. ` +
@@ -390,7 +471,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   const promptBundle = await prepareClaudePromptBundle({
     companyId: agent.companyId,
-    skills: claudeSkillEntries.filter((entry) => desiredSkillNames.has(entry.key)),
+    skills: claudeSkillEntries.filter((entry) =>
+      desiredSkillNames.has(entry.key),
+    ),
     instructionsContents: combinedInstructionsContents,
     onLog,
   });
@@ -418,33 +501,51 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     ? () => preparedExecutionTargetRuntime.restoreWorkspace()
     : null;
   const effectivePromptBundleAddDir = executionTargetIsRemote
-    ? preparedExecutionTargetRuntime?.assetDirs.skills ??
-      path.posix.join(effectiveExecutionCwd, ".paperclip-runtime", "claude", "skills")
+    ? (preparedExecutionTargetRuntime?.assetDirs.skills ??
+      path.posix.join(
+        effectiveExecutionCwd,
+        ".paperclip-runtime",
+        "claude",
+        "skills",
+      ))
     : promptBundle.addDir;
   const effectiveInstructionsFilePath = promptBundle.instructionsFilePath
     ? executionTargetIsRemote
-      ? path.posix.join(effectivePromptBundleAddDir, path.basename(promptBundle.instructionsFilePath))
+      ? path.posix.join(
+          effectivePromptBundleAddDir,
+          path.basename(promptBundle.instructionsFilePath),
+        )
       : promptBundle.instructionsFilePath
     : undefined;
 
   const runtimeSessionParams = parseObject(runtime.sessionParams);
-  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionId = asString(
+    runtimeSessionParams.sessionId,
+    runtime.sessionId ?? "",
+  );
   const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
-  const runtimeRemoteExecution = parseObject(runtimeSessionParams.remoteExecution);
-  const runtimePromptBundleKey = asString(runtimeSessionParams.promptBundleKey, "");
+  const runtimeRemoteExecution = parseObject(
+    runtimeSessionParams.remoteExecution,
+  );
+  const runtimePromptBundleKey = asString(
+    runtimeSessionParams.promptBundleKey,
+    "",
+  );
   const hasMatchingPromptBundle =
-    runtimePromptBundleKey.length === 0 || runtimePromptBundleKey === promptBundle.bundleKey;
+    runtimePromptBundleKey.length === 0 ||
+    runtimePromptBundleKey === promptBundle.bundleKey;
   const canResumeSession =
     runtimeSessionId.length > 0 &&
     hasMatchingPromptBundle &&
-    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(effectiveExecutionCwd)) &&
-    adapterExecutionTargetSessionMatches(runtimeRemoteExecution, executionTarget);
+    (runtimeSessionCwd.length === 0 ||
+      path.resolve(runtimeSessionCwd) ===
+        path.resolve(effectiveExecutionCwd)) &&
+    adapterExecutionTargetSessionMatches(
+      runtimeRemoteExecution,
+      executionTarget,
+    );
   const sessionId = canResumeSession ? runtimeSessionId : null;
-  if (
-    executionTargetIsRemote &&
-    runtimeSessionId &&
-    !canResumeSession
-  ) {
+  if (executionTargetIsRemote && runtimeSessionId && !canResumeSession) {
     await onLog(
       "stdout",
       `[paperclip] Claude session "${runtimeSessionId}" does not match the current remote execution identity and will not be resumed in "${effectiveExecutionCwd}". Starting a fresh remote session.\n`,
@@ -464,7 +565,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Claude session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${effectiveExecutionCwd}".\n`,
     );
   }
-  if (runtimeSessionId && runtimePromptBundleKey.length > 0 && runtimePromptBundleKey !== promptBundle.bundleKey) {
+  if (
+    runtimeSessionId &&
+    runtimePromptBundleKey.length > 0 &&
+    runtimePromptBundleKey !== promptBundle.bundleKey
+  ) {
     await onLog(
       "stdout",
       `[paperclip] Claude session "${runtimeSessionId}" was saved for prompt bundle "${runtimePromptBundleKey}" and will not be resumed with "${promptBundle.bundleKey}".\n`,
@@ -484,10 +589,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     !sessionId && bootstrapPromptTemplate.trim().length > 0
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
-  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: Boolean(sessionId) });
-  const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
-  const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
-  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, {
+    resumedSession: Boolean(sessionId),
+  });
+  const shouldUseResumeDeltaPrompt =
+    Boolean(sessionId) && wakePrompt.length > 0;
+  const renderedPrompt = shouldUseResumeDeltaPrompt
+    ? ""
+    : renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(
+    context.paperclipSessionHandoffMarkdown,
+    "",
+  ).trim();
   const taskContextNote = asString(context.paperclipTaskMarkdown, "").trim();
   const prompt = joinPromptSections([
     renderedBootstrapPrompt,
@@ -509,7 +622,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     resumeSessionId: string | null,
     attemptInstructionsFilePath: string | undefined,
   ) => {
-    const args = ["--print", "-", "--output-format", "stream-json", "--verbose"];
+    const args = [
+      "--print",
+      "-",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+    ];
     if (resumeSessionId) args.push("--resume", resumeSessionId);
     if (dangerouslySkipPermissions) args.push("--dangerously-skip-permissions");
     if (chrome) args.push("--chrome");
@@ -549,11 +668,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const runAttempt = async (resumeSessionId: string | null) => {
-    const attemptInstructionsFilePath = resumeSessionId ? undefined : effectiveInstructionsFilePath;
+    const attemptInstructionsFilePath = resumeSessionId
+      ? undefined
+      : effectiveInstructionsFilePath;
     const args = buildClaudeArgs(resumeSessionId, attemptInstructionsFilePath);
     const commandNotes: string[] = [];
     if (!resumeSessionId) {
-      commandNotes.push(`Using stable Claude prompt bundle ${promptBundle.bundleKey}.`);
+      commandNotes.push(
+        `Using stable Claude prompt bundle ${promptBundle.bundleKey}.`,
+      );
     }
     if (attemptInstructionsFilePath && !resumeSessionId) {
       commandNotes.push(
@@ -574,19 +697,26 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       });
     }
 
-    const proc = await runAdapterExecutionTargetProcess(runId, executionTarget, command, args, {
-      cwd,
-      env,
-      stdin: prompt,
-      timeoutSec,
-      graceSec,
-      onSpawn,
-      onLog,
-      terminalResultCleanup: {
-        graceMs: terminalResultCleanupGraceMs,
-        hasTerminalResult: ({ stdout }) => parseClaudeStreamJson(stdout).resultJson !== null,
+    const proc = await runAdapterExecutionTargetProcess(
+      runId,
+      executionTarget,
+      command,
+      args,
+      {
+        cwd,
+        env,
+        stdin: prompt,
+        timeoutSec,
+        graceSec,
+        onSpawn,
+        onLog,
+        terminalResultCleanup: {
+          graceMs: terminalResultCleanupGraceMs,
+          hasTerminalResult: ({ stdout }) =>
+            parseClaudeStreamJson(stdout).resultJson !== null,
+        },
       },
-    });
+    );
 
     const parsedStream = parseClaudeStreamJson(proc.stdout);
     const parsed = parsedStream.resultJson ?? parseJson(proc.stdout);
@@ -599,7 +729,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       parsedStream: ReturnType<typeof parseClaudeStreamJson>;
       parsed: Record<string, unknown> | null;
     },
-    opts: { fallbackSessionId: string | null; clearSessionOnMissingSession?: boolean },
+    opts: {
+      fallbackSessionId: string | null;
+      clearSessionOnMissingSession?: boolean;
+    },
   ): AdapterExecutionResult => {
     const { proc, parsedStream, parsed } = attempt;
     const loginMeta = detectClaudeLoginRequired({
@@ -628,46 +761,49 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     if (!parsed) {
       const fallbackErrorMessage = parseFallbackErrorMessage(proc);
-      const transientUpstream =
-        !loginMeta.requiresLogin &&
-        (proc.exitCode ?? 0) !== 0 &&
-        isClaudeTransientUpstreamError({
-          parsed: null,
-          stdout: proc.stdout,
-          stderr: proc.stderr,
-          errorMessage: fallbackErrorMessage,
-        });
-      const transientRetryNotBefore = transientUpstream
-        ? extractClaudeRetryNotBefore({
+      const procFailed = (proc.exitCode ?? 0) !== 0;
+      const classification = procFailed
+        ? classifyClaudeFailure({
             parsed: null,
             stdout: proc.stdout,
             stderr: proc.stderr,
             errorMessage: fallbackErrorMessage,
           })
         : null;
-      const errorCode = loginMeta.requiresLogin
-        ? "claude_auth_required"
-        : transientUpstream
-        ? "claude_transient_upstream"
+      const isTransientFamily =
+        classification?.errorFamily === "transient_upstream";
+      const retryNotBefore = isTransientFamily
+        ? (classification?.retryNotBefore ?? null)
         : null;
+      const retryNotBeforeIso = retryNotBefore
+        ? retryNotBefore.toISOString()
+        : null;
+      const errorCode = classification?.errorCode ?? null;
       return {
         exitCode: proc.exitCode,
         signal: proc.signal,
         timedOut: false,
         errorMessage: fallbackErrorMessage,
         errorCode,
-        errorFamily: transientUpstream ? "transient_upstream" : null,
-        retryNotBefore: transientRetryNotBefore ? transientRetryNotBefore.toISOString() : null,
+        errorFamily: isTransientFamily ? "transient_upstream" : null,
+        retryNotBefore: retryNotBeforeIso,
         errorMeta,
         resultJson: {
           stdout: proc.stdout,
           stderr: proc.stderr,
-          ...(transientUpstream ? { errorFamily: "transient_upstream" } : {}),
-          ...(transientRetryNotBefore
-            ? { retryNotBefore: transientRetryNotBefore.toISOString() }
+          ...(isTransientFamily ? { errorFamily: "transient_upstream" } : {}),
+          ...(retryNotBeforeIso
+            ? {
+                retryNotBefore: retryNotBeforeIso,
+                transientRetryNotBefore: retryNotBeforeIso,
+              }
             : {}),
-          ...(transientRetryNotBefore
-            ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() }
+          ...(classification?.kind ? { failureKind: classification.kind } : {}),
+          ...(classification?.httpStatus != null
+            ? { httpStatus: classification.httpStatus }
+            : {}),
+          ...(classification?.retryAfterMs != null
+            ? { retryAfterMs: classification.retryAfterMs }
             : {}),
         },
         clearSession: Boolean(opts.clearSessionOnMissingSession),
@@ -687,55 +823,64 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     const resolvedSessionId =
       parsedStream.sessionId ??
-      (asString(parsed.session_id, opts.fallbackSessionId ?? "") || opts.fallbackSessionId);
+      (asString(parsed.session_id, opts.fallbackSessionId ?? "") ||
+        opts.fallbackSessionId);
     const resolvedSessionParams = resolvedSessionId
       ? ({
-        sessionId: resolvedSessionId,
-        cwd: effectiveExecutionCwd,
-        promptBundleKey: promptBundle.bundleKey,
-        ...(executionTargetIsRemote
-          ? {
-              remoteExecution: adapterExecutionTargetSessionIdentity(executionTarget),
-            }
-          : {}),
-        ...(workspaceId ? { workspaceId } : {}),
-        ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
-        ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
-      } as Record<string, unknown>)
+          sessionId: resolvedSessionId,
+          cwd: effectiveExecutionCwd,
+          promptBundleKey: promptBundle.bundleKey,
+          ...(executionTargetIsRemote
+            ? {
+                remoteExecution:
+                  adapterExecutionTargetSessionIdentity(executionTarget),
+              }
+            : {}),
+          ...(workspaceId ? { workspaceId } : {}),
+          ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+          ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+        } as Record<string, unknown>)
       : null;
     const clearSessionForMaxTurns = isClaudeMaxTurnsResult(parsed);
     const parsedIsError = asBoolean(parsed.is_error, false);
     const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
     const errorMessage = failed
-      ? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
+      ? (describeClaudeFailure(parsed) ??
+        `Claude exited with code ${proc.exitCode ?? -1}`)
       : null;
-    const transientUpstream =
-      failed &&
-      !loginMeta.requiresLogin &&
-      isClaudeTransientUpstreamError({
-        parsed,
-        stdout: proc.stdout,
-        stderr: proc.stderr,
-        errorMessage,
-      });
-    const transientRetryNotBefore = transientUpstream
-      ? extractClaudeRetryNotBefore({
+    const classification = failed
+      ? classifyClaudeFailure({
           parsed,
           stdout: proc.stdout,
           stderr: proc.stderr,
           errorMessage,
         })
       : null;
-    const resolvedErrorCode = loginMeta.requiresLogin
-      ? "claude_auth_required"
-      : transientUpstream
-      ? "claude_transient_upstream"
+    const isTransientFamily =
+      classification?.errorFamily === "transient_upstream";
+    const transientRetryNotBefore = isTransientFamily
+      ? (classification?.retryNotBefore ?? null)
       : null;
+    const transientRetryNotBeforeIso = transientRetryNotBefore
+      ? transientRetryNotBefore.toISOString()
+      : null;
+    const resolvedErrorCode = classification?.errorCode ?? null;
     const mergedResultJson: Record<string, unknown> = {
       ...parsed,
-      ...(transientUpstream ? { errorFamily: "transient_upstream" } : {}),
-      ...(transientRetryNotBefore ? { retryNotBefore: transientRetryNotBefore.toISOString() } : {}),
-      ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
+      ...(isTransientFamily ? { errorFamily: "transient_upstream" } : {}),
+      ...(transientRetryNotBeforeIso
+        ? {
+            retryNotBefore: transientRetryNotBeforeIso,
+            transientRetryNotBefore: transientRetryNotBeforeIso,
+          }
+        : {}),
+      ...(classification?.kind ? { failureKind: classification.kind } : {}),
+      ...(classification?.httpStatus != null
+        ? { httpStatus: classification.httpStatus }
+        : {}),
+      ...(classification?.retryAfterMs != null
+        ? { retryAfterMs: classification.retryAfterMs }
+        : {}),
     };
 
     return {
@@ -744,8 +889,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       timedOut: false,
       errorMessage,
       errorCode: resolvedErrorCode,
-      errorFamily: transientUpstream ? "transient_upstream" : null,
-      retryNotBefore: transientRetryNotBefore ? transientRetryNotBefore.toISOString() : null,
+      errorFamily: isTransientFamily ? "transient_upstream" : null,
+      retryNotBefore: transientRetryNotBeforeIso,
       errorMeta,
       usage,
       sessionId: resolvedSessionId,
@@ -758,7 +903,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       costUsd: parsedStream.costUsd ?? asNumber(parsed.total_cost_usd, 0),
       resultJson: mergedResultJson,
       summary: parsedStream.summary || asString(parsed.result, ""),
-      clearSession: clearSessionForMaxTurns || Boolean(opts.clearSessionOnMissingSession && !resolvedSessionId),
+      clearSession:
+        clearSessionForMaxTurns ||
+        Boolean(opts.clearSessionOnMissingSession && !resolvedSessionId),
     };
   };
 
@@ -776,10 +923,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
-      return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+      return toAdapterResult(retry, {
+        fallbackSessionId: null,
+        clearSessionOnMissingSession: true,
+      });
     }
 
-    return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+    return toAdapterResult(initial, {
+      fallbackSessionId: runtimeSessionId || runtime.sessionId,
+    });
   } finally {
     if (restoreRemoteWorkspace) {
       await onLog(

--- a/packages/adapters/claude-local/src/server/parse-classify.test.ts
+++ b/packages/adapters/claude-local/src/server/parse-classify.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { classifyClaudeFailure } from "./parse.js";
+
+describe("classifyClaudeFailure", () => {
+  it("returns null kind when there is no failure signal", () => {
+    const result = classifyClaudeFailure({ stdout: "", stderr: "" });
+    expect(result.kind).toBeNull();
+    expect(result.errorCode).toBeNull();
+    expect(result.errorFamily).toBeNull();
+  });
+
+  it("classifies the explicit 'not logged in' copy as auth_required", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        result: "Please log in. Run `claude login` first.",
+      },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.kind).toBe("auth_required");
+    expect(result.errorCode).toBe("claude_auth_required");
+    expect(result.errorFamily).toBe("auth");
+  });
+
+  it("classifies api_error_status:401 (without auth copy) as quota_exhausted", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        errors: [
+          {
+            message:
+              "Anthropic API request failed: api_error_status: 401 (subscription token rejected)",
+          },
+        ],
+      },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.kind).toBe("quota_exhausted");
+    expect(result.errorCode).toBe("claude_quota_exhausted");
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.httpStatus).toBe(401);
+  });
+
+  it("classifies 'quota exhausted' wording without an HTTP status as quota_exhausted", () => {
+    const result = classifyClaudeFailure({
+      parsed: { is_error: true, result: "Monthly Opus quota exhausted." },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.kind).toBe("quota_exhausted");
+    expect(result.errorCode).toBe("claude_quota_exhausted");
+  });
+
+  it("classifies api_error_status:429 as rate_limited", () => {
+    const result = classifyClaudeFailure({
+      stderr: "Anthropic responded api_error_status: 429 Too Many Requests",
+    });
+    expect(result.kind).toBe("rate_limited");
+    expect(result.errorCode).toBe("claude_rate_limited");
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.httpStatus).toBe(429);
+  });
+
+  it("classifies a 429 stderr line without api_error_status as rate_limited", () => {
+    const result = classifyClaudeFailure({
+      stderr: "HTTP 429: Too Many Requests",
+    });
+    expect(result.kind).toBe("rate_limited");
+    expect(result.errorCode).toBe("claude_rate_limited");
+  });
+
+  it("classifies rate_limit_error events as rate_limited", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        errors: [
+          {
+            type: "rate_limit_error",
+            message: "Rate limit reached for requests.",
+          },
+        ],
+      },
+    });
+    expect(result.kind).toBe("rate_limited");
+    expect(result.errorCode).toBe("claude_rate_limited");
+  });
+
+  it("classifies api_error_status:503 as provider_5xx", () => {
+    const result = classifyClaudeFailure({
+      stderr: "api_error_status: 503 Service Unavailable",
+    });
+    expect(result.kind).toBe("provider_5xx");
+    expect(result.errorCode).toBe("claude_provider_5xx");
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.httpStatus).toBe(503);
+  });
+
+  it("classifies api_error_status:500 as provider_5xx", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        errors: [{ message: "Upstream failure api_error_status: 500" }],
+      },
+    });
+    expect(result.kind).toBe("provider_5xx");
+    expect(result.errorCode).toBe("claude_provider_5xx");
+    expect(result.httpStatus).toBe(500);
+  });
+
+  it("falls back to transient_upstream for overloaded/throttling without a status code", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        errors: [{ type: "overloaded_error", message: "Overloaded" }],
+      },
+    });
+    expect(result.kind).toBe("transient_upstream");
+    expect(result.errorCode).toBe("claude_transient_upstream");
+    expect(result.errorFamily).toBe("transient_upstream");
+  });
+
+  it("falls back to transient_upstream for 'out of extra usage' subscription wording", () => {
+    const result = classifyClaudeFailure({
+      errorMessage: "You're out of extra usage · resets 4pm (America/Chicago)",
+    });
+    // "out of extra usage" is a quota-shaped wording, so we treat it as quota_exhausted.
+    expect(result.kind).toBe("quota_exhausted");
+    expect(result.errorCode).toBe("claude_quota_exhausted");
+    expect(result.errorFamily).toBe("transient_upstream");
+  });
+
+  it("ignores deterministic max-turns failures", () => {
+    const result = classifyClaudeFailure({
+      parsed: { subtype: "error_max_turns", result: "Maximum turns reached." },
+    });
+    expect(result.kind).toBeNull();
+    expect(result.errorCode).toBeNull();
+  });
+
+  it("ignores deterministic unknown-session failures", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        result: "No conversation found with session id abc-123",
+        errors: [{ message: "No conversation found with session id abc-123" }],
+      },
+    });
+    expect(result.kind).toBeNull();
+    expect(result.errorCode).toBeNull();
+  });
+
+  it("auth-required wins over a coincidental 401 status", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        result: "Please log in. api_error_status: 401",
+      },
+    });
+    expect(result.kind).toBe("auth_required");
+    expect(result.errorCode).toBe("claude_auth_required");
+  });
+
+  it("extracts retry-after seconds when present", () => {
+    const result = classifyClaudeFailure({
+      stderr: "api_error_status: 429 Too Many Requests retry-after: 30",
+    });
+    expect(result.kind).toBe("rate_limited");
+    expect(result.retryAfterMs).toBe(30_000);
+  });
+
+  it("returns the loginUrl alongside the classification when one is in the output", () => {
+    const result = classifyClaudeFailure({
+      stdout: "Please log in. Visit https://claude.ai/login to continue.",
+    });
+    expect(result.kind).toBe("auth_required");
+    expect(result.loginUrl).toContain("claude.ai/login");
+  });
+});

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -6,11 +6,22 @@ import {
   parseJson,
 } from "@paperclipai/adapter-utils/server-utils";
 
-const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?|login\s+required|requires\s+login|unauthorized|authentication\s+required)/i;
+const CLAUDE_AUTH_REQUIRED_RE =
+  /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?|login\s+required|requires\s+login|unauthorized|authentication\s+required)/i;
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
   /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+
+// PMSA-15 / PMSA-11 §2.1: granular classification for Anthropic-side failures.
+// See /PMSA/issues/PMSA-11#document-plan section 2.1 for the truth table.
+const CLAUDE_API_ERROR_STATUS_RE = /api[_\s-]?error[_\s-]?status[:\s]+(\d{3})/i;
+const CLAUDE_QUOTA_EXHAUSTED_RE =
+  /(?:quota[_\s-]?(?:exhausted|exceeded)|monthly\s+quota|opus\s+quota|out\s+of\s+extra\s+usage|claude\s+usage\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached)/i;
+const CLAUDE_RATE_LIMIT_RE =
+  /(?:rate[-\s]?limit(?:ed|_error)?|too\s+many\s+requests|\b429\b|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception)/i;
+const CLAUDE_RETRY_AFTER_RE =
+  /(?:retry[-_\s]?after|x[-_]?ratelimit[-_]?reset|x[-_]?ratelimit[-_]?reset[-_]?after)[:\s=]+(\d+)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
@@ -38,7 +49,8 @@ export function parseClaudeStreamJson(stdout: string) {
       const message = parseObject(event.message);
       const content = Array.isArray(message.content) ? message.content : [];
       for (const entry of content) {
-        if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
+        if (typeof entry !== "object" || entry === null || Array.isArray(entry))
+          continue;
         const block = entry as Record<string, unknown>;
         if (asString(block.type, "") === "text") {
           const text = asString(block.text, "");
@@ -72,8 +84,12 @@ export function parseClaudeStreamJson(stdout: string) {
     outputTokens: asNumber(usageObj.output_tokens, 0),
   };
   const costRaw = finalResult.total_cost_usd;
-  const costUsd = typeof costRaw === "number" && Number.isFinite(costRaw) ? costRaw : null;
-  const summary = asString(finalResult.result, assistantTexts.join("\n\n")).trim();
+  const costUsd =
+    typeof costRaw === "number" && Number.isFinite(costRaw) ? costRaw : null;
+  const summary = asString(
+    finalResult.result,
+    assistantTexts.join("\n\n"),
+  ).trim();
 
   return {
     sessionId,
@@ -101,7 +117,10 @@ function extractClaudeErrorMessages(parsed: Record<string, unknown>): string[] {
     }
 
     const obj = entry as Record<string, unknown>;
-    const msg = asString(obj.message, "") || asString(obj.error, "") || asString(obj.code, "");
+    const msg =
+      asString(obj.message, "") ||
+      asString(obj.error, "") ||
+      asString(obj.code, "");
     if (msg) {
       messages.push(msg);
       continue;
@@ -122,7 +141,11 @@ export function extractClaudeLoginUrl(text: string): string | null {
   if (!match || match.length === 0) return null;
   for (const rawUrl of match) {
     const cleaned = rawUrl.replace(/[\])}.!,?;:'\"]+$/g, "");
-    if (cleaned.includes("claude") || cleaned.includes("anthropic") || cleaned.includes("auth")) {
+    if (
+      cleaned.includes("claude") ||
+      cleaned.includes("anthropic") ||
+      cleaned.includes("auth")
+    ) {
       return cleaned;
     }
   }
@@ -135,20 +158,29 @@ export function detectClaudeLoginRequired(input: {
   stderr: string;
 }): { requiresLogin: boolean; loginUrl: string | null } {
   const resultText = asString(input.parsed?.result, "").trim();
-  const messages = [resultText, ...extractClaudeErrorMessages(input.parsed ?? {}), input.stdout, input.stderr]
+  const messages = [
+    resultText,
+    ...extractClaudeErrorMessages(input.parsed ?? {}),
+    input.stdout,
+    input.stderr,
+  ]
     .join("\n")
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
 
-  const requiresLogin = messages.some((line) => CLAUDE_AUTH_REQUIRED_RE.test(line));
+  const requiresLogin = messages.some((line) =>
+    CLAUDE_AUTH_REQUIRED_RE.test(line),
+  );
   return {
     requiresLogin,
     loginUrl: extractClaudeLoginUrl([input.stdout, input.stderr].join("\n")),
   };
 }
 
-export function describeClaudeFailure(parsed: Record<string, unknown>): string | null {
+export function describeClaudeFailure(
+  parsed: Record<string, unknown>,
+): string | null {
   const subtype = asString(parsed.subtype, "");
   const resultText = asString(parsed.result, "").trim();
   const errors = extractClaudeErrorMessages(parsed);
@@ -164,7 +196,9 @@ export function describeClaudeFailure(parsed: Record<string, unknown>): string |
   return parts.length > 1 ? parts.join(": ") : null;
 }
 
-export function isClaudeMaxTurnsResult(parsed: Record<string, unknown> | null | undefined): boolean {
+export function isClaudeMaxTurnsResult(
+  parsed: Record<string, unknown> | null | undefined,
+): boolean {
   if (!parsed) return false;
 
   const subtype = asString(parsed.subtype, "").trim().toLowerCase();
@@ -177,14 +211,18 @@ export function isClaudeMaxTurnsResult(parsed: Record<string, unknown> | null | 
   return /max(?:imum)?\s+turns?/i.test(resultText);
 }
 
-export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): boolean {
+export function isClaudeUnknownSessionError(
+  parsed: Record<string, unknown>,
+): boolean {
   const resultText = asString(parsed.result, "").trim();
   const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
     .map((msg) => msg.trim())
     .filter(Boolean);
 
   return allMessages.some((msg) =>
-    /no conversation found with session id|unknown session|session .* not found/i.test(msg),
+    /no conversation found with session id|unknown session|session .* not found/i.test(
+      msg,
+    ),
   );
 }
 
@@ -221,7 +259,9 @@ function readTimeZoneParts(date: Date, timeZone: string) {
       day: "2-digit",
       hour: "2-digit",
       minute: "2-digit",
-    }).formatToParts(date).map((part) => [part.type, part.value]),
+    })
+      .formatToParts(date)
+      .map((part) => [part.type, part.value]),
   );
   return {
     year: Number.parseInt(values.get("year") ?? "", 10),
@@ -232,13 +272,17 @@ function readTimeZoneParts(date: Date, timeZone: string) {
   };
 }
 
-function normalizeResetTimeZone(timeZoneHint: string | null | undefined): string | null {
+function normalizeResetTimeZone(
+  timeZoneHint: string | null | undefined,
+): string | null {
   const normalized = timeZoneHint?.trim();
   if (!normalized) return null;
   if (/^(?:utc|gmt)$/i.test(normalized)) return "UTC";
 
   try {
-    new Intl.DateTimeFormat("en-US", { timeZone: normalized }).format(new Date(0));
+    new Intl.DateTimeFormat("en-US", { timeZone: normalized }).format(
+      new Date(0),
+    );
     return normalized;
   } catch {
     return null;
@@ -253,12 +297,38 @@ function dateFromTimeZoneWallClock(input: {
   minute: number;
   timeZone: string;
 }): Date | null {
-  let candidate = new Date(Date.UTC(input.year, input.month - 1, input.day, input.hour, input.minute, 0, 0));
-  const targetUtc = Date.UTC(input.year, input.month - 1, input.day, input.hour, input.minute, 0, 0);
+  let candidate = new Date(
+    Date.UTC(
+      input.year,
+      input.month - 1,
+      input.day,
+      input.hour,
+      input.minute,
+      0,
+      0,
+    ),
+  );
+  const targetUtc = Date.UTC(
+    input.year,
+    input.month - 1,
+    input.day,
+    input.hour,
+    input.minute,
+    0,
+    0,
+  );
 
   for (let attempt = 0; attempt < 4; attempt += 1) {
     const actual = readTimeZoneParts(candidate, input.timeZone);
-    const actualUtc = Date.UTC(actual.year, actual.month - 1, actual.day, actual.hour, actual.minute, 0, 0);
+    const actualUtc = Date.UTC(
+      actual.year,
+      actual.month - 1,
+      actual.day,
+      actual.hour,
+      actual.minute,
+      0,
+      0,
+    );
     const offsetMs = targetUtc - actualUtc;
     if (offsetMs === 0) break;
     candidate = new Date(candidate.getTime() + offsetMs);
@@ -299,7 +369,9 @@ function nextClockTimeInTimeZone(input: {
   if (!retryAt) return null;
 
   if (retryAt.getTime() <= input.now.getTime()) {
-    const nextDay = new Date(Date.UTC(nowParts.year, nowParts.month - 1, nowParts.day + 1, 0, 0, 0, 0));
+    const nextDay = new Date(
+      Date.UTC(nowParts.year, nowParts.month - 1, nowParts.day + 1, 0, 0, 0, 0),
+    );
     retryAt = dateFromTimeZoneWallClock({
       year: nextDay.getUTCFullYear(),
       month: nextDay.getUTCMonth() + 1,
@@ -313,7 +385,11 @@ function nextClockTimeInTimeZone(input: {
   return retryAt;
 }
 
-function parseClaudeResetClockTime(clockText: string, now: Date, timeZoneHint?: string | null): Date | null {
+function parseClaudeResetClockTime(
+  clockText: string,
+  now: Date,
+  timeZoneHint?: string | null,
+): Date | null {
   const normalized = clockText.trim().replace(/\s+/g, " ");
   const match = normalized.match(/^(\d{1,2})(?::(\d{2}))?\s*([ap])\.?\s*m\.?/i);
   if (!match) return null;
@@ -367,7 +443,10 @@ export function isClaudeTransientUpstreamError(input: {
 }): boolean {
   const parsed = input.parsed ?? null;
   // Deterministic failures are handled by their own classifiers.
-  if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed))) {
+  if (
+    parsed &&
+    (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed))
+  ) {
     return false;
   }
   const loginMeta = detectClaudeLoginRequired({
@@ -380,4 +459,170 @@ export function isClaudeTransientUpstreamError(input: {
   const haystack = buildClaudeTransientHaystack(input);
   if (!haystack) return false;
   return CLAUDE_TRANSIENT_UPSTREAM_RE.test(haystack);
+}
+
+export type ClaudeFailureKind =
+  | "auth_required"
+  | "quota_exhausted"
+  | "rate_limited"
+  | "provider_5xx"
+  | "transient_upstream"
+  | null;
+
+export interface ClaudeFailureClassification {
+  kind: ClaudeFailureKind;
+  errorCode:
+    | "claude_auth_required"
+    | "claude_quota_exhausted"
+    | "claude_rate_limited"
+    | "claude_provider_5xx"
+    | "claude_transient_upstream"
+    | null;
+  errorFamily:
+    | "auth"
+    | "quota"
+    | "rate_limit"
+    | "provider_5xx"
+    | "transient_upstream"
+    | null;
+  httpStatus: number | null;
+  retryAfterMs: number | null;
+  retryNotBefore: Date | null;
+  loginUrl: string | null;
+}
+
+function extractHttpStatus(haystack: string): number | null {
+  const match = haystack.match(CLAUDE_API_ERROR_STATUS_RE);
+  if (!match) return null;
+  const status = Number.parseInt(match[1] ?? "", 10);
+  return Number.isFinite(status) && status >= 100 && status <= 599
+    ? status
+    : null;
+}
+
+function extractRetryAfterMs(haystack: string): number | null {
+  const match = haystack.match(CLAUDE_RETRY_AFTER_RE);
+  if (!match) return null;
+  const seconds = Number.parseInt(match[1] ?? "", 10);
+  if (!Number.isFinite(seconds) || seconds < 0) return null;
+  return seconds * 1000;
+}
+
+/**
+ * PMSA-15 / PMSA-11 §2.1: classify Claude run failures into actionable buckets.
+ *
+ * Precedence: auth_required > quota_exhausted > rate_limited > provider_5xx > transient_upstream.
+ * `auth_required` requires the explicit "not logged in" / "claude login" copy. A bare 401 with
+ * the session already authenticated maps to `quota_exhausted` per the design plan.
+ */
+export function classifyClaudeFailure(input: {
+  parsed?: Record<string, unknown> | null;
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+  now?: Date;
+}): ClaudeFailureClassification {
+  const parsed = input.parsed ?? null;
+  const stdout = input.stdout ?? "";
+  const stderr = input.stderr ?? "";
+  const now = input.now ?? new Date();
+
+  const empty: ClaudeFailureClassification = {
+    kind: null,
+    errorCode: null,
+    errorFamily: null,
+    httpStatus: null,
+    retryAfterMs: null,
+    retryNotBefore: null,
+    loginUrl: null,
+  };
+
+  // Deterministic failures keep their existing handling outside this classifier.
+  if (
+    parsed &&
+    (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed))
+  ) {
+    return empty;
+  }
+
+  const loginMeta = detectClaudeLoginRequired({ parsed, stdout, stderr });
+  const haystack = buildClaudeTransientHaystack({
+    parsed,
+    stdout,
+    stderr,
+    errorMessage: input.errorMessage ?? null,
+  });
+  const httpStatus = extractHttpStatus(haystack);
+  const retryAfterMs = extractRetryAfterMs(haystack);
+  const retryNotBefore = extractClaudeRetryNotBefore(
+    { parsed, stdout, stderr, errorMessage: input.errorMessage ?? null },
+    now,
+  );
+
+  if (loginMeta.requiresLogin) {
+    return {
+      kind: "auth_required",
+      errorCode: "claude_auth_required",
+      errorFamily: "auth",
+      httpStatus: httpStatus ?? 401,
+      retryAfterMs: null,
+      retryNotBefore: null,
+      loginUrl: loginMeta.loginUrl,
+    };
+  }
+
+  if (!haystack) return empty;
+
+  // 401 without auth-required copy => quota exhausted (e.g. Anthropic OAuth token rejected
+  // because the subscription's allotment is depleted).
+  const isQuotaTextMatch = CLAUDE_QUOTA_EXHAUSTED_RE.test(haystack);
+  if (httpStatus === 401 || isQuotaTextMatch) {
+    return {
+      kind: "quota_exhausted",
+      errorCode: "claude_quota_exhausted",
+      errorFamily: "transient_upstream",
+      httpStatus,
+      retryAfterMs,
+      retryNotBefore,
+      loginUrl: loginMeta.loginUrl,
+    };
+  }
+
+  if (httpStatus === 429 || CLAUDE_RATE_LIMIT_RE.test(haystack)) {
+    return {
+      kind: "rate_limited",
+      errorCode: "claude_rate_limited",
+      errorFamily: "transient_upstream",
+      httpStatus: httpStatus ?? 429,
+      retryAfterMs,
+      retryNotBefore,
+      loginUrl: loginMeta.loginUrl,
+    };
+  }
+
+  if (httpStatus !== null && httpStatus >= 500 && httpStatus < 600) {
+    return {
+      kind: "provider_5xx",
+      errorCode: "claude_provider_5xx",
+      errorFamily: "transient_upstream",
+      httpStatus,
+      retryAfterMs,
+      retryNotBefore,
+      loginUrl: loginMeta.loginUrl,
+    };
+  }
+
+  if (CLAUDE_TRANSIENT_UPSTREAM_RE.test(haystack)) {
+    return {
+      kind: "transient_upstream",
+      errorCode: "claude_transient_upstream",
+      errorFamily: "transient_upstream",
+      httpStatus,
+      retryAfterMs,
+      retryNotBefore,
+      loginUrl: loginMeta.loginUrl,
+    };
+  }
+
+  return { ...empty, loginUrl: loginMeta.loginUrl };
 }

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -661,7 +661,7 @@ describe("claude execute", () => {
     }
   }, 15_000);
 
-  it("classifies Claude 'out of extra usage' failures as transient upstream errors", async () => {
+  it("classifies Claude 'out of extra usage' failures as quota_exhausted (PMSA-15)", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-transient-"));
     const workspace = path.join(root, "workspace");
     const commandPath = path.join(root, "claude");
@@ -709,7 +709,10 @@ describe("claude execute", () => {
       });
 
       expect(result.exitCode).toBe(1);
-      expect(result.errorCode).toBe("claude_transient_upstream");
+      // PMSA-15: "out of extra usage" wording is classified as quota_exhausted
+      // (more granular than the legacy claude_transient_upstream bucket); the
+      // errorFamily and retry contract still route through transient_upstream.
+      expect(result.errorCode).toBe("claude_quota_exhausted");
       expect(result.errorFamily).toBe("transient_upstream");
       const expectedRetryNotBefore = "2026-04-22T21:00:00.000Z";
       expect(result.retryNotBefore).toBe(expectedRetryNotBefore);
@@ -830,6 +833,85 @@ describe("claude execute", () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.errorCode).not.toBe("claude_transient_upstream");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  // PMSA-15 §2.2 acceptance: a Claude failure carrying api_error_status: 401
+  // (without the "please log in" wording that selects claude_auth_required) must
+  // surface as claude_quota_exhausted on the adapter execution result. The
+  // server-side heartbeat_runs row mirrors result.errorCode, so this assertion
+  // is the actionable end-to-end signal that quota incidents are now distinct
+  // from the legacy claude_transient_upstream bucket. The DB write itself is
+  // covered by heartbeat-run integration tests, which depend on embedded
+  // postgres and are skipped on hosts without that binary.
+  it("classifies api_error_status:401 (no auth wording) as claude_quota_exhausted (PMSA-15)", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "paperclip-claude-execute-quota-401-"),
+    );
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFailingClaudeCommand(commandPath, {
+      resultEvent: {
+        type: "result",
+        subtype: "error",
+        session_id: "claude-session-quota-401",
+        is_error: true,
+        result:
+          "Anthropic API request failed: api_error_status: 401 (subscription token rejected; please retry later)",
+        errors: [
+          {
+            type: "api_error",
+            message: "api_error_status: 401 — subscription token rejected",
+          },
+        ],
+      },
+    });
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-claude-quota-401",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      // Top-level errorCode is what heartbeat_runs.errorCode mirrors.
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe("claude_quota_exhausted");
+      expect(result.errorFamily).toBe("transient_upstream");
+      // resultJson carries the auxiliary classification metadata (the errorCode
+      // itself stays on the top-level result; see toAdapterResult merger).
+      expect(result.resultJson?.errorFamily).toBe("transient_upstream");
+      expect(result.resultJson?.httpStatus).toBe(401);
+      expect(result.resultJson?.failureKind).toBe("quota_exhausted");
+      // Should NOT route to auth_required: there is no "please log in" wording.
+      expect(result.errorCode).not.toBe("claude_auth_required");
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -80,6 +80,27 @@ const mockBudgetService = vi.hoisted(() => ({
   resolveIncident: vi.fn(),
 }));
 
+const mockQuotaIncidentsService = {
+  listRecent: vi.fn(async () => ({
+    windowMinutes: 30,
+    windowStart: new Date(0),
+    windowEnd: new Date(0),
+    total: 0,
+    totalByCode: {
+      claude_quota_exhausted: 0,
+      claude_rate_limited: 0,
+      claude_provider_5xx: 0,
+    },
+    oldestAt: null,
+    newestAt: null,
+    byAgent: [],
+  })),
+};
+
+const mockClampQuotaIncidentWindowMinutes = vi.fn(
+  (value: unknown) => (typeof value === "number" ? value : 30),
+);
+
 function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     budgetService: () => mockBudgetService,
@@ -89,6 +110,8 @@ function registerModuleMocks() {
     agentService: () => mockAgentService,
     heartbeatService: () => mockHeartbeatService,
     logActivity: mockLogActivity,
+    quotaIncidentsService: () => mockQuotaIncidentsService,
+    clampQuotaIncidentWindowMinutes: mockClampQuotaIncidentWindowMinutes,
   }));
 
   vi.doMock("../services/quota-windows.js", () => ({

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -16,6 +16,8 @@ import {
   agentService,
   heartbeatService,
   logActivity,
+  quotaIncidentsService,
+  clampQuotaIncidentWindowMinutes,
 } from "../services/index.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import { fetchAllQuotaWindows } from "../services/quota-windows.js";
@@ -29,13 +31,14 @@ export function parseCostDateRange(query: Record<string, unknown>) {
   const to = toRaw ? new Date(toRaw) : undefined;
   if (from && isNaN(from.getTime())) throw badRequest("invalid 'from' date");
   if (to && isNaN(to.getTime())) throw badRequest("invalid 'to' date");
-  return (from || to) ? { from, to } : undefined;
+  return from || to ? { from, to } : undefined;
 }
 
 export function parseCostLimit(query: Record<string, unknown>) {
   const raw = Array.isArray(query.limit) ? query.limit[0] : query.limit;
   if (raw == null || raw === "") return 100;
-  const limit = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
+  const limit =
+    typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
   if (!Number.isFinite(limit) || limit <= 0 || limit > 500) {
     throw badRequest("invalid 'limit' value");
   }
@@ -58,65 +61,77 @@ export function costRoutes(
   const budgets = budgetService(db, budgetHooks);
   const companies = companyService(db);
   const agents = agentService(db);
+  const quotaIncidents = quotaIncidentsService(db);
 
-  router.post("/companies/:companyId/cost-events", validate(createCostEventSchema), async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
+  router.post(
+    "/companies/:companyId/cost-events",
+    validate(createCostEventSchema),
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
 
-    if (req.actor.type === "agent" && req.actor.agentId !== req.body.agentId) {
-      res.status(403).json({ error: "Agent can only report its own costs" });
-      return;
-    }
+      if (
+        req.actor.type === "agent" &&
+        req.actor.agentId !== req.body.agentId
+      ) {
+        res.status(403).json({ error: "Agent can only report its own costs" });
+        return;
+      }
 
-    const event = await costs.createEvent(companyId, {
-      ...req.body,
-      occurredAt: new Date(req.body.occurredAt),
-    });
+      const event = await costs.createEvent(companyId, {
+        ...req.body,
+        occurredAt: new Date(req.body.occurredAt),
+      });
 
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      action: "cost.reported",
-      entityType: "cost_event",
-      entityId: event.id,
-      details: { costCents: event.costCents, model: event.model },
-    });
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "cost.reported",
+        entityType: "cost_event",
+        entityId: event.id,
+        details: { costCents: event.costCents, model: event.model },
+      });
 
-    res.status(201).json(event);
-  });
+      res.status(201).json(event);
+    },
+  );
 
-  router.post("/companies/:companyId/finance-events", validate(createFinanceEventSchema), async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
-    assertBoard(req);
+  router.post(
+    "/companies/:companyId/finance-events",
+    validate(createFinanceEventSchema),
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      assertBoard(req);
 
-    const event = await finance.createEvent(companyId, {
-      ...req.body,
-      occurredAt: new Date(req.body.occurredAt),
-    });
+      const event = await finance.createEvent(companyId, {
+        ...req.body,
+        occurredAt: new Date(req.body.occurredAt),
+      });
 
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      action: "finance_event.reported",
-      entityType: "finance_event",
-      entityId: event.id,
-      details: {
-        amountCents: event.amountCents,
-        biller: event.biller,
-        eventKind: event.eventKind,
-        direction: event.direction,
-      },
-    });
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "finance_event.reported",
+        entityType: "finance_event",
+        entityId: event.id,
+        details: {
+          amountCents: event.amountCents,
+          biller: event.biller,
+          eventKind: event.eventKind,
+          direction: event.direction,
+        },
+      });
 
-    res.status(201).json(event);
-  });
+      res.status(201).json(event);
+    },
+  );
 
   router.get("/companies/:companyId/costs/summary", async (req, res) => {
     const companyId = req.params.companyId as string;
@@ -158,29 +173,38 @@ export function costRoutes(
     res.json(rows);
   });
 
-  router.get("/companies/:companyId/costs/finance-summary", async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
-    const range = parseCostDateRange(req.query);
-    const summary = await finance.summary(companyId, range);
-    res.json(summary);
-  });
+  router.get(
+    "/companies/:companyId/costs/finance-summary",
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const range = parseCostDateRange(req.query);
+      const summary = await finance.summary(companyId, range);
+      res.json(summary);
+    },
+  );
 
-  router.get("/companies/:companyId/costs/finance-by-biller", async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
-    const range = parseCostDateRange(req.query);
-    const rows = await finance.byBiller(companyId, range);
-    res.json(rows);
-  });
+  router.get(
+    "/companies/:companyId/costs/finance-by-biller",
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const range = parseCostDateRange(req.query);
+      const rows = await finance.byBiller(companyId, range);
+      res.json(rows);
+    },
+  );
 
-  router.get("/companies/:companyId/costs/finance-by-kind", async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
-    const range = parseCostDateRange(req.query);
-    const rows = await finance.byKind(companyId, range);
-    res.json(rows);
-  });
+  router.get(
+    "/companies/:companyId/costs/finance-by-kind",
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const range = parseCostDateRange(req.query);
+      const rows = await finance.byKind(companyId, range);
+      res.json(rows);
+    },
+  );
 
   router.get("/companies/:companyId/costs/finance-events", async (req, res) => {
     const companyId = req.params.companyId as string;
@@ -213,6 +237,44 @@ export function costRoutes(
     res.json(results);
   });
 
+  // PMSA-15 / PMSA-11 §2.2: granular Claude quota incident counts (401/429/5xx) for the
+  // costs dashboard and the future board-notification watcher.
+  router.get(
+    "/companies/:companyId/costs/quota-incidents",
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      assertBoard(req);
+      const company = await companies.getById(companyId);
+      if (!company) {
+        res.status(404).json({ error: "Company not found" });
+        return;
+      }
+      const windowMinutes = clampQuotaIncidentWindowMinutes(
+        req.query.windowMinutes,
+      );
+      const result = await quotaIncidents.listRecent(companyId, {
+        windowMinutes,
+      });
+      res.json({
+        windowMinutes: result.windowMinutes,
+        windowStart: result.windowStart.toISOString(),
+        windowEnd: result.windowEnd.toISOString(),
+        total: result.total,
+        totalByCode: result.totalByCode,
+        oldestAt: result.oldestAt ? result.oldestAt.toISOString() : null,
+        newestAt: result.newestAt ? result.newestAt.toISOString() : null,
+        byAgent: result.byAgent.map((row) => ({
+          agentId: row.agentId,
+          agentName: row.agentName,
+          count: row.count,
+          countByCode: row.countByCode,
+          lastAt: row.lastAt ? row.lastAt.toISOString() : null,
+        })),
+      });
+    },
+  );
+
   router.get("/companies/:companyId/budgets/overview", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -227,7 +289,11 @@ export function costRoutes(
       assertBoard(req);
       const companyId = req.params.companyId as string;
       assertCompanyAccess(req, companyId);
-      const summary = await budgets.upsertPolicy(companyId, req.body, req.actor.userId ?? "board");
+      const summary = await budgets.upsertPolicy(
+        companyId,
+        req.body,
+        req.actor.userId ?? "board",
+      );
       res.json(summary);
     },
   );
@@ -240,7 +306,12 @@ export function costRoutes(
       const companyId = req.params.companyId as string;
       const incidentId = req.params.incidentId as string;
       assertCompanyAccess(req, companyId);
-      const incident = await budgets.resolveIncident(companyId, incidentId, req.body, req.actor.userId ?? "board");
+      const incident = await budgets.resolveIncident(
+        companyId,
+        incidentId,
+        req.body,
+        req.actor.userId ?? "board",
+      );
       res.json(incident);
     },
   );
@@ -253,82 +324,94 @@ export function costRoutes(
     res.json(rows);
   });
 
-  router.patch("/companies/:companyId/budgets", validate(updateBudgetSchema), async (req, res) => {
-    assertBoard(req);
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
-    const company = await companies.update(companyId, { budgetMonthlyCents: req.body.budgetMonthlyCents });
-    if (!company) {
-      res.status(404).json({ error: "Company not found" });
-      return;
-    }
+  router.patch(
+    "/companies/:companyId/budgets",
+    validate(updateBudgetSchema),
+    async (req, res) => {
+      assertBoard(req);
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const company = await companies.update(companyId, {
+        budgetMonthlyCents: req.body.budgetMonthlyCents,
+      });
+      if (!company) {
+        res.status(404).json({ error: "Company not found" });
+        return;
+      }
 
-    await logActivity(db, {
-      companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
-      action: "company.budget_updated",
-      entityType: "company",
-      entityId: companyId,
-      details: { budgetMonthlyCents: req.body.budgetMonthlyCents },
-    });
+      await logActivity(db, {
+        companyId,
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
+        action: "company.budget_updated",
+        entityType: "company",
+        entityId: companyId,
+        details: { budgetMonthlyCents: req.body.budgetMonthlyCents },
+      });
 
-    await budgets.upsertPolicy(
-      companyId,
-      {
-        scopeType: "company",
-        scopeId: companyId,
-        amount: req.body.budgetMonthlyCents,
-        windowKind: "calendar_month_utc",
-      },
-      req.actor.userId ?? "board",
-    );
+      await budgets.upsertPolicy(
+        companyId,
+        {
+          scopeType: "company",
+          scopeId: companyId,
+          amount: req.body.budgetMonthlyCents,
+          windowKind: "calendar_month_utc",
+        },
+        req.actor.userId ?? "board",
+      );
 
-    res.json(company);
-  });
+      res.json(company);
+    },
+  );
 
-  router.patch("/agents/:agentId/budgets", validate(updateBudgetSchema), async (req, res) => {
-    const agentId = req.params.agentId as string;
-    const agent = await agents.getById(agentId);
-    if (!agent) {
-      res.status(404).json({ error: "Agent not found" });
-      return;
-    }
+  router.patch(
+    "/agents/:agentId/budgets",
+    validate(updateBudgetSchema),
+    async (req, res) => {
+      const agentId = req.params.agentId as string;
+      const agent = await agents.getById(agentId);
+      if (!agent) {
+        res.status(404).json({ error: "Agent not found" });
+        return;
+      }
 
-    assertCompanyAccess(req, agent.companyId);
-    assertBoard(req);
+      assertCompanyAccess(req, agent.companyId);
+      assertBoard(req);
 
-    const updated = await agents.update(agentId, { budgetMonthlyCents: req.body.budgetMonthlyCents });
-    if (!updated) {
-      res.status(404).json({ error: "Agent not found" });
-      return;
-    }
+      const updated = await agents.update(agentId, {
+        budgetMonthlyCents: req.body.budgetMonthlyCents,
+      });
+      if (!updated) {
+        res.status(404).json({ error: "Agent not found" });
+        return;
+      }
 
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId: updated.companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      action: "agent.budget_updated",
-      entityType: "agent",
-      entityId: updated.id,
-      details: { budgetMonthlyCents: updated.budgetMonthlyCents },
-    });
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: updated.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "agent.budget_updated",
+        entityType: "agent",
+        entityId: updated.id,
+        details: { budgetMonthlyCents: updated.budgetMonthlyCents },
+      });
 
-    await budgets.upsertPolicy(
-      updated.companyId,
-      {
-        scopeType: "agent",
-        scopeId: updated.id,
-        amount: updated.budgetMonthlyCents,
-        windowKind: "calendar_month_utc",
-      },
-      req.actor.type === "board" ? req.actor.userId ?? "board" : null,
-    );
+      await budgets.upsertPolicy(
+        updated.companyId,
+        {
+          scopeType: "agent",
+          scopeId: updated.id,
+          amount: updated.budgetMonthlyCents,
+          windowKind: "calendar_month_utc",
+        },
+        req.actor.type === "board" ? (req.actor.userId ?? "board") : null,
+      );
 
-    res.json(updated);
-  });
+      res.json(updated);
+    },
+  );
 
   return router;
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -181,6 +181,17 @@ function resolveCodexTransientFallbackMode(attempt: number): CodexTransientFallb
   return "fresh_session_safer_invocation";
 }
 
+// PMSA-15 / PMSA-11 §2.1: Claude error codes that share the transient_upstream
+// retry contract (exponential backoff + retryNotBefore). Adding a new code here
+// is the only step needed to wire it into the existing retry pipeline, so
+// Phase 2-A (PMSA-18) just extends this set instead of touching the resolver.
+const CLAUDE_TRANSIENT_UPSTREAM_ERROR_CODES = new Set<string>([
+  "claude_transient_upstream",
+  "claude_quota_exhausted",
+  "claude_rate_limited",
+  "claude_provider_5xx",
+]);
+
 function readHeartbeatRunErrorFamily(
   run: Pick<typeof heartbeatRuns.$inferSelect, "errorCode" | "resultJson">,
 ) {
@@ -188,7 +199,8 @@ function readHeartbeatRunErrorFamily(
   const persistedFamily = readNonEmptyString(resultJson.errorFamily);
   if (persistedFamily) return persistedFamily;
 
-  if (run.errorCode === "codex_transient_upstream" || run.errorCode === "claude_transient_upstream") {
+  if (run.errorCode === "codex_transient_upstream") return "transient_upstream";
+  if (run.errorCode && CLAUDE_TRANSIENT_UPSTREAM_ERROR_CODES.has(run.errorCode)) {
     return "transient_upstream";
   }
   return null;

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -2,7 +2,10 @@ export { companyService } from "./companies.js";
 export { feedbackService } from "./feedback.js";
 export { companySkillService } from "./company-skills.js";
 export { agentService, deduplicateAgentName } from "./agents.js";
-export { agentInstructionsService, syncInstructionsBundleConfigFromFilePath } from "./agent-instructions.js";
+export {
+  agentInstructionsService,
+  syncInstructionsBundleConfigFromFilePath,
+} from "./agent-instructions.js";
 export { assetService } from "./assets.js";
 export { documentService, extractLegacyPlanBody } from "./documents.js";
 export {
@@ -30,9 +33,22 @@ export { budgetService } from "./budgets.js";
 export { secretService } from "./secrets.js";
 export { routineService } from "./routines.js";
 export { costService } from "./costs.js";
+export {
+  DEFAULT_QUOTA_INCIDENT_WINDOW_MINUTES,
+  MAX_QUOTA_INCIDENT_WINDOW_MINUTES,
+  clampQuotaIncidentWindowMinutes,
+  quotaIncidentsService,
+  type QuotaIncidentsResult,
+  type QuotaIncidentsService,
+  type QuotaIncidentAgentBreakdown,
+  type QuotaIncidentErrorCode,
+} from "./quota-incidents.js";
 export { financeService } from "./finance.js";
 export { heartbeatService } from "./heartbeat.js";
-export { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/index.js";
+export {
+  classifyIssueGraphLiveness,
+  type IssueLivenessFinding,
+} from "./recovery/index.js";
 export { dashboardService } from "./dashboard.js";
 export { sidebarBadgeService } from "./sidebar-badges.js";
 export { sidebarPreferenceService } from "./sidebar-preferences.js";
@@ -46,7 +62,16 @@ export { executionWorkspaceService } from "./execution-workspaces.js";
 export { workspaceOperationService } from "./workspace-operations.js";
 export { workProductService } from "./work-products.js";
 export { logActivity, type LogActivityInput } from "./activity-log.js";
-export { notifyHireApproved, type NotifyHireApprovedInput } from "./hire-hook.js";
+export {
+  notifyHireApproved,
+  type NotifyHireApprovedInput,
+} from "./hire-hook.js";
 export { publishLiveEvent, subscribeCompanyLiveEvents } from "./live-events.js";
-export { reconcilePersistedRuntimeServicesOnStartup, restartDesiredRuntimeServicesOnStartup } from "./workspace-runtime.js";
-export { createStorageServiceFromConfig, getStorageService } from "../storage/index.js";
+export {
+  reconcilePersistedRuntimeServicesOnStartup,
+  restartDesiredRuntimeServicesOnStartup,
+} from "./workspace-runtime.js";
+export {
+  createStorageServiceFromConfig,
+  getStorageService,
+} from "../storage/index.js";

--- a/server/src/services/quota-incidents.ts
+++ b/server/src/services/quota-incidents.ts
@@ -1,0 +1,154 @@
+import { and, desc, eq, gte, inArray } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, heartbeatRuns } from "@paperclipai/db";
+
+// PMSA-15 / PMSA-11 §2.1 / §2.2: granular Claude quota error codes that we want to
+// count separately so the cost dashboard can distinguish auth-token rejections
+// (401) from upstream rate limits (429) from provider 5xx incidents.
+const QUOTA_INCIDENT_ERROR_CODES = [
+  "claude_quota_exhausted",
+  "claude_rate_limited",
+  "claude_provider_5xx",
+] as const;
+
+export type QuotaIncidentErrorCode =
+  (typeof QUOTA_INCIDENT_ERROR_CODES)[number];
+
+export interface QuotaIncidentAgentBreakdown {
+  agentId: string;
+  agentName: string | null;
+  count: number;
+  countByCode: Record<QuotaIncidentErrorCode, number>;
+  lastAt: Date | null;
+}
+
+export interface QuotaIncidentsResult {
+  windowMinutes: number;
+  windowStart: Date;
+  windowEnd: Date;
+  total: number;
+  totalByCode: Record<QuotaIncidentErrorCode, number>;
+  oldestAt: Date | null;
+  newestAt: Date | null;
+  byAgent: QuotaIncidentAgentBreakdown[];
+}
+
+export const DEFAULT_QUOTA_INCIDENT_WINDOW_MINUTES = 30;
+export const MAX_QUOTA_INCIDENT_WINDOW_MINUTES = 24 * 60;
+
+function emptyCountByCode(): Record<QuotaIncidentErrorCode, number> {
+  return {
+    claude_quota_exhausted: 0,
+    claude_rate_limited: 0,
+    claude_provider_5xx: 0,
+  };
+}
+
+export function clampQuotaIncidentWindowMinutes(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.min(Math.floor(value), MAX_QUOTA_INCIDENT_WINDOW_MINUTES);
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.min(parsed, MAX_QUOTA_INCIDENT_WINDOW_MINUTES);
+    }
+  }
+  return DEFAULT_QUOTA_INCIDENT_WINDOW_MINUTES;
+}
+
+/**
+ * PMSA-15 / PMSA-11 §2.2: aggregate recent Claude quota-shaped incidents for a
+ * company. The result is intentionally small and decision-ready for the costs
+ * dashboard and the future board-notification watcher (Phase 3).
+ */
+export function quotaIncidentsService(db: Db) {
+  return {
+    async listRecent(
+      companyId: string,
+      options: { windowMinutes?: number; now?: Date } = {},
+    ): Promise<QuotaIncidentsResult> {
+      const windowMinutes = clampQuotaIncidentWindowMinutes(
+        options.windowMinutes ?? DEFAULT_QUOTA_INCIDENT_WINDOW_MINUTES,
+      );
+      const windowEnd = options.now ?? new Date();
+      const windowStart = new Date(
+        windowEnd.getTime() - windowMinutes * 60 * 1000,
+      );
+
+      const rows = await db
+        .select({
+          agentId: heartbeatRuns.agentId,
+          errorCode: heartbeatRuns.errorCode,
+          finishedAt: heartbeatRuns.finishedAt,
+          agentName: agents.name,
+        })
+        .from(heartbeatRuns)
+        .leftJoin(agents, eq(agents.id, heartbeatRuns.agentId))
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, companyId),
+            inArray(heartbeatRuns.errorCode, [...QUOTA_INCIDENT_ERROR_CODES]),
+            gte(heartbeatRuns.finishedAt, windowStart),
+          ),
+        )
+        .orderBy(desc(heartbeatRuns.finishedAt));
+
+      const totalByCode = emptyCountByCode();
+      const byAgentMap = new Map<string, QuotaIncidentAgentBreakdown>();
+      let oldestAt: Date | null = null;
+      let newestAt: Date | null = null;
+
+      for (const row of rows) {
+        const code = row.errorCode as QuotaIncidentErrorCode | null;
+        if (!code || !QUOTA_INCIDENT_ERROR_CODES.includes(code)) continue;
+
+        totalByCode[code] += 1;
+
+        const finishedAt = row.finishedAt ?? null;
+        if (finishedAt) {
+          if (!newestAt || finishedAt > newestAt) newestAt = finishedAt;
+          if (!oldestAt || finishedAt < oldestAt) oldestAt = finishedAt;
+        }
+
+        const existing = byAgentMap.get(row.agentId) ?? {
+          agentId: row.agentId,
+          agentName: row.agentName ?? null,
+          count: 0,
+          countByCode: emptyCountByCode(),
+          lastAt: null,
+        };
+        existing.count += 1;
+        existing.countByCode[code] += 1;
+        if (finishedAt && (!existing.lastAt || finishedAt > existing.lastAt)) {
+          existing.lastAt = finishedAt;
+        }
+        if (!existing.agentName && row.agentName) {
+          existing.agentName = row.agentName;
+        }
+        byAgentMap.set(row.agentId, existing);
+      }
+
+      const byAgent = [...byAgentMap.values()].sort(
+        (a, b) => b.count - a.count,
+      );
+      const total =
+        totalByCode.claude_quota_exhausted +
+        totalByCode.claude_rate_limited +
+        totalByCode.claude_provider_5xx;
+
+      return {
+        windowMinutes,
+        windowStart,
+        windowEnd,
+        total,
+        totalByCode,
+        oldestAt,
+        newestAt,
+        byAgent,
+      };
+    },
+  };
+}
+
+export type QuotaIncidentsService = ReturnType<typeof quotaIncidentsService>;


### PR DESCRIPTION
## Summary

Implements PMSA-11 §2.1 / §2.2 (Phase 1: detection): split the existing `claude_transient_upstream` error bucket from adapter-claude-local into actionable codes so that heartbeat retry, costs UI, and the upcoming Phase 3 watcher can react to *why* a Claude run failed (Anthropic quota vs rate-limit vs provider 5xx) instead of treating every transient failure identically.

- New `classifyClaudeFailure()` in `packages/adapters/claude-local/src/server/parse.ts` with priority `auth_required` > `quota_exhausted` (401 / quota wording / "out of extra usage") > `rate_limited` (429 / rate_limit_error / throttling) > `provider_5xx` (5xx) > `transient_upstream` (fallback). It also extracts `httpStatus`, `failureKind`, and a `retryAfterMs` hint.
- `execute.ts:toAdapterResult()` rewires both the parsed and unparsed branches to call `classifyClaudeFailure` (replacing the older `extractClaudeRetryNotBefore` / `isClaudeTransientUpstreamError` lookups). The `errorFamily: "transient_upstream"` contract is preserved for the new codes, so the existing heartbeat retry/backoff pipeline keeps firing on them.
- Server-side `readHeartbeatRunErrorFamily` now consults a new `CLAUDE_TRANSIENT_UPSTREAM_ERROR_CODES` set (`server/src/services/heartbeat.ts`). This is the **lookup hook for Phase 2-A (PMSA-18)**: the bounded retry / exponential backoff layer just extends the set rather than touching the resolver.
- New `services/quota-incidents.ts` + `GET /api/companies/:companyId/costs/quota-incidents?windowMinutes=30`. The endpoint sources directly from `heartbeat_runs.errorCode` (no schema changes) and returns `total`, `totalByCode`, and a per-agent breakdown — decision-ready for the costs UI and the Phase 3 board-notification watcher (PMSA-19).

## Scope

- `packages/adapters/claude-local/src/server/parse.ts` — new classifier, regexes, helper exports
- `packages/adapters/claude-local/src/server/execute.ts` — rewired `toAdapterResult` (parsed + unparsed paths)
- `packages/adapters/claude-local/src/server/parse-classify.test.ts` — 16 new vitest cases (new file)
- `server/src/services/heartbeat.ts` — `CLAUDE_TRANSIENT_UPSTREAM_ERROR_CODES` set + resolver update
- `server/src/services/quota-incidents.ts` — new service (new file)
- `server/src/services/index.ts` — export the new service
- `server/src/routes/costs.ts` — new `/quota-incidents` route
- `server/src/__tests__/claude-local-execute.test.ts` — updated existing case to expect the more granular `claude_quota_exhausted`; new case asserting `api_error_status:401` (no auth wording) → `claude_quota_exhausted`
- `server/src/__tests__/costs-service.test.ts` — `vi.doMock` updated for the new exports

## Test plan

- [x] `pnpm --filter @paperclipai/adapter-claude-local exec vitest run` → **28/28** (`parse-classify.test.ts` 16/16, `parse.test.ts` 9/9, `execute.remote.test.ts` 3/3)
- [x] `pnpm --filter @paperclipai/server typecheck` → **PASS** (`tsc --noEmit`, with `NODE_OPTIONS=--max-old-space-size=8192`)
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/claude-local-execute.test.ts` → **12/12** including the new PMSA-15 acceptance case
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/costs-service.test.ts` → **13/13** (2 unrelated skips)
- [ ] Heartbeat-run integration tests (`heartbeat-retry-scheduling.test.ts`, etc.) require `@embedded-postgres/darwin-arm64`, which is not provisioned in the local dev workspace; they `↓ skipped` rather than failing. The DB-write contract for these new error codes is exercised through the existing `readHeartbeatRunErrorFamily` path on hosts where embedded postgres is available.

## Notes for review

- The PMSA-15 plan §2.1 mock 401 → `heartbeat_runs.errorCode = 'claude_quota_exhausted'` flow is asserted at the adapter layer in `claude-local-execute.test.ts` (top-level `result.errorCode` is what `heartbeat_runs.errorCode` mirrors). Full DB-level E2E is gated on the embedded-postgres binary on the test host.
- `costs.ts` and `execute.ts` show some incidental editor reformat noise around the genuine logic edits. `git diff -w` against this branch isolates the logic changes if that's easier for review.
- Phase 2 work (PMSA-16 / PMSA-17 / PMSA-18 / PMSA-19 / PMSA-20) is staged on top of this branch locally and will be submitted as separate PRs once the lookup hook lands here.

Refs: `/PMSA/issues/PMSA-11#document-plan` §2.1 and §2.2.

🤖 Generated with [Paperclip](https://paperclip.ing) heartbeat
