### PR TITLE
feat(server): quota-aware bounded retry backoff for heartbeat (PMSA-18)

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import type {
+  AdapterExecutionContext,
+  AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
 import {
   adapterExecutionTargetIsRemote,
@@ -39,9 +42,8 @@ import {
   parseClaudeStreamJson,
   describeClaudeFailure,
   detectClaudeLoginRequired,
-  extractClaudeRetryNotBefore,
+  classifyClaudeFailure,
   isClaudeMaxTurnsResult,
-  isClaudeTransientUpstreamError,
   isClaudeUnknownSessionError,
 } from "./parse.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
@@ -87,7 +89,10 @@ function buildLoginResult(input: {
   };
 }
 
-function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
+function hasNonEmptyEnvValue(
+  env: Record<string, string>,
+  key: string,
+): boolean {
   const raw = env[key];
   return typeof raw === "string" && raw.trim().length > 0;
 }
@@ -100,12 +105,16 @@ function isBedrockAuth(env: Record<string, string>): boolean {
   );
 }
 
-function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
+function resolveClaudeBillingType(
+  env: Record<string, string>,
+): "api" | "subscription" | "metered_api" {
   if (isBedrockAuth(env)) return "metered_api";
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
 }
 
-async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {
+async function buildClaudeRuntimeConfig(
+  input: ClaudeExecutionInput,
+): Promise<ClaudeRuntimeConfig> {
   const { runId, agent, config, context, executionTarget, authToken } = input;
 
   const command = asString(config.command, "claude");
@@ -117,58 +126,82 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "") || null;
   const workspaceRepoRef = asString(workspaceContext.repoRef, "") || null;
   const workspaceBranch = asString(workspaceContext.branchName, "") || null;
-  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "") || null;
+  const workspaceWorktreePath =
+    asString(workspaceContext.worktreePath, "") || null;
   const agentHome = asString(workspaceContext.agentHome, "") || null;
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
-        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+        (value): value is Record<string, unknown> =>
+          typeof value === "object" && value !== null,
       )
     : [];
-  const runtimeServiceIntents = Array.isArray(context.paperclipRuntimeServiceIntents)
+  const runtimeServiceIntents = Array.isArray(
+    context.paperclipRuntimeServiceIntents,
+  )
     ? context.paperclipRuntimeServiceIntents.filter(
-        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+        (value): value is Record<string, unknown> =>
+          typeof value === "object" && value !== null,
       )
     : [];
   const runtimeServices = Array.isArray(context.paperclipRuntimeServices)
     ? context.paperclipRuntimeServices.filter(
-        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+        (value): value is Record<string, unknown> =>
+          typeof value === "object" && value !== null,
       )
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const useConfiguredInsteadOfAgentHome =
+    workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome
+    ? ""
+    : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
 
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
-    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+    typeof envConfig.PAPERCLIP_API_KEY === "string" &&
+    envConfig.PAPERCLIP_API_KEY.trim().length > 0;
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
   env.PAPERCLIP_RUN_ID = runId;
 
   const wakeTaskId =
-    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
-    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    (typeof context.taskId === "string" &&
+      context.taskId.trim().length > 0 &&
+      context.taskId.trim()) ||
+    (typeof context.issueId === "string" &&
+      context.issueId.trim().length > 0 &&
+      context.issueId.trim()) ||
     null;
   const wakeReason =
-    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+    typeof context.wakeReason === "string" &&
+    context.wakeReason.trim().length > 0
       ? context.wakeReason.trim()
       : null;
   const wakeCommentId =
-    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
-    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    (typeof context.wakeCommentId === "string" &&
+      context.wakeCommentId.trim().length > 0 &&
+      context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" &&
+      context.commentId.trim().length > 0 &&
+      context.commentId.trim()) ||
     null;
   const approvalId =
-    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+    typeof context.approvalId === "string" &&
+    context.approvalId.trim().length > 0
       ? context.approvalId.trim()
       : null;
   const approvalStatus =
-    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+    typeof context.approvalStatus === "string" &&
+    context.approvalStatus.trim().length > 0
       ? context.approvalStatus.trim()
       : null;
   const linkedIssueIds = Array.isArray(context.issueIds)
-    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    ? context.issueIds.filter(
+        (value): value is string =>
+          typeof value === "string" && value.trim().length > 0,
+      )
     : [];
   const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
 
@@ -224,7 +257,9 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
   }
   if (runtimeServiceIntents.length > 0) {
-    env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(runtimeServiceIntents);
+    env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(
+      runtimeServiceIntents,
+    );
   }
   if (runtimeServices.length > 0) {
     env.PAPERCLIP_RUNTIME_SERVICES_JSON = JSON.stringify(runtimeServices);
@@ -232,7 +267,8 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   if (runtimePrimaryUrl) {
     env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
   }
-  const targetPaperclipApiUrl = adapterExecutionTargetPaperclipApiUrl(executionTarget);
+  const targetPaperclipApiUrl =
+    adapterExecutionTargetPaperclipApiUrl(executionTarget);
   if (targetPaperclipApiUrl) {
     env.PAPERCLIP_API_URL = targetPaperclipApiUrl;
   }
@@ -246,8 +282,18 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   }
 
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
-  await ensureAdapterExecutionTargetCommandResolvable(command, executionTarget, cwd, runtimeEnv);
-  const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(command, executionTarget, cwd, runtimeEnv);
+  await ensureAdapterExecutionTargetCommandResolvable(
+    command,
+    executionTarget,
+    cwd,
+    runtimeEnv,
+  );
+  const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(
+    command,
+    executionTarget,
+    cwd,
+    runtimeEnv,
+  );
   const loggedEnv = buildInvocationEnvForLogs(env, {
     runtimeEnv,
     includeRuntimeKeys: ["HOME", "CLAUDE_CONFIG_DIR"],
@@ -294,13 +340,19 @@ export async function runClaudeLogin(input: {
     authToken: input.authToken,
   });
 
-  const proc = await runAdapterExecutionTargetProcess(input.runId, null, runtime.command, ["login"], {
-    cwd: runtime.cwd,
-    env: runtime.env,
-    timeoutSec: runtime.timeoutSec,
-    graceSec: runtime.graceSec,
-    onLog,
-  });
+  const proc = await runAdapterExecutionTargetProcess(
+    input.runId,
+    null,
+    runtime.command,
+    ["login"],
+    {
+      cwd: runtime.cwd,
+      env: runtime.env,
+      timeoutSec: runtime.timeoutSec,
+      graceSec: runtime.graceSec,
+      onLog,
+    },
+  );
 
   const loginMeta = detectClaudeLoginRequired({
     parsed: null,
@@ -314,13 +366,26 @@ export async function runClaudeLogin(input: {
   });
 }
 
-export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+export async function execute(
+  ctx: AdapterExecutionContext,
+): Promise<AdapterExecutionResult> {
+  const {
+    runId,
+    agent,
+    runtime,
+    config,
+    context,
+    onLog,
+    onMeta,
+    onSpawn,
+    authToken,
+  } = ctx;
   const executionTarget = readAdapterExecutionTarget({
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
   });
-  const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
+  const executionTargetIsRemote =
+    adapterExecutionTargetIsRemote(executionTarget);
 
   const promptTemplate = asString(
     config.promptTemplate,
@@ -330,9 +395,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effort = asString(config.effort, "");
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
-  const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+  const dangerouslySkipPermissions = asBoolean(
+    config.dangerouslySkipPermissions,
+    true,
+  );
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
-  const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  const instructionsFileDir = instructionsFilePath
+    ? `${path.dirname(instructionsFilePath)}/`
+    : "";
   const runtimeConfig = await buildClaudeRuntimeConfig({
     runId,
     agent,
@@ -354,7 +424,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     graceSec,
     extraArgs,
   } = runtimeConfig;
-  const effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
+  const effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(
+    executionTarget,
+    cwd,
+  );
   const terminalResultCleanupGraceMs = Math.max(
     0,
     asNumber(config.terminalResultCleanupGraceMs, 5_000),
@@ -365,15 +438,23 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     ),
   );
   const billingType = resolveClaudeBillingType(effectiveEnv);
-  const claudeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
-  const desiredSkillNames = new Set(resolveClaudeDesiredSkillNames(config, claudeSkillEntries));
+  const claudeSkillEntries = await readPaperclipRuntimeSkillEntries(
+    config,
+    __moduleDir,
+  );
+  const desiredSkillNames = new Set(
+    resolveClaudeDesiredSkillNames(config, claudeSkillEntries),
+  );
   // When instructionsFilePath is configured, build a stable content-addressed
   // file that includes both the file content and the path directive, so we only
   // need --append-system-prompt-file (Claude CLI forbids using both flags together).
   let combinedInstructionsContents: string | null = null;
   if (instructionsFilePath) {
     try {
-      const instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
+      const instructionsContent = await fs.readFile(
+        instructionsFilePath,
+        "utf-8",
+      );
       const pathDirective =
         `\nThe above agent instructions were loaded from ${instructionsFilePath}. ` +
         `Resolve any relative file references from ${instructionsFileDir}. ` +
@@ -390,7 +471,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   const promptBundle = await prepareClaudePromptBundle({
     companyId: agent.companyId,
-    skills: claudeSkillEntries.filter((entry) => desiredSkillNames.has(entry.key)),
+    skills: claudeSkillEntries.filter((entry) =>
+      desiredSkillNames.has(entry.key),
+    ),
     instructionsContents: combinedInstructionsContents,
     onLog,
   });
@@ -418,33 +501,51 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     ? () => preparedExecutionTargetRuntime.restoreWorkspace()
     : null;
   const effectivePromptBundleAddDir = executionTargetIsRemote
-    ? preparedExecutionTargetRuntime?.assetDirs.skills ??
-      path.posix.join(effectiveExecutionCwd, ".paperclip-runtime", "claude", "skills")
+    ? (preparedExecutionTargetRuntime?.assetDirs.skills ??
+      path.posix.join(
+        effectiveExecutionCwd,
+        ".paperclip-runtime",
+        "claude",
+        "skills",
+      ))
     : promptBundle.addDir;
   const effectiveInstructionsFilePath = promptBundle.instructionsFilePath
     ? executionTargetIsRemote
-      ? path.posix.join(effectivePromptBundleAddDir, path.basename(promptBundle.instructionsFilePath))
+      ? path.posix.join(
+          effectivePromptBundleAddDir,
+          path.basename(promptBundle.instructionsFilePath),
+        )
       : promptBundle.instructionsFilePath
     : undefined;
 
   const runtimeSessionParams = parseObject(runtime.sessionParams);
-  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionId = asString(
+    runtimeSessionParams.sessionId,
+    runtime.sessionId ?? "",
+  );
   const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
-  const runtimeRemoteExecution = parseObject(runtimeSessionParams.remoteExecution);
-  const runtimePromptBundleKey = asString(runtimeSessionParams.promptBundleKey, "");
+  const runtimeRemoteExecution = parseObject(
+    runtimeSessionParams.remoteExecution,
+  );
+  const runtimePromptBundleKey = asString(
+    runtimeSessionParams.promptBundleKey,
+    "",
+  );
   const hasMatchingPromptBundle =
-    runtimePromptBundleKey.length === 0 || runtimePromptBundleKey === promptBundle.bundleKey;
+    runtimePromptBundleKey.length === 0 ||
+    runtimePromptBundleKey === promptBundle.bundleKey;
   const canResumeSession =
     runtimeSessionId.length > 0 &&
     hasMatchingPromptBundle &&
-    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(effectiveExecutionCwd)) &&
-    adapterExecutionTargetSessionMatches(runtimeRemoteExecution, executionTarget);
+    (runtimeSessionCwd.length === 0 ||
+      path.resolve(runtimeSessionCwd) ===
+        path.resolve(effectiveExecutionCwd)) &&
+    adapterExecutionTargetSessionMatches(
+      runtimeRemoteExecution,
+      executionTarget,
+    );
   const sessionId = canResumeSession ? runtimeSessionId : null;
-  if (
-    executionTargetIsRemote &&
-    runtimeSessionId &&
-    !canResumeSession
-  ) {
+  if (executionTargetIsRemote && runtimeSessionId && !canResumeSession) {
     await onLog(
       "stdout",
       `[paperclip] Claude session "${runtimeSessionId}" does not match the current remote execution identity and will not be resumed in "${effectiveExecutionCwd}". Starting a fresh remote session.\n`,
@@ -464,7 +565,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Claude session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${effectiveExecutionCwd}".\n`,
     );
   }
-  if (runtimeSessionId && runtimePromptBundleKey.length > 0 && runtimePromptBundleKey !== promptBundle.bundleKey) {
+  if (
+    runtimeSessionId &&
+    runtimePromptBundleKey.length > 0 &&
+    runtimePromptBundleKey !== promptBundle.bundleKey
+  ) {
     await onLog(
       "stdout",
       `[paperclip] Claude session "${runtimeSessionId}" was saved for prompt bundle "${runtimePromptBundleKey}" and will not be resumed with "${promptBundle.bundleKey}".\n`,
@@ -484,10 +589,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     !sessionId && bootstrapPromptTemplate.trim().length > 0
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
-  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: Boolean(sessionId) });
-  const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
-  const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
-  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, {
+    resumedSession: Boolean(sessionId),
+  });
+  const shouldUseResumeDeltaPrompt =
+    Boolean(sessionId) && wakePrompt.length > 0;
+  const renderedPrompt = shouldUseResumeDeltaPrompt
+    ? ""
+    : renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(
+    context.paperclipSessionHandoffMarkdown,
+    "",
+  ).trim();
   const taskContextNote = asString(context.paperclipTaskMarkdown, "").trim();
   const prompt = joinPromptSections([
     renderedBootstrapPrompt,
@@ -509,7 +622,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     resumeSessionId: string | null,
     attemptInstructionsFilePath: string | undefined,
   ) => {
-    const args = ["--print", "-", "--output-format", "stream-json", "--verbose"];
+    const args = [
+      "--print",
+      "-",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+    ];
     if (resumeSessionId) args.push("--resume", resumeSessionId);
     if (dangerouslySkipPermissions) args.push("--dangerously-skip-permissions");
     if (chrome) args.push("--chrome");
@@ -549,11 +668,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const runAttempt = async (resumeSessionId: string | null) => {
-    const attemptInstructionsFilePath = resumeSessionId ? undefined : effectiveInstructionsFilePath;
+    const attemptInstructionsFilePath = resumeSessionId
+      ? undefined
+      : effectiveInstructionsFilePath;
     const args = buildClaudeArgs(resumeSessionId, attemptInstructionsFilePath);
     const commandNotes: string[] = [];
     if (!resumeSessionId) {
-      commandNotes.push(`Using stable Claude prompt bundle ${promptBundle.bundleKey}.`);
+      commandNotes.push(
+        `Using stable Claude prompt bundle ${promptBundle.bundleKey}.`,
+      );
     }
     if (attemptInstructionsFilePath && !resumeSessionId) {
       commandNotes.push(
@@ -574,19 +697,26 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       });
     }
 
-    const proc = await runAdapterExecutionTargetProcess(runId, executionTarget, command, args, {
-      cwd,
-      env,
-      stdin: prompt,
-      timeoutSec,
-      graceSec,
-      onSpawn,
-      onLog,
-      terminalResultCleanup: {
-        graceMs: terminalResultCleanupGraceMs,
-        hasTerminalResult: ({ stdout }) => parseClaudeStreamJson(stdout).resultJson !== null,
+    const proc = await runAdapterExecutionTargetProcess(
+      runId,
+      executionTarget,
+      command,
+      args,
+      {
+        cwd,
+        env,
+        stdin: prompt,
+        timeoutSec,
+        graceSec,
+        onSpawn,
+        onLog,
+        terminalResultCleanup: {
+          graceMs: terminalResultCleanupGraceMs,
+          hasTerminalResult: ({ stdout }) =>
+            parseClaudeStreamJson(stdout).resultJson !== null,
+        },
       },
-    });
+    );
 
     const parsedStream = parseClaudeStreamJson(proc.stdout);
     const parsed = parsedStream.resultJson ?? parseJson(proc.stdout);
@@ -599,7 +729,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       parsedStream: ReturnType<typeof parseClaudeStreamJson>;
       parsed: Record<string, unknown> | null;
     },
-    opts: { fallbackSessionId: string | null; clearSessionOnMissingSession?: boolean },
+    opts: {
+      fallbackSessionId: string | null;
+      clearSessionOnMissingSession?: boolean;
+    },
   ): AdapterExecutionResult => {
     const { proc, parsedStream, parsed } = attempt;
     const loginMeta = detectClaudeLoginRequired({
@@ -628,46 +761,49 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     if (!parsed) {
       const fallbackErrorMessage = parseFallbackErrorMessage(proc);
-      const transientUpstream =
-        !loginMeta.requiresLogin &&
-        (proc.exitCode ?? 0) !== 0 &&
-        isClaudeTransientUpstreamError({
-          parsed: null,
-          stdout: proc.stdout,
-          stderr: proc.stderr,
-          errorMessage: fallbackErrorMessage,
-        });
-      const transientRetryNotBefore = transientUpstream
-        ? extractClaudeRetryNotBefore({
+      const procFailed = (proc.exitCode ?? 0) !== 0;
+      const classification = procFailed
+        ? classifyClaudeFailure({
             parsed: null,
             stdout: proc.stdout,
             stderr: proc.stderr,
             errorMessage: fallbackErrorMessage,
           })
         : null;
-      const errorCode = loginMeta.requiresLogin
-        ? "claude_auth_required"
-        : transientUpstream
-        ? "claude_transient_upstream"
+      const isTransientFamily =
+        classification?.errorFamily === "transient_upstream";
+      const retryNotBefore = isTransientFamily
+        ? (classification?.retryNotBefore ?? null)
         : null;
+      const retryNotBeforeIso = retryNotBefore
+        ? retryNotBefore.toISOString()
+        : null;
+      const errorCode = classification?.errorCode ?? null;
       return {
         exitCode: proc.exitCode,
         signal: proc.signal,
         timedOut: false,
         errorMessage: fallbackErrorMessage,
         errorCode,
-        errorFamily: transientUpstream ? "transient_upstream" : null,
-        retryNotBefore: transientRetryNotBefore ? transientRetryNotBefore.toISOString() : null,
+        errorFamily: isTransientFamily ? "transient_upstream" : null,
+        retryNotBefore: retryNotBeforeIso,
         errorMeta,
         resultJson: {
           stdout: proc.stdout,
           stderr: proc.stderr,
-          ...(transientUpstream ? { errorFamily: "transient_upstream" } : {}),
-          ...(transientRetryNotBefore
-            ? { retryNotBefore: transientRetryNotBefore.toISOString() }
+          ...(isTransientFamily ? { errorFamily: "transient_upstream" } : {}),
+          ...(retryNotBeforeIso
+            ? {
+                retryNotBefore: retryNotBeforeIso,
+                transientRetryNotBefore: retryNotBeforeIso,
+              }
             : {}),
-          ...(transientRetryNotBefore
-            ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() }
+          ...(classification?.kind ? { failureKind: classification.kind } : {}),
+          ...(classification?.httpStatus != null
+            ? { httpStatus: classification.httpStatus }
+            : {}),
+          ...(classification?.retryAfterMs != null
+            ? { retryAfterMs: classification.retryAfterMs }
             : {}),
         },
         clearSession: Boolean(opts.clearSessionOnMissingSession),
@@ -687,55 +823,64 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     const resolvedSessionId =
       parsedStream.sessionId ??
-      (asString(parsed.session_id, opts.fallbackSessionId ?? "") || opts.fallbackSessionId);
+      (asString(parsed.session_id, opts.fallbackSessionId ?? "") ||
+        opts.fallbackSessionId);
     const resolvedSessionParams = resolvedSessionId
       ? ({
-        sessionId: resolvedSessionId,
-        cwd: effectiveExecutionCwd,
-        promptBundleKey: promptBundle.bundleKey,
-        ...(executionTargetIsRemote
-          ? {
-              remoteExecution: adapterExecutionTargetSessionIdentity(executionTarget),
-            }
-          : {}),
-        ...(workspaceId ? { workspaceId } : {}),
-        ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
-        ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
-      } as Record<string, unknown>)
+          sessionId: resolvedSessionId,
+          cwd: effectiveExecutionCwd,
+          promptBundleKey: promptBundle.bundleKey,
+          ...(executionTargetIsRemote
+            ? {
+                remoteExecution:
+                  adapterExecutionTargetSessionIdentity(executionTarget),
+              }
+            : {}),
+          ...(workspaceId ? { workspaceId } : {}),
+          ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+          ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+        } as Record<string, unknown>)
       : null;
     const clearSessionForMaxTurns = isClaudeMaxTurnsResult(parsed);
     const parsedIsError = asBoolean(parsed.is_error, false);
     const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
     const errorMessage = failed
-      ? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
+      ? (describeClaudeFailure(parsed) ??
+        `Claude exited with code ${proc.exitCode ?? -1}`)
       : null;
-    const transientUpstream =
-      failed &&
-      !loginMeta.requiresLogin &&
-      isClaudeTransientUpstreamError({
-        parsed,
-        stdout: proc.stdout,
-        stderr: proc.stderr,
-        errorMessage,
-      });
-    const transientRetryNotBefore = transientUpstream
-      ? extractClaudeRetryNotBefore({
+    const classification = failed
+      ? classifyClaudeFailure({
           parsed,
           stdout: proc.stdout,
           stderr: proc.stderr,
           errorMessage,
         })
       : null;
-    const resolvedErrorCode = loginMeta.requiresLogin
-      ? "claude_auth_required"
-      : transientUpstream
-      ? "claude_transient_upstream"
+    const isTransientFamily =
+      classification?.errorFamily === "transient_upstream";
+    const transientRetryNotBefore = isTransientFamily
+      ? (classification?.retryNotBefore ?? null)
       : null;
+    const transientRetryNotBeforeIso = transientRetryNotBefore
+      ? transientRetryNotBefore.toISOString()
+      : null;
+    const resolvedErrorCode = classification?.errorCode ?? null;
     const mergedResultJson: Record<string, unknown> = {
       ...parsed,
-      ...(transientUpstream ? { errorFamily: "transient_upstream" } : {}),
-      ...(transientRetryNotBefore ? { retryNotBefore: transientRetryNotBefore.toISOString() } : {}),
-      ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
+      ...(isTransientFamily ? { errorFamily: "transient_upstream" } : {}),
+      ...(transientRetryNotBeforeIso
+        ? {
+            retryNotBefore: transientRetryNotBeforeIso,
+            transientRetryNotBefore: transientRetryNotBeforeIso,
+          }
+        : {}),
+      ...(classification?.kind ? { failureKind: classification.kind } : {}),
+      ...(classification?.httpStatus != null
+        ? { httpStatus: classification.httpStatus }
+        : {}),
+      ...(classification?.retryAfterMs != null
+        ? { retryAfterMs: classification.retryAfterMs }
+        : {}),
     };
 
     return {
@@ -744,8 +889,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       timedOut: false,
       errorMessage,
       errorCode: resolvedErrorCode,
-      errorFamily: transientUpstream ? "transient_upstream" : null,
-      retryNotBefore: transientRetryNotBefore ? transientRetryNotBefore.toISOString() : null,
+      errorFamily: isTransientFamily ? "transient_upstream" : null,
+      retryNotBefore: transientRetryNotBeforeIso,
       errorMeta,
       usage,
       sessionId: resolvedSessionId,
@@ -758,7 +903,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       costUsd: parsedStream.costUsd ?? asNumber(parsed.total_cost_usd, 0),
       resultJson: mergedResultJson,
       summary: parsedStream.summary || asString(parsed.result, ""),
-      clearSession: clearSessionForMaxTurns || Boolean(opts.clearSessionOnMissingSession && !resolvedSessionId),
+      clearSession:
+        clearSessionForMaxTurns ||
+        Boolean(opts.clearSessionOnMissingSession && !resolvedSessionId),
     };
   };
 
@@ -776,10 +923,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
-      return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+      return toAdapterResult(retry, {
+        fallbackSessionId: null,
+        clearSessionOnMissingSession: true,
+      });
     }
 
-    return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+    return toAdapterResult(initial, {
+      fallbackSessionId: runtimeSessionId || runtime.sessionId,
+    });
   } finally {
     if (restoreRemoteWorkspace) {
       await onLog(

--- a/packages/adapters/claude-local/src/server/parse-classify.test.ts
+++ b/packages/adapters/claude-local/src/server/parse-classify.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { classifyClaudeFailure } from "./parse.js";
+
+describe("classifyClaudeFailure", () => {
+  it("returns null kind when there is no failure signal", () => {
+    const result = classifyClaudeFailure({ stdout: "", stderr: "" });
+    expect(result.kind).toBeNull();
+    expect(result.errorCode).toBeNull();
+    expect(result.errorFamily).toBeNull();
+  });
+
+  it("classifies the explicit 'not logged in' copy as auth_required", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        result: "Please log in. Run `claude login` first.",
+      },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.kind).toBe("auth_required");
+    expect(result.errorCode).toBe("claude_auth_required");
+    expect(result.errorFamily).toBe("auth");
+  });
+
+  it("classifies api_error_status:401 (without auth copy) as quota_exhausted", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        errors: [
+          {
+            message:
+              "Anthropic API request failed: api_error_status: 401 (subscription token rejected)",
+          },
+        ],
+      },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.kind).toBe("quota_exhausted");
+    expect(result.errorCode).toBe("claude_quota_exhausted");
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.httpStatus).toBe(401);
+  });
+
+  it("classifies 'quota exhausted' wording without an HTTP status as quota_exhausted", () => {
+    const result = classifyClaudeFailure({
+      parsed: { is_error: true, result: "Monthly Opus quota exhausted." },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.kind).toBe("quota_exhausted");
+    expect(result.errorCode).toBe("claude_quota_exhausted");
+  });
+
+  it("classifies api_error_status:429 as rate_limited", () => {
+    const result = classifyClaudeFailure({
+      stderr: "Anthropic responded api_error_status: 429 Too Many Requests",
+    });
+    expect(result.kind).toBe("rate_limited");
+    expect(result.errorCode).toBe("claude_rate_limited");
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.httpStatus).toBe(429);
+  });
+
+  it("classifies a 429 stderr line without api_error_status as rate_limited", () => {
+    const result = classifyClaudeFailure({
+      stderr: "HTTP 429: Too Many Requests",
+    });
+    expect(result.kind).toBe("rate_limited");
+    expect(result.errorCode).toBe("claude_rate_limited");
+  });
+
+  it("classifies rate_limit_error events as rate_limited", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        errors: [
+          {
+            type: "rate_limit_error",
+            message: "Rate limit reached for requests.",
+          },
+        ],
+      },
+    });
+    expect(result.kind).toBe("rate_limited");
+    expect(result.errorCode).toBe("claude_rate_limited");
+  });
+
+  it("classifies api_error_status:503 as provider_5xx", () => {
+    const result = classifyClaudeFailure({
+      stderr: "api_error_status: 503 Service Unavailable",
+    });
+    expect(result.kind).toBe("provider_5xx");
+    expect(result.errorCode).toBe("claude_provider_5xx");
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.httpStatus).toBe(503);
+  });
+
+  it("classifies api_error_status:500 as provider_5xx", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        errors: [{ message: "Upstream failure api_error_status: 500" }],
+      },
+    });
+    expect(result.kind).toBe("provider_5xx");
+    expect(result.errorCode).toBe("claude_provider_5xx");
+    expect(result.httpStatus).toBe(500);
+  });
+
+  it("falls back to transient_upstream for overloaded/throttling without a status code", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        errors: [{ type: "overloaded_error", message: "Overloaded" }],
+      },
+    });
+    expect(result.kind).toBe("transient_upstream");
+    expect(result.errorCode).toBe("claude_transient_upstream");
+    expect(result.errorFamily).toBe("transient_upstream");
+  });
+
+  it("falls back to transient_upstream for 'out of extra usage' subscription wording", () => {
+    const result = classifyClaudeFailure({
+      errorMessage: "You're out of extra usage · resets 4pm (America/Chicago)",
+    });
+    // "out of extra usage" is a quota-shaped wording, so we treat it as quota_exhausted.
+    expect(result.kind).toBe("quota_exhausted");
+    expect(result.errorCode).toBe("claude_quota_exhausted");
+    expect(result.errorFamily).toBe("transient_upstream");
+  });
+
+  it("ignores deterministic max-turns failures", () => {
+    const result = classifyClaudeFailure({
+      parsed: { subtype: "error_max_turns", result: "Maximum turns reached." },
+    });
+    expect(result.kind).toBeNull();
+    expect(result.errorCode).toBeNull();
+  });
+
+  it("ignores deterministic unknown-session failures", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        result: "No conversation found with session id abc-123",
+        errors: [{ message: "No conversation found with session id abc-123" }],
+      },
+    });
+    expect(result.kind).toBeNull();
+    expect(result.errorCode).toBeNull();
+  });
+
+  it("auth-required wins over a coincidental 401 status", () => {
+    const result = classifyClaudeFailure({
+      parsed: {
+        is_error: true,
+        result: "Please log in. api_error_status: 401",
+      },
+    });
+    expect(result.kind).toBe("auth_required");
+    expect(result.errorCode).toBe("claude_auth_required");
+  });
+
+  it("extracts retry-after seconds when present", () => {
+    const result = classifyClaudeFailure({
+      stderr: "api_error_status: 429 Too Many Requests retry-after: 30",
+    });
+    expect(result.kind).toBe("rate_limited");
+    expect(result.retryAfterMs).toBe(30_000);
+  });
+
+  it("returns the loginUrl alongside the classification when one is in the output", () => {
+    const result = classifyClaudeFailure({
+      stdout: "Please log in. Visit https://claude.ai/login to continue.",
+    });
+    expect(result.kind).toBe("auth_required");
+    expect(result.loginUrl).toContain("claude.ai/login");
+  });
+});

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -6,11 +6,22 @@ import {
   parseJson,
 } from "@paperclipai/adapter-utils/server-utils";
 
-const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?|login\s+required|requires\s+login|unauthorized|authentication\s+required)/i;
+const CLAUDE_AUTH_REQUIRED_RE =
+  /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?|login\s+required|requires\s+login|unauthorized|authentication\s+required)/i;
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
   /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+
+// PMSA-15 / PMSA-11 §2.1: granular classification for Anthropic-side failures.
+// See /PMSA/issues/PMSA-11#document-plan section 2.1 for the truth table.
+const CLAUDE_API_ERROR_STATUS_RE = /api[_\s-]?error[_\s-]?status[:\s]+(\d{3})/i;
+const CLAUDE_QUOTA_EXHAUSTED_RE =
+  /(?:quota[_\s-]?(?:exhausted|exceeded)|monthly\s+quota|opus\s+quota|out\s+of\s+extra\s+usage|claude\s+usage\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached)/i;
+const CLAUDE_RATE_LIMIT_RE =
+  /(?:rate[-\s]?limit(?:ed|_error)?|too\s+many\s+requests|\b429\b|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception)/i;
+const CLAUDE_RETRY_AFTER_RE =
+  /(?:retry[-_\s]?after|x[-_]?ratelimit[-_]?reset|x[-_]?ratelimit[-_]?reset[-_]?after)[:\s=]+(\d+)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
@@ -38,7 +49,8 @@ export function parseClaudeStreamJson(stdout: string) {
       const message = parseObject(event.message);
       const content = Array.isArray(message.content) ? message.content : [];
       for (const entry of content) {
-        if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
+        if (typeof entry !== "object" || entry === null || Array.isArray(entry))
+          continue;
         const block = entry as Record<string, unknown>;
         if (asString(block.type, "") === "text") {
           const text = asString(block.text, "");
@@ -72,8 +84,12 @@ export function parseClaudeStreamJson(stdout: string) {
     outputTokens: asNumber(usageObj.output_tokens, 0),
   };
   const costRaw = finalResult.total_cost_usd;
-  const costUsd = typeof costRaw === "number" && Number.isFinite(costRaw) ? costRaw : null;
-  const summary = asString(finalResult.result, assistantTexts.join("\n\n")).trim();
+  const costUsd =
+    typeof costRaw === "number" && Number.isFinite(costRaw) ? costRaw : null;
+  const summary = asString(
+    finalResult.result,
+    assistantTexts.join("\n\n"),
+  ).trim();
 
   return {
     sessionId,
@@ -101,7 +117,10 @@ function extractClaudeErrorMessages(parsed: Record<string, unknown>): string[] {
     }
 
     const obj = entry as Record<string, unknown>;
-    const msg = asString(obj.message, "") || asString(obj.error, "") || asString(obj.code, "");
+    const msg =
+      asString(obj.message, "") ||
+      asString(obj.error, "") ||
+      asString(obj.code, "");
     if (msg) {
       messages.push(msg);
       continue;
@@ -122,7 +141,11 @@ export function extractClaudeLoginUrl(text: string): string | null {
   if (!match || match.length === 0) return null;
   for (const rawUrl of match) {
     const cleaned = rawUrl.replace(/[\])}.!,?;:'\"]+$/g, "");
-    if (cleaned.includes("claude") || cleaned.includes("anthropic") || cleaned.includes("auth")) {
+    if (
+      cleaned.includes("claude") ||
+      cleaned.includes("anthropic") ||
+      cleaned.includes("auth")
+    ) {
       return cleaned;
     }
   }
@@ -135,20 +158,29 @@ export function detectClaudeLoginRequired(input: {
   stderr: string;
 }): { requiresLogin: boolean; loginUrl: string | null } {
   const resultText = asString(input.parsed?.result, "").trim();
-  const messages = [resultText, ...extractClaudeErrorMessages(input.parsed ?? {}), input.stdout, input.stderr]
+  const messages = [
+    resultText,
+    ...extractClaudeErrorMessages(input.parsed ?? {}),
+    input.stdout,
+    input.stderr,
+  ]
     .join("\n")
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
 
-  const requiresLogin = messages.some((line) => CLAUDE_AUTH_REQUIRED_RE.test(line));
+  const requiresLogin = messages.some((line) =>
+    CLAUDE_AUTH_REQUIRED_RE.test(line),
+  );
   return {
     requiresLogin,
     loginUrl: extractClaudeLoginUrl([input.stdout, input.stderr].join("\n")),
   };
 }
 
-export function describeClaudeFailure(parsed: Record<string, unknown>): string | null {
+export function describeClaudeFailure(
+  parsed: Record<string, unknown>,
+): string | null {
   const subtype = asString(parsed.subtype, "");
   const resultText = asString(parsed.result, "").trim();
   const errors = extractClaudeErrorMessages(parsed);
@@ -164,7 +196,9 @@ export function describeClaudeFailure(parsed: Record<string, unknown>): string |
   return parts.length > 1 ? parts.join(": ") : null;
 }
 
-export function isClaudeMaxTurnsResult(parsed: Record<string, unknown> | null | undefined): boolean {
+export function isClaudeMaxTurnsResult(
+  parsed: Record<string, unknown> | null | undefined,
+): boolean {
   if (!parsed) return false;
 
   const subtype = asString(parsed.subtype, "").trim().toLowerCase();
@@ -177,14 +211,18 @@ export function isClaudeMaxTurnsResult(parsed: Record<string, unknown> | null | 
   return /max(?:imum)?\s+turns?/i.test(resultText);
 }
 
-export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): boolean {
+export function isClaudeUnknownSessionError(
+  parsed: Record<string, unknown>,
+): boolean {
   const resultText = asString(parsed.result, "").trim();
   const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
     .map((msg) => msg.trim())
     .filter(Boolean);
 
   return allMessages.some((msg) =>
-    /no conversation found with session id|unknown session|session .* not found/i.test(msg),
+    /no conversation found with session id|unknown session|session .* not found/i.test(
+      msg,
+    ),
   );
 }
 
@@ -221,7 +259,9 @@ function readTimeZoneParts(date: Date, timeZone: string) {
       day: "2-digit",
       hour: "2-digit",
       minute: "2-digit",
-    }).formatToParts(date).map((part) => [part.type, part.value]),
+    })
+      .formatToParts(date)
+      .map((part) => [part.type, part.value]),
   );
   return {
     year: Number.parseInt(values.get("year") ?? "", 10),
@@ -232,13 +272,17 @@ function readTimeZoneParts(date: Date, timeZone: string) {
   };
 }
 
-function normalizeResetTimeZone(timeZoneHint: string | null | undefined): string | null {
+function normalizeResetTimeZone(
+  timeZoneHint: string | null | undefined,
+): string | null {
   const normalized = timeZoneHint?.trim();
   if (!normalized) return null;
   if (/^(?:utc|gmt)$/i.test(normalized)) return "UTC";
 
   try {
-    new Intl.DateTimeFormat("en-US", { timeZone: normalized }).format(new Date(0));
+    new Intl.DateTimeFormat("en-US", { timeZone: normalized }).format(
+      new Date(0),
+    );
     return normalized;
   } catch {
     return null;
@@ -253,12 +297,38 @@ function dateFromTimeZoneWallClock(input: {
   minute: number;
   timeZone: string;
 }): Date | null {
-  let candidate = new Date(Date.UTC(input.year, input.month - 1, input.day, input.hour, input.minute, 0, 0));
-  const targetUtc = Date.UTC(input.year, input.month - 1, input.day, input.hour, input.minute, 0, 0);
+  let candidate = new Date(
+    Date.UTC(
+      input.year,
+      input.month - 1,
+      input.day,
+      input.hour,
+      input.minute,
+      0,
+      0,
+    ),
+  );
+  const targetUtc = Date.UTC(
+    input.year,
+    input.month - 1,
+    input.day,
+    input.hour,
+    input.minute,
+    0,
+    0,
+  );
 
   for (let attempt = 0; attempt < 4; attempt += 1) {
     const actual = readTimeZoneParts(candidate, input.timeZone);
-    const actualUtc = Date.UTC(actual.year, actual.month - 1, actual.day, actual.hour, actual.minute, 0, 0);
+    const actualUtc = Date.UTC(
+      actual.year,
+      actual.month - 1,
+      actual.day,
+      actual.hour,
+      actual.minute,
+      0,
+      0,
+    );
     const offsetMs = targetUtc - actualUtc;
     if (offsetMs === 0) break;
     candidate = new Date(candidate.getTime() + offsetMs);
@@ -299,7 +369,9 @@ function nextClockTimeInTimeZone(input: {
   if (!retryAt) return null;
 
   if (retryAt.getTime() <= input.now.getTime()) {
-    const nextDay = new Date(Date.UTC(nowParts.year, nowParts.month - 1, nowParts.day + 1, 0, 0, 0, 0));
+    const nextDay = new Date(
+      Date.UTC(nowParts.year, nowParts.month - 1, nowParts.day + 1, 0, 0, 0, 0),
+    );
     retryAt = dateFromTimeZoneWallClock({
       year: nextDay.getUTCFullYear(),
       month: nextDay.getUTCMonth() + 1,
@@ -313,7 +385,11 @@ function nextClockTimeInTimeZone(input: {
   return retryAt;
 }
 
-function parseClaudeResetClockTime(clockText: string, now: Date, timeZoneHint?: string | null): Date | null {
+function parseClaudeResetClockTime(
+  clockText: string,
+  now: Date,
+  timeZoneHint?: string | null,
+): Date | null {
   const normalized = clockText.trim().replace(/\s+/g, " ");
   const match = normalized.match(/^(\d{1,2})(?::(\d{2}))?\s*([ap])\.?\s*m\.?/i);
   if (!match) return null;
@@ -367,7 +443,10 @@ export function isClaudeTransientUpstreamError(input: {
 }): boolean {
   const parsed = input.parsed ?? null;
   // Deterministic failures are handled by their own classifiers.
-  if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed))) {
+  if (
+    parsed &&
+    (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed))
+  ) {
     return false;
   }
   const loginMeta = detectClaudeLoginRequired({
@@ -380,4 +459,170 @@ export function isClaudeTransientUpstreamError(input: {
   const haystack = buildClaudeTransientHaystack(input);
   if (!haystack) return false;
   return CLAUDE_TRANSIENT_UPSTREAM_RE.test(haystack);
+}
+
+export type ClaudeFailureKind =
+  | "auth_required"
+  | "quota_exhausted"
+  | "rate_limited"
+  | "provider_5xx"
+  | "transient_upstream"
+  | null;
+
+export interface ClaudeFailureClassification {
+  kind: ClaudeFailureKind;
+  errorCode:
+    | "claude_auth_required"
+    | "claude_quota_exhausted"
+    | "claude_rate_limited"
+    | "claude_provider_5xx"
+    | "claude_transient_upstream"
+    | null;
+  errorFamily:
+    | "auth"
+    | "quota"
+    | "rate_limit"
+    | "provider_5xx"
+    | "transient_upstream"
+    | null;
+  httpStatus: number | null;
+  retryAfterMs: number | null;
+  retryNotBefore: Date | null;
+  loginUrl: string | null;
+}
+
+function extractHttpStatus(haystack: string): number | null {
+  const match = haystack.match(CLAUDE_API_ERROR_STATUS_RE);
+  if (!match) return null;
+  const status = Number.parseInt(match[1] ?? "", 10);
+  return Number.isFinite(status) && status >= 100 && status <= 599
+    ? status
+    : null;
+}
+
+function extractRetryAfterMs(haystack: string): number | null {
+  const match = haystack.match(CLAUDE_RETRY_AFTER_RE);
+  if (!match) return null;
+  const seconds = Number.parseInt(match[1] ?? "", 10);
+  if (!Number.isFinite(seconds) || seconds < 0) return null;
+  return seconds * 1000;
+}
+
+/**
+ * PMSA-15 / PMSA-11 §2.1: classify Claude run failures into actionable buckets.
+ *
+ * Precedence: auth_required > quota_exhausted > rate_limited > provider_5xx > transient_upstream.
+ * `auth_required` requires the explicit "not logged in" / "claude login" copy. A bare 401 with
+ * the session already authenticated maps to `quota_exhausted` per the design plan.
+ */
+export function classifyClaudeFailure(input: {
+  parsed?: Record<string, unknown> | null;
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+  now?: Date;
+}): ClaudeFailureClassification {
+  const parsed = input.parsed ?? null;
+  const stdout = input.stdout ?? "";
+  const stderr = input.stderr ?? "";
+  const now = input.now ?? new Date();
+
+  const empty: ClaudeFailureClassification = {
+    kind: null,
+    errorCode: null,
+    errorFamily: null,
+    httpStatus: null,
+    retryAfterMs: null,
+    retryNotBefore: null,
+    loginUrl: null,
+  };
+
+  // Deterministic failures keep their existing handling outside this classifier.
+  if (
+    parsed &&
+    (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed))
+  ) {
+    return empty;
+  }
+
+  const loginMeta = detectClaudeLoginRequired({ parsed, stdout, stderr });
+  const haystack = buildClaudeTransientHaystack({
+    parsed,
+    stdout,
+    stderr,
+    errorMessage: input.errorMessage ?? null,
+  });
+  const httpStatus = extractHttpStatus(haystack);
+  const retryAfterMs = extractRetryAfterMs(haystack);
+  const retryNotBefore = extractClaudeRetryNotBefore(
+    { parsed, stdout, stderr, errorMessage: input.errorMessage ?? null },
+    now,
+  );
+
+  if (loginMeta.requiresLogin) {
+    return {
+      kind: "auth_required",
+      errorCode: "claude_auth_required",
+      errorFamily: "auth",
+      httpStatus: httpStatus ?? 401,
+      retryAfterMs: null,
+      retryNotBefore: null,
+      loginUrl: loginMeta.loginUrl,
+    };
+  }
+
+  if (!haystack) return empty;
+
+  // 401 without auth-required copy => quota exhausted (e.g. Anthropic OAuth token rejected
+  // because the subscription's allotment is depleted).
+  const isQuotaTextMatch = CLAUDE_QUOTA_EXHAUSTED_RE.test(haystack);
+  if (httpStatus === 401 || isQuotaTextMatch) {
+    return {
+      kind: "quota_exhausted",
+      errorCode: "claude_quota_exhausted",
+      errorFamily: "transient_upstream",
+      httpStatus,
+      retryAfterMs,
+      retryNotBefore,
+      loginUrl: loginMeta.loginUrl,
+    };
+  }
+
+  if (httpStatus === 429 || CLAUDE_RATE_LIMIT_RE.test(haystack)) {
+    return {
+      kind: "rate_limited",
+      errorCode: "claude_rate_limited",
+      errorFamily: "transient_upstream",
+      httpStatus: httpStatus ?? 429,
+      retryAfterMs,
+      retryNotBefore,
+      loginUrl: loginMeta.loginUrl,
+    };
+  }
+
+  if (httpStatus !== null && httpStatus >= 500 && httpStatus < 600) {
+    return {
+      kind: "provider_5xx",
+      errorCode: "claude_provider_5xx",
+      errorFamily: "transient_upstream",
+      httpStatus,
+      retryAfterMs,
+      retryNotBefore,
+      loginUrl: loginMeta.loginUrl,
+    };
+  }
+
+  if (CLAUDE_TRANSIENT_UPSTREAM_RE.test(haystack)) {
+    return {
+      kind: "transient_upstream",
+      errorCode: "claude_transient_upstream",
+      errorFamily: "transient_upstream",
+      httpStatus,
+      retryAfterMs,
+      retryNotBefore,
+      loginUrl: loginMeta.loginUrl,
+    };
+  }
+
+  return { ...empty, loginUrl: loginMeta.loginUrl };
 }

--- a/packages/db/src/migrations/0071_company_metadata.sql
+++ b/packages/db/src/migrations/0071_company_metadata.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "companies" ADD COLUMN IF NOT EXISTS "metadata" jsonb;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -498,6 +498,13 @@
       "when": 1776780004000,
       "tag": "0070_active_run_output_watchdog",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1777132828000,
+      "tag": "0071_company_metadata",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/companies.ts
+++ b/packages/db/src/schema/companies.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, integer, timestamp, boolean, uniqueIndex } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, integer, timestamp, boolean, jsonb, uniqueIndex } from "drizzle-orm/pg-core";
 
 export const companies = pgTable(
   "companies",
@@ -23,6 +23,7 @@ export const companies = pgTable(
     feedbackDataSharingConsentByUserId: text("feedback_data_sharing_consent_by_user_id"),
     feedbackDataSharingTermsVersion: text("feedback_data_sharing_terms_version"),
     brandColor: text("brand_color"),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/shared/src/agent-priority.test.ts
+++ b/packages/shared/src/agent-priority.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentPriorityTierRank,
+  bumpAgentPriorityTier,
+  isAgentPriorityTier,
+  readAgentPriorityTier,
+  resolveDefaultAgentPriorityTier,
+} from "./agent-priority.js";
+
+describe("isAgentPriorityTier", () => {
+  it.each([
+    ["p0", true],
+    ["p1", true],
+    ["p2", true],
+    ["p3", true],
+    ["p4", false],
+    ["", false],
+    [null, false],
+    [undefined, false],
+    [123, false],
+  ])("treats %p as %p", (input, expected) => {
+    expect(isAgentPriorityTier(input)).toBe(expected);
+  });
+});
+
+describe("resolveDefaultAgentPriorityTier", () => {
+  it("returns role-based defaults", () => {
+    expect(resolveDefaultAgentPriorityTier({ role: "ceo", name: "CEO" })).toBe(
+      "p0",
+    );
+    expect(
+      resolveDefaultAgentPriorityTier({ role: "engineer", name: "Engineer" }),
+    ).toBe("p1");
+    expect(
+      resolveDefaultAgentPriorityTier({ role: "pm", name: "PRDWriter" }),
+    ).toBe("p2");
+    expect(
+      resolveDefaultAgentPriorityTier({
+        role: "researcher",
+        name: "TechResearcher",
+      }),
+    ).toBe("p3");
+  });
+
+  it("applies the InsightAnalyst name override even though role=researcher", () => {
+    expect(
+      resolveDefaultAgentPriorityTier({
+        role: "researcher",
+        name: "InsightAnalyst",
+      }),
+    ).toBe("p2");
+    expect(
+      resolveDefaultAgentPriorityTier({
+        role: "researcher",
+        name: "insight-analyst",
+      }),
+    ).toBe("p2");
+    expect(
+      resolveDefaultAgentPriorityTier({
+        role: "researcher",
+        name: "Insight Analyst",
+      }),
+    ).toBe("p2");
+  });
+
+  it("falls back to p2 for unknown role + name", () => {
+    expect(
+      resolveDefaultAgentPriorityTier({ role: "unknown", name: "Random" }),
+    ).toBe("p2");
+    expect(resolveDefaultAgentPriorityTier({ role: null, name: null })).toBe(
+      "p2",
+    );
+  });
+});
+
+describe("readAgentPriorityTier", () => {
+  it("prefers a stored valid tier over the default", () => {
+    expect(
+      readAgentPriorityTier(
+        { priorityTier: "p0" },
+        { role: "engineer", name: "Engineer" },
+      ),
+    ).toBe("p0");
+  });
+
+  it("ignores an invalid stored tier and falls back to defaults", () => {
+    expect(
+      readAgentPriorityTier(
+        { priorityTier: "p9" },
+        { role: "engineer", name: "Engineer" },
+      ),
+    ).toBe("p1");
+  });
+
+  it("handles null/undefined metadata", () => {
+    expect(readAgentPriorityTier(null, { role: "ceo", name: "CEO" })).toBe(
+      "p0",
+    );
+    expect(readAgentPriorityTier(undefined, { role: "ceo", name: "CEO" })).toBe(
+      "p0",
+    );
+  });
+});
+
+describe("bumpAgentPriorityTier", () => {
+  it("walks one step toward p0", () => {
+    expect(bumpAgentPriorityTier("p3")).toBe("p2");
+    expect(bumpAgentPriorityTier("p2")).toBe("p1");
+    expect(bumpAgentPriorityTier("p1")).toBe("p0");
+  });
+
+  it("stays at p0", () => {
+    expect(bumpAgentPriorityTier("p0")).toBe("p0");
+  });
+});
+
+describe("agentPriorityTierRank", () => {
+  it("orders p0 lowest (most-important)", () => {
+    expect(agentPriorityTierRank("p0")).toBe(0);
+    expect(agentPriorityTierRank("p1")).toBe(1);
+    expect(agentPriorityTierRank("p2")).toBe(2);
+    expect(agentPriorityTierRank("p3")).toBe(3);
+  });
+});

--- a/packages/shared/src/agent-priority.ts
+++ b/packages/shared/src/agent-priority.ts
@@ -1,0 +1,77 @@
+import {
+  AGENT_PRIORITY_TIERS,
+  AGENT_PRIORITY_TIER_DEFAULTS_BY_ROLE,
+  AGENT_PRIORITY_TIER_NAME_OVERRIDES,
+  DEFAULT_AGENT_PRIORITY_TIER,
+  type AgentPriorityTier,
+  type AgentRole,
+} from "./constants.js";
+import { normalizeAgentUrlKey } from "./agent-url-key.js";
+
+const AGENT_PRIORITY_TIER_SET: ReadonlySet<AgentPriorityTier> = new Set(
+  AGENT_PRIORITY_TIERS,
+);
+
+export function isAgentPriorityTier(
+  value: unknown,
+): value is AgentPriorityTier {
+  return (
+    typeof value === "string" &&
+    AGENT_PRIORITY_TIER_SET.has(value as AgentPriorityTier)
+  );
+}
+
+export interface ResolveAgentPriorityTierInput {
+  role: AgentRole | string | null | undefined;
+  name?: string | null;
+}
+
+// Picks the default tier for an agent based on its role, with a small
+// hand-curated by-name override map (case-insensitive, alphanumeric-only).
+// Used by both the create/hire path and the startup backfill so they can't
+// drift apart.
+export function resolveDefaultAgentPriorityTier(
+  input: ResolveAgentPriorityTierInput,
+): AgentPriorityTier {
+  const normalizedKey = normalizeAgentUrlKey(input.name)?.replace(/-/g, "");
+  if (normalizedKey) {
+    const override = AGENT_PRIORITY_TIER_NAME_OVERRIDES[normalizedKey];
+    if (override) return override;
+  }
+  if (typeof input.role === "string") {
+    const roleDefault = (
+      AGENT_PRIORITY_TIER_DEFAULTS_BY_ROLE as Record<string, AgentPriorityTier>
+    )[input.role];
+    if (roleDefault) return roleDefault;
+  }
+  return DEFAULT_AGENT_PRIORITY_TIER;
+}
+
+// Reads a stored `priorityTier` value from an agent metadata blob, falling
+// back to the role/name-derived default. Both `metadata` and the resolver
+// inputs are optional so callers can pass whichever subset they have.
+export function readAgentPriorityTier(
+  metadata: Record<string, unknown> | null | undefined,
+  fallback: ResolveAgentPriorityTierInput,
+): AgentPriorityTier {
+  if (metadata && typeof metadata === "object") {
+    const raw = (metadata as Record<string, unknown>).priorityTier;
+    if (isAgentPriorityTier(raw)) return raw;
+  }
+  return resolveDefaultAgentPriorityTier(fallback);
+}
+
+// Bumps a tier one step toward p0. p0 is already top-priority and stays p0.
+// Used by the semaphore aging path.
+export function bumpAgentPriorityTier(
+  tier: AgentPriorityTier,
+): AgentPriorityTier {
+  const idx = AGENT_PRIORITY_TIERS.indexOf(tier);
+  if (idx <= 0) return AGENT_PRIORITY_TIERS[0];
+  return AGENT_PRIORITY_TIERS[idx - 1];
+}
+
+// Numeric rank for ordering (p0 -> 0, p3 -> 3). Lower wins.
+export function agentPriorityTierRank(tier: AgentPriorityTier): number {
+  return AGENT_PRIORITY_TIERS.indexOf(tier);
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -35,7 +35,9 @@ export const AGENT_ADAPTER_TYPES = [
   "cursor",
   "openclaw_gateway",
 ] as const;
-export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number] | (string & {});
+export type AgentAdapterType =
+  | (typeof AGENT_ADAPTER_TYPES)[number]
+  | (string & {});
 
 export const AGENT_ROLES = [
   "ceo",
@@ -68,6 +70,58 @@ export const AGENT_ROLE_LABELS: Record<AgentRole, string> = {
 
 export const AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 5;
 export const WORKSPACE_BRANCH_ROUTINE_VARIABLE = "workspaceBranch";
+
+// Per-agent priority tiers used by the company-wide Opus concurrency
+// semaphore (PMSA-17 / [PMSA-11] §3.2). Stored on `agents.metadata.priorityTier`
+// and resolved at heartbeat time so high-priority work (CEO decisions, Engineer
+// dialogue runs) is not starved by long-running researcher heartbeats.
+//
+// Ordered most-important to least-important. The semaphore queues waiters by
+// (tier asc, queuedAt asc), and the aging path bumps a starved waiter up one
+// tier every AGENT_PRIORITY_TIER_AGING_INTERVAL_MS so p3 runs cannot wait
+// indefinitely behind an unbroken stream of p0/p1 traffic.
+export const AGENT_PRIORITY_TIERS = ["p0", "p1", "p2", "p3"] as const;
+export type AgentPriorityTier = (typeof AGENT_PRIORITY_TIERS)[number];
+
+export const AGENT_PRIORITY_TIER_LABELS: Record<AgentPriorityTier, string> = {
+  p0: "P0 — Critical",
+  p1: "P1 — High",
+  p2: "P2 — Default",
+  p3: "P3 — Background",
+};
+
+export const DEFAULT_AGENT_PRIORITY_TIER: AgentPriorityTier = "p2";
+
+// Default tier per agent role. Overrides by-name take precedence (e.g. the
+// research role spans both InsightAnalyst (p2) and TechResearcher (p3)).
+export const AGENT_PRIORITY_TIER_DEFAULTS_BY_ROLE: Record<
+  AgentRole,
+  AgentPriorityTier
+> = {
+  ceo: "p0",
+  cto: "p1",
+  cmo: "p1",
+  cfo: "p1",
+  engineer: "p1",
+  pm: "p2",
+  designer: "p2",
+  qa: "p2",
+  devops: "p2",
+  researcher: "p3",
+  general: "p2",
+};
+
+// Specific name overrides applied on top of the role-based default. Compared
+// against the agent's normalized url-key (lowercase, alphanumeric).
+// Keep this small — each entry expresses an intentional override of the role
+// default, not a per-agent personality tweak.
+export const AGENT_PRIORITY_TIER_NAME_OVERRIDES: Record<
+  string,
+  AgentPriorityTier
+> = {
+  insightanalyst: "p2",
+};
+
 export const AGENT_ICON_NAMES = [
   "bot",
   "cpu",
@@ -132,7 +186,8 @@ export const INBOX_MINE_ISSUE_STATUSES = [
   "blocked",
   "done",
 ] as const;
-export const INBOX_MINE_ISSUE_STATUS_FILTER = INBOX_MINE_ISSUE_STATUSES.join(",");
+export const INBOX_MINE_ISSUE_STATUS_FILTER =
+  INBOX_MINE_ISSUE_STATUSES.join(",");
 
 export const ISSUE_PRIORITIES = ["critical", "high", "medium", "low"] as const;
 export type IssuePriority = (typeof ISSUE_PRIORITIES)[number];
@@ -142,7 +197,8 @@ export const ISSUE_THREAD_INTERACTION_KINDS = [
   "ask_user_questions",
   "request_confirmation",
 ] as const;
-export type IssueThreadInteractionKind = (typeof ISSUE_THREAD_INTERACTION_KINDS)[number];
+export type IssueThreadInteractionKind =
+  (typeof ISSUE_THREAD_INTERACTION_KINDS)[number];
 
 export const ISSUE_THREAD_INTERACTION_STATUSES = [
   "pending",
@@ -152,7 +208,8 @@ export const ISSUE_THREAD_INTERACTION_STATUSES = [
   "expired",
   "failed",
 ] as const;
-export type IssueThreadInteractionStatus = (typeof ISSUE_THREAD_INTERACTION_STATUSES)[number];
+export type IssueThreadInteractionStatus =
+  (typeof ISSUE_THREAD_INTERACTION_STATUSES)[number];
 
 export const ISSUE_THREAD_INTERACTION_CONTINUATION_POLICIES = [
   "none",
@@ -162,7 +219,11 @@ export const ISSUE_THREAD_INTERACTION_CONTINUATION_POLICIES = [
 export type IssueThreadInteractionContinuationPolicy =
   (typeof ISSUE_THREAD_INTERACTION_CONTINUATION_POLICIES)[number];
 
-export const ISSUE_ORIGIN_KINDS = ["manual", "routine_execution", "stale_active_run_evaluation"] as const;
+export const ISSUE_ORIGIN_KINDS = [
+  "manual",
+  "routine_execution",
+  "stale_active_run_evaluation",
+] as const;
 export type BuiltInIssueOriginKind = (typeof ISSUE_ORIGIN_KINDS)[number];
 export type PluginIssueOriginKind = `plugin:${string}`;
 export type IssueOriginKind = BuiltInIssueOriginKind | PluginIssueOriginKind;
@@ -170,43 +231,83 @@ export type IssueOriginKind = BuiltInIssueOriginKind | PluginIssueOriginKind;
 export const ISSUE_RELATION_TYPES = ["blocks"] as const;
 export type IssueRelationType = (typeof ISSUE_RELATION_TYPES)[number];
 
-export const ISSUE_TREE_CONTROL_MODES = ["pause", "resume", "cancel", "restore"] as const;
+export const ISSUE_TREE_CONTROL_MODES = [
+  "pause",
+  "resume",
+  "cancel",
+  "restore",
+] as const;
 export type IssueTreeControlMode = (typeof ISSUE_TREE_CONTROL_MODES)[number];
 
 export const ISSUE_TREE_HOLD_STATUSES = ["active", "released"] as const;
 export type IssueTreeHoldStatus = (typeof ISSUE_TREE_HOLD_STATUSES)[number];
 
-export const ISSUE_TREE_HOLD_RELEASE_POLICY_STRATEGIES = ["manual", "after_active_runs_finish"] as const;
-export type IssueTreeHoldReleasePolicyStrategy = (typeof ISSUE_TREE_HOLD_RELEASE_POLICY_STRATEGIES)[number];
+export const ISSUE_TREE_HOLD_RELEASE_POLICY_STRATEGIES = [
+  "manual",
+  "after_active_runs_finish",
+] as const;
+export type IssueTreeHoldReleasePolicyStrategy =
+  (typeof ISSUE_TREE_HOLD_RELEASE_POLICY_STRATEGIES)[number];
 
-export const ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY = "continuation-summary" as const;
-export const SYSTEM_ISSUE_DOCUMENT_KEYS = [ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY] as const;
-export type SystemIssueDocumentKey = (typeof SYSTEM_ISSUE_DOCUMENT_KEYS)[number];
+export const ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY =
+  "continuation-summary" as const;
+export const SYSTEM_ISSUE_DOCUMENT_KEYS = [
+  ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
+] as const;
+export type SystemIssueDocumentKey =
+  (typeof SYSTEM_ISSUE_DOCUMENT_KEYS)[number];
 
-const SYSTEM_ISSUE_DOCUMENT_KEY_SET = new Set<string>(SYSTEM_ISSUE_DOCUMENT_KEYS);
+const SYSTEM_ISSUE_DOCUMENT_KEY_SET = new Set<string>(
+  SYSTEM_ISSUE_DOCUMENT_KEYS,
+);
 
-export function isSystemIssueDocumentKey(key: string): key is SystemIssueDocumentKey {
+export function isSystemIssueDocumentKey(
+  key: string,
+): key is SystemIssueDocumentKey {
   return SYSTEM_ISSUE_DOCUMENT_KEY_SET.has(key);
 }
-export const ISSUE_REFERENCE_SOURCE_KINDS = ["title", "description", "comment", "document"] as const;
-export type IssueReferenceSourceKind = (typeof ISSUE_REFERENCE_SOURCE_KINDS)[number];
+export const ISSUE_REFERENCE_SOURCE_KINDS = [
+  "title",
+  "description",
+  "comment",
+  "document",
+] as const;
+export type IssueReferenceSourceKind =
+  (typeof ISSUE_REFERENCE_SOURCE_KINDS)[number];
 
 export const ISSUE_EXECUTION_POLICY_MODES = ["normal", "auto"] as const;
-export type IssueExecutionPolicyMode = (typeof ISSUE_EXECUTION_POLICY_MODES)[number];
+export type IssueExecutionPolicyMode =
+  (typeof ISSUE_EXECUTION_POLICY_MODES)[number];
 
 export const ISSUE_EXECUTION_STAGE_TYPES = ["review", "approval"] as const;
-export type IssueExecutionStageType = (typeof ISSUE_EXECUTION_STAGE_TYPES)[number];
+export type IssueExecutionStageType =
+  (typeof ISSUE_EXECUTION_STAGE_TYPES)[number];
 
-export const ISSUE_EXECUTION_STATE_STATUSES = ["idle", "pending", "changes_requested", "completed"] as const;
-export type IssueExecutionStateStatus = (typeof ISSUE_EXECUTION_STATE_STATUSES)[number];
+export const ISSUE_EXECUTION_STATE_STATUSES = [
+  "idle",
+  "pending",
+  "changes_requested",
+  "completed",
+] as const;
+export type IssueExecutionStateStatus =
+  (typeof ISSUE_EXECUTION_STATE_STATUSES)[number];
 
-export const ISSUE_EXECUTION_DECISION_OUTCOMES = ["approved", "changes_requested"] as const;
-export type IssueExecutionDecisionOutcome = (typeof ISSUE_EXECUTION_DECISION_OUTCOMES)[number];
+export const ISSUE_EXECUTION_DECISION_OUTCOMES = [
+  "approved",
+  "changes_requested",
+] as const;
+export type IssueExecutionDecisionOutcome =
+  (typeof ISSUE_EXECUTION_DECISION_OUTCOMES)[number];
 
 export const GOAL_LEVELS = ["company", "team", "agent", "task"] as const;
 export type GoalLevel = (typeof GOAL_LEVELS)[number];
 
-export const GOAL_STATUSES = ["planned", "active", "achieved", "cancelled"] as const;
+export const GOAL_STATUSES = [
+  "planned",
+  "active",
+  "achieved",
+  "cancelled",
+] as const;
 export type GoalStatus = (typeof GOAL_STATUSES)[number];
 
 export const PROJECT_STATUSES = [
@@ -218,14 +319,26 @@ export const PROJECT_STATUSES = [
 ] as const;
 export type ProjectStatus = (typeof PROJECT_STATUSES)[number];
 
-export const ENVIRONMENT_DRIVERS = ["local", "ssh", "sandbox", "plugin"] as const;
+export const ENVIRONMENT_DRIVERS = [
+  "local",
+  "ssh",
+  "sandbox",
+  "plugin",
+] as const;
 export type EnvironmentDriver = (typeof ENVIRONMENT_DRIVERS)[number];
 
 export const ENVIRONMENT_STATUSES = ["active", "archived"] as const;
 export type EnvironmentStatus = (typeof ENVIRONMENT_STATUSES)[number];
 
-export const ENVIRONMENT_LEASE_STATUSES = ["active", "released", "expired", "failed", "retained"] as const;
-export type EnvironmentLeaseStatus = (typeof ENVIRONMENT_LEASE_STATUSES)[number];
+export const ENVIRONMENT_LEASE_STATUSES = [
+  "active",
+  "released",
+  "expired",
+  "failed",
+  "retained",
+] as const;
+export type EnvironmentLeaseStatus =
+  (typeof ENVIRONMENT_LEASE_STATUSES)[number];
 
 export const ENVIRONMENT_LEASE_POLICIES = [
   "ephemeral",
@@ -233,27 +346,53 @@ export const ENVIRONMENT_LEASE_POLICIES = [
   "reuse_by_execution_workspace",
   "retain_on_failure",
 ] as const;
-export type EnvironmentLeasePolicy = (typeof ENVIRONMENT_LEASE_POLICIES)[number];
+export type EnvironmentLeasePolicy =
+  (typeof ENVIRONMENT_LEASE_POLICIES)[number];
 
-export const ENVIRONMENT_LEASE_CLEANUP_STATUSES = ["pending", "success", "failed"] as const;
-export type EnvironmentLeaseCleanupStatus = (typeof ENVIRONMENT_LEASE_CLEANUP_STATUSES)[number];
+export const ENVIRONMENT_LEASE_CLEANUP_STATUSES = [
+  "pending",
+  "success",
+  "failed",
+] as const;
+export type EnvironmentLeaseCleanupStatus =
+  (typeof ENVIRONMENT_LEASE_CLEANUP_STATUSES)[number];
 
 export const ROUTINE_STATUSES = ["active", "paused", "archived"] as const;
 export type RoutineStatus = (typeof ROUTINE_STATUSES)[number];
 
-export const ROUTINE_CONCURRENCY_POLICIES = ["coalesce_if_active", "always_enqueue", "skip_if_active"] as const;
-export type RoutineConcurrencyPolicy = (typeof ROUTINE_CONCURRENCY_POLICIES)[number];
+export const ROUTINE_CONCURRENCY_POLICIES = [
+  "coalesce_if_active",
+  "always_enqueue",
+  "skip_if_active",
+] as const;
+export type RoutineConcurrencyPolicy =
+  (typeof ROUTINE_CONCURRENCY_POLICIES)[number];
 
-export const ROUTINE_CATCH_UP_POLICIES = ["skip_missed", "enqueue_missed_with_cap"] as const;
+export const ROUTINE_CATCH_UP_POLICIES = [
+  "skip_missed",
+  "enqueue_missed_with_cap",
+] as const;
 export type RoutineCatchUpPolicy = (typeof ROUTINE_CATCH_UP_POLICIES)[number];
 
 export const ROUTINE_TRIGGER_KINDS = ["schedule", "webhook", "api"] as const;
 export type RoutineTriggerKind = (typeof ROUTINE_TRIGGER_KINDS)[number];
 
-export const ROUTINE_TRIGGER_SIGNING_MODES = ["bearer", "hmac_sha256", "github_hmac", "none"] as const;
-export type RoutineTriggerSigningMode = (typeof ROUTINE_TRIGGER_SIGNING_MODES)[number];
+export const ROUTINE_TRIGGER_SIGNING_MODES = [
+  "bearer",
+  "hmac_sha256",
+  "github_hmac",
+  "none",
+] as const;
+export type RoutineTriggerSigningMode =
+  (typeof ROUTINE_TRIGGER_SIGNING_MODES)[number];
 
-export const ROUTINE_VARIABLE_TYPES = ["text", "textarea", "number", "boolean", "select"] as const;
+export const ROUTINE_VARIABLE_TYPES = [
+  "text",
+  "textarea",
+  "number",
+  "boolean",
+  "select",
+] as const;
 export type RoutineVariableType = (typeof ROUTINE_VARIABLE_TYPES)[number];
 
 export const ROUTINE_RUN_STATUSES = [
@@ -263,10 +402,15 @@ export const ROUTINE_RUN_STATUSES = [
   "issue_created",
   "completed",
   "failed",
- ] as const;
+] as const;
 export type RoutineRunStatus = (typeof ROUTINE_RUN_STATUSES)[number];
 
-export const ROUTINE_RUN_SOURCES = ["schedule", "manual", "api", "webhook"] as const;
+export const ROUTINE_RUN_SOURCES = [
+  "schedule",
+  "manual",
+  "api",
+  "webhook",
+] as const;
 export type RoutineRunSource = (typeof ROUTINE_RUN_SOURCES)[number];
 
 export const PAUSE_REASONS = ["manual", "budget", "system"] as const;
@@ -371,14 +515,19 @@ export type BudgetWindowKind = (typeof BUDGET_WINDOW_KINDS)[number];
 export const BUDGET_THRESHOLD_TYPES = ["soft", "hard"] as const;
 export type BudgetThresholdType = (typeof BUDGET_THRESHOLD_TYPES)[number];
 
-export const BUDGET_INCIDENT_STATUSES = ["open", "resolved", "dismissed"] as const;
+export const BUDGET_INCIDENT_STATUSES = [
+  "open",
+  "resolved",
+  "dismissed",
+] as const;
 export type BudgetIncidentStatus = (typeof BUDGET_INCIDENT_STATUSES)[number];
 
 export const BUDGET_INCIDENT_RESOLUTION_ACTIONS = [
   "keep_paused",
   "raise_budget_and_resume",
 ] as const;
-export type BudgetIncidentResolutionAction = (typeof BUDGET_INCIDENT_RESOLUTION_ACTIONS)[number];
+export type BudgetIncidentResolutionAction =
+  (typeof BUDGET_INCIDENT_RESOLUTION_ACTIONS)[number];
 
 export const HEARTBEAT_INVOCATION_SOURCES = [
   "timer",
@@ -386,9 +535,15 @@ export const HEARTBEAT_INVOCATION_SOURCES = [
   "on_demand",
   "automation",
 ] as const;
-export type HeartbeatInvocationSource = (typeof HEARTBEAT_INVOCATION_SOURCES)[number];
+export type HeartbeatInvocationSource =
+  (typeof HEARTBEAT_INVOCATION_SOURCES)[number];
 
-export const WAKEUP_TRIGGER_DETAILS = ["manual", "ping", "callback", "system"] as const;
+export const WAKEUP_TRIGGER_DETAILS = [
+  "manual",
+  "ping",
+  "callback",
+  "system",
+] as const;
 export type WakeupTriggerDetail = (typeof WAKEUP_TRIGGER_DETAILS)[number];
 
 export const WAKEUP_REQUEST_STATUSES = [
@@ -441,7 +596,12 @@ export type LiveEventType = (typeof LIVE_EVENT_TYPES)[number];
 export const PRINCIPAL_TYPES = ["user", "agent"] as const;
 export type PrincipalType = (typeof PRINCIPAL_TYPES)[number];
 
-export const MEMBERSHIP_STATUSES = ["pending", "active", "suspended", "archived"] as const;
+export const MEMBERSHIP_STATUSES = [
+  "pending",
+  "active",
+  "suspended",
+  "archived",
+] as const;
 export type MembershipStatus = (typeof MEMBERSHIP_STATUSES)[number];
 
 export const COMPANY_MEMBERSHIP_ROLES = [
@@ -459,9 +619,13 @@ export const HUMAN_COMPANY_MEMBERSHIP_ROLES = [
   "operator",
   "viewer",
 ] as const;
-export type HumanCompanyMembershipRole = (typeof HUMAN_COMPANY_MEMBERSHIP_ROLES)[number];
+export type HumanCompanyMembershipRole =
+  (typeof HUMAN_COMPANY_MEMBERSHIP_ROLES)[number];
 
-export const HUMAN_COMPANY_MEMBERSHIP_ROLE_LABELS: Record<HumanCompanyMembershipRole, string> = {
+export const HUMAN_COMPANY_MEMBERSHIP_ROLE_LABELS: Record<
+  HumanCompanyMembershipRole,
+  string
+> = {
   owner: "Owner",
   admin: "Admin",
   operator: "Operator",
@@ -480,7 +644,11 @@ export type InviteJoinType = (typeof INVITE_JOIN_TYPES)[number];
 export const JOIN_REQUEST_TYPES = ["human", "agent"] as const;
 export type JoinRequestType = (typeof JOIN_REQUEST_TYPES)[number];
 
-export const JOIN_REQUEST_STATUSES = ["pending_approval", "approved", "rejected"] as const;
+export const JOIN_REQUEST_STATUSES = [
+  "pending_approval",
+  "approved",
+  "rejected",
+] as const;
 export type JoinRequestStatus = (typeof JOIN_REQUEST_STATUSES)[number];
 
 export const PERMISSION_KEYS = [
@@ -618,19 +786,22 @@ export const PLUGIN_CAPABILITIES = [
 export type PluginCapability = (typeof PLUGIN_CAPABILITIES)[number];
 
 export const PLUGIN_DATABASE_NAMESPACE_MODES = ["schema"] as const;
-export type PluginDatabaseNamespaceMode = (typeof PLUGIN_DATABASE_NAMESPACE_MODES)[number];
+export type PluginDatabaseNamespaceMode =
+  (typeof PLUGIN_DATABASE_NAMESPACE_MODES)[number];
 
 export const PLUGIN_DATABASE_NAMESPACE_STATUSES = [
   "active",
   "migration_failed",
 ] as const;
-export type PluginDatabaseNamespaceStatus = (typeof PLUGIN_DATABASE_NAMESPACE_STATUSES)[number];
+export type PluginDatabaseNamespaceStatus =
+  (typeof PLUGIN_DATABASE_NAMESPACE_STATUSES)[number];
 
 export const PLUGIN_DATABASE_MIGRATION_STATUSES = [
   "applied",
   "failed",
 ] as const;
-export type PluginDatabaseMigrationStatus = (typeof PLUGIN_DATABASE_MIGRATION_STATUSES)[number];
+export type PluginDatabaseMigrationStatus =
+  (typeof PLUGIN_DATABASE_MIGRATION_STATUSES)[number];
 
 export const PLUGIN_DATABASE_CORE_READ_TABLES = [
   "companies",
@@ -647,20 +818,33 @@ export const PLUGIN_DATABASE_CORE_READ_TABLES = [
   "issue_approvals",
   "budget_incidents",
 ] as const;
-export type PluginDatabaseCoreReadTable = (typeof PLUGIN_DATABASE_CORE_READ_TABLES)[number];
+export type PluginDatabaseCoreReadTable =
+  (typeof PLUGIN_DATABASE_CORE_READ_TABLES)[number];
 
-export const PLUGIN_API_ROUTE_METHODS = ["GET", "POST", "PATCH", "DELETE"] as const;
+export const PLUGIN_API_ROUTE_METHODS = [
+  "GET",
+  "POST",
+  "PATCH",
+  "DELETE",
+] as const;
 export type PluginApiRouteMethod = (typeof PLUGIN_API_ROUTE_METHODS)[number];
 
-export const PLUGIN_API_ROUTE_AUTH_MODES = ["board", "agent", "board-or-agent", "webhook"] as const;
-export type PluginApiRouteAuthMode = (typeof PLUGIN_API_ROUTE_AUTH_MODES)[number];
+export const PLUGIN_API_ROUTE_AUTH_MODES = [
+  "board",
+  "agent",
+  "board-or-agent",
+  "webhook",
+] as const;
+export type PluginApiRouteAuthMode =
+  (typeof PLUGIN_API_ROUTE_AUTH_MODES)[number];
 
 export const PLUGIN_API_ROUTE_CHECKOUT_POLICIES = [
   "none",
   "required-for-agent-in-progress",
   "always-for-agent",
 ] as const;
-export type PluginApiRouteCheckoutPolicy = (typeof PLUGIN_API_ROUTE_CHECKOUT_POLICIES)[number];
+export type PluginApiRouteCheckoutPolicy =
+  (typeof PLUGIN_API_ROUTE_CHECKOUT_POLICIES)[number];
 
 /**
  * UI extension slot types. Each slot type corresponds to a mount point in the
@@ -733,7 +917,8 @@ export const PLUGIN_LAUNCHER_PLACEMENT_ZONES = [
   "commentContextMenuItem",
   "settingsPage",
 ] as const;
-export type PluginLauncherPlacementZone = (typeof PLUGIN_LAUNCHER_PLACEMENT_ZONES)[number];
+export type PluginLauncherPlacementZone =
+  (typeof PLUGIN_LAUNCHER_PLACEMENT_ZONES)[number];
 
 /**
  * Launcher action kinds describe what the launcher does when activated.
@@ -788,7 +973,8 @@ export const PLUGIN_UI_SLOT_ENTITY_TYPES = [
   "run",
   "comment",
 ] as const;
-export type PluginUiSlotEntityType = (typeof PLUGIN_UI_SLOT_ENTITY_TYPES)[number];
+export type PluginUiSlotEntityType =
+  (typeof PLUGIN_UI_SLOT_ENTITY_TYPES)[number];
 
 /**
  * Scope kinds for plugin state storage. Determines the granularity at which
@@ -809,11 +995,7 @@ export const PLUGIN_STATE_SCOPE_KINDS = [
 export type PluginStateScopeKind = (typeof PLUGIN_STATE_SCOPE_KINDS)[number];
 
 /** Statuses for a plugin's scheduled job definition. */
-export const PLUGIN_JOB_STATUSES = [
-  "active",
-  "paused",
-  "failed",
-] as const;
+export const PLUGIN_JOB_STATUSES = ["active", "paused", "failed"] as const;
 export type PluginJobStatus = (typeof PLUGIN_JOB_STATUSES)[number];
 
 /** Statuses for individual job run executions. */
@@ -828,11 +1010,7 @@ export const PLUGIN_JOB_RUN_STATUSES = [
 export type PluginJobRunStatus = (typeof PLUGIN_JOB_RUN_STATUSES)[number];
 
 /** What triggered a particular job run. */
-export const PLUGIN_JOB_RUN_TRIGGERS = [
-  "schedule",
-  "manual",
-  "retry",
-] as const;
+export const PLUGIN_JOB_RUN_TRIGGERS = ["schedule", "manual", "retry"] as const;
 export type PluginJobRunTrigger = (typeof PLUGIN_JOB_RUN_TRIGGERS)[number];
 
 /** Statuses for inbound webhook deliveries. */
@@ -841,7 +1019,8 @@ export const PLUGIN_WEBHOOK_DELIVERY_STATUSES = [
   "success",
   "failed",
 ] as const;
-export type PluginWebhookDeliveryStatus = (typeof PLUGIN_WEBHOOK_DELIVERY_STATUSES)[number];
+export type PluginWebhookDeliveryStatus =
+  (typeof PLUGIN_WEBHOOK_DELIVERY_STATUSES)[number];
 
 /**
  * Core domain event types that plugins can subscribe to via the

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,7 @@
-export { agentAdapterTypeSchema, optionalAgentAdapterTypeSchema } from "./adapter-type.js";
+export {
+  agentAdapterTypeSchema,
+  optionalAgentAdapterTypeSchema,
+} from "./adapter-type.js";
 export {
   COMPANY_STATUSES,
   DEPLOYMENT_MODES,
@@ -9,6 +12,11 @@ export {
   AGENT_ADAPTER_TYPES,
   AGENT_ROLES,
   AGENT_ROLE_LABELS,
+  AGENT_PRIORITY_TIERS,
+  AGENT_PRIORITY_TIER_LABELS,
+  AGENT_PRIORITY_TIER_DEFAULTS_BY_ROLE,
+  AGENT_PRIORITY_TIER_NAME_OVERRIDES,
+  DEFAULT_AGENT_PRIORITY_TIER,
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
   WORKSPACE_BRANCH_ROUTINE_VARIABLE,
   AGENT_ICON_NAMES,
@@ -113,6 +121,7 @@ export {
   type AgentStatus,
   type AgentAdapterType,
   type AgentRole,
+  type AgentPriorityTier,
   type AgentIconName,
   type IssueStatus,
   type IssuePriority,
@@ -864,8 +873,24 @@ export {
 } from "./validators/index.js";
 
 export { API_PREFIX, API } from "./api.js";
-export { normalizeAgentUrlKey, deriveAgentUrlKey, isUuidLike } from "./agent-url-key.js";
-export { deriveProjectUrlKey, normalizeProjectUrlKey, hasNonAsciiContent } from "./project-url-key.js";
+export {
+  normalizeAgentUrlKey,
+  deriveAgentUrlKey,
+  isUuidLike,
+} from "./agent-url-key.js";
+export {
+  agentPriorityTierRank,
+  bumpAgentPriorityTier,
+  isAgentPriorityTier,
+  readAgentPriorityTier,
+  resolveDefaultAgentPriorityTier,
+} from "./agent-priority.js";
+export type { ResolveAgentPriorityTierInput } from "./agent-priority.js";
+export {
+  deriveProjectUrlKey,
+  normalizeProjectUrlKey,
+  hasNonAsciiContent,
+} from "./project-url-key.js";
 export {
   AGENT_MENTION_SCHEME,
   PROJECT_MENTION_SCHEME,

--- a/packages/shared/src/validators/company.ts
+++ b/packages/shared/src/validators/company.ts
@@ -25,6 +25,7 @@ export const updateCompanySchema = createCompanySchema
     feedbackDataSharingTermsVersion: feedbackDataSharingTermsVersionSchema,
     brandColor: brandColorSchema,
     logoAssetId: logoAssetIdSchema,
+    metadata: z.record(z.unknown()).nullable().optional(),
   });
 
 export type UpdateCompany = z.infer<typeof updateCompanySchema>;

--- a/server/src/__tests__/heartbeat-quota-backoff.test.ts
+++ b/server/src/__tests__/heartbeat-quota-backoff.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS,
+  BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS,
+  computeBoundedTransientHeartbeatRetrySchedule,
+} from "../services/heartbeat.ts";
+
+// PMSA-18 / PMSA-11 §3.3: pure-function coverage for the schedule primitive
+// that scheduleBoundedRetryForRun consumes. Lives outside the integration
+// suite so it runs even on hosts without embedded Postgres.
+describe("computeBoundedTransientHeartbeatRetrySchedule (quota)", () => {
+  const now = new Date("2026-04-21T08:00:00.000Z");
+
+  it("uses the quota schedule (60s/240s/900s) when passed quota delays", () => {
+    const expected = [60_000, 240_000, 900_000];
+
+    expect(BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS).toEqual(expected);
+
+    for (let i = 0; i < expected.length; i += 1) {
+      const schedule = computeBoundedTransientHeartbeatRetrySchedule(
+        i + 1,
+        now,
+        () => 0.5, // disable jitter
+        BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS,
+      );
+      expect(schedule).not.toBeNull();
+      if (!schedule) continue;
+      expect(schedule.attempt).toBe(i + 1);
+      expect(schedule.maxAttempts).toBe(expected.length);
+      expect(schedule.baseDelayMs).toBe(expected[i]);
+      expect(schedule.delayMs).toBe(expected[i]);
+      expect(schedule.dueAt.getTime() - now.getTime()).toBe(expected[i]);
+    }
+  });
+
+  it("returns null past the quota cap so callers fall through to exhausted", () => {
+    expect(
+      computeBoundedTransientHeartbeatRetrySchedule(
+        BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS.length + 1,
+        now,
+        () => 0.5,
+        BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS,
+      ),
+    ).toBeNull();
+  });
+
+  it("preserves the legacy 4-step generic schedule when no delays arg is passed", () => {
+    const expected = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS;
+    const schedule = computeBoundedTransientHeartbeatRetrySchedule(
+      1,
+      now,
+      () => 0.5,
+    );
+    expect(schedule).not.toBeNull();
+    if (!schedule) return;
+    expect(schedule.maxAttempts).toBe(expected.length);
+    expect(schedule.baseDelayMs).toBe(expected[0]);
+  });
+
+  it("rejects non-positive attempt numbers", () => {
+    expect(
+      computeBoundedTransientHeartbeatRetrySchedule(
+        0,
+        now,
+        () => 0.5,
+        BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS,
+      ),
+    ).toBeNull();
+    expect(
+      computeBoundedTransientHeartbeatRetrySchedule(
+        -1,
+        now,
+        () => 0.5,
+        BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS,
+      ),
+    ).toBeNull();
+  });
+});

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -10,6 +10,7 @@ import {
   environmentLeases,
   heartbeatRunEvents,
   heartbeatRuns,
+  issueComments,
   issues,
 } from "@paperclipai/db";
 import {
@@ -18,11 +19,14 @@ import {
 } from "./helpers/embedded-postgres.js";
 import {
   BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS,
+  BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS,
   heartbeatService,
 } from "../services/heartbeat.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
-const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported
+  ? describe
+  : describe.skip;
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -33,10 +37,14 @@ if (!embeddedPostgresSupport.supported) {
 describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
   let db!: ReturnType<typeof createDb>;
   let heartbeat!: ReturnType<typeof heartbeatService>;
-  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let tempDb: Awaited<
+    ReturnType<typeof startEmbeddedPostgresTestDatabase>
+  > | null = null;
 
   beforeAll(async () => {
-    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-retry-scheduling-");
+    tempDb = await startEmbeddedPostgresTestDatabase(
+      "paperclip-heartbeat-retry-scheduling-",
+    );
     db = createDb(tempDb.connectionString);
     heartbeat = heartbeatService(db);
   }, 20_000);
@@ -44,6 +52,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
   afterEach(async () => {
     await db.delete(heartbeatRunEvents);
     await db.delete(environmentLeases);
+    await db.delete(issueComments);
     await db.delete(issues);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
@@ -70,7 +79,9 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     agentName?: string;
   }) {
     const adapterType = input.adapterType ?? "codex_local";
-    const agentName = input.agentName ?? (adapterType === "claude_local" ? "ClaudeCoder" : "CodexCoder");
+    const agentName =
+      input.agentName ??
+      (adapterType === "claude_local" ? "ClaudeCoder" : "CodexCoder");
     await db.insert(companies).values({
       id: input.companyId,
       name: "Paperclip",
@@ -105,7 +116,9 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       errorCode: input.errorCode,
       finishedAt: input.now,
       scheduledRetryAttempt: input.scheduledRetryAttempt ?? 0,
-      scheduledRetryReason: input.scheduledRetryAttempt ? "transient_failure" : null,
+      scheduledRetryReason: input.scheduledRetryAttempt
+        ? "transient_failure"
+        : null,
       resultJson: input.resultJson ?? {
         ...(input.errorFamily ? { errorFamily: input.errorFamily } : {}),
         ...(input.retryNotBefore
@@ -179,7 +192,9 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect(scheduled.outcome).toBe("scheduled");
     if (scheduled.outcome !== "scheduled") return;
 
-    const expectedDueAt = new Date(now.getTime() + BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS[0]);
+    const expectedDueAt = new Date(
+      now.getTime() + BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS[0],
+    );
     expect(scheduled.attempt).toBe(1);
     expect(scheduled.dueAt.toISOString()).toBe(expectedDueAt.toISOString());
 
@@ -195,9 +210,13 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       scheduledRetryAttempt: 1,
       scheduledRetryReason: "transient_failure",
     });
-    expect(retryRun?.scheduledRetryAt?.toISOString()).toBe(expectedDueAt.toISOString());
+    expect(retryRun?.scheduledRetryAt?.toISOString()).toBe(
+      expectedDueAt.toISOString(),
+    );
 
-    const earlyPromotion = await heartbeat.promoteDueScheduledRetries(new Date("2026-04-20T12:01:59.000Z"));
+    const earlyPromotion = await heartbeat.promoteDueScheduledRetries(
+      new Date("2026-04-20T12:01:59.000Z"),
+    );
     expect(earlyPromotion).toEqual({ promoted: 0, runIds: [] });
 
     const stillScheduled = await db
@@ -207,7 +226,8 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .then((rows) => rows[0] ?? null);
     expect(stillScheduled?.status).toBe("scheduled_retry");
 
-    const duePromotion = await heartbeat.promoteDueScheduledRetries(expectedDueAt);
+    const duePromotion =
+      await heartbeat.promoteDueScheduledRetries(expectedDueAt);
     expect(duePromotion).toEqual({ promoted: 1, runIds: [scheduled.run.id] });
 
     const promotedRun = await db
@@ -307,10 +327,13 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect(scheduled.outcome).toBe("scheduled");
     if (scheduled.outcome !== "scheduled") return;
 
-    await db.update(issues).set({
-      assigneeAgentId: newAgentId,
-      updatedAt: now,
-    }).where(eq(issues.id, issueId));
+    await db
+      .update(issues)
+      .set({
+        assigneeAgentId: newAgentId,
+        updatedAt: now,
+      })
+      .where(eq(issues.id, issueId));
 
     // Keep the new agent's queue from auto-claiming/executing during this unit test.
     await db.insert(heartbeatRuns).values(
@@ -460,12 +483,17 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect(scheduled.outcome).toBe("scheduled");
     if (scheduled.outcome !== "scheduled") return;
 
-    await db.update(issues).set({
-      assigneeAgentId: newAgentId,
-      updatedAt: now,
-    }).where(eq(issues.id, issueId));
+    await db
+      .update(issues)
+      .set({
+        assigneeAgentId: newAgentId,
+        updatedAt: now,
+      })
+      .where(eq(issues.id, issueId));
 
-    const promotion = await heartbeat.promoteDueScheduledRetries(scheduled.dueAt);
+    const promotion = await heartbeat.promoteDueScheduledRetries(
+      scheduled.dueAt,
+    );
     expect(promotion).toEqual({ promoted: 0, runIds: [] });
 
     const oldRetry = await db
@@ -559,12 +587,17 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect(scheduled.outcome).toBe("scheduled");
     if (scheduled.outcome !== "scheduled") return;
 
-    await db.update(issues).set({
-      status: "cancelled",
-      updatedAt: now,
-    }).where(eq(issues.id, issueId));
+    await db
+      .update(issues)
+      .set({
+        status: "cancelled",
+        updatedAt: now,
+      })
+      .where(eq(issues.id, issueId));
 
-    const promotion = await heartbeat.promoteDueScheduledRetries(scheduled.dueAt);
+    const promotion = await heartbeat.promoteDueScheduledRetries(
+      scheduled.dueAt,
+    );
     expect(promotion).toEqual({ promoted: 0, runIds: [] });
 
     const oldRetry = await db
@@ -712,14 +745,20 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, scheduled.run.id))
         .then((rows) => rows[0] ?? null);
-      expect((retryRun?.contextSnapshot as Record<string, unknown> | null)?.codexTransientFallbackMode).toBe(expectedMode);
+      expect(
+        (retryRun?.contextSnapshot as Record<string, unknown> | null)
+          ?.codexTransientFallbackMode,
+      ).toBe(expectedMode);
 
       const wakeupRequest = await db
         .select({ payload: agentWakeupRequests.payload })
         .from(agentWakeupRequests)
         .where(eq(agentWakeupRequests.id, retryRun?.wakeupRequestId ?? ""))
         .then((rows) => rows[0] ?? null);
-      expect((wakeupRequest?.payload as Record<string, unknown> | null)?.codexTransientFallbackMode).toBe(expectedMode);
+      expect(
+        (wakeupRequest?.payload as Record<string, unknown> | null)
+          ?.codexTransientFallbackMode,
+      ).toBe(expectedMode);
 
       await db.delete(heartbeatRunEvents);
       await db.delete(heartbeatRuns);
@@ -765,10 +804,13 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .where(eq(heartbeatRuns.id, scheduled.run.id))
       .then((rows) => rows[0] ?? null);
 
-    expect(retryRun?.scheduledRetryAt?.getTime()).toBe(retryNotBefore.getTime());
-    expect((retryRun?.contextSnapshot as Record<string, unknown> | null)?.transientRetryNotBefore).toBe(
-      retryNotBefore.toISOString(),
+    expect(retryRun?.scheduledRetryAt?.getTime()).toBe(
+      retryNotBefore.getTime(),
     );
+    expect(
+      (retryRun?.contextSnapshot as Record<string, unknown> | null)
+        ?.transientRetryNotBefore,
+    ).toBe(retryNotBefore.toISOString());
 
     const wakeupRequest = await db
       .select({ payload: agentWakeupRequests.payload })
@@ -776,9 +818,10 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .where(eq(agentWakeupRequests.id, retryRun?.wakeupRequestId ?? ""))
       .then((rows) => rows[0] ?? null);
 
-    expect((wakeupRequest?.payload as Record<string, unknown> | null)?.transientRetryNotBefore).toBe(
-      retryNotBefore.toISOString(),
-    );
+    expect(
+      (wakeupRequest?.payload as Record<string, unknown> | null)
+        ?.transientRetryNotBefore,
+    ).toBe(retryNotBefore.toISOString());
   });
 
   it("schedules bounded retries for claude_transient_upstream and honors its retry-not-before hint", async () => {
@@ -818,9 +861,14 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .where(eq(heartbeatRuns.id, scheduled.run.id))
       .then((rows) => rows[0] ?? null);
 
-    expect(retryRun?.scheduledRetryAt?.getTime()).toBe(retryNotBefore.getTime());
-    const contextSnapshot = (retryRun?.contextSnapshot as Record<string, unknown> | null) ?? {};
-    expect(contextSnapshot.transientRetryNotBefore).toBe(retryNotBefore.toISOString());
+    expect(retryRun?.scheduledRetryAt?.getTime()).toBe(
+      retryNotBefore.getTime(),
+    );
+    const contextSnapshot =
+      (retryRun?.contextSnapshot as Record<string, unknown> | null) ?? {};
+    expect(contextSnapshot.transientRetryNotBefore).toBe(
+      retryNotBefore.toISOString(),
+    );
     // Claude does not participate in the Codex fallback-mode ladder.
     expect(contextSnapshot.codexTransientFallbackMode ?? null).toBeNull();
 
@@ -830,8 +878,419 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .where(eq(agentWakeupRequests.id, retryRun?.wakeupRequestId ?? ""))
       .then((rows) => rows[0] ?? null);
 
-    expect((wakeupRequest?.payload as Record<string, unknown> | null)?.transientRetryNotBefore).toBe(
-      retryNotBefore.toISOString(),
+    expect(
+      (wakeupRequest?.payload as Record<string, unknown> | null)
+        ?.transientRetryNotBefore,
+    ).toBe(retryNotBefore.toISOString());
+  });
+
+  // PMSA-18 / PMSA-11 §3.3: quota / rate-limit errors take a tighter 3-step
+  // schedule (60s / 240s / 900s) instead of the legacy 4-step generic backoff.
+  it("uses the quota-specific 60s/240s/900s schedule for claude_quota_exhausted", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-04-21T08:00:00.000Z");
+
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      now,
+      errorCode: "claude_quota_exhausted",
+      errorFamily: "transient_upstream",
+      adapterType: "claude_local",
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+
+    const expectedDueAt = new Date(
+      now.getTime() + BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS[0],
     );
+    expect(scheduled.attempt).toBe(1);
+    expect(scheduled.maxAttempts).toBe(
+      BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS.length,
+    );
+    expect(scheduled.dueAt.toISOString()).toBe(expectedDueAt.toISOString());
+    // Sanity-check: did not regress to the legacy generic schedule.
+    expect(scheduled.dueAt.getTime() - now.getTime()).toBeLessThan(
+      BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS[0],
+    );
+  });
+
+  it("honors retry-after hints over the quota base schedule", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-04-21T09:00:00.000Z");
+    const retryNotBefore = new Date(now.getTime() + 30 * 60 * 1000);
+
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      now,
+      errorCode: "claude_rate_limited",
+      errorFamily: "transient_upstream",
+      adapterType: "claude_local",
+      retryNotBefore: retryNotBefore.toISOString(),
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+    expect(scheduled.dueAt.getTime()).toBe(retryNotBefore.getTime());
+
+    const retryRun = await db
+      .select({
+        scheduledRetryAt: heartbeatRuns.scheduledRetryAt,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, scheduled.run.id))
+      .then((rows) => rows[0] ?? null);
+    expect(retryRun?.scheduledRetryAt?.getTime()).toBe(
+      retryNotBefore.getTime(),
+    );
+    expect(
+      (retryRun?.contextSnapshot as Record<string, unknown> | null)
+        ?.transientRetryNotBefore,
+    ).toBe(retryNotBefore.toISOString());
+  });
+
+  // PMSA-18 / PMSA-11 §3.3: after the 3rd quota retry exhausts, the executing
+  // issue must be parked at `blocked` and a structured `quotaRetryExhausted`
+  // event must be emitted so the Phase 3 watcher can pick it up.
+  it("blocks the executing issue and emits quota_retry_exhausted after 3 attempts", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+    const now = new Date("2026-04-21T10:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ClaudeCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Quota retry exhaustion",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+      executionAgentNameKey: "claudecoder",
+      executionLockedAt: now,
+      issueNumber: 1,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-1`,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      status: "failed",
+      error: "Anthropic 401 quota_exhausted",
+      errorCode: "claude_quota_exhausted",
+      finishedAt: now,
+      scheduledRetryAttempt: BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS.length,
+      scheduledRetryReason: "transient_failure",
+      resultJson: { errorFamily: "transient_upstream" },
+      contextSnapshot: {
+        issueId,
+        wakeReason: "transient_failure_retry",
+      },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    const exhausted = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(exhausted).toEqual({
+      outcome: "retry_exhausted",
+      attempt: BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS.length + 1,
+      maxAttempts: BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS.length,
+    });
+
+    const issueAfter = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueAfter?.status).toBe("blocked");
+
+    const events = await db
+      .select({
+        message: heartbeatRunEvents.message,
+        payload: heartbeatRunEvents.payload,
+      })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId))
+      .orderBy(sql`${heartbeatRunEvents.id} asc`);
+
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    const exhaustedEvent = events.find((row) =>
+      row.message.includes("Bounded retry exhausted"),
+    );
+    expect(exhaustedEvent?.payload).toMatchObject({
+      retryReason: "transient_failure",
+      scheduledRetryAttempt: BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS.length,
+      maxAttempts: BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS.length,
+      errorCode: "claude_quota_exhausted",
+      quotaRetryExhausted: true,
+    });
+
+    const blockedEvent = events.find((row) =>
+      row.message.startsWith("quota_retry_exhausted"),
+    );
+    expect(blockedEvent?.payload).toMatchObject({
+      quotaRetryExhausted: true,
+      errorCode: "claude_quota_exhausted",
+      issueId,
+      issueStatus: "blocked",
+      maxAttempts: BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS.length,
+    });
+
+    const blockerComment = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(blockerComment?.body).toContain("claude_quota_exhausted");
+    expect(blockerComment?.body).toContain("bounded retry budget exhausted");
+  });
+
+  it("does not overwrite a manual blocker when quota retries exhaust", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+    const now = new Date("2026-04-21T11:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ClaudeCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Pre-blocked issue",
+      // Already manually blocked before quota retries gave up.
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+      executionAgentNameKey: "claudecoder",
+      executionLockedAt: now,
+      issueNumber: 1,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-1`,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      status: "failed",
+      error: "Anthropic 401 quota_exhausted",
+      errorCode: "claude_quota_exhausted",
+      finishedAt: now,
+      scheduledRetryAttempt: BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS.length,
+      scheduledRetryReason: "transient_failure",
+      resultJson: { errorFamily: "transient_upstream" },
+      contextSnapshot: {
+        issueId,
+        wakeReason: "transient_failure_retry",
+      },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    const exhausted = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+    expect(exhausted.outcome).toBe("retry_exhausted");
+
+    const issueAfter = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueAfter?.status).toBe("blocked");
+
+    const commentCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId))
+      .then((rows) => rows[0]?.count ?? 0);
+    // Already-blocked branch only emits the lifecycle run event — no
+    // duplicate user-facing comment.
+    expect(commentCount).toBe(0);
+
+    const blockedNoteEvent = await db
+      .select({
+        message: heartbeatRunEvents.message,
+        payload: heartbeatRunEvents.payload,
+      })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId))
+      .orderBy(sql`${heartbeatRunEvents.id} desc`)
+      .then((rows) => rows[0] ?? null);
+    expect(blockedNoteEvent?.message).toContain("already in blocked");
+    expect(blockedNoteEvent?.payload).toMatchObject({
+      quotaRetryExhausted: true,
+      issueId,
+      issueStatus: "blocked",
+    });
+  });
+
+  // PMSA-18: generic transient_upstream errors keep the legacy 4-step schedule
+  // and do NOT mark the issue blocked on exhaustion. This guards the carve-out
+  // between quota-shaped backoff and generic transient_upstream backoff.
+  it("does not block the issue for generic transient_upstream exhaustion", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+    const now = new Date("2026-04-21T12:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Generic transient exhaustion",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: now,
+      issueNumber: 1,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-1`,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      status: "failed",
+      error: "still transient",
+      errorCode: "claude_provider_5xx",
+      finishedAt: now,
+      scheduledRetryAttempt: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length,
+      scheduledRetryReason: "transient_failure",
+      resultJson: { errorFamily: "transient_upstream" },
+      contextSnapshot: {
+        issueId,
+        wakeReason: "transient_failure_retry",
+      },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    const exhausted = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(exhausted).toEqual({
+      outcome: "retry_exhausted",
+      attempt: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length + 1,
+      maxAttempts: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length,
+    });
+
+    const issueAfter = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueAfter?.status).toBe("in_progress");
+
+    const commentCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId))
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(commentCount).toBe(0);
   });
 });

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -1091,8 +1091,12 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .from(issueComments)
       .where(eq(issueComments.issueId, issueId))
       .then((rows) => rows[0] ?? null);
-    expect(blockerComment?.body).toContain("claude_quota_exhausted");
-    expect(blockerComment?.body).toContain("bounded retry budget exhausted");
+    expect(blockerComment?.body).toContain(
+      "Blocked: Anthropic Opus quota exhaustion",
+    );
+    expect(blockerComment?.body).toContain("hit Anthropic's Opus quota limit");
+    expect(blockerComment?.body).toContain("manually move this issue back");
+    expect(blockerComment?.body).not.toMatch(/PMSA-\d+/);
   });
 
   it("does not overwrite a manual blocker when quota retries exhaust", async () => {

--- a/server/src/__tests__/quota-priority-backfill.test.ts
+++ b/server/src/__tests__/quota-priority-backfill.test.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { agents, companies, createDb } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { backfillAgentPriorityTiers } from "../services/quota-priority-backfill.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported
+  ? describe
+  : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres quota priority backfill tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("backfillAgentPriorityTiers (PMSA-17)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<
+    ReturnType<typeof startEmbeddedPostgresTestDatabase>
+  > | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase(
+      "paperclip-quota-priority-backfill-",
+    );
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `PAP-${companyId.slice(0, 8)}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedAgent(
+    companyId: string,
+    input: {
+      name: string;
+      role: string;
+      metadata?: Record<string, unknown> | null;
+      status?: string;
+    },
+  ) {
+    const id = randomUUID();
+    await db.insert(agents).values({
+      id,
+      companyId,
+      name: input.name,
+      role: input.role as any,
+      status: (input.status ?? "idle") as any,
+      metadata: input.metadata ?? null,
+    });
+    return id;
+  }
+
+  it("assigns the documented tiers for the 5-agent MVP", async () => {
+    const companyId = await seedCompany();
+    const ceo = await seedAgent(companyId, { name: "CEO", role: "ceo" });
+    const engineer = await seedAgent(companyId, {
+      name: "Engineer",
+      role: "engineer",
+    });
+    const prdWriter = await seedAgent(companyId, {
+      name: "PRDWriter",
+      role: "pm",
+    });
+    const insightAnalyst = await seedAgent(companyId, {
+      name: "InsightAnalyst",
+      role: "researcher",
+    });
+    const techResearcher = await seedAgent(companyId, {
+      name: "TechResearcher",
+      role: "researcher",
+    });
+
+    const result = await backfillAgentPriorityTiers(db);
+    expect(result.scanned).toBe(5);
+    expect(result.updated).toHaveLength(5);
+    expect(result.skipped).toBe(0);
+
+    const tiers = new Map(
+      (
+        await db
+          .select({ id: agents.id, metadata: agents.metadata })
+          .from(agents)
+      ).map((row) => [
+        row.id,
+        (row.metadata as Record<string, unknown> | null)?.priorityTier,
+      ]),
+    );
+    expect(tiers.get(ceo)).toBe("p0");
+    expect(tiers.get(engineer)).toBe("p1");
+    expect(tiers.get(prdWriter)).toBe("p2");
+    expect(tiers.get(insightAnalyst)).toBe("p2");
+    expect(tiers.get(techResearcher)).toBe("p3");
+  });
+
+  it("preserves a previously-set valid tier", async () => {
+    const companyId = await seedCompany();
+    const id = await seedAgent(companyId, {
+      name: "Engineer",
+      role: "engineer",
+      metadata: { priorityTier: "p0", note: "manual override" },
+    });
+
+    const result = await backfillAgentPriorityTiers(db);
+    expect(result.updated).toHaveLength(0);
+    expect(result.skipped).toBeGreaterThan(0);
+
+    const row = await db
+      .select({ metadata: agents.metadata })
+      .from(agents)
+      .where(eq(agents.id, id))
+      .then((rows) => rows[0] ?? null);
+    const meta = row?.metadata as Record<string, unknown> | null;
+    expect(meta?.priorityTier).toBe("p0");
+    expect(meta?.note).toBe("manual override");
+  });
+
+  it("rewrites an invalid stored tier to the role default", async () => {
+    const companyId = await seedCompany();
+    const id = await seedAgent(companyId, {
+      name: "Engineer",
+      role: "engineer",
+      metadata: { priorityTier: "p9", retainedField: 42 },
+    });
+
+    const result = await backfillAgentPriorityTiers(db);
+    expect(result.updated).toHaveLength(1);
+    const row = await db
+      .select({ metadata: agents.metadata })
+      .from(agents)
+      .where(eq(agents.id, id))
+      .then((rows) => rows[0] ?? null);
+    const meta = row?.metadata as Record<string, unknown> | null;
+    expect(meta?.priorityTier).toBe("p1");
+    expect(meta?.retainedField).toBe(42);
+  });
+
+  it("skips terminated agents", async () => {
+    const companyId = await seedCompany();
+    const id = await seedAgent(companyId, {
+      name: "Old",
+      role: "engineer",
+      status: "terminated",
+    });
+
+    const result = await backfillAgentPriorityTiers(db);
+    expect(result.updated).toHaveLength(0);
+    expect(result.skipped).toBeGreaterThan(0);
+    const row = await db
+      .select({ metadata: agents.metadata })
+      .from(agents)
+      .where(eq(agents.id, id))
+      .then((rows) => rows[0] ?? null);
+    expect(row?.metadata).toBeNull();
+  });
+
+  it("is idempotent across repeated runs", async () => {
+    const companyId = await seedCompany();
+    await seedAgent(companyId, { name: "CEO", role: "ceo" });
+
+    const first = await backfillAgentPriorityTiers(db);
+    expect(first.updated).toHaveLength(1);
+    const second = await backfillAgentPriorityTiers(db);
+    expect(second.updated).toHaveLength(0);
+    expect(second.skipped).toBeGreaterThan(0);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,6 +36,7 @@ import {
   routineService,
 } from "./services/index.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
+import { releaseStaleInflightSlots } from "./services/provider-semaphore.js";
 import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
@@ -671,7 +672,21 @@ export async function startServer(): Promise<StartedServer> {
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any, { pluginWorkerManager });
     const routines = routineService(db as any, { pluginWorkerManager });
-  
+
+    // Reset the in-process Opus concurrency semaphore so any leftover state
+    // (hot-reload, partial previous boot) is discarded before we resume queued
+    // runs.
+    const semaphoreReset = releaseStaleInflightSlots();
+    if (
+      semaphoreReset.inflightCleared > 0 ||
+      semaphoreReset.waitersRejected > 0
+    ) {
+      logger.warn(
+        semaphoreReset,
+        "cleared stale provider semaphore state on startup",
+      );
+    }
+
     // Reap orphaned running runs at startup while in-memory execution state is empty,
     // then resume any persisted queued runs that were waiting on the previous process.
     void heartbeat

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,11 +37,18 @@ import {
 } from "./services/index.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
 import { releaseStaleInflightSlots } from "./services/provider-semaphore.js";
-import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
+import { backfillAgentPriorityTiers } from "./services/quota-priority-backfill.js";
+import {
+  buildRuntimeApiCandidateUrls,
+  choosePrimaryRuntimeApiUrl,
+} from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
-import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
+import {
+  getBoardClaimWarningUrl,
+  initializeBoardClaimChallenge,
+} from "./board-claim.js";
 import { maybePersistWorktreeRuntimePorts } from "./worktree-config.js";
 import { initTelemetry, getTelemetryClient } from "./telemetry.js";
 import { conflict } from "./errors.js";
@@ -78,7 +85,6 @@ type EmbeddedPostgresCtor = new (opts: {
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;
 
-
 export interface StartedServer {
   server: ReturnType<typeof createServer>;
   host: string;
@@ -94,45 +100,52 @@ export async function startServer(): Promise<StartedServer> {
     process.env.PAPERCLIP_SECRETS_PROVIDER = config.secretsProvider;
   }
   if (process.env.PAPERCLIP_SECRETS_STRICT_MODE === undefined) {
-    process.env.PAPERCLIP_SECRETS_STRICT_MODE = config.secretsStrictMode ? "true" : "false";
+    process.env.PAPERCLIP_SECRETS_STRICT_MODE = config.secretsStrictMode
+      ? "true"
+      : "false";
   }
   if (process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE === undefined) {
-    process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = config.secretsMasterKeyFilePath;
+    process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE =
+      config.secretsMasterKeyFilePath;
   }
-  
+
   type MigrationSummary =
     | "skipped"
     | "already applied"
     | "applied (empty database)"
     | "applied (pending migrations)";
-  
+
   function formatPendingMigrationSummary(migrations: string[]): string {
     if (migrations.length === 0) return "none";
     return migrations.length > 3
       ? `${migrations.slice(0, 3).join(", ")} (+${migrations.length - 3} more)`
       : migrations.join(", ");
   }
-  
+
   async function promptApplyMigrations(migrations: string[]): Promise<boolean> {
     if (process.env.PAPERCLIP_MIGRATION_AUTO_APPLY === "true") return true;
     if (process.env.PAPERCLIP_MIGRATION_PROMPT === "never") return false;
     if (!stdin.isTTY || !stdout.isTTY) return true;
-  
+
     const prompt = createInterface({ input: stdin, output: stdout });
     try {
-      const answer = (await prompt.question(
-        `Apply pending migrations (${formatPendingMigrationSummary(migrations)}) now? (y/N): `,
-      )).trim().toLowerCase();
+      const answer = (
+        await prompt.question(
+          `Apply pending migrations (${formatPendingMigrationSummary(migrations)}) now? (y/N): `,
+        )
+      )
+        .trim()
+        .toLowerCase();
       return answer === "y" || answer === "yes";
     } finally {
       prompt.close();
     }
   }
-  
+
   type EnsureMigrationsOptions = {
     autoApply?: boolean;
   };
-  
+
   async function ensureMigrations(
     connectionString: string,
     label: string,
@@ -140,7 +153,10 @@ export async function startServer(): Promise<StartedServer> {
   ): Promise<MigrationSummary> {
     const autoApply = opts?.autoApply === true;
     let state = await inspectMigrations(connectionString);
-    if (state.status === "needsMigrations" && state.reason === "pending-migrations") {
+    if (
+      state.status === "needsMigrations" &&
+      state.reason === "pending-migrations"
+    ) {
       const repair = await reconcilePendingMigrationHistory(connectionString);
       if (repair.repairedMigrations.length > 0) {
         logger.warn(
@@ -152,43 +168,63 @@ export async function startServer(): Promise<StartedServer> {
       }
     }
     if (state.status === "upToDate") return "already applied";
-    if (state.status === "needsMigrations" && state.reason === "no-migration-journal-non-empty-db") {
+    if (
+      state.status === "needsMigrations" &&
+      state.reason === "no-migration-journal-non-empty-db"
+    ) {
       logger.warn(
         { tableCount: state.tableCount },
         `${label} has existing tables but no migration journal. Run migrations manually to sync schema.`,
       );
-      const apply = autoApply ? true : await promptApplyMigrations(state.pendingMigrations);
+      const apply = autoApply
+        ? true
+        : await promptApplyMigrations(state.pendingMigrations);
       if (!apply) {
         throw new Error(
           `${label} has pending migrations (${formatPendingMigrationSummary(state.pendingMigrations)}). ` +
             "Refusing to start against a stale schema. Run pnpm db:migrate or set PAPERCLIP_MIGRATION_AUTO_APPLY=true.",
         );
       }
-  
-      logger.info({ pendingMigrations: state.pendingMigrations }, `Applying ${state.pendingMigrations.length} pending migrations for ${label}`);
+
+      logger.info(
+        { pendingMigrations: state.pendingMigrations },
+        `Applying ${state.pendingMigrations.length} pending migrations for ${label}`,
+      );
       await applyPendingMigrations(connectionString);
       return "applied (pending migrations)";
     }
-  
-    const apply = autoApply ? true : await promptApplyMigrations(state.pendingMigrations);
+
+    const apply = autoApply
+      ? true
+      : await promptApplyMigrations(state.pendingMigrations);
     if (!apply) {
       throw new Error(
         `${label} has pending migrations (${formatPendingMigrationSummary(state.pendingMigrations)}). ` +
           "Refusing to start against a stale schema. Run pnpm db:migrate or set PAPERCLIP_MIGRATION_AUTO_APPLY=true.",
       );
     }
-  
-    logger.info({ pendingMigrations: state.pendingMigrations }, `Applying ${state.pendingMigrations.length} pending migrations for ${label}`);
+
+    logger.info(
+      { pendingMigrations: state.pendingMigrations },
+      `Applying ${state.pendingMigrations.length} pending migrations for ${label}`,
+    );
     await applyPendingMigrations(connectionString);
     return "applied (pending migrations)";
   }
-  
+
   function isLoopbackHost(host: string): boolean {
     const normalized = host.trim().toLowerCase();
-    return normalized === "127.0.0.1" || normalized === "localhost" || normalized === "::1";
+    return (
+      normalized === "127.0.0.1" ||
+      normalized === "localhost" ||
+      normalized === "::1"
+    );
   }
 
-  function rewriteLocalUrlPort(rawUrl: string | undefined, port: number): string | undefined {
+  function rewriteLocalUrlPort(
+    rawUrl: string | undefined,
+    port: number,
+  ): string | undefined {
     if (!rawUrl) return undefined;
     try {
       const parsed = new URL(rawUrl);
@@ -199,11 +235,11 @@ export async function startServer(): Promise<StartedServer> {
       return rawUrl;
     }
   }
-  
+
   const LOCAL_BOARD_USER_ID = "local-board";
   const LOCAL_BOARD_USER_EMAIL = "local@paperclip.local";
   const LOCAL_BOARD_USER_NAME = "Board";
-  
+
   async function ensureLocalTrustedBoardPrincipal(db: any): Promise<void> {
     const now = new Date();
     const existingUser = await db
@@ -211,7 +247,7 @@ export async function startServer(): Promise<StartedServer> {
       .from(authUsers)
       .where(eq(authUsers.id, LOCAL_BOARD_USER_ID))
       .then((rows: Array<{ id: string }>) => rows[0] ?? null);
-  
+
     if (!existingUser) {
       await db.insert(authUsers).values({
         id: LOCAL_BOARD_USER_ID,
@@ -223,11 +259,16 @@ export async function startServer(): Promise<StartedServer> {
         updatedAt: now,
       });
     }
-  
+
     const role = await db
       .select({ id: instanceUserRoles.id })
       .from(instanceUserRoles)
-      .where(and(eq(instanceUserRoles.userId, LOCAL_BOARD_USER_ID), eq(instanceUserRoles.role, "instance_admin")))
+      .where(
+        and(
+          eq(instanceUserRoles.userId, LOCAL_BOARD_USER_ID),
+          eq(instanceUserRoles.role, "instance_admin"),
+        ),
+      )
       .then((rows: Array<{ id: string }>) => rows[0] ?? null);
     if (!role) {
       await db.insert(instanceUserRoles).values({
@@ -235,7 +276,7 @@ export async function startServer(): Promise<StartedServer> {
         role: "instance_admin",
       });
     }
-  
+
     const companyRows = await db.select({ id: companies.id }).from(companies);
     for (const company of companyRows) {
       const membership = await db
@@ -259,7 +300,7 @@ export async function startServer(): Promise<StartedServer> {
       });
     }
   }
-  
+
   let db;
   let pluginMigrationDb;
   let embeddedPostgres: EmbeddedPostgresInstance | null = null;
@@ -273,12 +314,17 @@ export async function startServer(): Promise<StartedServer> {
   if (config.databaseUrl) {
     const migrationUrl = config.databaseMigrationUrl ?? config.databaseUrl;
     migrationSummary = await ensureMigrations(migrationUrl, "PostgreSQL");
-  
+
     db = createDb(config.databaseUrl);
-    pluginMigrationDb = config.databaseMigrationUrl ? createDb(config.databaseMigrationUrl) : db;
+    pluginMigrationDb = config.databaseMigrationUrl
+      ? createDb(config.databaseMigrationUrl)
+      : db;
     logger.info("Using external PostgreSQL via DATABASE_URL/config");
     activeDatabaseConnectionString = config.databaseUrl;
-    startupDbInfo = { mode: "external-postgres", connectionString: config.databaseUrl };
+    startupDbInfo = {
+      mode: "external-postgres",
+      connectionString: config.databaseUrl,
+    };
   } else {
     const moduleName = "embedded-postgres";
     let EmbeddedPostgres: EmbeddedPostgresCtor;
@@ -290,29 +336,34 @@ export async function startServer(): Promise<StartedServer> {
         "Embedded PostgreSQL mode requires dependency `embedded-postgres`. Reinstall dependencies (without omitting required packages), or set DATABASE_URL for external Postgres.",
       );
     }
-  
+
     const dataDir = resolve(config.embeddedPostgresDataDir);
     const configuredPort = config.embeddedPostgresPort;
     let port = configuredPort;
     const logBuffer = createEmbeddedPostgresLogBuffer(120);
-    const verboseEmbeddedPostgresLogs = process.env.PAPERCLIP_EMBEDDED_POSTGRES_VERBOSE === "true";
+    const verboseEmbeddedPostgresLogs =
+      process.env.PAPERCLIP_EMBEDDED_POSTGRES_VERBOSE === "true";
     const appendEmbeddedPostgresLog = (message: unknown) => {
       logBuffer.append(message);
       if (!verboseEmbeddedPostgresLogs) {
         return;
       }
-      const lines = typeof message === "string"
-        ? message.split(/\r?\n/)
-        : message instanceof Error
-          ? [message.message]
-          : [String(message ?? "")];
+      const lines =
+        typeof message === "string"
+          ? message.split(/\r?\n/)
+          : message instanceof Error
+            ? [message.message]
+            : [String(message ?? "")];
       for (const lineRaw of lines) {
         const line = lineRaw.trim();
         if (!line) continue;
         logger.info({ embeddedPostgresLog: line }, "embedded-postgres");
       }
     };
-    const logEmbeddedPostgresFailure = (phase: "initialise" | "start", err: unknown) => {
+    const logEmbeddedPostgresFailure = (
+      phase: "initialise" | "start",
+      err: unknown,
+    ) => {
       const recentLogs = logBuffer.getRecentLogs();
       if (recentLogs.length > 0) {
         logger.error(
@@ -325,11 +376,13 @@ export async function startServer(): Promise<StartedServer> {
         );
       }
     };
-  
+
     if (config.databaseMode === "postgres") {
-      logger.warn("Database mode is postgres but no connection string was set; falling back to embedded PostgreSQL");
+      logger.warn(
+        "Database mode is postgres but no connection string was set; falling back to embedded PostgreSQL",
+      );
     }
-  
+
     const clusterVersionFile = resolve(dataDir, "PG_VERSION");
     const clusterAlreadyInitialized = existsSync(clusterVersionFile);
     const postmasterPidFile = resolve(dataDir, "postmaster.pid");
@@ -341,11 +394,13 @@ export async function startServer(): Promise<StartedServer> {
         return false;
       }
     };
-  
+
     const getRunningPid = (): number | null => {
       if (!existsSync(postmasterPidFile)) return null;
       try {
-        const pidLine = readFileSync(postmasterPidFile, "utf8").split("\n")[0]?.trim();
+        const pidLine = readFileSync(postmasterPidFile, "utf8")
+          .split("\n")[0]
+          ?.trim();
         const pid = Number(pidLine);
         if (!Number.isInteger(pid) || pid <= 0) return null;
         if (!isPidRunning(pid)) return null;
@@ -354,31 +409,44 @@ export async function startServer(): Promise<StartedServer> {
         return null;
       }
     };
-  
+
     const runningPid = getRunningPid();
     if (runningPid) {
-      logger.warn(`Embedded PostgreSQL already running; reusing existing process (pid=${runningPid}, port=${port})`);
+      logger.warn(
+        `Embedded PostgreSQL already running; reusing existing process (pid=${runningPid}, port=${port})`,
+      );
     } else {
       const configuredAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${configuredPort}/postgres`;
       try {
-        const actualDataDir = await getPostgresDataDirectory(configuredAdminConnectionString);
+        const actualDataDir = await getPostgresDataDirectory(
+          configuredAdminConnectionString,
+        );
         if (
           typeof actualDataDir !== "string" ||
           resolve(actualDataDir) !== resolve(dataDir)
         ) {
-          throw new Error("reachable postgres does not use the expected embedded data directory");
+          throw new Error(
+            "reachable postgres does not use the expected embedded data directory",
+          );
         }
-        await ensurePostgresDatabase(configuredAdminConnectionString, "paperclip");
+        await ensurePostgresDatabase(
+          configuredAdminConnectionString,
+          "paperclip",
+        );
         logger.warn(
           `Embedded PostgreSQL appears to already be reachable without a pid file; reusing existing server on configured port ${configuredPort}`,
         );
       } catch {
         const detectedPort = await detectPort(configuredPort);
         if (detectedPort !== configuredPort) {
-          logger.warn(`Embedded PostgreSQL port is in use; using next free port (requestedPort=${configuredPort}, selectedPort=${detectedPort})`);
+          logger.warn(
+            `Embedded PostgreSQL port is in use; using next free port (requestedPort=${configuredPort}, selectedPort=${detectedPort})`,
+          );
         }
         port = detectedPort;
-        logger.info(`Using embedded PostgreSQL because no DATABASE_URL set (dataDir=${dataDir}, port=${port})`);
+        logger.info(
+          `Using embedded PostgreSQL because no DATABASE_URL set (dataDir=${dataDir}, port=${port})`,
+        );
         embeddedPostgres = new EmbeddedPostgres({
           databaseDir: dataDir,
           user: "paperclip",
@@ -401,7 +469,9 @@ export async function startServer(): Promise<StartedServer> {
             });
           }
         } else {
-          logger.info(`Embedded PostgreSQL cluster already exists (${clusterVersionFile}); skipping init`);
+          logger.info(
+            `Embedded PostgreSQL cluster already exists (${clusterVersionFile}); skipping init`,
+          );
         }
 
         if (existsSync(postmasterPidFile)) {
@@ -420,22 +490,32 @@ export async function startServer(): Promise<StartedServer> {
         embeddedPostgresStartedByThisProcess = true;
       }
     }
-  
+
     const embeddedAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
-    const dbStatus = await ensurePostgresDatabase(embeddedAdminConnectionString, "paperclip");
+    const dbStatus = await ensurePostgresDatabase(
+      embeddedAdminConnectionString,
+      "paperclip",
+    );
     if (dbStatus === "created") {
       logger.info("Created embedded PostgreSQL database: paperclip");
     }
-  
+
     const embeddedConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`;
-    const shouldAutoApplyFirstRunMigrations = !clusterAlreadyInitialized || dbStatus === "created";
+    const shouldAutoApplyFirstRunMigrations =
+      !clusterAlreadyInitialized || dbStatus === "created";
     if (shouldAutoApplyFirstRunMigrations) {
-      logger.info("Detected first-run embedded PostgreSQL setup; applying pending migrations automatically");
+      logger.info(
+        "Detected first-run embedded PostgreSQL setup; applying pending migrations automatically",
+      );
     }
-    migrationSummary = await ensureMigrations(embeddedConnectionString, "Embedded PostgreSQL", {
-      autoApply: shouldAutoApplyFirstRunMigrations,
-    });
-  
+    migrationSummary = await ensureMigrations(
+      embeddedConnectionString,
+      "Embedded PostgreSQL",
+      {
+        autoApply: shouldAutoApplyFirstRunMigrations,
+      },
+    );
+
     db = createDb(embeddedConnectionString);
     pluginMigrationDb = db;
     logger.info("Embedded PostgreSQL ready");
@@ -443,32 +523,42 @@ export async function startServer(): Promise<StartedServer> {
     resolvedEmbeddedPostgresPort = port;
     startupDbInfo = { mode: "embedded-postgres", dataDir, port };
   }
-  
-  if (config.deploymentMode === "local_trusted" && !isLoopbackHost(config.host)) {
+
+  if (
+    config.deploymentMode === "local_trusted" &&
+    !isLoopbackHost(config.host)
+  ) {
     throw new Error(
       `local_trusted mode requires loopback host binding (received: ${config.host}). ` +
         "Use authenticated mode for non-loopback deployments.",
     );
   }
-  
-  if (config.deploymentMode === "local_trusted" && config.deploymentExposure !== "private") {
+
+  if (
+    config.deploymentMode === "local_trusted" &&
+    config.deploymentExposure !== "private"
+  ) {
     throw new Error("local_trusted mode only supports private exposure");
   }
-  
+
   if (config.deploymentMode === "authenticated") {
     if (config.authBaseUrlMode === "explicit" && !config.authPublicBaseUrl) {
       throw new Error("auth.baseUrlMode=explicit requires auth.publicBaseUrl");
     }
     if (config.deploymentExposure === "public") {
       if (config.authBaseUrlMode !== "explicit") {
-        throw new Error("authenticated public exposure requires auth.baseUrlMode=explicit");
+        throw new Error(
+          "authenticated public exposure requires auth.baseUrlMode=explicit",
+        );
       }
       if (!config.authPublicBaseUrl) {
-        throw new Error("authenticated public exposure requires auth.publicBaseUrl");
+        throw new Error(
+          "authenticated public exposure requires auth.publicBaseUrl",
+        );
       }
     }
   }
-  
+
   let authReady = config.deploymentMode === "local_trusted";
   let betterAuthHandler: RequestHandler | undefined;
   let resolveSession:
@@ -493,7 +583,9 @@ export async function startServer(): Promise<StartedServer> {
       .split(",")
       .map((value) => value.trim())
       .filter((value) => value.length > 0);
-    const effectiveTrustedOrigins = Array.from(new Set([...derivedTrustedOrigins, ...envTrustedOrigins]));
+    const effectiveTrustedOrigins = Array.from(
+      new Set([...derivedTrustedOrigins, ...envTrustedOrigins]),
+    );
     logger.info(
       {
         authBaseUrlMode: config.authBaseUrlMode,
@@ -506,29 +598,46 @@ export async function startServer(): Promise<StartedServer> {
       },
       "Authenticated mode auth origin configuration",
     );
-    const auth = createBetterAuthInstance(db as any, config, effectiveTrustedOrigins);
+    const auth = createBetterAuthInstance(
+      db as any,
+      config,
+      effectiveTrustedOrigins,
+    );
     betterAuthHandler = createBetterAuthHandler(auth);
     resolveSession = (req) => resolveBetterAuthSession(auth, req);
-    resolveSessionFromHeaders = (headers) => resolveBetterAuthSessionFromHeaders(auth, headers);
-    await initializeBoardClaimChallenge(db as any, { deploymentMode: config.deploymentMode });
+    resolveSessionFromHeaders = (headers) =>
+      resolveBetterAuthSessionFromHeaders(auth, headers);
+    await initializeBoardClaimChallenge(db as any, {
+      deploymentMode: config.deploymentMode,
+    });
     authReady = true;
   }
-  
+
   const listenPort = await detectPort(config.port);
   if (listenPort !== config.port) {
     config.port = listenPort;
   }
-  if (resolvedEmbeddedPostgresPort !== null && resolvedEmbeddedPostgresPort !== config.embeddedPostgresPort) {
+  if (
+    resolvedEmbeddedPostgresPort !== null &&
+    resolvedEmbeddedPostgresPort !== config.embeddedPostgresPort
+  ) {
     config.embeddedPostgresPort = resolvedEmbeddedPostgresPort;
   }
   if (config.authBaseUrlMode === "explicit" && config.authPublicBaseUrl) {
-    config.authPublicBaseUrl = rewriteLocalUrlPort(config.authPublicBaseUrl, listenPort);
+    config.authPublicBaseUrl = rewriteLocalUrlPort(
+      config.authPublicBaseUrl,
+      listenPort,
+    );
   }
   maybePersistWorktreeRuntimePorts({
     serverPort: listenPort,
     databasePort: resolvedEmbeddedPostgresPort,
   });
-  const uiMode = config.uiDevMiddleware ? "vite-dev" : config.serveUi ? "static" : "none";
+  const uiMode = config.uiDevMiddleware
+    ? "vite-dev"
+    : config.serveUi
+      ? "static"
+      : "none";
   const storageService = createStorageServiceFromConfig(config);
   const feedback = feedbackService(db as any, {
     shareClient: createFeedbackTraceShareClientFromConfig(config),
@@ -541,7 +650,9 @@ export async function startServer(): Promise<StartedServer> {
     if (databaseBackupInFlight) {
       const message = "Database backup already in progress";
       if (trigger === "scheduled") {
-        logger.warn("Skipping scheduled database backup because a previous backup is still running");
+        logger.warn(
+          "Skipping scheduled database backup because a previous backup is still running",
+        );
         return null;
       }
       throw conflict(message);
@@ -552,7 +663,10 @@ export async function startServer(): Promise<StartedServer> {
     const startedAtMs = Date.now();
     const label = trigger === "scheduled" ? "Automatic" : "Manual";
     try {
-      logger.info({ backupDir: config.databaseBackupDir, trigger }, `${label} database backup starting`);
+      logger.info(
+        { backupDir: config.databaseBackupDir, trigger },
+        `${label} database backup starting`,
+      );
       // Read retention from Instance Settings (DB) so changes take effect without restart.
       const generalSettings = await backupSettingsSvc.getGeneral();
       const retention = generalSettings.backupRetention;
@@ -587,7 +701,10 @@ export async function startServer(): Promise<StartedServer> {
       );
       return response;
     } catch (err) {
-      logger.error({ err, backupDir: config.databaseBackupDir, trigger }, `${label} database backup failed`);
+      logger.error(
+        { err, backupDir: config.databaseBackupDir, trigger },
+        `${label} database backup failed`,
+      );
       throw err;
     } finally {
       databaseBackupInFlight = false;
@@ -619,18 +736,22 @@ export async function startServer(): Promise<StartedServer> {
     resolveSession,
     pluginWorkerManager,
   });
-  const server = createServer(app as unknown as Parameters<typeof createServer>[0]);
+  const server = createServer(
+    app as unknown as Parameters<typeof createServer>[0],
+  );
 
   // Increase keep-alive timeouts to safely outlive default idle timeouts
   // of common reverse proxies and load balancers (like AWS ALB, Nginx, or Traefik).
   // This prevents intermittent 502/ECONNRESET errors caused by Node's 5s default.
   server.keepAliveTimeout = 185000;
   server.headersTimeout = 186000;
-  
+
   if (listenPort !== config.port) {
-    logger.warn(`Requested port is busy; using next free port (requestedPort=${config.port}, selectedPort=${listenPort})`);
+    logger.warn(
+      `Requested port is busy; using next free port (requestedPort=${config.port}, selectedPort=${listenPort})`,
+    );
   }
-  
+
   const runtimeListenHost = config.host;
   const runtimeApiUrl = choosePrimaryRuntimeApiUrl({
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,
@@ -644,13 +765,15 @@ export async function startServer(): Promise<StartedServer> {
     bindHost: runtimeListenHost,
     port: listenPort,
   });
-  const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
+  const configuredApiUrl =
+    process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
   process.env.PAPERCLIP_LISTEN_HOST = runtimeListenHost;
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
   process.env.PAPERCLIP_RUNTIME_API_URL = runtimeApiUrl;
-  process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify(runtimeApiCandidates);
+  process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON =
+    JSON.stringify(runtimeApiCandidates);
   process.env.PAPERCLIP_API_URL = configuredApiUrl;
-  
+
   setupLiveEventsWebSocketServer(server, db as any, {
     deploymentMode: config.deploymentMode,
     resolveSessionFromHeaders,
@@ -666,9 +789,12 @@ export async function startServer(): Promise<StartedServer> {
       }
     })
     .catch((err) => {
-      logger.error({ err }, "startup reconciliation of persisted runtime services failed");
+      logger.error(
+        { err },
+        "startup reconciliation of persisted runtime services failed",
+      );
     });
-  
+
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any, { pluginWorkerManager });
     const routines = routineService(db as any, { pluginWorkerManager });
@@ -687,6 +813,32 @@ export async function startServer(): Promise<StartedServer> {
       );
     }
 
+    // PMSA-17: ensure every active agent has metadata.priorityTier set so the
+    // priority-aware semaphore can use it without falling back to defaults at
+    // hot path. Idempotent — agents already carrying a valid tier are skipped.
+    void backfillAgentPriorityTiers(db as any)
+      .then((result) => {
+        if (result.updated.length > 0) {
+          logger.info(
+            {
+              scanned: result.scanned,
+              updated: result.updated.length,
+              skipped: result.skipped,
+              assignments: result.updated.map((row) => ({
+                agentId: row.agentId,
+                name: row.name,
+                role: row.role,
+                priorityTier: row.priorityTier,
+              })),
+            },
+            "backfilled agent.metadata.priorityTier",
+          );
+        }
+      })
+      .catch((err) => {
+        logger.error({ err }, "agent priorityTier backfill failed");
+      });
+
     // Reap orphaned running runs at startup while in-memory execution state is empty,
     // then resume any persisted queued runs that were waiting on the previous process.
     void heartbeat
@@ -702,7 +854,11 @@ export async function startServer(): Promise<StartedServer> {
           reconciled.escalated > 0
         ) {
           logger.warn(
-            { promotedScheduledRetries: promotion.promoted, promotedScheduledRetryRunIds: promotion.runIds, ...reconciled },
+            {
+              promotedScheduledRetries: promotion.promoted,
+              promotedScheduledRetryRunIds: promotion.runIds,
+              ...reconciled,
+            },
             "startup heartbeat recovery changed assigned issue state",
           );
         }
@@ -710,13 +866,19 @@ export async function startServer(): Promise<StartedServer> {
       .then(async () => {
         const reconciled = await heartbeat.reconcileIssueGraphLiveness();
         if (reconciled.escalationsCreated > 0) {
-          logger.warn({ ...reconciled }, "startup issue-graph liveness reconciliation created escalations");
+          logger.warn(
+            { ...reconciled },
+            "startup issue-graph liveness reconciliation created escalations",
+          );
         }
       })
       .then(async () => {
         const scanned = await heartbeat.scanSilentActiveRuns();
         if (scanned.created > 0 || scanned.escalated > 0) {
-          logger.warn({ ...scanned }, "startup active-run output watchdog created review work");
+          logger.warn(
+            { ...scanned },
+            "startup active-run output watchdog created review work",
+          );
         }
       })
       .catch((err) => {
@@ -744,7 +906,7 @@ export async function startServer(): Promise<StartedServer> {
         .catch((err) => {
           logger.error({ err }, "routine scheduler tick failed");
         });
-  
+
       // Periodically reap orphaned runs (5-min staleness threshold) and make sure
       // persisted queued work is still being driven forward.
       void heartbeat
@@ -760,7 +922,11 @@ export async function startServer(): Promise<StartedServer> {
             reconciled.escalated > 0
           ) {
             logger.warn(
-              { promotedScheduledRetries: promotion.promoted, promotedScheduledRetryRunIds: promotion.runIds, ...reconciled },
+              {
+                promotedScheduledRetries: promotion.promoted,
+                promotedScheduledRetryRunIds: promotion.runIds,
+                ...reconciled,
+              },
               "periodic heartbeat recovery changed assigned issue state",
             );
           }
@@ -768,13 +934,19 @@ export async function startServer(): Promise<StartedServer> {
         .then(async () => {
           const reconciled = await heartbeat.reconcileIssueGraphLiveness();
           if (reconciled.escalationsCreated > 0) {
-            logger.warn({ ...reconciled }, "periodic issue-graph liveness reconciliation created escalations");
+            logger.warn(
+              { ...reconciled },
+              "periodic issue-graph liveness reconciliation created escalations",
+            );
           }
         })
         .then(async () => {
           const scanned = await heartbeat.scanSilentActiveRuns();
           if (scanned.created > 0 || scanned.escalated > 0) {
-            logger.warn({ ...scanned }, "periodic active-run output watchdog created review work");
+            logger.warn(
+              { ...scanned },
+              "periodic active-run output watchdog created review work",
+            );
           }
         })
         .catch((err) => {
@@ -782,7 +954,7 @@ export async function startServer(): Promise<StartedServer> {
         });
     }, config.heartbeatSchedulerIntervalMs);
   }
-  
+
   if (config.databaseBackupEnabled) {
     const backupIntervalMs = config.databaseBackupIntervalMinutes * 60 * 1000;
 
@@ -800,7 +972,7 @@ export async function startServer(): Promise<StartedServer> {
       });
     }, backupIntervalMs);
   }
-  
+
   // Wait for external adapters to finish loading before accepting requests.
   // Without this, adapter type validation (assertKnownAdapterType) would
   // reject valid external adapter types during the startup loading window.
@@ -818,7 +990,10 @@ export async function startServer(): Promise<StartedServer> {
       server.off("error", onError);
       logger.info(`Server listening on ${config.host}:${listenPort}`);
       if (process.env.PAPERCLIP_OPEN_ON_LISTEN === "true") {
-        const openHost = config.host === "0.0.0.0" || config.host === "::" ? "127.0.0.1" : config.host;
+        const openHost =
+          config.host === "0.0.0.0" || config.host === "::"
+            ? "127.0.0.1"
+            : config.host;
         const url = `http://${openHost}:${listenPort}`;
         void import("open")
           .then((mod) => mod.default(url))
@@ -829,10 +1004,10 @@ export async function startServer(): Promise<StartedServer> {
             logger.warn({ err, url }, "Failed to open browser on startup");
           });
       }
-        printStartupBanner({
-          bind: config.bind,
-          host: config.host,
-          deploymentMode: config.deploymentMode,
+      printStartupBanner({
+        bind: config.bind,
+        host: config.host,
+        deploymentMode: config.deploymentMode,
         deploymentExposure: config.deploymentExposure,
         authReady,
         requestedPort: config.port,
@@ -867,7 +1042,7 @@ export async function startServer(): Promise<StartedServer> {
       resolveListen();
     });
   });
-  
+
   {
     const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
       const telemetryClient = getTelemetryClient();

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -16,6 +16,8 @@ import {
   agentService,
   heartbeatService,
   logActivity,
+  quotaIncidentsService,
+  clampQuotaIncidentWindowMinutes,
 } from "../services/index.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import { fetchAllQuotaWindows } from "../services/quota-windows.js";
@@ -29,13 +31,14 @@ export function parseCostDateRange(query: Record<string, unknown>) {
   const to = toRaw ? new Date(toRaw) : undefined;
   if (from && isNaN(from.getTime())) throw badRequest("invalid 'from' date");
   if (to && isNaN(to.getTime())) throw badRequest("invalid 'to' date");
-  return (from || to) ? { from, to } : undefined;
+  return from || to ? { from, to } : undefined;
 }
 
 export function parseCostLimit(query: Record<string, unknown>) {
   const raw = Array.isArray(query.limit) ? query.limit[0] : query.limit;
   if (raw == null || raw === "") return 100;
-  const limit = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
+  const limit =
+    typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
   if (!Number.isFinite(limit) || limit <= 0 || limit > 500) {
     throw badRequest("invalid 'limit' value");
   }
@@ -58,65 +61,77 @@ export function costRoutes(
   const budgets = budgetService(db, budgetHooks);
   const companies = companyService(db);
   const agents = agentService(db);
+  const quotaIncidents = quotaIncidentsService(db);
 
-  router.post("/companies/:companyId/cost-events", validate(createCostEventSchema), async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
+  router.post(
+    "/companies/:companyId/cost-events",
+    validate(createCostEventSchema),
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
 
-    if (req.actor.type === "agent" && req.actor.agentId !== req.body.agentId) {
-      res.status(403).json({ error: "Agent can only report its own costs" });
-      return;
-    }
+      if (
+        req.actor.type === "agent" &&
+        req.actor.agentId !== req.body.agentId
+      ) {
+        res.status(403).json({ error: "Agent can only report its own costs" });
+        return;
+      }
 
-    const event = await costs.createEvent(companyId, {
-      ...req.body,
-      occurredAt: new Date(req.body.occurredAt),
-    });
+      const event = await costs.createEvent(companyId, {
+        ...req.body,
+        occurredAt: new Date(req.body.occurredAt),
+      });
 
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      action: "cost.reported",
-      entityType: "cost_event",
-      entityId: event.id,
-      details: { costCents: event.costCents, model: event.model },
-    });
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "cost.reported",
+        entityType: "cost_event",
+        entityId: event.id,
+        details: { costCents: event.costCents, model: event.model },
+      });
 
-    res.status(201).json(event);
-  });
+      res.status(201).json(event);
+    },
+  );
 
-  router.post("/companies/:companyId/finance-events", validate(createFinanceEventSchema), async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
-    assertBoard(req);
+  router.post(
+    "/companies/:companyId/finance-events",
+    validate(createFinanceEventSchema),
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      assertBoard(req);
 
-    const event = await finance.createEvent(companyId, {
-      ...req.body,
-      occurredAt: new Date(req.body.occurredAt),
-    });
+      const event = await finance.createEvent(companyId, {
+        ...req.body,
+        occurredAt: new Date(req.body.occurredAt),
+      });
 
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      action: "finance_event.reported",
-      entityType: "finance_event",
-      entityId: event.id,
-      details: {
-        amountCents: event.amountCents,
-        biller: event.biller,
-        eventKind: event.eventKind,
-        direction: event.direction,
-      },
-    });
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "finance_event.reported",
+        entityType: "finance_event",
+        entityId: event.id,
+        details: {
+          amountCents: event.amountCents,
+          biller: event.biller,
+          eventKind: event.eventKind,
+          direction: event.direction,
+        },
+      });
 
-    res.status(201).json(event);
-  });
+      res.status(201).json(event);
+    },
+  );
 
   router.get("/companies/:companyId/costs/summary", async (req, res) => {
     const companyId = req.params.companyId as string;
@@ -158,29 +173,38 @@ export function costRoutes(
     res.json(rows);
   });
 
-  router.get("/companies/:companyId/costs/finance-summary", async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
-    const range = parseCostDateRange(req.query);
-    const summary = await finance.summary(companyId, range);
-    res.json(summary);
-  });
+  router.get(
+    "/companies/:companyId/costs/finance-summary",
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const range = parseCostDateRange(req.query);
+      const summary = await finance.summary(companyId, range);
+      res.json(summary);
+    },
+  );
 
-  router.get("/companies/:companyId/costs/finance-by-biller", async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
-    const range = parseCostDateRange(req.query);
-    const rows = await finance.byBiller(companyId, range);
-    res.json(rows);
-  });
+  router.get(
+    "/companies/:companyId/costs/finance-by-biller",
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const range = parseCostDateRange(req.query);
+      const rows = await finance.byBiller(companyId, range);
+      res.json(rows);
+    },
+  );
 
-  router.get("/companies/:companyId/costs/finance-by-kind", async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
-    const range = parseCostDateRange(req.query);
-    const rows = await finance.byKind(companyId, range);
-    res.json(rows);
-  });
+  router.get(
+    "/companies/:companyId/costs/finance-by-kind",
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const range = parseCostDateRange(req.query);
+      const rows = await finance.byKind(companyId, range);
+      res.json(rows);
+    },
+  );
 
   router.get("/companies/:companyId/costs/finance-events", async (req, res) => {
     const companyId = req.params.companyId as string;
@@ -213,6 +237,44 @@ export function costRoutes(
     res.json(results);
   });
 
+  // PMSA-15 / PMSA-11 §2.2: granular Claude quota incident counts (401/429/5xx) for the
+  // costs dashboard and the future board-notification watcher.
+  router.get(
+    "/companies/:companyId/costs/quota-incidents",
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      assertBoard(req);
+      const company = await companies.getById(companyId);
+      if (!company) {
+        res.status(404).json({ error: "Company not found" });
+        return;
+      }
+      const windowMinutes = clampQuotaIncidentWindowMinutes(
+        req.query.windowMinutes,
+      );
+      const result = await quotaIncidents.listRecent(companyId, {
+        windowMinutes,
+      });
+      res.json({
+        windowMinutes: result.windowMinutes,
+        windowStart: result.windowStart.toISOString(),
+        windowEnd: result.windowEnd.toISOString(),
+        total: result.total,
+        totalByCode: result.totalByCode,
+        oldestAt: result.oldestAt ? result.oldestAt.toISOString() : null,
+        newestAt: result.newestAt ? result.newestAt.toISOString() : null,
+        byAgent: result.byAgent.map((row) => ({
+          agentId: row.agentId,
+          agentName: row.agentName,
+          count: row.count,
+          countByCode: row.countByCode,
+          lastAt: row.lastAt ? row.lastAt.toISOString() : null,
+        })),
+      });
+    },
+  );
+
   router.get("/companies/:companyId/budgets/overview", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -227,7 +289,11 @@ export function costRoutes(
       assertBoard(req);
       const companyId = req.params.companyId as string;
       assertCompanyAccess(req, companyId);
-      const summary = await budgets.upsertPolicy(companyId, req.body, req.actor.userId ?? "board");
+      const summary = await budgets.upsertPolicy(
+        companyId,
+        req.body,
+        req.actor.userId ?? "board",
+      );
       res.json(summary);
     },
   );
@@ -240,7 +306,12 @@ export function costRoutes(
       const companyId = req.params.companyId as string;
       const incidentId = req.params.incidentId as string;
       assertCompanyAccess(req, companyId);
-      const incident = await budgets.resolveIncident(companyId, incidentId, req.body, req.actor.userId ?? "board");
+      const incident = await budgets.resolveIncident(
+        companyId,
+        incidentId,
+        req.body,
+        req.actor.userId ?? "board",
+      );
       res.json(incident);
     },
   );
@@ -253,82 +324,94 @@ export function costRoutes(
     res.json(rows);
   });
 
-  router.patch("/companies/:companyId/budgets", validate(updateBudgetSchema), async (req, res) => {
-    assertBoard(req);
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
-    const company = await companies.update(companyId, { budgetMonthlyCents: req.body.budgetMonthlyCents });
-    if (!company) {
-      res.status(404).json({ error: "Company not found" });
-      return;
-    }
+  router.patch(
+    "/companies/:companyId/budgets",
+    validate(updateBudgetSchema),
+    async (req, res) => {
+      assertBoard(req);
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const company = await companies.update(companyId, {
+        budgetMonthlyCents: req.body.budgetMonthlyCents,
+      });
+      if (!company) {
+        res.status(404).json({ error: "Company not found" });
+        return;
+      }
 
-    await logActivity(db, {
-      companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
-      action: "company.budget_updated",
-      entityType: "company",
-      entityId: companyId,
-      details: { budgetMonthlyCents: req.body.budgetMonthlyCents },
-    });
+      await logActivity(db, {
+        companyId,
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
+        action: "company.budget_updated",
+        entityType: "company",
+        entityId: companyId,
+        details: { budgetMonthlyCents: req.body.budgetMonthlyCents },
+      });
 
-    await budgets.upsertPolicy(
-      companyId,
-      {
-        scopeType: "company",
-        scopeId: companyId,
-        amount: req.body.budgetMonthlyCents,
-        windowKind: "calendar_month_utc",
-      },
-      req.actor.userId ?? "board",
-    );
+      await budgets.upsertPolicy(
+        companyId,
+        {
+          scopeType: "company",
+          scopeId: companyId,
+          amount: req.body.budgetMonthlyCents,
+          windowKind: "calendar_month_utc",
+        },
+        req.actor.userId ?? "board",
+      );
 
-    res.json(company);
-  });
+      res.json(company);
+    },
+  );
 
-  router.patch("/agents/:agentId/budgets", validate(updateBudgetSchema), async (req, res) => {
-    const agentId = req.params.agentId as string;
-    const agent = await agents.getById(agentId);
-    if (!agent) {
-      res.status(404).json({ error: "Agent not found" });
-      return;
-    }
+  router.patch(
+    "/agents/:agentId/budgets",
+    validate(updateBudgetSchema),
+    async (req, res) => {
+      const agentId = req.params.agentId as string;
+      const agent = await agents.getById(agentId);
+      if (!agent) {
+        res.status(404).json({ error: "Agent not found" });
+        return;
+      }
 
-    assertCompanyAccess(req, agent.companyId);
-    assertBoard(req);
+      assertCompanyAccess(req, agent.companyId);
+      assertBoard(req);
 
-    const updated = await agents.update(agentId, { budgetMonthlyCents: req.body.budgetMonthlyCents });
-    if (!updated) {
-      res.status(404).json({ error: "Agent not found" });
-      return;
-    }
+      const updated = await agents.update(agentId, {
+        budgetMonthlyCents: req.body.budgetMonthlyCents,
+      });
+      if (!updated) {
+        res.status(404).json({ error: "Agent not found" });
+        return;
+      }
 
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId: updated.companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      action: "agent.budget_updated",
-      entityType: "agent",
-      entityId: updated.id,
-      details: { budgetMonthlyCents: updated.budgetMonthlyCents },
-    });
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: updated.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "agent.budget_updated",
+        entityType: "agent",
+        entityId: updated.id,
+        details: { budgetMonthlyCents: updated.budgetMonthlyCents },
+      });
 
-    await budgets.upsertPolicy(
-      updated.companyId,
-      {
-        scopeType: "agent",
-        scopeId: updated.id,
-        amount: updated.budgetMonthlyCents,
-        windowKind: "calendar_month_utc",
-      },
-      req.actor.type === "board" ? req.actor.userId ?? "board" : null,
-    );
+      await budgets.upsertPolicy(
+        updated.companyId,
+        {
+          scopeType: "agent",
+          scopeId: updated.id,
+          amount: updated.budgetMonthlyCents,
+          windowKind: "calendar_month_utc",
+        },
+        req.actor.type === "board" ? (req.actor.userId ?? "board") : null,
+      );
 
-    res.json(updated);
-  });
+      res.json(updated);
+    },
+  );
 
   return router;
 }

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -16,7 +16,13 @@ import {
   issues,
   issueComments,
 } from "@paperclipai/db";
-import { AGENT_DEFAULT_MAX_CONCURRENT_RUNS, isUuidLike, normalizeAgentUrlKey } from "@paperclipai/shared";
+import {
+  AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
+  isUuidLike,
+  isAgentPriorityTier,
+  normalizeAgentUrlKey,
+  resolveDefaultAgentPriorityTier,
+} from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import { normalizeAgentPermissions } from "./agent-permissions.js";
 import { REDACTED_EVENT_VALUE, sanitizeRecord } from "../redaction.js";
@@ -44,7 +50,10 @@ const CONFIG_REVISION_FIELDS = [
 ] as const;
 
 type ConfigRevisionField = (typeof CONFIG_REVISION_FIELDS)[number];
-type AgentConfigSnapshot = Pick<typeof agents.$inferSelect, ConfigRevisionField>;
+type AgentConfigSnapshot = Pick<
+  typeof agents.$inferSelect,
+  ConfigRevisionField
+>;
 
 interface RevisionMetadata {
   createdByAgentId?: string | null;
@@ -79,17 +88,23 @@ function buildConfigSnapshot(
   row: Pick<typeof agents.$inferSelect, ConfigRevisionField>,
 ): AgentConfigSnapshot {
   const adapterConfig =
-    typeof row.adapterConfig === "object" && row.adapterConfig !== null && !Array.isArray(row.adapterConfig)
+    typeof row.adapterConfig === "object" &&
+    row.adapterConfig !== null &&
+    !Array.isArray(row.adapterConfig)
       ? sanitizeRecord(row.adapterConfig as Record<string, unknown>)
       : {};
   const runtimeConfig =
-    typeof row.runtimeConfig === "object" && row.runtimeConfig !== null && !Array.isArray(row.runtimeConfig)
+    typeof row.runtimeConfig === "object" &&
+    row.runtimeConfig !== null &&
+    !Array.isArray(row.runtimeConfig)
       ? sanitizeRecord(row.runtimeConfig as Record<string, unknown>)
       : {};
   const metadata =
-    typeof row.metadata === "object" && row.metadata !== null && !Array.isArray(row.metadata)
+    typeof row.metadata === "object" &&
+    row.metadata !== null &&
+    !Array.isArray(row.metadata)
       ? sanitizeRecord(row.metadata as Record<string, unknown>)
-      : row.metadata ?? null;
+      : (row.metadata ?? null);
   return {
     name: row.name,
     role: row.role,
@@ -107,13 +122,18 @@ function buildConfigSnapshot(
 
 function containsRedactedMarker(value: unknown): boolean {
   if (value === REDACTED_EVENT_VALUE) return true;
-  if (Array.isArray(value)) return value.some((item) => containsRedactedMarker(item));
+  if (Array.isArray(value))
+    return value.some((item) => containsRedactedMarker(item));
   if (typeof value !== "object" || value === null) return false;
-  return Object.values(value as Record<string, unknown>).some((entry) => containsRedactedMarker(entry));
+  return Object.values(value as Record<string, unknown>).some((entry) =>
+    containsRedactedMarker(entry),
+  );
 }
 
 function hasConfigPatchFields(data: Partial<typeof agents.$inferInsert>) {
-  return CONFIG_REVISION_FIELDS.some((field) => Object.prototype.hasOwnProperty.call(data, field));
+  return CONFIG_REVISION_FIELDS.some((field) =>
+    Object.prototype.hasOwnProperty.call(data, field),
+  );
 }
 
 function parseFiniteNumberLike(value: unknown): number | null {
@@ -123,8 +143,12 @@ function parseFiniteNumberLike(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function normalizeRuntimeConfigForNewAgent(runtimeConfig: unknown): Record<string, unknown> {
-  const normalizedRuntimeConfig = isPlainRecord(runtimeConfig) ? { ...runtimeConfig } : {};
+function normalizeRuntimeConfigForNewAgent(
+  runtimeConfig: unknown,
+): Record<string, unknown> {
+  const normalizedRuntimeConfig = isPlainRecord(runtimeConfig)
+    ? { ...runtimeConfig }
+    : {};
   const heartbeat = isPlainRecord(normalizedRuntimeConfig.heartbeat)
     ? { ...normalizedRuntimeConfig.heartbeat }
     : {};
@@ -135,15 +159,41 @@ function normalizeRuntimeConfigForNewAgent(runtimeConfig: unknown): Record<strin
   return normalizedRuntimeConfig;
 }
 
+// Ensures `metadata.priorityTier` is present and is a valid tier. Preserves
+// any existing valid tier; otherwise fills in the role/name-derived default.
+// Used by both the agent create path and the startup backfill so the rules
+// can't drift apart.
+export function ensureAgentPriorityTierInMetadata(
+  metadata: unknown,
+  identity: {
+    role: string | null | undefined;
+    name: string | null | undefined;
+  },
+): Record<string, unknown> {
+  const base = isPlainRecord(metadata) ? { ...metadata } : {};
+  if (!isAgentPriorityTier(base.priorityTier)) {
+    base.priorityTier = resolveDefaultAgentPriorityTier({
+      role: identity.role,
+      name: identity.name,
+    });
+  }
+  return base;
+}
+
 function diffConfigSnapshot(
   before: AgentConfigSnapshot,
   after: AgentConfigSnapshot,
 ): string[] {
-  return CONFIG_REVISION_FIELDS.filter((field) => !jsonEqual(before[field], after[field]));
+  return CONFIG_REVISION_FIELDS.filter(
+    (field) => !jsonEqual(before[field], after[field]),
+  );
 }
 
-function configPatchFromSnapshot(snapshot: unknown): Partial<typeof agents.$inferInsert> {
-  if (!isPlainRecord(snapshot)) throw unprocessable("Invalid revision snapshot");
+function configPatchFromSnapshot(
+  snapshot: unknown,
+): Partial<typeof agents.$inferInsert> {
+  if (!isPlainRecord(snapshot))
+    throw unprocessable("Invalid revision snapshot");
 
   if (typeof snapshot.name !== "string" || snapshot.name.length === 0) {
     throw unprocessable("Invalid revision snapshot: name");
@@ -151,32 +201,52 @@ function configPatchFromSnapshot(snapshot: unknown): Partial<typeof agents.$infe
   if (typeof snapshot.role !== "string" || snapshot.role.length === 0) {
     throw unprocessable("Invalid revision snapshot: role");
   }
-  if (typeof snapshot.adapterType !== "string" || snapshot.adapterType.length === 0) {
+  if (
+    typeof snapshot.adapterType !== "string" ||
+    snapshot.adapterType.length === 0
+  ) {
     throw unprocessable("Invalid revision snapshot: adapterType");
   }
-  if (typeof snapshot.budgetMonthlyCents !== "number" || !Number.isFinite(snapshot.budgetMonthlyCents)) {
+  if (
+    typeof snapshot.budgetMonthlyCents !== "number" ||
+    !Number.isFinite(snapshot.budgetMonthlyCents)
+  ) {
     throw unprocessable("Invalid revision snapshot: budgetMonthlyCents");
   }
 
   return {
     name: snapshot.name,
     role: snapshot.role,
-    title: typeof snapshot.title === "string" || snapshot.title === null ? snapshot.title : null,
+    title:
+      typeof snapshot.title === "string" || snapshot.title === null
+        ? snapshot.title
+        : null,
     reportsTo:
-      typeof snapshot.reportsTo === "string" || snapshot.reportsTo === null ? snapshot.reportsTo : null,
+      typeof snapshot.reportsTo === "string" || snapshot.reportsTo === null
+        ? snapshot.reportsTo
+        : null,
     capabilities:
-      typeof snapshot.capabilities === "string" || snapshot.capabilities === null
+      typeof snapshot.capabilities === "string" ||
+      snapshot.capabilities === null
         ? snapshot.capabilities
         : null,
     adapterType: snapshot.adapterType,
-    adapterConfig: isPlainRecord(snapshot.adapterConfig) ? snapshot.adapterConfig : {},
-    runtimeConfig: isPlainRecord(snapshot.runtimeConfig) ? snapshot.runtimeConfig : {},
+    adapterConfig: isPlainRecord(snapshot.adapterConfig)
+      ? snapshot.adapterConfig
+      : {},
+    runtimeConfig: isPlainRecord(snapshot.runtimeConfig)
+      ? snapshot.runtimeConfig
+      : {},
     defaultEnvironmentId:
-      typeof snapshot.defaultEnvironmentId === "string" || snapshot.defaultEnvironmentId === null
+      typeof snapshot.defaultEnvironmentId === "string" ||
+      snapshot.defaultEnvironmentId === null
         ? snapshot.defaultEnvironmentId
         : null,
     budgetMonthlyCents: Math.max(0, Math.floor(snapshot.budgetMonthlyCents)),
-    metadata: isPlainRecord(snapshot.metadata) || snapshot.metadata === null ? snapshot.metadata : null,
+    metadata:
+      isPlainRecord(snapshot.metadata) || snapshot.metadata === null
+        ? snapshot.metadata
+        : null,
   };
 }
 
@@ -190,7 +260,8 @@ export function hasAgentShortnameCollision(
 
   return existingAgents.some((agent) => {
     if (agent.status === "terminated") return false;
-    if (options?.excludeAgentId && agent.id === options.excludeAgentId) return false;
+    if (options?.excludeAgentId && agent.id === options.excludeAgentId)
+      return false;
     return normalizeAgentUrlKey(agent.name) === candidateShortname;
   });
 }
@@ -235,7 +306,10 @@ export function agentService(db: Db) {
     });
   }
 
-  async function getMonthlySpendByAgentIds(companyId: string, agentIds: string[]) {
+  async function getMonthlySpendByAgentIds(
+    companyId: string,
+    agentIds: string[],
+  ) {
     if (agentIds.length === 0) return new Map<string, number>();
     const { start, end } = currentUtcMonthWindow();
     const rows = await db
@@ -253,10 +327,14 @@ export function agentService(db: Db) {
         ),
       )
       .groupBy(costEvents.agentId);
-    return new Map(rows.map((row) => [row.agentId, Number(row.spentMonthlyCents ?? 0)]));
+    return new Map(
+      rows.map((row) => [row.agentId, Number(row.spentMonthlyCents ?? 0)]),
+    );
   }
 
-  async function hydrateAgentSpend<T extends { id: string; companyId: string; spentMonthlyCents: number }>(rows: T[]) {
+  async function hydrateAgentSpend<
+    T extends { id: string; companyId: string; spentMonthlyCents: number },
+  >(rows: T[]) {
     const agentIds = rows.map((row) => row.id);
     const companyId = rows[0]?.companyId;
     if (!companyId || agentIds.length === 0) return rows;
@@ -287,13 +365,18 @@ export function agentService(db: Db) {
     return manager;
   }
 
-  async function assertNoCycle(agentId: string, reportsTo: string | null | undefined) {
+  async function assertNoCycle(
+    agentId: string,
+    reportsTo: string | null | undefined,
+  ) {
     if (!reportsTo) return;
-    if (reportsTo === agentId) throw unprocessable("Agent cannot report to itself");
+    if (reportsTo === agentId)
+      throw unprocessable("Agent cannot report to itself");
 
     let cursor: string | null = reportsTo;
     while (cursor) {
-      if (cursor === agentId) throw unprocessable("Reporting relationship would create cycle");
+      if (cursor === agentId)
+        throw unprocessable("Reporting relationship would create cycle");
       const next = await getById(cursor);
       cursor = next?.reportsTo ?? null;
     }
@@ -316,7 +399,11 @@ export function agentService(db: Db) {
       .from(agents)
       .where(eq(agents.companyId, companyId));
 
-    const hasCollision = hasAgentShortnameCollision(candidateName, existingAgents, options);
+    const hasCollision = hasAgentShortnameCollision(
+      candidateName,
+      existingAgents,
+      options,
+    );
     if (hasCollision) {
       throw conflict(
         `Agent shortname '${candidateShortname}' is already in use in this company`,
@@ -332,7 +419,11 @@ export function agentService(db: Db) {
     const existing = await getById(id);
     if (!existing) return null;
 
-    if (existing.status === "terminated" && data.status && data.status !== "terminated") {
+    if (
+      existing.status === "terminated" &&
+      data.status &&
+      data.status !== "terminated"
+    ) {
       throw conflict("Terminated agents cannot be resumed");
     }
     if (
@@ -355,18 +446,26 @@ export function agentService(db: Db) {
       const previousShortname = normalizeAgentUrlKey(existing.name);
       const nextShortname = normalizeAgentUrlKey(data.name);
       if (previousShortname !== nextShortname) {
-        await assertCompanyShortnameAvailable(existing.companyId, data.name, { excludeAgentId: id });
+        await assertCompanyShortnameAvailable(existing.companyId, data.name, {
+          excludeAgentId: id,
+        });
       }
     }
 
     const normalizedPatch = { ...data } as Partial<typeof agents.$inferInsert>;
     if (data.permissions !== undefined) {
       const role = (data.role ?? existing.role) as string;
-      normalizedPatch.permissions = normalizeAgentPermissions(data.permissions, role);
+      normalizedPatch.permissions = normalizeAgentPermissions(
+        data.permissions,
+        role,
+      );
     }
 
-    const shouldRecordRevision = Boolean(options?.recordRevision) && hasConfigPatchFields(normalizedPatch);
-    const beforeConfig = shouldRecordRevision ? buildConfigSnapshot(existing) : null;
+    const shouldRecordRevision =
+      Boolean(options?.recordRevision) && hasConfigPatchFields(normalizedPatch);
+    const beforeConfig = shouldRecordRevision
+      ? buildConfigSnapshot(existing)
+      : null;
 
     const updated = await db
       .update(agents)
@@ -386,7 +485,8 @@ export function agentService(db: Db) {
           createdByAgentId: options?.recordRevision?.createdByAgentId ?? null,
           createdByUserId: options?.recordRevision?.createdByUserId ?? null,
           source: options?.recordRevision?.source ?? "patch",
-          rolledBackFromRevisionId: options?.recordRevision?.rolledBackFromRevisionId ?? null,
+          rolledBackFromRevisionId:
+            options?.recordRevision?.rolledBackFromRevisionId ?? null,
           changedKeys,
           beforeConfig: beforeConfig as unknown as Record<string, unknown>,
           afterConfig: afterConfig as unknown as Record<string, unknown>,
@@ -398,19 +498,28 @@ export function agentService(db: Db) {
   }
 
   return {
-    list: async (companyId: string, options?: { includeTerminated?: boolean }) => {
+    list: async (
+      companyId: string,
+      options?: { includeTerminated?: boolean },
+    ) => {
       const conditions = [eq(agents.companyId, companyId)];
       if (!options?.includeTerminated) {
         conditions.push(ne(agents.status, "terminated"));
       }
-      const rows = await db.select().from(agents).where(and(...conditions));
+      const rows = await db
+        .select()
+        .from(agents)
+        .where(and(...conditions));
       const hydrated = await hydrateAgentSpend(rows);
       return hydrated.map(normalizeAgentRow);
     },
 
     getById,
 
-    create: async (companyId: string, data: Omit<typeof agents.$inferInsert, "companyId">) => {
+    create: async (
+      companyId: string,
+      data: Omit<typeof agents.$inferInsert, "companyId">,
+    ) => {
       if (data.reportsTo) {
         await ensureManager(companyId, data.reportsTo);
       }
@@ -422,11 +531,28 @@ export function agentService(db: Db) {
       const uniqueName = deduplicateAgentName(data.name, existingAgents);
 
       const role = data.role ?? "general";
-      const normalizedPermissions = normalizeAgentPermissions(data.permissions, role);
-      const runtimeConfig = normalizeRuntimeConfigForNewAgent(data.runtimeConfig);
+      const normalizedPermissions = normalizeAgentPermissions(
+        data.permissions,
+        role,
+      );
+      const runtimeConfig = normalizeRuntimeConfigForNewAgent(
+        data.runtimeConfig,
+      );
+      const metadata = ensureAgentPriorityTierInMetadata(data.metadata, {
+        role,
+        name: uniqueName,
+      });
       const created = await db
         .insert(agents)
-        .values({ ...data, name: uniqueName, companyId, role, permissions: normalizedPermissions, runtimeConfig })
+        .values({
+          ...data,
+          name: uniqueName,
+          companyId,
+          role,
+          permissions: normalizedPermissions,
+          runtimeConfig,
+          metadata,
+        })
         .returning()
         .then((rows) => rows[0]);
 
@@ -435,10 +561,14 @@ export function agentService(db: Db) {
 
     update: updateAgent,
 
-    pause: async (id: string, reason: "manual" | "budget" | "system" = "manual") => {
+    pause: async (
+      id: string,
+      reason: "manual" | "budget" | "system" = "manual",
+    ) => {
       const existing = await getById(id);
       if (!existing) return null;
-      if (existing.status === "terminated") throw conflict("Cannot pause terminated agent");
+      if (existing.status === "terminated")
+        throw conflict("Cannot pause terminated agent");
 
       const updated = await db
         .update(agents)
@@ -457,7 +587,8 @@ export function agentService(db: Db) {
     resume: async (id: string) => {
       const existing = await getById(id);
       if (!existing) return null;
-      if (existing.status === "terminated") throw conflict("Cannot resume terminated agent");
+      if (existing.status === "terminated")
+        throw conflict("Cannot resume terminated agent");
       if (existing.status === "pending_approval") {
         throw conflict("Pending approval agents cannot be resumed");
       }
@@ -503,25 +634,44 @@ export function agentService(db: Db) {
       if (!existing) return null;
 
       return db.transaction(async (tx) => {
-        await tx.update(agents).set({ reportsTo: null }).where(eq(agents.reportsTo, id));
+        await tx
+          .update(agents)
+          .set({ reportsTo: null })
+          .where(eq(agents.reportsTo, id));
         await tx
           .update(issues)
           .set({ assigneeAgentId: null, createdByAgentId: null })
-          .where(or(eq(issues.assigneeAgentId, id), eq(issues.createdByAgentId, id)));
-        await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.agentId, id));
-        await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.agentId, id));
-        await tx.delete(activityLog).where(
-          or(
-            eq(activityLog.agentId, id),
-            sql`${activityLog.runId} in (select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.agentId} = ${id})`,
-          ),
-        );
-        await tx.delete(issueExecutionDecisions).where(eq(issueExecutionDecisions.actorAgentId, id));
-        await tx.delete(issueComments).where(eq(issueComments.authorAgentId, id));
+          .where(
+            or(eq(issues.assigneeAgentId, id), eq(issues.createdByAgentId, id)),
+          );
+        await tx
+          .delete(heartbeatRunEvents)
+          .where(eq(heartbeatRunEvents.agentId, id));
+        await tx
+          .delete(agentTaskSessions)
+          .where(eq(agentTaskSessions.agentId, id));
+        await tx
+          .delete(activityLog)
+          .where(
+            or(
+              eq(activityLog.agentId, id),
+              sql`${activityLog.runId} in (select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.agentId} = ${id})`,
+            ),
+          );
+        await tx
+          .delete(issueExecutionDecisions)
+          .where(eq(issueExecutionDecisions.actorAgentId, id));
+        await tx
+          .delete(issueComments)
+          .where(eq(issueComments.authorAgentId, id));
         await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.agentId, id));
-        await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, id));
+        await tx
+          .delete(agentWakeupRequests)
+          .where(eq(agentWakeupRequests.agentId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.agentId, id));
-        await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.agentId, id));
+        await tx
+          .delete(agentRuntimeState)
+          .where(eq(agentRuntimeState.agentId, id));
         const deleted = await tx
           .delete(agents)
           .where(eq(agents.id, id))
@@ -547,7 +697,10 @@ export function agentService(db: Db) {
       return existing ? { agent: existing, activated: false } : null;
     },
 
-    updatePermissions: async (id: string, permissions: { canCreateAgents: boolean }) => {
+    updatePermissions: async (
+      id: string,
+      permissions: { canCreateAgents: boolean },
+    ) => {
       const existing = await getById(id);
       if (!existing) return null;
 
@@ -575,7 +728,12 @@ export function agentService(db: Db) {
       db
         .select()
         .from(agentConfigRevisions)
-        .where(and(eq(agentConfigRevisions.agentId, id), eq(agentConfigRevisions.id, revisionId)))
+        .where(
+          and(
+            eq(agentConfigRevisions.agentId, id),
+            eq(agentConfigRevisions.id, revisionId),
+          ),
+        )
         .then((rows) => rows[0] ?? null),
 
     rollbackConfigRevision: async (
@@ -586,11 +744,18 @@ export function agentService(db: Db) {
       const revision = await db
         .select()
         .from(agentConfigRevisions)
-        .where(and(eq(agentConfigRevisions.agentId, id), eq(agentConfigRevisions.id, revisionId)))
+        .where(
+          and(
+            eq(agentConfigRevisions.agentId, id),
+            eq(agentConfigRevisions.id, revisionId),
+          ),
+        )
         .then((rows) => rows[0] ?? null);
       if (!revision) return null;
       if (containsRedactedMarker(revision.afterConfig)) {
-        throw unprocessable("Cannot roll back a revision that contains redacted secret values");
+        throw unprocessable(
+          "Cannot roll back a revision that contains redacted secret values",
+        );
       }
 
       const patch = configPatchFromSnapshot(revision.afterConfig);
@@ -664,7 +829,9 @@ export function agentService(db: Db) {
       const rows = await db
         .update(agentApiKeys)
         .set({ revokedAt: new Date() })
-        .where(and(eq(agentApiKeys.id, keyId), eq(agentApiKeys.agentId, agentId)))
+        .where(
+          and(eq(agentApiKeys.id, keyId), eq(agentApiKeys.agentId, agentId)),
+        )
         .returning();
       return rows[0] ?? null;
     },
@@ -673,7 +840,9 @@ export function agentService(db: Db) {
       const rows = await db
         .select()
         .from(agents)
-        .where(and(eq(agents.companyId, companyId), ne(agents.status, "terminated")));
+        .where(
+          and(eq(agents.companyId, companyId), ne(agents.status, "terminated")),
+        );
       const normalizedRows = rows.map(normalizeAgentRow);
       const byManager = new Map<string | null, typeof normalizedRows>();
       for (const row of normalizedRows) {
@@ -683,7 +852,9 @@ export function agentService(db: Db) {
         byManager.set(key, group);
       }
 
-      const build = (managerId: string | null): Array<Record<string, unknown>> => {
+      const build = (
+        managerId: string | null,
+      ): Array<Record<string, unknown>> => {
         const members = byManager.get(managerId) ?? [];
         return members.map((member) => ({
           ...member,
@@ -695,7 +866,12 @@ export function agentService(db: Db) {
     },
 
     getChainOfCommand: async (agentId: string) => {
-      const chain: { id: string; name: string; role: string; title: string | null }[] = [];
+      const chain: {
+        id: string;
+        name: string;
+        role: string;
+        title: string | null;
+      }[] = [];
       const visited = new Set<string>([agentId]);
       const start = await getById(agentId);
       let currentId = start?.reportsTo ?? null;
@@ -703,7 +879,12 @@ export function agentService(db: Db) {
         visited.add(currentId);
         const mgr = await getById(currentId);
         if (!mgr) break;
-        chain.push({ id: mgr.id, name: mgr.name, role: mgr.role, title: mgr.title ?? null });
+        chain.push({
+          id: mgr.id,
+          name: mgr.name,
+          role: mgr.role,
+          title: mgr.title ?? null,
+        });
         currentId = mgr.reportsTo ?? null;
       }
       return chain;
@@ -713,7 +894,12 @@ export function agentService(db: Db) {
       db
         .select()
         .from(heartbeatRuns)
-        .where(and(eq(heartbeatRuns.agentId, agentId), inArray(heartbeatRuns.status, ["queued", "running"]))),
+        .where(
+          and(
+            eq(heartbeatRuns.agentId, agentId),
+            inArray(heartbeatRuns.status, ["queued", "running"]),
+          ),
+        ),
 
     resolveByReference: async (companyId: string, reference: string) => {
       const raw = reference.trim();
@@ -734,10 +920,15 @@ export function agentService(db: Db) {
         return { agent: null, ambiguous: false } as const;
       }
 
-      const rows = await db.select().from(agents).where(eq(agents.companyId, companyId));
+      const rows = await db
+        .select()
+        .from(agents)
+        .where(eq(agents.companyId, companyId));
       const matches = rows
         .map(normalizeAgentRow)
-        .filter((agent) => agent.urlKey === urlKey && agent.status !== "terminated");
+        .filter(
+          (agent) => agent.urlKey === urlKey && agent.status !== "terminated",
+        );
       if (matches.length === 1) {
         return { agent: matches[0] ?? null, ambiguous: false } as const;
       }

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -51,6 +51,7 @@ export function companyService(db: Db) {
     feedbackDataSharingConsentByUserId: companies.feedbackDataSharingConsentByUserId,
     feedbackDataSharingTermsVersion: companies.feedbackDataSharingTermsVersion,
     brandColor: companies.brandColor,
+    metadata: companies.metadata,
     logoAssetId: companyLogos.assetId,
     createdAt: companies.createdAt,
     updatedAt: companies.updatedAt,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3899,26 +3899,35 @@ export function heartbeatService(
       return issueRow;
     }
 
-    const errorLabel =
-      opts.errorCode === "claude_rate_limited"
-        ? "Anthropic API rate limit"
-        : "Anthropic Opus quota exhaustion";
+    const isRateLimit = opts.errorCode === "claude_rate_limited";
+    const errorLabel = isRateLimit
+      ? "Anthropic API rate limit"
+      : "Anthropic Opus quota exhaustion";
+    const limitNoun = isRateLimit
+      ? "Anthropic's API rate limit"
+      : "Anthropic's Opus quota limit";
+    const retryNotBefore = readTransientRetryNotBeforeFromRun(run);
+    const expectedClearLine = retryNotBefore
+      ? `- Expected to clear after ${retryNotBefore.toISOString().replace(/\.\d{3}Z$/, "Z")} (per provider hint).`
+      : `- The quota / rate-limit window typically rolls over within hours; check the agent's usage panel.`;
+
     const commentBody = [
       `## Blocked: ${errorLabel}`,
       "",
-      `Hit \`${opts.errorCode}\` ${opts.attempts}/${opts.maxAttempts} times in a row; bounded retry budget exhausted.`,
+      `This agent hit ${limitNoun} ${opts.attempts} times in a row. We've parked the work to avoid burning more retries.`,
       "",
       "**What this means**",
       "",
-      `- Heartbeat will no longer auto-retry this run.`,
-      `- The issue is parked at \`blocked\` until quota recovers or the board takes manual action.`,
+      `- The agent will not auto-retry this issue automatically.`,
+      `- Status will stay \`blocked\` until quota recovers or you take action.`,
       "",
-      "**Suggested actions**",
+      "**What you can do**",
       "",
-      "- Wait for the Anthropic quota window to roll over and clear the blocker manually.",
-      "- Or top up / switch the affected agent to a fallback provider (PMSA-11 §3.4 / §3.5).",
+      expectedClearLine,
+      "- Or open the agent settings and switch its provider to a fallback (e.g. Sonnet or Bedrock).",
+      "- After either, manually move this issue back to `todo` to resume.",
       "",
-      `_Triggered by run \`${run.id}\` for agent ${agent.name ?? agent.id}._`,
+      `_Run: \`${run.id}\` · Agent: ${agent.name ?? agent.id}_`,
     ].join("\n");
 
     let blockedIssue: Awaited<ReturnType<typeof issuesSvc.update>> = null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3,7 +3,20 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lte, notInArray, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  getTableColumns,
+  gt,
+  inArray,
+  isNull,
+  lte,
+  notInArray,
+  or,
+  sql,
+} from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -39,16 +52,30 @@ import { logger } from "../middleware/logger.js";
 import { publishLiveEvent } from "./live-events.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
 import { getServerAdapter, runningProcesses } from "../adapters/index.js";
-import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
+import type {
+  AdapterExecutionResult,
+  AdapterInvocationMeta,
+  AdapterSessionCodec,
+  UsageSummary,
+} from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
-import { parseObject, asBoolean, asNumber, appendWithByteCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
+import {
+  parseObject,
+  asBoolean,
+  asNumber,
+  appendWithByteCap,
+  MAX_EXCERPT_BYTES,
+} from "../adapters/utils.js";
 import { costService } from "./costs.js";
 import { trackAgentFirstHeartbeat } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
 import { companySkillService } from "./company-skills.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService } from "./secrets.js";
-import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
+import {
+  resolveDefaultAgentWorkspaceDir,
+  resolveManagedProjectWorkspaceDir,
+} from "../home-paths.js";
 import {
   buildHeartbeatRunIssueComment,
   HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS,
@@ -64,7 +91,11 @@ import {
   classifyRunLiveness,
   type RunLivenessClassificationInput,
 } from "./run-liveness.js";
-import { logActivity, publishPluginDomainEvent, type LogActivityInput } from "./activity-log.js";
+import {
+  logActivity,
+  publishPluginDomainEvent,
+  type LogActivityInput,
+} from "./activity-log.js";
 import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
@@ -86,9 +117,15 @@ import {
   getIssueContinuationSummaryDocument,
   refreshIssueContinuationSummary,
 } from "./issue-continuation-summary.js";
-import { executionWorkspaceService, mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
+import {
+  executionWorkspaceService,
+  mergeExecutionWorkspaceConfig,
+} from "./execution-workspaces.js";
 import { workspaceOperationService } from "./workspace-operations.js";
-import { isProcessGroupAlive, terminateLocalService } from "./local-service-supervisor.js";
+import {
+  isProcessGroupAlive,
+  terminateLocalService,
+} from "./local-service-supervisor.js";
 import {
   buildExecutionWorkspaceAdapterConfig,
   gateProjectExecutionWorkspacePolicy,
@@ -109,7 +146,10 @@ import {
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
 import { recoveryService } from "./recovery/service.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
-import { redactCurrentUserText, redactCurrentUserValue } from "../log-redaction.js";
+import {
+  redactCurrentUserText,
+  redactCurrentUserValue,
+} from "../log-redaction.js";
 import {
   hasSessionCompactionThresholds,
   resolveSessionCompactionPolicy,
@@ -148,10 +188,27 @@ const MAX_INLINE_WAKE_COMMENTS = 8;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
-const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
-const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
-const HEARTBEAT_RUN_TERMINAL_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
-const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
+const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = [
+  "queued",
+  "running",
+  "scheduled_retry",
+] as const;
+const CANCELLABLE_HEARTBEAT_RUN_STATUSES = [
+  "queued",
+  "running",
+  "scheduled_retry",
+] as const;
+const HEARTBEAT_RUN_TERMINAL_STATUSES = [
+  "succeeded",
+  "failed",
+  "cancelled",
+  "timed_out",
+] as const;
+const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = [
+  "failed",
+  "cancelled",
+  "timed_out",
+] as const;
 export {
   ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS,
   ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
@@ -167,19 +224,32 @@ export const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS = [
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO = 0.25;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON = "transient_failure";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON = "transient_failure_retry";
-const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
+const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS =
+  BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
 type CodexTransientFallbackMode =
   | "same_session"
   | "safer_invocation"
   | "fresh_session"
   | "fresh_session_safer_invocation";
 
-function resolveCodexTransientFallbackMode(attempt: number): CodexTransientFallbackMode {
+function resolveCodexTransientFallbackMode(
+  attempt: number,
+): CodexTransientFallbackMode {
   if (attempt <= 1) return "same_session";
   if (attempt === 2) return "safer_invocation";
   if (attempt === 3) return "fresh_session";
   return "fresh_session_safer_invocation";
 }
+
+// PMSA-15 / PMSA-11 §2.1: Claude error codes that all share the transient_upstream
+// retry contract (exponential backoff + retryNotBefore). Adding a new code here is
+// the only step needed to wire it into the existing retry pipeline.
+const CLAUDE_TRANSIENT_UPSTREAM_ERROR_CODES = new Set([
+  "claude_transient_upstream",
+  "claude_quota_exhausted",
+  "claude_rate_limited",
+  "claude_provider_5xx",
+]);
 
 function readHeartbeatRunErrorFamily(
   run: Pick<typeof heartbeatRuns.$inferSelect, "errorCode" | "resultJson">,
@@ -188,16 +258,30 @@ function readHeartbeatRunErrorFamily(
   const persistedFamily = readNonEmptyString(resultJson.errorFamily);
   if (persistedFamily) return persistedFamily;
 
-  if (run.errorCode === "codex_transient_upstream" || run.errorCode === "claude_transient_upstream") {
+  if (run.errorCode === "codex_transient_upstream") {
+    return "transient_upstream";
+  }
+  if (
+    run.errorCode &&
+    CLAUDE_TRANSIENT_UPSTREAM_ERROR_CODES.has(run.errorCode)
+  ) {
     return "transient_upstream";
   }
   return null;
 }
 
-function readTransientRetryNotBeforeFromRun(run: Pick<typeof heartbeatRuns.$inferSelect, "resultJson">) {
+function readTransientRetryNotBeforeFromRun(
+  run: Pick<typeof heartbeatRuns.$inferSelect, "resultJson">,
+) {
   const resultJson = parseObject(run.resultJson);
   const value = resultJson.retryNotBefore ?? resultJson.transientRetryNotBefore;
-  if (!(typeof value === "string" || typeof value === "number" || value instanceof Date)) {
+  if (
+    !(
+      typeof value === "string" ||
+      typeof value === "number" ||
+      value instanceof Date
+    )
+  ) {
     return null;
   }
   const parsed = new Date(value);
@@ -222,7 +306,8 @@ function mergeAdapterRecoveryMetadata(input: {
 }) {
   const errorFamily = readNonEmptyString(input.errorFamily);
   const retryNotBefore = readNonEmptyString(input.retryNotBefore);
-  if (!input.resultJson && !errorFamily && !retryNotBefore) return input.resultJson ?? null;
+  if (!input.resultJson && !errorFamily && !retryNotBefore)
+    return input.resultJson ?? null;
 
   return {
     ...(input.resultJson ?? {}),
@@ -235,7 +320,9 @@ function mergeAdapterRecoveryMetadata(input: {
       : {}),
   };
 }
-const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set(["approval_approved"]);
+const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set([
+  "approval_approved",
+]);
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
@@ -245,7 +332,8 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "opencode_local",
   "pi_local",
 ]);
-const INLINE_BASE64_IMAGE_DATA_RE = /("type":"image","source":\{"type":"base64","data":")([A-Za-z0-9+/=]{1024,})(")/g;
+const INLINE_BASE64_IMAGE_DATA_RE =
+  /("type":"image","source":\{"type":"base64","data":")([A-Za-z0-9+/=]{1024,})(")/g;
 
 type RuntimeConfigSecretResolver = Pick<
   ReturnType<typeof secretService>,
@@ -258,12 +346,16 @@ export async function resolveExecutionRunAdapterConfig(input: {
   projectEnv: unknown;
   secretsSvc: RuntimeConfigSecretResolver;
 }) {
-  const { config: resolvedConfig, secretKeys } = await input.secretsSvc.resolveAdapterConfigForRuntime(
-    input.companyId,
-    input.executionRunConfig,
-  );
+  const { config: resolvedConfig, secretKeys } =
+    await input.secretsSvc.resolveAdapterConfigForRuntime(
+      input.companyId,
+      input.executionRunConfig,
+    );
   const projectEnvResolution = input.projectEnv
-    ? await input.secretsSvc.resolveEnvBindings(input.companyId, input.projectEnv)
+    ? await input.secretsSvc.resolveEnvBindings(
+        input.companyId,
+        input.projectEnv,
+      )
     : { env: {}, secretKeys: new Set<string>() };
   if (Object.keys(projectEnvResolution.env).length > 0) {
     resolvedConfig.env = {
@@ -295,11 +387,7 @@ export function applyRunScopedMentionedSkillKeys(
   skillKeys: string[],
 ): Record<string, unknown> {
   const normalizedSkillKeys = Array.from(
-    new Set(
-      skillKeys
-        .map((value) => value.trim())
-        .filter(Boolean),
-    ),
+    new Set(skillKeys.map((value) => value.trim()).filter(Boolean)),
   );
   if (normalizedSkillKeys.length === 0) return config;
 
@@ -319,7 +407,8 @@ export function computeBoundedTransientHeartbeatRetrySchedule(
   const baseDelayMs = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS[attempt - 1];
   if (typeof baseDelayMs !== "number") return null;
   const sample = Math.min(1, Math.max(0, random()));
-  const jitterMultiplier = 1 + (((sample * 2) - 1) * BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO);
+  const jitterMultiplier =
+    1 + (sample * 2 - 1) * BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO;
   const delayMs = Math.max(1_000, Math.round(baseDelayMs * jitterMultiplier));
   return {
     attempt,
@@ -343,7 +432,9 @@ async function resolveRunScopedMentionedSkillKeys(input: {
       description: issues.description,
     })
     .from(issues)
-    .where(and(eq(issues.id, input.issueId), eq(issues.companyId, input.companyId)))
+    .where(
+      and(eq(issues.id, input.issueId), eq(issues.companyId, input.companyId)),
+    )
     .then((rows) => rows[0] ?? null);
   if (!issue) return [];
 
@@ -398,7 +489,9 @@ export function applyPersistedExecutionWorkspaceConfig(input: {
     if (input.workspaceConfig?.workspaceRuntime === null) {
       delete nextConfig.workspaceRuntime;
     } else if (input.workspaceConfig?.workspaceRuntime) {
-      nextConfig.workspaceRuntime = { ...input.workspaceConfig.workspaceRuntime };
+      nextConfig.workspaceRuntime = {
+        ...input.workspaceConfig.workspaceRuntime,
+      };
     }
     if (input.workspaceConfig?.desiredState === null) {
       delete nextConfig.desiredState;
@@ -414,9 +507,11 @@ export function applyPersistedExecutionWorkspaceConfig(input: {
 
   if (input.workspaceConfig && input.mode === "isolated_workspace") {
     const nextStrategy = parseObject(nextConfig.workspaceStrategy);
-    if (input.workspaceConfig.provisionCommand === null) delete nextStrategy.provisionCommand;
+    if (input.workspaceConfig.provisionCommand === null)
+      delete nextStrategy.provisionCommand;
     else nextStrategy.provisionCommand = input.workspaceConfig.provisionCommand;
-    if (input.workspaceConfig.teardownCommand === null) delete nextStrategy.teardownCommand;
+    if (input.workspaceConfig.teardownCommand === null)
+      delete nextStrategy.teardownCommand;
     else nextStrategy.teardownCommand = input.workspaceConfig.teardownCommand;
     nextConfig.workspaceStrategy = nextStrategy;
   }
@@ -444,7 +539,9 @@ export function mergeExecutionWorkspaceMetadataForPersistence(input: {
   return mergeExecutionWorkspaceConfig(base, input.configSnapshot);
 }
 
-export function stripWorkspaceRuntimeFromExecutionRunConfig(config: Record<string, unknown>) {
+export function stripWorkspaceRuntimeFromExecutionRunConfig(
+  config: Record<string, unknown>,
+) {
   const nextConfig = { ...config };
   delete nextConfig.workspaceRuntime;
   return nextConfig;
@@ -454,15 +551,23 @@ export function buildRealizedExecutionWorkspaceFromPersisted(input: {
   base: ExecutionWorkspaceInput;
   workspace: ExecutionWorkspace;
 }): RealizedExecutionWorkspace | null {
-  const cwd = readNonEmptyString(input.workspace.cwd) ?? readNonEmptyString(input.workspace.providerRef);
+  const cwd =
+    readNonEmptyString(input.workspace.cwd) ??
+    readNonEmptyString(input.workspace.providerRef);
   if (!cwd) {
     return null;
   }
 
-  const strategy = input.workspace.strategyType === "git_worktree" ? "git_worktree" : "project_primary";
+  const strategy =
+    input.workspace.strategyType === "git_worktree"
+      ? "git_worktree"
+      : "project_primary";
   return {
     baseCwd: input.base.baseCwd,
-    source: input.workspace.mode === "shared_workspace" ? "project_primary" : "task_session",
+    source:
+      input.workspace.mode === "shared_workspace"
+        ? "project_primary"
+        : "task_session",
     projectId: input.workspace.projectId ?? input.base.projectId,
     workspaceId: input.workspace.projectWorkspaceId ?? input.base.workspaceId,
     repoUrl: input.workspace.repoUrl ?? input.base.repoUrl,
@@ -470,7 +575,10 @@ export function buildRealizedExecutionWorkspaceFromPersisted(input: {
     strategy,
     cwd,
     branchName: input.workspace.branchName ?? null,
-    worktreePath: strategy === "git_worktree" ? (readNonEmptyString(input.workspace.providerRef) ?? cwd) : null,
+    worktreePath:
+      strategy === "git_worktree"
+        ? (readNonEmptyString(input.workspace.providerRef) ?? cwd)
+        : null,
     warnings: [],
     created: false,
   };
@@ -491,36 +599,50 @@ function buildExecutionWorkspaceConfigSnapshot(
   }
 
   if ("workspaceStrategy" in config) {
-    snapshot.provisionCommand = typeof strategy.provisionCommand === "string" ? strategy.provisionCommand : null;
-    snapshot.teardownCommand = typeof strategy.teardownCommand === "string" ? strategy.teardownCommand : null;
+    snapshot.provisionCommand =
+      typeof strategy.provisionCommand === "string"
+        ? strategy.provisionCommand
+        : null;
+    snapshot.teardownCommand =
+      typeof strategy.teardownCommand === "string"
+        ? strategy.teardownCommand
+        : null;
   }
 
   if ("workspaceRuntime" in config) {
     const workspaceRuntime = parseObject(config.workspaceRuntime);
-    snapshot.workspaceRuntime = Object.keys(workspaceRuntime).length > 0 ? workspaceRuntime : null;
+    snapshot.workspaceRuntime =
+      Object.keys(workspaceRuntime).length > 0 ? workspaceRuntime : null;
   }
   if ("desiredState" in config) {
     snapshot.desiredState =
-      config.desiredState === "running" || config.desiredState === "stopped" || config.desiredState === "manual"
+      config.desiredState === "running" ||
+      config.desiredState === "stopped" ||
+      config.desiredState === "manual"
         ? config.desiredState
         : null;
   }
   if ("serviceStates" in config) {
     const serviceStates = parseObject(config.serviceStates);
-    snapshot.serviceStates = Object.keys(serviceStates).length > 0
-      ? Object.fromEntries(
-          Object.entries(serviceStates).filter(([, state]) =>
-            state === "running" || state === "stopped" || state === "manual"
-          ),
-        ) as ExecutionWorkspaceConfig["serviceStates"]
-      : null;
+    snapshot.serviceStates =
+      Object.keys(serviceStates).length > 0
+        ? (Object.fromEntries(
+            Object.entries(serviceStates).filter(
+              ([, state]) =>
+                state === "running" ||
+                state === "stopped" ||
+                state === "manual",
+            ),
+          ) as ExecutionWorkspaceConfig["serviceStates"])
+        : null;
   }
 
-  const hasSnapshot = Object.values(snapshot).some((value) => {
-    if (value === null) return false;
-    if (typeof value === "object") return Object.keys(value).length > 0;
-    return true;
-  }) || hasExplicitEnvironmentSelection;
+  const hasSnapshot =
+    Object.values(snapshot).some((value) => {
+      if (value === null) return false;
+      if (typeof value === "object") return Object.keys(value).length > 0;
+      return true;
+    }) || hasExplicitEnvironmentSelection;
   return hasSnapshot ? snapshot : null;
 }
 
@@ -530,7 +652,12 @@ function deriveRepoNameFromRepoUrl(repoUrl: string | null): string | null {
   try {
     const parsed = new URL(trimmed);
     const cleanedPath = parsed.pathname.replace(/\/+$/, "");
-    const repoName = cleanedPath.split("/").filter(Boolean).pop()?.replace(/\.git$/i, "") ?? "";
+    const repoName =
+      cleanedPath
+        .split("/")
+        .filter(Boolean)
+        .pop()
+        ?.replace(/\.git$/i, "") ?? "";
     return repoName || null;
   } catch {
     return null;
@@ -584,7 +711,9 @@ async function ensureManagedProjectWorkspace(input: {
     return { cwd, warning: null };
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to prepare managed checkout for "${input.repoUrl}" at "${cwd}": ${reason}`);
+    throw new Error(
+      `Failed to prepare managed checkout for "${input.repoUrl}" at "${cwd}": ${reason}`,
+    );
   }
 }
 
@@ -638,24 +767,66 @@ const heartbeatRunListColumns = {
 } as const;
 
 const heartbeatRunListContextColumns = {
-  contextIssueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("contextIssueId"),
-  contextTaskId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'taskId'`.as("contextTaskId"),
-  contextTaskKey: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'taskKey'`.as("contextTaskKey"),
-  contextCommentId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'commentId'`.as("contextCommentId"),
-  contextWakeCommentId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'wakeCommentId'`.as("contextWakeCommentId"),
-  contextWakeReason: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'wakeReason'`.as("contextWakeReason"),
-  contextWakeSource: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'wakeSource'`.as("contextWakeSource"),
-  contextWakeTriggerDetail: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'wakeTriggerDetail'`.as("contextWakeTriggerDetail"),
+  contextIssueId: sql<
+    string | null
+  >`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("contextIssueId"),
+  contextTaskId: sql<
+    string | null
+  >`${heartbeatRuns.contextSnapshot} ->> 'taskId'`.as("contextTaskId"),
+  contextTaskKey: sql<
+    string | null
+  >`${heartbeatRuns.contextSnapshot} ->> 'taskKey'`.as("contextTaskKey"),
+  contextCommentId: sql<
+    string | null
+  >`${heartbeatRuns.contextSnapshot} ->> 'commentId'`.as("contextCommentId"),
+  contextWakeCommentId: sql<
+    string | null
+  >`${heartbeatRuns.contextSnapshot} ->> 'wakeCommentId'`.as(
+    "contextWakeCommentId",
+  ),
+  contextWakeReason: sql<
+    string | null
+  >`${heartbeatRuns.contextSnapshot} ->> 'wakeReason'`.as("contextWakeReason"),
+  contextWakeSource: sql<
+    string | null
+  >`${heartbeatRuns.contextSnapshot} ->> 'wakeSource'`.as("contextWakeSource"),
+  contextWakeTriggerDetail: sql<
+    string | null
+  >`${heartbeatRuns.contextSnapshot} ->> 'wakeTriggerDetail'`.as(
+    "contextWakeTriggerDetail",
+  ),
 } as const;
 
 const heartbeatRunListResultColumns = {
-  resultSummary: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'summary', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultSummary"),
-  resultResult: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'result', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultResult"),
-  resultMessage: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'message', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultMessage"),
-  resultError: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'error', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultError"),
-  resultTotalCostUsd: sql<string | null>`${heartbeatRuns.resultJson} ->> 'total_cost_usd'`.as("resultTotalCostUsd"),
-  resultCostUsd: sql<string | null>`${heartbeatRuns.resultJson} ->> 'cost_usd'`.as("resultCostUsd"),
-  resultCostUsdCamel: sql<string | null>`${heartbeatRuns.resultJson} ->> 'costUsd'`.as("resultCostUsdCamel"),
+  resultSummary: sql<
+    string | null
+  >`left(${heartbeatRuns.resultJson} ->> 'summary', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as(
+    "resultSummary",
+  ),
+  resultResult: sql<
+    string | null
+  >`left(${heartbeatRuns.resultJson} ->> 'result', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as(
+    "resultResult",
+  ),
+  resultMessage: sql<
+    string | null
+  >`left(${heartbeatRuns.resultJson} ->> 'message', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as(
+    "resultMessage",
+  ),
+  resultError: sql<
+    string | null
+  >`left(${heartbeatRuns.resultJson} ->> 'error', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as(
+    "resultError",
+  ),
+  resultTotalCostUsd: sql<
+    string | null
+  >`${heartbeatRuns.resultJson} ->> 'total_cost_usd'`.as("resultTotalCostUsd"),
+  resultCostUsd: sql<
+    string | null
+  >`${heartbeatRuns.resultJson} ->> 'cost_usd'`.as("resultCostUsd"),
+  resultCostUsdCamel: sql<
+    string | null
+  >`${heartbeatRuns.resultJson} ->> 'costUsd'`.as("resultCostUsdCamel"),
 } as const;
 
 const heartbeatRunSafeResultJsonColumn = sql<Record<string, unknown> | null>`
@@ -746,7 +917,9 @@ const heartbeatRunIssueSummaryColumns = {
   lastOutputSeq: heartbeatRuns.lastOutputSeq,
   lastOutputStream: heartbeatRuns.lastOutputStream,
   lastOutputBytes: heartbeatRuns.lastOutputBytes,
-  issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
+  issueId: sql<
+    string | null
+  >`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
 } as const;
 
 function appendExcerpt(prev: string, chunk: string) {
@@ -759,14 +932,18 @@ function truncateRunEventString(value: string) {
   return `${value.slice(0, MAX_RUN_EVENT_PAYLOAD_STRING_CHARS)}\n[truncated ${omittedChars} chars]`;
 }
 
-function boundRunEventValue(value: unknown, depth: number, seen: WeakSet<object>): unknown {
+function boundRunEventValue(
+  value: unknown,
+  depth: number,
+  seen: WeakSet<object>,
+): unknown {
   if (typeof value === "string") {
     return truncateRunEventString(value);
   }
   if (
-    value === null
-    || typeof value === "number"
-    || typeof value === "boolean"
+    value === null ||
+    typeof value === "number" ||
+    typeof value === "boolean"
   ) {
     return value;
   }
@@ -811,7 +988,10 @@ function boundRunEventValue(value: unknown, depth: number, seen: WeakSet<object>
   }
 
   const out: Record<string, unknown> = {};
-  for (const [key, entryValue] of entries.slice(0, MAX_RUN_EVENT_PAYLOAD_OBJECT_KEYS)) {
+  for (const [key, entryValue] of entries.slice(
+    0,
+    MAX_RUN_EVENT_PAYLOAD_OBJECT_KEYS,
+  )) {
     out[key] = boundRunEventValue(entryValue, depth + 1, seen);
   }
   if (entries.length > MAX_RUN_EVENT_PAYLOAD_OBJECT_KEYS) {
@@ -822,18 +1002,25 @@ function boundRunEventValue(value: unknown, depth: number, seen: WeakSet<object>
   return out;
 }
 
-export function boundHeartbeatRunEventPayloadForStorage(payload: Record<string, unknown>): Record<string, unknown> {
+export function boundHeartbeatRunEventPayloadForStorage(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
   const bounded = boundRunEventValue(payload, 0, new WeakSet());
   return parseObject(bounded) ?? { _truncated: true };
 }
 
 function redactInlineBase64ImageData(chunk: string) {
-  return chunk.replace(INLINE_BASE64_IMAGE_DATA_RE, (_match, prefix: string, data: string, suffix: string) =>
-    `${prefix}[omitted base64 image data: ${data.length} chars]${suffix}`,
+  return chunk.replace(
+    INLINE_BASE64_IMAGE_DATA_RE,
+    (_match, prefix: string, data: string, suffix: string) =>
+      `${prefix}[omitted base64 image data: ${data.length} chars]${suffix}`,
   );
 }
 
-export function compactRunLogChunk(chunk: string, maxChars = MAX_PERSISTED_LOG_CHUNK_CHARS) {
+export function compactRunLogChunk(
+  chunk: string,
+  maxChars = MAX_PERSISTED_LOG_CHUNK_CHARS,
+) {
   const normalized = redactInlineBase64ImageData(chunk);
   if (normalized.length <= maxChars) return normalized;
 
@@ -845,9 +1032,14 @@ export function compactRunLogChunk(chunk: string, maxChars = MAX_PERSISTED_LOG_C
 }
 
 function normalizeMaxConcurrentRuns(value: unknown) {
-  const parsed = Math.floor(asNumber(value, HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT));
+  const parsed = Math.floor(
+    asNumber(value, HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT),
+  );
   if (!Number.isFinite(parsed)) return HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT;
-  return Math.max(HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
+  return Math.max(
+    HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT,
+    Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed),
+  );
 }
 
 interface WakeupOptions {
@@ -899,14 +1091,19 @@ type ProjectWorkspaceCandidate = {
   id: string;
 };
 
-export function prioritizeProjectWorkspaceCandidatesForRun<T extends ProjectWorkspaceCandidate>(
-  rows: T[],
-  preferredWorkspaceId: string | null | undefined,
-): T[] {
+export function prioritizeProjectWorkspaceCandidatesForRun<
+  T extends ProjectWorkspaceCandidate,
+>(rows: T[], preferredWorkspaceId: string | null | undefined): T[] {
   if (!preferredWorkspaceId) return rows;
-  const preferredIndex = rows.findIndex((row) => row.id === preferredWorkspaceId);
+  const preferredIndex = rows.findIndex(
+    (row) => row.id === preferredWorkspaceId,
+  );
   if (preferredIndex <= 0) return rows;
-  return [rows[preferredIndex]!, ...rows.slice(0, preferredIndex), ...rows.slice(preferredIndex + 1)];
+  return [
+    rows[preferredIndex]!,
+    ...rows.slice(0, preferredIndex),
+    ...rows.slice(preferredIndex + 1),
+  ];
 }
 
 function readNonEmptyString(value: unknown): string | null {
@@ -971,31 +1168,39 @@ export function summarizeHeartbeatRunListResultJson(input: {
 }
 
 function summarizeRunFailureForIssueComment(
-  run: Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode"> | null | undefined,
+  run:
+    | Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode">
+    | null
+    | undefined,
 ) {
   if (!run) return null;
 
   const errorCode = readNonEmptyString(run.errorCode)?.trim() ?? null;
   const rawError = readNonEmptyString(run.error)?.trim() ?? null;
   const apiMessageMatch = rawError?.match(/"message"\s*:\s*"([^"]+)"/);
-  const firstLine = rawError
-    ?.split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(Boolean) ?? null;
+  const firstLine =
+    rawError
+      ?.split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? null;
   const summarySource = apiMessageMatch?.[1] ?? firstLine;
   const summary =
     summarySource && summarySource.length > 240
       ? `${summarySource.slice(0, 237)}...`
       : summarySource;
 
-  if (errorCode && summary) return ` Latest retry failure: \`${errorCode}\` - ${summary}.`;
+  if (errorCode && summary)
+    return ` Latest retry failure: \`${errorCode}\` - ${summary}.`;
   if (errorCode) return ` Latest retry failure: \`${errorCode}\`.`;
   if (summary) return ` Latest retry failure: ${summary}.`;
   return null;
 }
 
 function didAutomaticRecoveryFail(
-  latestRun: Pick<typeof heartbeatRuns.$inferSelect, "status" | "contextSnapshot"> | null,
+  latestRun: Pick<
+    typeof heartbeatRuns.$inferSelect,
+    "status" | "contextSnapshot"
+  > | null,
   expectedRetryReason: "assignment_recovery" | "issue_continuation_needed",
 ) {
   if (!latestRun) return false;
@@ -1031,10 +1236,17 @@ function normalizeLedgerBillingType(value: unknown): BillingType {
 }
 
 function resolveLedgerBiller(result: AdapterExecutionResult): string {
-  return readNonEmptyString(result.biller) ?? readNonEmptyString(result.provider) ?? "unknown";
+  return (
+    readNonEmptyString(result.biller) ??
+    readNonEmptyString(result.provider) ??
+    "unknown"
+  );
 }
 
-function normalizeBilledCostCents(costUsd: number | null | undefined, billingType: BillingType): number {
+function normalizeBilledCostCents(
+  costUsd: number | null | undefined,
+  billingType: BillingType,
+): number {
   if (billingType === "subscription_included") return 0;
   if (typeof costUsd !== "number" || !Number.isFinite(costUsd)) return 0;
   return Math.max(0, Math.round(costUsd * 100));
@@ -1088,26 +1300,29 @@ export function buildExplicitResumeSessionOverride(input: {
     input.resumeRunSessionIdAfter ?? input.resumeRunSessionIdBefore,
   );
   const taskSessionParams = normalizeSessionParams(
-    input.sessionCodec.deserialize(input.taskSession?.sessionParamsJson ?? null),
+    input.sessionCodec.deserialize(
+      input.taskSession?.sessionParamsJson ?? null,
+    ),
   );
   const taskSessionDisplayId = truncateDisplayId(
     input.taskSession?.sessionDisplayId ??
-      (input.sessionCodec.getDisplayId ? input.sessionCodec.getDisplayId(taskSessionParams) : null) ??
+      (input.sessionCodec.getDisplayId
+        ? input.sessionCodec.getDisplayId(taskSessionParams)
+        : null) ??
       readNonEmptyString(taskSessionParams?.sessionId),
   );
   const canReuseTaskSessionParams =
     input.taskSession != null &&
-    (
-      input.taskSession.lastRunId === input.resumeFromRunId ||
-      (!!desiredDisplayId && taskSessionDisplayId === desiredDisplayId)
-    );
-  const sessionParams =
-    canReuseTaskSessionParams
-      ? taskSessionParams
-      : desiredDisplayId
-        ? { sessionId: desiredDisplayId }
-        : null;
-  const sessionDisplayId = desiredDisplayId ?? (canReuseTaskSessionParams ? taskSessionDisplayId : null);
+    (input.taskSession.lastRunId === input.resumeFromRunId ||
+      (!!desiredDisplayId && taskSessionDisplayId === desiredDisplayId));
+  const sessionParams = canReuseTaskSessionParams
+    ? taskSessionParams
+    : desiredDisplayId
+      ? { sessionId: desiredDisplayId }
+      : null;
+  const sessionDisplayId =
+    desiredDisplayId ??
+    (canReuseTaskSessionParams ? taskSessionDisplayId : null);
 
   if (!sessionDisplayId && !sessionParams) return null;
   return {
@@ -1116,11 +1331,16 @@ export function buildExplicitResumeSessionOverride(input: {
   };
 }
 
-function normalizeUsageTotals(usage: UsageSummary | null | undefined): UsageTotals | null {
+function normalizeUsageTotals(
+  usage: UsageSummary | null | undefined,
+): UsageTotals | null {
   if (!usage) return null;
   return {
     inputTokens: Math.max(0, Math.floor(asNumber(usage.inputTokens, 0))),
-    cachedInputTokens: Math.max(0, Math.floor(asNumber(usage.cachedInputTokens, 0))),
+    cachedInputTokens: Math.max(
+      0,
+      Math.floor(asNumber(usage.cachedInputTokens, 0)),
+    ),
     outputTokens: Math.max(0, Math.floor(asNumber(usage.outputTokens, 0))),
   };
 }
@@ -1131,15 +1351,24 @@ function readRawUsageTotals(usageJson: unknown): UsageTotals | null {
 
   const inputTokens = Math.max(
     0,
-    Math.floor(asNumber(parsed.rawInputTokens, asNumber(parsed.inputTokens, 0))),
+    Math.floor(
+      asNumber(parsed.rawInputTokens, asNumber(parsed.inputTokens, 0)),
+    ),
   );
   const cachedInputTokens = Math.max(
     0,
-    Math.floor(asNumber(parsed.rawCachedInputTokens, asNumber(parsed.cachedInputTokens, 0))),
+    Math.floor(
+      asNumber(
+        parsed.rawCachedInputTokens,
+        asNumber(parsed.cachedInputTokens, 0),
+      ),
+    ),
   );
   const outputTokens = Math.max(
     0,
-    Math.floor(asNumber(parsed.rawOutputTokens, asNumber(parsed.outputTokens, 0))),
+    Math.floor(
+      asNumber(parsed.rawOutputTokens, asNumber(parsed.outputTokens, 0)),
+    ),
   );
 
   if (inputTokens <= 0 && cachedInputTokens <= 0 && outputTokens <= 0) {
@@ -1153,19 +1382,25 @@ function readRawUsageTotals(usageJson: unknown): UsageTotals | null {
   };
 }
 
-function deriveNormalizedUsageDelta(current: UsageTotals | null, previous: UsageTotals | null): UsageTotals | null {
+function deriveNormalizedUsageDelta(
+  current: UsageTotals | null,
+  previous: UsageTotals | null,
+): UsageTotals | null {
   if (!current) return null;
   if (!previous) return { ...current };
 
-  const inputTokens = current.inputTokens >= previous.inputTokens
-    ? current.inputTokens - previous.inputTokens
-    : current.inputTokens;
-  const cachedInputTokens = current.cachedInputTokens >= previous.cachedInputTokens
-    ? current.cachedInputTokens - previous.cachedInputTokens
-    : current.cachedInputTokens;
-  const outputTokens = current.outputTokens >= previous.outputTokens
-    ? current.outputTokens - previous.outputTokens
-    : current.outputTokens;
+  const inputTokens =
+    current.inputTokens >= previous.inputTokens
+      ? current.inputTokens - previous.inputTokens
+      : current.inputTokens;
+  const cachedInputTokens =
+    current.cachedInputTokens >= previous.cachedInputTokens
+      ? current.cachedInputTokens - previous.cachedInputTokens
+      : current.cachedInputTokens;
+  const outputTokens =
+    current.outputTokens >= previous.outputTokens
+      ? current.outputTokens - previous.outputTokens
+      : current.outputTokens;
 
   return {
     inputTokens: Math.max(0, inputTokens),
@@ -1179,8 +1414,11 @@ function formatCount(value: number | null | undefined) {
   return value.toLocaleString("en-US");
 }
 
-export function parseSessionCompactionPolicy(agent: typeof agents.$inferSelect): SessionCompactionPolicy {
-  return resolveSessionCompactionPolicy(agent.adapterType, agent.runtimeConfig).policy;
+export function parseSessionCompactionPolicy(
+  agent: typeof agents.$inferSelect,
+): SessionCompactionPolicy {
+  return resolveSessionCompactionPolicy(agent.adapterType, agent.runtimeConfig)
+    .policy;
 }
 
 export function resolveRuntimeSessionParamsForWorkspace(input: {
@@ -1189,7 +1427,9 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
   resolvedWorkspace: ResolvedWorkspaceForRun;
 }) {
   const { agentId, previousSessionParams, resolvedWorkspace } = input;
-  const previousSessionId = readNonEmptyString(previousSessionParams?.sessionId);
+  const previousSessionId = readNonEmptyString(
+    previousSessionParams?.sessionId,
+  );
   const previousCwd = readNonEmptyString(previousSessionParams?.cwd);
   if (!previousSessionId || !previousCwd) {
     return {
@@ -1223,7 +1463,9 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
       warning: null as string | null,
     };
   }
-  const previousWorkspaceId = readNonEmptyString(previousSessionParams?.workspaceId);
+  const previousWorkspaceId = readNonEmptyString(
+    previousSessionParams?.workspaceId,
+  );
   if (
     previousWorkspaceId &&
     resolvedWorkspace.workspaceId &&
@@ -1239,9 +1481,12 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
     ...(previousSessionParams ?? {}),
     cwd: projectCwd,
   };
-  if (resolvedWorkspace.workspaceId) migratedSessionParams.workspaceId = resolvedWorkspace.workspaceId;
-  if (resolvedWorkspace.repoUrl) migratedSessionParams.repoUrl = resolvedWorkspace.repoUrl;
-  if (resolvedWorkspace.repoRef) migratedSessionParams.repoRef = resolvedWorkspace.repoRef;
+  if (resolvedWorkspace.workspaceId)
+    migratedSessionParams.workspaceId = resolvedWorkspace.workspaceId;
+  if (resolvedWorkspace.repoUrl)
+    migratedSessionParams.repoUrl = resolvedWorkspace.repoUrl;
+  if (resolvedWorkspace.repoRef)
+    migratedSessionParams.repoRef = resolvedWorkspace.repoRef;
 
   return {
     sessionParams: migratedSessionParams,
@@ -1347,7 +1592,11 @@ function allowsIssueInteractionWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
-  if (!wakeReason || !ISSUE_TREE_CONTROL_INTERACTION_WAKE_REASONS.has(wakeReason)) return false;
+  if (
+    !wakeReason ||
+    !ISSUE_TREE_CONTROL_INTERACTION_WAKE_REASONS.has(wakeReason)
+  )
+    return false;
   return Boolean(deriveCommentId(contextSnapshot, null));
 }
 
@@ -1392,13 +1641,17 @@ export function formatRuntimeWorkspaceWarningLog(warning: string) {
 function describeSessionResetReason(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
-  if (contextSnapshot?.forceFreshSession === true) return "forceFreshSession was requested";
+  if (contextSnapshot?.forceFreshSession === true)
+    return "forceFreshSession was requested";
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (wakeReason === "issue_assigned") return "wake reason is issue_assigned";
-  if (wakeReason === "execution_review_requested") return "wake reason is execution_review_requested";
-  if (wakeReason === "execution_approval_requested") return "wake reason is execution_approval_requested";
-  if (wakeReason === "execution_changes_requested") return "wake reason is execution_changes_requested";
+  if (wakeReason === "execution_review_requested")
+    return "wake reason is execution_review_requested";
+  if (wakeReason === "execution_approval_requested")
+    return "wake reason is execution_approval_requested";
+  if (wakeReason === "execution_changes_requested")
+    return "wake reason is execution_changes_requested";
   return null;
 }
 
@@ -1436,11 +1689,17 @@ function shouldQueueFollowupForRunningIssueWake(input: {
 }) {
   if (input.wakeCommentId) return true;
   const wakeReason = readNonEmptyString(input.contextSnapshot?.wakeReason);
-  return Boolean(wakeReason && RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP.has(wakeReason));
+  return Boolean(
+    wakeReason && RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP.has(wakeReason),
+  );
 }
 
 function isCheckoutConflictError(error: unknown): boolean {
-  return error instanceof HttpError && error.status === 409 && error.message === "Issue checkout conflict";
+  return (
+    error instanceof HttpError &&
+    error.status === 409 &&
+    error.message === "Issue checkout conflict"
+  );
 }
 
 function deriveCommentId(
@@ -1513,7 +1772,10 @@ function enrichWakeContextSnapshot(input: {
   const commentIdFromPayload = readNonEmptyString(payload?.["commentId"]);
   const taskKey = deriveTaskKey(contextSnapshot, payload);
   const wakeCommentId = deriveCommentId(contextSnapshot, payload);
-  const wakeCommentIds = mergeWakeCommentIds(contextSnapshot, commentIdFromPayload);
+  const wakeCommentIds = mergeWakeCommentIds(
+    contextSnapshot,
+    commentIdFromPayload,
+  );
 
   if (!readNonEmptyString(contextSnapshot["wakeReason"]) && reason) {
     contextSnapshot.wakeReason = reason;
@@ -1527,7 +1789,10 @@ function enrichWakeContextSnapshot(input: {
   if (!readNonEmptyString(contextSnapshot["taskKey"]) && taskKey) {
     contextSnapshot.taskKey = taskKey;
   }
-  if (!readNonEmptyString(contextSnapshot["commentId"]) && commentIdFromPayload) {
+  if (
+    !readNonEmptyString(contextSnapshot["commentId"]) &&
+    commentIdFromPayload
+  ) {
     contextSnapshot.commentId = commentIdFromPayload;
   }
   if (wakeCommentIds.length > 0) {
@@ -1538,13 +1803,19 @@ function enrichWakeContextSnapshot(input: {
     // Once comment ids are normalized into the snapshot, rebuild the structured
     // wake payload from those ids later instead of carrying forward stale data.
     delete contextSnapshot[PAPERCLIP_WAKE_PAYLOAD_KEY];
-  } else if (!readNonEmptyString(contextSnapshot["wakeCommentId"]) && wakeCommentId) {
+  } else if (
+    !readNonEmptyString(contextSnapshot["wakeCommentId"]) &&
+    wakeCommentId
+  ) {
     contextSnapshot.wakeCommentId = wakeCommentId;
   }
   if (!readNonEmptyString(contextSnapshot["wakeSource"]) && source) {
     contextSnapshot.wakeSource = source;
   }
-  if (!readNonEmptyString(contextSnapshot["wakeTriggerDetail"]) && triggerDetail) {
+  if (
+    !readNonEmptyString(contextSnapshot["wakeTriggerDetail"]) &&
+    triggerDetail
+  ) {
     contextSnapshot.wakeTriggerDetail = triggerDetail;
   }
 
@@ -1583,23 +1854,19 @@ async function buildPaperclipWakePayload(input: {
   db: Db;
   companyId: string;
   contextSnapshot: Record<string, unknown>;
-  continuationSummary?:
-    | {
-        key: string;
-        title: string | null;
-        body: string;
-        updatedAt: Date;
-      }
-    | null;
-  issueSummary?:
-    | {
-        id: string;
-        identifier: string | null;
-        title: string;
-        status: string;
-        priority: string;
-      }
-    | null;
+  continuationSummary?: {
+    key: string;
+    title: string | null;
+    body: string;
+    updatedAt: Date;
+  } | null;
+  issueSummary?: {
+    id: string;
+    identifier: string | null;
+    title: string;
+    status: string;
+    priority: string;
+  } | null;
 }) {
   const executionStage = parseObject(input.contextSnapshot.executionStage);
   const commentIds = extractWakeCommentIds(input.contextSnapshot);
@@ -1617,10 +1884,17 @@ async function buildPaperclipWakePayload(input: {
             priority: issues.priority,
           })
           .from(issues)
-          .where(and(eq(issues.id, issueId), eq(issues.companyId, input.companyId)))
+          .where(
+            and(eq(issues.id, issueId), eq(issues.companyId, input.companyId)),
+          )
           .then((rows) => rows[0] ?? null)
       : null);
-  if (commentIds.length === 0 && Object.keys(executionStage).length === 0 && !issueSummary) return null;
+  if (
+    commentIds.length === 0 &&
+    Object.keys(executionStage).length === 0 &&
+    !issueSummary
+  )
+    return null;
 
   const commentRows =
     commentIds.length === 0
@@ -1642,7 +1916,9 @@ async function buildPaperclipWakePayload(input: {
             ),
           );
 
-  const commentsById = new Map(commentRows.map((comment) => [comment.id, comment]));
+  const commentsById = new Map(
+    commentRows.map((comment) => [comment.id, comment]),
+  );
   const comments: Array<Record<string, unknown>> = [];
   let remainingBodyChars = MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS;
   let truncated = false;
@@ -1661,13 +1937,19 @@ async function buildPaperclipWakePayload(input: {
     }
 
     const fullBody = row.body;
-    const allowedBodyChars = Math.min(MAX_INLINE_WAKE_COMMENT_BODY_CHARS, remainingBodyChars);
+    const allowedBodyChars = Math.min(
+      MAX_INLINE_WAKE_COMMENT_BODY_CHARS,
+      remainingBodyChars,
+    );
     if (allowedBodyChars <= 0) {
       truncated = true;
       break;
     }
 
-    const body = fullBody.length > allowedBodyChars ? fullBody.slice(0, allowedBodyChars) : fullBody;
+    const body =
+      fullBody.length > allowedBodyChars
+        ? fullBody.slice(0, allowedBodyChars)
+        : fullBody;
     const bodyTruncated = body.length < fullBody.length;
     if (bodyTruncated) truncated = true;
     remainingBodyChars -= body.length;
@@ -1697,34 +1979,60 @@ async function buildPaperclipWakePayload(input: {
           priority: issueSummary.priority,
         }
       : null,
-    childIssueSummaries: Array.isArray(input.contextSnapshot.childIssueSummaries)
+    childIssueSummaries: Array.isArray(
+      input.contextSnapshot.childIssueSummaries,
+    )
       ? input.contextSnapshot.childIssueSummaries
       : [],
-    childIssueSummaryTruncated: input.contextSnapshot.childIssueSummaryTruncated === true,
-    livenessContinuation: readNonEmptyString(input.contextSnapshot.livenessContinuationState) ||
-      readNonEmptyString(input.contextSnapshot.livenessContinuationInstruction) ||
-      readNonEmptyString(input.contextSnapshot.livenessContinuationSourceRunId) ||
+    childIssueSummaryTruncated:
+      input.contextSnapshot.childIssueSummaryTruncated === true,
+    livenessContinuation:
+      readNonEmptyString(input.contextSnapshot.livenessContinuationState) ||
+      readNonEmptyString(
+        input.contextSnapshot.livenessContinuationInstruction,
+      ) ||
+      readNonEmptyString(
+        input.contextSnapshot.livenessContinuationSourceRunId,
+      ) ||
       typeof input.contextSnapshot.livenessContinuationAttempt === "number"
-      ? {
-          attempt: input.contextSnapshot.livenessContinuationAttempt,
-          maxAttempts: input.contextSnapshot.livenessContinuationMaxAttempts,
-          sourceRunId: readNonEmptyString(input.contextSnapshot.livenessContinuationSourceRunId),
-          state: readNonEmptyString(input.contextSnapshot.livenessContinuationState),
-          reason: readNonEmptyString(input.contextSnapshot.livenessContinuationReason),
-          instruction: readNonEmptyString(input.contextSnapshot.livenessContinuationInstruction),
-        }
-      : null,
-    checkedOutByHarness: input.contextSnapshot[PAPERCLIP_HARNESS_CHECKOUT_KEY] === true,
-    dependencyBlockedInteraction: input.contextSnapshot.dependencyBlockedInteraction === true,
+        ? {
+            attempt: input.contextSnapshot.livenessContinuationAttempt,
+            maxAttempts: input.contextSnapshot.livenessContinuationMaxAttempts,
+            sourceRunId: readNonEmptyString(
+              input.contextSnapshot.livenessContinuationSourceRunId,
+            ),
+            state: readNonEmptyString(
+              input.contextSnapshot.livenessContinuationState,
+            ),
+            reason: readNonEmptyString(
+              input.contextSnapshot.livenessContinuationReason,
+            ),
+            instruction: readNonEmptyString(
+              input.contextSnapshot.livenessContinuationInstruction,
+            ),
+          }
+        : null,
+    checkedOutByHarness:
+      input.contextSnapshot[PAPERCLIP_HARNESS_CHECKOUT_KEY] === true,
+    dependencyBlockedInteraction:
+      input.contextSnapshot.dependencyBlockedInteraction === true,
     treeHoldInteraction: input.contextSnapshot.treeHoldInteraction === true,
     activeTreeHold: parseObject(input.contextSnapshot.activeTreeHold),
-    unresolvedBlockerIssueIds: Array.isArray(input.contextSnapshot.unresolvedBlockerIssueIds)
-      ? input.contextSnapshot.unresolvedBlockerIssueIds.filter((value): value is string => typeof value === "string" && value.length > 0)
+    unresolvedBlockerIssueIds: Array.isArray(
+      input.contextSnapshot.unresolvedBlockerIssueIds,
+    )
+      ? input.contextSnapshot.unresolvedBlockerIssueIds.filter(
+          (value): value is string =>
+            typeof value === "string" && value.length > 0,
+        )
       : [],
-    unresolvedBlockerSummaries: Array.isArray(input.contextSnapshot.unresolvedBlockerSummaries)
+    unresolvedBlockerSummaries: Array.isArray(
+      input.contextSnapshot.unresolvedBlockerSummaries,
+    )
       ? input.contextSnapshot.unresolvedBlockerSummaries
       : [],
-    executionStage: Object.keys(executionStage).length > 0 ? executionStage : null,
+    executionStage:
+      Object.keys(executionStage).length > 0 ? executionStage : null,
     continuationSummary: continuationSummary
       ? {
           key: continuationSummary.key,
@@ -1751,7 +2059,10 @@ async function buildPaperclipWakePayload(input: {
 }
 
 function runTaskKey(run: typeof heartbeatRuns.$inferSelect) {
-  return deriveTaskKey(run.contextSnapshot as Record<string, unknown> | null, null);
+  return deriveTaskKey(
+    run.contextSnapshot as Record<string, unknown> | null,
+    null,
+  );
 }
 
 function isSameTaskScope(left: string | null, right: string | null) {
@@ -1810,7 +2121,11 @@ export function buildPaperclipTaskMarkdown(input: {
     }
   }
   if (wakeComment?.body.trim()) {
-    lines.push("", "Latest wake comment:", fenceTaskText(wakeComment.body.trim()));
+    lines.push(
+      "",
+      "Latest wake comment:",
+      fenceTaskText(wakeComment.body.trim()),
+    );
   }
   lines.push("", "Use this task context as the current assignment.");
   return lines.join("\n");
@@ -1820,7 +2135,8 @@ export function buildPaperclipTaskMarkdown(input: {
 // On Linux, PIDs can be recycled, so this is a best-effort signal rather
 // than proof that the original child is still alive.
 function isProcessAlive(pid: number | null | undefined) {
-  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0)
+    return false;
   try {
     process.kill(pid, 0);
     return true;
@@ -1848,7 +2164,9 @@ async function terminateHeartbeatRunProcess(input: {
           ? pid
           : (processGroupId ?? 0),
       processGroupId:
-        typeof processGroupId === "number" && Number.isInteger(processGroupId) && processGroupId > 0
+        typeof processGroupId === "number" &&
+        Number.isInteger(processGroupId) &&
+        processGroupId > 0
           ? processGroupId
           : null,
     },
@@ -1856,10 +2174,13 @@ async function terminateHeartbeatRunProcess(input: {
   );
 }
 
-function buildProcessLossMessage(run: {
-  processPid: number | null;
-  processGroupId: number | null;
-}, options?: { descendantOnly?: boolean }) {
+function buildProcessLossMessage(
+  run: {
+    processPid: number | null;
+    processGroupId: number | null;
+  },
+  options?: { descendantOnly?: boolean },
+) {
   if (options?.descendantOnly && run.processGroupId) {
     return `Process lost -- parent pid ${run.processPid ?? "unknown"} exited, but descendant process group ${run.processGroupId} was still alive and was terminated`;
   }
@@ -1887,7 +2208,9 @@ const defaultSessionCodec: AdapterSessionCodec = {
   deserialize(raw: unknown) {
     const asObj = parseObject(raw);
     if (Object.keys(asObj).length > 0) return asObj;
-    const sessionId = readNonEmptyString((raw as Record<string, unknown> | null)?.sessionId);
+    const sessionId = readNonEmptyString(
+      (raw as Record<string, unknown> | null)?.sessionId,
+    );
     if (sessionId) return { sessionId };
     return null;
   },
@@ -1905,7 +2228,9 @@ function getAdapterSessionCodec(adapterType: string) {
   return adapter.sessionCodec ?? defaultSessionCodec;
 }
 
-function normalizeSessionParams(params: Record<string, unknown> | null | undefined) {
+function normalizeSessionParams(
+  params: Record<string, unknown> | null | undefined,
+) {
   if (!params) return null;
   return Object.keys(params).length > 0 ? params : null;
 }
@@ -1917,7 +2242,13 @@ function resolveNextSessionState(input: {
   previousDisplayId: string | null;
   previousLegacySessionId: string | null;
 }) {
-  const { codec, adapterResult, previousParams, previousDisplayId, previousLegacySessionId } = input;
+  const {
+    codec,
+    adapterResult,
+    previousParams,
+    previousDisplayId,
+    previousLegacySessionId,
+  } = input;
 
   if (adapterResult.clearSession) {
     return {
@@ -1933,16 +2264,20 @@ function resolveNextSessionState(input: {
   const explicitSessionId = readNonEmptyString(adapterResult.sessionId);
   const hasExplicitDisplay = adapterResult.sessionDisplayId !== undefined;
   const explicitDisplayId = readNonEmptyString(adapterResult.sessionDisplayId);
-  const shouldUsePrevious = !hasExplicitParams && !hasExplicitSessionId && !hasExplicitDisplay;
+  const shouldUsePrevious =
+    !hasExplicitParams && !hasExplicitSessionId && !hasExplicitDisplay;
 
-  const candidateParams =
-    hasExplicitParams
-      ? explicitParams
-      : hasExplicitSessionId
-        ? (explicitSessionId ? { sessionId: explicitSessionId } : null)
-        : previousParams;
+  const candidateParams = hasExplicitParams
+    ? explicitParams
+    : hasExplicitSessionId
+      ? explicitSessionId
+        ? { sessionId: explicitSessionId }
+        : null
+      : previousParams;
 
-  const serialized = normalizeSessionParams(codec.serialize(normalizeSessionParams(candidateParams) ?? null));
+  const serialized = normalizeSessionParams(
+    codec.serialize(normalizeSessionParams(candidateParams) ?? null),
+  );
   const deserialized = normalizeSessionParams(codec.deserialize(serialized));
 
   const displayId = truncateDisplayId(
@@ -1967,14 +2302,19 @@ function resolveNextSessionState(input: {
   };
 }
 
-export type HeartbeatEnvironmentRuntime = ReturnType<typeof environmentRuntimeService>;
+export type HeartbeatEnvironmentRuntime = ReturnType<
+  typeof environmentRuntimeService
+>;
 
 export interface HeartbeatServiceOptions {
   pluginWorkerManager?: PluginWorkerManager;
   environmentRuntime?: HeartbeatEnvironmentRuntime;
 }
 
-export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) {
+export function heartbeatService(
+  db: Db,
+  options: HeartbeatServiceOptions = {},
+) {
   const instanceSettings = instanceSettingsService(db);
   const getCurrentUserRedactionOptions = async () => ({
     enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
@@ -1987,9 +2327,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   const treeControlSvc = issueTreeControlService(db);
   const executionWorkspacesSvc = executionWorkspaceService(db);
   const environmentsSvc = environmentService(db);
-  const environmentRuntime = options.environmentRuntime ?? environmentRuntimeService(db, {
-    pluginWorkerManager: options.pluginWorkerManager,
-  });
+  const environmentRuntime =
+    options.environmentRuntime ??
+    environmentRuntimeService(db, {
+      pluginWorkerManager: options.pluginWorkerManager,
+    });
   const envOrchestrator = environmentRunOrchestrator(db, {
     pluginWorkerManager: options.pluginWorkerManager,
     environmentRuntime,
@@ -2006,16 +2348,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function hasUnsafeTextProjectionDatabase() {
     if (!unsafeTextProjectionPromise) {
       unsafeTextProjectionPromise = db
-        .execute(sql`select current_setting('server_encoding') as server_encoding`)
+        .execute(
+          sql`select current_setting('server_encoding') as server_encoding`,
+        )
         .then((rows) => {
           const first = Array.isArray(rows) ? rows[0] : null;
-          const serverEncoding = typeof first === "object" && first !== null
-            ? (first as Record<string, unknown>).server_encoding
-            : null;
-          return typeof serverEncoding === "string" && serverEncoding.toUpperCase() === "SQL_ASCII";
+          const serverEncoding =
+            typeof first === "object" && first !== null
+              ? (first as Record<string, unknown>).server_encoding
+              : null;
+          return (
+            typeof serverEncoding === "string" &&
+            serverEncoding.toUpperCase() === "SQL_ASCII"
+          );
         })
         .catch((err) => {
-          logger.warn({ err }, "failed to inspect database server encoding; using conservative heartbeat result projection");
+          logger.warn(
+            { err },
+            "failed to inspect database server encoding; using conservative heartbeat result projection",
+          );
           return true;
         });
     }
@@ -2030,8 +2381,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
-  async function getRun(runId: string, opts?: { unsafeFullResultJson?: boolean }) {
-    const safeForLegacyEncoding = !opts?.unsafeFullResultJson && await hasUnsafeTextProjectionDatabase();
+  async function getRun(
+    runId: string,
+    opts?: { unsafeFullResultJson?: boolean },
+  ) {
+    const safeForLegacyEncoding =
+      !opts?.unsafeFullResultJson && (await hasUnsafeTextProjectionDatabase());
     return db
       .select(
         opts?.unsafeFullResultJson
@@ -2134,7 +2489,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         createdAt: heartbeatRuns.createdAt,
       })
       .from(heartbeatRuns)
-      .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.sessionIdAfter, sessionId)))
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.sessionIdAfter, sessionId),
+        ),
+      )
       .orderBy(asc(heartbeatRuns.createdAt), asc(heartbeatRuns.id))
       .limit(1)
       .then((rows) => rows[0] ?? null);
@@ -2155,7 +2515,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    const previousRun = await getLatestRunForSession(agentId, sessionId, { excludeRunId: runId });
+    const previousRun = await getLatestRunForSession(agentId, sessionId, {
+      excludeRunId: runId,
+    });
     const previousRawUsage = readRawUsageTotals(previousRun?.usageJson);
     return {
       normalizedUsage: deriveNormalizedUsageDelta(rawUsage, previousRawUsage),
@@ -2190,7 +2552,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    const fetchLimit = Math.max(policy.maxSessionRuns > 0 ? policy.maxSessionRuns + 1 : 0, 4);
+    const fetchLimit = Math.max(
+      policy.maxSessionRuns > 0 ? policy.maxSessionRuns + 1 : 0,
+      4,
+    );
     const runs = await db
       .select({
         id: heartbeatRuns.id,
@@ -2200,7 +2565,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ...heartbeatRunListResultColumns,
       })
       .from(heartbeatRuns)
-      .where(and(eq(heartbeatRuns.agentId, agent.id), eq(heartbeatRuns.sessionIdAfter, sessionId)))
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agent.id),
+          eq(heartbeatRuns.sessionIdAfter, sessionId),
+        ),
+      )
       .orderBy(desc(heartbeatRuns.createdAt))
       .limit(fetchLimit);
 
@@ -2217,13 +2587,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const oldestRun =
       policy.maxSessionAgeHours > 0
         ? await getOldestRunForSession(agent.id, sessionId)
-        : runs[runs.length - 1] ?? latestRun;
+        : (runs[runs.length - 1] ?? latestRun);
     const latestRawUsage = readRawUsageTotals(latestRun?.usageJson);
     const sessionAgeHours =
       latestRun && oldestRun
         ? Math.max(
             0,
-            (new Date(latestRun.createdAt).getTime() - new Date(oldestRun.createdAt).getTime()) / (1000 * 60 * 60),
+            (new Date(latestRun.createdAt).getTime() -
+              new Date(oldestRun.createdAt).getTime()) /
+              (1000 * 60 * 60),
           )
         : 0;
 
@@ -2238,7 +2610,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       reason =
         `session raw input reached ${formatCount(latestRawUsage.inputTokens)} tokens ` +
         `(threshold ${formatCount(policy.maxRawInputTokens)})`;
-    } else if (policy.maxSessionAgeHours > 0 && sessionAgeHours >= policy.maxSessionAgeHours) {
+    } else if (
+      policy.maxSessionAgeHours > 0 &&
+      sessionAgeHours >= policy.maxSessionAgeHours
+    ) {
       reason = `session age reached ${Math.floor(sessionAgeHours)} hours`;
     }
 
@@ -2343,7 +2718,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const resumeContext = parseObject(resumeRun.contextSnapshot);
     const resumeTaskKey = deriveTaskKey(resumeContext, null) ?? taskKey;
     const resumeTaskSession = resumeTaskKey
-      ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, resumeTaskKey)
+      ? await getTaskSession(
+          agent.companyId,
+          agent.id,
+          agent.adapterType,
+          resumeTaskKey,
+        )
       : null;
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
     const sessionOverride = buildExplicitResumeSessionOverride({
@@ -2359,7 +2739,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       resumeFromRunId,
       taskKey: resumeTaskKey,
       issueId: readNonEmptyString(resumeContext.issueId),
-      taskId: readNonEmptyString(resumeContext.taskId) ?? readNonEmptyString(resumeContext.issueId),
+      taskId:
+        readNonEmptyString(resumeContext.taskId) ??
+        readNonEmptyString(resumeContext.issueId),
       sessionDisplayId: sessionOverride.sessionDisplayId,
       sessionParams: sessionOverride.sessionParams,
     };
@@ -2373,7 +2755,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   ): Promise<ResolvedWorkspaceForRun> {
     const issueId = readNonEmptyString(context.issueId);
     const contextProjectId = readNonEmptyString(context.projectId);
-    const contextProjectWorkspaceId = readNonEmptyString(context.projectWorkspaceId);
+    const contextProjectWorkspaceId = readNonEmptyString(
+      context.projectWorkspaceId,
+    );
     const issueProjectRef = issueId
       ? await db
           .select({
@@ -2381,7 +2765,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             projectWorkspaceId: issues.projectWorkspaceId,
           })
           .from(issues)
-          .where(and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)))
+          .where(
+            and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)),
+          )
           .then((rows) => rows[0] ?? null)
       : null;
     const issueProjectId = issueProjectRef?.projectId ?? null;
@@ -2417,14 +2803,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     if (projectWorkspaceRows.length > 0) {
       const preferredWorkspace = preferredProjectWorkspaceId
-        ? projectWorkspaceRows.find((workspace) => workspace.id === preferredProjectWorkspaceId) ?? null
+        ? (projectWorkspaceRows.find(
+            (workspace) => workspace.id === preferredProjectWorkspaceId,
+          ) ?? null)
         : null;
       const missingProjectCwds: string[] = [];
       let hasConfiguredProjectCwd = false;
       let preferredWorkspaceWarning: string | null = null;
       if (preferredProjectWorkspaceId && !preferredWorkspace) {
-        preferredWorkspaceWarning =
-          `Selected project workspace "${preferredProjectWorkspaceId}" is not available on this project.`;
+        preferredWorkspaceWarning = `Selected project workspace "${preferredProjectWorkspaceId}" is not available on this project.`;
       }
       for (const workspace of projectWorkspaceRows) {
         let projectCwd = readNonEmptyString(workspace.cwd);
@@ -2433,14 +2820,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           try {
             const managedWorkspace = await ensureManagedProjectWorkspace({
               companyId: agent.companyId,
-              projectId: workspaceProjectId ?? resolvedProjectId ?? workspace.projectId,
+              projectId:
+                workspaceProjectId ?? resolvedProjectId ?? workspace.projectId,
               repoUrl: readNonEmptyString(workspace.repoUrl),
             });
             projectCwd = managedWorkspace.cwd;
             managedWorkspaceWarning = managedWorkspace.warning;
           } catch (error) {
             if (preferredWorkspace?.id === workspace.id) {
-              preferredWorkspaceWarning = error instanceof Error ? error.message : String(error);
+              preferredWorkspaceWarning =
+                error instanceof Error ? error.message : String(error);
             }
             continue;
           }
@@ -2459,14 +2848,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             repoUrl: workspace.repoUrl,
             repoRef: workspace.repoRef,
             workspaceHints,
-            warnings: [preferredWorkspaceWarning, managedWorkspaceWarning].filter(
-              (value): value is string => Boolean(value),
-            ),
+            warnings: [
+              preferredWorkspaceWarning,
+              managedWorkspaceWarning,
+            ].filter((value): value is string => Boolean(value)),
           };
         }
         if (preferredWorkspace?.id === workspace.id) {
-          preferredWorkspaceWarning =
-            `Selected project workspace path "${projectCwd}" is not available yet.`;
+          preferredWorkspaceWarning = `Selected project workspace path "${projectCwd}" is not available yet.`;
         }
         missingProjectCwds.push(projectCwd);
       }
@@ -2678,8 +3067,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           triggerDetail: updated.triggerDetail,
           error: updated.error ?? null,
           errorCode: updated.errorCode ?? null,
-          startedAt: updated.startedAt ? new Date(updated.startedAt).toISOString() : null,
-          finishedAt: updated.finishedAt ? new Date(updated.finishedAt).toISOString() : null,
+          startedAt: updated.startedAt
+            ? new Date(updated.startedAt).toISOString()
+            : null,
+          finishedAt: updated.finishedAt
+            ? new Date(updated.finishedAt).toISOString()
+            : null,
         },
       });
       publishRunLifecyclePluginEvent(updated);
@@ -2688,7 +3081,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return updated;
   }
 
-  function publishRunLifecyclePluginEvent(run: typeof heartbeatRuns.$inferSelect) {
+  function publishRunLifecyclePluginEvent(
+    run: typeof heartbeatRuns.$inferSelect,
+  ) {
     const eventType =
       run.status === "running"
         ? "agent.run.started"
@@ -2717,11 +3112,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         triggerDetail: run.triggerDetail,
         error: run.error ?? null,
         errorCode: run.errorCode ?? null,
-        issueId: typeof run.contextSnapshot === "object" && run.contextSnapshot !== null
-          ? (run.contextSnapshot as Record<string, unknown>).issueId ?? null
-          : null,
+        issueId:
+          typeof run.contextSnapshot === "object" &&
+          run.contextSnapshot !== null
+            ? ((run.contextSnapshot as Record<string, unknown>).issueId ?? null)
+            : null,
         startedAt: run.startedAt ? new Date(run.startedAt).toISOString() : null,
-        finishedAt: run.finishedAt ? new Date(run.finishedAt).toISOString() : null,
+        finishedAt: run.finishedAt
+          ? new Date(run.finishedAt).toISOString()
+          : null,
       },
     });
   }
@@ -2763,9 +3162,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
   }
 
-  async function handleRunLivenessContinuation(run: typeof heartbeatRuns.$inferSelect) {
+  async function handleRunLivenessContinuation(
+    run: typeof heartbeatRuns.$inferSelect,
+  ) {
     const livenessState = run.livenessState as RunLivenessState | null;
-    if (livenessState !== "plan_only" && livenessState !== "empty_response") return;
+    if (livenessState !== "plan_only" && livenessState !== "empty_response")
+      return;
 
     const context = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(context.issueId);
@@ -2800,25 +3202,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const budgetBlock =
       issue && agent
         ? await budgets.getInvocationBlock(issue.companyId, agent.id, {
-          issueId: issue.id,
-          projectId: issue.projectId,
-        })
+            issueId: issue.id,
+            projectId: issue.projectId,
+          })
         : null;
 
     const nextAttempt = readContinuationAttempt(run.continuationAttempt) + 1;
     const idempotencyKey = issue
       ? buildRunLivenessContinuationIdempotencyKey({
-        issueId: issue.id,
-        sourceRunId: run.id,
-        livenessState,
-        nextAttempt,
-      })
+          issueId: issue.id,
+          sourceRunId: run.id,
+          livenessState,
+          nextAttempt,
+        })
       : null;
     const existingWake = idempotencyKey
       ? await findExistingRunLivenessContinuationWake(db, {
-        companyId: run.companyId,
-        idempotencyKey,
-      })
+          companyId: run.companyId,
+          idempotencyKey,
+        })
       : null;
 
     const decision = decideRunLivenessContinuation({
@@ -2939,7 +3341,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .set({
         processPid: meta.pid,
         processGroupId: meta.processGroupId,
-        processStartedAt: Number.isNaN(startedAt.getTime()) ? new Date() : startedAt,
+        processStartedAt: Number.isNaN(startedAt.getTime())
+          ? new Date()
+          : startedAt,
         updatedAt: new Date(),
       })
       .where(eq(heartbeatRuns.id, runId))
@@ -2955,7 +3359,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         errorCode: null,
         updatedAt: new Date(),
       })
-      .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.status, "running"), eq(heartbeatRuns.errorCode, DETACHED_PROCESS_ERROR_CODE)))
+      .where(
+        and(
+          eq(heartbeatRuns.id, runId),
+          eq(heartbeatRuns.status, "running"),
+          eq(heartbeatRuns.errorCode, DETACHED_PROCESS_ERROR_CODE),
+        ),
+      )
       .returning()
       .then((rows) => rows[0] ?? null);
     if (!updated) return null;
@@ -2964,14 +3374,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       eventType: "lifecycle",
       stream: "system",
       level: "info",
-      message: "Detached child process reported activity; cleared detached warning",
+      message:
+        "Detached child process reported activity; cleared detached warning",
     });
     return updated;
   }
 
   async function patchRunIssueCommentStatus(
     runId: string,
-    patch: Partial<Pick<typeof heartbeatRuns.$inferInsert, "issueCommentStatus" | "issueCommentSatisfiedByCommentId" | "issueCommentRetryQueuedAt">>,
+    patch: Partial<
+      Pick<
+        typeof heartbeatRuns.$inferInsert,
+        | "issueCommentStatus"
+        | "issueCommentSatisfiedByCommentId"
+        | "issueCommentRetryQueuedAt"
+      >
+    >,
   ) {
     return db
       .update(heartbeatRuns)
@@ -2981,7 +3399,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
-  async function findRunIssueComment(runId: string, companyId: string, issueId: string) {
+  async function findRunIssueComment(
+    runId: string,
+    companyId: string,
+    issueId: string,
+  ) {
     return db
       .select({
         id: issueComments.id,
@@ -3065,7 +3487,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const issue = await tx
         .select({ id: issues.id })
         .from(issues)
-        .where(and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)))
+        .where(
+          and(
+            eq(issues.companyId, run.companyId),
+            eq(issues.executionRunId, run.id),
+          ),
+        )
         .then((rows) => rows[0] ?? null);
       if (!issue) return null;
 
@@ -3155,7 +3582,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return retryRun;
   }
 
-  async function hasDeferredIssueCommentWake(companyId: string, issueId: string, agentId: string) {
+  async function hasDeferredIssueCommentWake(
+    companyId: string,
+    issueId: string,
+    agentId: string,
+  ) {
     const deferredPayloads = await db
       .select({ payload: agentWakeupRequests.payload })
       .from(agentWakeupRequests)
@@ -3170,7 +3601,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     return deferredPayloads.some(({ payload }) => {
       const parsedPayload = parseObject(payload);
-      const deferredContext = parseObject(parsedPayload[DEFERRED_WAKE_CONTEXT_KEY]);
+      const deferredContext = parseObject(
+        parsedPayload[DEFERRED_WAKE_CONTEXT_KEY],
+      );
       return Boolean(deriveCommentId(deferredContext, parsedPayload));
     });
   }
@@ -3192,7 +3625,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return { outcome: "not_applicable" as const, queuedRun: null };
     }
 
-    const postedComment = await findRunIssueComment(run.id, run.companyId, issueId);
+    const postedComment = await findRunIssueComment(
+      run.id,
+      run.companyId,
+      issueId,
+    );
     if (postedComment) {
       await patchRunIssueCommentStatus(run.id, {
         issueCommentStatus: "satisfied",
@@ -3202,7 +3639,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return { outcome: "satisfied" as const, queuedRun: null };
     }
 
-    if (readNonEmptyString(contextSnapshot.retryReason) === "missing_issue_comment") {
+    if (
+      readNonEmptyString(contextSnapshot.retryReason) ===
+      "missing_issue_comment"
+    ) {
       await patchRunIssueCommentStatus(run.id, {
         issueCommentStatus: "retry_exhausted",
         issueCommentSatisfiedByCommentId: null,
@@ -3211,7 +3651,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         eventType: "lifecycle",
         stream: "system",
         level: "warn",
-        message: "Run ended without an issue comment after one retry; no further comment wake will be queued",
+        message:
+          "Run ended without an issue comment after one retry; no further comment wake will be queued",
       });
       return { outcome: "retry_exhausted" as const, queuedRun: null };
     }
@@ -3227,7 +3668,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return { outcome: "not_applicable" as const, queuedRun: null };
     }
 
-    if (await hasDeferredIssueCommentWake(run.companyId, issueId, run.agentId)) {
+    if (
+      await hasDeferredIssueCommentWake(run.companyId, issueId, run.agentId)
+    ) {
       await patchRunIssueCommentStatus(run.id, {
         issueCommentStatus: "not_applicable",
         issueCommentSatisfiedByCommentId: null,
@@ -3237,18 +3680,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         eventType: "lifecycle",
         stream: "system",
         level: "info",
-        message: "Run ended without an issue comment; a deferred comment wake already exists for this issue",
+        message:
+          "Run ended without an issue comment; a deferred comment wake already exists for this issue",
       });
       return { outcome: "not_applicable" as const, queuedRun: null };
     }
 
-    const queuedRun = await enqueueMissingIssueCommentRetry(run, agent, issueId);
+    const queuedRun = await enqueueMissingIssueCommentRetry(
+      run,
+      agent,
+      issueId,
+    );
     if (queuedRun) {
       await appendRunEvent(run, await nextRunEventSeq(run.id), {
         eventType: "lifecycle",
         stream: "system",
         level: "warn",
-        message: "Run ended without an issue comment; queued one follow-up wake to require a comment",
+        message:
+          "Run ended without an issue comment; queued one follow-up wake to require a comment",
       });
       return { outcome: "retry_queued" as const, queuedRun };
     }
@@ -3332,7 +3781,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             executionLockedAt: now,
             updatedAt: now,
           })
-          .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
+          .where(
+            and(
+              eq(issues.id, issueId),
+              eq(issues.companyId, run.companyId),
+              eq(issues.executionRunId, run.id),
+            ),
+          );
       }
 
       return retryRun;
@@ -3354,7 +3809,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       eventType: "lifecycle",
       stream: "system",
       level: "warn",
-      message: "Queued automatic retry after orphaned child process was confirmed dead",
+      message:
+        "Queued automatic retry after orphaned child process was confirmed dead",
       payload: {
         retryOfRunId: run.id,
       },
@@ -3374,10 +3830,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
   ) {
     const now = opts?.now ?? new Date();
-    const retryReason = opts?.retryReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON;
-    const wakeReason = opts?.wakeReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON;
+    const retryReason =
+      opts?.retryReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON;
+    const wakeReason =
+      opts?.wakeReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON;
     const nextAttempt = (run.scheduledRetryAttempt ?? 0) + 1;
-    const baseSchedule = computeBoundedTransientHeartbeatRetrySchedule(nextAttempt, now, opts?.random);
+    const baseSchedule = computeBoundedTransientHeartbeatRetrySchedule(
+      nextAttempt,
+      now,
+      opts?.random,
+    );
     const transientRecovery =
       retryReason === BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON
         ? readTransientRecoveryContractFromRun(run)
@@ -3407,11 +3869,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
     const schedule =
-      transientRetryNotBefore && transientRetryNotBefore.getTime() > baseSchedule.dueAt.getTime()
+      transientRetryNotBefore &&
+      transientRetryNotBefore.getTime() > baseSchedule.dueAt.getTime()
         ? {
             ...baseSchedule,
             dueAt: transientRetryNotBefore,
-            delayMs: Math.max(0, transientRetryNotBefore.getTime() - now.getTime()),
+            delayMs: Math.max(
+              0,
+              transientRetryNotBefore.getTime() - now.getTime(),
+            ),
           }
         : baseSchedule;
 
@@ -3424,10 +3890,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       retryOfRunId: run.id,
       wakeReason,
       retryReason,
-      ...(transientRecovery ? { errorFamily: transientRecovery.errorFamily } : {}),
+      ...(transientRecovery
+        ? { errorFamily: transientRecovery.errorFamily }
+        : {}),
       scheduledRetryAttempt: schedule.attempt,
       scheduledRetryAt: schedule.dueAt.toISOString(),
-      ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
+      ...(transientRetryNotBefore
+        ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() }
+        : {}),
       ...(codexTransientFallbackMode ? { codexTransientFallbackMode } : {}),
     };
 
@@ -3444,11 +3914,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             ...(issueId ? { issueId } : {}),
             retryOfRunId: run.id,
             retryReason,
-            ...(transientRecovery ? { errorFamily: transientRecovery.errorFamily } : {}),
+            ...(transientRecovery
+              ? { errorFamily: transientRecovery.errorFamily }
+              : {}),
             scheduledRetryAttempt: schedule.attempt,
             scheduledRetryAt: schedule.dueAt.toISOString(),
-            ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
-            ...(codexTransientFallbackMode ? { codexTransientFallbackMode } : {}),
+            ...(transientRetryNotBefore
+              ? {
+                  transientRetryNotBefore:
+                    transientRetryNotBefore.toISOString(),
+                }
+              : {}),
+            ...(codexTransientFallbackMode
+              ? { codexTransientFallbackMode }
+              : {}),
           },
           status: "queued",
           requestedByActorType: "system",
@@ -3473,7 +3952,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           scheduledRetryAt: schedule.dueAt,
           scheduledRetryAttempt: schedule.attempt,
           scheduledRetryReason: retryReason,
-          continuationAttempt: readContinuationAttempt(retryContextSnapshot.livenessContinuationAttempt),
+          continuationAttempt: readContinuationAttempt(
+            retryContextSnapshot.livenessContinuationAttempt,
+          ),
           updatedAt: now,
         })
         .returning()
@@ -3496,7 +3977,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             executionLockedAt: now,
             updatedAt: now,
           })
-          .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
+          .where(
+            and(
+              eq(issues.id, issueId),
+              eq(issues.companyId, run.companyId),
+              eq(issues.executionRunId, run.id),
+            ),
+          );
       }
 
       return scheduledRun;
@@ -3510,12 +3997,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       payload: {
         retryRunId: retryRun.id,
         retryReason,
-        ...(transientRecovery ? { errorFamily: transientRecovery.errorFamily } : {}),
+        ...(transientRecovery
+          ? { errorFamily: transientRecovery.errorFamily }
+          : {}),
         scheduledRetryAttempt: schedule.attempt,
         scheduledRetryAt: schedule.dueAt.toISOString(),
         baseDelayMs: schedule.baseDelayMs,
         delayMs: schedule.delayMs,
-        ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
+        ...(transientRetryNotBefore
+          ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() }
+          : {}),
         ...(codexTransientFallbackMode ? { codexTransientFallbackMode } : {}),
       },
     });
@@ -3539,13 +4030,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           lte(heartbeatRuns.scheduledRetryAt, now),
         ),
       )
-      .orderBy(asc(heartbeatRuns.scheduledRetryAt), asc(heartbeatRuns.createdAt), asc(heartbeatRuns.id))
+      .orderBy(
+        asc(heartbeatRuns.scheduledRetryAt),
+        asc(heartbeatRuns.createdAt),
+        asc(heartbeatRuns.id),
+      )
       .limit(50);
 
     const promotedRunIds: string[] = [];
 
     for (const dueRun of dueRuns) {
-      const dueRunIssueId = readNonEmptyString(parseObject(dueRun.contextSnapshot).issueId);
+      const dueRunIssueId = readNonEmptyString(
+        parseObject(dueRun.contextSnapshot).issueId,
+      );
       if (dueRunIssueId) {
         const issue = await db
           .select({
@@ -3555,10 +4052,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             executionRunId: issues.executionRunId,
           })
           .from(issues)
-          .where(and(eq(issues.id, dueRunIssueId), eq(issues.companyId, dueRun.companyId)))
+          .where(
+            and(
+              eq(issues.id, dueRunIssueId),
+              eq(issues.companyId, dueRun.companyId),
+            ),
+          )
           .then((rows) => rows[0] ?? null);
 
-        if (issue && (issue.assigneeAgentId !== dueRun.agentId || issue.status === "cancelled")) {
+        if (
+          issue &&
+          (issue.assigneeAgentId !== dueRun.agentId ||
+            issue.status === "cancelled")
+        ) {
           const issueCancelled = issue.status === "cancelled";
           const reason = issueCancelled
             ? "Cancelled because the issue was cancelled before the scheduled retry became due"
@@ -3569,7 +4075,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               status: "cancelled",
               finishedAt: now,
               error: reason,
-              errorCode: issueCancelled ? "issue_cancelled" : "issue_reassigned",
+              errorCode: issueCancelled
+                ? "issue_cancelled"
+                : "issue_reassigned",
               updatedAt: now,
             })
             .where(
@@ -3605,7 +4113,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 executionLockedAt: null,
                 updatedAt: now,
               })
-              .where(and(eq(issues.id, issue.id), eq(issues.executionRunId, cancelled.id)));
+              .where(
+                and(
+                  eq(issues.id, issue.id),
+                  eq(issues.executionRunId, cancelled.id),
+                ),
+              );
           }
 
           await appendRunEvent(cancelled, await nextRunEventSeq(cancelled.id), {
@@ -3619,7 +4132,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               issueId: issue.id,
               issueStatus: issue.status,
               scheduledRetryAttempt: cancelled.scheduledRetryAttempt,
-              scheduledRetryAt: cancelled.scheduledRetryAt ? new Date(cancelled.scheduledRetryAt).toISOString() : null,
+              scheduledRetryAt: cancelled.scheduledRetryAt
+                ? new Date(cancelled.scheduledRetryAt).toISOString()
+                : null,
               scheduledRetryReason: cancelled.scheduledRetryReason,
               previousRetryAgentId: cancelled.agentId,
               currentAssigneeAgentId: issue.assigneeAgentId,
@@ -3652,10 +4167,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         eventType: "lifecycle",
         stream: "system",
         level: "info",
-        message: "Scheduled retry became due and was promoted to the queued run pool",
+        message:
+          "Scheduled retry became due and was promoted to the queued run pool",
         payload: {
           scheduledRetryAttempt: promoted.scheduledRetryAttempt,
-          scheduledRetryAt: promoted.scheduledRetryAt ? new Date(promoted.scheduledRetryAt).toISOString() : null,
+          scheduledRetryAt: promoted.scheduledRetryAt
+            ? new Date(promoted.scheduledRetryAt).toISOString()
+            : null,
           scheduledRetryReason: promoted.scheduledRetryReason,
         },
       });
@@ -3686,8 +4204,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return {
       enabled: asBoolean(heartbeat.enabled, false),
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
-      wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
-      maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      wakeOnDemand: asBoolean(
+        heartbeat.wakeOnDemand ??
+          heartbeat.wakeOnAssignment ??
+          heartbeat.wakeOnOnDemand ??
+          heartbeat.wakeOnAutomation,
+        true,
+      ),
+      maxConcurrentRuns: normalizeMaxConcurrentRuns(
+        heartbeat.maxConcurrentRuns,
+      ),
     };
   }
 
@@ -3710,13 +4236,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     companyId: string,
     queuedRuns: Array<typeof heartbeatRuns.$inferSelect>,
   ) {
-    const issueIds = [...new Set(
-      queuedRuns
-        .map((run) => readNonEmptyString(parseObject(run.contextSnapshot).issueId))
-        .filter((issueId): issueId is string => Boolean(issueId)),
-    )];
+    const issueIds = [
+      ...new Set(
+        queuedRuns
+          .map((run) =>
+            readNonEmptyString(parseObject(run.contextSnapshot).issueId),
+          )
+          .filter((issueId): issueId is string => Boolean(issueId)),
+      ),
+    ];
     if (issueIds.length === 0) {
-      return new Map<string, Awaited<ReturnType<typeof issuesSvc.getDependencyReadiness>>>();
+      return new Map<
+        string,
+        Awaited<ReturnType<typeof issuesSvc.getDependencyReadiness>>
+      >();
     }
     return issuesSvc.listDependencyReadiness(companyId, issueIds);
   }
@@ -3725,7 +4258,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const [{ count }] = await db
       .select({ count: sql<number>`count(*)` })
       .from(heartbeatRuns)
-      .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "running")));
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.status, "running"),
+        ),
+      );
     return Number(count ?? 0);
   }
 
@@ -3733,19 +4271,33 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (run.status !== "queued") return run;
     const agent = await getAgent(run.agentId);
     if (!agent) {
-      await cancelRunInternal(run.id, "Cancelled because the agent no longer exists");
+      await cancelRunInternal(
+        run.id,
+        "Cancelled because the agent no longer exists",
+      );
       return null;
     }
-    if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
-      await cancelRunInternal(run.id, "Cancelled because the agent is not invokable");
+    if (
+      agent.status === "paused" ||
+      agent.status === "terminated" ||
+      agent.status === "pending_approval"
+    ) {
+      await cancelRunInternal(
+        run.id,
+        "Cancelled because the agent is not invokable",
+      );
       return null;
     }
 
     const context = parseObject(run.contextSnapshot);
-    const budgetBlock = await budgets.getInvocationBlock(run.companyId, run.agentId, {
-      issueId: readNonEmptyString(context.issueId),
-      projectId: readNonEmptyString(context.projectId),
-    });
+    const budgetBlock = await budgets.getInvocationBlock(
+      run.companyId,
+      run.agentId,
+      {
+        issueId: readNonEmptyString(context.issueId),
+        projectId: readNonEmptyString(context.projectId),
+      },
+    );
     if (budgetBlock) {
       await cancelRunInternal(run.id, budgetBlock.reason);
       return null;
@@ -3753,17 +4305,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const issueId = readNonEmptyString(context.issueId);
     if (issueId) {
-      const activePauseHold = await treeControlSvc.getActivePauseHoldGate(run.companyId, issueId);
-      const treeHoldInteractionWake = activePauseHold && await isVerifiedIssueTreeControlInteractionWake(db, {
-        companyId: run.companyId,
+      const activePauseHold = await treeControlSvc.getActivePauseHoldGate(
+        run.companyId,
         issueId,
-        agentId: run.agentId,
-        runId: run.id,
-        wakeupRequestId: run.wakeupRequestId,
-        contextSnapshot: context,
-      });
+      );
+      const treeHoldInteractionWake =
+        activePauseHold &&
+        (await isVerifiedIssueTreeControlInteractionWake(db, {
+          companyId: run.companyId,
+          issueId,
+          agentId: run.agentId,
+          runId: run.id,
+          wakeupRequestId: run.wakeupRequestId,
+          contextSnapshot: context,
+        }));
       if (activePauseHold && !treeHoldInteractionWake) {
-        await cancelRunInternal(run.id, "Cancelled because issue is held by an active subtree pause hold");
+        await cancelRunInternal(
+          run.id,
+          "Cancelled because issue is held by an active subtree pause hold",
+        );
         await logActivity(db, {
           companyId: run.companyId,
           actorType: "system",
@@ -3778,18 +4338,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             holdId: activePauseHold.holdId,
             rootIssueId: activePauseHold.rootIssueId,
             source: "heartbeat.claim_queued_run",
-            securityPrinciples: ["Complete Mediation", "Fail Securely", "Secure Defaults"],
+            securityPrinciples: [
+              "Complete Mediation",
+              "Fail Securely",
+              "Secure Defaults",
+            ],
           },
         });
         return null;
       }
 
-      const dependencyReadiness = await issuesSvc.listDependencyReadiness(run.companyId, [issueId]);
+      const dependencyReadiness = await issuesSvc.listDependencyReadiness(
+        run.companyId,
+        [issueId],
+      );
       const readiness = dependencyReadiness.get(issueId);
       const unresolvedBlockerCount = readiness?.unresolvedBlockerCount ?? 0;
       if (unresolvedBlockerCount > 0 && !allowsIssueInteractionWake(context)) {
-        await cancelQueuedRunForBlockedDependencies(run, issueId, readiness?.unresolvedBlockerIssueIds ?? []);
-        logger.info({ runId: run.id, issueId, unresolvedBlockerCount }, "claimQueuedRun: cancelled blocked queued run");
+        await cancelQueuedRunForBlockedDependencies(
+          run,
+          issueId,
+          readiness?.unresolvedBlockerIssueIds ?? [],
+        );
+        logger.info(
+          { runId: run.id, issueId, unresolvedBlockerCount },
+          "claimQueuedRun: cancelled blocked queued run",
+        );
         return null;
       }
     }
@@ -3802,7 +4376,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         startedAt: run.startedAt ?? claimedAt,
         updatedAt: claimedAt,
       })
-      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
+      .where(
+        and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")),
+      )
       .returning()
       .then((rows) => rows[0] ?? null);
     if (!claimed) return null;
@@ -3818,8 +4394,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         triggerDetail: claimed.triggerDetail,
         error: claimed.error ?? null,
         errorCode: claimed.errorCode ?? null,
-        startedAt: claimed.startedAt ? new Date(claimed.startedAt).toISOString() : null,
-        finishedAt: claimed.finishedAt ? new Date(claimed.finishedAt).toISOString() : null,
+        startedAt: claimed.startedAt
+          ? new Date(claimed.startedAt).toISOString()
+          : null,
+        finishedAt: claimed.finishedAt
+          ? new Date(claimed.finishedAt).toISOString()
+          : null,
       },
     });
     publishRunLifecyclePluginEvent(claimed);
@@ -3828,7 +4408,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     // Fix A (lazy locking): stamp executionRunId now that the run is actually running,
     // not at queue time. Guard is idempotent — safe if called more than once.
-    const claimedIssueId = readNonEmptyString(parseObject(claimed.contextSnapshot).issueId);
+    const claimedIssueId = readNonEmptyString(
+      parseObject(claimed.contextSnapshot).issueId,
+    );
     if (claimedIssueId) {
       const claimedAgent = await getAgent(claimed.agentId);
       await db
@@ -3846,7 +4428,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             // Mention/context runs can touch an issue, but only the current assignee
             // owns the issue execution lock shown as the active run.
             eq(issues.assigneeAgentId, claimed.agentId),
-            or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
+            or(
+              isNull(issues.executionRunId),
+              eq(issues.executionRunId, claimed.id),
+            ),
           ),
         );
     }
@@ -3946,7 +4531,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     if (isFirstHeartbeat && updated) {
       const tc = getTelemetryClient();
-      if (tc) trackAgentFirstHeartbeat(tc, { agentRole: updated.role, agentId: updated.id });
+      if (tc)
+        trackAgentFirstHeartbeat(tc, {
+          agentRole: updated.role,
+          agentId: updated.id,
+        });
     }
 
     if (updated) {
@@ -3981,7 +4570,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       errorCode: options?.errorCode ?? null,
       errorMessage: options?.errorMessage ?? null,
     });
-    return mergeHeartbeatRunStopMetadata(options?.resultJson ?? null, stopMetadata);
+    return mergeHeartbeatRunStopMetadata(
+      options?.resultJson ?? null,
+      stopMetadata,
+    );
   }
 
   function countValue(value: unknown) {
@@ -3990,7 +4582,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   function dateValue(value: unknown) {
-    if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+    if (value instanceof Date)
+      return Number.isNaN(value.getTime()) ? null : value;
     if (typeof value === "string" || typeof value === "number") {
       const parsed = new Date(value);
       return Number.isNaN(parsed.getTime()) ? null : parsed;
@@ -4014,50 +4607,58 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   ): Promise<RunLivenessClassificationInput> {
     const context = parseObject(run.contextSnapshot);
     const contextIssueId = readNonEmptyString(context.issueId);
-    const continuationAttempt = asNumber(context.continuationAttempt, run.continuationAttempt ?? 0);
+    const continuationAttempt = asNumber(
+      context.continuationAttempt,
+      run.continuationAttempt ?? 0,
+    );
 
     const issue = contextIssueId
       ? await db
-        .select({
-          status: issues.status,
-          title: issues.title,
-          description: issues.description,
-        })
-        .from(issues)
-        .where(and(eq(issues.companyId, run.companyId), eq(issues.id, contextIssueId)))
-        .then((rows) => rows[0] ?? null)
+          .select({
+            status: issues.status,
+            title: issues.title,
+            description: issues.description,
+          })
+          .from(issues)
+          .where(
+            and(
+              eq(issues.companyId, run.companyId),
+              eq(issues.id, contextIssueId),
+            ),
+          )
+          .then((rows) => rows[0] ?? null)
       : null;
 
     const [commentStats] = contextIssueId
       ? await db
-        .select({
-          count: sql<number>`count(*)::int`,
-          latestAt: sql<Date | null>`max(${issueComments.createdAt})`,
-        })
-        .from(issueComments)
-        .where(
-          and(
-            eq(issueComments.companyId, run.companyId),
-            eq(issueComments.issueId, contextIssueId),
-            eq(issueComments.createdByRunId, run.id),
-          ),
-        )
+          .select({
+            count: sql<number>`count(*)::int`,
+            latestAt: sql<Date | null>`max(${issueComments.createdAt})`,
+          })
+          .from(issueComments)
+          .where(
+            and(
+              eq(issueComments.companyId, run.companyId),
+              eq(issueComments.issueId, contextIssueId),
+              eq(issueComments.createdByRunId, run.id),
+            ),
+          )
       : [{ count: 0, latestAt: null }];
 
     const issueCommentBodies = contextIssueId
       ? await db
-        .select({ body: issueComments.body })
-        .from(issueComments)
-        .where(
-          and(
-            eq(issueComments.companyId, run.companyId),
-            eq(issueComments.issueId, contextIssueId),
-            eq(issueComments.createdByRunId, run.id),
-          ),
-        )
-        .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
-        .limit(5)
-        .then((rows) => rows.reverse().map((row) => row.body))
+          .select({ body: issueComments.body })
+          .from(issueComments)
+          .where(
+            and(
+              eq(issueComments.companyId, run.companyId),
+              eq(issueComments.issueId, contextIssueId),
+              eq(issueComments.createdByRunId, run.id),
+            ),
+          )
+          .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+          .limit(5)
+          .then((rows) => rows.reverse().map((row) => row.body))
       : [];
 
     const continuationSummary = contextIssueId
@@ -4066,38 +4667,41 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const [documentStats] = contextIssueId
       ? await db
-        .select({
-          count: sql<number>`count(*)::int`,
-          planCount: sql<number>`count(*) filter (where ${issueDocuments.key} = 'plan')::int`,
-          latestAt: sql<Date | null>`max(${documentRevisions.createdAt})`,
-        })
-        .from(documentRevisions)
-        .innerJoin(issueDocuments, eq(documentRevisions.documentId, issueDocuments.documentId))
-        .where(
-          and(
-            eq(documentRevisions.companyId, run.companyId),
-            eq(documentRevisions.createdByRunId, run.id),
-            eq(issueDocuments.companyId, run.companyId),
-            eq(issueDocuments.issueId, contextIssueId),
-            sql`${issueDocuments.key} != ${ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY}`,
-          ),
-        )
+          .select({
+            count: sql<number>`count(*)::int`,
+            planCount: sql<number>`count(*) filter (where ${issueDocuments.key} = 'plan')::int`,
+            latestAt: sql<Date | null>`max(${documentRevisions.createdAt})`,
+          })
+          .from(documentRevisions)
+          .innerJoin(
+            issueDocuments,
+            eq(documentRevisions.documentId, issueDocuments.documentId),
+          )
+          .where(
+            and(
+              eq(documentRevisions.companyId, run.companyId),
+              eq(documentRevisions.createdByRunId, run.id),
+              eq(issueDocuments.companyId, run.companyId),
+              eq(issueDocuments.issueId, contextIssueId),
+              sql`${issueDocuments.key} != ${ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY}`,
+            ),
+          )
       : [{ count: 0, planCount: 0, latestAt: null }];
 
     const [workProductStats] = contextIssueId
       ? await db
-        .select({
-          count: sql<number>`count(*)::int`,
-          latestAt: sql<Date | null>`max(${issueWorkProducts.createdAt})`,
-        })
-        .from(issueWorkProducts)
-        .where(
-          and(
-            eq(issueWorkProducts.companyId, run.companyId),
-            eq(issueWorkProducts.issueId, contextIssueId),
-            eq(issueWorkProducts.createdByRunId, run.id),
-          ),
-        )
+          .select({
+            count: sql<number>`count(*)::int`,
+            latestAt: sql<Date | null>`max(${issueWorkProducts.createdAt})`,
+          })
+          .from(issueWorkProducts)
+          .where(
+            and(
+              eq(issueWorkProducts.companyId, run.companyId),
+              eq(issueWorkProducts.issueId, contextIssueId),
+              eq(issueWorkProducts.createdByRunId, run.id),
+            ),
+          )
       : [{ count: 0, latestAt: null }];
 
     const [workspaceOperationStats] = await db
@@ -4106,7 +4710,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         latestAt: sql<Date | null>`max(${workspaceOperations.startedAt})`,
       })
       .from(workspaceOperations)
-      .where(and(eq(workspaceOperations.companyId, run.companyId), eq(workspaceOperations.heartbeatRunId, run.id)));
+      .where(
+        and(
+          eq(workspaceOperations.companyId, run.companyId),
+          eq(workspaceOperations.heartbeatRunId, run.id),
+        ),
+      );
 
     const [activityStats] = await db
       .select({
@@ -4128,7 +4737,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         latestAt: sql<Date | null>`max(${heartbeatRunEvents.createdAt}) filter (where ${heartbeatRunEvents.eventType} not in ('lifecycle', 'adapter.invoke', 'error'))`,
       })
       .from(heartbeatRunEvents)
-      .where(and(eq(heartbeatRunEvents.companyId, run.companyId), eq(heartbeatRunEvents.runId, run.id)));
+      .where(
+        and(
+          eq(heartbeatRunEvents.companyId, run.companyId),
+          eq(heartbeatRunEvents.runId, run.id),
+        ),
+      );
 
     return {
       runStatus: run.status,
@@ -4165,7 +4779,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     run: typeof heartbeatRuns.$inferSelect,
     resultJson?: Record<string, unknown> | null,
   ) {
-    const classification = classifyRunLiveness(await buildRunLivenessInput(run, resultJson));
+    const classification = classifyRunLiveness(
+      await buildRunLivenessInput(run, resultJson),
+    );
     return db
       .update(heartbeatRuns)
       .set({
@@ -4199,7 +4815,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const reaped: string[] = [];
 
     for (const { run, adapterType, adapterConfig } of activeRuns) {
-      if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
+      if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id))
+        continue;
 
       // Apply staleness threshold to avoid false positives
       if (staleThresholdMs > 0) {
@@ -4208,8 +4825,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
-      const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
-      const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
+      const processPidAlive =
+        tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
+      const processGroupAlive =
+        tracksLocalChild &&
+        run.processGroupId &&
+        isProcessGroupAlive(run.processGroupId);
       if (processPidAlive) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
@@ -4218,15 +4839,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             errorCode: DETACHED_PROCESS_ERROR_CODE,
           });
           if (detachedRun) {
-            await appendRunEvent(detachedRun, await nextRunEventSeq(detachedRun.id), {
-              eventType: "lifecycle",
-              stream: "system",
-              level: "warn",
-              message: detachedMessage,
-              payload: {
-                processPid: run.processPid,
+            await appendRunEvent(
+              detachedRun,
+              await nextRunEventSeq(detachedRun.id),
+              {
+                eventType: "lifecycle",
+                stream: "system",
+                level: "warn",
+                message: detachedMessage,
+                payload: {
+                  processPid: run.processPid,
+                },
               },
-            });
+            );
           }
         }
         continue;
@@ -4241,8 +4866,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         });
       }
 
-      const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
-      const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const shouldRetry =
+        tracksLocalChild &&
+        (!!run.processPid || !!run.processGroupId) &&
+        (run.processLossRetryCount ?? 0) < 1;
+      const baseMessage = buildProcessLossMessage(
+        run,
+        descendantOnlyCleanup ? { descendantOnly: true } : undefined,
+      );
 
       let finalizedRun = await setRunStatus(run.id, "failed", {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
@@ -4254,7 +4885,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           {
             resultJson: parseObject(run.resultJson),
             errorCode: "process_lost",
-            errorMessage: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+            errorMessage: shouldRetry
+              ? `${baseMessage}; retrying once`
+              : baseMessage,
           },
         ),
       });
@@ -4264,7 +4897,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
       if (!finalizedRun) finalizedRun = await getRun(run.id);
       if (!finalizedRun) continue;
-      finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
+      finalizedRun =
+        (await classifyAndPersistRunLiveness(
+          finalizedRun,
+          parseObject(finalizedRun.resultJson),
+        )) ?? finalizedRun;
 
       let retriedRun: typeof heartbeatRuns.$inferSelect | null = null;
       if (shouldRetry) {
@@ -4276,20 +4913,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         await releaseIssueExecutionAndPromote(finalizedRun);
       }
 
-      await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
-        eventType: "lifecycle",
-        stream: "system",
-        level: "error",
-        message: shouldRetry
-          ? `${baseMessage}; queued retry ${retriedRun?.id ?? ""}`.trim()
-          : baseMessage,
-        payload: {
-          ...(run.processPid ? { processPid: run.processPid } : {}),
-          ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
-          ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
-          ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
+      await appendRunEvent(
+        finalizedRun,
+        await nextRunEventSeq(finalizedRun.id),
+        {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "error",
+          message: shouldRetry
+            ? `${baseMessage}; queued retry ${retriedRun?.id ?? ""}`.trim()
+            : baseMessage,
+          payload: {
+            ...(run.processPid ? { processPid: run.processPid } : {}),
+            ...(run.processGroupId
+              ? { processGroupId: run.processGroupId }
+              : {}),
+            ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
+            ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
+          },
         },
-      });
+      );
 
       await finalizeAgentStatus(run.agentId, "failed");
       await startNextQueuedRunForAgent(run.agentId);
@@ -4298,7 +4941,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (reaped.length > 0) {
-      logger.warn({ reapedCount: reaped.length, runIds: reaped }, "reaped orphaned heartbeat runs");
+      logger.warn(
+        { reapedCount: reaped.length, runIds: reaped },
+        "reaped orphaned heartbeat runs",
+      );
     }
     return { reaped: reaped.length, runIds: reaped };
   }
@@ -4321,25 +4967,40 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
   function issueIdFromRunContext(contextSnapshot: unknown) {
     const context = parseObject(contextSnapshot);
-    return readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
+    return (
+      readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId)
+    );
   }
 
   function issueIdFromWakePayload(payload: unknown) {
     const parsed = parseObject(payload);
     const nestedContext = parseObject(parsed[DEFERRED_WAKE_CONTEXT_KEY]);
-    return readNonEmptyString(parsed.issueId) ??
+    return (
+      readNonEmptyString(parsed.issueId) ??
       readNonEmptyString(nestedContext.issueId) ??
-      readNonEmptyString(nestedContext.taskId);
+      readNonEmptyString(nestedContext.taskId)
+    );
   }
 
-  async function scanSilentActiveRuns(opts?: { now?: Date; companyId?: string }) {
+  async function scanSilentActiveRuns(opts?: {
+    now?: Date;
+    companyId?: string;
+  }) {
     return recovery.scanSilentActiveRuns(opts);
   }
 
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
-      "id" | "companyId" | "status" | "lastOutputAt" | "lastOutputSeq" | "lastOutputStream" | "processStartedAt" | "startedAt" | "createdAt"
+      | "id"
+      | "companyId"
+      | "status"
+      | "lastOutputAt"
+      | "lastOutputSeq"
+      | "lastOutputStream"
+      | "processStartedAt"
+      | "startedAt"
+      | "createdAt"
     >,
     now = new Date(),
   ) {
@@ -4363,11 +5024,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const outputTokens = usage?.outputTokens ?? 0;
     const cachedInputTokens = usage?.cachedInputTokens ?? 0;
     const billingType = normalizeLedgerBillingType(result.billingType);
-    const additionalCostCents = normalizeBilledCostCents(result.costUsd, billingType);
-    const hasTokenUsage = inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0;
+    const additionalCostCents = normalizeBilledCostCents(
+      result.costUsd,
+      billingType,
+    );
+    const hasTokenUsage =
+      inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0;
     const provider = result.provider ?? "unknown";
     const biller = resolveLedgerBiller(result);
-    const ledgerScope = await resolveLedgerScopeForRun(db, agent.companyId, run);
+    const ledgerScope = await resolveLedgerScopeForRun(
+      db,
+      agent.companyId,
+      run,
+    );
 
     await db
       .update(agentRuntimeState)
@@ -4409,27 +5078,46 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return withAgentStartLock(agentId, async () => {
       const agent = await getAgent(agentId);
       if (!agent) return [];
-      if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
+      if (
+        agent.status === "paused" ||
+        agent.status === "terminated" ||
+        agent.status === "pending_approval"
+      ) {
         return [];
       }
       const policy = parseHeartbeatPolicy(agent);
       const runningCount = await countRunningRunsForAgent(agentId);
-      const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
+      const availableSlots = Math.max(
+        0,
+        policy.maxConcurrentRuns - runningCount,
+      );
       if (availableSlots <= 0) return [];
 
       const queuedRuns = await db
         .select()
         .from(heartbeatRuns)
-        .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")))
+        .where(
+          and(
+            eq(heartbeatRuns.agentId, agentId),
+            eq(heartbeatRuns.status, "queued"),
+          ),
+        )
         .orderBy(asc(heartbeatRuns.createdAt));
       if (queuedRuns.length === 0) return [];
 
-      const dependencyReadiness = await listQueuedRunDependencyReadiness(agent.companyId, queuedRuns);
-      const queuedIssueIds = [...new Set(
-        queuedRuns
-          .map((run) => readNonEmptyString(parseObject(run.contextSnapshot).issueId))
-          .filter((issueId): issueId is string => Boolean(issueId)),
-      )];
+      const dependencyReadiness = await listQueuedRunDependencyReadiness(
+        agent.companyId,
+        queuedRuns,
+      );
+      const queuedIssueIds = [
+        ...new Set(
+          queuedRuns
+            .map((run) =>
+              readNonEmptyString(parseObject(run.contextSnapshot).issueId),
+            )
+            .filter((issueId): issueId is string => Boolean(issueId)),
+        ),
+      ];
       const issueRows = await db
         .select({
           id: issues.id,
@@ -4439,25 +5127,53 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .from(issues)
         .where(
           queuedIssueIds.length > 0
-            ? and(eq(issues.companyId, agent.companyId), inArray(issues.id, queuedIssueIds))
+            ? and(
+                eq(issues.companyId, agent.companyId),
+                inArray(issues.id, queuedIssueIds),
+              )
             : sql`false`,
         );
       const issueById = new Map(issueRows.map((row) => [row.id, row]));
       const prioritizedRuns = [...queuedRuns].sort((left, right) => {
-        const leftIssueId = readNonEmptyString(parseObject(left.contextSnapshot).issueId);
-        const rightIssueId = readNonEmptyString(parseObject(right.contextSnapshot).issueId);
-        const leftReadiness = leftIssueId ? dependencyReadiness.get(leftIssueId) : null;
-        const rightReadiness = rightIssueId ? dependencyReadiness.get(rightIssueId) : null;
-        const leftReady = leftIssueId ? (leftReadiness?.isDependencyReady ?? true) : true;
-        const rightReady = rightIssueId ? (rightReadiness?.isDependencyReady ?? true) : true;
+        const leftIssueId = readNonEmptyString(
+          parseObject(left.contextSnapshot).issueId,
+        );
+        const rightIssueId = readNonEmptyString(
+          parseObject(right.contextSnapshot).issueId,
+        );
+        const leftReadiness = leftIssueId
+          ? dependencyReadiness.get(leftIssueId)
+          : null;
+        const rightReadiness = rightIssueId
+          ? dependencyReadiness.get(rightIssueId)
+          : null;
+        const leftReady = leftIssueId
+          ? (leftReadiness?.isDependencyReady ?? true)
+          : true;
+        const rightReady = rightIssueId
+          ? (rightReadiness?.isDependencyReady ?? true)
+          : true;
         const leftIssue = leftIssueId ? issueById.get(leftIssueId) : null;
         const rightIssue = rightIssueId ? issueById.get(rightIssueId) : null;
-        const leftRank = leftIssueId ? (leftReady ? (leftIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
-        const rightRank = rightIssueId ? (rightReady ? (rightIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
+        const leftRank = leftIssueId
+          ? leftReady
+            ? leftIssue?.status === "in_progress"
+              ? 0
+              : 1
+            : 3
+          : 2;
+        const rightRank = rightIssueId
+          ? rightReady
+            ? rightIssue?.status === "in_progress"
+              ? 0
+              : 1
+            : 3
+          : 2;
         if (leftRank !== rightRank) return leftRank - rightRank;
         const leftPriorityRank = issueRunPriorityRank(leftIssue?.priority);
         const rightPriorityRank = issueRunPriorityRank(rightIssue?.priority);
-        if (leftPriorityRank !== rightPriorityRank) return leftPriorityRank - rightPriorityRank;
+        if (leftPriorityRank !== rightPriorityRank)
+          return leftPriorityRank - rightPriorityRank;
         return left.createdAt.getTime() - right.createdAt.getTime();
       });
 
@@ -4471,7 +5187,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       for (const claimedRun of claimedRuns) {
         void executeRun(claimedRun.id).catch((err) => {
-          logger.error({ err, runId: claimedRun.id }, "queued heartbeat execution failed");
+          logger.error(
+            { err, runId: claimedRun.id },
+            "queued heartbeat execution failed",
+          );
         });
       }
       return claimedRuns;
@@ -4495,283 +5214,349 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     activeRunExecutions.add(run.id);
 
     try {
-    const agent = await getAgent(run.agentId);
-    if (!agent) {
-      await setRunStatus(runId, "failed", {
-        error: "Agent not found",
-        errorCode: "agent_not_found",
-        finishedAt: new Date(),
-      });
-      await setWakeupStatus(run.wakeupRequestId, "failed", {
-        finishedAt: new Date(),
-        error: "Agent not found",
-      });
-      const failedRun = await getRun(runId);
-      if (failedRun) await releaseIssueExecutionAndPromote(failedRun);
-      return;
-    }
-
-    const runtime = await ensureRuntimeState(agent);
-    const context = parseObject(run.contextSnapshot);
-    const taskKey = deriveTaskKeyWithHeartbeatFallback(context, null);
-    const sessionCodec = getAdapterSessionCodec(agent.adapterType);
-    const issueId = readNonEmptyString(context.issueId);
-    let issueContext = issueId ? await getIssueExecutionContext(agent.companyId, issueId) : null;
-    const issueDependencyReadiness = issueId
-      ? await issuesSvc.listDependencyReadiness(agent.companyId, [issueId]).then((rows) => rows.get(issueId) ?? null)
-      : null;
-    if (
-      issueId &&
-      issueContext &&
-      shouldAutoCheckoutIssueForWake({
-        contextSnapshot: context,
-        issueStatus: issueContext.status,
-        issueAssigneeAgentId: issueContext.assigneeAgentId,
-        isDependencyReady: issueDependencyReadiness?.isDependencyReady ?? true,
-        agentId: agent.id,
-      })
-    ) {
-      try {
-        await issuesSvc.checkout(issueId, agent.id, ["todo", "backlog", "blocked"], run.id);
-        context[PAPERCLIP_HARNESS_CHECKOUT_KEY] = true;
-      } catch (error) {
-        if (!isCheckoutConflictError(error)) throw error;
-        context[PAPERCLIP_HARNESS_CHECKOUT_KEY] = false;
+      const agent = await getAgent(run.agentId);
+      if (!agent) {
+        await setRunStatus(runId, "failed", {
+          error: "Agent not found",
+          errorCode: "agent_not_found",
+          finishedAt: new Date(),
+        });
+        await setWakeupStatus(run.wakeupRequestId, "failed", {
+          finishedAt: new Date(),
+          error: "Agent not found",
+        });
+        const failedRun = await getRun(runId);
+        if (failedRun) await releaseIssueExecutionAndPromote(failedRun);
+        return;
       }
-      issueContext = await getIssueExecutionContext(agent.companyId, issueId);
-    }
-    const wakeCommentId = deriveCommentId(context, null);
-    const wakeCommentContext =
-      issueContext && wakeCommentId
-        ? await db
-            .select({
-              id: issueComments.id,
-              body: issueComments.body,
-            })
-            .from(issueComments)
-            .where(and(
-              eq(issueComments.id, wakeCommentId),
-              eq(issueComments.issueId, issueContext.id),
-              eq(issueComments.companyId, agent.companyId),
-            ))
-            .then((rows) => rows[0] ?? null)
+
+      const runtime = await ensureRuntimeState(agent);
+      const context = parseObject(run.contextSnapshot);
+      const taskKey = deriveTaskKeyWithHeartbeatFallback(context, null);
+      const sessionCodec = getAdapterSessionCodec(agent.adapterType);
+      const issueId = readNonEmptyString(context.issueId);
+      let issueContext = issueId
+        ? await getIssueExecutionContext(agent.companyId, issueId)
         : null;
-    const issueAssigneeOverrides =
-      issueContext && issueContext.assigneeAgentId === agent.id
-        ? parseIssueAssigneeAdapterOverrides(
-            issueContext.assigneeAdapterOverrides,
+      const issueDependencyReadiness = issueId
+        ? await issuesSvc
+            .listDependencyReadiness(agent.companyId, [issueId])
+            .then((rows) => rows.get(issueId) ?? null)
+        : null;
+      if (
+        issueId &&
+        issueContext &&
+        shouldAutoCheckoutIssueForWake({
+          contextSnapshot: context,
+          issueStatus: issueContext.status,
+          issueAssigneeAgentId: issueContext.assigneeAgentId,
+          isDependencyReady:
+            issueDependencyReadiness?.isDependencyReady ?? true,
+          agentId: agent.id,
+        })
+      ) {
+        try {
+          await issuesSvc.checkout(
+            issueId,
+            agent.id,
+            ["todo", "backlog", "blocked"],
+            run.id,
+          );
+          context[PAPERCLIP_HARNESS_CHECKOUT_KEY] = true;
+        } catch (error) {
+          if (!isCheckoutConflictError(error)) throw error;
+          context[PAPERCLIP_HARNESS_CHECKOUT_KEY] = false;
+        }
+        issueContext = await getIssueExecutionContext(agent.companyId, issueId);
+      }
+      const wakeCommentId = deriveCommentId(context, null);
+      const wakeCommentContext =
+        issueContext && wakeCommentId
+          ? await db
+              .select({
+                id: issueComments.id,
+                body: issueComments.body,
+              })
+              .from(issueComments)
+              .where(
+                and(
+                  eq(issueComments.id, wakeCommentId),
+                  eq(issueComments.issueId, issueContext.id),
+                  eq(issueComments.companyId, agent.companyId),
+                ),
+              )
+              .then((rows) => rows[0] ?? null)
+          : null;
+      const issueAssigneeOverrides =
+        issueContext && issueContext.assigneeAgentId === agent.id
+          ? parseIssueAssigneeAdapterOverrides(
+              issueContext.assigneeAdapterOverrides,
+            )
+          : null;
+      const isolatedWorkspacesEnabled = (
+        await instanceSettings.getExperimental()
+      ).enableIsolatedWorkspaces;
+      const issueExecutionWorkspaceSettings = isolatedWorkspacesEnabled
+        ? parseIssueExecutionWorkspaceSettings(
+            issueContext?.executionWorkspaceSettings,
           )
         : null;
-    const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
-    const issueExecutionWorkspaceSettings = isolatedWorkspacesEnabled
-      ? parseIssueExecutionWorkspaceSettings(issueContext?.executionWorkspaceSettings)
-      : null;
-    const contextProjectId = readNonEmptyString(context.projectId);
-    const executionProjectId = issueContext?.projectId ?? contextProjectId;
-    const projectContext = executionProjectId
-      ? await db
-          .select({
-            executionWorkspacePolicy: projects.executionWorkspacePolicy,
-            env: projects.env,
-          })
-          .from(projects)
-          .where(and(eq(projects.id, executionProjectId), eq(projects.companyId, agent.companyId)))
-          .then((rows) => rows[0] ?? null)
-      : null;
-    const projectExecutionWorkspacePolicy = gateProjectExecutionWorkspacePolicy(
-      parseProjectExecutionWorkspacePolicy(projectContext?.executionWorkspacePolicy),
-      isolatedWorkspacesEnabled,
-    );
-    const taskSession = taskKey
-      ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, taskKey)
-      : null;
-    const resetTaskSession = shouldResetTaskSessionForWake(context);
-    const sessionResetReason = describeSessionResetReason(context);
-    const taskSessionForRun = resetTaskSession ? null : taskSession;
-    const explicitResumeSessionParams = normalizeSessionParams(
-      sessionCodec.deserialize(parseObject(context.resumeSessionParams)),
-    );
-    const explicitResumeSessionDisplayId = truncateDisplayId(
-      readNonEmptyString(context.resumeSessionDisplayId) ??
-        (sessionCodec.getDisplayId ? sessionCodec.getDisplayId(explicitResumeSessionParams) : null) ??
-        readNonEmptyString(explicitResumeSessionParams?.sessionId),
-    );
-    const previousSessionParams =
-      explicitResumeSessionParams ??
-      (explicitResumeSessionDisplayId ? { sessionId: explicitResumeSessionDisplayId } : null) ??
-      normalizeSessionParams(sessionCodec.deserialize(taskSessionForRun?.sessionParamsJson ?? null));
-    const config = parseObject(agent.adapterConfig);
-    const requestedExecutionWorkspaceMode = resolveExecutionWorkspaceMode({
-      projectPolicy: projectExecutionWorkspacePolicy,
-      issueSettings: issueExecutionWorkspaceSettings,
-      legacyUseProjectWorkspace: issueAssigneeOverrides?.useProjectWorkspace ?? null,
-    });
-    const resolvedWorkspace = await resolveWorkspaceForRun(
-      agent,
-      context,
-      previousSessionParams,
-      { useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default" },
-    );
-    const issueRef = issueContext
-      ? {
-          id: issueContext.id,
-          identifier: issueContext.identifier,
-          title: issueContext.title,
-          status: issueContext.status,
-          priority: issueContext.priority,
-          description: issueContext.description,
-          projectId: issueContext.projectId,
-          projectWorkspaceId: issueContext.projectWorkspaceId,
-          executionWorkspaceId: issueContext.executionWorkspaceId,
-          executionWorkspacePreference: issueContext.executionWorkspacePreference,
-        }
-      : null;
-    const continuationSummary = issueRef
-      ? await getIssueContinuationSummaryDocument(db, issueRef.id)
-      : null;
-    if (continuationSummary) {
-      context.paperclipContinuationSummary = {
-        key: continuationSummary.key,
-        title: continuationSummary.title,
-        body: continuationSummary.body,
-        updatedAt: continuationSummary.updatedAt.toISOString(),
-      };
-    } else {
-      delete context.paperclipContinuationSummary;
-    }
-    const paperclipWakePayload = await buildPaperclipWakePayload({
-      db,
-      companyId: agent.companyId,
-      contextSnapshot: context,
-      continuationSummary,
-      issueSummary: issueRef
+      const contextProjectId = readNonEmptyString(context.projectId);
+      const executionProjectId = issueContext?.projectId ?? contextProjectId;
+      const projectContext = executionProjectId
+        ? await db
+            .select({
+              executionWorkspacePolicy: projects.executionWorkspacePolicy,
+              env: projects.env,
+            })
+            .from(projects)
+            .where(
+              and(
+                eq(projects.id, executionProjectId),
+                eq(projects.companyId, agent.companyId),
+              ),
+            )
+            .then((rows) => rows[0] ?? null)
+        : null;
+      const projectExecutionWorkspacePolicy =
+        gateProjectExecutionWorkspacePolicy(
+          parseProjectExecutionWorkspacePolicy(
+            projectContext?.executionWorkspacePolicy,
+          ),
+          isolatedWorkspacesEnabled,
+        );
+      const taskSession = taskKey
+        ? await getTaskSession(
+            agent.companyId,
+            agent.id,
+            agent.adapterType,
+            taskKey,
+          )
+        : null;
+      const resetTaskSession = shouldResetTaskSessionForWake(context);
+      const sessionResetReason = describeSessionResetReason(context);
+      const taskSessionForRun = resetTaskSession ? null : taskSession;
+      const explicitResumeSessionParams = normalizeSessionParams(
+        sessionCodec.deserialize(parseObject(context.resumeSessionParams)),
+      );
+      const explicitResumeSessionDisplayId = truncateDisplayId(
+        readNonEmptyString(context.resumeSessionDisplayId) ??
+          (sessionCodec.getDisplayId
+            ? sessionCodec.getDisplayId(explicitResumeSessionParams)
+            : null) ??
+          readNonEmptyString(explicitResumeSessionParams?.sessionId),
+      );
+      const previousSessionParams =
+        explicitResumeSessionParams ??
+        (explicitResumeSessionDisplayId
+          ? { sessionId: explicitResumeSessionDisplayId }
+          : null) ??
+        normalizeSessionParams(
+          sessionCodec.deserialize(
+            taskSessionForRun?.sessionParamsJson ?? null,
+          ),
+        );
+      const config = parseObject(agent.adapterConfig);
+      const requestedExecutionWorkspaceMode = resolveExecutionWorkspaceMode({
+        projectPolicy: projectExecutionWorkspacePolicy,
+        issueSettings: issueExecutionWorkspaceSettings,
+        legacyUseProjectWorkspace:
+          issueAssigneeOverrides?.useProjectWorkspace ?? null,
+      });
+      const resolvedWorkspace = await resolveWorkspaceForRun(
+        agent,
+        context,
+        previousSessionParams,
+        {
+          useProjectWorkspace:
+            requestedExecutionWorkspaceMode !== "agent_default",
+        },
+      );
+      const issueRef = issueContext
         ? {
-            id: issueRef.id,
-            identifier: issueRef.identifier,
-            title: issueRef.title,
-            status: issueRef.status,
-            priority: issueRef.priority,
+            id: issueContext.id,
+            identifier: issueContext.identifier,
+            title: issueContext.title,
+            status: issueContext.status,
+            priority: issueContext.priority,
+            description: issueContext.description,
+            projectId: issueContext.projectId,
+            projectWorkspaceId: issueContext.projectWorkspaceId,
+            executionWorkspaceId: issueContext.executionWorkspaceId,
+            executionWorkspacePreference:
+              issueContext.executionWorkspacePreference,
           }
-        : null,
-    });
-    if (paperclipWakePayload) {
-      context[PAPERCLIP_WAKE_PAYLOAD_KEY] = paperclipWakePayload;
-    } else {
-      delete context[PAPERCLIP_WAKE_PAYLOAD_KEY];
-    }
-    const taskMarkdown = buildPaperclipTaskMarkdown({
-      issue: issueRef
-        ? {
-            id: issueRef.id,
-            identifier: issueRef.identifier,
-            title: issueRef.title,
-            description: issueRef.description,
-          }
-        : null,
-      wakeComment: wakeCommentContext,
-    });
-    if (issueRef) {
-      context.paperclipIssue = {
-        id: issueRef.id,
-        identifier: issueRef.identifier,
-        title: issueRef.title,
-        description: issueRef.description,
-      };
-    } else {
-      delete context.paperclipIssue;
-    }
-    if (wakeCommentContext) {
-      context.paperclipWakeComment = wakeCommentContext;
-    } else {
-      delete context.paperclipWakeComment;
-    }
-    if (taskMarkdown) {
-      context.paperclipTaskMarkdown = taskMarkdown;
-    } else {
-      delete context.paperclipTaskMarkdown;
-    }
-    const existingExecutionWorkspace =
-      issueRef?.executionWorkspaceId ? await executionWorkspacesSvc.getById(issueRef.executionWorkspaceId) : null;
-    const shouldReuseExisting =
-      issueRef?.executionWorkspacePreference === "reuse_existing" &&
-      existingExecutionWorkspace !== null &&
-      existingExecutionWorkspace.status !== "archived";
-    const persistedExecutionWorkspaceMode = shouldReuseExisting && existingExecutionWorkspace
-      ? issueExecutionWorkspaceModeForPersistedWorkspace(existingExecutionWorkspace.mode)
-      : null;
-    const effectiveExecutionWorkspaceMode: ReturnType<typeof resolveExecutionWorkspaceMode> =
-      persistedExecutionWorkspaceMode === "isolated_workspace" ||
-      persistedExecutionWorkspaceMode === "operator_branch" ||
-      persistedExecutionWorkspaceMode === "agent_default"
-        ? persistedExecutionWorkspaceMode
-        : requestedExecutionWorkspaceMode;
-    const defaultEnvironment = await environmentsSvc.ensureLocalEnvironment(agent.companyId);
-    const selectedEnvironmentId = resolveExecutionWorkspaceEnvironmentId({
-      projectPolicy: projectExecutionWorkspacePolicy,
-      issueSettings: issueExecutionWorkspaceSettings,
-      workspaceConfig: existingExecutionWorkspace?.config ?? null,
-      agentDefaultEnvironmentId: agent.defaultEnvironmentId,
-      defaultEnvironmentId: defaultEnvironment.id,
-    });
-    const workspaceManagedConfig = shouldReuseExisting
-      ? { ...config }
-      : buildExecutionWorkspaceAdapterConfig({
-          agentConfig: config,
-          projectPolicy: projectExecutionWorkspacePolicy,
-          issueSettings: issueExecutionWorkspaceSettings,
-          mode: requestedExecutionWorkspaceMode,
-          legacyUseProjectWorkspace: issueAssigneeOverrides?.useProjectWorkspace ?? null,
+        : null;
+      const continuationSummary = issueRef
+        ? await getIssueContinuationSummaryDocument(db, issueRef.id)
+        : null;
+      if (continuationSummary) {
+        context.paperclipContinuationSummary = {
+          key: continuationSummary.key,
+          title: continuationSummary.title,
+          body: continuationSummary.body,
+          updatedAt: continuationSummary.updatedAt.toISOString(),
+        };
+      } else {
+        delete context.paperclipContinuationSummary;
+      }
+      const paperclipWakePayload = await buildPaperclipWakePayload({
+        db,
+        companyId: agent.companyId,
+        contextSnapshot: context,
+        continuationSummary,
+        issueSummary: issueRef
+          ? {
+              id: issueRef.id,
+              identifier: issueRef.identifier,
+              title: issueRef.title,
+              status: issueRef.status,
+              priority: issueRef.priority,
+            }
+          : null,
+      });
+      if (paperclipWakePayload) {
+        context[PAPERCLIP_WAKE_PAYLOAD_KEY] = paperclipWakePayload;
+      } else {
+        delete context[PAPERCLIP_WAKE_PAYLOAD_KEY];
+      }
+      const taskMarkdown = buildPaperclipTaskMarkdown({
+        issue: issueRef
+          ? {
+              id: issueRef.id,
+              identifier: issueRef.identifier,
+              title: issueRef.title,
+              description: issueRef.description,
+            }
+          : null,
+        wakeComment: wakeCommentContext,
+      });
+      if (issueRef) {
+        context.paperclipIssue = {
+          id: issueRef.id,
+          identifier: issueRef.identifier,
+          title: issueRef.title,
+          description: issueRef.description,
+        };
+      } else {
+        delete context.paperclipIssue;
+      }
+      if (wakeCommentContext) {
+        context.paperclipWakeComment = wakeCommentContext;
+      } else {
+        delete context.paperclipWakeComment;
+      }
+      if (taskMarkdown) {
+        context.paperclipTaskMarkdown = taskMarkdown;
+      } else {
+        delete context.paperclipTaskMarkdown;
+      }
+      const existingExecutionWorkspace = issueRef?.executionWorkspaceId
+        ? await executionWorkspacesSvc.getById(issueRef.executionWorkspaceId)
+        : null;
+      const shouldReuseExisting =
+        issueRef?.executionWorkspacePreference === "reuse_existing" &&
+        existingExecutionWorkspace !== null &&
+        existingExecutionWorkspace.status !== "archived";
+      const persistedExecutionWorkspaceMode =
+        shouldReuseExisting && existingExecutionWorkspace
+          ? issueExecutionWorkspaceModeForPersistedWorkspace(
+              existingExecutionWorkspace.mode,
+            )
+          : null;
+      const effectiveExecutionWorkspaceMode: ReturnType<
+        typeof resolveExecutionWorkspaceMode
+      > =
+        persistedExecutionWorkspaceMode === "isolated_workspace" ||
+        persistedExecutionWorkspaceMode === "operator_branch" ||
+        persistedExecutionWorkspaceMode === "agent_default"
+          ? persistedExecutionWorkspaceMode
+          : requestedExecutionWorkspaceMode;
+      const defaultEnvironment = await environmentsSvc.ensureLocalEnvironment(
+        agent.companyId,
+      );
+      const selectedEnvironmentId = resolveExecutionWorkspaceEnvironmentId({
+        projectPolicy: projectExecutionWorkspacePolicy,
+        issueSettings: issueExecutionWorkspaceSettings,
+        workspaceConfig: existingExecutionWorkspace?.config ?? null,
+        agentDefaultEnvironmentId: agent.defaultEnvironmentId,
+        defaultEnvironmentId: defaultEnvironment.id,
+      });
+      const workspaceManagedConfig = shouldReuseExisting
+        ? { ...config }
+        : buildExecutionWorkspaceAdapterConfig({
+            agentConfig: config,
+            projectPolicy: projectExecutionWorkspacePolicy,
+            issueSettings: issueExecutionWorkspaceSettings,
+            mode: requestedExecutionWorkspaceMode,
+            legacyUseProjectWorkspace:
+              issueAssigneeOverrides?.useProjectWorkspace ?? null,
+          });
+      const persistedWorkspaceManagedConfig =
+        applyPersistedExecutionWorkspaceConfig({
+          config: workspaceManagedConfig,
+          workspaceConfig: existingExecutionWorkspace?.config ?? null,
+          mode: effectiveExecutionWorkspaceMode,
         });
-    const persistedWorkspaceManagedConfig = applyPersistedExecutionWorkspaceConfig({
-      config: workspaceManagedConfig,
-      workspaceConfig: existingExecutionWorkspace?.config ?? null,
-      mode: effectiveExecutionWorkspaceMode,
-    });
-    const mergedConfig = issueAssigneeOverrides?.adapterConfig
-      ? { ...persistedWorkspaceManagedConfig, ...issueAssigneeOverrides.adapterConfig }
-      : persistedWorkspaceManagedConfig;
-    const configSnapshot = buildExecutionWorkspaceConfigSnapshot(mergedConfig, selectedEnvironmentId);
-    const executionRunConfig = stripWorkspaceRuntimeFromExecutionRunConfig(mergedConfig);
-    const { resolvedConfig, secretKeys } = await resolveExecutionRunAdapterConfig({
-      companyId: agent.companyId,
-      executionRunConfig,
-      projectEnv: projectContext?.env ?? null,
-      secretsSvc,
-    });
-    const runScopedMentionedSkillKeys = await resolveRunScopedMentionedSkillKeys({
-      db,
-      companyId: agent.companyId,
-      issueId,
-    });
-    const effectiveResolvedConfig = applyRunScopedMentionedSkillKeys(
-      resolvedConfig,
-      runScopedMentionedSkillKeys,
-    );
-    const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId);
-    let runtimeConfig = {
-      ...effectiveResolvedConfig,
-      paperclipRuntimeSkills: runtimeSkillEntries,
-    };
-    const workspaceOperationRecorder = workspaceOperationsSvc.createRecorder({
-      companyId: agent.companyId,
-      heartbeatRunId: run.id,
-      executionWorkspaceId: existingExecutionWorkspace?.id ?? null,
-    });
-    const executionWorkspaceBase = {
-      baseCwd: resolvedWorkspace.cwd,
-      source: resolvedWorkspace.source,
-      projectId: resolvedWorkspace.projectId,
-      workspaceId: resolvedWorkspace.workspaceId,
-      repoUrl: resolvedWorkspace.repoUrl,
-      repoRef: resolvedWorkspace.repoRef,
-    } satisfies ExecutionWorkspaceInput;
-    const reusedExecutionWorkspace = shouldReuseExisting && existingExecutionWorkspace
-      ? buildRealizedExecutionWorkspaceFromPersisted({
-          base: executionWorkspaceBase,
-          workspace: existingExecutionWorkspace,
-        })
-      : null;
-    const executionWorkspace = reusedExecutionWorkspace ?? await realizeExecutionWorkspace({
+      const mergedConfig = issueAssigneeOverrides?.adapterConfig
+        ? {
+            ...persistedWorkspaceManagedConfig,
+            ...issueAssigneeOverrides.adapterConfig,
+          }
+        : persistedWorkspaceManagedConfig;
+      const configSnapshot = buildExecutionWorkspaceConfigSnapshot(
+        mergedConfig,
+        selectedEnvironmentId,
+      );
+      const executionRunConfig =
+        stripWorkspaceRuntimeFromExecutionRunConfig(mergedConfig);
+      const { resolvedConfig, secretKeys } =
+        await resolveExecutionRunAdapterConfig({
+          companyId: agent.companyId,
+          executionRunConfig,
+          projectEnv: projectContext?.env ?? null,
+          secretsSvc,
+        });
+      const runScopedMentionedSkillKeys =
+        await resolveRunScopedMentionedSkillKeys({
+          db,
+          companyId: agent.companyId,
+          issueId,
+        });
+      const effectiveResolvedConfig = applyRunScopedMentionedSkillKeys(
+        resolvedConfig,
+        runScopedMentionedSkillKeys,
+      );
+      const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(
+        agent.companyId,
+      );
+      let runtimeConfig = {
+        ...effectiveResolvedConfig,
+        paperclipRuntimeSkills: runtimeSkillEntries,
+      };
+      const workspaceOperationRecorder = workspaceOperationsSvc.createRecorder({
+        companyId: agent.companyId,
+        heartbeatRunId: run.id,
+        executionWorkspaceId: existingExecutionWorkspace?.id ?? null,
+      });
+      const executionWorkspaceBase = {
+        baseCwd: resolvedWorkspace.cwd,
+        source: resolvedWorkspace.source,
+        projectId: resolvedWorkspace.projectId,
+        workspaceId: resolvedWorkspace.workspaceId,
+        repoUrl: resolvedWorkspace.repoUrl,
+        repoRef: resolvedWorkspace.repoRef,
+      } satisfies ExecutionWorkspaceInput;
+      const reusedExecutionWorkspace =
+        shouldReuseExisting && existingExecutionWorkspace
+          ? buildRealizedExecutionWorkspaceFromPersisted({
+              base: executionWorkspaceBase,
+              workspace: existingExecutionWorkspace,
+            })
+          : null;
+      const executionWorkspace =
+        reusedExecutionWorkspace ??
+        (await realizeExecutionWorkspace({
           base: executionWorkspaceBase,
           config: runtimeConfig,
           issue: issueRef,
@@ -4781,484 +5566,178 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             companyId: agent.companyId,
           },
           recorder: workspaceOperationRecorder,
+        }));
+      const resolvedProjectId =
+        executionWorkspace.projectId ??
+        issueRef?.projectId ??
+        executionProjectId ??
+        null;
+      const resolvedProjectWorkspaceId =
+        issueRef?.projectWorkspaceId ?? resolvedWorkspace.workspaceId ?? null;
+      let persistedExecutionWorkspace = null;
+      const nextExecutionWorkspaceMetadata =
+        mergeExecutionWorkspaceMetadataForPersistence({
+          existingMetadata: existingExecutionWorkspace?.metadata ?? null,
+          source: executionWorkspace.source,
+          createdByRuntime: executionWorkspace.created,
+          configSnapshot,
+          shouldReuseExisting,
         });
-    const resolvedProjectId = executionWorkspace.projectId ?? issueRef?.projectId ?? executionProjectId ?? null;
-    const resolvedProjectWorkspaceId = issueRef?.projectWorkspaceId ?? resolvedWorkspace.workspaceId ?? null;
-    let persistedExecutionWorkspace = null;
-    const nextExecutionWorkspaceMetadata = mergeExecutionWorkspaceMetadataForPersistence({
-      existingMetadata: existingExecutionWorkspace?.metadata ?? null,
-      source: executionWorkspace.source,
-      createdByRuntime: executionWorkspace.created,
-      configSnapshot,
-      shouldReuseExisting,
-    });
-    try {
-      persistedExecutionWorkspace = shouldReuseExisting && existingExecutionWorkspace
-        ? await executionWorkspacesSvc.update(existingExecutionWorkspace.id, {
-            cwd: executionWorkspace.cwd,
-            repoUrl: executionWorkspace.repoUrl,
-            baseRef: executionWorkspace.repoRef,
-            branchName: executionWorkspace.branchName,
-            providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
-            providerRef: executionWorkspace.worktreePath,
-            status: "active",
-            lastUsedAt: new Date(),
-            metadata: nextExecutionWorkspaceMetadata,
-          })
-        : resolvedProjectId
-          ? await executionWorkspacesSvc.create({
-              companyId: agent.companyId,
-              projectId: resolvedProjectId,
-              projectWorkspaceId: resolvedProjectWorkspaceId,
-              sourceIssueId: issueRef?.id ?? null,
-              mode:
-                requestedExecutionWorkspaceMode === "isolated_workspace"
-                  ? "isolated_workspace"
-                  : requestedExecutionWorkspaceMode === "operator_branch"
-                    ? "operator_branch"
-                    : requestedExecutionWorkspaceMode === "agent_default"
-                      ? "adapter_managed"
-                      : "shared_workspace",
-              strategyType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "project_primary",
-              name: executionWorkspace.branchName ?? issueRef?.identifier ?? `workspace-${agent.id.slice(0, 8)}`,
-              status: "active",
-              cwd: executionWorkspace.cwd,
-              repoUrl: executionWorkspace.repoUrl,
-              baseRef: executionWorkspace.repoRef,
-              branchName: executionWorkspace.branchName,
-              providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
-              providerRef: executionWorkspace.worktreePath,
-              lastUsedAt: new Date(),
-              openedAt: new Date(),
-              metadata: nextExecutionWorkspaceMetadata,
-            })
-          : null;
-    } catch (error) {
-      if (executionWorkspace.created) {
-        try {
-          await cleanupExecutionWorkspaceArtifacts({
-            workspace: {
-              id: existingExecutionWorkspace?.id ?? `transient-${run.id}`,
-              cwd: executionWorkspace.cwd,
-              providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
-              providerRef: executionWorkspace.worktreePath,
-              branchName: executionWorkspace.branchName,
-              repoUrl: executionWorkspace.repoUrl,
-              baseRef: executionWorkspace.repoRef,
-              projectId: resolvedProjectId,
-              projectWorkspaceId: resolvedProjectWorkspaceId,
-              sourceIssueId: issueRef?.id ?? null,
-              metadata: {
-                createdByRuntime: true,
-                source: executionWorkspace.source,
+      try {
+        persistedExecutionWorkspace =
+          shouldReuseExisting && existingExecutionWorkspace
+            ? await executionWorkspacesSvc.update(
+                existingExecutionWorkspace.id,
+                {
+                  cwd: executionWorkspace.cwd,
+                  repoUrl: executionWorkspace.repoUrl,
+                  baseRef: executionWorkspace.repoRef,
+                  branchName: executionWorkspace.branchName,
+                  providerType:
+                    executionWorkspace.strategy === "git_worktree"
+                      ? "git_worktree"
+                      : "local_fs",
+                  providerRef: executionWorkspace.worktreePath,
+                  status: "active",
+                  lastUsedAt: new Date(),
+                  metadata: nextExecutionWorkspaceMetadata,
+                },
+              )
+            : resolvedProjectId
+              ? await executionWorkspacesSvc.create({
+                  companyId: agent.companyId,
+                  projectId: resolvedProjectId,
+                  projectWorkspaceId: resolvedProjectWorkspaceId,
+                  sourceIssueId: issueRef?.id ?? null,
+                  mode:
+                    requestedExecutionWorkspaceMode === "isolated_workspace"
+                      ? "isolated_workspace"
+                      : requestedExecutionWorkspaceMode === "operator_branch"
+                        ? "operator_branch"
+                        : requestedExecutionWorkspaceMode === "agent_default"
+                          ? "adapter_managed"
+                          : "shared_workspace",
+                  strategyType:
+                    executionWorkspace.strategy === "git_worktree"
+                      ? "git_worktree"
+                      : "project_primary",
+                  name:
+                    executionWorkspace.branchName ??
+                    issueRef?.identifier ??
+                    `workspace-${agent.id.slice(0, 8)}`,
+                  status: "active",
+                  cwd: executionWorkspace.cwd,
+                  repoUrl: executionWorkspace.repoUrl,
+                  baseRef: executionWorkspace.repoRef,
+                  branchName: executionWorkspace.branchName,
+                  providerType:
+                    executionWorkspace.strategy === "git_worktree"
+                      ? "git_worktree"
+                      : "local_fs",
+                  providerRef: executionWorkspace.worktreePath,
+                  lastUsedAt: new Date(),
+                  openedAt: new Date(),
+                  metadata: nextExecutionWorkspaceMetadata,
+                })
+              : null;
+      } catch (error) {
+        if (executionWorkspace.created) {
+          try {
+            await cleanupExecutionWorkspaceArtifacts({
+              workspace: {
+                id: existingExecutionWorkspace?.id ?? `transient-${run.id}`,
+                cwd: executionWorkspace.cwd,
+                providerType:
+                  executionWorkspace.strategy === "git_worktree"
+                    ? "git_worktree"
+                    : "local_fs",
+                providerRef: executionWorkspace.worktreePath,
+                branchName: executionWorkspace.branchName,
+                repoUrl: executionWorkspace.repoUrl,
+                baseRef: executionWorkspace.repoRef,
+                projectId: resolvedProjectId,
+                projectWorkspaceId: resolvedProjectWorkspaceId,
+                sourceIssueId: issueRef?.id ?? null,
+                metadata: {
+                  createdByRuntime: true,
+                  source: executionWorkspace.source,
+                },
               },
-            },
-            projectWorkspace: {
-              cwd: resolvedWorkspace.cwd,
-              cleanupCommand: null,
-            },
-            cleanupCommand: configSnapshot?.cleanupCommand ?? null,
-            teardownCommand: configSnapshot?.teardownCommand ?? projectExecutionWorkspacePolicy?.workspaceStrategy?.teardownCommand ?? null,
-            recorder: workspaceOperationRecorder,
-          });
-        } catch (cleanupError) {
-          logger.warn(
-            {
-              runId: run.id,
-              issueId,
-              executionWorkspaceCwd: executionWorkspace.cwd,
-              cleanupError: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
-            },
-            "Failed to cleanup realized execution workspace after persistence failure",
-          );
-        }
-      }
-      throw error;
-    }
-    await workspaceOperationRecorder.attachExecutionWorkspaceId(persistedExecutionWorkspace?.id ?? null);
-    if (
-      existingExecutionWorkspace &&
-      persistedExecutionWorkspace &&
-      existingExecutionWorkspace.id !== persistedExecutionWorkspace.id &&
-      existingExecutionWorkspace.status === "active"
-    ) {
-      await executionWorkspacesSvc.update(existingExecutionWorkspace.id, {
-        status: "idle",
-        cleanupReason: null,
-      });
-    }
-    if (issueId && persistedExecutionWorkspace) {
-      const nextIssueWorkspaceMode = issueExecutionWorkspaceModeForPersistedWorkspace(persistedExecutionWorkspace.mode);
-      const shouldSwitchIssueToExistingWorkspace =
-        issueRef?.executionWorkspacePreference === "reuse_existing" ||
-        requestedExecutionWorkspaceMode === "isolated_workspace" ||
-        requestedExecutionWorkspaceMode === "operator_branch";
-      const nextIssuePatch: Record<string, unknown> = {};
-      if (issueRef?.executionWorkspaceId !== persistedExecutionWorkspace.id) {
-        nextIssuePatch.executionWorkspaceId = persistedExecutionWorkspace.id;
-      }
-      if (resolvedProjectWorkspaceId && issueRef?.projectWorkspaceId !== resolvedProjectWorkspaceId) {
-        nextIssuePatch.projectWorkspaceId = resolvedProjectWorkspaceId;
-      }
-      if (shouldSwitchIssueToExistingWorkspace) {
-        nextIssuePatch.executionWorkspacePreference = "reuse_existing";
-        nextIssuePatch.executionWorkspaceSettings = {
-          ...(issueExecutionWorkspaceSettings ?? {}),
-          mode: nextIssueWorkspaceMode,
-        };
-      }
-      if (Object.keys(nextIssuePatch).length > 0) {
-        await issuesSvc.update(issueId, nextIssuePatch);
-      }
-    }
-    if (persistedExecutionWorkspace) {
-      context.executionWorkspaceId = persistedExecutionWorkspace.id;
-      await db
-        .update(heartbeatRuns)
-        .set({
-          contextSnapshot: context,
-          updatedAt: new Date(),
-        })
-        .where(eq(heartbeatRuns.id, run.id));
-    }
-    const persistedEnvironmentId = persistedExecutionWorkspace?.config?.environmentId ?? selectedEnvironmentId;
-    const acquiredEnvironment = await envOrchestrator.acquireForRun({
-      companyId: agent.companyId,
-      selectedEnvironmentId: persistedEnvironmentId,
-      defaultEnvironmentId: defaultEnvironment.id,
-      adapterType: agent.adapterType,
-      issueId: issueId ?? null,
-      heartbeatRunId: run.id,
-      agentId: agent.id,
-      persistedExecutionWorkspace,
-    });
-    const selectedEnvironment = acquiredEnvironment.environment;
-    let activeEnvironmentLease = {
-      environment: acquiredEnvironment.environment,
-      lease: acquiredEnvironment.lease,
-      leaseContext: acquiredEnvironment.leaseContext,
-    };
-    const realizationResult = await envOrchestrator.realizeForRun({
-      environment: selectedEnvironment,
-      lease: activeEnvironmentLease.lease,
-      adapterType: agent.adapterType,
-      companyId: agent.companyId,
-      issueId: issueId ?? null,
-      heartbeatRunId: run.id,
-      executionWorkspace,
-      effectiveExecutionWorkspaceMode,
-      persistedExecutionWorkspace,
-    });
-    activeEnvironmentLease = {
-      ...activeEnvironmentLease,
-      lease: realizationResult.lease,
-    };
-    persistedExecutionWorkspace = realizationResult.persistedExecutionWorkspace;
-    const workspaceRealization = realizationResult.workspaceRealization;
-    const executionTarget = realizationResult.executionTarget;
-    const remoteExecution = realizationResult.remoteExecution;
-    context.paperclipEnvironment = {
-      id: selectedEnvironment.id,
-      name: selectedEnvironment.name,
-      driver: selectedEnvironment.driver,
-      leaseId: activeEnvironmentLease.lease.id,
-      workspaceRealization,
-      ...(typeof activeEnvironmentLease.lease.metadata?.remoteCwd === "string"
-        ? {
-            remoteCwd: activeEnvironmentLease.lease.metadata.remoteCwd,
-            host:
-              typeof activeEnvironmentLease.lease.metadata?.host === "string"
-                ? activeEnvironmentLease.lease.metadata.host
-                : undefined,
-            port:
-              typeof activeEnvironmentLease.lease.metadata?.port === "number"
-                ? activeEnvironmentLease.lease.metadata.port
-                : undefined,
-            username:
-              typeof activeEnvironmentLease.lease.metadata?.username === "string"
-                ? activeEnvironmentLease.lease.metadata.username
-                : undefined,
+              projectWorkspace: {
+                cwd: resolvedWorkspace.cwd,
+                cleanupCommand: null,
+              },
+              cleanupCommand: configSnapshot?.cleanupCommand ?? null,
+              teardownCommand:
+                configSnapshot?.teardownCommand ??
+                projectExecutionWorkspacePolicy?.workspaceStrategy
+                  ?.teardownCommand ??
+                null,
+              recorder: workspaceOperationRecorder,
+            });
+          } catch (cleanupError) {
+            logger.warn(
+              {
+                runId: run.id,
+                issueId,
+                executionWorkspaceCwd: executionWorkspace.cwd,
+                cleanupError:
+                  cleanupError instanceof Error
+                    ? cleanupError.message
+                    : String(cleanupError),
+              },
+              "Failed to cleanup realized execution workspace after persistence failure",
+            );
           }
-        : {}),
-    };
-    await db
-      .update(heartbeatRuns)
-      .set({
-        contextSnapshot: context,
-        updatedAt: new Date(),
-      })
-      .where(eq(heartbeatRuns.id, run.id));
-    const runtimeSessionResolution = resolveRuntimeSessionParamsForWorkspace({
-      agentId: agent.id,
-      previousSessionParams,
-      resolvedWorkspace: {
-        ...resolvedWorkspace,
-        cwd: executionWorkspace.cwd,
-      },
-    });
-    const runtimeSessionParams = runtimeSessionResolution.sessionParams;
-    const runtimeWorkspaceWarnings = [
-      ...resolvedWorkspace.warnings,
-      ...executionWorkspace.warnings,
-      ...(runtimeSessionResolution.warning ? [runtimeSessionResolution.warning] : []),
-      ...(resetTaskSession && sessionResetReason
-        ? [
-            taskKey
-              ? `Skipping saved session resume for task "${taskKey}" because ${sessionResetReason}.`
-              : `Skipping saved session resume because ${sessionResetReason}.`,
-          ]
-        : []),
-    ];
-    context.paperclipWorkspace = {
-      cwd: executionWorkspace.cwd,
-      source: executionWorkspace.source,
-      mode: effectiveExecutionWorkspaceMode,
-      strategy: executionWorkspace.strategy,
-      projectId: executionWorkspace.projectId,
-      workspaceId: executionWorkspace.workspaceId,
-      repoUrl: executionWorkspace.repoUrl,
-      repoRef: executionWorkspace.repoRef,
-      branchName: executionWorkspace.branchName,
-      worktreePath: executionWorkspace.worktreePath,
-      realization: workspaceRealization,
-      agentHome: await (async () => {
-        const home = resolveDefaultAgentWorkspaceDir(agent.id);
-        await fs.mkdir(home, { recursive: true });
-        return home;
-      })(),
-    };
-    context.paperclipWorkspaces = resolvedWorkspace.workspaceHints;
-    const runtimeServiceIntents = (() => {
-      const runtimeConfig = parseObject(resolvedConfig.workspaceRuntime);
-      return Array.isArray(runtimeConfig.services)
-        ? runtimeConfig.services.filter(
-            (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
-          )
-        : [];
-    })();
-    if (runtimeServiceIntents.length > 0) {
-      context.paperclipRuntimeServiceIntents = runtimeServiceIntents;
-    } else {
-      delete context.paperclipRuntimeServiceIntents;
-    }
-    if (executionWorkspace.projectId && !readNonEmptyString(context.projectId)) {
-      context.projectId = executionWorkspace.projectId;
-    }
-    const runtimeSessionFallback = taskKey || resetTaskSession ? null : runtime.sessionId;
-    let previousSessionDisplayId = truncateDisplayId(
-      explicitResumeSessionDisplayId ??
-        taskSessionForRun?.sessionDisplayId ??
-        (sessionCodec.getDisplayId ? sessionCodec.getDisplayId(runtimeSessionParams) : null) ??
-        readNonEmptyString(runtimeSessionParams?.sessionId) ??
-        runtimeSessionFallback,
-    );
-    let runtimeSessionIdForAdapter =
-      readNonEmptyString(runtimeSessionParams?.sessionId) ?? runtimeSessionFallback;
-    let runtimeSessionParamsForAdapter = runtimeSessionParams;
-
-    const sessionCompaction = await evaluateSessionCompaction({
-      agent,
-      sessionId: previousSessionDisplayId ?? runtimeSessionIdForAdapter,
-      issueId,
-      continuationSummaryBody: continuationSummary?.body ?? null,
-    });
-    if (sessionCompaction.rotate) {
-      context.paperclipSessionHandoffMarkdown = sessionCompaction.handoffMarkdown;
-      context.paperclipSessionRotationReason = sessionCompaction.reason;
-      context.paperclipPreviousSessionId = previousSessionDisplayId ?? runtimeSessionIdForAdapter;
-      runtimeSessionIdForAdapter = null;
-      runtimeSessionParamsForAdapter = null;
-      previousSessionDisplayId = null;
-      if (sessionCompaction.reason) {
-        runtimeWorkspaceWarnings.push(
-          `Starting a fresh session because ${sessionCompaction.reason}.`,
-        );
-      }
-    } else {
-      delete context.paperclipSessionHandoffMarkdown;
-      delete context.paperclipSessionRotationReason;
-      delete context.paperclipPreviousSessionId;
-    }
-
-    const runtimeForAdapter = {
-      sessionId: runtimeSessionIdForAdapter,
-      sessionParams: runtimeSessionParamsForAdapter,
-      sessionDisplayId: previousSessionDisplayId,
-      taskKey,
-    };
-
-    let seq = 1;
-    let handle: RunLogHandle | null = null;
-    let stdoutExcerpt = "";
-    let stderrExcerpt = "";
-    let outputSeq = Number(run.lastOutputSeq ?? 0);
-    let lastOutputFlushAt: Date | null = run.lastOutputAt ?? null;
-    const outputProgressState: {
-      pending: {
-      at: Date;
-      seq: number;
-      stream: "stdout" | "stderr";
-      bytes: number;
-      } | null;
-    } = { pending: null };
-    let persistedLogBytes = Number(run.logBytes ?? 0);
-    const flushOutputProgress = async (opts?: { force?: boolean }) => {
-      const pendingOutputProgress = outputProgressState.pending;
-      if (!pendingOutputProgress) return;
-      const shouldFlush =
-        opts?.force === true ||
-        !lastOutputFlushAt ||
-        pendingOutputProgress.at.getTime() - lastOutputFlushAt.getTime() >= ACTIVE_RUN_OUTPUT_PROGRESS_FLUSH_INTERVAL_MS;
-      if (!shouldFlush) return;
-      await db
-        .update(heartbeatRuns)
-        .set({
-          lastOutputAt: pendingOutputProgress.at,
-          lastOutputSeq: pendingOutputProgress.seq,
-          lastOutputStream: pendingOutputProgress.stream,
-          lastOutputBytes: pendingOutputProgress.bytes,
-          updatedAt: new Date(),
-        })
-        .where(eq(heartbeatRuns.id, run.id));
-      lastOutputFlushAt = pendingOutputProgress.at;
-      outputProgressState.pending = null;
-    };
-    try {
-      const startedAt = run.startedAt ?? new Date();
-      const runningWithSession = await db
-        .update(heartbeatRuns)
-        .set({
-          startedAt,
-          sessionIdBefore: runtimeForAdapter.sessionDisplayId ?? runtimeForAdapter.sessionId,
-          contextSnapshot: context,
-          updatedAt: new Date(),
-        })
-        .where(eq(heartbeatRuns.id, run.id))
-        .returning()
-        .then((rows) => rows[0] ?? null);
-      if (runningWithSession) run = runningWithSession;
-
-      const runningAgent = await db
-        .update(agents)
-        .set({ status: "running", updatedAt: new Date() })
-        .where(eq(agents.id, agent.id))
-        .returning()
-        .then((rows) => rows[0] ?? null);
-
-      if (runningAgent) {
-        publishLiveEvent({
-          companyId: runningAgent.companyId,
-          type: "agent.status",
-          payload: {
-            agentId: runningAgent.id,
-            status: runningAgent.status,
-            outcome: "running",
-          },
-        });
-      }
-
-      const currentRun = run;
-      await appendRunEvent(currentRun, seq++, {
-        eventType: "lifecycle",
-        stream: "system",
-        level: "info",
-        message: "run started",
-      });
-
-      handle = await runLogStore.begin({
-        companyId: run.companyId,
-        agentId: run.agentId,
-        runId,
-      });
-
-      await db
-        .update(heartbeatRuns)
-        .set({
-          logStore: handle.store,
-          logRef: handle.logRef,
-          updatedAt: new Date(),
-        })
-        .where(eq(heartbeatRuns.id, runId));
-
-      const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
-      const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
-        const sanitizedChunk = compactRunLogChunk(
-          redactCurrentUserText(chunk, currentUserRedactionOptions),
-        );
-        if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
-        if (stream === "stderr") stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
-        const ts = new Date().toISOString();
-
-        let appendedBytes = 0;
-        if (handle) {
-          appendedBytes = await runLogStore.append(handle, {
-            stream,
-            chunk: sanitizedChunk,
-            ts,
-          });
-          persistedLogBytes += appendedBytes;
         }
-        outputSeq += 1;
-        outputProgressState.pending = {
-          at: new Date(ts),
-          seq: outputSeq,
-          stream,
-          bytes: persistedLogBytes,
-        };
-        await flushOutputProgress();
-
-        const payloadChunk =
-          sanitizedChunk.length > MAX_LIVE_LOG_CHUNK_BYTES
-            ? sanitizedChunk.slice(sanitizedChunk.length - MAX_LIVE_LOG_CHUNK_BYTES)
-            : sanitizedChunk;
-
-        publishLiveEvent({
-          companyId: run.companyId,
-          type: "heartbeat.run.log",
-          payload: {
-            runId: run.id,
-            agentId: run.agentId,
-            ts,
-            stream,
-            chunk: payloadChunk,
-            truncated: payloadChunk.length !== sanitizedChunk.length,
-          },
-        });
-      };
-      if (runScopedMentionedSkillKeys.length > 0) {
-        await onLog(
-          "stdout",
-          `[paperclip] Enabled run-scoped skills from issue mentions: ${runScopedMentionedSkillKeys.join(", ")}\n`,
-        );
+        throw error;
       }
-      for (const warning of runtimeWorkspaceWarnings) {
-        const logEntry = formatRuntimeWorkspaceWarningLog(warning);
-        await onLog(logEntry.stream, logEntry.chunk);
-      }
-      const adapterEnv = Object.fromEntries(
-        Object.entries(parseObject(resolvedConfig.env)).filter(
-          (entry): entry is [string, string] => typeof entry[0] === "string" && typeof entry[1] === "string",
-        ),
+      await workspaceOperationRecorder.attachExecutionWorkspaceId(
+        persistedExecutionWorkspace?.id ?? null,
       );
-      const runtimeServices = await ensureRuntimeServicesForRun({
-        db,
-        runId: run.id,
-        agent: {
-          id: agent.id,
-          name: agent.name,
-          companyId: agent.companyId,
-        },
-        issue: issueRef,
-        workspace: executionWorkspace,
-        executionWorkspaceId: persistedExecutionWorkspace?.id ?? issueRef?.executionWorkspaceId ?? null,
-        config: effectiveResolvedConfig,
-        adapterEnv,
-        onLog,
-      });
-      if (runtimeServices.length > 0) {
-        context.paperclipRuntimeServices = runtimeServices;
-        context.paperclipRuntimePrimaryUrl =
-          runtimeServices.find((service) => readNonEmptyString(service.url))?.url ?? null;
+      if (
+        existingExecutionWorkspace &&
+        persistedExecutionWorkspace &&
+        existingExecutionWorkspace.id !== persistedExecutionWorkspace.id &&
+        existingExecutionWorkspace.status === "active"
+      ) {
+        await executionWorkspacesSvc.update(existingExecutionWorkspace.id, {
+          status: "idle",
+          cleanupReason: null,
+        });
+      }
+      if (issueId && persistedExecutionWorkspace) {
+        const nextIssueWorkspaceMode =
+          issueExecutionWorkspaceModeForPersistedWorkspace(
+            persistedExecutionWorkspace.mode,
+          );
+        const shouldSwitchIssueToExistingWorkspace =
+          issueRef?.executionWorkspacePreference === "reuse_existing" ||
+          requestedExecutionWorkspaceMode === "isolated_workspace" ||
+          requestedExecutionWorkspaceMode === "operator_branch";
+        const nextIssuePatch: Record<string, unknown> = {};
+        if (issueRef?.executionWorkspaceId !== persistedExecutionWorkspace.id) {
+          nextIssuePatch.executionWorkspaceId = persistedExecutionWorkspace.id;
+        }
+        if (
+          resolvedProjectWorkspaceId &&
+          issueRef?.projectWorkspaceId !== resolvedProjectWorkspaceId
+        ) {
+          nextIssuePatch.projectWorkspaceId = resolvedProjectWorkspaceId;
+        }
+        if (shouldSwitchIssueToExistingWorkspace) {
+          nextIssuePatch.executionWorkspacePreference = "reuse_existing";
+          nextIssuePatch.executionWorkspaceSettings = {
+            ...(issueExecutionWorkspaceSettings ?? {}),
+            mode: nextIssueWorkspaceMode,
+          };
+        }
+        if (Object.keys(nextIssuePatch).length > 0) {
+          await issuesSvc.update(issueId, nextIssuePatch);
+        }
+      }
+      if (persistedExecutionWorkspace) {
+        context.executionWorkspaceId = persistedExecutionWorkspace.id;
         await db
           .update(heartbeatRuns)
           .set({
@@ -5267,463 +5746,964 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           })
           .where(eq(heartbeatRuns.id, run.id));
       }
-      if (issueId && (executionWorkspace.created || runtimeServices.some((service) => !service.reused))) {
-        try {
-          await issuesSvc.addComment(
-            issueId,
-            buildWorkspaceReadyComment({
-              workspace: executionWorkspace,
-              runtimeServices,
-            }),
-            { agentId: agent.id, runId: run.id },
-          );
-        } catch (err) {
-          await onLog(
-            "stderr",
-            `[paperclip] Failed to post workspace-ready comment: ${err instanceof Error ? err.message : String(err)}\n`,
-          );
-        }
+      const persistedEnvironmentId =
+        persistedExecutionWorkspace?.config?.environmentId ??
+        selectedEnvironmentId;
+      const acquiredEnvironment = await envOrchestrator.acquireForRun({
+        companyId: agent.companyId,
+        selectedEnvironmentId: persistedEnvironmentId,
+        defaultEnvironmentId: defaultEnvironment.id,
+        adapterType: agent.adapterType,
+        issueId: issueId ?? null,
+        heartbeatRunId: run.id,
+        agentId: agent.id,
+        persistedExecutionWorkspace,
+      });
+      const selectedEnvironment = acquiredEnvironment.environment;
+      let activeEnvironmentLease = {
+        environment: acquiredEnvironment.environment,
+        lease: acquiredEnvironment.lease,
+        leaseContext: acquiredEnvironment.leaseContext,
+      };
+      const realizationResult = await envOrchestrator.realizeForRun({
+        environment: selectedEnvironment,
+        lease: activeEnvironmentLease.lease,
+        adapterType: agent.adapterType,
+        companyId: agent.companyId,
+        issueId: issueId ?? null,
+        heartbeatRunId: run.id,
+        executionWorkspace,
+        effectiveExecutionWorkspaceMode,
+        persistedExecutionWorkspace,
+      });
+      activeEnvironmentLease = {
+        ...activeEnvironmentLease,
+        lease: realizationResult.lease,
+      };
+      persistedExecutionWorkspace =
+        realizationResult.persistedExecutionWorkspace;
+      const workspaceRealization = realizationResult.workspaceRealization;
+      const executionTarget = realizationResult.executionTarget;
+      const remoteExecution = realizationResult.remoteExecution;
+      context.paperclipEnvironment = {
+        id: selectedEnvironment.id,
+        name: selectedEnvironment.name,
+        driver: selectedEnvironment.driver,
+        leaseId: activeEnvironmentLease.lease.id,
+        workspaceRealization,
+        ...(typeof activeEnvironmentLease.lease.metadata?.remoteCwd === "string"
+          ? {
+              remoteCwd: activeEnvironmentLease.lease.metadata.remoteCwd,
+              host:
+                typeof activeEnvironmentLease.lease.metadata?.host === "string"
+                  ? activeEnvironmentLease.lease.metadata.host
+                  : undefined,
+              port:
+                typeof activeEnvironmentLease.lease.metadata?.port === "number"
+                  ? activeEnvironmentLease.lease.metadata.port
+                  : undefined,
+              username:
+                typeof activeEnvironmentLease.lease.metadata?.username ===
+                "string"
+                  ? activeEnvironmentLease.lease.metadata.username
+                  : undefined,
+            }
+          : {}),
+      };
+      await db
+        .update(heartbeatRuns)
+        .set({
+          contextSnapshot: context,
+          updatedAt: new Date(),
+        })
+        .where(eq(heartbeatRuns.id, run.id));
+      const runtimeSessionResolution = resolveRuntimeSessionParamsForWorkspace({
+        agentId: agent.id,
+        previousSessionParams,
+        resolvedWorkspace: {
+          ...resolvedWorkspace,
+          cwd: executionWorkspace.cwd,
+        },
+      });
+      const runtimeSessionParams = runtimeSessionResolution.sessionParams;
+      const runtimeWorkspaceWarnings = [
+        ...resolvedWorkspace.warnings,
+        ...executionWorkspace.warnings,
+        ...(runtimeSessionResolution.warning
+          ? [runtimeSessionResolution.warning]
+          : []),
+        ...(resetTaskSession && sessionResetReason
+          ? [
+              taskKey
+                ? `Skipping saved session resume for task "${taskKey}" because ${sessionResetReason}.`
+                : `Skipping saved session resume because ${sessionResetReason}.`,
+            ]
+          : []),
+      ];
+      context.paperclipWorkspace = {
+        cwd: executionWorkspace.cwd,
+        source: executionWorkspace.source,
+        mode: effectiveExecutionWorkspaceMode,
+        strategy: executionWorkspace.strategy,
+        projectId: executionWorkspace.projectId,
+        workspaceId: executionWorkspace.workspaceId,
+        repoUrl: executionWorkspace.repoUrl,
+        repoRef: executionWorkspace.repoRef,
+        branchName: executionWorkspace.branchName,
+        worktreePath: executionWorkspace.worktreePath,
+        realization: workspaceRealization,
+        agentHome: await (async () => {
+          const home = resolveDefaultAgentWorkspaceDir(agent.id);
+          await fs.mkdir(home, { recursive: true });
+          return home;
+        })(),
+      };
+      context.paperclipWorkspaces = resolvedWorkspace.workspaceHints;
+      const runtimeServiceIntents = (() => {
+        const runtimeConfig = parseObject(resolvedConfig.workspaceRuntime);
+        return Array.isArray(runtimeConfig.services)
+          ? runtimeConfig.services.filter(
+              (value): value is Record<string, unknown> =>
+                typeof value === "object" && value !== null,
+            )
+          : [];
+      })();
+      if (runtimeServiceIntents.length > 0) {
+        context.paperclipRuntimeServiceIntents = runtimeServiceIntents;
+      } else {
+        delete context.paperclipRuntimeServiceIntents;
       }
-      const onAdapterMeta = async (meta: AdapterInvocationMeta) => {
-        if (meta.env && secretKeys.size > 0) {
-          for (const key of secretKeys) {
-            if (key in meta.env) meta.env[key] = "***REDACTED***";
-          }
+      if (
+        executionWorkspace.projectId &&
+        !readNonEmptyString(context.projectId)
+      ) {
+        context.projectId = executionWorkspace.projectId;
+      }
+      const runtimeSessionFallback =
+        taskKey || resetTaskSession ? null : runtime.sessionId;
+      let previousSessionDisplayId = truncateDisplayId(
+        explicitResumeSessionDisplayId ??
+          taskSessionForRun?.sessionDisplayId ??
+          (sessionCodec.getDisplayId
+            ? sessionCodec.getDisplayId(runtimeSessionParams)
+            : null) ??
+          readNonEmptyString(runtimeSessionParams?.sessionId) ??
+          runtimeSessionFallback,
+      );
+      let runtimeSessionIdForAdapter =
+        readNonEmptyString(runtimeSessionParams?.sessionId) ??
+        runtimeSessionFallback;
+      let runtimeSessionParamsForAdapter = runtimeSessionParams;
+
+      const sessionCompaction = await evaluateSessionCompaction({
+        agent,
+        sessionId: previousSessionDisplayId ?? runtimeSessionIdForAdapter,
+        issueId,
+        continuationSummaryBody: continuationSummary?.body ?? null,
+      });
+      if (sessionCompaction.rotate) {
+        context.paperclipSessionHandoffMarkdown =
+          sessionCompaction.handoffMarkdown;
+        context.paperclipSessionRotationReason = sessionCompaction.reason;
+        context.paperclipPreviousSessionId =
+          previousSessionDisplayId ?? runtimeSessionIdForAdapter;
+        runtimeSessionIdForAdapter = null;
+        runtimeSessionParamsForAdapter = null;
+        previousSessionDisplayId = null;
+        if (sessionCompaction.reason) {
+          runtimeWorkspaceWarnings.push(
+            `Starting a fresh session because ${sessionCompaction.reason}.`,
+          );
         }
+      } else {
+        delete context.paperclipSessionHandoffMarkdown;
+        delete context.paperclipSessionRotationReason;
+        delete context.paperclipPreviousSessionId;
+      }
+
+      const runtimeForAdapter = {
+        sessionId: runtimeSessionIdForAdapter,
+        sessionParams: runtimeSessionParamsForAdapter,
+        sessionDisplayId: previousSessionDisplayId,
+        taskKey,
+      };
+
+      let seq = 1;
+      let handle: RunLogHandle | null = null;
+      let stdoutExcerpt = "";
+      let stderrExcerpt = "";
+      let outputSeq = Number(run.lastOutputSeq ?? 0);
+      let lastOutputFlushAt: Date | null = run.lastOutputAt ?? null;
+      const outputProgressState: {
+        pending: {
+          at: Date;
+          seq: number;
+          stream: "stdout" | "stderr";
+          bytes: number;
+        } | null;
+      } = { pending: null };
+      let persistedLogBytes = Number(run.logBytes ?? 0);
+      const flushOutputProgress = async (opts?: { force?: boolean }) => {
+        const pendingOutputProgress = outputProgressState.pending;
+        if (!pendingOutputProgress) return;
+        const shouldFlush =
+          opts?.force === true ||
+          !lastOutputFlushAt ||
+          pendingOutputProgress.at.getTime() - lastOutputFlushAt.getTime() >=
+            ACTIVE_RUN_OUTPUT_PROGRESS_FLUSH_INTERVAL_MS;
+        if (!shouldFlush) return;
+        await db
+          .update(heartbeatRuns)
+          .set({
+            lastOutputAt: pendingOutputProgress.at,
+            lastOutputSeq: pendingOutputProgress.seq,
+            lastOutputStream: pendingOutputProgress.stream,
+            lastOutputBytes: pendingOutputProgress.bytes,
+            updatedAt: new Date(),
+          })
+          .where(eq(heartbeatRuns.id, run.id));
+        lastOutputFlushAt = pendingOutputProgress.at;
+        outputProgressState.pending = null;
+      };
+      try {
+        const startedAt = run.startedAt ?? new Date();
+        const runningWithSession = await db
+          .update(heartbeatRuns)
+          .set({
+            startedAt,
+            sessionIdBefore:
+              runtimeForAdapter.sessionDisplayId ?? runtimeForAdapter.sessionId,
+            contextSnapshot: context,
+            updatedAt: new Date(),
+          })
+          .where(eq(heartbeatRuns.id, run.id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (runningWithSession) run = runningWithSession;
+
+        const runningAgent = await db
+          .update(agents)
+          .set({ status: "running", updatedAt: new Date() })
+          .where(eq(agents.id, agent.id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+
+        if (runningAgent) {
+          publishLiveEvent({
+            companyId: runningAgent.companyId,
+            type: "agent.status",
+            payload: {
+              agentId: runningAgent.id,
+              status: runningAgent.status,
+              outcome: "running",
+            },
+          });
+        }
+
+        const currentRun = run;
         await appendRunEvent(currentRun, seq++, {
-          eventType: "adapter.invoke",
+          eventType: "lifecycle",
           stream: "system",
           level: "info",
-          message: "adapter invocation",
-          payload: meta as unknown as Record<string, unknown>,
+          message: "run started",
         });
-      };
 
-      const adapter = getServerAdapter(agent.adapterType);
-      const authToken = adapter.supportsLocalAgentJwt
-        ? createLocalAgentJwt(agent.id, agent.companyId, agent.adapterType, run.id)
-        : null;
-      if (adapter.supportsLocalAgentJwt && !authToken) {
-        logger.warn(
-          {
-            companyId: agent.companyId,
-            agentId: agent.id,
-            runId: run.id,
-            adapterType: agent.adapterType,
-          },
-          "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
-        );
-      }
-      const adapterResult = await adapter.execute({
-        runId: run.id,
-        agent,
-        runtime: runtimeForAdapter,
-        config: runtimeConfig,
-        context,
-        executionTarget,
-        executionTransport: remoteExecution
-          ? { remoteExecution: remoteExecution as unknown as Record<string, unknown> }
-          : undefined,
-        onLog,
-        onMeta: onAdapterMeta,
-        onSpawn: async (meta) => {
-          await persistRunProcessMetadata(run.id, {
-            pid: meta.pid,
-            processGroupId:
-              "processGroupId" in meta && typeof meta.processGroupId === "number"
-                ? meta.processGroupId
-                : null,
-            startedAt: meta.startedAt,
-          });
-        },
-        authToken: authToken ?? undefined,
-      });
-      const adapterManagedRuntimeServices = adapterResult.runtimeServices
-        ? await persistAdapterManagedRuntimeServices({
-            db,
-            adapterType: agent.adapterType,
-            runId: run.id,
-            agent: {
-              id: agent.id,
-              name: agent.name,
-              companyId: agent.companyId,
-            },
-            issue: issueRef,
-            workspace: executionWorkspace,
-            reports: adapterResult.runtimeServices,
-          })
-        : [];
-      if (adapterManagedRuntimeServices.length > 0) {
-        const combinedRuntimeServices = [
-          ...runtimeServices,
-          ...adapterManagedRuntimeServices,
-        ];
-        context.paperclipRuntimeServices = combinedRuntimeServices;
-        context.paperclipRuntimePrimaryUrl =
-          combinedRuntimeServices.find((service) => readNonEmptyString(service.url))?.url ?? null;
+        handle = await runLogStore.begin({
+          companyId: run.companyId,
+          agentId: run.agentId,
+          runId,
+        });
+
         await db
           .update(heartbeatRuns)
           .set({
-            contextSnapshot: context,
+            logStore: handle.store,
+            logRef: handle.logRef,
             updatedAt: new Date(),
           })
-          .where(eq(heartbeatRuns.id, run.id));
-        if (issueId) {
+          .where(eq(heartbeatRuns.id, runId));
+
+        const currentUserRedactionOptions =
+          await getCurrentUserRedactionOptions();
+        const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
+          const sanitizedChunk = compactRunLogChunk(
+            redactCurrentUserText(chunk, currentUserRedactionOptions),
+          );
+          if (stream === "stdout")
+            stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
+          if (stream === "stderr")
+            stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
+          const ts = new Date().toISOString();
+
+          let appendedBytes = 0;
+          if (handle) {
+            appendedBytes = await runLogStore.append(handle, {
+              stream,
+              chunk: sanitizedChunk,
+              ts,
+            });
+            persistedLogBytes += appendedBytes;
+          }
+          outputSeq += 1;
+          outputProgressState.pending = {
+            at: new Date(ts),
+            seq: outputSeq,
+            stream,
+            bytes: persistedLogBytes,
+          };
+          await flushOutputProgress();
+
+          const payloadChunk =
+            sanitizedChunk.length > MAX_LIVE_LOG_CHUNK_BYTES
+              ? sanitizedChunk.slice(
+                  sanitizedChunk.length - MAX_LIVE_LOG_CHUNK_BYTES,
+                )
+              : sanitizedChunk;
+
+          publishLiveEvent({
+            companyId: run.companyId,
+            type: "heartbeat.run.log",
+            payload: {
+              runId: run.id,
+              agentId: run.agentId,
+              ts,
+              stream,
+              chunk: payloadChunk,
+              truncated: payloadChunk.length !== sanitizedChunk.length,
+            },
+          });
+        };
+        if (runScopedMentionedSkillKeys.length > 0) {
+          await onLog(
+            "stdout",
+            `[paperclip] Enabled run-scoped skills from issue mentions: ${runScopedMentionedSkillKeys.join(", ")}\n`,
+          );
+        }
+        for (const warning of runtimeWorkspaceWarnings) {
+          const logEntry = formatRuntimeWorkspaceWarningLog(warning);
+          await onLog(logEntry.stream, logEntry.chunk);
+        }
+        const adapterEnv = Object.fromEntries(
+          Object.entries(parseObject(resolvedConfig.env)).filter(
+            (entry): entry is [string, string] =>
+              typeof entry[0] === "string" && typeof entry[1] === "string",
+          ),
+        );
+        const runtimeServices = await ensureRuntimeServicesForRun({
+          db,
+          runId: run.id,
+          agent: {
+            id: agent.id,
+            name: agent.name,
+            companyId: agent.companyId,
+          },
+          issue: issueRef,
+          workspace: executionWorkspace,
+          executionWorkspaceId:
+            persistedExecutionWorkspace?.id ??
+            issueRef?.executionWorkspaceId ??
+            null,
+          config: effectiveResolvedConfig,
+          adapterEnv,
+          onLog,
+        });
+        if (runtimeServices.length > 0) {
+          context.paperclipRuntimeServices = runtimeServices;
+          context.paperclipRuntimePrimaryUrl =
+            runtimeServices.find((service) => readNonEmptyString(service.url))
+              ?.url ?? null;
+          await db
+            .update(heartbeatRuns)
+            .set({
+              contextSnapshot: context,
+              updatedAt: new Date(),
+            })
+            .where(eq(heartbeatRuns.id, run.id));
+        }
+        if (
+          issueId &&
+          (executionWorkspace.created ||
+            runtimeServices.some((service) => !service.reused))
+        ) {
           try {
             await issuesSvc.addComment(
               issueId,
               buildWorkspaceReadyComment({
                 workspace: executionWorkspace,
-                runtimeServices: adapterManagedRuntimeServices,
+                runtimeServices,
               }),
               { agentId: agent.id, runId: run.id },
             );
           } catch (err) {
             await onLog(
               "stderr",
-              `[paperclip] Failed to post adapter-managed runtime comment: ${err instanceof Error ? err.message : String(err)}\n`,
+              `[paperclip] Failed to post workspace-ready comment: ${err instanceof Error ? err.message : String(err)}\n`,
             );
           }
         }
-      }
-      const nextSessionState = resolveNextSessionState({
-        codec: sessionCodec,
-        adapterResult,
-        previousParams: previousSessionParams,
-        previousDisplayId: runtimeForAdapter.sessionDisplayId,
-        previousLegacySessionId: runtimeForAdapter.sessionId,
-      });
-      const rawUsage = normalizeUsageTotals(adapterResult.usage);
-      const sessionUsageResolution = await resolveNormalizedUsageForSession({
-        agentId: agent.id,
-        runId: run.id,
-        sessionId: nextSessionState.displayId ?? nextSessionState.legacySessionId,
-        rawUsage,
-      });
-      const normalizedUsage = sessionUsageResolution.normalizedUsage;
-
-      let outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
-      const latestRun = await getRun(run.id);
-      if (isHeartbeatRunTerminalStatus(latestRun?.status)) {
-        outcome = latestRun.status;
-      } else if (adapterResult.timedOut) {
-        outcome = "timed_out";
-      } else if ((adapterResult.exitCode ?? 0) === 0 && !adapterResult.errorMessage) {
-        outcome = "succeeded";
-      } else {
-        outcome = "failed";
-      }
-      const runErrorMessage =
-        outcome === "cancelled"
-          ? (latestRun?.error ?? adapterResult.errorMessage ?? "Cancelled")
-          : outcome === "succeeded"
-            ? null
-            : redactCurrentUserText(
-                adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
-                currentUserRedactionOptions,
-              );
-      const runErrorCode =
-        outcome === "timed_out"
-          ? "timeout"
-          : outcome === "cancelled"
-            ? (latestRun?.errorCode ?? "cancelled")
-            : outcome === "failed"
-              ? (adapterResult.errorCode ?? "adapter_failed")
-              : null;
-
-      let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
-      if (handle) {
-        logSummary = await runLogStore.finalize(handle);
-      }
-      const finalLogBytes = logSummary?.bytes;
-      if (outputProgressState.pending && typeof finalLogBytes === "number") {
-        outputProgressState.pending.bytes = finalLogBytes;
-      }
-      await flushOutputProgress({ force: true });
-
-      const status =
-        outcome === "succeeded"
-          ? "succeeded"
-          : outcome === "cancelled"
-            ? "cancelled"
-            : outcome === "timed_out"
-              ? "timed_out"
-              : "failed";
-
-      const usageJson =
-        normalizedUsage || adapterResult.costUsd != null
-          ? ({
-              ...(normalizedUsage ?? {}),
-              ...(rawUsage ? {
-                rawInputTokens: rawUsage.inputTokens,
-                rawCachedInputTokens: rawUsage.cachedInputTokens,
-                rawOutputTokens: rawUsage.outputTokens,
-              } : {}),
-              ...(sessionUsageResolution.derivedFromSessionTotals ? { usageSource: "session_delta" } : {}),
-              ...((nextSessionState.displayId ?? nextSessionState.legacySessionId)
-                ? { persistedSessionId: nextSessionState.displayId ?? nextSessionState.legacySessionId }
-                : {}),
-              sessionReused: runtimeForAdapter.sessionId != null || runtimeForAdapter.sessionDisplayId != null,
-              taskSessionReused: taskSessionForRun != null,
-              freshSession: runtimeForAdapter.sessionId == null && runtimeForAdapter.sessionDisplayId == null,
-              sessionRotated: sessionCompaction.rotate,
-              sessionRotationReason: sessionCompaction.reason,
-              provider: readNonEmptyString(adapterResult.provider) ?? "unknown",
-              biller: resolveLedgerBiller(adapterResult),
-              model: readNonEmptyString(adapterResult.model) ?? "unknown",
-              ...(adapterResult.costUsd != null ? { costUsd: adapterResult.costUsd } : {}),
-              billingType: normalizeLedgerBillingType(adapterResult.billingType),
-            } as Record<string, unknown>)
-          : null;
-
-      const persistedResultJson = mergeHeartbeatRunResultJson(
-        mergeRunStopMetadataForAgent(agent, outcome, {
-          resultJson: mergeAdapterRecoveryMetadata({
-            resultJson: adapterResult.resultJson ?? null,
-            errorFamily: adapterResult.errorFamily ?? null,
-            retryNotBefore: adapterResult.retryNotBefore ?? null,
-          }),
-          errorCode: runErrorCode,
-          errorMessage: runErrorMessage,
-        }),
-        adapterResult.summary ?? null,
-      );
-
-      let persistedRun = await setRunStatus(run.id, status, {
-        finishedAt: new Date(),
-        error: runErrorMessage,
-        errorCode: runErrorCode,
-        exitCode: adapterResult.exitCode,
-        signal: adapterResult.signal,
-        usageJson,
-        resultJson: persistedResultJson,
-        sessionIdAfter: nextSessionState.displayId ?? nextSessionState.legacySessionId,
-        stdoutExcerpt,
-        stderrExcerpt,
-        logBytes: logSummary?.bytes,
-        logSha256: logSummary?.sha256,
-        logCompressed: logSummary?.compressed ?? false,
-      });
-      if (persistedRun) {
-        persistedRun = await classifyAndPersistRunLiveness(persistedRun, persistedResultJson) ?? persistedRun;
-      }
-
-      await setWakeupStatus(run.wakeupRequestId, outcome === "succeeded" ? "completed" : status, {
-        finishedAt: new Date(),
-        error: runErrorMessage,
-      });
-
-      const finalizedRun = persistedRun ?? (await getRun(run.id));
-      if (finalizedRun) {
-        await appendRunEvent(finalizedRun, seq++, {
-          eventType: "lifecycle",
-          stream: "system",
-          level: outcome === "succeeded" ? "info" : "error",
-          message: `run ${outcome}`,
-          payload: {
-            status,
-            exitCode: adapterResult.exitCode,
-          },
-        });
-        const livenessRun = finalizedRun;
-        await refreshContinuationSummaryForRun(livenessRun, agent);
-        if (issueId && outcome === "succeeded") {
-          try {
-            const existingRunComment = await findRunIssueComment(livenessRun.id, livenessRun.companyId, issueId);
-            if (!existingRunComment) {
-              const issueComment = buildHeartbeatRunIssueComment(persistedResultJson);
-              if (issueComment) {
-                await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id, runId: livenessRun.id });
-              }
+        const onAdapterMeta = async (meta: AdapterInvocationMeta) => {
+          if (meta.env && secretKeys.size > 0) {
+            for (const key of secretKeys) {
+              if (key in meta.env) meta.env[key] = "***REDACTED***";
             }
-          } catch (err) {
-            await onLog(
-              "stderr",
-              `[paperclip] Failed to post run summary comment: ${err instanceof Error ? err.message : String(err)}\n`,
+          }
+          await appendRunEvent(currentRun, seq++, {
+            eventType: "adapter.invoke",
+            stream: "system",
+            level: "info",
+            message: "adapter invocation",
+            payload: meta as unknown as Record<string, unknown>,
+          });
+        };
+
+        const adapter = getServerAdapter(agent.adapterType);
+        const authToken = adapter.supportsLocalAgentJwt
+          ? createLocalAgentJwt(
+              agent.id,
+              agent.companyId,
+              agent.adapterType,
+              run.id,
+            )
+          : null;
+        if (adapter.supportsLocalAgentJwt && !authToken) {
+          logger.warn(
+            {
+              companyId: agent.companyId,
+              agentId: agent.id,
+              runId: run.id,
+              adapterType: agent.adapterType,
+            },
+            "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
+          );
+        }
+        const adapterResult = await adapter.execute({
+          runId: run.id,
+          agent,
+          runtime: runtimeForAdapter,
+          config: runtimeConfig,
+          context,
+          executionTarget,
+          executionTransport: remoteExecution
+            ? {
+                remoteExecution: remoteExecution as unknown as Record<
+                  string,
+                  unknown
+                >,
+              }
+            : undefined,
+          onLog,
+          onMeta: onAdapterMeta,
+          onSpawn: async (meta) => {
+            await persistRunProcessMetadata(run.id, {
+              pid: meta.pid,
+              processGroupId:
+                "processGroupId" in meta &&
+                typeof meta.processGroupId === "number"
+                  ? meta.processGroupId
+                  : null,
+              startedAt: meta.startedAt,
+            });
+          },
+          authToken: authToken ?? undefined,
+        });
+        const adapterManagedRuntimeServices = adapterResult.runtimeServices
+          ? await persistAdapterManagedRuntimeServices({
+              db,
+              adapterType: agent.adapterType,
+              runId: run.id,
+              agent: {
+                id: agent.id,
+                name: agent.name,
+                companyId: agent.companyId,
+              },
+              issue: issueRef,
+              workspace: executionWorkspace,
+              reports: adapterResult.runtimeServices,
+            })
+          : [];
+        if (adapterManagedRuntimeServices.length > 0) {
+          const combinedRuntimeServices = [
+            ...runtimeServices,
+            ...adapterManagedRuntimeServices,
+          ];
+          context.paperclipRuntimeServices = combinedRuntimeServices;
+          context.paperclipRuntimePrimaryUrl =
+            combinedRuntimeServices.find((service) =>
+              readNonEmptyString(service.url),
+            )?.url ?? null;
+          await db
+            .update(heartbeatRuns)
+            .set({
+              contextSnapshot: context,
+              updatedAt: new Date(),
+            })
+            .where(eq(heartbeatRuns.id, run.id));
+          if (issueId) {
+            try {
+              await issuesSvc.addComment(
+                issueId,
+                buildWorkspaceReadyComment({
+                  workspace: executionWorkspace,
+                  runtimeServices: adapterManagedRuntimeServices,
+                }),
+                { agentId: agent.id, runId: run.id },
+              );
+            } catch (err) {
+              await onLog(
+                "stderr",
+                `[paperclip] Failed to post adapter-managed runtime comment: ${err instanceof Error ? err.message : String(err)}\n`,
+              );
+            }
+          }
+        }
+        const nextSessionState = resolveNextSessionState({
+          codec: sessionCodec,
+          adapterResult,
+          previousParams: previousSessionParams,
+          previousDisplayId: runtimeForAdapter.sessionDisplayId,
+          previousLegacySessionId: runtimeForAdapter.sessionId,
+        });
+        const rawUsage = normalizeUsageTotals(adapterResult.usage);
+        const sessionUsageResolution = await resolveNormalizedUsageForSession({
+          agentId: agent.id,
+          runId: run.id,
+          sessionId:
+            nextSessionState.displayId ?? nextSessionState.legacySessionId,
+          rawUsage,
+        });
+        const normalizedUsage = sessionUsageResolution.normalizedUsage;
+
+        let outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
+        const latestRun = await getRun(run.id);
+        if (isHeartbeatRunTerminalStatus(latestRun?.status)) {
+          outcome = latestRun.status;
+        } else if (adapterResult.timedOut) {
+          outcome = "timed_out";
+        } else if (
+          (adapterResult.exitCode ?? 0) === 0 &&
+          !adapterResult.errorMessage
+        ) {
+          outcome = "succeeded";
+        } else {
+          outcome = "failed";
+        }
+        const runErrorMessage =
+          outcome === "cancelled"
+            ? (latestRun?.error ?? adapterResult.errorMessage ?? "Cancelled")
+            : outcome === "succeeded"
+              ? null
+              : redactCurrentUserText(
+                  adapterResult.errorMessage ??
+                    (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
+                  currentUserRedactionOptions,
+                );
+        const runErrorCode =
+          outcome === "timed_out"
+            ? "timeout"
+            : outcome === "cancelled"
+              ? (latestRun?.errorCode ?? "cancelled")
+              : outcome === "failed"
+                ? (adapterResult.errorCode ?? "adapter_failed")
+                : null;
+
+        let logSummary: {
+          bytes: number;
+          sha256?: string;
+          compressed: boolean;
+        } | null = null;
+        if (handle) {
+          logSummary = await runLogStore.finalize(handle);
+        }
+        const finalLogBytes = logSummary?.bytes;
+        if (outputProgressState.pending && typeof finalLogBytes === "number") {
+          outputProgressState.pending.bytes = finalLogBytes;
+        }
+        await flushOutputProgress({ force: true });
+
+        const status =
+          outcome === "succeeded"
+            ? "succeeded"
+            : outcome === "cancelled"
+              ? "cancelled"
+              : outcome === "timed_out"
+                ? "timed_out"
+                : "failed";
+
+        const usageJson =
+          normalizedUsage || adapterResult.costUsd != null
+            ? ({
+                ...(normalizedUsage ?? {}),
+                ...(rawUsage
+                  ? {
+                      rawInputTokens: rawUsage.inputTokens,
+                      rawCachedInputTokens: rawUsage.cachedInputTokens,
+                      rawOutputTokens: rawUsage.outputTokens,
+                    }
+                  : {}),
+                ...(sessionUsageResolution.derivedFromSessionTotals
+                  ? { usageSource: "session_delta" }
+                  : {}),
+                ...((nextSessionState.displayId ??
+                nextSessionState.legacySessionId)
+                  ? {
+                      persistedSessionId:
+                        nextSessionState.displayId ??
+                        nextSessionState.legacySessionId,
+                    }
+                  : {}),
+                sessionReused:
+                  runtimeForAdapter.sessionId != null ||
+                  runtimeForAdapter.sessionDisplayId != null,
+                taskSessionReused: taskSessionForRun != null,
+                freshSession:
+                  runtimeForAdapter.sessionId == null &&
+                  runtimeForAdapter.sessionDisplayId == null,
+                sessionRotated: sessionCompaction.rotate,
+                sessionRotationReason: sessionCompaction.reason,
+                provider:
+                  readNonEmptyString(adapterResult.provider) ?? "unknown",
+                biller: resolveLedgerBiller(adapterResult),
+                model: readNonEmptyString(adapterResult.model) ?? "unknown",
+                ...(adapterResult.costUsd != null
+                  ? { costUsd: adapterResult.costUsd }
+                  : {}),
+                billingType: normalizeLedgerBillingType(
+                  adapterResult.billingType,
+                ),
+              } as Record<string, unknown>)
+            : null;
+
+        const persistedResultJson = mergeHeartbeatRunResultJson(
+          mergeRunStopMetadataForAgent(agent, outcome, {
+            resultJson: mergeAdapterRecoveryMetadata({
+              resultJson: adapterResult.resultJson ?? null,
+              errorFamily: adapterResult.errorFamily ?? null,
+              retryNotBefore: adapterResult.retryNotBefore ?? null,
+            }),
+            errorCode: runErrorCode,
+            errorMessage: runErrorMessage,
+          }),
+          adapterResult.summary ?? null,
+        );
+
+        let persistedRun = await setRunStatus(run.id, status, {
+          finishedAt: new Date(),
+          error: runErrorMessage,
+          errorCode: runErrorCode,
+          exitCode: adapterResult.exitCode,
+          signal: adapterResult.signal,
+          usageJson,
+          resultJson: persistedResultJson,
+          sessionIdAfter:
+            nextSessionState.displayId ?? nextSessionState.legacySessionId,
+          stdoutExcerpt,
+          stderrExcerpt,
+          logBytes: logSummary?.bytes,
+          logSha256: logSummary?.sha256,
+          logCompressed: logSummary?.compressed ?? false,
+        });
+        if (persistedRun) {
+          persistedRun =
+            (await classifyAndPersistRunLiveness(
+              persistedRun,
+              persistedResultJson,
+            )) ?? persistedRun;
+        }
+
+        await setWakeupStatus(
+          run.wakeupRequestId,
+          outcome === "succeeded" ? "completed" : status,
+          {
+            finishedAt: new Date(),
+            error: runErrorMessage,
+          },
+        );
+
+        const finalizedRun = persistedRun ?? (await getRun(run.id));
+        if (finalizedRun) {
+          await appendRunEvent(finalizedRun, seq++, {
+            eventType: "lifecycle",
+            stream: "system",
+            level: outcome === "succeeded" ? "info" : "error",
+            message: `run ${outcome}`,
+            payload: {
+              status,
+              exitCode: adapterResult.exitCode,
+            },
+          });
+          const livenessRun = finalizedRun;
+          await refreshContinuationSummaryForRun(livenessRun, agent);
+          if (issueId && outcome === "succeeded") {
+            try {
+              const existingRunComment = await findRunIssueComment(
+                livenessRun.id,
+                livenessRun.companyId,
+                issueId,
+              );
+              if (!existingRunComment) {
+                const issueComment =
+                  buildHeartbeatRunIssueComment(persistedResultJson);
+                if (issueComment) {
+                  await issuesSvc.addComment(issueId, issueComment, {
+                    agentId: agent.id,
+                    runId: livenessRun.id,
+                  });
+                }
+              }
+            } catch (err) {
+              await onLog(
+                "stderr",
+                `[paperclip] Failed to post run summary comment: ${err instanceof Error ? err.message : String(err)}\n`,
+              );
+            }
+          }
+          if (
+            outcome === "failed" &&
+            readTransientRecoveryContractFromRun(livenessRun)
+          ) {
+            await scheduleBoundedRetryForRun(livenessRun, agent);
+          }
+          await finalizeIssueCommentPolicy(livenessRun, agent);
+          await releaseIssueExecutionAndPromote(livenessRun);
+          await handleRunLivenessContinuation(livenessRun);
+        }
+
+        if (finalizedRun) {
+          await updateRuntimeState(
+            agent,
+            finalizedRun,
+            adapterResult,
+            {
+              legacySessionId: nextSessionState.legacySessionId,
+            },
+            normalizedUsage,
+          );
+          if (taskKey) {
+            if (
+              adapterResult.clearSession ||
+              (!nextSessionState.params && !nextSessionState.displayId)
+            ) {
+              await clearTaskSessions(agent.companyId, agent.id, {
+                taskKey,
+                adapterType: agent.adapterType,
+              });
+            } else {
+              await upsertTaskSession({
+                companyId: agent.companyId,
+                agentId: agent.id,
+                adapterType: agent.adapterType,
+                taskKey,
+                sessionParamsJson: nextSessionState.params,
+                sessionDisplayId: nextSessionState.displayId,
+                lastRunId: finalizedRun.id,
+                lastError:
+                  outcome === "succeeded"
+                    ? null
+                    : (adapterResult.errorMessage ?? "run_failed"),
+              });
+            }
+          }
+        }
+        await finalizeAgentStatus(agent.id, outcome);
+      } catch (err) {
+        const message = redactCurrentUserText(
+          err instanceof Error ? err.message : "Unknown adapter failure",
+          await getCurrentUserRedactionOptions(),
+        );
+        logger.error({ err, runId }, "heartbeat execution failed");
+
+        let logSummary: {
+          bytes: number;
+          sha256?: string;
+          compressed: boolean;
+        } | null = null;
+        if (handle) {
+          try {
+            logSummary = await runLogStore.finalize(handle);
+          } catch (finalizeErr) {
+            logger.warn(
+              { err: finalizeErr, runId },
+              "failed to finalize run log after error",
             );
           }
         }
-        if (outcome === "failed" && readTransientRecoveryContractFromRun(livenessRun)) {
-          await scheduleBoundedRetryForRun(livenessRun, agent);
+        const finalLogBytes = logSummary?.bytes;
+        if (outputProgressState.pending && typeof finalLogBytes === "number") {
+          outputProgressState.pending.bytes = finalLogBytes;
         }
-        await finalizeIssueCommentPolicy(livenessRun, agent);
-        await releaseIssueExecutionAndPromote(livenessRun);
-        await handleRunLivenessContinuation(livenessRun);
-      }
+        await flushOutputProgress({ force: true }).catch((flushErr) => {
+          logger.warn(
+            { err: flushErr, runId },
+            "failed to flush run output progress after error",
+          );
+        });
 
-      if (finalizedRun) {
-        await updateRuntimeState(agent, finalizedRun, adapterResult, {
-          legacySessionId: nextSessionState.legacySessionId,
-        }, normalizedUsage);
-        if (taskKey) {
-          if (adapterResult.clearSession || (!nextSessionState.params && !nextSessionState.displayId)) {
-            await clearTaskSessions(agent.companyId, agent.id, {
-              taskKey,
-              adapterType: agent.adapterType,
-            });
-          } else {
+        const failedRun = await setRunStatus(run.id, "failed", {
+          error: message,
+          errorCode: "adapter_failed",
+          finishedAt: new Date(),
+          resultJson: mergeRunStopMetadataForAgent(agent, "failed", {
+            errorCode: "adapter_failed",
+            errorMessage: message,
+          }),
+          stdoutExcerpt,
+          stderrExcerpt,
+          logBytes: logSummary?.bytes,
+          logSha256: logSummary?.sha256,
+          logCompressed: logSummary?.compressed ?? false,
+        });
+        await setWakeupStatus(run.wakeupRequestId, "failed", {
+          finishedAt: new Date(),
+          error: message,
+        });
+
+        if (failedRun) {
+          await appendRunEvent(failedRun, seq++, {
+            eventType: "error",
+            stream: "system",
+            level: "error",
+            message,
+          });
+          const livenessRun =
+            (await classifyAndPersistRunLiveness(failedRun)) ?? failedRun;
+          await refreshContinuationSummaryForRun(livenessRun, agent);
+          await finalizeIssueCommentPolicy(livenessRun, agent);
+          await releaseIssueExecutionAndPromote(livenessRun);
+
+          await updateRuntimeState(
+            agent,
+            livenessRun,
+            {
+              exitCode: null,
+              signal: null,
+              timedOut: false,
+              errorMessage: message,
+            },
+            {
+              legacySessionId: runtimeForAdapter.sessionId,
+            },
+          );
+
+          if (
+            taskKey &&
+            (previousSessionParams || previousSessionDisplayId || taskSession)
+          ) {
             await upsertTaskSession({
               companyId: agent.companyId,
               agentId: agent.id,
               adapterType: agent.adapterType,
               taskKey,
-              sessionParamsJson: nextSessionState.params,
-              sessionDisplayId: nextSessionState.displayId,
-              lastRunId: finalizedRun.id,
-              lastError: outcome === "succeeded" ? null : (adapterResult.errorMessage ?? "run_failed"),
+              sessionParamsJson: previousSessionParams,
+              sessionDisplayId: previousSessionDisplayId,
+              lastRunId: failedRun.id,
+              lastError: message,
             });
           }
         }
+
+        await finalizeAgentStatus(agent.id, "failed");
       }
-      await finalizeAgentStatus(agent.id, outcome);
-    } catch (err) {
-      const message = redactCurrentUserText(
-        err instanceof Error ? err.message : "Unknown adapter failure",
-        await getCurrentUserRedactionOptions(),
+    } catch (outerErr) {
+      // Setup code before adapter.execute threw (e.g. ensureRuntimeState, resolveWorkspaceForRun).
+      // The inner catch did not fire, so we must record the failure here.
+      const message =
+        outerErr instanceof Error ? outerErr.message : "Unknown setup failure";
+      logger.error(
+        { err: outerErr, runId },
+        "heartbeat execution setup failed",
       );
-      logger.error({ err, runId }, "heartbeat execution failed");
-
-      let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
-      if (handle) {
-        try {
-          logSummary = await runLogStore.finalize(handle);
-        } catch (finalizeErr) {
-          logger.warn({ err: finalizeErr, runId }, "failed to finalize run log after error");
-        }
-      }
-      const finalLogBytes = logSummary?.bytes;
-      if (outputProgressState.pending && typeof finalLogBytes === "number") {
-        outputProgressState.pending.bytes = finalLogBytes;
-      }
-      await flushOutputProgress({ force: true }).catch((flushErr) => {
-        logger.warn({ err: flushErr, runId }, "failed to flush run output progress after error");
-      });
-
-      const failedRun = await setRunStatus(run.id, "failed", {
+      const setupFailureAgent = await getAgent(run.agentId).catch(() => null);
+      await setRunStatus(runId, "failed", {
         error: message,
         errorCode: "adapter_failed",
         finishedAt: new Date(),
-        resultJson: mergeRunStopMetadataForAgent(agent, "failed", {
-          errorCode: "adapter_failed",
-          errorMessage: message,
-        }),
-        stdoutExcerpt,
-        stderrExcerpt,
-        logBytes: logSummary?.bytes,
-        logSha256: logSummary?.sha256,
-        logCompressed: logSummary?.compressed ?? false,
-      });
+        ...(setupFailureAgent
+          ? {
+              resultJson: mergeRunStopMetadataForAgent(
+                setupFailureAgent,
+                "failed",
+                {
+                  errorCode: "adapter_failed",
+                  errorMessage: message,
+                },
+              ),
+            }
+          : {}),
+      }).catch(() => undefined);
       await setWakeupStatus(run.wakeupRequestId, "failed", {
         finishedAt: new Date(),
         error: message,
-      });
-
+      }).catch(() => undefined);
+      const failedRun = await getRun(runId).catch(() => null);
       if (failedRun) {
-        await appendRunEvent(failedRun, seq++, {
+        // Emit a run-log event so the failure is visible in the run timeline,
+        // consistent with what the inner catch block does for adapter failures.
+        await appendRunEvent(failedRun, 1, {
           eventType: "error",
           stream: "system",
           level: "error",
           message,
-        });
-        const livenessRun = await classifyAndPersistRunLiveness(failedRun) ?? failedRun;
-        await refreshContinuationSummaryForRun(livenessRun, agent);
-        await finalizeIssueCommentPolicy(livenessRun, agent);
-        await releaseIssueExecutionAndPromote(livenessRun);
-
-        await updateRuntimeState(agent, livenessRun, {
-          exitCode: null,
-          signal: null,
-          timedOut: false,
-          errorMessage: message,
-        }, {
-          legacySessionId: runtimeForAdapter.sessionId,
-        });
-
-        if (taskKey && (previousSessionParams || previousSessionDisplayId || taskSession)) {
-          await upsertTaskSession({
-            companyId: agent.companyId,
-            agentId: agent.id,
-            adapterType: agent.adapterType,
-            taskKey,
-            sessionParamsJson: previousSessionParams,
-            sessionDisplayId: previousSessionDisplayId,
-            lastRunId: failedRun.id,
-            lastError: message,
-          });
+        }).catch(() => undefined);
+        const livenessRun = await classifyAndPersistRunLiveness(
+          failedRun,
+        ).catch(() => failedRun);
+        const failedAgent =
+          setupFailureAgent ?? (await getAgent(run.agentId).catch(() => null));
+        if (failedAgent) {
+          await refreshContinuationSummaryForRun(
+            livenessRun,
+            failedAgent,
+          ).catch(() => undefined);
+          await finalizeIssueCommentPolicy(livenessRun, failedAgent).catch(
+            () => undefined,
+          );
         }
+        await releaseIssueExecutionAndPromote(livenessRun).catch(
+          () => undefined,
+        );
       }
-
-      await finalizeAgentStatus(agent.id, "failed");
+      // Ensure the agent is not left stuck in "running" if the inner catch handler's
+      // DB calls threw (e.g. a transient DB error in finalizeAgentStatus).
+      await finalizeAgentStatus(run.agentId, "failed").catch(() => undefined);
+    } finally {
+      const latestRun = await getRun(run.id).catch(() => null);
+      const releaseResult = await envOrchestrator
+        .releaseForRun({
+          heartbeatRunId: run.id,
+          companyId: run.companyId,
+          agentId: run.agentId,
+          status: leaseReleaseStatusForRunStatus(latestRun?.status),
+          failureReason: latestRun?.error ?? undefined,
+        })
+        .catch((err) => {
+          logger.warn(
+            { err, runId: run.id },
+            "failed to release environment leases for heartbeat run",
+          );
+          return null;
+        });
+      for (const releaseError of releaseResult?.errors ?? []) {
+        logger.warn(
+          {
+            err: releaseError.error,
+            leaseId: releaseError.leaseId,
+            runId: run.id,
+          },
+          "failed to release environment lease for heartbeat run",
+        );
+      }
+      await releaseRuntimeServicesForRun(run.id).catch(() => undefined);
+      activeRunExecutions.delete(run.id);
+      await startNextQueuedRunForAgent(run.agentId);
     }
-    } catch (outerErr) {
-          // Setup code before adapter.execute threw (e.g. ensureRuntimeState, resolveWorkspaceForRun).
-          // The inner catch did not fire, so we must record the failure here.
-          const message = outerErr instanceof Error ? outerErr.message : "Unknown setup failure";
-          logger.error({ err: outerErr, runId }, "heartbeat execution setup failed");
-          const setupFailureAgent = await getAgent(run.agentId).catch(() => null);
-          await setRunStatus(runId, "failed", {
-            error: message,
-            errorCode: "adapter_failed",
-            finishedAt: new Date(),
-            ...(setupFailureAgent ? {
-              resultJson: mergeRunStopMetadataForAgent(setupFailureAgent, "failed", {
-                errorCode: "adapter_failed",
-                errorMessage: message,
-              }),
-            } : {}),
-          }).catch(() => undefined);
-          await setWakeupStatus(run.wakeupRequestId, "failed", {
-            finishedAt: new Date(),
-            error: message,
-          }).catch(() => undefined);
-          const failedRun = await getRun(runId).catch(() => null);
-          if (failedRun) {
-            // Emit a run-log event so the failure is visible in the run timeline,
-            // consistent with what the inner catch block does for adapter failures.
-            await appendRunEvent(failedRun, 1, {
-              eventType: "error",
-              stream: "system",
-              level: "error",
-              message,
-            }).catch(() => undefined);
-            const livenessRun = await classifyAndPersistRunLiveness(failedRun).catch(() => failedRun);
-            const failedAgent = setupFailureAgent ?? await getAgent(run.agentId).catch(() => null);
-            if (failedAgent) {
-              await refreshContinuationSummaryForRun(livenessRun, failedAgent).catch(() => undefined);
-              await finalizeIssueCommentPolicy(livenessRun, failedAgent).catch(() => undefined);
-            }
-            await releaseIssueExecutionAndPromote(livenessRun).catch(() => undefined);
-          }
-          // Ensure the agent is not left stuck in "running" if the inner catch handler's
-          // DB calls threw (e.g. a transient DB error in finalizeAgentStatus).
-          await finalizeAgentStatus(run.agentId, "failed").catch(() => undefined);
-        } finally {
-          const latestRun = await getRun(run.id).catch(() => null);
-          const releaseResult = await envOrchestrator.releaseForRun({
-            heartbeatRunId: run.id,
-            companyId: run.companyId,
-            agentId: run.agentId,
-            status: leaseReleaseStatusForRunStatus(latestRun?.status),
-            failureReason: latestRun?.error ?? undefined,
-          }).catch((err) => {
-            logger.warn({ err, runId: run.id }, "failed to release environment leases for heartbeat run");
-            return null;
-          });
-          for (const releaseError of releaseResult?.errors ?? []) {
-            logger.warn(
-              { err: releaseError.error, leaseId: releaseError.leaseId, runId: run.id },
-              "failed to release environment lease for heartbeat run",
-            );
-          }
-          await releaseRuntimeServicesForRun(run.id).catch(() => undefined);
-          activeRunExecutions.delete(run.id);
-          await startNextQueuedRunForAgent(run.agentId);
-        }
   }
 
   function buildImmediateExecutionPathRecoveryComment(input: {
     status: "todo" | "in_progress";
-    latestRun: Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode"> | null | undefined;
+    latestRun:
+      | Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode">
+      | null
+      | undefined;
   }) {
     const failureSummary = summarizeRunFailureForIssueComment(input.latestRun);
     if (input.status === "todo") {
@@ -5741,7 +6721,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     );
   }
 
-  async function releaseIssueExecutionAndPromote(run: typeof heartbeatRuns.$inferSelect) {
+  async function releaseIssueExecutionAndPromote(
+    run: typeof heartbeatRuns.$inferSelect,
+  ) {
     const runContext = parseObject(run.contextSnapshot);
     const contextIssueId = readNonEmptyString(runContext.issueId);
     const taskKey = deriveTaskKeyWithHeartbeatFallback(runContext, null);
@@ -5773,7 +6755,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .where(
           and(
             eq(issues.companyId, run.companyId),
-            contextIssueId ? eq(issues.id, contextIssueId) : eq(issues.executionRunId, run.id),
+            contextIssueId
+              ? eq(issues.id, contextIssueId)
+              : eq(issues.executionRunId, run.id),
           ),
         )
         .then((rows) => rows[0] ?? null);
@@ -5828,7 +6812,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             .set({
               status: "failed",
               finishedAt: new Date(),
-              error: "Deferred wake could not be promoted: agent is not invokable",
+              error:
+                "Deferred wake could not be promoted: agent is not invokable",
               updatedAt: new Date(),
             })
             .where(eq(agentWakeupRequests.id, deferred.id));
@@ -5836,16 +6821,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
 
         const deferredPayload = parseObject(deferred.payload);
-        const deferredContextSeed = parseObject(deferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
-        const activePauseHold = await treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id);
-        const treeHoldInteractionWake = activePauseHold && await isVerifiedIssueTreeControlInteractionWake(tx, {
-          companyId: issue.companyId,
-          issueId: issue.id,
-          agentId: deferred.agentId,
-          contextSnapshot: deferredContextSeed,
-          requestedByActorType: deferred.requestedByActorType,
-          requestedByActorId: deferred.requestedByActorId,
-        });
+        const deferredContextSeed = parseObject(
+          deferredPayload[DEFERRED_WAKE_CONTEXT_KEY],
+        );
+        const activePauseHold = await treeControlSvc.getActivePauseHoldGate(
+          issue.companyId,
+          issue.id,
+        );
+        const treeHoldInteractionWake =
+          activePauseHold &&
+          (await isVerifiedIssueTreeControlInteractionWake(tx, {
+            companyId: issue.companyId,
+            issueId: issue.id,
+            agentId: deferred.agentId,
+            contextSnapshot: deferredContextSeed,
+            requestedByActorType: deferred.requestedByActorType,
+            requestedByActorId: deferred.requestedByActorId,
+          }));
         if (activePauseHold && !treeHoldInteractionWake) {
           await tx
             .update(agentWakeupRequests)
@@ -5859,7 +6851,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           continue;
         }
 
-        const promotedContextSeed: Record<string, unknown> = { ...deferredContextSeed };
+        const promotedContextSeed: Record<string, unknown> = {
+          ...deferredContextSeed,
+        };
         if (activePauseHold) {
           promotedContextSeed.treeHoldInteraction = true;
           promotedContextSeed.activeTreeHold = {
@@ -5872,16 +6866,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           };
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
-        const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        const deferredWakeReason = readNonEmptyString(
+          deferredContextSeed.wakeReason,
+        );
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.
         const shouldReopenDeferredCommentWake =
           deferredCommentIds.length > 0 &&
           (issue.status === "done" || issue.status === "cancelled") &&
-          (
-            deferred.requestedByActorType === "user" ||
-            deferredWakeReason === "issue_reopened_via_comment"
-          );
+          (deferred.requestedByActorType === "user" ||
+            deferredWakeReason === "issue_reopened_via_comment");
         let reopenedActivity: LogActivityInput | null = null;
 
         if (shouldReopenDeferredCommentWake) {
@@ -5924,11 +6918,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         }
 
-        const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
+        const promotedReason =
+          readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
         const promotedSource =
-          (readNonEmptyString(deferred.source) as WakeupOptions["source"]) ?? "automation";
+          (readNonEmptyString(deferred.source) as WakeupOptions["source"]) ??
+          "automation";
         const promotedTriggerDetail =
-          (readNonEmptyString(deferred.triggerDetail) as WakeupOptions["triggerDetail"]) ?? null;
+          (readNonEmptyString(
+            deferred.triggerDetail,
+          ) as WakeupOptions["triggerDetail"]) ?? null;
         const promotedPayload = deferredPayload;
         delete promotedPayload[DEFERRED_WAKE_CONTEXT_KEY];
 
@@ -5945,7 +6943,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
         const sessionBefore =
           readNonEmptyString(promotedContextSnapshot.resumeSessionDisplayId) ??
-          await resolveSessionBeforeForWakeup(deferredAgent, promotedTaskKey);
+          (await resolveSessionBeforeForWakeup(deferredAgent, promotedTaskKey));
         const promotedContinuationAttempt = readContinuationAttempt(
           promotedContextSnapshot.livenessContinuationAttempt,
         );
@@ -5988,7 +6986,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             updatedAt: now,
           })
           // Promoted mention wakes are issue-scoped, not issue ownership transfers.
-          .where(and(eq(issues.id, issue.id), eq(issues.assigneeAgentId, deferredAgent.id)));
+          .where(
+            and(
+              eq(issues.id, issue.id),
+              eq(issues.assigneeAgentId, deferredAgent.id),
+            ),
+          );
 
         return {
           kind: "promoted" as const,
@@ -6001,7 +7004,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         (issue.status === "todo" || issue.status === "in_progress") &&
         !issue.assigneeUserId &&
         issue.assigneeAgentId === run.agentId &&
-        (run.status === "failed" || run.status === "timed_out" || run.status === "cancelled");
+        (run.status === "failed" ||
+          run.status === "timed_out" ||
+          run.status === "cancelled");
 
       if (!issueNeedsImmediateRecovery) {
         return { kind: "released" as const };
@@ -6013,7 +7018,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .where(
           and(
             eq(heartbeatRuns.companyId, issue.companyId),
-            inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+            inArray(heartbeatRuns.status, [
+              ...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES,
+            ]),
             sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
             sql`${heartbeatRuns.id} <> ${run.id}`,
           ),
@@ -6024,14 +7031,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return { kind: "released" as const };
       }
 
-      if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+      if (
+        await isAutomaticRecoverySuppressedByPauseHold(
+          db,
+          issue.companyId,
+          issue.id,
+          treeControlSvc,
+        )
+      ) {
         return { kind: "released" as const };
       }
 
       const shouldBlockImmediately =
         !recoveryAgentInvokable ||
         !recoveryAgent ||
-        didAutomaticRecoveryFail(run, issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed");
+        didAutomaticRecoveryFail(
+          run,
+          issue.status === "todo"
+            ? "assignment_recovery"
+            : "issue_continuation_needed",
+        );
       if (shouldBlockImmediately) {
         const comment = buildImmediateExecutionPathRecoveryComment({
           status: issue.status as "todo" | "in_progress",
@@ -6045,10 +7064,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         };
       }
 
-      const retryReason = issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed";
-      const recoveryReason = issue.status === "todo" ? "issue_assignment_recovery" : "issue_continuation_needed";
+      const retryReason =
+        issue.status === "todo"
+          ? "assignment_recovery"
+          : "issue_continuation_needed";
+      const recoveryReason =
+        issue.status === "todo"
+          ? "issue_assignment_recovery"
+          : "issue_continuation_needed";
       const recoverySource =
-        issue.status === "todo" ? "issue.assignment_recovery" : "issue.continuation_recovery";
+        issue.status === "todo"
+          ? "issue.assignment_recovery"
+          : "issue.continuation_recovery";
       const now = new Date();
       const wakeupRequest = await tx
         .insert(agentWakeupRequests)
@@ -6121,7 +7148,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (promotionResult?.kind === "blocked") {
       await recovery.escalateStrandedAssignedIssue({
         issue: promotionResult.issue,
-        previousStatus: promotionResult.previousStatus as "todo" | "in_progress",
+        previousStatus: promotionResult.previousStatus as
+          | "todo"
+          | "in_progress",
         latestRun: run,
         comment: promotionResult.comment,
       });
@@ -6131,7 +7160,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const promotedRun = promotionResult?.run ?? null;
     if (!promotedRun) return;
 
-    if (promotionResult?.kind === "promoted" && promotionResult.reopenedActivity) {
+    if (
+      promotionResult?.kind === "promoted" &&
+      promotionResult.reopenedActivity
+    ) {
       await logActivity(db, promotionResult.reopenedActivity);
     }
 
@@ -6153,7 +7185,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {
     const source = opts.source ?? "on_demand";
     const triggerDetail = opts.triggerDetail ?? null;
-    const contextSnapshot: Record<string, unknown> = { ...(opts.contextSnapshot ?? {}) };
+    const contextSnapshot: Record<string, unknown> = {
+      ...(opts.contextSnapshot ?? {}),
+    };
     const reason = opts.reason ?? null;
     const payload = opts.payload ?? null;
     const {
@@ -6168,31 +7202,51 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       triggerDetail,
       payload,
     });
-    let issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload;
+    let issueId =
+      readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload;
 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");
-    const explicitResumeSession = await resolveExplicitResumeSessionOverride(agent, payload, taskKey);
+    const explicitResumeSession = await resolveExplicitResumeSessionOverride(
+      agent,
+      payload,
+      taskKey,
+    );
     if (explicitResumeSession) {
-      enrichedContextSnapshot.resumeFromRunId = explicitResumeSession.resumeFromRunId;
-      enrichedContextSnapshot.resumeSessionDisplayId = explicitResumeSession.sessionDisplayId;
-      enrichedContextSnapshot.resumeSessionParams = explicitResumeSession.sessionParams;
-      if (!readNonEmptyString(enrichedContextSnapshot.issueId) && explicitResumeSession.issueId) {
+      enrichedContextSnapshot.resumeFromRunId =
+        explicitResumeSession.resumeFromRunId;
+      enrichedContextSnapshot.resumeSessionDisplayId =
+        explicitResumeSession.sessionDisplayId;
+      enrichedContextSnapshot.resumeSessionParams =
+        explicitResumeSession.sessionParams;
+      if (
+        !readNonEmptyString(enrichedContextSnapshot.issueId) &&
+        explicitResumeSession.issueId
+      ) {
         enrichedContextSnapshot.issueId = explicitResumeSession.issueId;
       }
-      if (!readNonEmptyString(enrichedContextSnapshot.taskId) && explicitResumeSession.taskId) {
+      if (
+        !readNonEmptyString(enrichedContextSnapshot.taskId) &&
+        explicitResumeSession.taskId
+      ) {
         enrichedContextSnapshot.taskId = explicitResumeSession.taskId;
       }
-      if (!readNonEmptyString(enrichedContextSnapshot.taskKey) && explicitResumeSession.taskKey) {
+      if (
+        !readNonEmptyString(enrichedContextSnapshot.taskKey) &&
+        explicitResumeSession.taskKey
+      ) {
         enrichedContextSnapshot.taskKey = explicitResumeSession.taskKey;
       }
       issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueId;
     }
-    const effectiveTaskKey = readNonEmptyString(enrichedContextSnapshot.taskKey) ?? taskKey;
+    const effectiveTaskKey =
+      readNonEmptyString(enrichedContextSnapshot.taskKey) ?? taskKey;
     const sessionBefore =
       explicitResumeSession?.sessionDisplayId ??
-      await resolveSessionBeforeForWakeup(agent, effectiveTaskKey);
-    const continuationAttempt = readContinuationAttempt(enrichedContextSnapshot.livenessContinuationAttempt);
+      (await resolveSessionBeforeForWakeup(agent, effectiveTaskKey));
+    const continuationAttempt = readContinuationAttempt(
+      enrichedContextSnapshot.livenessContinuationAttempt,
+    );
 
     const writeSkippedRequest = async (skipReason: string) => {
       await db.insert(agentWakeupRequests).values({
@@ -6215,14 +7269,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       projectId = await db
         .select({ projectId: issues.projectId })
         .from(issues)
-        .where(and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)))
+        .where(
+          and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)),
+        )
         .then((rows) => rows[0]?.projectId ?? null);
     }
 
-    const budgetBlock = await budgets.getInvocationBlock(agent.companyId, agentId, {
-      issueId,
-      projectId,
-    });
+    const budgetBlock = await budgets.getInvocationBlock(
+      agent.companyId,
+      agentId,
+      {
+        issueId,
+        projectId,
+      },
+    );
     if (budgetBlock) {
       await writeSkippedRequest("budget.blocked");
       throw conflict(budgetBlock.reason, {
@@ -6236,7 +7296,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       agent.status === "terminated" ||
       agent.status === "pending_approval"
     ) {
-      throw conflict("Agent is not invokable in its current state", { status: agent.status });
+      throw conflict("Agent is not invokable in its current state", {
+        status: agent.status,
+      });
     }
 
     const policy = parseHeartbeatPolicy(agent);
@@ -6251,16 +7313,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (issueId) {
-      const activePauseHold = await treeControlSvc.getActivePauseHoldGate(agent.companyId, issueId);
+      const activePauseHold = await treeControlSvc.getActivePauseHoldGate(
+        agent.companyId,
+        issueId,
+      );
       if (activePauseHold) {
-        const treeHoldInteractionWake = await isVerifiedIssueTreeControlInteractionWake(db, {
-          companyId: agent.companyId,
-          issueId,
-          agentId,
-          contextSnapshot: enrichedContextSnapshot,
-          requestedByActorType: opts.requestedByActorType,
-          requestedByActorId: opts.requestedByActorId,
-        });
+        const treeHoldInteractionWake =
+          await isVerifiedIssueTreeControlInteractionWake(db, {
+            companyId: agent.companyId,
+            issueId,
+            agentId,
+            contextSnapshot: enrichedContextSnapshot,
+            requestedByActorType: opts.requestedByActorType,
+            requestedByActorId: opts.requestedByActorId,
+          });
 
         if (!treeHoldInteractionWake) {
           await writeSkippedRequest("issue_tree_hold_active");
@@ -6279,7 +7345,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               requestedReason: reason,
               source,
               triggerDetail,
-              securityPrinciples: ["Complete Mediation", "Fail Securely", "Secure Defaults"],
+              securityPrinciples: [
+                "Complete Mediation",
+                "Fail Securely",
+                "Secure Defaults",
+              ],
             },
           });
           return null;
@@ -6318,7 +7388,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             executionAgentNameKey: issues.executionAgentNameKey,
           })
           .from(issues)
-          .where(and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)))
+          .where(
+            and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)),
+          )
           .then((rows) => rows[0] ?? null);
 
         if (!issue) {
@@ -6338,7 +7410,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           return { kind: "skipped" as const };
         }
 
-        const cancelStaleScheduledRetry = async (scheduledRun: typeof heartbeatRuns.$inferSelect) => {
+        const cancelStaleScheduledRetry = async (
+          scheduledRun: typeof heartbeatRuns.$inferSelect,
+        ) => {
           const issueCancelled = issue.status === "cancelled";
           if (
             scheduledRun.status !== "scheduled_retry" ||
@@ -6357,10 +7431,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               status: "cancelled",
               finishedAt: now,
               error: reason,
-              errorCode: issueCancelled ? "issue_cancelled" : "issue_reassigned",
+              errorCode: issueCancelled
+                ? "issue_cancelled"
+                : "issue_reassigned",
               updatedAt: now,
             })
-            .where(and(eq(heartbeatRuns.id, scheduledRun.id), eq(heartbeatRuns.status, "scheduled_retry")))
+            .where(
+              and(
+                eq(heartbeatRuns.id, scheduledRun.id),
+                eq(heartbeatRuns.status, "scheduled_retry"),
+              ),
+            )
             .returning()
             .then((rows) => rows[0] ?? null);
 
@@ -6387,11 +7468,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 executionLockedAt: null,
                 updatedAt: now,
               })
-              .where(and(eq(issues.id, issue.id), eq(issues.executionRunId, scheduledRun.id)));
+              .where(
+                and(
+                  eq(issues.id, issue.id),
+                  eq(issues.executionRunId, scheduledRun.id),
+                ),
+              );
           }
 
           const [eventSeq] = await tx
-            .select({ maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})` })
+            .select({
+              maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})`,
+            })
             .from(heartbeatRunEvents)
             .where(eq(heartbeatRunEvents.runId, cancelled.id));
 
@@ -6410,7 +7498,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               issueId: issue.id,
               issueStatus: issue.status,
               scheduledRetryAttempt: cancelled.scheduledRetryAttempt,
-              scheduledRetryAt: cancelled.scheduledRetryAt ? new Date(cancelled.scheduledRetryAt).toISOString() : null,
+              scheduledRetryAt: cancelled.scheduledRetryAt
+                ? new Date(cancelled.scheduledRetryAt).toISOString()
+                : null,
               scheduledRetryReason: cancelled.scheduledRetryReason,
               previousRetryAgentId: cancelled.agentId,
               currentAssigneeAgentId: issue.assigneeAgentId,
@@ -6422,10 +7512,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
         let activeExecutionRun = issue.executionRunId
           ? await tx
-            .select()
-            .from(heartbeatRuns)
-            .where(eq(heartbeatRuns.id, issue.executionRunId))
-            .then((rows) => rows[0] ?? null)
+              .select()
+              .from(heartbeatRuns)
+              .where(eq(heartbeatRuns.id, issue.executionRunId))
+              .then((rows) => rows[0] ?? null)
           : null;
 
         if (
@@ -6437,7 +7527,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           activeExecutionRun = null;
         }
 
-        if (activeExecutionRun && await cancelStaleScheduledRetry(activeExecutionRun)) {
+        if (
+          activeExecutionRun &&
+          (await cancelStaleScheduledRetry(activeExecutionRun))
+        ) {
           activeExecutionRun = null;
         }
 
@@ -6460,7 +7553,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             .where(
               and(
                 eq(heartbeatRuns.companyId, issue.companyId),
-                inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+                inArray(heartbeatRuns.status, [
+                  ...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES,
+                ]),
                 sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
               ),
             )
@@ -6485,7 +7580,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 .update(issues)
                 .set({
                   executionRunId: legacyRun.id,
-                  executionAgentNameKey: normalizeAgentNameKey(legacyAgent?.name),
+                  executionAgentNameKey: normalizeAgentNameKey(
+                    legacyAgent?.name,
+                  ),
                   executionLockedAt: new Date(),
                   updatedAt: new Date(),
                 })
@@ -6494,11 +7591,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         }
 
-        const dependencyReadiness = await issuesSvc.listDependencyReadiness(
-          issue.companyId,
-          [issue.id],
-          tx,
-        ).then((rows) => rows.get(issue.id) ?? null);
+        const dependencyReadiness = await issuesSvc
+          .listDependencyReadiness(issue.companyId, [issue.id], tx)
+          .then((rows) => rows.get(issue.id) ?? null);
 
         // Blocked descendants should stay idle until the final blocker resolves.
         // Human comment/mention wakes are the exception: they may run in a
@@ -6510,17 +7605,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
         if (blockedInteractionWake) {
           enrichedContextSnapshot.dependencyBlockedInteraction = true;
-          enrichedContextSnapshot.unresolvedBlockerIssueIds = dependencyReadiness.unresolvedBlockerIssueIds;
-          enrichedContextSnapshot.unresolvedBlockerCount = dependencyReadiness.unresolvedBlockerCount;
-          enrichedContextSnapshot.unresolvedBlockerSummaries = await listUnresolvedBlockerSummaries(
-            tx,
-            issue.companyId,
-            issue.id,
-            dependencyReadiness.unresolvedBlockerIssueIds,
-          );
+          enrichedContextSnapshot.unresolvedBlockerIssueIds =
+            dependencyReadiness.unresolvedBlockerIssueIds;
+          enrichedContextSnapshot.unresolvedBlockerCount =
+            dependencyReadiness.unresolvedBlockerCount;
+          enrichedContextSnapshot.unresolvedBlockerSummaries =
+            await listUnresolvedBlockerSummaries(
+              tx,
+              issue.companyId,
+              issue.id,
+              dependencyReadiness.unresolvedBlockerIssueIds,
+            );
         }
 
-        if (!activeExecutionRun && dependencyReadiness && !dependencyReadiness.isDependencyReady && !blockedInteractionWake) {
+        if (
+          !activeExecutionRun &&
+          dependencyReadiness &&
+          !dependencyReadiness.isDependencyReady &&
+          !blockedInteractionWake
+        ) {
           await tx.insert(agentWakeupRequests).values({
             companyId: agent.companyId,
             agentId,
@@ -6530,7 +7633,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             payload: {
               ...(payload ?? {}),
               issueId,
-              unresolvedBlockerIssueIds: dependencyReadiness.unresolvedBlockerIssueIds,
+              unresolvedBlockerIssueIds:
+                dependencyReadiness.unresolvedBlockerIssueIds,
             },
             status: "skipped",
             requestedByActorType: opts.requestedByActorType ?? null,
@@ -6551,9 +7655,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             normalizeAgentNameKey(issue.executionAgentNameKey) ??
             normalizeAgentNameKey(executionAgent?.name);
           const isSameExecutionAgent =
-            Boolean(executionAgentNameKey) && executionAgentNameKey === agentNameKey;
+            Boolean(executionAgentNameKey) &&
+            executionAgentNameKey === agentNameKey;
           const shouldQueueFollowupForRunningWake =
-            shouldQueueFollowupForRunningIssueWake({ contextSnapshot: enrichedContextSnapshot, wakeCommentId }) &&
+            shouldQueueFollowupForRunningIssueWake({
+              contextSnapshot: enrichedContextSnapshot,
+              wakeCommentId,
+            }) &&
             activeExecutionRun.status === "running" &&
             isSameExecutionAgent;
 
@@ -6613,8 +7721,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             .then((rows) => rows[0] ?? null);
 
           if (existingDeferred) {
-            const existingDeferredPayload = parseObject(existingDeferred.payload);
-            const existingDeferredContext = parseObject(existingDeferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
+            const existingDeferredPayload = parseObject(
+              existingDeferred.payload,
+            );
+            const existingDeferredContext = parseObject(
+              existingDeferredPayload[DEFERRED_WAKE_CONTEXT_KEY],
+            );
             const mergedDeferredContext = mergeCoalescedContextSnapshot(
               existingDeferredContext,
               enrichedContextSnapshot,
@@ -6702,7 +7814,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return { kind: "queued" as const, run: newRun };
       });
 
-      if (outcome.kind === "deferred" || outcome.kind === "skipped") return null;
+      if (outcome.kind === "deferred" || outcome.kind === "skipped")
+        return null;
       if (outcome.kind === "coalesced") {
         await startNextQueuedRunForAgent(agent.id);
         return outcome.run;
@@ -6728,27 +7841,45 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const activeRuns = await db
       .select()
       .from(heartbeatRuns)
-      .where(and(eq(heartbeatRuns.agentId, agentId), inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES])))
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agentId),
+          inArray(heartbeatRuns.status, [
+            ...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES,
+          ]),
+        ),
+      )
       .orderBy(desc(heartbeatRuns.createdAt));
 
     const sameScopeQueuedRun = activeRuns.find(
-      (candidate) => candidate.status === "queued" && isSameTaskScope(runTaskKey(candidate), taskKey),
+      (candidate) =>
+        candidate.status === "queued" &&
+        isSameTaskScope(runTaskKey(candidate), taskKey),
     );
     const sameScopeScheduledRetryRun = activeRuns.find(
-      (candidate) => candidate.status === "scheduled_retry" && isSameTaskScope(runTaskKey(candidate), taskKey),
+      (candidate) =>
+        candidate.status === "scheduled_retry" &&
+        isSameTaskScope(runTaskKey(candidate), taskKey),
     );
     const sameScopeRunningRun = activeRuns.find(
-      (candidate) => candidate.status === "running" && isSameTaskScope(runTaskKey(candidate), taskKey),
+      (candidate) =>
+        candidate.status === "running" &&
+        isSameTaskScope(runTaskKey(candidate), taskKey),
     );
     const shouldQueueFollowupForRunningWake =
       Boolean(sameScopeRunningRun) &&
       !sameScopeQueuedRun &&
-      shouldQueueFollowupForRunningIssueWake({ contextSnapshot: enrichedContextSnapshot, wakeCommentId });
+      shouldQueueFollowupForRunningIssueWake({
+        contextSnapshot: enrichedContextSnapshot,
+        wakeCommentId,
+      });
 
     const coalescedTargetRun =
       sameScopeQueuedRun ??
       sameScopeScheduledRetryRun ??
-      (shouldQueueFollowupForRunningWake ? null : sameScopeRunningRun ?? null);
+      (shouldQueueFollowupForRunningWake
+        ? null
+        : (sameScopeRunningRun ?? null));
 
     if (coalescedTargetRun) {
       const mergedContextSnapshot = mergeCoalescedContextSnapshot(
@@ -6842,8 +7973,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function listProjectScopedRunIds(companyId: string, projectId: string) {
-    const runIssueId = sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`;
-    const effectiveProjectId = sql<string | null>`coalesce(${heartbeatRuns.contextSnapshot} ->> 'projectId', ${issues.projectId}::text)`;
+    const runIssueId = sql<
+      string | null
+    >`${heartbeatRuns.contextSnapshot} ->> 'issueId'`;
+    const effectiveProjectId = sql<
+      string | null
+    >`coalesce(${heartbeatRuns.contextSnapshot} ->> 'projectId', ${issues.projectId}::text)`;
 
     const rows = await db
       .selectDistinctOn([heartbeatRuns.id], { id: heartbeatRuns.id })
@@ -6858,7 +7993,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .where(
         and(
           eq(heartbeatRuns.companyId, companyId),
-          inArray(heartbeatRuns.status, [...CANCELLABLE_HEARTBEAT_RUN_STATUSES]),
+          inArray(heartbeatRuns.status, [
+            ...CANCELLABLE_HEARTBEAT_RUN_STATUSES,
+          ]),
           sql`${effectiveProjectId} = ${projectId}`,
         ),
       );
@@ -6866,12 +8003,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return rows.map((row) => row.id);
   }
 
-  async function listProjectScopedWakeupIds(companyId: string, projectId: string) {
-    const wakeIssueId = sql<string | null>`${agentWakeupRequests.payload} ->> 'issueId'`;
-    const effectiveProjectId = sql<string | null>`coalesce(${agentWakeupRequests.payload} ->> 'projectId', ${issues.projectId}::text)`;
+  async function listProjectScopedWakeupIds(
+    companyId: string,
+    projectId: string,
+  ) {
+    const wakeIssueId = sql<
+      string | null
+    >`${agentWakeupRequests.payload} ->> 'issueId'`;
+    const effectiveProjectId = sql<
+      string | null
+    >`coalesce(${agentWakeupRequests.payload} ->> 'projectId', ${issues.projectId}::text)`;
 
     const rows = await db
-      .selectDistinctOn([agentWakeupRequests.id], { id: agentWakeupRequests.id })
+      .selectDistinctOn([agentWakeupRequests.id], {
+        id: agentWakeupRequests.id,
+      })
       .from(agentWakeupRequests)
       .leftJoin(
         issues,
@@ -6883,7 +8029,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .where(
         and(
           eq(agentWakeupRequests.companyId, companyId),
-          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+          inArray(agentWakeupRequests.status, [
+            "queued",
+            "deferred_issue_execution",
+          ]),
           sql`${agentWakeupRequests.runId} is null`,
           sql`${effectiveProjectId} = ${projectId}`,
         ),
@@ -6892,7 +8041,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return rows.map((row) => row.id);
   }
 
-  async function cancelPendingWakeupsForBudgetScope(scope: BudgetEnforcementScope) {
+  async function cancelPendingWakeupsForBudgetScope(
+    scope: BudgetEnforcementScope,
+  ) {
     const now = new Date();
     let wakeupIds: string[] = [];
 
@@ -6903,7 +8054,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .where(
           and(
             eq(agentWakeupRequests.companyId, scope.companyId),
-            inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+            inArray(agentWakeupRequests.status, [
+              "queued",
+              "deferred_issue_execution",
+            ]),
             sql`${agentWakeupRequests.runId} is null`,
           ),
         )
@@ -6916,13 +8070,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           and(
             eq(agentWakeupRequests.companyId, scope.companyId),
             eq(agentWakeupRequests.agentId, scope.scopeId),
-            inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+            inArray(agentWakeupRequests.status, [
+              "queued",
+              "deferred_issue_execution",
+            ]),
             sql`${agentWakeupRequests.runId} is null`,
           ),
         )
         .then((rows) => rows.map((row) => row.id));
     } else {
-      wakeupIds = await listProjectScopedWakeupIds(scope.companyId, scope.scopeId);
+      wakeupIds = await listProjectScopedWakeupIds(
+        scope.companyId,
+        scope.scopeId,
+      );
     }
 
     if (wakeupIds.length === 0) return 0;
@@ -6940,10 +8100,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return wakeupIds.length;
   }
 
-  async function cancelRunInternal(runId: string, reason = "Cancelled by control plane") {
+  async function cancelRunInternal(
+    runId: string,
+    reason = "Cancelled by control plane",
+  ) {
     const run = await getRun(runId);
     if (!run) throw notFound("Heartbeat run not found");
-    if (!CANCELLABLE_HEARTBEAT_RUN_STATUSES.includes(run.status as (typeof CANCELLABLE_HEARTBEAT_RUN_STATUSES)[number])) return run;
+    if (
+      !CANCELLABLE_HEARTBEAT_RUN_STATUSES.includes(
+        run.status as (typeof CANCELLABLE_HEARTBEAT_RUN_STATUSES)[number],
+      )
+    )
+      return run;
     const agent = await getAgent(run.agentId);
 
     const running = runningProcesses.get(run.id);
@@ -6964,13 +8132,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       finishedAt: new Date(),
       error: reason,
       errorCode: "cancelled",
-      ...(agent ? {
-        resultJson: mergeRunStopMetadataForAgent(agent, "cancelled", {
-          resultJson: parseObject(run.resultJson),
-          errorCode: "cancelled",
-          errorMessage: reason,
-        }),
-      } : {}),
+      ...(agent
+        ? {
+            resultJson: mergeRunStopMetadataForAgent(agent, "cancelled", {
+              resultJson: parseObject(run.resultJson),
+              errorCode: "cancelled",
+              errorMessage: reason,
+            }),
+          }
+        : {}),
     });
 
     await setWakeupStatus(run.wakeupRequestId, "cancelled", {
@@ -6994,25 +8164,37 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return cancelled;
   }
 
-  async function cancelActiveForAgentInternal(agentId: string, reason = "Cancelled due to agent pause") {
+  async function cancelActiveForAgentInternal(
+    agentId: string,
+    reason = "Cancelled due to agent pause",
+  ) {
     const agent = await getAgent(agentId);
     const runs = await db
       .select()
       .from(heartbeatRuns)
-      .where(and(eq(heartbeatRuns.agentId, agentId), inArray(heartbeatRuns.status, [...CANCELLABLE_HEARTBEAT_RUN_STATUSES])));
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agentId),
+          inArray(heartbeatRuns.status, [
+            ...CANCELLABLE_HEARTBEAT_RUN_STATUSES,
+          ]),
+        ),
+      );
 
     for (const run of runs) {
       await setRunStatus(run.id, "cancelled", {
         finishedAt: new Date(),
         error: reason,
         errorCode: "cancelled",
-        ...(agent ? {
-          resultJson: mergeRunStopMetadataForAgent(agent, "cancelled", {
-            resultJson: parseObject(run.resultJson),
-            errorCode: "cancelled",
-            errorMessage: reason,
-          }),
-        } : {}),
+        ...(agent
+          ? {
+              resultJson: mergeRunStopMetadataForAgent(agent, "cancelled", {
+                resultJson: parseObject(run.resultJson),
+                errorCode: "cancelled",
+                errorMessage: reason,
+              }),
+            }
+          : {}),
       });
 
       await setWakeupStatus(run.wakeupRequestId, "cancelled", {
@@ -7042,7 +8224,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
   async function cancelBudgetScopeWork(scope: BudgetEnforcementScope) {
     if (scope.scopeType === "agent") {
-      await cancelActiveForAgentInternal(scope.scopeId, "Cancelled due to budget pause");
+      await cancelActiveForAgentInternal(
+        scope.scopeId,
+        "Cancelled due to budget pause",
+      );
       await cancelPendingWakeupsForBudgetScope(scope);
       return;
     }
@@ -7050,15 +8235,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const runIds =
       scope.scopeType === "company"
         ? await db
-          .select({ id: heartbeatRuns.id })
-          .from(heartbeatRuns)
-          .where(
-            and(
-              eq(heartbeatRuns.companyId, scope.companyId),
-              inArray(heartbeatRuns.status, [...CANCELLABLE_HEARTBEAT_RUN_STATUSES]),
-            ),
-          )
-          .then((rows) => rows.map((row) => row.id))
+            .select({ id: heartbeatRuns.id })
+            .from(heartbeatRuns)
+            .where(
+              and(
+                eq(heartbeatRuns.companyId, scope.companyId),
+                inArray(heartbeatRuns.status, [
+                  ...CANCELLABLE_HEARTBEAT_RUN_STATUSES,
+                ]),
+              ),
+            )
+            .then((rows) => rows.map((row) => row.id))
         : await listProjectScopedRunIds(scope.companyId, scope.scopeId);
 
     for (const runId of runIds) {
@@ -7088,7 +8275,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .from(heartbeatRuns)
         .where(
           agentId
-            ? and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.agentId, agentId))
+            ? and(
+                eq(heartbeatRuns.companyId, companyId),
+                eq(heartbeatRuns.agentId, agentId),
+              )
             : eq(heartbeatRuns.companyId, companyId),
         )
         .orderBy(desc(heartbeatRuns.createdAt));
@@ -7161,13 +8351,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const latestTaskSession = await db
         .select()
         .from(agentTaskSessions)
-        .where(and(eq(agentTaskSessions.companyId, agent.companyId), eq(agentTaskSessions.agentId, agent.id)))
+        .where(
+          and(
+            eq(agentTaskSessions.companyId, agent.companyId),
+            eq(agentTaskSessions.agentId, agent.id),
+          ),
+        )
         .orderBy(desc(agentTaskSessions.updatedAt))
         .limit(1)
         .then((rows) => rows[0] ?? null);
       return {
         ...ensured,
-        sessionDisplayId: latestTaskSession?.sessionDisplayId ?? ensured.sessionId,
+        sessionDisplayId:
+          latestTaskSession?.sessionDisplayId ?? ensured.sessionId,
         sessionParamsJson: latestTaskSession?.sessionParamsJson ?? null,
       };
     },
@@ -7179,11 +8375,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return db
         .select()
         .from(agentTaskSessions)
-        .where(and(eq(agentTaskSessions.companyId, agent.companyId), eq(agentTaskSessions.agentId, agentId)))
-        .orderBy(desc(agentTaskSessions.updatedAt), desc(agentTaskSessions.createdAt));
+        .where(
+          and(
+            eq(agentTaskSessions.companyId, agent.companyId),
+            eq(agentTaskSessions.agentId, agentId),
+          ),
+        )
+        .orderBy(
+          desc(agentTaskSessions.updatedAt),
+          desc(agentTaskSessions.createdAt),
+        );
     },
 
-    resetRuntimeSession: async (agentId: string, opts?: { taskKey?: string | null }) => {
+    resetRuntimeSession: async (
+      agentId: string,
+      opts?: { taskKey?: string | null },
+    ) => {
       const agent = await getAgent(agentId);
       if (!agent) throw notFound("Agent not found");
       await ensureRuntimeState(agent);
@@ -7222,7 +8429,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       db
         .select()
         .from(heartbeatRunEvents)
-        .where(and(eq(heartbeatRunEvents.runId, runId), gt(heartbeatRunEvents.seq, afterSeq)))
+        .where(
+          and(
+            eq(heartbeatRunEvents.runId, runId),
+            gt(heartbeatRunEvents.seq, afterSeq),
+          ),
+        )
         .orderBy(asc(heartbeatRunEvents.seq))
         .limit(Math.max(1, Math.min(limit, 1000))),
 
@@ -7246,16 +8458,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     readLog: async (
-      runOrLookup: string | {
-        id: string;
-        companyId: string;
-        logStore: string | null;
-        logRef: string | null;
-      },
+      runOrLookup:
+        | string
+        | {
+            id: string;
+            companyId: string;
+            logStore: string | null;
+            logRef: string | null;
+          },
       opts?: { offset?: number; limitBytes?: number },
     ) => {
-      const run = typeof runOrLookup === "string" ? await getRunLogAccess(runOrLookup) : runOrLookup;
-      const runId = typeof runOrLookup === "string" ? runOrLookup : runOrLookup.id;
+      const run =
+        typeof runOrLookup === "string"
+          ? await getRunLogAccess(runOrLookup)
+          : runOrLookup;
+      const runId =
+        typeof runOrLookup === "string" ? runOrLookup : runOrLookup.id;
       if (!run) throw notFound("Heartbeat run not found");
       if (!run.logStore || !run.logRef) throw notFound("Run log not found");
 
@@ -7283,7 +8501,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       source: "timer" | "assignment" | "on_demand" | "automation" = "on_demand",
       contextSnapshot: Record<string, unknown> = {},
       triggerDetail: "manual" | "ping" | "callback" | "system" = "manual",
-      actor?: { actorType?: "user" | "agent" | "system"; actorId?: string | null },
+      actor?: {
+        actorType?: "user" | "agent" | "system";
+        actorId?: string | null;
+      },
     ) =>
       enqueueWakeup(agentId, {
         source,
@@ -7334,12 +8555,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       let skipped = 0;
 
       for (const agent of allAgents) {
-        if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
+        if (
+          agent.status === "paused" ||
+          agent.status === "terminated" ||
+          agent.status === "pending_approval"
+        )
+          continue;
         const policy = parseHeartbeatPolicy(agent);
         if (!policy.enabled || policy.intervalSec <= 0) continue;
 
         checked += 1;
-        const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
+        const baseline = new Date(
+          agent.lastHeartbeatAt ?? agent.createdAt,
+        ).getTime();
         const elapsedMs = now.getTime() - baseline;
         if (elapsedMs < policy.intervalSec * 1000) continue;
 
@@ -7364,7 +8592,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     cancelRun: (runId: string) => cancelRunInternal(runId),
 
-    cancelActiveForAgent: (agentId: string) => cancelActiveForAgentInternal(agentId),
+    cancelActiveForAgent: (agentId: string) =>
+      cancelActiveForAgentInternal(agentId),
 
     cancelBudgetScopeWork,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -22,6 +22,7 @@ import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
   ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
   isEnvironmentDriverSupportedForAdapter,
+  readAgentPriorityTier,
   type BillingType,
   type EnvironmentLeaseStatus,
   type ExecutionWorkspace,
@@ -6204,6 +6205,10 @@ export function heartbeatService(
           const capacity = resolveOpusConcurrencyCapacity(
             companyRow?.metadata ?? null,
           );
+          const priorityTier = readAgentPriorityTier(
+            (agent.metadata ?? null) as Record<string, unknown> | null,
+            { role: agent.role, name: agent.name },
+          );
           const beforeInflight = getInflightCount(providerSlotKey);
           const beforeWaiters = getWaiterCount(providerSlotKey);
           if (beforeInflight >= capacity) {
@@ -6218,11 +6223,14 @@ export function heartbeatService(
                 waiters: beforeWaiters,
                 capacity,
                 model: configuredModel,
+                priorityTier,
               },
             });
           }
           const slotWaitStart = Date.now();
-          await acquireProviderSlot(providerSlotKey, run.id, capacity);
+          await acquireProviderSlot(providerSlotKey, run.id, capacity, {
+            priorityTier,
+          });
           const waitedMs = Date.now() - slotWaitStart;
           if (waitedMs > 0 && beforeInflight >= capacity) {
             await appendRunEvent(currentRun, seq++, {
@@ -6234,6 +6242,7 @@ export function heartbeatService(
                 providerSlotKey,
                 waitedMs,
                 capacity,
+                priorityTier,
               },
             });
           }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -232,11 +232,37 @@ export const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS = [
   30 * 60 * 1000,
   2 * 60 * 60 * 1000,
 ] as const;
+// PMSA-18 / PMSA-11 §3.3: quota / rate-limit failures get a tighter, shorter
+// backoff than the generic transient_upstream contract. Three attempts at
+// 60s / 240s / 900s, after which we stop retrying and move the executing
+// issue to `blocked` so the board sees the stall (Phase 3 watcher will turn
+// the same signal into a notification).
+export const BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS = [
+  60 * 1000,
+  240 * 1000,
+  900 * 1000,
+] as const;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO = 0.25;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON = "transient_failure";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON = "transient_failure_retry";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS =
   BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
+const QUOTA_BACKOFF_ERROR_CODES = new Set<string>([
+  "claude_quota_exhausted",
+  "claude_rate_limited",
+]);
+
+function isQuotaBackoffErrorCode(code: string | null | undefined): boolean {
+  return typeof code === "string" && QUOTA_BACKOFF_ERROR_CODES.has(code);
+}
+
+function resolveBoundedRetryDelaysForErrorCode(
+  errorCode: string | null | undefined,
+): readonly number[] {
+  return isQuotaBackoffErrorCode(errorCode)
+    ? BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS
+    : BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS;
+}
 type CodexTransientFallbackMode =
   | "same_session"
   | "safer_invocation"
@@ -411,11 +437,12 @@ export function applyRunScopedMentionedSkillKeys(
 
 export function computeBoundedTransientHeartbeatRetrySchedule(
   attempt: number,
-  now = new Date(),
+  now: Date = new Date(),
   random: () => number = Math.random,
+  delays: readonly number[] = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS,
 ) {
   if (!Number.isInteger(attempt) || attempt <= 0) return null;
-  const baseDelayMs = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS[attempt - 1];
+  const baseDelayMs = delays[attempt - 1];
   if (typeof baseDelayMs !== "number") return null;
   const sample = Math.min(1, Math.max(0, random()));
   const jitterMultiplier =
@@ -426,7 +453,7 @@ export function computeBoundedTransientHeartbeatRetrySchedule(
     baseDelayMs,
     delayMs,
     dueAt: new Date(now.getTime() + delayMs),
-    maxAttempts: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS,
+    maxAttempts: delays.length,
   };
 }
 
@@ -3830,6 +3857,116 @@ export function heartbeatService(
     return queued;
   }
 
+  // PMSA-18 / PMSA-11 §3.3: after the bounded quota retry contract is
+  // exhausted, freeze the executing issue at `blocked` with a clear comment
+  // so the board can intervene (top up quota, escalate, or re-queue). The
+  // structured run event is the Phase 3 watcher's pickup signal.
+  async function markQuotaExhaustedIssueBlocked(
+    run: typeof heartbeatRuns.$inferSelect,
+    agent: typeof agents.$inferSelect,
+    opts: { errorCode: string; attempts: number; maxAttempts: number },
+  ) {
+    const contextSnapshot = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    if (!issueId) return null;
+
+    const issueRow = await db
+      .select({
+        id: issues.id,
+        status: issues.status,
+        identifier: issues.identifier,
+      })
+      .from(issues)
+      .where(and(eq(issues.companyId, run.companyId), eq(issues.id, issueId)))
+      .then((rows) => rows[0] ?? null);
+    if (!issueRow) return null;
+    if (issueRow.status === "blocked" || issueRow.status === "cancelled") {
+      // Don't overwrite a manual blocker or undo a cancellation.
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: `quota_retry_exhausted (${opts.errorCode}); issue already in ${issueRow.status}, leaving status untouched`,
+        payload: {
+          quotaRetryExhausted: true,
+          errorCode: opts.errorCode,
+          attempts: opts.attempts,
+          maxAttempts: opts.maxAttempts,
+          issueId,
+          issueStatus: issueRow.status,
+        },
+      });
+      return issueRow;
+    }
+
+    const errorLabel =
+      opts.errorCode === "claude_rate_limited"
+        ? "Anthropic API rate limit"
+        : "Anthropic Opus quota exhaustion";
+    const commentBody = [
+      `## Blocked: ${errorLabel}`,
+      "",
+      `Hit \`${opts.errorCode}\` ${opts.attempts}/${opts.maxAttempts} times in a row; bounded retry budget exhausted.`,
+      "",
+      "**What this means**",
+      "",
+      `- Heartbeat will no longer auto-retry this run.`,
+      `- The issue is parked at \`blocked\` until quota recovers or the board takes manual action.`,
+      "",
+      "**Suggested actions**",
+      "",
+      "- Wait for the Anthropic quota window to roll over and clear the blocker manually.",
+      "- Or top up / switch the affected agent to a fallback provider (PMSA-11 §3.4 / §3.5).",
+      "",
+      `_Triggered by run \`${run.id}\` for agent ${agent.name ?? agent.id}._`,
+    ].join("\n");
+
+    let blockedIssue: Awaited<ReturnType<typeof issuesSvc.update>> = null;
+    try {
+      blockedIssue = await issuesSvc.update(issueId, {
+        status: "blocked",
+        actorAgentId: agent.id,
+      });
+    } catch (err) {
+      logger.warn(
+        { err, issueId, runId: run.id },
+        "failed to mark issue blocked after quota retry exhaustion",
+      );
+    }
+
+    if (blockedIssue) {
+      try {
+        await issuesSvc.addComment(issueId, commentBody, {
+          agentId: agent.id,
+          runId: run.id,
+        });
+      } catch (err) {
+        logger.warn(
+          { err, issueId, runId: run.id },
+          "failed to post quota-exhaustion blocker comment",
+        );
+      }
+    }
+
+    await appendRunEvent(run, await nextRunEventSeq(run.id), {
+      eventType: "lifecycle",
+      stream: "system",
+      level: "error",
+      message: `quota_retry_exhausted (${opts.errorCode}); issue ${issueRow.identifier ?? issueId} marked blocked`,
+      payload: {
+        quotaRetryExhausted: true,
+        errorCode: opts.errorCode,
+        attempts: opts.attempts,
+        maxAttempts: opts.maxAttempts,
+        issueId,
+        issueStatus: blockedIssue ? "blocked" : issueRow.status,
+        agentId: agent.id,
+      },
+    });
+
+    return blockedIssue ?? issueRow;
+  }
+
   async function scheduleBoundedRetryForRun(
     run: typeof heartbeatRuns.$inferSelect,
     agent: typeof agents.$inferSelect,
@@ -3846,10 +3983,16 @@ export function heartbeatService(
     const wakeReason =
       opts?.wakeReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON;
     const nextAttempt = (run.scheduledRetryAttempt ?? 0) + 1;
+    // PMSA-18: claude_quota_exhausted / claude_rate_limited get the tighter
+    // 60s/240s/900s schedule with a hard cap of 3 attempts. Everything else
+    // keeps the legacy 2/10/30/120-min generic transient_upstream contract.
+    const retryDelays = resolveBoundedRetryDelaysForErrorCode(run.errorCode);
+    const isQuotaBackoff = isQuotaBackoffErrorCode(run.errorCode);
     const baseSchedule = computeBoundedTransientHeartbeatRetrySchedule(
       nextAttempt,
       now,
       opts?.random,
+      retryDelays,
     );
     const transientRecovery =
       retryReason === BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON
@@ -3862,6 +4005,7 @@ export function heartbeatService(
     const transientRetryNotBefore = transientRecovery?.retryNotBefore ?? null;
 
     if (!baseSchedule) {
+      const exhaustedMaxAttempts = retryDelays.length;
       await appendRunEvent(run, await nextRunEventSeq(run.id), {
         eventType: "lifecycle",
         stream: "system",
@@ -3870,13 +4014,28 @@ export function heartbeatService(
         payload: {
           retryReason,
           scheduledRetryAttempt: run.scheduledRetryAttempt ?? 0,
-          maxAttempts: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS,
+          maxAttempts: exhaustedMaxAttempts,
+          ...(isQuotaBackoff
+            ? { errorCode: run.errorCode, quotaRetryExhausted: true }
+            : {}),
         },
       });
+      // PMSA-18 / PMSA-11 §3.3: when quota retries run out, transition the
+      // executing issue to `blocked` and emit a Phase 3-consumable event so a
+      // future watcher service can notify the board. Generic transient_upstream
+      // exhaustion intentionally keeps the existing behavior (just stop
+      // retrying) — only quota/rate-limit errors freeze the issue.
+      if (isQuotaBackoff) {
+        await markQuotaExhaustedIssueBlocked(run, agent, {
+          errorCode: run.errorCode ?? "claude_quota_exhausted",
+          attempts: run.scheduledRetryAttempt ?? 0,
+          maxAttempts: exhaustedMaxAttempts,
+        });
+      }
       return {
         outcome: "retry_exhausted" as const,
         attempt: nextAttempt,
-        maxAttempts: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS,
+        maxAttempts: exhaustedMaxAttempts,
       };
     }
     const schedule =

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -34,6 +34,7 @@ import {
   agentTaskSessions,
   agentWakeupRequests,
   activityLog,
+  companies,
   companySkills as companySkillsTable,
   documentRevisions,
   issueDocuments,
@@ -146,6 +147,15 @@ import {
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
 import { recoveryService } from "./recovery/service.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
+import {
+  acquireProviderSlot,
+  buildOpusSlotKey,
+  getInflightCount,
+  getWaiterCount,
+  releaseProviderSlot,
+  resolveOpusConcurrencyCapacity,
+  shouldThrottleProviderRun,
+} from "./provider-semaphore.js";
 import {
   redactCurrentUserText,
   redactCurrentUserValue,
@@ -6176,36 +6186,95 @@ export function heartbeatService(
             "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
           );
         }
-        const adapterResult = await adapter.execute({
-          runId: run.id,
-          agent,
-          runtime: runtimeForAdapter,
-          config: runtimeConfig,
-          context,
-          executionTarget,
-          executionTransport: remoteExecution
-            ? {
-                remoteExecution: remoteExecution as unknown as Record<
-                  string,
-                  unknown
-                >,
-              }
-            : undefined,
-          onLog,
-          onMeta: onAdapterMeta,
-          onSpawn: async (meta) => {
-            await persistRunProcessMetadata(run.id, {
-              pid: meta.pid,
-              processGroupId:
-                "processGroupId" in meta &&
-                typeof meta.processGroupId === "number"
-                  ? meta.processGroupId
-                  : null,
-              startedAt: meta.startedAt,
+        const configuredModel = readNonEmptyString(
+          (runtimeConfig as Record<string, unknown>).model,
+        );
+        const providerSlotKey = shouldThrottleProviderRun({
+          adapterType: agent.adapterType,
+          model: configuredModel,
+        })
+          ? buildOpusSlotKey(agent.companyId)
+          : null;
+        if (providerSlotKey) {
+          const companyRow = await db
+            .select({ metadata: companies.metadata })
+            .from(companies)
+            .where(eq(companies.id, agent.companyId))
+            .then((rows) => rows[0] ?? null);
+          const capacity = resolveOpusConcurrencyCapacity(
+            companyRow?.metadata ?? null,
+          );
+          const beforeInflight = getInflightCount(providerSlotKey);
+          const beforeWaiters = getWaiterCount(providerSlotKey);
+          if (beforeInflight >= capacity) {
+            await appendRunEvent(currentRun, seq++, {
+              eventType: "lifecycle",
+              stream: "system",
+              level: "info",
+              message: "waiting on company-wide Opus concurrency slot",
+              payload: {
+                providerSlotKey,
+                inflight: beforeInflight,
+                waiters: beforeWaiters,
+                capacity,
+                model: configuredModel,
+              },
             });
-          },
-          authToken: authToken ?? undefined,
-        });
+          }
+          const slotWaitStart = Date.now();
+          await acquireProviderSlot(providerSlotKey, run.id, capacity);
+          const waitedMs = Date.now() - slotWaitStart;
+          if (waitedMs > 0 && beforeInflight >= capacity) {
+            await appendRunEvent(currentRun, seq++, {
+              eventType: "lifecycle",
+              stream: "system",
+              level: "info",
+              message: "acquired company-wide Opus concurrency slot",
+              payload: {
+                providerSlotKey,
+                waitedMs,
+                capacity,
+              },
+            });
+          }
+        }
+        let adapterResult;
+        try {
+          adapterResult = await adapter.execute({
+            runId: run.id,
+            agent,
+            runtime: runtimeForAdapter,
+            config: runtimeConfig,
+            context,
+            executionTarget,
+            executionTransport: remoteExecution
+              ? {
+                  remoteExecution: remoteExecution as unknown as Record<
+                    string,
+                    unknown
+                  >,
+                }
+              : undefined,
+            onLog,
+            onMeta: onAdapterMeta,
+            onSpawn: async (meta) => {
+              await persistRunProcessMetadata(run.id, {
+                pid: meta.pid,
+                processGroupId:
+                  "processGroupId" in meta &&
+                  typeof meta.processGroupId === "number"
+                    ? meta.processGroupId
+                    : null,
+                startedAt: meta.startedAt,
+              });
+            },
+            authToken: authToken ?? undefined,
+          });
+        } finally {
+          if (providerSlotKey) {
+            releaseProviderSlot(providerSlotKey, run.id);
+          }
+        }
         const adapterManagedRuntimeServices = adapterResult.runtimeServices
           ? await persistAdapterManagedRuntimeServices({
               db,

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -2,7 +2,10 @@ export { companyService } from "./companies.js";
 export { feedbackService } from "./feedback.js";
 export { companySkillService } from "./company-skills.js";
 export { agentService, deduplicateAgentName } from "./agents.js";
-export { agentInstructionsService, syncInstructionsBundleConfigFromFilePath } from "./agent-instructions.js";
+export {
+  agentInstructionsService,
+  syncInstructionsBundleConfigFromFilePath,
+} from "./agent-instructions.js";
 export { assetService } from "./assets.js";
 export { documentService, extractLegacyPlanBody } from "./documents.js";
 export {
@@ -30,9 +33,22 @@ export { budgetService } from "./budgets.js";
 export { secretService } from "./secrets.js";
 export { routineService } from "./routines.js";
 export { costService } from "./costs.js";
+export {
+  DEFAULT_QUOTA_INCIDENT_WINDOW_MINUTES,
+  MAX_QUOTA_INCIDENT_WINDOW_MINUTES,
+  clampQuotaIncidentWindowMinutes,
+  quotaIncidentsService,
+  type QuotaIncidentsResult,
+  type QuotaIncidentsService,
+  type QuotaIncidentAgentBreakdown,
+  type QuotaIncidentErrorCode,
+} from "./quota-incidents.js";
 export { financeService } from "./finance.js";
 export { heartbeatService } from "./heartbeat.js";
-export { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/index.js";
+export {
+  classifyIssueGraphLiveness,
+  type IssueLivenessFinding,
+} from "./recovery/index.js";
 export { dashboardService } from "./dashboard.js";
 export { sidebarBadgeService } from "./sidebar-badges.js";
 export { sidebarPreferenceService } from "./sidebar-preferences.js";
@@ -46,7 +62,16 @@ export { executionWorkspaceService } from "./execution-workspaces.js";
 export { workspaceOperationService } from "./workspace-operations.js";
 export { workProductService } from "./work-products.js";
 export { logActivity, type LogActivityInput } from "./activity-log.js";
-export { notifyHireApproved, type NotifyHireApprovedInput } from "./hire-hook.js";
+export {
+  notifyHireApproved,
+  type NotifyHireApprovedInput,
+} from "./hire-hook.js";
 export { publishLiveEvent, subscribeCompanyLiveEvents } from "./live-events.js";
-export { reconcilePersistedRuntimeServicesOnStartup, restartDesiredRuntimeServicesOnStartup } from "./workspace-runtime.js";
-export { createStorageServiceFromConfig, getStorageService } from "../storage/index.js";
+export {
+  reconcilePersistedRuntimeServicesOnStartup,
+  restartDesiredRuntimeServicesOnStartup,
+} from "./workspace-runtime.js";
+export {
+  createStorageServiceFromConfig,
+  getStorageService,
+} from "../storage/index.js";

--- a/server/src/services/provider-semaphore.test.ts
+++ b/server/src/services/provider-semaphore.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __resetProviderSemaphoreForTests,
+  acquireProviderSlot,
+  buildOpusSlotKey,
+  getInflightCount,
+  getWaiterCount,
+  isOpusModel,
+  releaseProviderSlot,
+  releaseStaleInflightSlots,
+  resolveOpusConcurrencyCapacity,
+  shouldThrottleProviderRun,
+  snapshotProviderSemaphore,
+} from "./provider-semaphore.js";
+
+afterEach(() => {
+  __resetProviderSemaphoreForTests();
+});
+
+describe("isOpusModel", () => {
+  it.each([
+    ["claude-opus-4-7", true],
+    ["claude-opus-4-6", true],
+    ["us.anthropic.claude-opus-4-6-v1", true],
+    ["claude-sonnet-4-6", false],
+    ["claude-haiku-4-6", false],
+    ["us.anthropic.claude-sonnet-4-5-20250929-v2:0", false],
+    ["", false],
+    [null, false],
+    [undefined, false],
+  ])("classifies %s as opus=%s", (model, expected) => {
+    expect(isOpusModel(model)).toBe(expected);
+  });
+});
+
+describe("shouldThrottleProviderRun", () => {
+  it("only throttles claude_local + opus models", () => {
+    expect(
+      shouldThrottleProviderRun({
+        adapterType: "claude_local",
+        model: "claude-opus-4-7",
+      }),
+    ).toBe(true);
+    expect(
+      shouldThrottleProviderRun({
+        adapterType: "claude_local",
+        model: "claude-sonnet-4-6",
+      }),
+    ).toBe(false);
+    expect(
+      shouldThrottleProviderRun({
+        adapterType: "codex_local",
+        model: "claude-opus-4-7",
+      }),
+    ).toBe(false);
+    expect(
+      shouldThrottleProviderRun({
+        adapterType: "claude_local",
+        model: null,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveOpusConcurrencyCapacity", () => {
+  it("uses default when metadata is missing or invalid", () => {
+    expect(resolveOpusConcurrencyCapacity(null)).toBe(2);
+    expect(resolveOpusConcurrencyCapacity(undefined)).toBe(2);
+    expect(resolveOpusConcurrencyCapacity({})).toBe(2);
+    expect(resolveOpusConcurrencyCapacity({ opusConcurrencyMax: "3" })).toBe(2);
+    expect(
+      resolveOpusConcurrencyCapacity({ opusConcurrencyMax: Number.NaN }),
+    ).toBe(2);
+  });
+
+  it("clamps configured values to safe bounds", () => {
+    expect(resolveOpusConcurrencyCapacity({ opusConcurrencyMax: 0 })).toBe(1);
+    expect(resolveOpusConcurrencyCapacity({ opusConcurrencyMax: -5 })).toBe(1);
+    expect(resolveOpusConcurrencyCapacity({ opusConcurrencyMax: 1000 })).toBe(
+      32,
+    );
+    expect(resolveOpusConcurrencyCapacity({ opusConcurrencyMax: 5 })).toBe(5);
+    expect(resolveOpusConcurrencyCapacity({ opusConcurrencyMax: 3.7 })).toBe(3);
+  });
+});
+
+describe("acquire/release semaphore", () => {
+  it("admits up to capacity, then queues additional acquires", async () => {
+    const key = buildOpusSlotKey("company-a");
+    const capacity = 2;
+
+    await acquireProviderSlot(key, "run-1", capacity);
+    await acquireProviderSlot(key, "run-2", capacity);
+    expect(getInflightCount(key)).toBe(capacity);
+
+    let run3Granted = false;
+    const run3 = acquireProviderSlot(key, "run-3", capacity).then(() => {
+      run3Granted = true;
+    });
+
+    // Give the microtask queue a chance to run; run-3 must remain pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(run3Granted).toBe(false);
+    expect(getWaiterCount(key)).toBe(1);
+
+    releaseProviderSlot(key, "run-1");
+    await run3;
+    expect(run3Granted).toBe(true);
+    expect(getInflightCount(key)).toBe(capacity);
+    expect(getWaiterCount(key)).toBe(0);
+  });
+
+  it("queues 6th simultaneous acquire when capacity is 5 (5-agent scenario)", async () => {
+    const key = buildOpusSlotKey("company-b");
+    const capacity = 5;
+
+    const acquires = [
+      acquireProviderSlot(key, "run-1", capacity),
+      acquireProviderSlot(key, "run-2", capacity),
+      acquireProviderSlot(key, "run-3", capacity),
+      acquireProviderSlot(key, "run-4", capacity),
+      acquireProviderSlot(key, "run-5", capacity),
+    ];
+    await Promise.all(acquires);
+    expect(getInflightCount(key)).toBe(capacity);
+
+    let sixthGranted = false;
+    const sixth = acquireProviderSlot(key, "run-6", capacity).then(() => {
+      sixthGranted = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(sixthGranted).toBe(false);
+    expect(getWaiterCount(key)).toBe(1);
+    expect(getInflightCount(key)).toBe(capacity);
+
+    releaseProviderSlot(key, "run-3");
+    await sixth;
+    expect(sixthGranted).toBe(true);
+    expect(getInflightCount(key)).toBe(capacity);
+    expect(getWaiterCount(key)).toBe(0);
+
+    // Cleanup so subsequent tests start clean.
+    for (const id of ["run-1", "run-2", "run-4", "run-5", "run-6"]) {
+      releaseProviderSlot(key, id);
+    }
+    expect(getInflightCount(key)).toBe(0);
+  });
+
+  it("preserves FIFO ordering when multiple waiters are queued", async () => {
+    const key = buildOpusSlotKey("company-c");
+    const capacity = 1;
+    await acquireProviderSlot(key, "holder", capacity);
+
+    const order: string[] = [];
+    const w1 = acquireProviderSlot(key, "w1", capacity).then(() => {
+      order.push("w1");
+      releaseProviderSlot(key, "w1");
+    });
+    const w2 = acquireProviderSlot(key, "w2", capacity).then(() => {
+      order.push("w2");
+      releaseProviderSlot(key, "w2");
+    });
+    const w3 = acquireProviderSlot(key, "w3", capacity).then(() => {
+      order.push("w3");
+      releaseProviderSlot(key, "w3");
+    });
+
+    await Promise.resolve();
+    expect(getWaiterCount(key)).toBe(3);
+    releaseProviderSlot(key, "holder");
+
+    await Promise.all([w1, w2, w3]);
+    expect(order).toEqual(["w1", "w2", "w3"]);
+    expect(getInflightCount(key)).toBe(0);
+  });
+
+  it("isolates inflight sets per company key", async () => {
+    const keyA = buildOpusSlotKey("company-d");
+    const keyB = buildOpusSlotKey("company-e");
+    await acquireProviderSlot(keyA, "run-1", 1);
+    await acquireProviderSlot(keyB, "run-1", 1);
+    expect(getInflightCount(keyA)).toBe(1);
+    expect(getInflightCount(keyB)).toBe(1);
+    releaseProviderSlot(keyA, "run-1");
+    expect(getInflightCount(keyA)).toBe(0);
+    expect(getInflightCount(keyB)).toBe(1);
+  });
+
+  it("re-entrant acquire on the same runId is a no-op", async () => {
+    const key = buildOpusSlotKey("company-f");
+    await acquireProviderSlot(key, "run-1", 2);
+    await acquireProviderSlot(key, "run-1", 2);
+    expect(getInflightCount(key)).toBe(1);
+    releaseProviderSlot(key, "run-1");
+    expect(getInflightCount(key)).toBe(0);
+  });
+
+  it("supports AbortSignal to cancel a queued waiter", async () => {
+    const key = buildOpusSlotKey("company-g");
+    await acquireProviderSlot(key, "holder", 1);
+    const controller = new AbortController();
+    const cancelled = acquireProviderSlot(key, "waiter", 1, {
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    expect(getWaiterCount(key)).toBe(1);
+    controller.abort(new Error("test cancel"));
+    await expect(cancelled).rejects.toThrow("test cancel");
+    expect(getWaiterCount(key)).toBe(0);
+    releaseProviderSlot(key, "holder");
+  });
+});
+
+describe("releaseStaleInflightSlots", () => {
+  it("clears any leftover inflight set and rejects pending waiters", async () => {
+    const key = buildOpusSlotKey("company-h");
+    await acquireProviderSlot(key, "run-1", 1);
+    const queued = acquireProviderSlot(key, "run-2", 1);
+    await Promise.resolve();
+    const result = releaseStaleInflightSlots();
+    expect(result.inflightCleared).toBe(1);
+    expect(result.waitersRejected).toBe(1);
+    await expect(queued).rejects.toThrow(
+      "provider semaphore reset on bootstrap",
+    );
+    expect(getInflightCount(key)).toBe(0);
+    expect(getWaiterCount(key)).toBe(0);
+  });
+});
+
+describe("snapshotProviderSemaphore", () => {
+  it("returns the current map state", async () => {
+    const key = buildOpusSlotKey("company-i");
+    await acquireProviderSlot(key, "run-1", 1);
+    const queued = acquireProviderSlot(key, "run-2", 1).catch(() => undefined);
+    await Promise.resolve();
+    const snapshot = snapshotProviderSemaphore();
+    expect(snapshot.inflight).toEqual([{ key, runIds: ["run-1"] }]);
+    expect(snapshot.waiting).toEqual([{ key, runIds: ["run-2"] }]);
+    releaseStaleInflightSlots();
+    await queued;
+  });
+});

--- a/server/src/services/provider-semaphore.test.ts
+++ b/server/src/services/provider-semaphore.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   __resetProviderSemaphoreForTests,
   acquireProviderSlot,
+  bumpWaiterPriority,
   buildOpusSlotKey,
   getInflightCount,
   getWaiterCount,
@@ -230,6 +231,269 @@ describe("releaseStaleInflightSlots", () => {
   });
 });
 
+describe("priority-aware ordering (PMSA-17)", () => {
+  it("serves p0 waiters before p2 waiters even when p2 enqueued first", async () => {
+    const key = buildOpusSlotKey("company-prio-1");
+    const capacity = 1;
+    await acquireProviderSlot(key, "holder", capacity);
+
+    const order: string[] = [];
+    const lowFirst = acquireProviderSlot(key, "p2-first", capacity, {
+      priorityTier: "p2",
+    }).then(() => {
+      order.push("p2-first");
+      releaseProviderSlot(key, "p2-first");
+    });
+    const highSecond = acquireProviderSlot(key, "p0-second", capacity, {
+      priorityTier: "p0",
+    }).then(() => {
+      order.push("p0-second");
+      releaseProviderSlot(key, "p0-second");
+    });
+    await Promise.resolve();
+    expect(getWaiterCount(key)).toBe(2);
+
+    releaseProviderSlot(key, "holder");
+    await Promise.all([lowFirst, highSecond]);
+    expect(order).toEqual(["p0-second", "p2-first"]);
+  });
+
+  it("preserves FIFO within the same tier", async () => {
+    const key = buildOpusSlotKey("company-prio-2");
+    const capacity = 1;
+    await acquireProviderSlot(key, "holder", capacity);
+
+    const order: string[] = [];
+    const a = acquireProviderSlot(key, "p1-a", capacity, {
+      priorityTier: "p1",
+    }).then(() => {
+      order.push("p1-a");
+      releaseProviderSlot(key, "p1-a");
+    });
+    const b = acquireProviderSlot(key, "p1-b", capacity, {
+      priorityTier: "p1",
+    }).then(() => {
+      order.push("p1-b");
+      releaseProviderSlot(key, "p1-b");
+    });
+    const c = acquireProviderSlot(key, "p1-c", capacity, {
+      priorityTier: "p1",
+    }).then(() => {
+      order.push("p1-c");
+      releaseProviderSlot(key, "p1-c");
+    });
+    await Promise.resolve();
+    expect(getWaiterCount(key)).toBe(3);
+
+    releaseProviderSlot(key, "holder");
+    await Promise.all([a, b, c]);
+    expect(order).toEqual(["p1-a", "p1-b", "p1-c"]);
+  });
+
+  it("p0 waiter cuts ahead of an already-queued p3 plus a fresh p2", async () => {
+    // Five-agent dogfood scenario: p3 researcher heartbeat, p2 PRD writer,
+    // and a p0 CEO decision all converge on a single Opus slot. CEO must
+    // run first regardless of arrival order.
+    const key = buildOpusSlotKey("company-prio-3");
+    const capacity = 1;
+    await acquireProviderSlot(key, "holder", capacity);
+
+    const order: string[] = [];
+    const p3 = acquireProviderSlot(key, "researcher", capacity, {
+      priorityTier: "p3",
+    }).then(() => {
+      order.push("researcher");
+      releaseProviderSlot(key, "researcher");
+    });
+    const p2 = acquireProviderSlot(key, "prd-writer", capacity, {
+      priorityTier: "p2",
+    }).then(() => {
+      order.push("prd-writer");
+      releaseProviderSlot(key, "prd-writer");
+    });
+    const p0 = acquireProviderSlot(key, "ceo", capacity, {
+      priorityTier: "p0",
+    }).then(() => {
+      order.push("ceo");
+      releaseProviderSlot(key, "ceo");
+    });
+    await Promise.resolve();
+    expect(getWaiterCount(key)).toBe(3);
+
+    releaseProviderSlot(key, "holder");
+    await Promise.all([p3, p2, p0]);
+    expect(order).toEqual(["ceo", "prd-writer", "researcher"]);
+  });
+
+  it("falls back to p2 when no priorityTier is supplied", async () => {
+    const key = buildOpusSlotKey("company-prio-4");
+    await acquireProviderSlot(key, "holder", 1);
+    const queued = acquireProviderSlot(key, "default-tier", 1).catch(
+      () => undefined,
+    );
+    await Promise.resolve();
+    const snap = snapshotProviderSemaphore();
+    const matching = snap.waiting.find((row) => row.key === key);
+    expect(matching?.tiers).toEqual(["p2"]);
+    releaseStaleInflightSlots();
+    await queued;
+  });
+});
+
+describe("aging promotes starved waiters (PMSA-17)", () => {
+  it("treats a p3 waiter that has waited > aging interval as p2 on next pick", async () => {
+    const key = buildOpusSlotKey("company-aging-1");
+    const capacity = 1;
+    let nowMs = 1_000_000;
+    const now = () => nowMs;
+    const agingIntervalMs = 60_000; // 1 min for test simplicity
+
+    await acquireProviderSlot(key, "holder", capacity);
+
+    // Two waiters arrive at the same instant: one p3, one p2.
+    const order: string[] = [];
+    const old = acquireProviderSlot(key, "old-p3", capacity, {
+      priorityTier: "p3",
+      agingIntervalMs,
+      now,
+    }).then(() => {
+      order.push("old-p3");
+      releaseProviderSlot(key, "old-p3", { agingIntervalMs, now });
+    });
+    await Promise.resolve();
+
+    nowMs += agingIntervalMs + 100; // p3 has now waited > 1 interval
+    const fresh = acquireProviderSlot(key, "fresh-p2", capacity, {
+      priorityTier: "p2",
+      agingIntervalMs,
+      now,
+    }).then(() => {
+      order.push("fresh-p2");
+      releaseProviderSlot(key, "fresh-p2", { agingIntervalMs, now });
+    });
+    await Promise.resolve();
+    expect(getWaiterCount(key)).toBe(2);
+
+    // The aged p3 (now effectively p2) was enqueued first, so FIFO within p2
+    // promotes it ahead of the freshly-arrived p2.
+    releaseProviderSlot(key, "holder", { agingIntervalMs, now });
+    await Promise.all([old, fresh]);
+    expect(order).toEqual(["old-p3", "fresh-p2"]);
+  });
+
+  it("walks p3 -> p2 -> p1 -> p0 across multiple aging intervals", async () => {
+    const key = buildOpusSlotKey("company-aging-2");
+    const capacity = 1;
+    let nowMs = 1_000_000;
+    const now = () => nowMs;
+    const agingIntervalMs = 60_000;
+    await acquireProviderSlot(key, "holder", capacity);
+
+    const aged = acquireProviderSlot(key, "aged-p3", capacity, {
+      priorityTier: "p3",
+      agingIntervalMs,
+      now,
+    });
+    await Promise.resolve();
+
+    // Wait long enough for 3 aging steps (p3 -> p2 -> p1 -> p0).
+    nowMs += agingIntervalMs * 3 + 100;
+
+    let fresh0Resolved = false;
+    const fresh0 = acquireProviderSlot(key, "fresh-p0", capacity, {
+      priorityTier: "p0",
+      agingIntervalMs,
+      now,
+    }).then(() => {
+      fresh0Resolved = true;
+      releaseProviderSlot(key, "fresh-p0", { agingIntervalMs, now });
+    });
+    await Promise.resolve();
+    expect(getWaiterCount(key)).toBe(2);
+
+    releaseProviderSlot(key, "holder", { agingIntervalMs, now });
+    await aged;
+    // The aged p3 has been promoted to p0 by aging; it shares tier with the
+    // fresh p0, and (within tier) FIFO breaks the tie in favour of the older
+    // entry. Fresh p0 still runs second, not blocked indefinitely.
+    expect(fresh0Resolved).toBe(false);
+    releaseProviderSlot(key, "aged-p3", { agingIntervalMs, now });
+    await fresh0;
+  });
+
+  it("bumpWaiterPriority shortcuts the timer-based aging path", async () => {
+    const key = buildOpusSlotKey("company-aging-3");
+    await acquireProviderSlot(key, "holder", 1);
+    const order: string[] = [];
+    const low = acquireProviderSlot(key, "p3-bumped", 1, {
+      priorityTier: "p3",
+    }).then(() => {
+      order.push("p3-bumped");
+      releaseProviderSlot(key, "p3-bumped");
+    });
+    const mid = acquireProviderSlot(key, "p2-stable", 1, {
+      priorityTier: "p2",
+    }).then(() => {
+      order.push("p2-stable");
+      releaseProviderSlot(key, "p2-stable");
+    });
+    await Promise.resolve();
+    expect(getWaiterCount(key)).toBe(2);
+
+    // p3 -> p2 (tied) keeps FIFO (p3-bumped enqueued first), then p2 -> p1
+    // pushes it ahead of the stable p2.
+    expect(bumpWaiterPriority(key, "p3-bumped")).toEqual({
+      promoted: true,
+      tier: "p2",
+    });
+    expect(bumpWaiterPriority(key, "p3-bumped")).toEqual({
+      promoted: true,
+      tier: "p1",
+    });
+
+    releaseProviderSlot(key, "holder");
+    await Promise.all([low, mid]);
+    expect(order).toEqual(["p3-bumped", "p2-stable"]);
+  });
+
+  it("bumpWaiterPriority no-ops at p0", async () => {
+    const key = buildOpusSlotKey("company-aging-4");
+    await acquireProviderSlot(key, "holder", 1);
+    const queued = acquireProviderSlot(key, "p0-already", 1, {
+      priorityTier: "p0",
+    }).catch(() => undefined);
+    await Promise.resolve();
+    expect(bumpWaiterPriority(key, "p0-already")).toEqual({
+      promoted: false,
+      tier: "p0",
+    });
+    releaseStaleInflightSlots();
+    await queued;
+  });
+
+  it("returns release telemetry for a promoted waiter", async () => {
+    const key = buildOpusSlotKey("company-aging-5");
+    let nowMs = 1_000_000;
+    const now = () => nowMs;
+    const agingIntervalMs = 60_000;
+    await acquireProviderSlot(key, "holder", 1);
+    const queued = acquireProviderSlot(key, "waiter-1", 1, {
+      priorityTier: "p3",
+      agingIntervalMs,
+      now,
+    });
+    await Promise.resolve();
+    nowMs += agingIntervalMs + 50;
+    const result = releaseProviderSlot(key, "holder", { agingIntervalMs, now });
+    expect(result.promotedRunId).toBe("waiter-1");
+    expect(result.promotedInitialTier).toBe("p3");
+    expect(result.promotedTier).toBe("p2");
+    expect(result.promotedWaitedMs).toBe(agingIntervalMs + 50);
+    await queued;
+    releaseProviderSlot(key, "waiter-1", { agingIntervalMs, now });
+  });
+});
+
 describe("snapshotProviderSemaphore", () => {
   it("returns the current map state", async () => {
     const key = buildOpusSlotKey("company-i");
@@ -238,7 +502,9 @@ describe("snapshotProviderSemaphore", () => {
     await Promise.resolve();
     const snapshot = snapshotProviderSemaphore();
     expect(snapshot.inflight).toEqual([{ key, runIds: ["run-1"] }]);
-    expect(snapshot.waiting).toEqual([{ key, runIds: ["run-2"] }]);
+    expect(snapshot.waiting).toEqual([
+      { key, runIds: ["run-2"], tiers: ["p2"] },
+    ]);
     releaseStaleInflightSlots();
     await queued;
   });

--- a/server/src/services/provider-semaphore.ts
+++ b/server/src/services/provider-semaphore.ts
@@ -9,7 +9,21 @@
 // - State lives in-memory; the Paperclip server is single-process today.
 // - Process restart drops all waiters, but heartbeat_runs.queued is persisted
 //   in DB and `startNextQueuedRunForAgent()` will re-pick those on next tick.
-// - FIFO ordering only. Per-agent priority is layered on in PMSA-17 (Phase 2-B).
+// - Waiters are ordered (priorityTier asc, enqueuedAt asc) so a CEO (p0)
+//   heartbeat always preempts a backlog of researcher (p3) heartbeats waiting
+//   on the same Opus slot. PMSA-17 / [PMSA-11] §3.2.
+// - Aging: a waiter that has been queued longer than
+//   AGENT_PRIORITY_TIER_AGING_INTERVAL_MS bumps one tier toward p0 every
+//   interval, so p3 work cannot be starved indefinitely behind a steady
+//   stream of higher-priority arrivals. PMSA-17 / [PMSA-11] §3.2.
+
+import {
+  AGENT_PRIORITY_TIERS,
+  agentPriorityTierRank,
+  bumpAgentPriorityTier,
+  DEFAULT_AGENT_PRIORITY_TIER,
+  type AgentPriorityTier,
+} from "@paperclipai/shared";
 
 const OPUS_PROVIDER = "anthropic" as const;
 const OPUS_MODEL_FAMILY = "opus" as const;
@@ -17,6 +31,10 @@ const OPUS_MODEL_FAMILY = "opus" as const;
 const DEFAULT_OPUS_CAPACITY = 2;
 const MIN_OPUS_CAPACITY = 1;
 const MAX_OPUS_CAPACITY = 32;
+
+// Time a waiter must sit in the queue before it is bumped one tier toward p0.
+// Five minutes per the [PMSA-11] §3.2 starvation-prevention requirement.
+export const AGENT_PRIORITY_TIER_AGING_INTERVAL_MS = 5 * 60 * 1000;
 
 export type ProviderSlotKey =
   `${string}:${typeof OPUS_PROVIDER}:${typeof OPUS_MODEL_FAMILY}`;
@@ -26,6 +44,10 @@ interface Waiter {
   resolve: () => void;
   reject: (err: Error) => void;
   enqueuedAt: number;
+  // Tier captured at enqueue time. agedTier folds in any aging promotions
+  // applied since enqueue so we keep the original priority for telemetry.
+  initialTier: AgentPriorityTier;
+  agedTier: AgentPriorityTier;
 }
 
 const inflight = new Map<ProviderSlotKey, Set<string>>();
@@ -71,6 +93,61 @@ export function resolveOpusConcurrencyCapacity(
 
 export interface AcquireProviderSlotOptions {
   signal?: AbortSignal;
+  priorityTier?: AgentPriorityTier;
+  // Override for tests so we don't have to advance real clock 5 minutes.
+  agingIntervalMs?: number;
+  now?: () => number;
+}
+
+// Compares two waiters under the (tier asc, enqueuedAt asc) ordering used
+// for both queue insertion and pop selection. Returns negative if `a` should
+// be served first, positive if `b`, zero if tied.
+function compareWaiters(a: Waiter, b: Waiter): number {
+  const tierDelta =
+    agentPriorityTierRank(a.agedTier) - agentPriorityTierRank(b.agedTier);
+  if (tierDelta !== 0) return tierDelta;
+  return a.enqueuedAt - b.enqueuedAt;
+}
+
+// Re-applies aging to every waiter in the queue. Called immediately before
+// any selection (insert or pop) so the queue is always evaluated against the
+// freshest aging snapshot. O(n) — n is bounded by number of agents per
+// company, so cheap in practice.
+function applyAgingToQueue(
+  queue: Waiter[],
+  now: number,
+  agingIntervalMs: number,
+): void {
+  if (agingIntervalMs <= 0) return;
+  for (const waiter of queue) {
+    const waited = now - waiter.enqueuedAt;
+    if (waited <= 0) continue;
+    const bumps = Math.floor(waited / agingIntervalMs);
+    if (bumps <= 0) continue;
+    const initialIdx = agentPriorityTierRank(waiter.initialTier);
+    const targetIdx = Math.max(0, initialIdx - bumps);
+    const targetTier = AGENT_PRIORITY_TIERS[targetIdx];
+    if (
+      agentPriorityTierRank(targetTier) < agentPriorityTierRank(waiter.agedTier)
+    ) {
+      waiter.agedTier = targetTier;
+    }
+  }
+}
+
+// Insert a waiter while keeping the queue sorted by (agedTier asc,
+// enqueuedAt asc). Linear scan from the back since most arrivals share the
+// p2 default tier and append-at-tail is the common case.
+function insertWaiterOrdered(queue: Waiter[], waiter: Waiter): void {
+  let insertAt = queue.length;
+  for (let i = queue.length - 1; i >= 0; i--) {
+    if (compareWaiters(queue[i], waiter) <= 0) {
+      insertAt = i + 1;
+      break;
+    }
+    insertAt = i;
+  }
+  queue.splice(insertAt, 0, waiter);
 }
 
 export async function acquireProviderSlot(
@@ -93,15 +170,22 @@ export async function acquireProviderSlot(
     return;
   }
 
+  const now = options.now ? options.now() : Date.now();
+  const agingIntervalMs =
+    options.agingIntervalMs ?? AGENT_PRIORITY_TIER_AGING_INTERVAL_MS;
+  const initialTier = options.priorityTier ?? DEFAULT_AGENT_PRIORITY_TIER;
   const queue = waiters.get(key) ?? [];
   return new Promise<void>((resolve, reject) => {
     const waiter: Waiter = {
       runId,
       resolve,
       reject,
-      enqueuedAt: Date.now(),
+      enqueuedAt: now,
+      initialTier,
+      agedTier: initialTier,
     };
-    queue.push(waiter);
+    applyAgingToQueue(queue, now, agingIntervalMs);
+    insertWaiterOrdered(queue, waiter);
     waiters.set(key, queue);
 
     if (options.signal) {
@@ -129,10 +213,25 @@ export async function acquireProviderSlot(
   });
 }
 
+export interface ReleaseProviderSlotOptions {
+  // Override for tests so we don't have to advance real clock 5 minutes.
+  agingIntervalMs?: number;
+  now?: () => number;
+}
+
+export interface ReleaseProviderSlotResult {
+  released: boolean;
+  promotedRunId: string | null;
+  promotedTier: AgentPriorityTier | null;
+  promotedInitialTier: AgentPriorityTier | null;
+  promotedWaitedMs: number | null;
+}
+
 export function releaseProviderSlot(
   key: ProviderSlotKey,
   runId: string,
-): { released: boolean; promotedRunId: string | null } {
+  options: ReleaseProviderSlotOptions = {},
+): ReleaseProviderSlotResult {
   const occupants = inflight.get(key);
   let released = false;
   if (occupants?.delete(runId)) {
@@ -142,18 +241,40 @@ export function releaseProviderSlot(
 
   const queue = waiters.get(key);
   if (!queue || queue.length === 0) {
-    return { released, promotedRunId: null };
+    return {
+      released,
+      promotedRunId: null,
+      promotedTier: null,
+      promotedInitialTier: null,
+      promotedWaitedMs: null,
+    };
   }
 
-  // Promote the next waiter so the slot is handed off without a tick gap.
-  const nextOccupants = inflight.get(key) ?? new Set<string>();
+  // Re-evaluate aging right before the pick so a waiter that has crossed
+  // the aging threshold while sitting at the back is promoted before the
+  // selection runs.
+  const now = options.now ? options.now() : Date.now();
+  const agingIntervalMs =
+    options.agingIntervalMs ?? AGENT_PRIORITY_TIER_AGING_INTERVAL_MS;
+  applyAgingToQueue(queue, now, agingIntervalMs);
+  queue.sort(compareWaiters);
+
   const next = queue.shift()!;
   if (queue.length === 0) waiters.delete(key);
   else waiters.set(key, queue);
+
+  const nextOccupants = inflight.get(key) ?? new Set<string>();
   nextOccupants.add(next.runId);
   inflight.set(key, nextOccupants);
   next.resolve();
-  return { released, promotedRunId: next.runId };
+
+  return {
+    released,
+    promotedRunId: next.runId,
+    promotedTier: next.agedTier,
+    promotedInitialTier: next.initialTier,
+    promotedWaitedMs: now - next.enqueuedAt,
+  };
 }
 
 export function getInflightCount(key: ProviderSlotKey): number {
@@ -166,7 +287,11 @@ export function getWaiterCount(key: ProviderSlotKey): number {
 
 export interface ProviderSemaphoreSnapshot {
   inflight: Array<{ key: ProviderSlotKey; runIds: string[] }>;
-  waiting: Array<{ key: ProviderSlotKey; runIds: string[] }>;
+  waiting: Array<{
+    key: ProviderSlotKey;
+    runIds: string[];
+    tiers: AgentPriorityTier[];
+  }>;
 }
 
 export function snapshotProviderSemaphore(): ProviderSemaphoreSnapshot {
@@ -178,8 +303,28 @@ export function snapshotProviderSemaphore(): ProviderSemaphoreSnapshot {
     waiting: Array.from(waiters.entries()).map(([key, list]) => ({
       key,
       runIds: list.map((w) => w.runId),
+      tiers: list.map((w) => w.agedTier),
     })),
   };
+}
+
+// Bumps a known waiter one tier toward p0. Currently exposed so tests and
+// future explicit-promotion paths (manual ops escalation) can shortcut the
+// time-based aging logic. No-op when the waiter is already at p0.
+export function bumpWaiterPriority(
+  key: ProviderSlotKey,
+  runId: string,
+): { promoted: boolean; tier: AgentPriorityTier | null } {
+  const queue = waiters.get(key);
+  if (!queue) return { promoted: false, tier: null };
+  const waiter = queue.find((w) => w.runId === runId);
+  if (!waiter) return { promoted: false, tier: null };
+  const next = bumpAgentPriorityTier(waiter.agedTier);
+  if (next === waiter.agedTier)
+    return { promoted: false, tier: waiter.agedTier };
+  waiter.agedTier = next;
+  queue.sort(compareWaiters);
+  return { promoted: true, tier: next };
 }
 
 // Called at server bootstrap. The in-memory map is naturally empty after a

--- a/server/src/services/provider-semaphore.ts
+++ b/server/src/services/provider-semaphore.ts
@@ -1,0 +1,214 @@
+// Company-wide concurrency semaphore for Opus model invocations.
+//
+// Acts as an in-process gate that throttles `claude_local` adapter executions
+// per company so the shared Anthropic Opus quota is not blown by simultaneous
+// agent runs. Other adapters (codex, gemini, ...) and non-Opus Claude models
+// bypass the gate entirely.
+//
+// Design notes:
+// - State lives in-memory; the Paperclip server is single-process today.
+// - Process restart drops all waiters, but heartbeat_runs.queued is persisted
+//   in DB and `startNextQueuedRunForAgent()` will re-pick those on next tick.
+// - FIFO ordering only. Per-agent priority is layered on in PMSA-17 (Phase 2-B).
+
+const OPUS_PROVIDER = "anthropic" as const;
+const OPUS_MODEL_FAMILY = "opus" as const;
+
+const DEFAULT_OPUS_CAPACITY = 2;
+const MIN_OPUS_CAPACITY = 1;
+const MAX_OPUS_CAPACITY = 32;
+
+export type ProviderSlotKey =
+  `${string}:${typeof OPUS_PROVIDER}:${typeof OPUS_MODEL_FAMILY}`;
+
+interface Waiter {
+  runId: string;
+  resolve: () => void;
+  reject: (err: Error) => void;
+  enqueuedAt: number;
+}
+
+const inflight = new Map<ProviderSlotKey, Set<string>>();
+const waiters = new Map<ProviderSlotKey, Waiter[]>();
+
+export function buildOpusSlotKey(companyId: string): ProviderSlotKey {
+  return `${companyId}:${OPUS_PROVIDER}:${OPUS_MODEL_FAMILY}` as ProviderSlotKey;
+}
+
+export function isOpusModel(model: string | null | undefined): boolean {
+  if (!model) return false;
+  const normalized = model.toLowerCase();
+  // Anthropic-style ids: "claude-opus-4-7", "claude-opus-4-6"
+  if (normalized.startsWith("claude-opus-")) return true;
+  // Bedrock-style ids: "us.anthropic.claude-opus-4-6-v1", ARN with .claude-opus-...
+  if (normalized.includes("anthropic.claude-opus-")) return true;
+  return false;
+}
+
+export function shouldThrottleProviderRun(input: {
+  adapterType: string;
+  model: string | null | undefined;
+}): boolean {
+  if (input.adapterType !== "claude_local") return false;
+  return isOpusModel(input.model);
+}
+
+export function resolveOpusConcurrencyCapacity(
+  metadata: Record<string, unknown> | null | undefined,
+): number {
+  const raw =
+    metadata && typeof metadata === "object"
+      ? (metadata as Record<string, unknown>).opusConcurrencyMax
+      : undefined;
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return DEFAULT_OPUS_CAPACITY;
+  }
+  const truncated = Math.trunc(raw);
+  if (truncated < MIN_OPUS_CAPACITY) return MIN_OPUS_CAPACITY;
+  if (truncated > MAX_OPUS_CAPACITY) return MAX_OPUS_CAPACITY;
+  return truncated;
+}
+
+export interface AcquireProviderSlotOptions {
+  signal?: AbortSignal;
+}
+
+export async function acquireProviderSlot(
+  key: ProviderSlotKey,
+  runId: string,
+  capacity: number,
+  options: AcquireProviderSlotOptions = {},
+): Promise<void> {
+  if (capacity < MIN_OPUS_CAPACITY) capacity = MIN_OPUS_CAPACITY;
+
+  const occupants = inflight.get(key) ?? new Set<string>();
+  if (occupants.has(runId)) {
+    // Already holds a slot — re-entrant acquire is a no-op so callers can be
+    // safely retried from defensive try/finally blocks.
+    return;
+  }
+  if (occupants.size < capacity) {
+    occupants.add(runId);
+    inflight.set(key, occupants);
+    return;
+  }
+
+  const queue = waiters.get(key) ?? [];
+  return new Promise<void>((resolve, reject) => {
+    const waiter: Waiter = {
+      runId,
+      resolve,
+      reject,
+      enqueuedAt: Date.now(),
+    };
+    queue.push(waiter);
+    waiters.set(key, queue);
+
+    if (options.signal) {
+      const onAbort = () => {
+        const current = waiters.get(key);
+        if (!current) return;
+        const idx = current.indexOf(waiter);
+        if (idx >= 0) {
+          current.splice(idx, 1);
+          if (current.length === 0) waiters.delete(key);
+          else waiters.set(key, current);
+        }
+        reject(
+          options.signal?.reason instanceof Error
+            ? options.signal.reason
+            : new Error("acquireProviderSlot aborted"),
+        );
+      };
+      if (options.signal.aborted) {
+        onAbort();
+        return;
+      }
+      options.signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
+export function releaseProviderSlot(
+  key: ProviderSlotKey,
+  runId: string,
+): { released: boolean; promotedRunId: string | null } {
+  const occupants = inflight.get(key);
+  let released = false;
+  if (occupants?.delete(runId)) {
+    released = true;
+    if (occupants.size === 0) inflight.delete(key);
+  }
+
+  const queue = waiters.get(key);
+  if (!queue || queue.length === 0) {
+    return { released, promotedRunId: null };
+  }
+
+  // Promote the next waiter so the slot is handed off without a tick gap.
+  const nextOccupants = inflight.get(key) ?? new Set<string>();
+  const next = queue.shift()!;
+  if (queue.length === 0) waiters.delete(key);
+  else waiters.set(key, queue);
+  nextOccupants.add(next.runId);
+  inflight.set(key, nextOccupants);
+  next.resolve();
+  return { released, promotedRunId: next.runId };
+}
+
+export function getInflightCount(key: ProviderSlotKey): number {
+  return inflight.get(key)?.size ?? 0;
+}
+
+export function getWaiterCount(key: ProviderSlotKey): number {
+  return waiters.get(key)?.length ?? 0;
+}
+
+export interface ProviderSemaphoreSnapshot {
+  inflight: Array<{ key: ProviderSlotKey; runIds: string[] }>;
+  waiting: Array<{ key: ProviderSlotKey; runIds: string[] }>;
+}
+
+export function snapshotProviderSemaphore(): ProviderSemaphoreSnapshot {
+  return {
+    inflight: Array.from(inflight.entries()).map(([key, set]) => ({
+      key,
+      runIds: Array.from(set),
+    })),
+    waiting: Array.from(waiters.entries()).map(([key, list]) => ({
+      key,
+      runIds: list.map((w) => w.runId),
+    })),
+  };
+}
+
+// Called at server bootstrap. The in-memory map is naturally empty after a
+// process restart, so this only matters when something has put state in
+// `inflight` before bootstrap completes (tests, hot-reload). It also rejects
+// any stranded waiters so leftover callers do not hang forever.
+export function releaseStaleInflightSlots(): {
+  inflightCleared: number;
+  waitersRejected: number;
+} {
+  let inflightCleared = 0;
+  for (const set of inflight.values()) inflightCleared += set.size;
+  inflight.clear();
+
+  let waitersRejected = 0;
+  for (const queue of waiters.values()) {
+    for (const waiter of queue) {
+      waitersRejected++;
+      waiter.reject(new Error("provider semaphore reset on bootstrap"));
+    }
+  }
+  waiters.clear();
+
+  return { inflightCleared, waitersRejected };
+}
+
+// Test-only: forcibly clears all state without calling waiter rejectors.
+// Useful when a test wants a clean slate without observing the rejection.
+export function __resetProviderSemaphoreForTests(): void {
+  inflight.clear();
+  waiters.clear();
+}

--- a/server/src/services/quota-incidents.ts
+++ b/server/src/services/quota-incidents.ts
@@ -1,0 +1,154 @@
+import { and, desc, eq, gte, inArray } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, heartbeatRuns } from "@paperclipai/db";
+
+// PMSA-15 / PMSA-11 §2.1 / §2.2: granular Claude quota error codes that we want to
+// count separately so the cost dashboard can distinguish auth-token rejections
+// (401) from upstream rate limits (429) from provider 5xx incidents.
+const QUOTA_INCIDENT_ERROR_CODES = [
+  "claude_quota_exhausted",
+  "claude_rate_limited",
+  "claude_provider_5xx",
+] as const;
+
+export type QuotaIncidentErrorCode =
+  (typeof QUOTA_INCIDENT_ERROR_CODES)[number];
+
+export interface QuotaIncidentAgentBreakdown {
+  agentId: string;
+  agentName: string | null;
+  count: number;
+  countByCode: Record<QuotaIncidentErrorCode, number>;
+  lastAt: Date | null;
+}
+
+export interface QuotaIncidentsResult {
+  windowMinutes: number;
+  windowStart: Date;
+  windowEnd: Date;
+  total: number;
+  totalByCode: Record<QuotaIncidentErrorCode, number>;
+  oldestAt: Date | null;
+  newestAt: Date | null;
+  byAgent: QuotaIncidentAgentBreakdown[];
+}
+
+export const DEFAULT_QUOTA_INCIDENT_WINDOW_MINUTES = 30;
+export const MAX_QUOTA_INCIDENT_WINDOW_MINUTES = 24 * 60;
+
+function emptyCountByCode(): Record<QuotaIncidentErrorCode, number> {
+  return {
+    claude_quota_exhausted: 0,
+    claude_rate_limited: 0,
+    claude_provider_5xx: 0,
+  };
+}
+
+export function clampQuotaIncidentWindowMinutes(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.min(Math.floor(value), MAX_QUOTA_INCIDENT_WINDOW_MINUTES);
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.min(parsed, MAX_QUOTA_INCIDENT_WINDOW_MINUTES);
+    }
+  }
+  return DEFAULT_QUOTA_INCIDENT_WINDOW_MINUTES;
+}
+
+/**
+ * PMSA-15 / PMSA-11 §2.2: aggregate recent Claude quota-shaped incidents for a
+ * company. The result is intentionally small and decision-ready for the costs
+ * dashboard and the future board-notification watcher (Phase 3).
+ */
+export function quotaIncidentsService(db: Db) {
+  return {
+    async listRecent(
+      companyId: string,
+      options: { windowMinutes?: number; now?: Date } = {},
+    ): Promise<QuotaIncidentsResult> {
+      const windowMinutes = clampQuotaIncidentWindowMinutes(
+        options.windowMinutes ?? DEFAULT_QUOTA_INCIDENT_WINDOW_MINUTES,
+      );
+      const windowEnd = options.now ?? new Date();
+      const windowStart = new Date(
+        windowEnd.getTime() - windowMinutes * 60 * 1000,
+      );
+
+      const rows = await db
+        .select({
+          agentId: heartbeatRuns.agentId,
+          errorCode: heartbeatRuns.errorCode,
+          finishedAt: heartbeatRuns.finishedAt,
+          agentName: agents.name,
+        })
+        .from(heartbeatRuns)
+        .leftJoin(agents, eq(agents.id, heartbeatRuns.agentId))
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, companyId),
+            inArray(heartbeatRuns.errorCode, [...QUOTA_INCIDENT_ERROR_CODES]),
+            gte(heartbeatRuns.finishedAt, windowStart),
+          ),
+        )
+        .orderBy(desc(heartbeatRuns.finishedAt));
+
+      const totalByCode = emptyCountByCode();
+      const byAgentMap = new Map<string, QuotaIncidentAgentBreakdown>();
+      let oldestAt: Date | null = null;
+      let newestAt: Date | null = null;
+
+      for (const row of rows) {
+        const code = row.errorCode as QuotaIncidentErrorCode | null;
+        if (!code || !QUOTA_INCIDENT_ERROR_CODES.includes(code)) continue;
+
+        totalByCode[code] += 1;
+
+        const finishedAt = row.finishedAt ?? null;
+        if (finishedAt) {
+          if (!newestAt || finishedAt > newestAt) newestAt = finishedAt;
+          if (!oldestAt || finishedAt < oldestAt) oldestAt = finishedAt;
+        }
+
+        const existing = byAgentMap.get(row.agentId) ?? {
+          agentId: row.agentId,
+          agentName: row.agentName ?? null,
+          count: 0,
+          countByCode: emptyCountByCode(),
+          lastAt: null,
+        };
+        existing.count += 1;
+        existing.countByCode[code] += 1;
+        if (finishedAt && (!existing.lastAt || finishedAt > existing.lastAt)) {
+          existing.lastAt = finishedAt;
+        }
+        if (!existing.agentName && row.agentName) {
+          existing.agentName = row.agentName;
+        }
+        byAgentMap.set(row.agentId, existing);
+      }
+
+      const byAgent = [...byAgentMap.values()].sort(
+        (a, b) => b.count - a.count,
+      );
+      const total =
+        totalByCode.claude_quota_exhausted +
+        totalByCode.claude_rate_limited +
+        totalByCode.claude_provider_5xx;
+
+      return {
+        windowMinutes,
+        windowStart,
+        windowEnd,
+        total,
+        totalByCode,
+        oldestAt,
+        newestAt,
+        byAgent,
+      };
+    },
+  };
+}
+
+export type QuotaIncidentsService = ReturnType<typeof quotaIncidentsService>;

--- a/server/src/services/quota-priority-backfill.ts
+++ b/server/src/services/quota-priority-backfill.ts
@@ -1,0 +1,89 @@
+// Backfills `agents.metadata.priorityTier` for any agent that does not yet
+// have a valid value. Runs once at server bootstrap so the existing 5-agent
+// MVP (CEO / Engineer / PRDWriter / InsightAnalyst / TechResearcher) gets
+// tier values without requiring a SQL migration. Idempotent: agents that
+// already carry a valid tier are skipped.
+//
+// PMSA-17 / [PMSA-11] §3.2 — applies the role/name defaults defined in
+// shared/constants.ts (AGENT_PRIORITY_TIER_DEFAULTS_BY_ROLE plus the small
+// AGENT_PRIORITY_TIER_NAME_OVERRIDES map).
+
+import { eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents } from "@paperclipai/db";
+import {
+  type AgentPriorityTier,
+  isAgentPriorityTier,
+  resolveDefaultAgentPriorityTier,
+} from "@paperclipai/shared";
+
+export interface QuotaPriorityBackfillRow {
+  agentId: string;
+  companyId: string;
+  name: string;
+  role: string;
+  priorityTier: AgentPriorityTier;
+}
+
+export interface QuotaPriorityBackfillResult {
+  scanned: number;
+  updated: QuotaPriorityBackfillRow[];
+  skipped: number;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function backfillAgentPriorityTiers(
+  db: Db,
+): Promise<QuotaPriorityBackfillResult> {
+  const rows = await db
+    .select({
+      id: agents.id,
+      companyId: agents.companyId,
+      name: agents.name,
+      role: agents.role,
+      metadata: agents.metadata,
+      status: agents.status,
+    })
+    .from(agents);
+
+  const updates: QuotaPriorityBackfillRow[] = [];
+  let skipped = 0;
+
+  for (const row of rows) {
+    // Terminated agents stay as-is — no need to dirty their config.
+    if (row.status === "terminated") {
+      skipped++;
+      continue;
+    }
+
+    const metadata = isPlainRecord(row.metadata) ? row.metadata : null;
+    if (metadata && isAgentPriorityTier(metadata.priorityTier)) {
+      skipped++;
+      continue;
+    }
+
+    const tier = resolveDefaultAgentPriorityTier({
+      role: row.role,
+      name: row.name,
+    });
+    const nextMetadata = { ...(metadata ?? {}), priorityTier: tier };
+
+    await db
+      .update(agents)
+      .set({ metadata: nextMetadata, updatedAt: new Date() })
+      .where(eq(agents.id, row.id));
+
+    updates.push({
+      agentId: row.id,
+      companyId: row.companyId,
+      name: row.name,
+      role: row.role,
+      priorityTier: tier,
+    });
+  }
+
+  return { scanned: rows.length, updated: updates, skipped };
+}

--- a/ui/src/components/AgentProperties.tsx
+++ b/ui/src/components/AgentProperties.tsx
@@ -1,6 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@/lib/router";
-import { AGENT_ROLE_LABELS, type Agent, type AgentRuntimeState } from "@paperclipai/shared";
+import {
+  AGENT_PRIORITY_TIER_LABELS,
+  AGENT_ROLE_LABELS,
+  readAgentPriorityTier,
+  type Agent,
+  type AgentPriorityTier,
+  type AgentRuntimeState,
+} from "@paperclipai/shared";
 import { agentsApi } from "../api/agents";
 import { useCompany } from "../context/CompanyContext";
 import { getAdapterLabel } from "../adapters/adapter-display-registry";
@@ -9,6 +16,7 @@ import { StatusBadge } from "./StatusBadge";
 import { Identity } from "./Identity";
 import { formatDate, agentUrl } from "../lib/utils";
 import { Separator } from "@/components/ui/separator";
+import { Badge } from "@/components/ui/badge";
 
 interface AgentPropertiesProps {
   agent: Agent;
@@ -17,11 +25,31 @@ interface AgentPropertiesProps {
 
 const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;
 
-function PropertyRow({ label, children }: { label: string; children: React.ReactNode }) {
+const PRIORITY_TIER_BADGE_VARIANT: Record<
+  AgentPriorityTier,
+  "default" | "secondary" | "outline"
+> = {
+  p0: "default",
+  p1: "default",
+  p2: "secondary",
+  p3: "outline",
+};
+
+function PropertyRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="flex items-start gap-3 py-1.5">
-      <span className="text-xs text-muted-foreground shrink-0 w-20 mt-0.5">{label}</span>
-      <div className="flex items-center gap-1.5 min-w-0 flex-1 flex-wrap">{children}</div>
+      <span className="text-xs text-muted-foreground shrink-0 w-20 mt-0.5">
+        {label}
+      </span>
+      <div className="flex items-center gap-1.5 min-w-0 flex-1 flex-wrap">
+        {children}
+      </div>
     </div>
   );
 }
@@ -35,7 +63,14 @@ export function AgentProperties({ agent, runtimeState }: AgentPropertiesProps) {
     enabled: !!selectedCompanyId && !!agent.reportsTo,
   });
 
-  const reportsToAgent = agent.reportsTo ? agents?.find((a) => a.id === agent.reportsTo) : null;
+  const reportsToAgent = agent.reportsTo
+    ? agents?.find((a) => a.id === agent.reportsTo)
+    : null;
+
+  const priorityTier = readAgentPriorityTier(agent.metadata, {
+    role: agent.role,
+    name: agent.name,
+  });
 
   return (
     <div className="space-y-4">
@@ -44,7 +79,22 @@ export function AgentProperties({ agent, runtimeState }: AgentPropertiesProps) {
           <StatusBadge status={agent.status} />
         </PropertyRow>
         <PropertyRow label="Role">
-          <span className="text-sm">{roleLabels[agent.role] ?? agent.role}</span>
+          <span className="text-sm">
+            {roleLabels[agent.role] ?? agent.role}
+          </span>
+        </PropertyRow>
+        <PropertyRow label="Priority">
+          <Badge
+            variant={PRIORITY_TIER_BADGE_VARIANT[priorityTier]}
+            className="text-xs font-mono uppercase tracking-wide"
+            aria-label={`Opus quota priority tier ${priorityTier}`}
+            title={AGENT_PRIORITY_TIER_LABELS[priorityTier]}
+          >
+            {priorityTier}
+          </Badge>
+          <span className="text-xs text-muted-foreground">
+            {AGENT_PRIORITY_TIER_LABELS[priorityTier].replace(/^p\d\s—\s/i, "")}
+          </span>
         </PropertyRow>
         {agent.title && (
           <PropertyRow label="Title">
@@ -52,7 +102,9 @@ export function AgentProperties({ agent, runtimeState }: AgentPropertiesProps) {
           </PropertyRow>
         )}
         <PropertyRow label="Adapter">
-          <span className="text-sm font-mono">{getAdapterLabel(agent.adapterType)}</span>
+          <span className="text-sm font-mono">
+            {getAdapterLabel(agent.adapterType)}
+          </span>
         </PropertyRow>
       </div>
 
@@ -62,13 +114,18 @@ export function AgentProperties({ agent, runtimeState }: AgentPropertiesProps) {
         {(runtimeState?.sessionDisplayId ?? runtimeState?.sessionId) && (
           <PropertyRow label="Session">
             <span className="text-xs font-mono">
-              {String(runtimeState.sessionDisplayId ?? runtimeState.sessionId).slice(0, 12)}...
+              {String(
+                runtimeState.sessionDisplayId ?? runtimeState.sessionId,
+              ).slice(0, 12)}
+              ...
             </span>
           </PropertyRow>
         )}
         {runtimeState?.lastError && (
           <PropertyRow label="Last error">
-            <span className="text-xs text-red-600 dark:text-red-400 break-words min-w-0">{runtimeState.lastError}</span>
+            <span className="text-xs text-red-600 dark:text-red-400 break-words min-w-0">
+              {runtimeState.lastError}
+            </span>
           </PropertyRow>
         )}
         {agent.lastHeartbeatAt && (
@@ -83,7 +140,9 @@ export function AgentProperties({ agent, runtimeState }: AgentPropertiesProps) {
                 <Identity name={reportsToAgent.name} size="sm" />
               </Link>
             ) : (
-              <span className="text-sm font-mono">{agent.reportsTo.slice(0, 8)}</span>
+              <span className="text-sm font-mono">
+                {agent.reportsTo.slice(0, 8)}
+              </span>
             )}
           </PropertyRow>
         )}


### PR DESCRIPTION
## Summary

Implements PMSA-11 §3.3: separate the quota / rate-limit retry contract from the generic `transient_upstream` backoff and freeze the executing issue once the bounded retry budget is exhausted.

- New `BOUNDED_TRANSIENT_QUOTA_RETRY_DELAYS_MS = [60s, 240s, 900s]`. `claude_quota_exhausted` and `claude_rate_limited` now route through this 3-attempt schedule; everything else (`claude_provider_5xx`, `claude_transient_upstream`, `codex_transient_upstream`, generic `adapter_failed`) keeps the legacy 4-step 2/10/30/120-min schedule.
- On exhaustion, the executing issue is moved to `blocked`, a board-readable comment is posted, and a structured `quotaRetryExhausted` lifecycle run event is emitted as the pickup signal for the future Phase 3 watcher (PMSA-19).
- Already-blocked / cancelled issues are left untouched; only the lifecycle event is emitted in that branch (no duplicate user-facing comment).
- Generic `transient_upstream` exhaustion keeps prior behavior (no issue status change).
- Anthropic-`Retry-After` hints (carried through `resultJson.retryNotBefore` by PMSA-15) still override the base schedule when later than the quota backoff target.

### Board comment rewrite (CEO follow-up)

The auto-posted blocker comment is rewritten in plain operator language:

- Lead with what happened (`This agent hit Anthropic's Opus quota limit N times in a row`) instead of the raw error code.
- Replace the internal spec cross-reference with concrete actions: wait for quota to roll over, or open agent settings and switch provider to a fallback (Sonnet / Bedrock), then move the issue back to `todo`.
- When `resultJson.retryNotBefore` is present, surface it as `Expected to clear after <ISO timestamp>` so the board has a concrete recovery window. Falls back to a generic "rolls over within hours" line otherwise.
- `claude_rate_limited` keeps the "Anthropic API rate limit" label switch.

## Stacking

This PR stacks on #4488 (PMSA-15). Review / merge order: `#4488` → this PR. The branch contains PMSA-15/16/17/18 commits; once #4488 lands, this PR will rebase down to just the PMSA-16/17/18 deltas.

## Test plan

- [x] `pnpm exec vitest run server/src/__tests__/heartbeat-quota-backoff.test.ts` — pure-function unit suite that pins the 60s/240s/900s delays and the cap behavior. Runs without embedded Postgres. Pass on this host.
- [ ] `server/src/__tests__/heartbeat-retry-scheduling.test.ts` — embedded-pg integration coverage for quota schedule selection, retry-after override, blocked-on-exhaustion (issue status, comment text, structured event), do-not-overwrite-manual-blocker, and the carve-out that generic `transient_upstream` exhaustion does NOT block the issue. Skipped locally (no `@embedded-postgres/darwin-arm64` binary on this host) — relies on CI to run.
- [ ] Existing server test suite remains green on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
