### PR TITLE
Promote the conversation to the primary surface on issue detail

### DIFF
--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -12,6 +12,7 @@ import {
   createContext,
   Component,
   forwardRef,
+  useCallback,
   useContext,
   useEffect,
   useImperativeHandle,
@@ -103,7 +104,7 @@ import { cn, formatDateTime, formatShortDate } from "../lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
-import { AlertTriangle, ArrowRight, Brain, Check, ChevronDown, Copy, Hammer, Loader2, MoreHorizontal, Paperclip, PauseCircle, Search, Square, ThumbsDown, ThumbsUp } from "lucide-react";
+import { AlertTriangle, ArrowDown, ArrowRight, Brain, Check, ChevronDown, Copy, Hammer, Loader2, MoreHorizontal, Paperclip, PauseCircle, Search, Square, ThumbsDown, ThumbsUp } from "lucide-react";
 import { IssueBlockedNotice } from "./IssueBlockedNotice";
 
 interface IssueChatMessageContext {
@@ -275,6 +276,7 @@ interface IssueChatThreadProps {
   showJumpToLatest?: boolean;
   emptyMessage?: string;
   variant?: "full" | "embedded";
+  layout?: "stacked" | "filled";
   enableLiveTranscriptPolling?: boolean;
   transcriptsByRunId?: ReadonlyMap<string, readonly IssueChatTranscriptEntry[]>;
   hasOutputForRun?: (runId: string) => boolean;
@@ -2073,17 +2075,26 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
     setBody(loadDraft(draftKey));
   }, [draftKey]);
 
+  const pendingDraftRef = useRef<{ key: string; body: string } | null>(null);
+
   useEffect(() => {
-    if (!draftKey) return;
+    if (!draftKey) {
+      pendingDraftRef.current = null;
+      return;
+    }
     if (draftTimer.current) clearTimeout(draftTimer.current);
+    pendingDraftRef.current = { key: draftKey, body };
     draftTimer.current = setTimeout(() => {
       saveDraft(draftKey, body);
+      pendingDraftRef.current = null;
     }, DRAFT_DEBOUNCE_MS);
   }, [body, draftKey]);
 
   useEffect(() => {
     return () => {
       if (draftTimer.current) clearTimeout(draftTimer.current);
+      const pending = pendingDraftRef.current;
+      if (pending) saveDraft(pending.key, pending.body);
     };
   }, []);
 
@@ -2478,6 +2489,7 @@ export function IssueChatThread({
   showJumpToLatest,
   emptyMessage,
   variant = "full",
+  layout = "stacked",
   enableLiveTranscriptPolling = true,
   transcriptsByRunId,
   hasOutputForRun: hasOutputForRunOverride,
@@ -2496,6 +2508,10 @@ export function IssueChatThread({
   const hasScrolledRef = useRef(false);
   const bottomAnchorRef = useRef<HTMLDivElement | null>(null);
   const composerViewportAnchorRef = useRef<HTMLDivElement | null>(null);
+  const filledViewportRef = useRef<HTMLDivElement | null>(null);
+  const stuckToBottomRef = useRef(true);
+  const initialScrollDoneRef = useRef(false);
+  const [showFilledJumpPill, setShowFilledJumpPill] = useState(false);
   const composerViewportSnapshotRef = useRef<ReturnType<typeof captureComposerViewportSnapshot>>(null);
   const preserveComposerViewportRef = useRef(false);
   const pendingSubmitScrollRef = useRef(false);
@@ -2701,8 +2717,51 @@ export function IssueChatThread({
   }, [location.hash, messages]);
 
   function handleJumpToLatest() {
+    if (layout === "filled") {
+      const el = filledViewportRef.current;
+      if (el) {
+        el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+        stuckToBottomRef.current = true;
+        setShowFilledJumpPill(false);
+        return;
+      }
+    }
     bottomAnchorRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }
+
+  useLayoutEffect(() => {
+    if (layout !== "filled") return;
+    if (initialScrollDoneRef.current) return;
+    if (messages.length === 0) return;
+    const el = filledViewportRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    stuckToBottomRef.current = true;
+    initialScrollDoneRef.current = true;
+  }, [layout, messages.length]);
+
+  useLayoutEffect(() => {
+    if (layout !== "filled") return;
+    if (!initialScrollDoneRef.current) return;
+    const el = filledViewportRef.current;
+    if (!el) return;
+    if (stuckToBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+      return;
+    }
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distanceFromBottom > 120) setShowFilledJumpPill(true);
+  }, [layout, messages]);
+
+  const handleFilledScroll = useCallback(() => {
+    if (layout !== "filled") return;
+    const el = filledViewportRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const atBottom = distanceFromBottom <= 24;
+    stuckToBottomRef.current = atBottom;
+    setShowFilledJumpPill(distanceFromBottom > 120);
+  }, [layout]);
 
   const chatCtx = useMemo<IssueChatMessageContext>(
     () => ({
@@ -2747,7 +2806,7 @@ export function IssueChatThread({
     ],
   );
 
-  const resolvedShowJumpToLatest = showJumpToLatest ?? variant === "full";
+  const resolvedShowJumpToLatest = showJumpToLatest ?? (variant === "full" && layout !== "filled");
   const resolvedEmptyMessage = emptyMessage
     ?? (variant === "embedded"
       ? "No run output yet."
@@ -2756,6 +2815,114 @@ export function IssueChatThread({
     () => messages.map((message) => `${message.id}:${message.role}:${message.content.length}:${message.status?.type ?? "none"}`).join("|"),
     [messages],
   );
+
+  const messagesBlock = (
+    <IssueChatErrorBoundary
+      resetKey={errorBoundaryResetKey}
+      messages={messages}
+      emptyMessage={resolvedEmptyMessage}
+      variant={variant}
+    >
+      <div data-testid="thread-root">
+        <div
+          data-testid="thread-viewport"
+          className={variant === "embedded" ? "space-y-3" : "space-y-4"}
+        >
+          {messages.length === 0 ? (
+            <div className={cn(
+              "text-center text-sm text-muted-foreground",
+              variant === "embedded"
+                ? "rounded-xl border border-dashed border-border/70 bg-background/60 px-4 py-6"
+                : "rounded-2xl border border-dashed border-border bg-card px-6 py-10",
+            )}>
+              {resolvedEmptyMessage}
+            </div>
+          ) : (
+            messages.map((message) => {
+              if (message.role === "user") {
+                return <IssueChatUserMessage key={message.id} message={message} />;
+              }
+              if (message.role === "assistant") {
+                return <IssueChatAssistantMessage key={message.id} message={message} />;
+              }
+              return <IssueChatSystemMessage key={message.id} message={message} />;
+            })
+          )}
+          {showComposer ? (
+            <div data-testid="issue-chat-thread-notices" className="space-y-2">
+              <IssueBlockedNotice
+                issueStatus={issueStatus}
+                blockers={unresolvedBlockers}
+                blockerAttention={blockerAttention}
+              />
+              <IssueAssigneePausedNotice agent={assignedAgent} />
+            </div>
+          ) : null}
+          <div ref={bottomAnchorRef} />
+          {showComposer ? (
+            <div
+              aria-hidden
+              data-testid="issue-chat-bottom-spacer"
+              style={{ height: bottomSpacerHeight }}
+            />
+          ) : null}
+        </div>
+      </div>
+    </IssueChatErrorBoundary>
+  );
+
+  const composerBlock = showComposer ? (
+    <div ref={composerViewportAnchorRef}>
+      <IssueChatComposer
+        ref={composerRef}
+        onImageUpload={imageUploadHandler}
+        onAttachImage={onAttachImage}
+        draftKey={draftKey}
+        enableReassign={enableReassign}
+        reassignOptions={reassignOptions}
+        currentAssigneeValue={currentAssigneeValue}
+        suggestedAssigneeValue={suggestedAssigneeValue}
+        mentions={mentions}
+        agentMap={agentMap}
+        composerDisabledReason={composerDisabledReason}
+        composerHint={composerHint}
+        issueStatus={issueStatus}
+      />
+    </div>
+  ) : null;
+
+  if (layout === "filled") {
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        <IssueChatCtx.Provider value={chatCtx}>
+          <div className="relative flex h-full min-h-0 flex-col">
+            <div
+              ref={filledViewportRef}
+              onScroll={handleFilledScroll}
+              className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-5"
+            >
+              {messagesBlock}
+            </div>
+            {showFilledJumpPill ? (
+              <button
+                type="button"
+                onClick={handleJumpToLatest}
+                className="pointer-events-auto absolute bottom-[88px] left-1/2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-border/70 bg-background px-3 py-1.5 text-[12px] font-medium text-foreground shadow-md transition-all hover:bg-accent"
+              >
+                <ArrowDown className="h-3.5 w-3.5" />
+                Jump to latest
+              </button>
+            ) : null}
+            {composerBlock ? (
+              <div className="border-t border-border/70 bg-background/95 px-4 py-3 sm:px-5 backdrop-blur supports-[backdrop-filter]:bg-background/85">
+                {composerBlock}
+              </div>
+            ) : null}
+          </div>
+        </IssueChatCtx.Provider>
+      </AssistantRuntimeProvider>
+    );
+  }
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
@@ -2772,84 +2939,13 @@ export function IssueChatThread({
             </button>
           </div>
         ) : null}
-
-        <IssueChatErrorBoundary
-          resetKey={errorBoundaryResetKey}
-          messages={messages}
-          emptyMessage={resolvedEmptyMessage}
-          variant={variant}
-        >
-          <div data-testid="thread-root">
-            <div
-              data-testid="thread-viewport"
-              className={variant === "embedded" ? "space-y-3" : "space-y-4"}
-            >
-              {messages.length === 0 ? (
-                <div className={cn(
-                  "text-center text-sm text-muted-foreground",
-                  variant === "embedded"
-                    ? "rounded-xl border border-dashed border-border/70 bg-background/60 px-4 py-6"
-                    : "rounded-2xl border border-dashed border-border bg-card px-6 py-10",
-                )}>
-                  {resolvedEmptyMessage}
-                </div>
-              ) : (
-                // Keep transcript rendering independent from assistant-ui's
-                // index-scoped message providers; live transcripts can shrink
-                // or regroup while the runtime still holds stale indices.
-                messages.map((message) => {
-                  if (message.role === "user") {
-                    return <IssueChatUserMessage key={message.id} message={message} />;
-                  }
-                  if (message.role === "assistant") {
-                    return <IssueChatAssistantMessage key={message.id} message={message} />;
-                  }
-                  return <IssueChatSystemMessage key={message.id} message={message} />;
-                })
-              )}
-              {showComposer ? (
-                <div data-testid="issue-chat-thread-notices" className="space-y-2">
-                  <IssueBlockedNotice
-                    issueStatus={issueStatus}
-                    blockers={unresolvedBlockers}
-                    blockerAttention={blockerAttention}
-                  />
-                  <IssueAssigneePausedNotice agent={assignedAgent} />
-                </div>
-              ) : null}
-              <div ref={bottomAnchorRef} />
-              {showComposer ? (
-                <div
-                  aria-hidden
-                  data-testid="issue-chat-bottom-spacer"
-                  style={{ height: bottomSpacerHeight }}
-                />
-              ) : null}
-            </div>
-          </div>
-        </IssueChatErrorBoundary>
-
+        {messagesBlock}
         {showComposer ? (
           <div
-            ref={composerViewportAnchorRef}
             data-testid="issue-chat-composer-dock"
             className="sticky bottom-[calc(env(safe-area-inset-bottom)+20px)] z-20 space-y-2 bg-gradient-to-t from-background via-background/95 to-background/0 pt-6"
           >
-            <IssueChatComposer
-              ref={composerRef}
-              onImageUpload={imageUploadHandler}
-              onAttachImage={onAttachImage}
-              draftKey={draftKey}
-              enableReassign={enableReassign}
-              reassignOptions={reassignOptions}
-              currentAssigneeValue={currentAssigneeValue}
-              suggestedAssigneeValue={suggestedAssigneeValue}
-              mentions={mentions}
-              agentMap={agentMap}
-              composerDisabledReason={composerDisabledReason}
-              composerHint={composerHint}
-              issueStatus={issueStatus}
-            />
+            {composerBlock}
           </div>
         ) : null}
       </div>

--- a/ui/src/components/IssueDocumentsSection.test.tsx
+++ b/ui/src/components/IssueDocumentsSection.test.tsx
@@ -163,6 +163,13 @@ async function flush() {
   });
 }
 
+function seedExpandedDocs(issueId: string, ...docKeys: string[]) {
+  window.localStorage.setItem(
+    `paperclip:issue-document-expanded:${issueId}`,
+    JSON.stringify(docKeys),
+  );
+}
+
 function createIssueDocument(overrides: Partial<IssueDocument> = {}): IssueDocument {
   return {
     id: "document-1",
@@ -284,6 +291,7 @@ describe("IssueDocumentsSection", () => {
         body: "# Handoff",
       }),
     ]);
+    seedExpandedDocs(issue.id, "plan");
 
     await act(async () => {
       root.render(
@@ -418,6 +426,7 @@ describe("IssueDocumentsSection", () => {
         }),
       ],
     );
+    seedExpandedDocs(issue.id, "plan");
 
     await act(async () => {
       root.render(
@@ -497,6 +506,7 @@ describe("IssueDocumentsSection", () => {
         }),
       ],
     );
+    seedExpandedDocs(issue.id, "plan");
 
     await act(async () => {
       root.render(
@@ -558,6 +568,7 @@ describe("IssueDocumentsSection", () => {
     });
 
     mockIssuesApi.listDocuments.mockResolvedValue([document]);
+    seedExpandedDocs(issue.id, "plan");
 
     await act(async () => {
       root.render(

--- a/ui/src/components/IssueDocumentsSection.tsx
+++ b/ui/src/components/IssueDocumentsSection.tsx
@@ -52,12 +52,12 @@ type DocumentConflictState = {
 
 const DOCUMENT_AUTOSAVE_DEBOUNCE_MS = 900;
 const DOCUMENT_KEY_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
-const getFoldedDocumentsStorageKey = (issueId: string) => `paperclip:issue-document-folds:${issueId}`;
+const getExpandedDocumentsStorageKey = (issueId: string) => `paperclip:issue-document-expanded:${issueId}`;
 
-function loadFoldedDocumentKeys(issueId: string) {
+function loadExpandedDocumentKeys(issueId: string) {
   if (typeof window === "undefined") return [];
   try {
-    const raw = window.localStorage.getItem(getFoldedDocumentsStorageKey(issueId));
+    const raw = window.localStorage.getItem(getExpandedDocumentsStorageKey(issueId));
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === "string") : [];
@@ -66,9 +66,9 @@ function loadFoldedDocumentKeys(issueId: string) {
   }
 }
 
-function saveFoldedDocumentKeys(issueId: string, keys: string[]) {
+function saveExpandedDocumentKeys(issueId: string, keys: string[]) {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(getFoldedDocumentsStorageKey(issueId), JSON.stringify(keys));
+  window.localStorage.setItem(getExpandedDocumentsStorageKey(issueId), JSON.stringify(keys));
 }
 
 function renderFoldableBody(body: string, className?: string) {
@@ -164,7 +164,7 @@ export function IssueDocumentsSection({
   const [error, setError] = useState<string | null>(null);
   const [draft, setDraft] = useState<DraftState | null>(null);
   const [documentConflict, setDocumentConflict] = useState<DocumentConflictState | null>(null);
-  const [foldedDocumentKeys, setFoldedDocumentKeys] = useState<string[]>(() => loadFoldedDocumentKeys(issue.id));
+  const [expandedDocumentKeys, setExpandedDocumentKeys] = useState<string[]>(() => loadExpandedDocumentKeys(issue.id));
   const [autosaveDocumentKey, setAutosaveDocumentKey] = useState<string | null>(null);
   const [copiedDocumentKey, setCopiedDocumentKey] = useState<string | null>(null);
   const [highlightDocumentKey, setHighlightDocumentKey] = useState<string | null>(null);
@@ -330,7 +330,7 @@ export function IssueDocumentsSection({
     const doc = sortedDocuments.find((entry) => entry.key === key);
     if (!doc) return;
     const conflictedDraft = documentConflict?.key === key ? documentConflict.localDraft : null;
-    setFoldedDocumentKeys((current) => current.filter((entry) => entry !== key));
+    setExpandedDocumentKeys((current) => current.includes(key) ? current : [...current, key]);
     resetAutosaveState();
     setDocumentConflict((current) => current?.key === key ? current : null);
     setDraft({
@@ -406,6 +406,7 @@ export function IssueDocumentsSection({
       return true;
     }
 
+    const wasNew = currentDraft.isNew;
     const save = async () => {
       const saved = await upsertDocument.mutateAsync({
         ...currentDraft,
@@ -429,6 +430,11 @@ export function IssueDocumentsSection({
           isNew: false,
         };
       });
+      if (wasNew) {
+        setExpandedDocumentKeys((current) =>
+          current.includes(saved.key) ? current : [...current, saved.key],
+        );
+      }
       syncDocumentCaches(saved);
       invalidateIssueDocuments();
     };
@@ -457,7 +463,7 @@ export function IssueDocumentsSection({
             },
             showRemote: true,
           });
-          setFoldedDocumentKeys((current) => current.filter((key) => key !== normalizedKey));
+          setExpandedDocumentKeys((current) => current.includes(normalizedKey) ? current : [...current, normalizedKey]);
           setError(null);
           resetAutosaveState();
           return false;
@@ -558,7 +564,7 @@ export function IssueDocumentsSection({
     resetAutosaveState();
     setDraft((current) => current?.key === doc.key ? null : current);
     setDocumentConflict((current) => current?.key === doc.key ? null : current);
-    setFoldedDocumentKeys((current) => current.filter((entry) => entry !== doc.key));
+    setExpandedDocumentKeys((current) => current.includes(doc.key) ? current : [...current, doc.key]);
     setSelectedRevisionIds((current) => ({ ...current, [doc.key]: selectedRevision.id }));
     setError(null);
   }, [documentConflict, draft, getDocumentRevisions, resetAutosaveState, returnToLatestRevision]);
@@ -587,7 +593,7 @@ export function IssueDocumentsSection({
   };
 
   useEffect(() => {
-    setFoldedDocumentKeys(loadFoldedDocumentKeys(issue.id));
+    setExpandedDocumentKeys(loadExpandedDocumentKeys(issue.id));
   }, [issue.id]);
 
   useEffect(() => {
@@ -595,19 +601,20 @@ export function IssueDocumentsSection({
   }, [issue.id, location.hash]);
 
   useEffect(() => {
+    if (documents === undefined) return;
     const validKeys = new Set(sortedDocuments.map((doc) => doc.key));
-    setFoldedDocumentKeys((current) => {
+    setExpandedDocumentKeys((current) => {
       const next = current.filter((key) => validKeys.has(key));
       if (next.length !== current.length) {
-        saveFoldedDocumentKeys(issue.id, next);
+        saveExpandedDocumentKeys(issue.id, next);
       }
       return next;
     });
-  }, [issue.id, sortedDocuments]);
+  }, [documents, issue.id, sortedDocuments]);
 
   useEffect(() => {
-    saveFoldedDocumentKeys(issue.id, foldedDocumentKeys);
-  }, [foldedDocumentKeys, issue.id]);
+    saveExpandedDocumentKeys(issue.id, expandedDocumentKeys);
+  }, [expandedDocumentKeys, issue.id]);
 
   useEffect(() => {
     if (!documentConflict) return;
@@ -627,7 +634,7 @@ export function IssueDocumentsSection({
     const targetExists = sortedDocuments.some((doc) => doc.key === documentKey)
       || (documentKey === "plan" && Boolean(issue.legacyPlanDocument));
     if (!targetExists || hasScrolledToHashRef.current) return;
-    setFoldedDocumentKeys((current) => current.filter((key) => key !== documentKey));
+    setExpandedDocumentKeys((current) => current.includes(documentKey) ? current : [...current, documentKey]);
     const element = document.getElementById(`document-${documentKey}`);
     if (!element) return;
     hasScrolledToHashRef.current = true;
@@ -680,7 +687,7 @@ export function IssueDocumentsSection({
   const documentBodyShellClassName = "mt-3";
   const documentBodyContentClassName = "paperclip-edit-in-place-content min-h-[220px] text-[15px] leading-7";
   const toggleFoldedDocument = (key: string) => {
-    setFoldedDocumentKeys((current) =>
+    setExpandedDocumentKeys((current) =>
       current.includes(key)
         ? current.filter((entry) => entry !== key)
         : [...current, key],
@@ -791,7 +798,7 @@ export function IssueDocumentsSection({
         {sortedDocuments.map((doc) => {
           const activeDraft = draft?.key === doc.key && !draft.isNew ? draft : null;
           const activeConflict = documentConflict?.key === doc.key ? documentConflict : null;
-          const isFolded = foldedDocumentKeys.includes(doc.key);
+          const isFolded = !expandedDocumentKeys.includes(doc.key);
           const rawRevisionHistory = getDocumentRevisions(doc.key);
           const revisionState = deriveDocumentRevisionState(doc, rawRevisionHistory);
           const revisionHistory = revisionState.revisions;

--- a/ui/src/pages/IssueChatUxLab.tsx
+++ b/ui/src/pages/IssueChatUxLab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -18,7 +18,21 @@ import {
   issueChatUxTranscriptsByRunId,
 } from "../fixtures/issueChatUxFixtures";
 import { cn } from "../lib/utils";
-import { Bot, Brain, FlaskConical, Loader2, MessagesSquare, Route, Sparkles, WandSparkles } from "lucide-react";
+import {
+  Bot,
+  Brain,
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  FlaskConical,
+  GripVertical,
+  Layout as LayoutIcon,
+  Loader2,
+  MessagesSquare,
+  Route,
+  Sparkles,
+  WandSparkles,
+} from "lucide-react";
 
 const noop = async () => {};
 
@@ -131,6 +145,490 @@ function RotatingReasoningDemo({ intervalMs = 2200 }: { intervalMs?: number }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Chat-first layout v1 (mock)
+// ---------------------------------------------------------------------------
+
+const MOCK_ISSUE_TITLE = "Smooth out reasoning ticker animation on long-running runs";
+const MOCK_ISSUE_BODY = `When the assistant streams a long chain of reasoning, the rotating ticker pops abruptly between lines. We see this most on runs longer than ~30s where 6+ lines cycle in quick succession.
+
+**Repro**
+1. Open any in-progress issue with an active assistant reply.
+2. Watch the reasoning ticker under the run header.
+3. Note the exit/entry happens in the same frame, causing a flash.
+
+**Expected**
+The exiting line should slide up + fade while the entering line slides in from below — symmetric, ~280ms cubic-bezier.
+
+**Notes**
+- Component lives in IssueChatThread / RotatingReasoningDemo
+- Don't tie this to the live transcript stream timing — keep the animation independent from message arrival.
+- Mobile should keep the same easing but reduce vertical travel by ~40%.
+`;
+
+type MockDoc = { id: string; title: string; kind: string; updated: string; body: string };
+
+const MOCK_DOCUMENTS: MockDoc[] = [
+  {
+    id: "doc-plan",
+    title: "Plan: animation ticker rework",
+    kind: "Plan",
+    updated: "12m ago",
+    body: "1. Add paired exit/enter animation\n2. Decouple from stream tick\n3. Mobile: reduce travel\n4. Verify on /tests/ux/chat",
+  },
+  {
+    id: "doc-spec",
+    title: "Spec: cot-line transitions",
+    kind: "Spec",
+    updated: "2h ago",
+    body: "Two-span ticker. Exit: translateY(-100%) + opacity 0 over 280ms. Enter: translateY(100% → 0) over 280ms.",
+  },
+  {
+    id: "doc-notes",
+    title: "Review notes from prior run",
+    kind: "Notes",
+    updated: "yesterday",
+    body: "Reviewer asked about reduced-motion behavior. We should respect prefers-reduced-motion and snap-cut.",
+  },
+];
+
+const SPLIT_STORAGE_KEY = "issue-chat-ux-lab.chat-first.split-pct";
+const MIN_RIGHT_PCT = 28;
+const MAX_RIGHT_PCT = 60;
+
+function useStickySplitPct(defaultPct: number) {
+  const [pct, setPct] = useState<number>(() => {
+    if (typeof window === "undefined") return defaultPct;
+    const raw = window.localStorage.getItem(SPLIT_STORAGE_KEY);
+    const parsed = raw ? Number(raw) : NaN;
+    if (Number.isFinite(parsed) && parsed >= MIN_RIGHT_PCT && parsed <= MAX_RIGHT_PCT) return parsed;
+    return defaultPct;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(SPLIT_STORAGE_KEY, String(Math.round(pct)));
+  }, [pct]);
+  return [pct, setPct] as const;
+}
+
+/** Drag handle between two columns. Reports the right column's percentage. */
+function SplitHandle({
+  containerRef,
+  rightPct,
+  setRightPct,
+}: {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  rightPct: number;
+  setRightPct: (n: number) => void;
+}) {
+  const draggingRef = useRef(false);
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    draggingRef.current = true;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!draggingRef.current || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const xFromRight = rect.right - e.clientX;
+      const pct = (xFromRight / rect.width) * 100;
+      const clamped = Math.max(MIN_RIGHT_PCT, Math.min(MAX_RIGHT_PCT, pct));
+      setRightPct(clamped);
+    },
+    [containerRef, setRightPct],
+  );
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    draggingRef.current = false;
+    try {
+      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      /* noop */
+    }
+  }, []);
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-valuenow={Math.round(100 - rightPct)}
+      aria-valuemin={100 - MAX_RIGHT_PCT}
+      aria-valuemax={100 - MIN_RIGHT_PCT}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onDoubleClick={() => setRightPct(40)}
+      className="group relative hidden w-1.5 cursor-col-resize items-center justify-center bg-border/30 transition-colors hover:bg-border md:flex"
+      title="Drag to resize · double-click to reset to 60/40"
+    >
+      <div className="absolute inset-y-0 -inset-x-2" />
+      <GripVertical className="relative z-10 h-4 w-4 text-muted-foreground/40 opacity-0 transition-opacity group-hover:opacity-100" />
+    </div>
+  );
+}
+
+/** Truncates a long markdown-ish body with a Show more / Show less toggle. */
+function TruncatedBody({ body, lines = 6 }: { body: string; lines?: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [overflowing, setOverflowing] = useState(true);
+
+  useLayoutEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+    setOverflowing(el.scrollHeight > el.clientHeight + 2);
+  }, [body, lines]);
+
+  return (
+    <div className="space-y-2">
+      <div
+        ref={measureRef}
+        className={cn(
+          "whitespace-pre-wrap text-[13px] leading-6 text-foreground/80",
+          !expanded && "overflow-hidden",
+        )}
+        style={!expanded ? { display: "-webkit-box", WebkitLineClamp: lines, WebkitBoxOrient: "vertical" } : undefined}
+      >
+        {body}
+      </div>
+      {(overflowing || expanded) && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function DocumentList({
+  docs,
+  openId,
+  onToggle,
+}: {
+  docs: MockDoc[];
+  openId: string | null;
+  onToggle: (id: string) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      {docs.map((doc) => {
+        const open = openId === doc.id;
+        return (
+          <div key={doc.id} className="overflow-hidden rounded-lg border border-border/60 bg-background/70">
+            <button
+              type="button"
+              onClick={() => onToggle(doc.id)}
+              className="flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors hover:bg-accent/30"
+            >
+              <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium text-foreground">{doc.title}</div>
+                <div className="text-[11px] text-muted-foreground">
+                  {doc.kind} · updated {doc.updated}
+                </div>
+              </div>
+              {open ? (
+                <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+              )}
+            </button>
+            {open && (
+              <div className="border-t border-border/60 bg-accent/10 px-3 py-2.5 text-[12.5px] leading-5 text-foreground/80 whitespace-pre-wrap">
+                {doc.body}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Right rail: issue header + truncated body + documents. */
+function IssueRail({
+  collapsibleOnMobile = false,
+  initiallyCollapsedMobile = true,
+}: {
+  collapsibleOnMobile?: boolean;
+  initiallyCollapsedMobile?: boolean;
+}) {
+  const [openDoc, setOpenDoc] = useState<string | null>("doc-plan");
+  const [mobileOpen, setMobileOpen] = useState(!initiallyCollapsedMobile);
+
+  return (
+    <aside className="flex h-full min-h-0 flex-col bg-background/60">
+      {collapsibleOnMobile && (
+        <button
+          type="button"
+          onClick={() => setMobileOpen((v) => !v)}
+          className="flex items-center justify-between gap-2 border-b border-border/70 px-4 py-2.5 text-left md:hidden"
+        >
+          <div className="min-w-0">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">Issue</div>
+            <div className="truncate text-sm font-medium text-foreground">{MOCK_ISSUE_TITLE}</div>
+          </div>
+          {mobileOpen ? <ChevronDown className="h-4 w-4 shrink-0" /> : <ChevronRight className="h-4 w-4 shrink-0" />}
+        </button>
+      )}
+      <div
+        className={cn(
+          "flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 sm:p-5",
+          collapsibleOnMobile && !mobileOpen && "hidden md:flex",
+        )}
+      >
+        <header className="space-y-2">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Badge variant="outline" className="rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.18em]">
+              ISSUE-482
+            </Badge>
+            <Badge className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.16em] text-amber-700 dark:text-amber-300">
+              In progress
+            </Badge>
+            <Badge variant="outline" className="rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.16em]">
+              UI · animations
+            </Badge>
+          </div>
+          <h3 className="text-base font-semibold leading-snug tracking-tight text-foreground">
+            {MOCK_ISSUE_TITLE}
+          </h3>
+          <div className="text-[11px] text-muted-foreground">
+            Opened by Frank · assigned to <span className="text-foreground/80">CodexCoder</span>
+          </div>
+        </header>
+
+        <section>
+          <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Description
+          </div>
+          <TruncatedBody body={MOCK_ISSUE_BODY} />
+        </section>
+
+        <section>
+          <div className="mb-1.5 flex items-center justify-between">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Documents · {MOCK_DOCUMENTS.length}
+            </div>
+            <button type="button" className="text-[11px] text-muted-foreground hover:text-foreground">
+              View all
+            </button>
+          </div>
+          <DocumentList docs={MOCK_DOCUMENTS} openId={openDoc} onToggle={(id) => setOpenDoc((cur) => (cur === id ? null : id))} />
+        </section>
+
+        <section>
+          <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Activity
+          </div>
+          <div className="rounded-lg border border-dashed border-border/60 bg-background/50 px-3 py-2.5 text-[12px] text-muted-foreground">
+            Inline activity events appear in the conversation timeline (see chat column).
+            Switch this rail to a separate &quot;Activity&quot; tab if needed — TBD.
+          </div>
+        </section>
+      </div>
+    </aside>
+  );
+}
+
+function ChatColumn() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center gap-2 border-b border-border/70 bg-background/70 px-4 py-2.5">
+        <MessagesSquare className="h-4 w-4 text-muted-foreground" />
+        <div className="text-sm font-medium text-foreground">Conversation</div>
+        <div className="ml-auto text-[11px] text-muted-foreground">
+          Auto-jumps to latest on open · stays put while you scroll
+        </div>
+      </div>
+      <IssueChatThread
+        layout="filled"
+        comments={issueChatUxLiveComments}
+        linkedRuns={issueChatUxLinkedRuns.slice(0, 1)}
+        timelineEvents={issueChatUxLiveEvents}
+        liveRuns={issueChatUxLiveRuns}
+        issueStatus="todo"
+        agentMap={issueChatUxAgentMap}
+        currentUserId="user-1"
+        onAdd={noop}
+        onVote={noop}
+        onCancelRun={noop}
+        onInterruptQueued={noop}
+        draftKey="issue-chat-ux-lab-chatfirst"
+        enableReassign
+        reassignOptions={issueChatUxReassignOptions}
+        currentAssigneeValue="agent:agent-1"
+        suggestedAssigneeValue="agent:agent-2"
+        mentions={issueChatUxMentions}
+        enableLiveTranscriptPolling={false}
+        transcriptsByRunId={issueChatUxTranscriptsByRunId}
+        hasOutputForRun={(runId) => issueChatUxTranscriptsByRunId.has(runId)}
+      />
+    </div>
+  );
+}
+
+type LayoutMode = "current" | "chat-first";
+
+function ChatFirstPreview() {
+  const [mode, setMode] = useState<LayoutMode>("chat-first");
+  const [rightPct, setRightPct] = useStickySplitPct(40);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const presets: { label: string; right: number }[] = useMemo(
+    () => [
+      { label: "60 / 40", right: 40 },
+      { label: "50 / 50", right: 50 },
+      { label: "70 / 30", right: 30 },
+    ],
+    [],
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="inline-flex rounded-full border border-border/70 bg-background/80 p-0.5 text-[11px] font-medium">
+          {(["current", "chat-first"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={cn(
+                "rounded-full px-3 py-1 transition-colors",
+                mode === m
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {m === "current" ? "Current (top-down)" : "Chat-first (proposed)"}
+            </button>
+          ))}
+        </div>
+
+        {mode === "chat-first" && (
+          <>
+            <div className="hidden items-center gap-1 md:inline-flex">
+              <span className="text-[11px] text-muted-foreground">Split:</span>
+              {presets.map((p) => (
+                <button
+                  key={p.label}
+                  type="button"
+                  onClick={() => setRightPct(p.right)}
+                  className={cn(
+                    "rounded-full border px-2.5 py-0.5 text-[11px] transition-colors",
+                    Math.round(rightPct) === p.right
+                      ? "border-foreground/60 bg-foreground/[0.06] text-foreground"
+                      : "border-border/70 text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {p.label}
+                </button>
+              ))}
+              <span className="ml-2 text-[11px] tabular-nums text-muted-foreground">
+                chat {Math.round(100 - rightPct)}% / issue {Math.round(rightPct)}%
+              </span>
+            </div>
+            <div className="ml-auto text-[11px] text-muted-foreground">
+              Drag the divider · double-click to reset
+            </div>
+          </>
+        )}
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border border-border/70 bg-background shadow-[0_24px_60px_rgba(15,23,42,0.08)]">
+        {mode === "current" ? (
+          <CurrentLayoutPreview />
+        ) : (
+          <div
+            ref={containerRef}
+            className="flex h-[78vh] min-h-[640px] w-full flex-col md:flex-row"
+          >
+            <div
+              className="flex min-h-0 min-w-0 flex-1 flex-col"
+              style={{ flexBasis: `${100 - rightPct}%` }}
+            >
+              <ChatColumn />
+            </div>
+            <SplitHandle containerRef={containerRef} rightPct={rightPct} setRightPct={setRightPct} />
+            <div
+              className="flex min-h-0 flex-col border-t border-border/70 md:border-l md:border-t-0"
+              style={{ flexBasis: `${rightPct}%` }}
+            >
+              <IssueRail collapsibleOnMobile />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-dashed border-border/60 bg-accent/10 px-4 py-3 text-[12px] text-muted-foreground">
+        <div className="mb-1 font-medium text-foreground">Mobile behavior (resize the viewport &lt; md)</div>
+        Chat takes the full screen with the composer pinned. The issue collapses into a tappable header at the top
+        of the chat column — tap to unfold the truncated description and documents in place. No bottom-sheet for v1
+        to keep gestures predictable.
+      </div>
+    </div>
+  );
+}
+
+/** "Current" layout reference: stacked top-down. Reuses the existing chat thread with composer. */
+function CurrentLayoutPreview() {
+  return (
+    <div className="flex flex-col">
+      <div className="border-b border-border/70 bg-background/70 p-4 sm:p-5">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant="outline" className="rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.18em]">
+            ISSUE-482
+          </Badge>
+          <Badge className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.16em] text-amber-700 dark:text-amber-300">
+            In progress
+          </Badge>
+        </div>
+        <h3 className="mt-2 text-base font-semibold leading-snug tracking-tight text-foreground">
+          {MOCK_ISSUE_TITLE}
+        </h3>
+        <div className="mt-2 text-[13px] leading-6 text-foreground/80 whitespace-pre-wrap">
+          {MOCK_ISSUE_BODY}
+        </div>
+      </div>
+      <div className="border-b border-border/70 bg-background/40 p-4 sm:p-5">
+        <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          Documents
+        </div>
+        <DocumentList docs={MOCK_DOCUMENTS} openId={null} onToggle={() => {}} />
+      </div>
+      <div className="p-4 sm:p-5">
+        <div className="mb-2 inline-flex rounded-full border border-border/70 bg-background/80 p-0.5 text-[11px] font-medium">
+          <span className="rounded-full bg-foreground px-3 py-1 text-background">Chat</span>
+          <span className="rounded-full px-3 py-1 text-muted-foreground">Activity</span>
+        </div>
+        <IssueChatThread
+          comments={issueChatUxLiveComments}
+          linkedRuns={issueChatUxLinkedRuns.slice(0, 1)}
+          timelineEvents={issueChatUxLiveEvents}
+          liveRuns={issueChatUxLiveRuns}
+          issueStatus="todo"
+          agentMap={issueChatUxAgentMap}
+          currentUserId="user-1"
+          onAdd={noop}
+          onVote={noop}
+          draftKey="issue-chat-ux-lab-current-ref"
+          mentions={issueChatUxMentions}
+          enableLiveTranscriptPolling={false}
+          transcriptsByRunId={issueChatUxTranscriptsByRunId}
+          hasOutputForRun={(runId) => issueChatUxTranscriptsByRunId.has(runId)}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
 export function IssueChatUxLab() {
   const [showComposer, setShowComposer] = useState(true);
 
@@ -194,6 +692,20 @@ export function IssueChatUxLab() {
           </aside>
         </div>
       </div>
+
+      <LabSection
+        id="chat-first-layout"
+        eyebrow="Layout proposal"
+        title="Chat-first issue layout v1"
+        description="Mock of the proposed redesign: full-height chat on the left with a pinned composer, issue + documents on the right rail. Toggle between the current top-down stack and the new chat-first layout to A/B them. Resize the split, persist your preference, and check the &lt; md viewport for mobile collapse."
+        accentClassName="bg-[linear-gradient(180deg,rgba(6,182,212,0.07),transparent_28%),var(--background)]"
+      >
+        <div className="mb-4 flex items-center gap-2 rounded-xl border border-cyan-500/30 bg-cyan-500/[0.06] px-3 py-2 text-[12px] text-cyan-900 dark:text-cyan-200">
+          <LayoutIcon className="h-4 w-4 shrink-0" />
+          Mock only — composer, document open, and split state are fixture-backed and don&apos;t persist to the server.
+        </div>
+        <ChatFirstPreview />
+      </LabSection>
 
       <LabSection
         id="rotating-text"

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type DragEvent, type Ref } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ChangeEvent, type DragEvent, type ReactNode, type Ref } from "react";
 import { pickTextColorForPillBg } from "@/lib/color-contrast";
 import { Link, useLocation, useNavigate, useNavigationType, useParams } from "@/lib/router";
 import { useInfiniteQuery, useQuery, useMutation, useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/react-query";
@@ -102,13 +102,14 @@ import { shouldRenderRichSubIssuesSection } from "../lib/issue-detail-subissues"
 import { filterIssueDescendants } from "../lib/issue-tree";
 import { buildSubIssueDefaultsForViewer } from "../lib/subIssueDefaults";
 import {
-  Activity as ActivityIcon,
   Archive,
   ArrowLeft,
   Check,
+  ChevronDown,
   ChevronRight,
   Copy,
   EyeOff,
+  GripVertical,
   Hexagon,
   ListTree,
   MessageSquare,
@@ -119,6 +120,7 @@ import {
   PlayCircle,
   Plus,
   Repeat,
+  Settings2,
   SlidersHorizontal,
   Trash2,
   XCircle,
@@ -595,6 +597,7 @@ type IssueDetailChatTabProps = {
     interaction: IssueThreadInteraction,
     answers: AskUserQuestionsAnswer[],
   ) => Promise<void>;
+  layout?: "stacked" | "filled";
 };
 
 const IssueDetailChatTab = memo(function IssueDetailChatTab({
@@ -638,6 +641,7 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   onAcceptInteraction,
   onRejectInteraction,
   onSubmitInteractionAnswers,
+  layout = "stacked",
 }: IssueDetailChatTabProps) {
   const { data: activity } = useQuery({
     queryKey: queryKeys.issues.activity(issueId),
@@ -772,70 +776,86 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
     [resolvedActivity],
   );
 
+  const loadEarlierStrip = hasOlderComments ? (
+    <div className={cn("flex justify-center", layout === "filled" ? "shrink-0 border-b border-border/40 px-3 py-1.5" : "")}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={commentsLoadingOlder}
+        onClick={onLoadOlderComments}
+      >
+        {commentsLoadingOlder ? "Loading earlier comments..." : "Load earlier comments"}
+      </Button>
+    </div>
+  ) : null;
+
+  const thread = (
+    <IssueChatThread
+      layout={layout}
+      composerRef={composerRef}
+      comments={commentsWithRunMeta}
+      interactions={interactions}
+      feedbackVotes={feedbackVotes}
+      feedbackDataSharingPreference={feedbackDataSharingPreference}
+      feedbackTermsUrl={feedbackTermsUrl}
+      linkedRuns={timelineRuns}
+      timelineEvents={timelineEvents}
+      liveRuns={resolvedLiveRuns}
+      activeRun={resolvedActiveRun}
+      blockedBy={blockedBy ?? []}
+      blockerAttention={blockerAttention}
+      companyId={companyId}
+      projectId={projectId}
+      issueStatus={issueStatus}
+      agentMap={agentMap}
+      currentUserId={currentUserId}
+      userLabelMap={userLabelMap}
+      userProfileMap={userProfileMap}
+      draftKey={draftKey}
+      enableReassign
+      reassignOptions={reassignOptions}
+      currentAssigneeValue={currentAssigneeValue}
+      suggestedAssigneeValue={suggestedAssigneeValue}
+      mentions={mentions}
+      composerDisabledReason={composerDisabledReason}
+      composerHint={composerHint}
+      onVote={onVote}
+      onAdd={onAdd}
+      imageUploadHandler={onImageUpload}
+      onAttachImage={onAttachImage}
+      onInterruptQueued={onInterruptQueued}
+      onCancelQueued={onCancelQueued}
+      interruptingQueuedRunId={interruptingQueuedRunId}
+      stoppingRunId={interruptingQueuedRunId}
+      onStopRun={onInterruptQueued}
+      onAcceptInteraction={onAcceptInteraction}
+      onRejectInteraction={onRejectInteraction}
+      onSubmitInteractionAnswers={(interaction, answers) =>
+        onSubmitInteractionAnswers(interaction, answers)
+      }
+      onCancelRun={runningIssueRun
+        ? async () => {
+            await onInterruptQueued(runningIssueRun.id);
+          }
+        : undefined}
+      onImageClick={onImageClick}
+    />
+  );
+
+  if (layout === "filled") {
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        {loadEarlierStrip}
+        <div className="flex min-h-0 flex-1 flex-col">{thread}</div>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-3">
-      {hasOlderComments ? (
-        <div className="flex justify-center">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={commentsLoadingOlder}
-            onClick={onLoadOlderComments}
-          >
-            {commentsLoadingOlder ? "Loading earlier comments..." : "Load earlier comments"}
-          </Button>
-        </div>
-      ) : null}
-      <IssueChatThread
-        composerRef={composerRef}
-        comments={commentsWithRunMeta}
-        interactions={interactions}
-        feedbackVotes={feedbackVotes}
-        feedbackDataSharingPreference={feedbackDataSharingPreference}
-        feedbackTermsUrl={feedbackTermsUrl}
-        linkedRuns={timelineRuns}
-        timelineEvents={timelineEvents}
-        liveRuns={resolvedLiveRuns}
-        activeRun={resolvedActiveRun}
-        blockedBy={blockedBy ?? []}
-        blockerAttention={blockerAttention}
-        companyId={companyId}
-        projectId={projectId}
-        issueStatus={issueStatus}
-        agentMap={agentMap}
-        currentUserId={currentUserId}
-        userLabelMap={userLabelMap}
-        userProfileMap={userProfileMap}
-        draftKey={draftKey}
-        enableReassign
-        reassignOptions={reassignOptions}
-        currentAssigneeValue={currentAssigneeValue}
-        suggestedAssigneeValue={suggestedAssigneeValue}
-        mentions={mentions}
-        composerDisabledReason={composerDisabledReason}
-        composerHint={composerHint}
-        onVote={onVote}
-        onAdd={onAdd}
-        imageUploadHandler={onImageUpload}
-        onAttachImage={onAttachImage}
-        onInterruptQueued={onInterruptQueued}
-        onCancelQueued={onCancelQueued}
-        interruptingQueuedRunId={interruptingQueuedRunId}
-        stoppingRunId={interruptingQueuedRunId}
-        onStopRun={onInterruptQueued}
-        onAcceptInteraction={onAcceptInteraction}
-        onRejectInteraction={onRejectInteraction}
-        onSubmitInteractionAnswers={(interaction, answers) =>
-          onSubmitInteractionAnswers(interaction, answers)
-        }
-        onCancelRun={runningIssueRun
-          ? async () => {
-              await onInterruptQueued(runningIssueRun.id);
-            }
-          : undefined}
-        onImageClick={onImageClick}
-      />
+      {loadEarlierStrip}
+      {thread}
     </div>
   );
 });
@@ -1020,11 +1040,177 @@ function IssueDetailActivityTab({
   );
 }
 
+const ISSUE_DETAIL_SPLIT_STORAGE_KEY = "paperclip:issue-detail.split-pct";
+const ISSUE_DETAIL_SPLIT_MIN = 28;
+const ISSUE_DETAIL_SPLIT_MAX = 60;
+const ISSUE_DETAIL_RAIL_MIN_PX = 420;
+const ISSUE_DETAIL_CHAT_MIN_PX = 640;
+const ISSUE_DETAIL_STACK_THRESHOLD_PX = ISSUE_DETAIL_RAIL_MIN_PX + ISSUE_DETAIL_CHAT_MIN_PX + 24;
+
+function useMeasuredWidth(externalRef?: React.MutableRefObject<HTMLDivElement | null>) {
+  const [width, setWidth] = useState(0);
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const setRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (externalRef) externalRef.current = node;
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+      if (!node) return;
+      setWidth(node.getBoundingClientRect().width);
+      if (typeof ResizeObserver === "undefined") return;
+      const obs = new ResizeObserver((entries) => {
+        const e = entries[0];
+        if (e) setWidth(e.contentRect.width);
+      });
+      obs.observe(node);
+      observerRef.current = obs;
+    },
+    [externalRef],
+  );
+  return [setRef, width] as const;
+}
+
+function useStickyBoolean(key: string, defaultValue: boolean) {
+  const [value, setValue] = useState<boolean>(() => {
+    if (typeof window === "undefined") return defaultValue;
+    const raw = window.localStorage.getItem(key);
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return defaultValue;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(key, String(value));
+  }, [key, value]);
+  return [value, setValue] as const;
+}
+
+function TruncatedDescription({
+  signal,
+  children,
+}: {
+  signal: string;
+  children: ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const measureRef = useRef<HTMLDivElement | null>(null);
+  const [overflowing, setOverflowing] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+    setOverflowing(el.scrollHeight > el.clientHeight + 2);
+  }, [signal, expanded]);
+
+  return (
+    <div className="space-y-1.5">
+      <div
+        ref={measureRef}
+        className={cn(
+          "focus-within:line-clamp-none focus-within:overflow-visible",
+          !expanded && "line-clamp-6",
+        )}
+      >
+        {children}
+      </div>
+      {(overflowing || expanded) && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function useStickyIssueDetailSplitPct(defaultPct: number) {
+  const [pct, setPct] = useState<number>(() => {
+    if (typeof window === "undefined") return defaultPct;
+    const raw = window.localStorage.getItem(ISSUE_DETAIL_SPLIT_STORAGE_KEY);
+    const parsed = raw ? Number(raw) : NaN;
+    if (Number.isFinite(parsed) && parsed >= ISSUE_DETAIL_SPLIT_MIN && parsed <= ISSUE_DETAIL_SPLIT_MAX) {
+      return parsed;
+    }
+    return defaultPct;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(ISSUE_DETAIL_SPLIT_STORAGE_KEY, String(Math.round(pct)));
+  }, [pct]);
+  return [pct, setPct] as const;
+}
+
+function IssueDetailSplitHandle({
+  containerRef,
+  rightPct,
+  setRightPct,
+}: {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  rightPct: number;
+  setRightPct: (n: number) => void;
+}) {
+  const draggingRef = useRef(false);
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    draggingRef.current = true;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!draggingRef.current || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const xFromRight = rect.right - e.clientX;
+      const pct = (xFromRight / rect.width) * 100;
+      const minPctFromRailPx = (ISSUE_DETAIL_RAIL_MIN_PX / rect.width) * 100;
+      const maxPctFromChatPx = 100 - (ISSUE_DETAIL_CHAT_MIN_PX / rect.width) * 100;
+      const lowerBound = Math.max(ISSUE_DETAIL_SPLIT_MIN, minPctFromRailPx);
+      const upperBound = Math.min(ISSUE_DETAIL_SPLIT_MAX, maxPctFromChatPx);
+      const clamped = Math.max(lowerBound, Math.min(upperBound, pct));
+      setRightPct(clamped);
+    },
+    [containerRef, setRightPct],
+  );
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    draggingRef.current = false;
+    try {
+      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      /* noop */
+    }
+  }, []);
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-valuenow={Math.round(100 - rightPct)}
+      aria-valuemin={100 - ISSUE_DETAIL_SPLIT_MAX}
+      aria-valuemax={100 - ISSUE_DETAIL_SPLIT_MIN}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onDoubleClick={() => setRightPct(40)}
+      className="group relative hidden w-1.5 cursor-col-resize items-center justify-center bg-border/30 transition-colors hover:bg-border md:flex"
+      title="Drag to resize · double-click to reset"
+    >
+      <div className="absolute inset-y-0 -inset-x-2" />
+      <GripVertical className="relative z-10 h-4 w-4 text-muted-foreground/40 opacity-0 transition-opacity group-hover:opacity-100" />
+    </div>
+  );
+}
+
 export function IssueDetail() {
   const { issueId } = useParams<{ issueId: string }>();
   const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialog();
-  const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
+  const { closePanel } = usePanel();
   const { setBreadcrumbs, setMobileToolbar } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -1036,6 +1222,7 @@ export function IssueDetail() {
   const [copied, setCopied] = useState(false);
   const [mobilePropsOpen, setMobilePropsOpen] = useState(false);
   const [detailTab, setDetailTab] = useState("chat");
+  const [chatView, setChatView] = useState<"chat" | "activity">("chat");
   const [handoffFocusSignal, setHandoffFocusSignal] = useState(0);
   const [pendingApprovalAction, setPendingApprovalAction] = useState<{
     approvalId: string;
@@ -1058,6 +1245,10 @@ export function IssueDetail() {
   const lastMarkedReadIssueIdRef = useRef<string | null>(null);
   const commentComposerRef = useRef<IssueChatComposerHandle | null>(null);
   const cancelledQueuedOptimisticCommentIdsRef = useRef(new Set<string>());
+  const splitContainerRef = useRef<HTMLDivElement | null>(null);
+  const [splitContainerCallbackRef, measuredContainerWidth] = useMeasuredWidth(splitContainerRef);
+  const [rightPct, setRightPct] = useStickyIssueDetailSplitPct(40);
+  const [detailsOpen, setDetailsOpen] = useStickyBoolean("paperclip:issue-detail.details-open", false);
   const resolvedIssueDetailState = useMemo(
     () => readIssueDetailLocationState(issueId, location.state, location.search),
     [issueId, location.state, location.search],
@@ -2291,28 +2482,9 @@ export function IssueDetail() {
   }, [issue?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (!panelIssue) {
-      closePanel();
-      return;
-    }
-    openPanel(
-      <IssueProperties
-        issue={panelIssue}
-        childIssues={panelChildIssues}
-        onAddSubIssue={openNewSubIssue}
-        onUpdate={handleIssuePropertiesUpdate}
-      />
-    );
+    closePanel();
     return () => closePanel();
-  }, [
-    closePanel,
-    handleIssuePropertiesUpdate,
-    issuePanelKey,
-    openNewSubIssue,
-    openPanel,
-    panelChildIssues,
-    panelIssue,
-  ]);
+  }, [closePanel]);
 
   const goToInboxShortcutArmedRef = useRef(false);
   const goToInboxShortcutTimeoutRef = useRef<number | null>(null);
@@ -2417,7 +2589,7 @@ export function IssueDetail() {
       if (action === "focus_comment") {
         event.preventDefault();
         event.stopPropagation();
-        setDetailTab("chat");
+        setChatView("chat");
         setPendingCommentComposerFocusKey((current) => current + 1);
       }
     };
@@ -2438,15 +2610,15 @@ export function IssueDetail() {
     if (!hash.startsWith("#document-")) return;
     const documentKey = decodeURIComponent(hash.slice("#document-".length));
     if (documentKey !== ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY) return;
-    setDetailTab("activity");
+    setChatView("activity");
     setHandoffFocusSignal((current) => current + 1);
   }, [location.hash]);
 
   useEffect(() => {
     if (pendingCommentComposerFocusKey === 0) return;
-    if (detailTab !== "chat") return;
+    if (chatView !== "chat") return;
     commentComposerRef.current?.focus();
-  }, [detailTab, pendingCommentComposerFocusKey]);
+  }, [chatView, pendingCommentComposerFocusKey]);
 
   const isImageAttachment = (attachment: IssueAttachment) => attachment.contentType.startsWith("image/");
   const attachmentList = attachments ?? [];
@@ -2770,8 +2942,347 @@ export function IssueDetail() {
     </>
   );
 
+  const stackedLayout =
+    isMobile || (measuredContainerWidth > 0 && measuredContainerWidth < ISSUE_DETAIL_STACK_THRESHOLD_PX);
+
+  const renderChatTab = (chatLayout: "stacked" | "filled") => (
+    <IssueDetailChatTab
+      key={issue.id}
+      layout={chatLayout}
+      issueId={issue.id}
+      companyId={issue.companyId}
+      projectId={issue.projectId ?? null}
+      issueStatus={issue.status}
+      executionRunId={issue.executionRunId ?? null}
+      blockedBy={issue.blockedBy ?? []}
+      blockerAttention={issue.blockerAttention ?? null}
+      comments={threadComments}
+      locallyQueuedCommentRunIds={locallyQueuedCommentRunIds}
+      interactions={interactions}
+      hasOlderComments={hasOlderComments}
+      commentsLoadingOlder={commentsLoadingOlder}
+      onLoadOlderComments={loadOlderComments}
+      composerRef={commentComposerRef}
+      feedbackVotes={feedbackVotes}
+      feedbackDataSharingPreference={feedbackDataSharingPreference}
+      feedbackTermsUrl={FEEDBACK_TERMS_URL}
+      agentMap={agentMap}
+      currentUserId={currentUserId}
+      userLabelMap={userLabelMap}
+      userProfileMap={userProfileMap}
+      draftKey={`paperclip:issue-comment-draft:${issue.id}`}
+      reassignOptions={commentReassignOptions}
+      currentAssigneeValue={actualAssigneeValue}
+      suggestedAssigneeValue={suggestedAssigneeValue}
+      mentions={mentionOptions}
+      composerDisabledReason={commentComposerDisabledReason}
+      composerHint={composerHint}
+      queuedCommentReason={queuedCommentReason}
+      onVote={handleCommentVote}
+      onAdd={handleChatAdd}
+      onImageUpload={handleCommentImageUpload}
+      onAttachImage={handleCommentAttachImage}
+      onInterruptQueued={handleInterruptQueuedRun}
+      onCancelQueued={handleCancelQueuedComment}
+      interruptingQueuedRunId={interruptQueuedComment.isPending ? interruptQueuedComment.variables ?? null : null}
+      onImageClick={handleChatImageClick}
+      onAcceptInteraction={handleAcceptInteraction}
+      onRejectInteraction={handleRejectInteraction}
+      onSubmitInteractionAnswers={handleSubmitInteractionAnswers}
+    />
+  );
+
+  const activityElement = (
+    <IssueDetailActivityTab
+      key={issue.id}
+      issueId={issue.id}
+      companyId={issue.companyId}
+      issueStatus={issue.status}
+      childIssues={childIssues}
+      agentMap={agentMap}
+      hasLiveRuns={hasLiveRuns}
+      currentUserId={currentUserId}
+      userProfileMap={userProfileMap}
+      pendingApprovalAction={pendingApprovalAction}
+      handoffFocusSignal={handoffFocusSignal}
+      onApprovalAction={(approvalId, action) => {
+        approvalDecision.mutate({ approvalId, action });
+      }}
+    />
+  );
+
+  const renderChatColumn = (mode: "filled" | "stacked") => {
+    const toggle = (
+      <div
+        className={cn(
+          "flex items-center gap-1",
+          mode === "filled"
+            ? "border-b border-border/60 bg-background/95 px-3 py-2 backdrop-blur supports-[backdrop-filter]:bg-background/85"
+            : "",
+        )}
+      >
+        <div className="inline-flex rounded-full border border-border/70 bg-background/80 p-0.5 text-[11px] font-medium">
+          {(["chat", "activity"] as const).map((view) => (
+            <button
+              key={view}
+              type="button"
+              onClick={() => setChatView(view)}
+              className={cn(
+                "rounded-full px-3 py-1 transition-colors capitalize",
+                chatView === view
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+              aria-pressed={chatView === view}
+            >
+              {view}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+
+    if (mode === "filled") {
+      return (
+        <div className="flex h-full min-h-0 flex-col">
+          {toggle}
+          {chatView === "chat" ? (
+            <div className="flex min-h-0 flex-1 flex-col">{renderChatTab("filled")}</div>
+          ) : (
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-4 sm:px-5">
+              {activityElement}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-3">
+        {toggle}
+        {chatView === "chat" ? renderChatTab("stacked") : activityElement}
+      </div>
+    );
+  };
+
   return (
-    <div className="max-w-3xl space-y-6">
+    <>
+    <div
+      ref={splitContainerCallbackRef}
+      className={cn(stackedLayout ? "space-y-6" : "flex h-full min-h-0")}
+    >
+      {!stackedLayout && (
+        <div
+          className="flex min-h-0 min-w-0 flex-col"
+          style={{ flexBasis: `${100 - rightPct}%` }}
+        >
+          {renderChatColumn("filled")}
+        </div>
+      )}
+      {!stackedLayout && (
+        <IssueDetailSplitHandle
+          containerRef={splitContainerRef}
+          rightPct={rightPct}
+          setRightPct={setRightPct}
+        />
+      )}
+      <aside
+        className={cn(
+          stackedLayout
+            ? "space-y-6"
+            : "flex min-h-0 flex-col overflow-y-auto border-l border-border/70",
+        )}
+        style={!stackedLayout ? { flexBasis: `${rightPct}%` } : undefined}
+      >
+        <header
+          className={cn(
+            "border-b border-border/60 space-y-2",
+            stackedLayout
+              ? "pb-3"
+              : "sticky top-0 z-20 bg-background/95 px-5 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/85",
+          )}
+        >
+          <div className="flex items-center gap-2 min-w-0">
+            <StatusIcon
+              status={issue.status}
+              blockerAttention={issue.blockerAttention}
+              onChange={(status) => updateIssue.mutate({ status })}
+            />
+            <span className="text-sm font-mono text-muted-foreground shrink-0">
+              {issue.identifier ?? issue.id.slice(0, 8)}
+            </span>
+            {hasLiveRuns && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-cyan-500/10 border border-cyan-500/30 px-2 py-0.5 text-[10px] font-medium text-cyan-600 dark:text-cyan-400 shrink-0">
+                <span className="relative flex h-1.5 w-1.5">
+                  <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-cyan-400 opacity-75" />
+                  <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-cyan-400" />
+                </span>
+                Live
+              </span>
+            )}
+            {issue.originKind === "routine_execution" && issue.originId && (
+              <Link
+                to={`/routines/${issue.originId}`}
+                className="inline-flex items-center gap-1 rounded-full bg-violet-500/10 border border-violet-500/30 px-2 py-0.5 text-[10px] font-medium text-violet-600 dark:text-violet-400 shrink-0 hover:bg-violet-500/20 transition-colors"
+              >
+                <Repeat className="h-3 w-3" />
+                Routine
+              </Link>
+            )}
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className={cn("ml-auto shrink-0", detailsOpen && "bg-accent text-foreground")}
+              onClick={() => setDetailsOpen((v) => !v)}
+              title={detailsOpen ? "Hide issue settings" : "Show issue settings"}
+              aria-expanded={detailsOpen}
+              aria-label="Issue settings"
+            >
+              <Settings2 className="h-4 w-4" />
+            </Button>
+            <Popover open={moreOpen} onOpenChange={setMoreOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  className="shrink-0"
+                  aria-label="More issue actions"
+                  title="More issue actions"
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      setMoreOpen(true);
+                    }
+                  }}
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-52 p-1" align="end">
+                <button
+                  className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
+                  onClick={() => {
+                    void copyIssueToClipboard();
+                    setMoreOpen(false);
+                  }}
+                >
+                  {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
+                  Copy as markdown
+                </button>
+                {canArchiveFromInbox && (
+                  <button
+                    className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 disabled:opacity-50"
+                    disabled={archivePending}
+                    onClick={() => {
+                      if (!archivePending && issue?.id) archiveFromInbox.mutate(issue.id);
+                      setMoreOpen(false);
+                    }}
+                  >
+                    <Archive className="h-3 w-3" />
+                    Archive from inbox
+                  </button>
+                )}
+                {canShowSubtreeControls ? (
+                  <>
+                    <div className="my-1 h-px bg-border" />
+                    <button
+                      className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
+                      onClick={() => {
+                        setTreeControlMode("pause");
+                        setTreeControlCancelConfirmed(false);
+                        setTreeControlOpen(true);
+                        setMoreOpen(false);
+                      }}
+                    >
+                      <PauseCircle className="h-3 w-3" />
+                      Pause subtree...
+                    </button>
+                    {canResumeSubtree ? (
+                      <button
+                        className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
+                        onClick={() => {
+                          setTreeControlMode("resume");
+                          setTreeControlWakeAgentsOnResume(true);
+                          setTreeControlOpen(true);
+                          setMoreOpen(false);
+                        }}
+                      >
+                        <PlayCircle className="h-3 w-3" />
+                        Resume subtree
+                      </button>
+                    ) : null}
+                    <button
+                      className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-destructive"
+                      onClick={() => {
+                        setTreeControlMode("cancel");
+                        setTreeControlCancelConfirmed(false);
+                        setTreeControlOpen(true);
+                        setMoreOpen(false);
+                      }}
+                    >
+                      <XCircle className="h-3 w-3" />
+                      Cancel subtree...
+                    </button>
+                    {canRestoreSubtree ? (
+                      <button
+                        className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
+                        onClick={() => {
+                          setTreeControlMode("restore");
+                          setTreeControlWakeAgentsOnResume(false);
+                          setTreeControlCancelConfirmed(false);
+                          setTreeControlOpen(true);
+                          setMoreOpen(false);
+                        }}
+                      >
+                        <Repeat className="h-3 w-3" />
+                        Restore subtree...
+                      </button>
+                    ) : null}
+                  </>
+                ) : null}
+                <div className="my-1 h-px bg-border" />
+                <button
+                  className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-destructive"
+                  onClick={() => {
+                    updateIssue.mutate(
+                      { hiddenAt: new Date().toISOString() },
+                      { onSuccess: () => navigate("/issues/all") },
+                    );
+                    setMoreOpen(false);
+                  }}
+                >
+                  <EyeOff className="h-3 w-3" />
+                  Hide this Issue
+                </button>
+              </PopoverContent>
+            </Popover>
+          </div>
+          <InlineEditor
+            value={issue.title}
+            onSave={(title) => updateIssue.mutateAsync({ title })}
+            as="h2"
+            className="text-xl font-bold"
+          />
+        </header>
+
+        {detailsOpen && (
+          <div
+            className={cn(
+              "border-b border-border/60 bg-accent/5",
+              stackedLayout ? "pb-3" : "px-5 py-3",
+            )}
+          >
+            <IssueProperties
+              issue={panelIssue ?? issue}
+              childIssues={panelChildIssues}
+              onAddSubIssue={openNewSubIssue}
+              onUpdate={handleIssuePropertiesUpdate}
+              inline={stackedLayout}
+            />
+          </div>
+        )}
+
+        <div className={cn("space-y-6", !stackedLayout && "p-5")}>
       {/* Parent chain breadcrumb */}
       {ancestors.length > 0 && (
         <nav className="flex items-center gap-1 text-xs text-muted-foreground flex-wrap">
@@ -2873,233 +3384,7 @@ export function IssueDetail() {
         </div>
       )}
 
-      <div className="space-y-3">
-        <div className="flex items-center gap-2 min-w-0 flex-wrap">
-          <StatusIcon
-            status={issue.status}
-            blockerAttention={issue.blockerAttention}
-            onChange={(status) => updateIssue.mutate({ status })}
-          />
-          <PriorityIcon
-            priority={issue.priority}
-            onChange={(priority) => updateIssue.mutate({ priority })}
-          />
-          <span className="text-sm font-mono text-muted-foreground shrink-0">{issue.identifier ?? issue.id.slice(0, 8)}</span>
-
-          {hasLiveRuns && (
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-cyan-500/10 border border-cyan-500/30 px-2 py-0.5 text-[10px] font-medium text-cyan-600 dark:text-cyan-400 shrink-0">
-              <span className="relative flex h-1.5 w-1.5">
-                <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-cyan-400 opacity-75" />
-                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-cyan-400" />
-              </span>
-              Live
-            </span>
-          )}
-
-          {issue.originKind === "routine_execution" && issue.originId && (
-            <Link
-              to={`/routines/${issue.originId}`}
-              className="inline-flex items-center gap-1 rounded-full bg-violet-500/10 border border-violet-500/30 px-2 py-0.5 text-[10px] font-medium text-violet-600 dark:text-violet-400 shrink-0 hover:bg-violet-500/20 transition-colors"
-            >
-              <Repeat className="h-3 w-3" />
-              Routine
-            </Link>
-          )}
-
-          {issue.projectId ? (
-            <Link
-              to={`/projects/${issue.projectId}`}
-              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors rounded px-1 -mx-1 py-0.5 min-w-0"
-            >
-              <Hexagon className="h-3 w-3 shrink-0" />
-              <span className="truncate">{resolvedProject?.name ?? issue.project?.name ?? issue.projectId.slice(0, 8)}</span>
-            </Link>
-          ) : (
-            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground opacity-50 px-1 -mx-1 py-0.5">
-              <Hexagon className="h-3 w-3 shrink-0" />
-              No project
-            </span>
-          )}
-
-          {(issue.labels ?? []).length > 0 && (
-            <div className="hidden sm:flex items-center gap-1">
-              {(issue.labels ?? []).slice(0, 4).map((label) => (
-                <span
-                  key={label.id}
-                  className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium"
-                  style={{
-                    borderColor: label.color,
-                    color: pickTextColorForPillBg(label.color, 0.12),
-                    backgroundColor: `${label.color}1f`,
-                  }}
-                >
-                  {label.name}
-                </span>
-              ))}
-              {(issue.labels ?? []).length > 4 && (
-                <span className="text-[10px] text-muted-foreground">+{(issue.labels ?? []).length - 4}</span>
-              )}
-            </div>
-          )}
-
-          {!(isMobile && isFromInbox) && (
-            <div className="ml-auto flex items-center gap-0.5 md:hidden shrink-0">
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                onClick={copyIssueToClipboard}
-                title="Copy issue as markdown"
-              >
-                {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                onClick={() => setMobilePropsOpen(true)}
-                title="Properties"
-              >
-                <SlidersHorizontal className="h-4 w-4" />
-              </Button>
-            </div>
-          )}
-
-          <div className="hidden md:flex items-center md:ml-auto shrink-0">
-            {canArchiveFromInbox && (
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                onClick={() => {
-                  if (!archivePending && issue?.id) archiveFromInbox.mutate(issue.id);
-                }}
-                disabled={archivePending}
-                title="Archive from inbox"
-                aria-label="Archive from inbox"
-              >
-                <Archive className="h-4 w-4" />
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              onClick={copyIssueToClipboard}
-              title="Copy issue as markdown"
-            >
-              {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              className={cn(
-                "shrink-0 transition-opacity duration-200",
-                panelVisible ? "opacity-0 pointer-events-none w-0 overflow-hidden" : "opacity-100",
-              )}
-              onClick={() => setPanelVisible(true)}
-              title="Show properties"
-            >
-              <SlidersHorizontal className="h-4 w-4" />
-            </Button>
-
-            <Popover open={moreOpen} onOpenChange={setMoreOpen}>
-              <PopoverTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  className="shrink-0"
-                  aria-label="More issue actions"
-                  title="More issue actions"
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault();
-                      setMoreOpen(true);
-                    }
-                  }}
-                >
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </PopoverTrigger>
-            <PopoverContent className="w-52 p-1" align="end">
-              {canShowSubtreeControls ? (
-                <>
-                  <button
-                    className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
-                    onClick={() => {
-                      setTreeControlMode("pause");
-                      setTreeControlCancelConfirmed(false);
-                      setTreeControlOpen(true);
-                      setMoreOpen(false);
-                    }}
-                  >
-                    <PauseCircle className="h-3 w-3" />
-                    Pause subtree...
-                  </button>
-                  {canResumeSubtree ? (
-                    <button
-                      className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
-                      onClick={() => {
-                        setTreeControlMode("resume");
-                        setTreeControlWakeAgentsOnResume(true);
-                        setTreeControlOpen(true);
-                        setMoreOpen(false);
-                      }}
-                    >
-                      <PlayCircle className="h-3 w-3" />
-                      Resume subtree
-                    </button>
-                  ) : null}
-                  <button
-                    className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-destructive"
-                    onClick={() => {
-                      setTreeControlMode("cancel");
-                      setTreeControlCancelConfirmed(false);
-                      setTreeControlOpen(true);
-                      setMoreOpen(false);
-                    }}
-                  >
-                    <XCircle className="h-3 w-3" />
-                    Cancel subtree...
-                  </button>
-                  {canRestoreSubtree ? (
-                    <button
-                      className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
-                      onClick={() => {
-                        setTreeControlMode("restore");
-                        setTreeControlWakeAgentsOnResume(false);
-                        setTreeControlCancelConfirmed(false);
-                        setTreeControlOpen(true);
-                        setMoreOpen(false);
-                      }}
-                    >
-                      <Repeat className="h-3 w-3" />
-                      Restore subtree...
-                    </button>
-                  ) : null}
-                </>
-              ) : null}
-              <button
-                className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-destructive"
-                onClick={() => {
-                  updateIssue.mutate(
-                    { hiddenAt: new Date().toISOString() },
-                    { onSuccess: () => navigate("/issues/all") },
-                  );
-                  setMoreOpen(false);
-                }}
-              >
-                <EyeOff className="h-3 w-3" />
-                Hide this Issue
-              </button>
-            </PopoverContent>
-            </Popover>
-          </div>
-        </div>
-
-        <InlineEditor
-          value={issue.title}
-          onSave={(title) => updateIssue.mutateAsync({ title })}
-          as="h2"
-          className="text-xl font-bold"
-        />
-
+      <TruncatedDescription signal={issue.description ?? ""}>
         <InlineEditor
           value={issue.description ?? ""}
           onSave={(description) => updateIssue.mutateAsync({ description })}
@@ -3117,7 +3402,7 @@ export function IssueDetail() {
             await uploadAttachment.mutateAsync(file);
           }}
         />
-      </div>
+      </TruncatedDescription>
 
       <PluginSlotOutlet
         slotTypes={["toolbarButton", "contextMenuItem"]}
@@ -3363,115 +3648,35 @@ export function IssueDetail() {
         onUpdate={(data) => updateIssue.mutate(data)}
       />
 
-      <Separator />
-
-      <Tabs value={detailTab} onValueChange={setDetailTab} className="space-y-3">
-        <TabsList variant="line" className="w-full justify-start gap-1">
-          <TabsTrigger value="chat" className="gap-1.5">
-            <MessageSquare className="h-3.5 w-3.5" />
-            Chat
-          </TabsTrigger>
-          <TabsTrigger value="activity" className="gap-1.5">
-            <ActivityIcon className="h-3.5 w-3.5" />
-            Activity
-          </TabsTrigger>
-          <TabsTrigger value="related-work" className="gap-1.5">
-            <ListTree className="h-3.5 w-3.5" />
-            Related work
-          </TabsTrigger>
+      {issuePluginTabItems.length > 0 && (
+        <Tabs
+          value={activePluginTab?.value ?? issuePluginTabItems[0]!.value}
+          onValueChange={setDetailTab}
+          className="space-y-3"
+        >
+          <TabsList variant="line" className="w-full justify-start gap-1">
+            {issuePluginTabItems.map((item) => (
+              <TabsTrigger key={item.value} value={item.value}>
+                {item.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
           {issuePluginTabItems.map((item) => (
-            <TabsTrigger key={item.value} value={item.value}>
-              {item.label}
-            </TabsTrigger>
+            <TabsContent key={item.value} value={item.value}>
+              <PluginSlotMount
+                slot={item.slot}
+                context={{
+                  companyId: issue.companyId,
+                  projectId: issue.projectId ?? null,
+                  entityId: issue.id,
+                  entityType: "issue",
+                }}
+                missingBehavior="placeholder"
+              />
+            </TabsContent>
           ))}
-        </TabsList>
-
-        <TabsContent value="chat">
-          {detailTab === "chat" ? (
-            <IssueDetailChatTab
-              issueId={issue.id}
-              companyId={issue.companyId}
-              projectId={issue.projectId ?? null}
-              issueStatus={issue.status}
-              executionRunId={issue.executionRunId ?? null}
-              blockedBy={issue.blockedBy ?? []}
-              blockerAttention={issue.blockerAttention ?? null}
-              comments={threadComments}
-              locallyQueuedCommentRunIds={locallyQueuedCommentRunIds}
-              interactions={interactions}
-              hasOlderComments={hasOlderComments}
-              commentsLoadingOlder={commentsLoadingOlder}
-              onLoadOlderComments={loadOlderComments}
-              composerRef={commentComposerRef}
-              feedbackVotes={feedbackVotes}
-              feedbackDataSharingPreference={feedbackDataSharingPreference}
-              feedbackTermsUrl={FEEDBACK_TERMS_URL}
-              agentMap={agentMap}
-              currentUserId={currentUserId}
-              userLabelMap={userLabelMap}
-              userProfileMap={userProfileMap}
-              draftKey={`paperclip:issue-comment-draft:${issue.id}`}
-              reassignOptions={commentReassignOptions}
-              currentAssigneeValue={actualAssigneeValue}
-              suggestedAssigneeValue={suggestedAssigneeValue}
-              mentions={mentionOptions}
-              composerDisabledReason={commentComposerDisabledReason}
-              composerHint={composerHint}
-              queuedCommentReason={queuedCommentReason}
-              onVote={handleCommentVote}
-              onAdd={handleChatAdd}
-              onImageUpload={handleCommentImageUpload}
-              onAttachImage={handleCommentAttachImage}
-              onInterruptQueued={handleInterruptQueuedRun}
-              onCancelQueued={handleCancelQueuedComment}
-              interruptingQueuedRunId={interruptQueuedComment.isPending ? interruptQueuedComment.variables ?? null : null}
-              onImageClick={handleChatImageClick}
-              onAcceptInteraction={handleAcceptInteraction}
-              onRejectInteraction={handleRejectInteraction}
-              onSubmitInteractionAnswers={handleSubmitInteractionAnswers}
-            />
-          ) : null}
-        </TabsContent>
-
-        <TabsContent value="activity">
-          {detailTab === "activity" ? (
-            <IssueDetailActivityTab
-              issueId={issue.id}
-              companyId={issue.companyId}
-              issueStatus={issue.status}
-              childIssues={childIssues}
-              agentMap={agentMap}
-              hasLiveRuns={hasLiveRuns}
-              currentUserId={currentUserId}
-              userProfileMap={userProfileMap}
-              pendingApprovalAction={pendingApprovalAction}
-              handoffFocusSignal={handoffFocusSignal}
-              onApprovalAction={(approvalId, action) => {
-                approvalDecision.mutate({ approvalId, action });
-              }}
-            />
-          ) : null}
-        </TabsContent>
-
-        <TabsContent value="related-work">
-          <IssueRelatedWorkPanel relatedWork={issue.relatedWork} />
-        </TabsContent>
-
-        {activePluginTab && (
-          <TabsContent value={activePluginTab.value}>
-            <PluginSlotMount
-              slot={activePluginTab.slot}
-              context={{
-                companyId: issue.companyId,
-                projectId: issue.projectId ?? null,
-                entityId: issue.id,
-                entityType: "issue",
-              }}
-              missingBehavior="placeholder"
-            />
-          </TabsContent>
-        )}
-      </Tabs>
+        </Tabs>
+      )}
 
       <Dialog open={treeControlOpen} onOpenChange={setTreeControlOpen}>
         <DialogContent className="flex max-h-[calc(100dvh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-[560px]">
@@ -3624,26 +3829,35 @@ export function IssueDetail() {
         </DialogContent>
       </Dialog>
 
-      {/* Mobile properties drawer */}
-      <Sheet open={mobilePropsOpen} onOpenChange={setMobilePropsOpen}>
-        <SheetContent side="bottom" className="max-h-[85dvh] pb-[env(safe-area-inset-bottom)]">
-          <SheetHeader>
-            <SheetTitle className="text-sm">Properties</SheetTitle>
-          </SheetHeader>
-          <ScrollArea className="flex-1 overflow-y-auto">
-            <div className="px-4 pb-4">
-              <IssueProperties
-                issue={issue}
-                childIssues={childIssues}
-                onAddSubIssue={openNewSubIssue}
-                onUpdate={(data) => updateIssue.mutate(data)}
-                inline
-              />
-            </div>
-          </ScrollArea>
-        </SheetContent>
-      </Sheet>
-      <ScrollToBottom />
+      {stackedLayout && (
+        <>
+          <Separator />
+          {renderChatColumn("stacked")}
+        </>
+      )}
+        </div>
+      </aside>
     </div>
+
+    <Sheet open={mobilePropsOpen} onOpenChange={setMobilePropsOpen}>
+      <SheetContent side="bottom" className="max-h-[85dvh] pb-[env(safe-area-inset-bottom)]">
+        <SheetHeader>
+          <SheetTitle className="text-sm">Properties</SheetTitle>
+        </SheetHeader>
+        <ScrollArea className="flex-1 overflow-y-auto">
+          <div className="px-4 pb-4">
+            <IssueProperties
+              issue={issue}
+              childIssues={childIssues}
+              onAddSubIssue={openNewSubIssue}
+              onUpdate={(data) => updateIssue.mutate(data)}
+              inline
+            />
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+    <ScrollToBottom />
+    </>
   );
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and operators spend most of their time in issues talking to those agents.
> - The issue detail page is where all of that happens — comments, plan revisions, approvals.
> - Today the chat lives in a tabbed split at the bottom of a long scrolling page. To catch up on a new agent message you scroll the whole window down; the composer scrolls away with it.
> - This PR makes the conversation the primary surface: a chat-first 60/40 split with a pinned composer and a sticky-header rail on wide viewports, falling back to the legacy stacked layout when the page can't fit both columns comfortably.
> - The day-to-day benefit is that "an update arrived" and "I can see it and reply" are one click apart instead of a scroll.

## What Changed

- **Chat-first split on wide viewports.** `IssueDetail` now renders a 60/40 split (chat left, rail right) above ~1080 px container width. Drag handle for resize, persisted in localStorage, with pixel-min floors so neither column can shrink into uselessness. Below the threshold the page snaps back to the existing stacked layout.
- **`IssueChatThread` got a `layout` prop.** New `"filled"` mode runs an internal scroll viewport with the composer pinned at the bottom, auto-scroll-to-latest on first load, sticky-on-bottom follow during streams, and a "Jump to latest" pill when you've scrolled away. Default `"stacked"` is unchanged so other callers aren't affected.
- **Sticky rail header** — status, identifier, title, live pill, plus a `Settings2` toggle and a More menu (copy / archive / hide). The toggle reveals a foldable details panel where `IssueProperties` is now inlined, replacing the global `PropertiesPanel` push for this page.
- **Description truncates to 6 lines** with show-more / show-less. The clamp drops via `focus-within` while the inline editor is active so editing isn't cut off.
- **Per-document collapse defaults to closed** in `IssueDocumentsSection`. Storage key migrated; old fold-state entries become inert. Newly-created docs auto-expand on save.
- **Activity preserved as a `[Chat | Activity]` toggle** inside the chat column instead of a separate tab beneath the page. Continuation-summary deep links flip the toggle automatically.
- **Lab page** at `/tests/ux/chat` got a chat-first preview section to iterate on the design with fixture data, no live backend needed.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @paperclipai/ui exec tsc -b` — clean
- `pnpm --filter @paperclipai/ui exec vitest run` — 497 / 497 across 99 files
- Drove it manually on `/issues/:id` and `/tests/ux/chat` at desktop and narrow-window sizes. Resize, fold, document expansion, Chat/Activity toggle, sticky header behavior all behave as designed.

## Risks

- This is a real visual reshuffle of `IssueDetail`. Worth a UX pass on a real touch device — I haven't tested on phones.
- Per-document fold preferences reset once because of the storage-key rename. Not data loss, just a "everything's collapsed again" on first visit.
- The persisted split percentage isn't re-clamped when the viewport shrinks. A user who saved 28% on a narrow window could see a sub-min rail when the window grows just past the stack threshold. Self-corrects on the next drag.
- UI-only, no migrations.

## Screenshots (after)

<img width="2326" height="1710" alt="Screenshot_2026-04-24__18 40 492x" src="https://github.com/user-attachments/assets/a62b8c4b-a1a6-4e56-a5bd-2cbefd71dcaf" />
<img width="2326" height="1710" alt="Screenshot_2026-04-24__18 44 442x" src="https://github.com/user-attachments/assets/6bc36800-7038-4d01-8db3-d5549cca4dcd" />


## Model Used

- Anthropic Claude `claude-opus-4-7` (Opus 4.7, 1M context), tool-enabled coding mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — *to attach as a comment*
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
