### PR TITLE
fix(auth): reject invalid local trusted auth fallback

### DIFF
--- a/server/src/__tests__/auth-session-route.test.ts
+++ b/server/src/__tests__/auth-session-route.test.ts
@@ -17,11 +17,21 @@ function createSelectChain(rows: unknown[]) {
 
 function createDb() {
   return {
-    select: vi
-      .fn()
-      .mockImplementationOnce(() => createSelectChain([]))
-      .mockImplementationOnce(() => createSelectChain([])),
+    select: vi.fn(() => createSelectChain([])),
   } as any;
+}
+
+function createActorApp(deploymentMode: "authenticated" | "local_trusted") {
+  const app = express();
+  app.use(
+    actorMiddleware(createDb(), {
+      deploymentMode,
+    }),
+  );
+  app.get("/actor", (req, res) => {
+    res.json(req.actor);
+  });
+  return app;
 }
 
 describe("actorMiddleware authenticated session profile", () => {
@@ -56,6 +66,68 @@ describe("actorMiddleware authenticated session profile", () => {
       companyIds: [],
       memberships: [],
       isInstanceAdmin: false,
+    });
+  });
+});
+
+describe("actorMiddleware local trusted auth fallback", () => {
+  it("keeps no-auth local requests on the implicit board actor", async () => {
+    const res = await request(createActorApp("local_trusted")).get("/actor");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "board",
+      userId: "local-board",
+      source: "local_implicit",
+    });
+  });
+
+  it("does not fall back to local board for invalid bearer auth", async () => {
+    const res = await request(createActorApp("local_trusted"))
+      .get("/actor")
+      .set("Authorization", "Bearer not-a-real-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      type: "none",
+      source: "none",
+    });
+  });
+
+  it("does not fall back to local board for empty bearer auth", async () => {
+    const res = await request(createActorApp("local_trusted"))
+      .get("/actor")
+      .set("Authorization", "Bearer ");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      type: "none",
+      source: "none",
+    });
+  });
+
+  it("does not fall back to local board for unsupported explicit auth schemes", async () => {
+    const res = await request(createActorApp("local_trusted"))
+      .get("/actor")
+      .set("Authorization", "Basic not-supported");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      type: "none",
+      source: "none",
+    });
+  });
+
+  it("does not attach run id to unsupported explicit auth schemes", async () => {
+    const res = await request(createActorApp("local_trusted"))
+      .get("/actor")
+      .set("Authorization", "Basic not-supported")
+      .set("X-Paperclip-Run-Id", "run-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      type: "none",
+      source: "none",
     });
   });
 });

--- a/server/src/__tests__/auth-session-route.test.ts
+++ b/server/src/__tests__/auth-session-route.test.ts
@@ -1,7 +1,18 @@
 import express from "express";
 import request from "supertest";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { actorMiddleware } from "../middleware/auth.js";
+
+const mockBoardAuthService = vi.hoisted(() => ({
+  findBoardApiKeyByToken: vi.fn(async () => null),
+  resolveBoardAccess: vi.fn(),
+  touchBoardApiKey: vi.fn(),
+}));
+
+vi.mock("../services/board-auth.js", () => ({
+  boardAuthService: () => mockBoardAuthService,
+}));
 
 function createSelectChain(rows: unknown[]) {
   return {
@@ -15,16 +26,30 @@ function createSelectChain(rows: unknown[]) {
   };
 }
 
-function createDb() {
+function createUpdateChain() {
   return {
-    select: vi.fn(() => createSelectChain([])),
+    set() {
+      return {
+        where() {
+          return Promise.resolve([]);
+        },
+      };
+    },
+  };
+}
+
+function createDb(selectResults: unknown[][] = []) {
+  const pendingSelects = [...selectResults];
+  return {
+    select: vi.fn(() => createSelectChain(pendingSelects.shift() ?? [])),
+    update: vi.fn(() => createUpdateChain()),
   } as any;
 }
 
-function createActorApp(deploymentMode: "authenticated" | "local_trusted") {
+function createActorApp(deploymentMode: "authenticated" | "local_trusted", db = createDb()) {
   const app = express();
   app.use(
-    actorMiddleware(createDb(), {
+    actorMiddleware(db, {
       deploymentMode,
     }),
   );
@@ -33,6 +58,22 @@ function createActorApp(deploymentMode: "authenticated" | "local_trusted") {
   });
   return app;
 }
+
+const originalJwtSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBoardAuthService.findBoardApiKeyByToken.mockResolvedValue(null);
+  process.env.PAPERCLIP_AGENT_JWT_SECRET = "test-agent-jwt-secret";
+});
+
+afterEach(() => {
+  if (originalJwtSecret === undefined) {
+    delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+  } else {
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = originalJwtSecret;
+  }
+});
 
 describe("actorMiddleware authenticated session profile", () => {
   it("preserves the signed-in user name and email on the board actor", async () => {
@@ -123,6 +164,86 @@ describe("actorMiddleware local trusted auth fallback", () => {
       .get("/actor")
       .set("Authorization", "Basic not-supported")
       .set("X-Paperclip-Run-Id", "run-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      type: "none",
+      source: "none",
+    });
+  });
+
+  it("does not continue past a board key whose user no longer resolves", async () => {
+    const db = createDb();
+    mockBoardAuthService.findBoardApiKeyByToken.mockResolvedValue({
+      id: "board-key-1",
+      userId: "deleted-user",
+    });
+    mockBoardAuthService.resolveBoardAccess.mockResolvedValue({
+      user: null,
+      companyIds: [],
+      memberships: [],
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(createActorApp("local_trusted", db))
+      .get("/actor")
+      .set("Authorization", "Bearer board-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      type: "none",
+      source: "none",
+    });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to local board when a valid agent JWT has the wrong company", async () => {
+    const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");
+    expect(token).toBeTruthy();
+    const db = createDb([
+      [],
+      [{ id: "agent-1", companyId: "company-2", status: "idle" }],
+    ]);
+
+    const res = await request(createActorApp("local_trusted", db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      type: "none",
+      source: "none",
+    });
+  });
+
+  it("does not fall back to local board when a valid agent JWT resolves to a terminated agent", async () => {
+    const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");
+    expect(token).toBeTruthy();
+    const db = createDb([
+      [],
+      [{ id: "agent-1", companyId: "company-1", status: "terminated" }],
+    ]);
+
+    const res = await request(createActorApp("local_trusted", db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      type: "none",
+      source: "none",
+    });
+  });
+
+  it("does not fall back to local board when an API key resolves to a terminated agent", async () => {
+    const db = createDb([
+      [{ id: "agent-key-1", agentId: "agent-1", companyId: "company-1" }],
+      [{ id: "agent-1", companyId: "company-1", status: "terminated" }],
+    ]);
+
+    const res = await request(createActorApp("local_trusted", db))
+      .get("/actor")
+      .set("Authorization", "Bearer agent-api-key");
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -13,6 +13,10 @@ function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
 }
 
+function unauthenticatedActor(): Request["actor"] {
+  return { type: "none", source: "none" };
+}
+
 interface ActorMiddlewareOptions {
   deploymentMode: DeploymentMode;
   resolveSession?: (req: Request) => Promise<BetterAuthSessionResult | null>;
@@ -31,11 +35,12 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
             isInstanceAdmin: true,
             source: "local_implicit",
           }
-        : { type: "none", source: "none" };
+        : unauthenticatedActor();
 
     const runIdHeader = req.header("x-paperclip-run-id");
 
     const authHeader = req.header("authorization");
+    const explicitAuthHeader = typeof authHeader === "string" && authHeader.trim().length > 0;
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {
       if (opts.deploymentMode === "authenticated" && opts.resolveSession) {
         let session: BetterAuthSessionResult | null = null;
@@ -85,6 +90,11 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
           return;
         }
       }
+      if (explicitAuthHeader) {
+        req.actor = unauthenticatedActor();
+        next();
+        return;
+      }
       if (runIdHeader) req.actor.runId = runIdHeader;
       next();
       return;
@@ -92,6 +102,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
 
     const token = authHeader.slice("bearer ".length).trim();
     if (!token) {
+      req.actor = unauthenticatedActor();
       next();
       return;
     }
@@ -128,6 +139,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
     if (!key) {
       const claims = verifyLocalAgentJwt(token);
       if (!claims) {
+        req.actor = unauthenticatedActor();
         next();
         return;
       }
@@ -139,11 +151,13 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         .then((rows) => rows[0] ?? null);
 
       if (!agentRecord || agentRecord.companyId !== claims.company_id) {
+        req.actor = unauthenticatedActor();
         next();
         return;
       }
 
       if (agentRecord.status === "terminated" || agentRecord.status === "pending_approval") {
+        req.actor = unauthenticatedActor();
         next();
         return;
       }
@@ -172,6 +186,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       .then((rows) => rows[0] ?? null);
 
     if (!agentRecord || agentRecord.status === "terminated" || agentRecord.status === "pending_approval") {
+      req.actor = unauthenticatedActor();
       next();
       return;
     }

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -127,6 +127,9 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         next();
         return;
       }
+      req.actor = unauthenticatedActor();
+      next();
+      return;
     }
 
     const tokenHash = hashToken(token);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents that mutate company state through the same HTTP API used by board operators.
> - In local trusted mode, unauthenticated local board requests intentionally receive the implicit board actor for operator convenience.
> - That convenience boundary must not apply when a request explicitly presents credentials and those credentials fail validation.
> - Current upstream keeps the default local board actor when a bearer token is malformed, expired, revoked, or otherwise invalid.
> - That can turn an authentication failure into board-level access, matching the failure mode reported in #1314 and previously addressed by the closed, unmerged #1315.
> - This pull request revives that security boundary on current `master` without changing run-id attribution, comment wake behavior, Hermes support, or local runtime dependencies.
> - The benefit is that explicit auth failure resolves to an unauthenticated actor instead of inheriting local board authority.

## What Changed

- Added a small `unauthenticatedActor()` helper in `server/src/middleware/auth.ts`.
- Clear the actor to `{ type: "none", source: "none" }` when an explicit unsupported auth scheme is sent.
- Clear the actor to `{ type: "none", source: "none" }` when a bearer token is empty, invalid, fails JWT verification, maps to the wrong company, maps to a pending/terminated agent, or maps to a pending/terminated agent API key.
- Added regression coverage proving no-auth local trusted requests still use the implicit board actor, while invalid/empty/unsupported explicit auth does not.

## Verification

- `git diff --check`
- `pnpm exec vitest run server/src/__tests__/auth-session-route.test.ts`
- `pnpm --filter @paperclipai/server exec tsc --noEmit`

## Risks

- Low risk for normal local board usage: requests with no `Authorization` header still receive the existing `local_implicit` board actor.
- Intentional behavior change for clients that send bad explicit auth in local trusted mode: they now become unauthenticated instead of falling through to board.
- This does not attempt to solve run-id attribution or comment wake cascades; those remain separate from this security boundary and are being discussed in #401, #4268, and #4441.

Fixes #1314.
Revives the security boundary from #1315 on current `master`.

## Model Used

- OpenAI Codex, GPT-5.5, extra-high reasoning, Codex desktop tool use with shell and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
