### PR TITLE
feat(inbox): resolve failed runs server-side

### DIFF
--- a/server/src/__tests__/inbox-dismissals.test.ts
+++ b/server/src/__tests__/inbox-dismissals.test.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
 import {
+  activityLog,
   agents,
   approvals,
   companies,
@@ -16,6 +20,8 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { inboxDismissalService } from "../services/inbox-dismissals.ts";
 import { sidebarBadgeService } from "../services/sidebar-badges.ts";
+import { errorHandler } from "../middleware/error-handler.js";
+import { inboxDismissalRoutes } from "../routes/inbox-dismissals.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -40,6 +46,7 @@ describeEmbeddedPostgres("inbox dismissals", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(activityLog);
     await db.delete(inboxDismissals);
     await db.delete(joinRequests);
     await db.delete(invites);
@@ -75,6 +82,18 @@ describeEmbeddedPostgres("inbox dismissals", () => {
     expect(dismissals[0]?.itemKey).toBe("approval:approval-1");
     expect(new Date(dismissals[0]?.dismissedAt ?? 0).toISOString()).toBe(secondDismissedAt.toISOString());
   });
+
+  function createInboxDismissalApp(actor: Record<string, unknown>) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = actor;
+      next();
+    });
+    app.use("/api", inboxDismissalRoutes(db));
+    app.use(errorHandler);
+    return app;
+  }
 
   it("honors dismissal timestamps and resurfaces approvals with newer activity", async () => {
     const companyId = randomUUID();
@@ -208,5 +227,121 @@ describeEmbeddedPostgres("inbox dismissals", () => {
       failedRuns: 1,
       joinRequests: 0,
     });
+  });
+
+  it("resolves a failed heartbeat run without mutating run history", async () => {
+    const companyId = randomUUID();
+    const userId = "board-user";
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "failed",
+      createdAt: new Date("2026-03-11T01:00:00.000Z"),
+      updatedAt: new Date("2026-03-11T01:00:00.000Z"),
+    });
+
+    const app = createInboxDismissalApp({
+      type: "board",
+      source: "local_implicit",
+      userId,
+    });
+
+    const response = await request(app)
+      .post(`/api/heartbeat-runs/${runId}/resolve`)
+      .send({})
+      .expect(201);
+
+    expect(response.body).toMatchObject({
+      companyId,
+      userId,
+      itemKey: `run:${runId}`,
+    });
+
+    const dismissedAtByKey = new Map(
+      (await dismissalsSvc.list(companyId, userId)).map((dismissal) => [
+        dismissal.itemKey,
+        new Date(dismissal.dismissedAt).getTime(),
+      ]),
+    );
+    const badges = await badgesSvc.get(companyId, { dismissals: dismissedAtByKey });
+
+    expect(badges.failedRuns).toBe(0);
+    expect(badges.inbox).toBe(0);
+
+    const [persistedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(persistedRun?.status).toBe("failed");
+  });
+
+  it("does not resolve successful heartbeat runs", async () => {
+    const companyId = randomUUID();
+    const userId = "board-user";
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "succeeded",
+      createdAt: new Date("2026-03-11T01:00:00.000Z"),
+      updatedAt: new Date("2026-03-11T01:00:00.000Z"),
+    });
+
+    const app = createInboxDismissalApp({
+      type: "board",
+      source: "local_implicit",
+      userId,
+    });
+
+    await request(app)
+      .post(`/api/heartbeat-runs/${runId}/resolve`)
+      .send({})
+      .expect(400);
+
+    await expect(dismissalsSvc.list(companyId, userId)).resolves.toHaveLength(0);
   });
 });

--- a/server/src/__tests__/inbox-dismissals.test.ts
+++ b/server/src/__tests__/inbox-dismissals.test.ts
@@ -296,6 +296,66 @@ describeEmbeddedPostgres("inbox dismissals", () => {
     expect(persistedRun?.status).toBe("failed");
   });
 
+  it("does not disclose heartbeat runs outside the board actor companies", async () => {
+    const actorCompanyId = randomUUID();
+    const runCompanyId = randomUUID();
+    const userId = "board-user";
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: actorCompanyId,
+        name: "Actor Company",
+        issuePrefix: "ACT",
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: runCompanyId,
+        name: "Run Company",
+        issuePrefix: "RUN",
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId: runCompanyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: runCompanyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "failed",
+      createdAt: new Date("2026-03-11T01:00:00.000Z"),
+      updatedAt: new Date("2026-03-11T01:00:00.000Z"),
+    });
+
+    const app = createInboxDismissalApp({
+      type: "board",
+      source: "session",
+      userId,
+      companyIds: [actorCompanyId],
+      memberships: [{ companyId: actorCompanyId, status: "active", membershipRole: "member" }],
+    });
+
+    await request(app)
+      .post(`/api/heartbeat-runs/${runId}/resolve`)
+      .send({})
+      .expect(404);
+
+    await expect(dismissalsSvc.list(runCompanyId, userId)).resolves.toHaveLength(0);
+  });
+
   it("does not resolve successful heartbeat runs", async () => {
     const companyId = randomUUID();
     const userId = "board-user";

--- a/server/src/routes/inbox-dismissals.ts
+++ b/server/src/routes/inbox-dismissals.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { z } from "zod";
 import type { Db } from "@paperclipai/db";
+import { heartbeatRuns } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
 import { validate } from "../middleware/validate.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { inboxDismissalService, logActivity } from "../services/index.js";
@@ -12,6 +14,54 @@ const inboxDismissalSchema = z.object({
 export function inboxDismissalRoutes(db: Db) {
   const router = Router();
   const svc = inboxDismissalService(db);
+
+  router.post("/heartbeat-runs/:runId/resolve", async (req, res) => {
+    const runId = req.params.runId as string;
+    const [run] = await db
+      .select({ id: heartbeatRuns.id, companyId: heartbeatRuns.companyId, status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .limit(1);
+
+    if (!run) {
+      res.status(404).json({ error: "Heartbeat run not found" });
+      return;
+    }
+
+    assertCompanyAccess(req, run.companyId);
+    if (req.actor.type !== "board") {
+      res.status(403).json({ error: "Board authentication required" });
+      return;
+    }
+    if (!req.actor.userId) {
+      res.status(403).json({ error: "Board user context required" });
+      return;
+    }
+    if (run.status !== "failed" && run.status !== "timed_out") {
+      res.status(400).json({ error: "Only failed or timed out heartbeat runs can be resolved" });
+      return;
+    }
+
+    const dismissal = await svc.dismiss(run.companyId, req.actor.userId, `run:${run.id}`, new Date());
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: run.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "heartbeat_run.resolved",
+      entityType: "heartbeat_run",
+      entityId: run.id,
+      details: {
+        userId: req.actor.userId,
+        itemKey: dismissal.itemKey,
+        resolvedAt: dismissal.dismissedAt,
+      },
+    });
+
+    res.status(201).json(dismissal);
+  });
 
   router.get("/companies/:companyId/inbox-dismissals", async (req, res) => {
     const companyId = req.params.companyId as string;

--- a/server/src/routes/inbox-dismissals.ts
+++ b/server/src/routes/inbox-dismissals.ts
@@ -2,9 +2,9 @@ import { Router } from "express";
 import { z } from "zod";
 import type { Db } from "@paperclipai/db";
 import { heartbeatRuns } from "@paperclipai/db";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { validate } from "../middleware/validate.js";
-import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import { inboxDismissalService, logActivity } from "../services/index.js";
 
 const inboxDismissalSchema = z.object({
@@ -16,11 +16,28 @@ export function inboxDismissalRoutes(db: Db) {
   const svc = inboxDismissalService(db);
 
   router.post("/heartbeat-runs/:runId/resolve", async (req, res) => {
+    assertBoard(req);
+    if (!req.actor.userId) {
+      res.status(403).json({ error: "Board user context required" });
+      return;
+    }
+
     const runId = req.params.runId as string;
+    const canSeeAllCompanies = req.actor.source === "local_implicit" || req.actor.isInstanceAdmin === true;
+    const visibleCompanyIds = canSeeAllCompanies ? [] : req.actor.companyIds ?? [];
+    if (!canSeeAllCompanies && visibleCompanyIds.length === 0) {
+      res.status(404).json({ error: "Heartbeat run not found" });
+      return;
+    }
+
     const [run] = await db
       .select({ id: heartbeatRuns.id, companyId: heartbeatRuns.companyId, status: heartbeatRuns.status })
       .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.id, runId))
+      .where(
+        canSeeAllCompanies
+          ? eq(heartbeatRuns.id, runId)
+          : and(eq(heartbeatRuns.id, runId), inArray(heartbeatRuns.companyId, visibleCompanyIds)),
+      )
       .limit(1);
 
     if (!run) {
@@ -29,14 +46,6 @@ export function inboxDismissalRoutes(db: Db) {
     }
 
     assertCompanyAccess(req, run.companyId);
-    if (req.actor.type !== "board") {
-      res.status(403).json({ error: "Board authentication required" });
-      return;
-    }
-    if (!req.actor.userId) {
-      res.status(403).json({ error: "Board user context required" });
-      return;
-    }
     if (run.status !== "failed" && run.status !== "timed_out") {
       res.status(400).json({ error: "Only failed or timed out heartbeat runs can be resolved" });
       return;

--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -1,6 +1,7 @@
 import type {
   HeartbeatRun,
   HeartbeatRunEvent,
+  InboxDismissal,
   InstanceSchedulerHeartbeatAgent,
   WorkspaceOperation,
 } from "@paperclipai/shared";
@@ -75,6 +76,7 @@ export const heartbeatsApi = {
     return api.get<HeartbeatRun[]>(`/companies/${companyId}/heartbeat-runs${qs ? `?${qs}` : ""}`);
   },
   get: (runId: string) => api.get<HeartbeatRun>(`/heartbeat-runs/${runId}`),
+  resolveFailedRun: (runId: string) => api.post<InboxDismissal>(`/heartbeat-runs/${runId}/resolve`, {}),
   events: (runId: string, afterSeq = 0, limit = 200) =>
     api.get<HeartbeatRunEvent[]>(
       `/heartbeat-runs/${runId}/events?afterSeq=${encodeURIComponent(String(afterSeq))}&limit=${encodeURIComponent(String(limit))}`,

--- a/ui/src/hooks/useInboxBadge.ts
+++ b/ui/src/hooks/useInboxBadge.ts
@@ -61,7 +61,11 @@ export function useInboxDismissals(companyId: string | null | undefined) {
   });
 
   const dismissMutation = useMutation({
-    mutationFn: ({ itemKey }: { itemKey: string }) => inboxDismissalsApi.dismiss(companyId!, itemKey),
+    mutationFn: ({ itemKey }: { itemKey: string }) => {
+      const runId = itemKey.startsWith("run:") ? itemKey.slice("run:".length) : null;
+      if (runId) return heartbeatsApi.resolveFailedRun(runId);
+      return inboxDismissalsApi.dismiss(companyId!, itemKey);
+    },
     onMutate: async ({ itemKey }) => {
       if (!companyId) return { previous: [] as typeof dismissals };
       await queryClient.cancelQueries({ queryKey });

--- a/ui/src/hooks/useInboxBadge.ts
+++ b/ui/src/hooks/useInboxBadge.ts
@@ -48,6 +48,8 @@ export function useDismissedInboxAlerts() {
   return { dismissed, dismiss };
 }
 
+type InboxDismissOptions = { resolveFailedRun?: boolean };
+
 export function useInboxDismissals(companyId: string | null | undefined) {
   const queryClient = useQueryClient();
   const queryKey = companyId
@@ -61,9 +63,9 @@ export function useInboxDismissals(companyId: string | null | undefined) {
   });
 
   const dismissMutation = useMutation({
-    mutationFn: ({ itemKey }: { itemKey: string }) => {
+    mutationFn: ({ itemKey, options }: { itemKey: string; options?: InboxDismissOptions }) => {
       const runId = itemKey.startsWith("run:") ? itemKey.slice("run:".length) : null;
-      if (runId) return heartbeatsApi.resolveFailedRun(runId);
+      if (options?.resolveFailedRun && runId) return heartbeatsApi.resolveFailedRun(runId);
       return inboxDismissalsApi.dismiss(companyId!, itemKey);
     },
     onMutate: async ({ itemKey }) => {
@@ -104,7 +106,7 @@ export function useInboxDismissals(companyId: string | null | undefined) {
   return {
     dismissals,
     dismissedAtByKey,
-    dismiss: (itemKey: string) => dismissMutation.mutate({ itemKey }),
+    dismiss: (itemKey: string, options?: InboxDismissOptions) => dismissMutation.mutate({ itemKey, options }),
     isPending: dismissMutation.isPending,
   };
 }

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -1565,13 +1565,13 @@ export function Inbox() {
     }, 300);
   }, [markItemRead]);
 
-  const handleArchiveNonIssue = useCallback((key: string) => {
+  const handleArchiveNonIssue = useCallback((key: string, options?: { resolveFailedRun?: boolean }) => {
     setArchivingNonIssueIds((prev) => new Set(prev).add(key));
     setTimeout(() => {
       if (key.startsWith("alert:")) {
         dismissAlert(key);
       } else {
-        dismissInboxItem(key);
+        dismissInboxItem(key, options);
       }
       setArchivingNonIssueIds((prev) => {
         const next = new Set(prev);
@@ -2369,12 +2369,12 @@ export function Inbox() {
                           issueById={issueById}
                           agentName={agentName(item.run.agentId)}
                           issueLinkState={issueLinkState}
-                          onDismiss={() => dismissInboxItem(runKey)}
+                          onDismiss={() => dismissInboxItem(runKey, { resolveFailedRun: true })}
                           onRetry={() => retryRunMutation.mutate(item.run)}
                           isRetrying={retryingRunIds.has(item.run.id)}
                           unreadState={nonIssueUnreadState(runKey)}
                           onMarkRead={() => handleMarkNonIssueRead(runKey)}
-                          onArchive={canArchiveFromTab ? () => handleArchiveNonIssue(runKey) : undefined}
+                          onArchive={canArchiveFromTab ? () => handleArchiveNonIssue(runKey, { resolveFailedRun: true }) : undefined}
                           archiveDisabled={isArchiving}
                           className={
                             isArchiving
@@ -2388,7 +2388,7 @@ export function Inbox() {
                           key={runKey}
                           selected={isSelected}
                           disabled={isArchiving}
-                          onArchive={() => handleArchiveNonIssue(runKey)}
+                          onArchive={() => handleArchiveNonIssue(runKey, { resolveFailedRun: true })}
                         >
                           {row}
                         </SwipeToArchive>


### PR DESCRIPTION
## Summary
- add a server-side `POST /heartbeat-runs/:runId/resolve` endpoint for failed/timed-out runs
- preserve heartbeat run history while recording the acknowledgement as the existing server-backed inbox dismissal for `run:<id>`
- route failed-run archive/dismiss actions through the new endpoint so Focus/sidebar counts exclude acknowledged failures

## Tests
- `pnpm exec vitest run server/src/__tests__/inbox-dismissals.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
