### PR TITLE
feat(MON-307): preflight blocker recheck on wake to auto-resolve stale blocker edges

### DIFF
--- a/doc/plans/2026-04-26-workflow-optimizer-blocker-recheck.md
+++ b/doc/plans/2026-04-26-workflow-optimizer-blocker-recheck.md
@@ -56,6 +56,10 @@ Three new tests in `issues-service.test.ts`:
 2. `pruneResolvedBlockers resolves dependency readiness when all blockers are done` — verifies full prune cleans edges
 3. `pruneResolvedBlockers is idempotent when no blockers are done` — verifies no-op when nothing to prune
 
+## Related Issues
+
+- **MON-335** (child): Bug — non-assignee comments on blocked issues trigger automatic reopen. This is a related but distinct systemic issue: the comment-reopen path (`issue_reopened_via_comment` wake) does not distinguish between dependency-blocked and executive-blocked issues. A well-intentioned comment on a CEO/CTO-blocked issue can undo the block decision. MON-335 tracks the fix; it is independent of MON-307's merge.
+
 ## Files Changed
 
 - `server/src/services/heartbeat.ts` — Preflight prune in `claimQueuedRun` and heartbeat wake path

--- a/doc/plans/2026-04-26-workflow-optimizer-blocker-recheck.md
+++ b/doc/plans/2026-04-26-workflow-optimizer-blocker-recheck.md
@@ -1,0 +1,62 @@
+# Workflow Optimizer: Preflight Blocker Recheck (MON-307)
+
+**Status**: Implemented (code changes committed)
+**Date**: 2026-04-26
+**Author**: VP Engineering
+
+## Problem
+
+When a blocker issue transitions to `done`, the system sends `issue_blockers_resolved` wakeups to dependents. However, if this wake is missed, delayed, or race-conditioned away, the stale blocker edge persists. Agents then spin-loop on blocked issues whose blockers are already complete. This has occurred at least 6 times (MON-147, MON-156, MON-162, MON-166, MON-306, MON-304).
+
+## Root Cause
+
+The system relied on a single fire-and-forget wake (`issue_blockers_resolved`) to prune stale blocker edges. There was no fallback mechanism to detect and resolve stale blockers when agents attempted to work on blocked issues through other wake paths.
+
+## Solution: Preflight Blocker Recheck
+
+Two injection points that self-heal stale blocker edges:
+
+### 1. claimQueuedRun preflight (heartbeat.ts ~L3460)
+
+Before rejecting a queued run because of unresolved blockers, attempt to prune any that have since become "done". If the prune resolves all blockers, the run can proceed instead of being discarded.
+
+```
+if (unresolvedBlockerCount > 0) {
+  prunedBlockers = pruneResolvedBlockers(issueId, { agentId: run.agentId })
+  if prunedBlockers.removedBlockedByIssueIds.length > 0:
+    re-evaluate dependencyReadiness
+    log activity with source "heartbeat.preflight_blocker_recheck"
+}
+```
+
+### 2. Heartbeat wake preflight (heartbeat.ts ~L4870)
+
+Extended the existing blocker prune beyond `issue_blockers_resolved` and `issue_children_completed` wake reasons. For ANY wake on an issue with unresolved blockers, attempt to prune stale edges before proceeding with the heartbeat.
+
+```
+if (issueId && issueContext && !resolvedBlockerPruneSource) {
+  readiness = listDependencyReadiness(...)
+  if (!readiness.isDependencyReady) {
+    prunedBlockers = pruneResolvedBlockers(issueId, { agentId: agent.id })
+    if prunedBlockers.removedBlockedByIssueIds.length > 0:
+      log activity with source "heartbeat.preflight_blocker_recheck"
+      refresh issueContext
+  }
+}
+```
+
+## Observability
+
+Both paths log activity with `action: "issue.blockers_updated"` and `source: "heartbeat.preflight_blocker_recheck"`, making it easy to audit how often the fallback mechanism fires vs. the primary `issue_blockers_resolved` wake path.
+
+## Tests Added
+
+Three new tests in `issues-service.test.ts`:
+1. `pruneResolvedBlockers removes done blockers and keeps remaining ones` — verifies partial prune (some blockers still active)
+2. `pruneResolvedBlockers resolves dependency readiness when all blockers are done` — verifies full prune cleans edges
+3. `pruneResolvedBlockers is idempotent when no blockers are done` — verifies no-op when nothing to prune
+
+## Files Changed
+
+- `server/src/services/heartbeat.ts` — Preflight prune in `claimQueuedRun` and heartbeat wake path
+- `server/src/__tests__/issues-service.test.ts` — 3 new tests for `pruneResolvedBlockers`

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1620,6 +1620,109 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     });
   });
 
+  it("pruneResolvedBlockers removes done blockers and keeps remaining ones", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const blockerADone = randomUUID();
+    const blockerBDone = randomUUID();
+    const blockerCActive = randomUUID();
+    const blockedId = randomUUID();
+    await db.insert(issues).values([
+      { id: blockerADone, companyId, title: "Blocker A (done)", status: "done", priority: "medium" },
+      { id: blockerBDone, companyId, title: "Blocker B (done)", status: "done", priority: "medium" },
+      { id: blockerCActive, companyId, title: "Blocker C (active)", status: "in_progress", priority: "medium" },
+      { id: blockedId, companyId, title: "Blocked issue", status: "todo", priority: "medium" },
+    ]);
+    await svc.update(blockedId, { blockedByIssueIds: [blockerADone, blockerBDone, blockerCActive] });
+
+    // Before pruning, all 3 blockers are in the relation
+    const readinessBefore = await svc.getDependencyReadiness(blockedId);
+    expect(readinessBefore.blockerIssueIds).toHaveLength(3);
+    expect(readinessBefore.unresolvedBlockerIssueIds).toHaveLength(1);
+    expect(readinessBefore.unresolvedBlockerIssueIds).toContain(blockerCActive);
+    expect(readinessBefore.isDependencyReady).toBe(false);
+
+    // Prune should remove the two done blockers and leave only the active one
+    const pruned = await svc.pruneResolvedBlockers(blockedId, { agentId: null });
+    expect(pruned.removedBlockedByIssueIds).toHaveLength(2);
+    expect(pruned.removedBlockedByIssueIds).toEqual(expect.arrayContaining([blockerADone, blockerBDone]));
+    expect(pruned.remainingBlockedByIssueIds).toEqual([blockerCActive]);
+
+    // After pruning, readiness reflects the pruned state
+    const readinessAfter = await svc.getDependencyReadiness(blockedId);
+    expect(readinessAfter.blockerIssueIds).toHaveLength(1);
+    expect(readinessAfter.unresolvedBlockerIssueIds).toHaveLength(1);
+    expect(readinessAfter.isDependencyReady).toBe(false);
+  });
+
+  it("pruneResolvedBlockers resolves dependency readiness when all blockers are done", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const blockerADone = randomUUID();
+    const blockerBDone = randomUUID();
+    const blockedId = randomUUID();
+    await db.insert(issues).values([
+      { id: blockerADone, companyId, title: "Blocker A (done)", status: "done", priority: "medium" },
+      { id: blockerBDone, companyId, title: "Blocker B (done)", status: "done", priority: "medium" },
+      { id: blockedId, companyId, title: "Blocked issue", status: "todo", priority: "medium" },
+    ]);
+    await svc.update(blockedId, { blockedByIssueIds: [blockerADone, blockerBDone] });
+
+    // Before pruning, dependency readiness is already "ready" because getDependencyReadiness
+    // live-queries blocker statuses. But the stale blocker edges still exist in issueRelations.
+    const readinessBefore = await svc.getDependencyReadiness(blockedId);
+    expect(readinessBefore.isDependencyReady).toBe(true);
+    expect(readinessBefore.unresolvedBlockerCount).toBe(0);
+    // However, blockerIssueIds still contains the done blockers (edges not yet pruned)
+    expect(readinessBefore.blockerIssueIds).toHaveLength(2);
+
+    // Prune removes all done blocker edges
+    const pruned = await svc.pruneResolvedBlockers(blockedId, { agentId: null });
+    expect(pruned.removedBlockedByIssueIds).toHaveLength(2);
+    expect(pruned.remainingBlockedByIssueIds).toEqual([]);
+
+    // After pruning, the blocker edges are removed from issueRelations
+    const readinessAfter = await svc.getDependencyReadiness(blockedId);
+    expect(readinessAfter.unresolvedBlockerCount).toBe(0);
+    expect(readinessAfter.isDependencyReady).toBe(true);
+    expect(readinessAfter.blockerIssueIds).toHaveLength(0);
+  });
+
+  it("pruneResolvedBlockers is idempotent when no blockers are done", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const blockerActive = randomUUID();
+    const blockedId = randomUUID();
+    await db.insert(issues).values([
+      { id: blockerActive, companyId, title: "Blocker (active)", status: "in_progress", priority: "medium" },
+      { id: blockedId, companyId, title: "Blocked issue", status: "todo", priority: "medium" },
+    ]);
+    await svc.update(blockedId, { blockedByIssueIds: [blockerActive] });
+
+    // Pruning when no blockers are done should be a no-op
+    const pruned = await svc.pruneResolvedBlockers(blockedId, { agentId: null });
+    expect(pruned.removedBlockedByIssueIds).toEqual([]);
+    expect(pruned.remainingBlockedByIssueIds).toEqual([blockerActive]);
+  });
+
   it("rejects execution when unresolved blockers remain", async () => {
     const companyId = randomUUID();
     const assigneeAgentId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4568,25 +4568,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     let issueContext = issueId ? await getIssueExecutionContext(agent.companyId, issueId) : null;
     const resolvedBlockerPruneSource = autoResumeResolvedBlockerPruneSource(wakeReason);
     if (issueId && issueContext && resolvedBlockerPruneSource) {
-      const prunedBlockers = await issuesSvc.pruneResolvedBlockers(issueId, { agentId: agent.id });
-      if (prunedBlockers.removedBlockedByIssueIds.length > 0) {
-        await logActivity(db, {
-          companyId: prunedBlockers.companyId,
-          actorType: "agent",
-          actorId: agent.id,
-          agentId: agent.id,
-          runId: run.id,
-          action: "issue.blockers_updated",
-          entityType: "issue",
-          entityId: issueId,
-          details: {
-            identifier: issueContext.identifier,
-            source: resolvedBlockerPruneSource,
-            blockedByIssueIds: prunedBlockers.remainingBlockedByIssueIds,
-            removedBlockedByIssueIds: prunedBlockers.removedBlockedByIssueIds,
-          },
-        });
-        issueContext = await getIssueExecutionContext(agent.companyId, issueId);
+      // Guard: only prune if the issue still has unresolved blockers to avoid
+      // unnecessary DB round-trips on every standard prune-source wake.
+      const readinessBeforePrune = await issuesSvc.listDependencyReadiness(agent.companyId, [issueId]);
+      if (!readinessBeforePrune.get(issueId)?.isDependencyReady) {
+        const prunedBlockers = await issuesSvc.pruneResolvedBlockers(issueId, { agentId: agent.id });
+        if (prunedBlockers.removedBlockedByIssueIds.length > 0) {
+          await logActivity(db, {
+            companyId: prunedBlockers.companyId,
+            actorType: "agent",
+            actorId: agent.id,
+            agentId: agent.id,
+            runId: run.id,
+            action: "issue.blockers_updated",
+            entityType: "issue",
+            entityId: issueId,
+            details: {
+              identifier: issueContext.identifier,
+              source: resolvedBlockerPruneSource,
+              blockedByIssueIds: prunedBlockers.remainingBlockedByIssueIds,
+              removedBlockedByIssueIds: prunedBlockers.removedBlockedByIssueIds,
+            },
+          });
+          issueContext = await getIssueExecutionContext(agent.companyId, issueId);
+        }
       }
     }
 
@@ -4595,9 +4600,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     // applied, attempt to prune anyway. This catches cases where the original
     // issue_blockers_resolved wake was missed, delayed, or race-conditioned away.
     if (issueId && issueContext && !resolvedBlockerPruneSource) {
-      const initialReadiness = issueId
-        ? await issuesSvc.listDependencyReadiness(agent.companyId, [issueId]).then((rows) => rows.get(issueId) ?? null)
-        : null;
+      const initialReadiness = await issuesSvc
+        .listDependencyReadiness(agent.companyId, [issueId])
+        .then((rows) => rows.get(issueId) ?? null);
       if (initialReadiness && !initialReadiness.isDependencyReady) {
         const prunedBlockers = await issuesSvc.pruneResolvedBlockers(issueId, { agentId: agent.id });
         if (prunedBlockers.removedBlockedByIssueIds.length > 0) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2079,7 +2079,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         executionWorkspaceId: issues.executionWorkspaceId,
         executionWorkspacePreference: issues.executionWorkspacePreference,
         assigneeAgentId: issues.assigneeAgentId,
-        checkoutRunId: issues.checkoutRunId,
         assigneeAdapterOverrides: issues.assigneeAdapterOverrides,
         executionWorkspaceSettings: issues.executionWorkspaceSettings,
       })
@@ -4645,26 +4644,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       })
     ) {
       try {
-        const shouldRecordHarnessCheckout =
-          issueContext.status !== "in_progress" || issueContext.checkoutRunId !== run.id;
-        const checkedOutIssue = await issuesSvc.checkout(issueId, agent.id, ["todo", "backlog", "blocked"], run.id);
+        await issuesSvc.checkout(issueId, agent.id, ["todo", "backlog", "blocked"], run.id);
         context[PAPERCLIP_HARNESS_CHECKOUT_KEY] = true;
-        if (shouldRecordHarnessCheckout && checkedOutIssue.checkoutRunId === run.id) {
-          await logActivity(db, {
-            companyId: checkedOutIssue.companyId,
-            actorType: "agent",
-            actorId: agent.id,
-            agentId: agent.id,
-            runId: run.id,
-            action: "issue.checked_out",
-            entityType: "issue",
-            entityId: issueId,
-            details: {
-              agentId: agent.id,
-              source: "heartbeat.auto_checkout",
-            },
-          });
-        }
       } catch (error) {
         if (!isCheckoutConflictError(error)) throw error;
         context[PAPERCLIP_HARNESS_CHECKOUT_KEY] = false;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1430,6 +1430,18 @@ function shouldAutoCheckoutIssueForWake(input: {
   return true;
 }
 
+function autoResumeResolvedBlockerPruneSource(
+  wakeReason: string | null,
+): string | null {
+  if (wakeReason === "issue_blockers_resolved") {
+    return "heartbeat.issue_blockers_resolved_auto_resume";
+  }
+  if (wakeReason === "issue_children_completed") {
+    return "heartbeat.issue_children_completed_auto_resume";
+  }
+  return null;
+}
+
 function shouldQueueFollowupForRunningIssueWake(input: {
   contextSnapshot: Record<string, unknown> | null | undefined;
   wakeCommentId: string | null;
@@ -2067,6 +2079,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         executionWorkspaceId: issues.executionWorkspaceId,
         executionWorkspacePreference: issues.executionWorkspacePreference,
         assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
         assigneeAdapterOverrides: issues.assigneeAdapterOverrides,
         executionWorkspaceSettings: issues.executionWorkspaceSettings,
       })
@@ -3784,10 +3797,45 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return null;
       }
 
-      const dependencyReadiness = await issuesSvc.listDependencyReadiness(run.companyId, [issueId]);
-      const readiness = dependencyReadiness.get(issueId);
-      const unresolvedBlockerCount = readiness?.unresolvedBlockerCount ?? 0;
+      let dependencyReadiness = await issuesSvc.listDependencyReadiness(run.companyId, [issueId]);
+      let unresolvedBlockerCount = dependencyReadiness.get(issueId)?.unresolvedBlockerCount ?? 0;
+
+      // Preflight blocker recheck (MON-307): If the issue has unresolved blockers,
+      // attempt to prune any that have since become "done". This makes the system
+      // self-healing when an issue_blockers_resolved wake was missed or delayed,
+      // preventing agents from spin-looping on issues whose blockers are already
+      // complete.
+      if (unresolvedBlockerCount > 0) {
+        const prunedBlockers = await issuesSvc.pruneResolvedBlockers(issueId, { agentId: run.agentId });
+        if (prunedBlockers.removedBlockedByIssueIds.length > 0) {
+          logger.info(
+            { runId: run.id, issueId, removedBlockers: prunedBlockers.removedBlockedByIssueIds, remainingBlockers: prunedBlockers.remainingBlockedByIssueIds },
+            "claimQueuedRun: preflight prune removed stale blocker edges",
+          );
+          await logActivity(db, {
+            companyId: run.companyId,
+            actorType: "agent",
+            actorId: run.agentId,
+            agentId: run.agentId,
+            runId: run.id,
+            action: "issue.blockers_updated",
+            entityType: "issue",
+            entityId: issueId,
+            details: {
+              source: "heartbeat.preflight_blocker_recheck",
+              blockedByIssueIds: prunedBlockers.remainingBlockedByIssueIds,
+              removedBlockedByIssueIds: prunedBlockers.removedBlockedByIssueIds,
+            },
+          });
+
+          // Re-evaluate dependency readiness after pruning
+          dependencyReadiness = await issuesSvc.listDependencyReadiness(run.companyId, [issueId]);
+          unresolvedBlockerCount = dependencyReadiness.get(issueId)?.unresolvedBlockerCount ?? 0;
+        }
+      }
+
       if (unresolvedBlockerCount > 0 && !allowsIssueInteractionWake(context)) {
+        const readiness = dependencyReadiness.get(issueId);
         await cancelQueuedRunForBlockedDependencies(run, issueId, readiness?.unresolvedBlockerIssueIds ?? []);
         logger.info({ runId: run.id, issueId, unresolvedBlockerCount }, "claimQueuedRun: cancelled blocked queued run");
         return null;
@@ -4516,7 +4564,67 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const taskKey = deriveTaskKeyWithHeartbeatFallback(context, null);
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
     const issueId = readNonEmptyString(context.issueId);
+    const wakeReason = readNonEmptyString(context.wakeReason);
     let issueContext = issueId ? await getIssueExecutionContext(agent.companyId, issueId) : null;
+    const resolvedBlockerPruneSource = autoResumeResolvedBlockerPruneSource(wakeReason);
+    if (issueId && issueContext && resolvedBlockerPruneSource) {
+      const prunedBlockers = await issuesSvc.pruneResolvedBlockers(issueId, { agentId: agent.id });
+      if (prunedBlockers.removedBlockedByIssueIds.length > 0) {
+        await logActivity(db, {
+          companyId: prunedBlockers.companyId,
+          actorType: "agent",
+          actorId: agent.id,
+          agentId: agent.id,
+          runId: run.id,
+          action: "issue.blockers_updated",
+          entityType: "issue",
+          entityId: issueId,
+          details: {
+            identifier: issueContext.identifier,
+            source: resolvedBlockerPruneSource,
+            blockedByIssueIds: prunedBlockers.remainingBlockedByIssueIds,
+            removedBlockedByIssueIds: prunedBlockers.removedBlockedByIssueIds,
+          },
+        });
+        issueContext = await getIssueExecutionContext(agent.companyId, issueId);
+      }
+    }
+
+    // MON-307: Preflight blocker recheck on any wake for a blocked issue.
+    // If the issue has unresolved blockers but none of the standard prune sources
+    // applied, attempt to prune anyway. This catches cases where the original
+    // issue_blockers_resolved wake was missed, delayed, or race-conditioned away.
+    if (issueId && issueContext && !resolvedBlockerPruneSource) {
+      const initialReadiness = issueId
+        ? await issuesSvc.listDependencyReadiness(agent.companyId, [issueId]).then((rows) => rows.get(issueId) ?? null)
+        : null;
+      if (initialReadiness && !initialReadiness.isDependencyReady) {
+        const prunedBlockers = await issuesSvc.pruneResolvedBlockers(issueId, { agentId: agent.id });
+        if (prunedBlockers.removedBlockedByIssueIds.length > 0) {
+          logger.info(
+            { runId: run.id, agentId: agent.id, issueId, wakeReason, removedBlockers: prunedBlockers.removedBlockedByIssueIds, remainingBlockers: prunedBlockers.remainingBlockedByIssueIds },
+            "heartbeat: preflight blocker recheck pruned stale blocker edges",
+          );
+          await logActivity(db, {
+            companyId: prunedBlockers.companyId,
+            actorType: "agent",
+            actorId: agent.id,
+            agentId: agent.id,
+            runId: run.id,
+            action: "issue.blockers_updated",
+            entityType: "issue",
+            entityId: issueId,
+            details: {
+              identifier: issueContext.identifier,
+              source: "heartbeat.preflight_blocker_recheck",
+              blockedByIssueIds: prunedBlockers.remainingBlockedByIssueIds,
+              removedBlockedByIssueIds: prunedBlockers.removedBlockedByIssueIds,
+            },
+          });
+          issueContext = await getIssueExecutionContext(agent.companyId, issueId);
+        }
+      }
+    }
     const issueDependencyReadiness = issueId
       ? await issuesSvc.listDependencyReadiness(agent.companyId, [issueId]).then((rows) => rows.get(issueId) ?? null)
       : null;
@@ -4532,8 +4640,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       })
     ) {
       try {
-        await issuesSvc.checkout(issueId, agent.id, ["todo", "backlog", "blocked"], run.id);
+        const shouldRecordHarnessCheckout =
+          issueContext.status !== "in_progress" || issueContext.checkoutRunId !== run.id;
+        const checkedOutIssue = await issuesSvc.checkout(issueId, agent.id, ["todo", "backlog", "blocked"], run.id);
         context[PAPERCLIP_HARNESS_CHECKOUT_KEY] = true;
+        if (shouldRecordHarnessCheckout && checkedOutIssue.checkoutRunId === run.id) {
+          await logActivity(db, {
+            companyId: checkedOutIssue.companyId,
+            actorType: "agent",
+            actorId: agent.id,
+            agentId: agent.id,
+            runId: run.id,
+            action: "issue.checked_out",
+            entityType: "issue",
+            entityId: issueId,
+            details: {
+              agentId: agent.id,
+              source: "heartbeat.auto_checkout",
+            },
+          });
+        }
       } catch (error) {
         if (!isCheckoutConflictError(error)) throw error;
         context[PAPERCLIP_HARNESS_CHECKOUT_KEY] = false;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -165,6 +165,13 @@ export type IssueDependencyReadiness = {
   allBlockersDone: boolean;
   isDependencyReady: boolean;
 };
+export type ResolvedBlockerPruneResult = {
+  issueId: string;
+  companyId: string;
+  blockedByIssueIds: string[];
+  remainingBlockedByIssueIds: string[];
+  removedBlockedByIssueIds: string[];
+};
 export type ChildIssueCompletionSummary = {
   id: string;
   identifier: string | null;
@@ -1704,6 +1711,68 @@ export function issueService(db: Db) {
     );
   }
 
+  async function pruneResolvedBlockersForIssue(
+    issueId: string,
+    actor: { agentId?: string | null; userId?: string | null } = {},
+    dbOrTx: any = db,
+  ): Promise<ResolvedBlockerPruneResult> {
+    const runPrune = async (tx: any) => {
+      await tx.execute(
+        sql`select ${issues.id} from ${issues} where ${issues.id} = ${issueId} for update`,
+      );
+
+      const issue = await tx
+        .select({ id: issues.id, companyId: issues.companyId })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows: Array<{ id: string; companyId: string }>) => rows[0] ?? null);
+      if (!issue) throw notFound("Issue not found");
+
+      const blockerRows = await tx
+        .select({
+          blockerIssueId: issueRelations.issueId,
+          blockerStatus: issues.status,
+        })
+        .from(issueRelations)
+        .innerJoin(issues, eq(issueRelations.issueId, issues.id))
+        .where(
+          and(
+            eq(issueRelations.companyId, issue.companyId),
+            eq(issueRelations.type, "blocks"),
+            eq(issueRelations.relatedIssueId, issueId),
+          ),
+        );
+
+      const blockedByIssueIds = blockerRows.map((row: { blockerIssueId: string }) => row.blockerIssueId);
+      const remainingBlockedByIssueIds = blockerRows
+        .filter((row: { blockerStatus: string }) => row.blockerStatus !== "done")
+        .map((row: { blockerIssueId: string }) => row.blockerIssueId);
+      const removedBlockedByIssueIds = blockerRows
+        .filter((row: { blockerStatus: string }) => row.blockerStatus === "done")
+        .map((row: { blockerIssueId: string }) => row.blockerIssueId);
+
+      if (removedBlockedByIssueIds.length > 0) {
+        await syncBlockedByIssueIds(
+          issueId,
+          issue.companyId,
+          remainingBlockedByIssueIds,
+          actor,
+          tx,
+        );
+      }
+
+      return {
+        issueId,
+        companyId: issue.companyId,
+        blockedByIssueIds,
+        remainingBlockedByIssueIds,
+        removedBlockedByIssueIds,
+      };
+    };
+
+    return dbOrTx === db ? db.transaction(runPrune) : runPrune(dbOrTx);
+  }
+
   async function isTerminalOrMissingHeartbeatRun(runId: string) {
     const run = await db
       .select({ status: heartbeatRuns.status })
@@ -2162,6 +2231,12 @@ export function issueService(db: Db) {
     listDependencyReadiness: async (companyId: string, issueIds: string[], dbOrTx: any = db) => {
       return listIssueDependencyReadinessMap(dbOrTx, companyId, issueIds);
     },
+
+    pruneResolvedBlockers: async (
+      issueId: string,
+      actor: { agentId?: string | null; userId?: string | null } = {},
+      dbOrTx: any = db,
+    ) => pruneResolvedBlockersForIssue(issueId, actor, dbOrTx),
 
     listBlockerAttention: async (
       companyId: string,


### PR DESCRIPTION
## feat(MON-307): Preflight blocker recheck on wake to auto-resolve stale blocker edges

### Problem
When dependency blockers are resolved upstream, the dependent blocked issue often stays blocked indefinitely because nothing prunes the stale blocker edge.

### Solution
Added a preflight blocker recheck in the heartbeat wake path. On issue_blockers_resolved and issue_children_completed wake reasons, immediately prune resolved blocker edges. On any wake for a blocked issue, check dependencyReadiness and auto-resolve stale blockers.

### Files Changed (after rebase)
- doc/plans/2026-04-26-workflow-optimizer-blocker-recheck.md
- server/src/services/heartbeat.ts
- server/src/services/issues.ts
- server/src/__tests__/issues-service.test.ts

### Review Feedback Addressed
- P2: Removed redundant null guard inside guaranteed-truthy branch
- P2: Added readiness guard to standard prune-source path
- P1: Removed unrelated ops docs that were bundled in the original PR

Clean diff: 4 files, 359 insertions, 3 deletions.