### PR TITLE
Pass pluginDbId through registerPluginTools so executeTool finds workers

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1826,7 +1826,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,17 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin's unique identifier (manifest id / pluginKey)
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - Database UUID used by the worker manager. Required for
+   *   tool dispatch to find the running worker; falls back to `pluginId` for
+   *   backwards-compat but that path silently breaks `executeTool` since the
+   *   worker manager keys by DB UUID, not by manifest id.
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +434,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Summary

`POST /api/plugins/tools/execute` returns `"worker for plugin "<pluginKey>" is not running"` for any plugin installed or upgraded at runtime, even when the worker is healthy and all other bridge calls (`/actions/:key`, `/data/:key`) succeed against the same worker. Two-line semantic fix.

## Root cause

When a plugin transitions to `ready` via the lifecycle event path (install / upgrade / re-enable), `plugin-loader.ts` calls:

```ts
toolDispatcher.registerPluginTools(pluginKey, manifest);   // 2 args
```

The dispatcher's public `registerPluginTools` signature is also 2-arg, so it forwards to:

```ts
registry.registerPlugin(pluginId, manifest);   // pluginDbId defaults to pluginId
```

`registry.registerPlugin` accepts an optional `pluginDbId` (the database UUID) used by `executeTool` to look up the worker. When omitted, it falls back to the manifest id (`pluginKey`).

At execute time the registry runs:

```ts
if (!workerManager.isRunning(tool.pluginDbId)) {
  throw new Error(`...worker for plugin "${pluginId}" is not running.`);
}
```

But `workerManager` keys workers by their **database UUID**, not by manifest id. The `isRunning(pluginKey)` lookup misses → the dispatcher reports the worker as not running and refuses to dispatch.

The startup-time path (`loadPluginTools`, called at server boot) already passes `plugin.id` (the DB UUID) as the third argument correctly, so this bug only affects plugins installed/upgraded after server start.

## Fix

- Extend `PluginToolDispatcher.registerPluginTools` and its impl with an optional `pluginDbId?: string` and forward it to the underlying registry.
- `plugin-loader.ts` already has `pluginId` (the DB UUID) in scope; pass it as the third argument.

## Backwards compatibility

`pluginDbId` is optional, so any existing caller (in-tree or external) that still passes 2 args keeps the previous (broken) behavior. The doc comment on the interface now explains why callers should always pass it. No behavior change for callers that already pass 3 args (e.g. the existing `loadPluginTools` boot path).

## Verification

Found while exposing an externally-installed plugin's `chat` tool to an agent. With the patch:

- `POST /api/plugins/tools/execute` succeeds end-to-end and returns the tool's result
- `GET /api/plugins/tools` shows the tool with the correct DB UUID under `pluginId`
- No effect on the `/bridge/data` or `/bridge/action` paths (which already worked correctly via the worker manager directly)

## Test plan

- [ ] Install an external plugin that declares a `manifest.tools[]` entry (e.g. via `POST /api/plugins/install` with `isLocalPath:true`)
- [ ] Confirm `GET /api/plugins/tools` returns the tool keyed to the plugin's DB UUID
- [ ] Confirm `POST /api/plugins/tools/execute` reaches the worker and returns a result
- [ ] Without this patch: same calls return `"worker for plugin ... is not running"` even though the worker is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)