### PR TITLE
fix(server): validate X-Paperclip-Run-Id header against UUID regex

### DIFF
--- a/server/src/__tests__/auth-middleware.test.ts
+++ b/server/src/__tests__/auth-middleware.test.ts
@@ -1,0 +1,96 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import type { Db } from "@paperclipai/db";
+import { actorMiddleware } from "../middleware/auth.js";
+import { createLocalAgentJwt } from "../agent-auth-jwt.js";
+import * as boardAuthModule from "../services/board-auth.js";
+
+describe("actorMiddleware run id header validation", () => {
+  const secretEnv = "PAPERCLIP_AGENT_JWT_SECRET";
+  const ttlEnv = "PAPERCLIP_AGENT_JWT_TTL_SECONDS";
+  const originalEnv = {
+    secret: process.env[secretEnv],
+    ttl: process.env[ttlEnv],
+  };
+
+  beforeEach(() => {
+    process.env[secretEnv] = "test-secret";
+    process.env[ttlEnv] = "3600";
+    vi.spyOn(boardAuthModule, "boardAuthService").mockReturnValue({
+      findBoardApiKeyByToken: vi.fn().mockResolvedValue(null),
+      resolveBoardAccess: vi.fn(),
+      touchBoardApiKey: vi.fn(),
+    } as unknown as ReturnType<typeof boardAuthModule.boardAuthService>);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalEnv.secret === undefined) delete process.env[secretEnv];
+    else process.env[secretEnv] = originalEnv.secret;
+    if (originalEnv.ttl === undefined) delete process.env[ttlEnv];
+    else process.env[ttlEnv] = originalEnv.ttl;
+  });
+
+  it("keeps a valid UUID run id header", async () => {
+    const app = express();
+    const db = {} as Db;
+    app.use(actorMiddleware(db, { deploymentMode: "local_trusted" }));
+    app.get("/actor", (req, res) => res.json(req.actor));
+
+    const runId = "11111111-1111-4111-8111-111111111111";
+    const res = await request(app).get("/actor").set("X-Paperclip-Run-Id", runId);
+
+    expect(res.status).toBe(200);
+    expect(res.body.runId).toBe(runId);
+  });
+
+  it("drops a malformed run id header", async () => {
+    const app = express();
+    const db = {} as Db;
+    app.use(actorMiddleware(db, { deploymentMode: "local_trusted" }));
+    app.get("/actor", (req, res) => res.json(req.actor));
+
+    const res = await request(app).get("/actor").set("X-Paperclip-Run-Id", "24916751496-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.runId).toBeUndefined();
+  });
+
+  it("falls back to the JWT run id when the header is malformed", async () => {
+    const agentId = "22222222-2222-4222-8222-222222222222";
+    const companyId = "33333333-3333-4333-8333-333333333333";
+    const jwtRunId = "44444444-4444-4444-8444-444444444444";
+    const token = createLocalAgentJwt(agentId, companyId, "codex_local", jwtRunId);
+    let selectCall = 0;
+    const db = {
+      select: vi.fn(() => {
+        selectCall += 1;
+        const rows =
+          selectCall === 1
+            ? []
+            : [{ id: agentId, companyId, status: "running" }];
+        return {
+          from: vi.fn(() => ({
+            where: vi.fn(() => ({
+              then: async (cb: (value: typeof rows) => unknown) => cb(rows),
+            })),
+          })),
+        };
+      }),
+    } as unknown as Db;
+
+    const app = express();
+    app.use(actorMiddleware(db, { deploymentMode: "authenticated" }));
+    app.get("/actor", (req, res) => res.json(req.actor));
+
+    const res = await request(app)
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", "not-a-uuid");
+
+    expect(res.status).toBe(200);
+    expect(res.body.type).toBe("agent");
+    expect(res.body.runId).toBe(jwtRunId);
+  });
+});

--- a/server/src/__tests__/auth-middleware.test.ts
+++ b/server/src/__tests__/auth-middleware.test.ts
@@ -45,6 +45,19 @@ describe("actorMiddleware run id header validation", () => {
     expect(res.body.runId).toBe(runId);
   });
 
+  it("keeps a valid UUID v7 run id header", async () => {
+    const app = express();
+    const db = {} as Db;
+    app.use(actorMiddleware(db, { deploymentMode: "local_trusted" }));
+    app.get("/actor", (req, res) => res.json(req.actor));
+
+    const runId = "77777777-7777-7777-8777-777777777777";
+    const res = await request(app).get("/actor").set("X-Paperclip-Run-Id", runId);
+
+    expect(res.status).toBe(200);
+    expect(res.body.runId).toBe(runId);
+  });
+
   it("drops a malformed run id header", async () => {
     const app = express();
     const db = {} as Db;

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -9,8 +9,16 @@ import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
+}
+
+function parseRunIdHeader(value: string | undefined) {
+  if (!value) return undefined;
+  const normalized = value.trim();
+  return UUID_RE.test(normalized) ? normalized : undefined;
 }
 
 interface ActorMiddlewareOptions {
@@ -26,7 +34,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         ? { type: "board", userId: "local-board", isInstanceAdmin: true, source: "local_implicit" }
         : { type: "none", source: "none" };
 
-    const runIdHeader = req.header("x-paperclip-run-id");
+    const runIdHeader = parseRunIdHeader(req.header("x-paperclip-run-id") ?? undefined);
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -9,7 +9,7 @@ import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents, and the server middleware decides how request identity and run metadata enter that system.
> - `actorMiddleware` sits on the request boundary for both board and agent callers, so malformed metadata there can poison downstream persistence.
> - `X-Paperclip-Run-Id` is stored in UUID-backed columns, which means accepting arbitrary strings at the header layer can surface as database 500s instead of a safe no-op.
> - MAR-363 addressed that by validating the header before assigning `req.actor.runId`.
> - The first pass used a version-constrained UUID regex, which fixed malformed values like `24916751496-1` but also rejected valid canonical UUID v7 values.
> - This pull request broadens the validation to accept canonical UUID shape regardless of version nibble, while still rejecting malformed non-UUID headers.
> - The benefit is that the middleware stays permissive for legitimate callers, including modern UUID generators, without reintroducing the Postgres failure mode.

## What Changed

- Relaxed the `X-Paperclip-Run-Id` regex in `server/src/middleware/auth.ts` to accept canonical UUID shape without constraining the version nibble to `1-5`
- Added a focused test proving a UUID v7 header is preserved by `actorMiddleware`
- Kept the existing malformed-header rejection and JWT fallback behavior unchanged

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/auth-middleware.test.ts`

## Risks

- Low risk. This slightly broadens accepted UUID variants at the request boundary, but still enforces canonical UUID shape and variant bits, so malformed values continue to be dropped.

## Model Used

- OpenAI GPT-5 Codex via Codex local agent runtime (`gpt-5.4`), with tool use and shell execution in the local workspace

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
