### PR TITLE
feat: add agent instructions sync tooling

### DIFF
--- a/docs/guides/board-operator/agent-instructions-sync.md
+++ b/docs/guides/board-operator/agent-instructions-sync.md
@@ -1,0 +1,103 @@
+---
+title: Agent Instructions Sync
+summary: Materialize live instructions into canonical AGENTS.md files and switch local agents to external mode
+---
+
+For local Paperclip agents, the cleanest way to avoid instruction drift is to use a canonical `AGENTS.md` on disk and point the agent at that file with `instructionsBundleMode: external`.
+
+This avoids maintaining both:
+
+- a git-tracked instructions file
+- a second managed bundle copy under the Paperclip instance directory
+
+## Recommended Pattern
+
+Use `AGENTS.md` as the canonical file name everywhere. Keep one file per agent in your source tree, then run the migration script as a board user or an ancestor manager for the target agent.
+
+The migration flow is:
+
+1. Export the agent's live `AGENTS.md` into the canonical source path.
+2. Rename or remove any legacy `AGENT.md`.
+3. Switch the agent from `managed` to `external` mode so future runs read directly from the canonical file.
+4. Verify the bundle metadata now points at the external path.
+
+## Manifest Format
+
+Create a JSON manifest:
+
+```json
+{
+  "agents": [
+    {
+      "agentId": "11111111-1111-4111-8111-111111111111",
+      "label": "Lead Engineer",
+      "sourceFile": "/absolute/path/to/agents/lead-engineer/AGENTS.md"
+    }
+  ]
+}
+```
+
+Fields:
+
+- `agentId`: Paperclip agent id
+- `sourceFile`: canonical AGENTS path to write and later read at runtime
+- `entryFile`: optional, defaults to `AGENTS.md`
+- `legacyFile`: optional legacy singular path to back up or remove
+- `label`: optional human-readable name for script output
+
+## Migrate
+
+Dry run:
+
+```sh
+tsx scripts/migrate-agent-instructions-to-external.ts \
+  --manifest ./agent-instructions.json
+```
+
+Write canonical files but keep the agents on managed bundles:
+
+```sh
+tsx scripts/migrate-agent-instructions-to-external.ts \
+  --manifest ./agent-instructions.json \
+  --write-files
+```
+
+Write files and switch agents to external mode:
+
+```sh
+tsx scripts/migrate-agent-instructions-to-external.ts \
+  --manifest ./agent-instructions.json \
+  --write-files \
+  --switch-mode
+```
+
+Remove a legacy `AGENT.md` instead of backing it up:
+
+```sh
+tsx scripts/migrate-agent-instructions-to-external.ts \
+  --manifest ./agent-instructions.json \
+  --write-files \
+  --switch-mode \
+  --remove-legacy
+```
+
+## Drift Checks
+
+If you keep any agents on managed bundles temporarily, or if you want a cron/CI guardrail, compare the canonical files against the live bundles:
+
+```sh
+tsx scripts/check-agent-instructions-drift.ts \
+  --manifest ./agent-instructions.json
+```
+
+The command exits non-zero when any source file is missing or differs from the live bundle.
+
+## Permissions
+
+Switching bundle mode or updating instructions paths is restricted:
+
+- the target agent can update itself
+- an ancestor manager can update descendants
+- board users can update any agent
+
+If you only have read access, you can still run the drift checker and you can still materialize source files from live bundles, but the final `--switch-mode` step must be run by an authorized actor.

--- a/docs/guides/board-operator/importing-and-exporting.md
+++ b/docs/guides/board-operator/importing-and-exporting.md
@@ -13,8 +13,8 @@ Exported packages follow the [Agent Companies specification](/companies/companie
 my-company/
 ├── COMPANY.md          # Company metadata
 ├── agents/
-│   ├── ceo/AGENT.md    # Agent instructions + frontmatter
-│   └── cto/AGENT.md
+│   ├── ceo/AGENTS.md   # Agent instructions + frontmatter
+│   └── cto/AGENTS.md
 ├── projects/
 │   └── main/PROJECT.md
 ├── skills/
@@ -25,7 +25,7 @@ my-company/
 ```
 
 - **COMPANY.md** defines company name, description, and metadata.
-- **AGENT.md** files contain agent identity, role, and instructions.
+- **AGENTS.md** files contain agent identity, role, and instructions. Legacy `AGENT.md` is still accepted for older packages, but new packages should standardize on `AGENTS.md`.
 - **SKILL.md** files are compatible with the Agent Skills ecosystem.
 - **.paperclip.yaml** holds Paperclip-specific config (adapter types, env inputs, budgets) as an optional sidecar.
 

--- a/scripts/check-agent-instructions-drift.ts
+++ b/scripts/check-agent-instructions-drift.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env npx tsx
+import fs from "node:fs/promises";
+import path from "node:path";
+
+type ManifestEntry = {
+  agentId: string;
+  sourceFile: string;
+  entryFile?: string;
+  label?: string;
+};
+
+type Manifest = {
+  agents: ManifestEntry[];
+};
+
+type AgentFileResponse = {
+  content: string;
+};
+
+function parseArgs(argv: string[]) {
+  const flags = new Map<string, string | boolean>();
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token?.startsWith("--")) continue;
+    const [flag, inlineValue] = token.split("=", 2);
+    if (inlineValue !== undefined) {
+      flags.set(flag, inlineValue);
+      continue;
+    }
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      flags.set(flag, true);
+      continue;
+    }
+    flags.set(flag, next);
+    index += 1;
+  }
+
+  const manifestPath = flags.get("--manifest");
+  if (typeof manifestPath !== "string" || manifestPath.trim().length === 0) {
+    throw new Error("Missing required --manifest <path> option.");
+  }
+
+  const apiBase = typeof flags.get("--api-base") === "string"
+    ? String(flags.get("--api-base")).trim()
+    : process.env.PAPERCLIP_API_URL?.trim();
+  if (!apiBase) {
+    throw new Error("Missing API base. Pass --api-base or set PAPERCLIP_API_URL.");
+  }
+
+  const token = typeof flags.get("--token") === "string"
+    ? String(flags.get("--token")).trim()
+    : process.env.PAPERCLIP_API_KEY?.trim();
+  if (!token) {
+    throw new Error("Missing API token. Pass --token or set PAPERCLIP_API_KEY.");
+  }
+
+  return {
+    manifestPath,
+    apiBase,
+    token,
+    json: flags.has("--json"),
+  };
+}
+
+function ensureManifest(value: unknown): Manifest {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Manifest must be a JSON object with an agents array.");
+  }
+  const agents = (value as { agents?: unknown }).agents;
+  if (!Array.isArray(agents) || agents.length === 0) {
+    throw new Error("Manifest agents array is required and cannot be empty.");
+  }
+  return value as Manifest;
+}
+
+function resolveFromManifest(manifestDir: string, targetPath: string) {
+  if (path.isAbsolute(targetPath)) return targetPath;
+  return path.resolve(manifestDir, targetPath);
+}
+
+async function requestJson<T>(apiBase: string, token: string, targetPath: string): Promise<T> {
+  const response = await fetch(new URL(targetPath, apiBase), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GET ${targetPath} failed: ${response.status} ${body}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const manifestAbsolutePath = path.resolve(options.manifestPath);
+  const manifestDir = path.dirname(manifestAbsolutePath);
+  const manifestRaw = await fs.readFile(manifestAbsolutePath, "utf8");
+  const manifest = ensureManifest(JSON.parse(manifestRaw));
+
+  const results: Array<{
+    agentId: string;
+    label: string;
+    sourceFile: string;
+    status: "match" | "missing_source" | "drift";
+  }> = [];
+
+  for (const entry of manifest.agents) {
+    const entryFile = entry.entryFile?.trim() || "AGENTS.md";
+    const label = entry.label?.trim() || entry.agentId;
+    const sourceFile = resolveFromManifest(manifestDir, entry.sourceFile);
+    const liveFile = await requestJson<AgentFileResponse>(
+      options.apiBase,
+      options.token,
+      `/api/agents/${entry.agentId}/instructions-bundle/file?path=${encodeURIComponent(entryFile)}`,
+    );
+
+    let localContent: string;
+    try {
+      localContent = await fs.readFile(sourceFile, "utf8");
+    } catch {
+      results.push({ agentId: entry.agentId, label, sourceFile, status: "missing_source" });
+      continue;
+    }
+
+    results.push({
+      agentId: entry.agentId,
+      label,
+      sourceFile,
+      status: localContent === liveFile.content ? "match" : "drift",
+    });
+  }
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ ok: results.every((entry) => entry.status === "match"), results }, null, 2)}\n`);
+  } else {
+    for (const result of results) {
+      console.log(`${result.status.toUpperCase()}: ${result.label} -> ${result.sourceFile}`);
+    }
+  }
+
+  if (results.some((entry) => entry.status !== "match")) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/generate-company-assets.ts
+++ b/scripts/generate-company-assets.ts
@@ -149,10 +149,10 @@ function parseCompanyPackage(companyDir: string): CompanyPackage | null {
   const agents: CompanyPortabilityManifest["agents"] = [];
   if (fs.existsSync(agentsDir)) {
     for (const agentSlug of fs.readdirSync(agentsDir)) {
-      const agentMdName = fs.existsSync(path.join(agentsDir, agentSlug, "AGENT.md"))
-        ? "AGENT.md"
-        : fs.existsSync(path.join(agentsDir, agentSlug, "AGENTS.md"))
-          ? "AGENTS.md"
+      const agentMdName = fs.existsSync(path.join(agentsDir, agentSlug, "AGENTS.md"))
+        ? "AGENTS.md"
+        : fs.existsSync(path.join(agentsDir, agentSlug, "AGENT.md"))
+          ? "AGENT.md"
           : null;
       if (!agentMdName) continue;
       const agentMdPath = path.join(agentsDir, agentSlug, agentMdName);

--- a/scripts/migrate-agent-instructions-to-external.ts
+++ b/scripts/migrate-agent-instructions-to-external.ts
@@ -1,0 +1,288 @@
+#!/usr/bin/env npx tsx
+import fs from "node:fs/promises";
+import path from "node:path";
+
+type ManifestEntry = {
+  agentId: string;
+  sourceFile: string;
+  entryFile?: string;
+  legacyFile?: string;
+  label?: string;
+};
+
+type Manifest = {
+  agents: ManifestEntry[];
+};
+
+type AgentFileResponse = {
+  path: string;
+  content: string;
+};
+
+type AgentBundleResponse = {
+  mode: "managed" | "external" | null;
+  rootPath: string | null;
+  entryFile: string;
+  files: Array<{ path: string }>;
+};
+
+type AgentRecord = {
+  agentId: string;
+  label: string;
+  sourceFile: string;
+  entryFile: string;
+  wroteSourceFile: boolean;
+  movedLegacyFile: string | null;
+  switchedMode: boolean;
+  verification: "skipped" | "ok";
+  notes: string[];
+};
+
+function parseArgs(argv: string[]) {
+  const flags = new Map<string, string | boolean>();
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token?.startsWith("--")) continue;
+    const [flag, inlineValue] = token.split("=", 2);
+    if (inlineValue !== undefined) {
+      flags.set(flag, inlineValue);
+      continue;
+    }
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      flags.set(flag, true);
+      continue;
+    }
+    flags.set(flag, next);
+    index += 1;
+  }
+
+  const manifestPath = flags.get("--manifest");
+  if (typeof manifestPath !== "string" || manifestPath.trim().length === 0) {
+    throw new Error("Missing required --manifest <path> option.");
+  }
+
+  const apiBase = typeof flags.get("--api-base") === "string"
+    ? String(flags.get("--api-base")).trim()
+    : process.env.PAPERCLIP_API_URL?.trim();
+  if (!apiBase) {
+    throw new Error("Missing API base. Pass --api-base or set PAPERCLIP_API_URL.");
+  }
+
+  const token = typeof flags.get("--token") === "string"
+    ? String(flags.get("--token")).trim()
+    : process.env.PAPERCLIP_API_KEY?.trim();
+  if (!token) {
+    throw new Error("Missing API token. Pass --token or set PAPERCLIP_API_KEY.");
+  }
+
+  return {
+    manifestPath,
+    apiBase,
+    token,
+    writeFiles: flags.has("--write-files"),
+    switchMode: flags.has("--switch-mode"),
+    removeLegacy: flags.has("--remove-legacy"),
+    json: flags.has("--json"),
+  };
+}
+
+function ensureManifest(value: unknown): Manifest {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Manifest must be a JSON object with an agents array.");
+  }
+  const agents = (value as { agents?: unknown }).agents;
+  if (!Array.isArray(agents) || agents.length === 0) {
+    throw new Error("Manifest agents array is required and cannot be empty.");
+  }
+  for (const [index, entry] of agents.entries()) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new Error(`Manifest agents[${index}] must be an object.`);
+    }
+    const agentId = (entry as { agentId?: unknown }).agentId;
+    const sourceFile = (entry as { sourceFile?: unknown }).sourceFile;
+    if (typeof agentId !== "string" || agentId.trim().length === 0) {
+      throw new Error(`Manifest agents[${index}].agentId is required.`);
+    }
+    if (typeof sourceFile !== "string" || sourceFile.trim().length === 0) {
+      throw new Error(`Manifest agents[${index}].sourceFile is required.`);
+    }
+  }
+  return value as Manifest;
+}
+
+function resolveFromManifest(manifestDir: string, targetPath: string) {
+  if (path.isAbsolute(targetPath)) return targetPath;
+  return path.resolve(manifestDir, targetPath);
+}
+
+async function requestJson<T>(apiBase: string, token: string, targetPath: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(new URL(targetPath, apiBase), {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`${init?.method ?? "GET"} ${targetPath} failed: ${response.status} ${body}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+async function pathExists(targetPath: string) {
+  try {
+    await fs.stat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function maybeReadUtf8(targetPath: string) {
+  try {
+    return await fs.readFile(targetPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const manifestAbsolutePath = path.resolve(options.manifestPath);
+  const manifestDir = path.dirname(manifestAbsolutePath);
+  const manifestRaw = await fs.readFile(manifestAbsolutePath, "utf8");
+  const manifest = ensureManifest(JSON.parse(manifestRaw));
+  const timestamp = new Date().toISOString().replaceAll(":", "").replaceAll(".", "");
+  const results: AgentRecord[] = [];
+
+  for (const entry of manifest.agents) {
+    const entryFile = entry.entryFile?.trim() || "AGENTS.md";
+    const sourceFile = resolveFromManifest(manifestDir, entry.sourceFile);
+    const legacyFile = resolveFromManifest(
+      manifestDir,
+      entry.legacyFile?.trim() || path.join(path.dirname(entry.sourceFile), "AGENT.md"),
+    );
+    const label = entry.label?.trim() || entry.agentId;
+
+    const notes: string[] = [];
+    const liveFile = await requestJson<AgentFileResponse>(
+      options.apiBase,
+      options.token,
+      `/api/agents/${entry.agentId}/instructions-bundle/file?path=${encodeURIComponent(entryFile)}`,
+    );
+    const currentSource = await maybeReadUtf8(sourceFile);
+    let wroteSourceFile = false;
+    let movedLegacyFile: string | null = null;
+
+    if (currentSource !== liveFile.content) {
+      notes.push(currentSource === null ? "source file missing" : "source file drifted from live bundle");
+      if (options.writeFiles) {
+        await fs.mkdir(path.dirname(sourceFile), { recursive: true });
+        await fs.writeFile(sourceFile, liveFile.content, "utf8");
+        wroteSourceFile = true;
+      }
+    }
+
+    if (legacyFile !== sourceFile && await pathExists(legacyFile)) {
+      if (options.writeFiles) {
+        if (options.removeLegacy) {
+          await fs.rm(legacyFile, { force: true });
+          movedLegacyFile = "(removed)";
+        } else {
+          const backupPath = `${legacyFile}.bak.${timestamp}`;
+          await fs.rename(legacyFile, backupPath);
+          movedLegacyFile = backupPath;
+        }
+      } else {
+        notes.push(`legacy file present at ${legacyFile}`);
+      }
+    }
+
+    let switchedMode = false;
+    if (options.switchMode) {
+      const bundle = await requestJson<AgentBundleResponse>(
+        options.apiBase,
+        options.token,
+        `/api/agents/${entry.agentId}/instructions-bundle`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            mode: "external",
+            rootPath: path.dirname(sourceFile),
+            entryFile: path.basename(sourceFile),
+            clearLegacyPromptTemplate: true,
+          }),
+        },
+      );
+      switchedMode = bundle.mode === "external"
+        && bundle.rootPath === path.dirname(sourceFile)
+        && bundle.entryFile === path.basename(sourceFile);
+      if (!switchedMode) {
+        throw new Error(`Agent ${label} did not switch to the requested external bundle root.`);
+      }
+    }
+
+    let verification: AgentRecord["verification"] = "skipped";
+    if (options.writeFiles || options.switchMode) {
+      const verifiedBundle = await requestJson<AgentBundleResponse>(
+        options.apiBase,
+        options.token,
+        `/api/agents/${entry.agentId}/instructions-bundle`,
+      );
+      const verifiedSource = await fs.readFile(sourceFile, "utf8");
+      if (verifiedSource !== liveFile.content) {
+        throw new Error(`Verification failed for ${label}: source file does not match exported bundle content.`);
+      }
+      if (options.switchMode) {
+        if (
+          verifiedBundle.mode !== "external"
+          || verifiedBundle.rootPath !== path.dirname(sourceFile)
+          || verifiedBundle.entryFile !== path.basename(sourceFile)
+        ) {
+          throw new Error(`Verification failed for ${label}: bundle metadata does not point at the external source file.`);
+        }
+      }
+      verification = "ok";
+    }
+
+    results.push({
+      agentId: entry.agentId,
+      label,
+      sourceFile,
+      entryFile,
+      wroteSourceFile,
+      movedLegacyFile,
+      switchedMode,
+      verification,
+      notes,
+    });
+  }
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ ok: true, results }, null, 2)}\n`);
+    return;
+  }
+
+  for (const result of results) {
+    console.log(`== ${result.label} ==`);
+    console.log(`source: ${result.sourceFile}`);
+    console.log(`wrote source: ${result.wroteSourceFile ? "yes" : "no"}`);
+    console.log(`legacy moved: ${result.movedLegacyFile ?? "no"}`);
+    console.log(`switched mode: ${result.switchedMode ? "yes" : "no"}`);
+    console.log(`verification: ${result.verification}`);
+    if (result.notes.length > 0) {
+      console.log(`notes: ${result.notes.join("; ")}`);
+    }
+    console.log("");
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/ui/src/pages/CompanyExport.tsx
+++ b/ui/src/pages/CompanyExport.tsx
@@ -47,7 +47,7 @@ import {
 /**
  * Extract the set of agent/project/task slugs that are "checked" based on
  * which file paths are in the checked set.
- *   agents/{slug}/AGENT.md   → agents slug
+ *   agents/{slug}/AGENTS.md  → agents slug
  *   projects/{slug}/PROJECT.md → projects slug
  *   tasks/{slug}/TASK.md     → tasks slug
  */


### PR DESCRIPTION
## Summary
- add scripts to materialize live agent bundles into canonical `AGENTS.md` files and compare them for drift
- document the recommended external-mode workflow for local agents and standardize docs/helpers on `AGENTS.md`
- prefer plural `AGENTS.md` over legacy `AGENT.md` in company package examples and asset generation

## Validation
- `pnpm exec tsx scripts/migrate-agent-instructions-to-external.ts --manifest /tmp/mar400-agent-manifest.json --json`
- `pnpm exec tsx scripts/migrate-agent-instructions-to-external.ts --manifest /tmp/mar400-agent-manifest.json --write-files --json`
- `pnpm exec tsx scripts/check-agent-instructions-drift.ts --manifest /tmp/mar400-agent-manifest.json --json`
- `pnpm exec tsx scripts/migrate-agent-instructions-to-external.ts --manifest /tmp/mar400-self-manifest.json --write-files --switch-mode --json`

## Notes
- I also materialized canonical files under `/home/atlas/knowledge/organization/agents/*/AGENTS.md` locally and verified all 5 match current live bundles.
- Only the target agent, an ancestor manager, or a board user can switch another agent to external mode, so the self-agent end-to-end migration was validated here and the remaining 4 mode flips need an authorized follow-up run.
