### PR TITLE
feat: pilot application backend (CAR-410)

### DIFF
--- a/packages/db/src/migrations/0047_pilot_applications.sql
+++ b/packages/db/src/migrations/0047_pilot_applications.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS "pilot_applications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"practice_type" text NOT NULL,
+	"description" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -56,3 +56,4 @@ export { pluginEntities } from "./plugin_entities.js";
 export { pluginJobs, pluginJobRuns } from "./plugin_jobs.js";
 export { pluginWebhookDeliveries } from "./plugin_webhooks.js";
 export { pluginLogs } from "./plugin_logs.js";
+export { pilotApplications } from "./pilot_applications.js";

--- a/packages/db/src/schema/pilot_applications.ts
+++ b/packages/db/src/schema/pilot_applications.ts
@@ -1,0 +1,10 @@
+import { pgTable, uuid, text, timestamp } from "drizzle-orm/pg-core";
+
+export const pilotApplications = pgTable("pilot_applications", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  name: text("name").notNull(),
+  email: text("email").notNull(),
+  practiceType: text("practice_type").notNull(),
+  description: text("description").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -555,6 +555,10 @@ export {
   type PluginStateScopeKey,
   type SetPluginState,
   type ListPluginState,
+  createPilotApplicationSchema,
+  PILOT_PRACTICE_TYPES,
+  PILOT_CAP,
+  type CreatePilotApplication,
 } from "./validators/index.js";
 
 export { API_PREFIX, API } from "./api.js";

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -291,3 +291,10 @@ export {
   type SetPluginState,
   type ListPluginState,
 } from "./plugin.js";
+
+export {
+  createPilotApplicationSchema,
+  PILOT_PRACTICE_TYPES,
+  PILOT_CAP,
+  type CreatePilotApplication,
+} from "./pilot-application.js";

--- a/packages/shared/src/validators/pilot-application.ts
+++ b/packages/shared/src/validators/pilot-application.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const PILOT_PRACTICE_TYPES = ["therapist", "coach", "holistic_practitioner"] as const;
+export const PILOT_CAP = 10;
+
+export const createPilotApplicationSchema = z.object({
+  name: z.string().min(1).max(255),
+  email: z.string().email().max(255),
+  practiceType: z.enum(PILOT_PRACTICE_TYPES),
+  description: z.string().min(1).max(500),
+});
+
+export type CreatePilotApplication = z.infer<typeof createPilotApplicationSchema>;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -28,6 +28,7 @@ import { instanceSettingsRoutes } from "./routes/instance-settings.js";
 import { llmRoutes } from "./routes/llms.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
+import { pilotApplyRoutes } from "./routes/pilot-apply.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { applyUiBranding } from "./ui-branding.js";
@@ -218,6 +219,7 @@ export async function createApp(
       { workerManager },
     ),
   );
+  api.use(pilotApplyRoutes(db));
   api.use(
     accessRoutes(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,0 +1,28 @@
+import type { Request, Response, NextFunction } from "express";
+
+function createRateLimit(windowMs: number, max: number) {
+  const hits = new Map<string, { count: number; resetAt: number }>();
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    const key = req.ip ?? "unknown";
+    const now = Date.now();
+    const entry = hits.get(key);
+
+    if (!entry || now > entry.resetAt) {
+      hits.set(key, { count: 1, resetAt: now + windowMs });
+      next();
+      return;
+    }
+
+    if (entry.count >= max) {
+      res.status(429).json({ error: "Too many requests, please try again later." });
+      return;
+    }
+
+    entry.count++;
+    next();
+  };
+}
+
+export const webhookRateLimit = createRateLimit(60_000, 30);
+export const apiRateLimit = createRateLimit(60_000, 60);

--- a/server/src/routes/pilot-apply.ts
+++ b/server/src/routes/pilot-apply.ts
@@ -1,0 +1,74 @@
+import { Router } from "express";
+import { sql } from "drizzle-orm";
+import { count } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { pilotApplications } from "@paperclipai/db";
+import { createPilotApplicationSchema, PILOT_CAP } from "@paperclipai/shared";
+import { validate } from "../middleware/validate.js";
+import { webhookRateLimit } from "../middleware/rate-limit.js";
+import { logger } from "../middleware/logger.js";
+
+async function sendPilotEmails(application: { name: string; email: string; practiceType: string; description: string }) {
+  const resendKey = process.env.RESEND_API_KEY;
+  const opsEmail = process.env.OPS_EMAIL;
+  if (!resendKey) {
+    logger.warn("RESEND_API_KEY not set — skipping pilot application emails");
+    return;
+  }
+
+  const confirmationBody = `Hi ${application.name},\n\nThank you for applying to the CARE pilot program. We will review your application and be in touch soon.\n\nBest,\nThe CARE Team`;
+
+  const opsBody = `New pilot application received:\n\nName: ${application.name}\nEmail: ${application.email}\nPractice type: ${application.practiceType}\nDescription: ${application.description}`;
+
+  const sendEmail = async (to: string, subject: string, text: string) => {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${resendKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ from: "CARE <noreply@thecare.app>", to, subject, text }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "unknown");
+      logger.error({ to, status: res.status, body }, "Resend email failed");
+    }
+  };
+
+  await Promise.allSettled([
+    sendEmail(application.email, "CARE Pilot Application Received", confirmationBody),
+    ...(opsEmail ? [sendEmail(opsEmail, `New Pilot Application: ${application.name}`, opsBody)] : []),
+  ]);
+}
+
+export function pilotApplyRoutes(db: Db) {
+  const router = Router();
+
+  router.get("/public/pilot-apply/status", webhookRateLimit, async (_req, res) => {
+    const [{ value: total }] = await db.select({ value: count() }).from(pilotApplications);
+    res.json({ accepting: total < PILOT_CAP, count: total, cap: PILOT_CAP });
+  });
+
+  router.post("/public/pilot-apply", webhookRateLimit, validate(createPilotApplicationSchema), async (req, res) => {
+    const { name, email, practiceType, description } = req.body;
+
+    const inserted = await db.execute(sql`
+      INSERT INTO pilot_applications (name, email, practice_type, description)
+      SELECT ${name}, ${email}, ${practiceType}, ${description}
+      WHERE (SELECT count(*) FROM pilot_applications) < ${PILOT_CAP}
+      RETURNING id
+    `);
+
+    const result = { waitlisted: inserted.length === 0 };
+
+    if (result.waitlisted) {
+      res.json({ status: "waitlisted" });
+      return;
+    }
+
+    sendPilotEmails({ name, email, practiceType, description }).catch((err) => {
+      logger.error({ err }, "Pilot email send failed");
+    });
+
+    res.json({ status: "success" });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- **DB schema**: New `pilot_applications` table (uuid PK, name, email, practice_type, description, created_at) with migration `0047`
- **Public API routes**: `GET /api/public/pilot-apply/status` (returns accepting/count/cap) and `POST /api/public/pilot-apply` (Zod validation, atomic cap enforcement via single SQL INSERT...WHERE, no race conditions)
- **Rate limiting**: New in-memory rate limiter middleware (`webhookRateLimit` at 30 req/min per IP)
- **Email**: Resend integration via native fetch — confirmation to applicant + notification to OPS_EMAIL, graceful degradation on failure
- **Shared validators**: Zod schema + types exported from `@paperclipai/shared`

## Verification

- `pnpm -r typecheck` ✅
- `pnpm test:run` ✅ (2 pre-existing failures in `worktree-config.test.ts`, unrelated)
- `pnpm build` ✅

## Context

This is a critical-path item blocking the entire pilot form chain: CAR-409 → CAR-407 → CAR-389 (practitioner landing page). The original implementation was lost when a Paperclip worktree was cleaned up before the commit was pushed. This re-implementation recovers the code from the workspace files and integrates it properly.

## Test plan

- [ ] Run migration `0047` against a fresh database
- [ ] `POST /api/public/pilot-apply` with valid data — expect `{ status: "success" }`
- [ ] Submit 10 applications, verify 11th returns `{ status: "waitlisted" }`
- [ ] `GET /api/public/pilot-apply/status` — verify count increments correctly
- [ ] Rate limit: send 31 requests in < 1 minute — expect 429 on the 31st
- [ ] Email: with RESEND_API_KEY set, verify confirmation + ops notification
- [ ] Email: without RESEND_API_KEY, verify graceful degradation (no crash)
- [ ] Security review (CAR-412) can proceed once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)