### PR TITLE
Stop non-continuable run recovery loops

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -588,6 +588,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     runId: string;
     previousStatus: "todo" | "in_progress";
     retryReason: "assignment_recovery" | "issue_continuation_needed" | "unknown";
+    livenessState?: string;
+    livenessReason?: string;
   }) {
     const recovery = await waitForValue(async () =>
       db.select().from(issues).where(
@@ -612,6 +614,12 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(recovery.title).toContain("Recover stalled issue");
     expect(recovery.description).toContain(`Previous source status: \`${input.previousStatus}\``);
     expect(recovery.description).toContain(`Retry reason: \`${input.retryReason}\``);
+    if (input.livenessState) {
+      expect(recovery.description).toContain(`Liveness: Latest liveness: \`${input.livenessState}\``);
+    }
+    if (input.livenessReason) {
+      expect(recovery.description).toContain(input.livenessReason);
+    }
     expect(recovery.description).toContain("Fix the runtime/adapter problem");
 
     const relation = await db
@@ -1556,6 +1564,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       runId,
       previousStatus: "in_progress",
       retryReason: "unknown",
+      livenessState: "needs_followup",
+      livenessReason: "Run produced useful output but no concrete action evidence",
     });
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
@@ -1568,7 +1578,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .select()
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.agentId, agentId));
-    expect(runs).toHaveLength(1);
+    const sourceIssueRuns = runs.filter((run) => {
+      const contextSnapshot = run.contextSnapshot as { issueId?: string } | null;
+      return contextSnapshot?.issueId === issueId;
+    });
+    expect(sourceIssueRuns).toHaveLength(1);
   });
 
   it("escalates in-progress work when the latest successful run declared a blocker", async () => {
@@ -1599,11 +1613,13 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       runId,
       previousStatus: "in_progress",
       retryReason: "unknown",
+      livenessState: "blocked",
+      livenessReason: "Run output declared a concrete blocker",
     });
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
     expect(comments).toHaveLength(1);
-    expect(comments[0]?.body).toContain("latest successful run requires manual follow-up or declared a blocker");
+    expect(comments[0]?.body).toContain("latest successful run requires manual follow-up or has declared a blocker");
     expect(comments[0]?.body).toContain("Run output declared a concrete blocker");
     expect(comments[0]?.body).toContain(`Recovery issue: [${recovery.identifier}]`);
 
@@ -1611,7 +1627,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .select()
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.agentId, agentId));
-    expect(runs).toHaveLength(1);
+    const sourceIssueRuns = runs.filter((run) => {
+      const contextSnapshot = run.contextSnapshot as { issueId?: string } | null;
+      return contextSnapshot?.issueId === issueId;
+    });
+    expect(sourceIssueRuns).toHaveLength(1);
   });
 
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -457,6 +457,16 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     status: "todo" | "in_progress";
     runStatus: "failed" | "timed_out" | "cancelled" | "succeeded";
     retryReason?: "assignment_recovery" | "issue_continuation_needed" | null;
+    livenessState?:
+      | "failed"
+      | "completed"
+      | "advanced"
+      | "plan_only"
+      | "empty_response"
+      | "needs_followup"
+      | "blocked"
+      | null;
+    livenessReason?: string | null;
     assignToUser?: boolean;
     activePauseHold?: boolean;
   }) {
@@ -524,6 +534,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       updatedAt: new Date("2026-03-19T00:05:00.000Z"),
       errorCode: input.runStatus === "succeeded" ? null : "process_lost",
       error: input.runStatus === "succeeded" ? null : "run failed before issue advanced",
+      livenessState: input.livenessState ?? null,
+      livenessReason: input.livenessReason ?? null,
     });
 
     await db.insert(issues).values([
@@ -575,7 +587,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     issueId: string;
     runId: string;
     previousStatus: "todo" | "in_progress";
-    retryReason: "assignment_recovery" | "issue_continuation_needed";
+    retryReason: "assignment_recovery" | "issue_continuation_needed" | "unknown";
   }) {
     const recovery = await waitForValue(async () =>
       db.select().from(issues).where(
@@ -1517,6 +1529,89 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     if (retryRun) {
       await waitForRunToSettle(heartbeat, retryRun.id);
     }
+  });
+
+  it("escalates in-progress work when the latest successful run needs manual follow-up", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "needs_followup",
+      livenessReason: "Run produced useful output but no concrete action evidence",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    const recovery = await expectStrandedRecoveryArtifacts({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "in_progress",
+      retryReason: "unknown",
+    });
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("latest successful run requires manual follow-up");
+    expect(comments[0]?.body).toContain("Run produced useful output but no concrete action evidence");
+    expect(comments[0]?.body).toContain(`Recovery issue: [${recovery.identifier}]`);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+  });
+
+  it("escalates in-progress work when the latest successful run declared a blocker", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "blocked",
+      livenessReason: "Run output declared a concrete blocker",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    const recovery = await expectStrandedRecoveryArtifacts({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "in_progress",
+      retryReason: "unknown",
+    });
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("latest successful run requires manual follow-up or declared a blocker");
+    expect(comments[0]?.body).toContain("Run output declared a concrete blocker");
+    expect(comments[0]?.body).toContain(`Recovery issue: [${recovery.identifier}]`);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
   });
 
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {

--- a/server/src/__tests__/run-continuations.test.ts
+++ b/server/src/__tests__/run-continuations.test.ts
@@ -127,6 +127,8 @@ describe("run liveness continuations", () => {
   it("skips non-actionable and guarded issues", () => {
     const guardedCases = [
       { livenessState: "advanced" as const },
+      { livenessState: "needs_followup" as const },
+      { livenessState: "blocked" as const },
       { issue: issue({ status: "done" }) },
       { issue: issue({ assigneeAgentId: "other-agent" }) },
       { issue: issue({ executionState: { status: "pending" } }) },

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -121,8 +121,8 @@ function summarizeRunFailureForIssueComment(run: LatestIssueRun) {
 function summarizeRunLivenessForIssueComment(run: LatestIssueRun) {
   if (!run) return null;
 
-  const livenessState = readNonEmptyString(run.livenessState);
-  const livenessReason = readNonEmptyString(run.livenessReason);
+  const livenessState = readNonEmptyString(run.livenessState)?.trim() ?? null;
+  const livenessReason = readNonEmptyString(run.livenessReason)?.trim() ?? null;
   if (livenessState && livenessReason) {
     return ` Latest liveness: \`${livenessState}\` - ${livenessReason}.`;
   }
@@ -1247,6 +1247,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       : "none";
     const retryReason = readNonEmptyString(parseObject(input.latestRun?.contextSnapshot)?.retryReason) ?? "unknown";
     const failureSummary = summarizeRunFailureForIssueComment(input.latestRun);
+    const livenessSummary = summarizeRunLivenessForIssueComment(input.latestRun);
 
     return [
       "Paperclip escalated an assigned issue with no live execution path and created this explicit recovery task.",
@@ -1260,6 +1261,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       `- Detected invariant: \`stranded_assigned_issue\``,
       `- Retry reason: \`${retryReason}\``,
       failureSummary ? `- Failure: ${failureSummary.trim()}` : "- Failure: none recorded",
+      livenessSummary ? `- Liveness: ${livenessSummary.trim()}` : "- Liveness: none recorded",
       "",
       "## Ownership",
       "",
@@ -1535,7 +1537,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           latestRun,
           comment:
             "Paperclip stopped automatic continuation because the latest successful run requires manual follow-up " +
-            `or declared a blocker, and this assigned \`in_progress\` issue has no live execution path.${livenessSummary ?? ""} ` +
+            `or has declared a blocker, and this assigned \`in_progress\` issue has no live execution path.${livenessSummary ?? ""} ` +
             "Moving it to `blocked` so it is visible for intervention.",
         });
         if (updated) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -62,7 +62,14 @@ type RecoveryWakeup = (
 
 type LatestIssueRun = Pick<
   typeof heartbeatRuns.$inferSelect,
-  "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot"
+  | "id"
+  | "agentId"
+  | "status"
+  | "error"
+  | "errorCode"
+  | "contextSnapshot"
+  | "livenessState"
+  | "livenessReason"
 > | null;
 
 type WatchdogDecisionActor =
@@ -109,6 +116,24 @@ function summarizeRunFailureForIssueComment(run: LatestIssueRun) {
   if (errorCode) return ` Latest retry failure: \`${errorCode}\`.`;
   if (summary) return ` Latest retry failure: ${summary}.`;
   return null;
+}
+
+function summarizeRunLivenessForIssueComment(run: LatestIssueRun) {
+  if (!run) return null;
+
+  const livenessState = readNonEmptyString(run.livenessState);
+  const livenessReason = readNonEmptyString(run.livenessReason);
+  if (livenessState && livenessReason) {
+    return ` Latest liveness: \`${livenessState}\` - ${livenessReason}.`;
+  }
+  if (livenessState) return ` Latest liveness: \`${livenessState}\`.`;
+  if (livenessReason) return ` Latest liveness: ${livenessReason}.`;
+  return null;
+}
+
+function isNonContinuableSuccessfulRun(run: LatestIssueRun) {
+  return run?.status === "succeeded" &&
+    (run.livenessState === "needs_followup" || run.livenessState === "blocked");
 }
 
 function didAutomaticRecoveryFail(
@@ -289,12 +314,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         error: heartbeatRuns.error,
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
+        livenessState: heartbeatRuns.livenessState,
+        livenessReason: heartbeatRuns.livenessReason,
       })
       .from(heartbeatRuns)
       .where(
         and(
           eq(heartbeatRuns.companyId, companyId),
-          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+          or(
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+            sql`${heartbeatRuns.contextSnapshot} ->> 'taskId' = ${issueId}`,
+          ),
         ),
       )
       .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
@@ -1219,14 +1249,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const failureSummary = summarizeRunFailureForIssueComment(input.latestRun);
 
     return [
-      "Paperclip exhausted automatic recovery for an assigned issue and created this explicit recovery task.",
+      "Paperclip escalated an assigned issue with no live execution path and created this explicit recovery task.",
       "",
       "## Source",
       "",
       `- Source issue: ${sourceIssue}`,
       `- Previous source status: \`${input.previousStatus}\``,
-      `- Latest retry run: ${runLink}`,
-      `- Latest retry status: \`${input.latestRun?.status ?? "unknown"}\``,
+      `- Latest relevant run: ${runLink}`,
+      `- Latest run status: \`${input.latestRun?.status ?? "unknown"}\``,
       `- Detected invariant: \`stranded_assigned_issue\``,
       `- Retry reason: \`${retryReason}\``,
       failureSummary ? `- Failure: ${failureSummary.trim()}` : "- Failure: none recorded",
@@ -1395,6 +1425,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         latestRunId: input.latestRun?.id ?? null,
         latestRunStatus: input.latestRun?.status ?? null,
         latestRunErrorCode: input.latestRun?.errorCode ?? null,
+        latestRunLivenessState: input.latestRun?.livenessState ?? null,
+        latestRunLivenessReason: input.latestRun?.livenessReason ?? null,
         recoveryIssueId: recoveryIssue?.id ?? null,
         blockerIssueIds: nextBlockerIds,
       },
@@ -1493,6 +1525,25 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
       if (!latestRun && !issue.checkoutRunId && !issue.executionRunId) {
         result.skipped += 1;
+        continue;
+      }
+      if (isNonContinuableSuccessfulRun(latestRun)) {
+        const livenessSummary = summarizeRunLivenessForIssueComment(latestRun);
+        const updated = await escalateStrandedAssignedIssue({
+          issue,
+          previousStatus: "in_progress",
+          latestRun,
+          comment:
+            "Paperclip stopped automatic continuation because the latest successful run requires manual follow-up " +
+            `or declared a blocker, and this assigned \`in_progress\` issue has no live execution path.${livenessSummary ?? ""} ` +
+            "Moving it to `blocked` so it is visible for intervention.",
+        });
+        if (updated) {
+          result.escalated += 1;
+          result.issueIds.push(issue.id);
+        } else {
+          result.skipped += 1;
+        }
         continue;
       }
       if (didAutomaticRecoveryFail(latestRun, "issue_continuation_needed")) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The heartbeat and recovery services keep assigned issues moving when runs are lost, fail, or leave work without a live execution path
> - Some successful runs are intentionally non-continuable because they need manual follow-up or have declared a blocker
> - Before this change, stranded issue recovery could convert those successful non-continuable runs into another `issue_continuation_needed` wake
> - That could keep requeueing the same issue even though liveness classification had already decided it was not safe to auto-continue
> - This pull request makes stranded recovery respect those liveness states and escalate the issue to `blocked`
> - The benefit is that stuck work becomes visible for human or manager intervention instead of looping silently

## What Changed

- Carry latest run `livenessState` and `livenessReason` into stranded issue recovery
- Treat successful `needs_followup` and `blocked` runs as non-continuable in `reconcileStrandedAssignedIssues`
- Move affected source issues to `blocked` with liveness context in both the source issue comment and recovery issue description
- Match latest issue runs by `issueId` or legacy `taskId`
- Add regression coverage for `needs_followup`, `blocked`, and non-actionable liveness continuation states

## Verification

- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run server/src/__tests__/run-liveness.test.ts server/src/__tests__/run-continuations.test.ts`
- `git diff --check upstream/master...HEAD`
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "latest successful run"` was attempted locally, but embedded Postgres tests are skipped on this host because initdb reports an existing data directory. CI runs this suite.

## Risks

- Low risk: this only changes recovery behavior after a successful run has already been classified as non-continuable.
- The main behavior change is intentional: Paperclip now blocks and surfaces those stranded issues instead of scheduling another automatic continuation.
- Existing failed, timed out, cancelled, `plan_only`, and `empty_response` recovery paths are unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex in ChatGPT, GPT-5.5, extra-high reasoning, with local shell, git, GitHub CLI, GitNexus, and xAI Grok review via the local `grok_client.py` module

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
