### PR TITLE
fix: always pass --max-turns to Claude Code

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -329,7 +329,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const model = asString(config.model, "");
   const effort = asString(config.effort, "");
   const chrome = asBoolean(config.chrome, false);
-  const maxTurns = asNumber(config.maxTurnsPerRun, 0);
+  const maxTurns = asNumber(config.maxTurnsPerRun, 0) || 1000;
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -153,7 +153,7 @@ export async function testEnvironment(
       const model = asString(config.model, "").trim();
       const effort = asString(config.effort, "").trim();
       const chrome = asBoolean(config.chrome, false);
-      const maxTurns = asNumber(config.maxTurnsPerRun, 0);
+      const maxTurns = asNumber(config.maxTurnsPerRun, 0) || 1000;
       const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
       const extraArgs = (() => {
         const fromExtraArgs = asStringArray(config.extraArgs);


### PR DESCRIPTION
## Thinking Path

> - When `maxTurnsPerRun` is unset or 0 in an agent's config, the adapter previously omitted `--max-turns` from the Claude Code invocation. That sounds harmless ("let the runtime decide"), but Claude Code's own default is 50 — too low for most agent runs, especially Engineering/CTO roles working through multi-step issues.
> - Symptom in production: long-form agents would silently truncate at turn 50 without an obvious failure mode; operators saw "task incomplete" outputs and re-queued work.
> - Fix: when the config doesn't specify a value (or specifies 0), fall back to 1000, which matches the UI placeholder and the company-portability default. This makes the run behavior explicit rather than implicit on adapter quirks, and preserves operator control via the explicit per-agent setting.

## What Changed

- `packages/adapters/claude-local/src/server/execute.ts`: `maxTurns: cfg.maxTurnsPerRun || 1000` instead of conditionally omitting.
- `packages/adapters/claude-local/src/server/test.ts`: mirror change in the test/dry-run path.

Two-line change, one logical fix.

## Verification

- pnpm -r typecheck ✅
- pnpm test:run ✅
- pnpm build ✅
- Production: agents that previously truncated at 50 now run to completion; operators see explicit `--max-turns 1000` in run command logs.

## Risks

- Agents that *intentionally* relied on 50 (none observed in our deployment) would now run longer. Operators retain explicit control via `maxTurnsPerRun`; setting any positive integer overrides the fallback.
- Companion to the proactive session-rotation PR, which lowers the *default* for new agents to 200 — operators who want short runs configure that; the 1000 fallback only applies when nothing is set.

## Checklist

- [x] Behaviour matches spec
- [x] `pnpm -r typecheck` passes
- [x] `pnpm test:run` passes
- [x] `pnpm build` passes
- [x] Contracts in sync across layers

Split out from #4472 (CI/CD foundation) per Greptile review — kept focused on a single behavior fix with no unrelated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)