### PR TITLE
ci(pr): bootstrap lockfile when a new workspace package is added

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -70,6 +72,30 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+
+      - name: Bootstrap lockfile if a new workspace package was added
+        run: |
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          added="$(git diff --name-only --diff-filter=A "$base_sha" "$head_sha" || true)"
+          new_pkgs=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              packages/plugins/examples/plugin-orchestration-smoke-example/package.json)
+                continue
+                ;;
+              packages/*/package.json|packages/*/*/package.json|packages/*/*/*/package.json)
+                new_pkgs="${new_pkgs}${new_pkgs:+ }${f}"
+                ;;
+            esac
+          done <<<"$added"
+          if [ -n "$new_pkgs" ]; then
+            echo "::notice title=Lockfile bootstrap::New workspace package(s) detected (${new_pkgs}). Running 'pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile' to align pnpm-lock.yaml before the strict install."
+            pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile
+          else
+            echo "No new workspace package detected — keeping strict --frozen-lockfile install."
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -97,6 +123,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -108,6 +136,30 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+
+      - name: Bootstrap lockfile if a new workspace package was added
+        run: |
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          added="$(git diff --name-only --diff-filter=A "$base_sha" "$head_sha" || true)"
+          new_pkgs=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              packages/plugins/examples/plugin-orchestration-smoke-example/package.json)
+                continue
+                ;;
+              packages/*/package.json|packages/*/*/package.json|packages/*/*/*/package.json)
+                new_pkgs="${new_pkgs}${new_pkgs:+ }${f}"
+                ;;
+            esac
+          done <<<"$added"
+          if [ -n "$new_pkgs" ]; then
+            echo "::notice title=Lockfile bootstrap::New workspace package(s) detected (${new_pkgs}). Running 'pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile' to align pnpm-lock.yaml before the strict install."
+            pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile
+          else
+            echo "No new workspace package detected — keeping strict --frozen-lockfile install."
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,11 +81,15 @@ jobs:
           new_pkgs=""
           while IFS= read -r f; do
             [ -z "$f" ] && continue
+            # bash `case` `*` matches `/`, so `packages/*/package.json`
+            # covers nested workspace packages at any depth. Exclusions
+            # mirror the negations in pnpm-workspace.yaml.
             case "$f" in
-              packages/plugins/examples/plugin-orchestration-smoke-example/package.json)
+              packages/plugins/examples/plugin-orchestration-smoke-example/package.json|\
+              packages/plugins/sandbox-providers/*)
                 continue
                 ;;
-              packages/*/package.json|packages/*/*/package.json|packages/*/*/*/package.json)
+              packages/*/package.json)
                 new_pkgs="${new_pkgs}${new_pkgs:+ }${f}"
                 ;;
             esac
@@ -145,11 +149,15 @@ jobs:
           new_pkgs=""
           while IFS= read -r f; do
             [ -z "$f" ] && continue
+            # bash `case` `*` matches `/`, so `packages/*/package.json`
+            # covers nested workspace packages at any depth. Exclusions
+            # mirror the negations in pnpm-workspace.yaml.
             case "$f" in
-              packages/plugins/examples/plugin-orchestration-smoke-example/package.json)
+              packages/plugins/examples/plugin-orchestration-smoke-example/package.json|\
+              packages/plugins/sandbox-providers/*)
                 continue
                 ;;
-              packages/*/package.json|packages/*/*/package.json|packages/*/*/*/package.json)
+              packages/*/package.json)
                 new_pkgs="${new_pkgs}${new_pkgs:+ }${f}"
                 ;;
             esac


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The `pr.yml` workflow gates every PR with `policy`, `verify`, and `e2e` jobs
> - `verify` and `e2e` run `pnpm install --frozen-lockfile`, while `policy` blocks any direct `pnpm-lock.yaml` edit in a PR (lockfile changes are owned by the post-merge `refresh-lockfile` workflow)
> - That trio is internally inconsistent: any PR that adds a new workspace package (e.g. a fresh adapter or plugin under `packages/...`) cannot pass CI — `--frozen-lockfile` rejects an out-of-date lockfile, and the PR cannot update it. The post-merge refresh only runs after master, so there is no path through the standard PR flow. PR #4166 (`feat(ollama): M3`) hit this directly: both `verify` and `e2e` failed at install time on `@paperclipai/adapter-ollama-local` and `@paperclipai/plugin-ollama`.
> - This PR keeps `--frozen-lockfile` as the strict default but adds a narrowly-gated bootstrap step in `verify` and `e2e` that pre-aligns the lockfile only when the PR diff actually adds a new workspace `package.json`.
> - The benefit is that adding a new workspace package becomes a normal PR again, without weakening lockfile guarantees on every other PR.

## What Changed

- `verify` and `e2e` jobs now bump checkout to `fetch-depth: 0` so the PR base SHA is reachable.
- New step `Bootstrap lockfile if a new workspace package was added` (identical in both jobs):
  - Computes `git diff --name-only --diff-filter=A` between `pull_request.base.sha` and `pull_request.head.sha`.
  - Matches added paths against workspace globs derived from `pnpm-workspace.yaml` (`packages/*/package.json`, `packages/*/*/package.json`, `packages/*/*/*/package.json`), explicitly excluding the `plugin-orchestration-smoke-example` fixture (which is a non-workspace example and already negated in `pnpm-workspace.yaml`).
  - When at least one new workspace `package.json` is detected, emits a GitHub Actions `::notice title=Lockfile bootstrap::` log line naming the package(s) and runs `pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile` to align `pnpm-lock.yaml` in the runner.
  - When no new package is detected, logs `No new workspace package detected — keeping strict --frozen-lockfile install.` and falls through unchanged.
- The existing `Install dependencies` step (`pnpm install --frozen-lockfile`) is retained verbatim. On the bootstrap path it now runs against an aligned lockfile; on every other PR it behaves exactly as before.

## Verification

- YAML parsed locally: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr.yml'))"` → OK.
- Logical walk-through:
  - **PR with no new workspace package (this PR)**: `git diff --diff-filter=A` returns nothing matching the workspace globs → bootstrap step prints the no-op log line and exits 0 → `pnpm install --frozen-lockfile` runs as today. Expected outcome on this PR's own CI: green `verify` / `e2e`, with the `No new workspace package detected` log entry visible in both job traces (acts as the live test of the conditional).
  - **PR adding a new package** (e.g. `packages/adapters/foo/package.json`): the added file matches `packages/*/*/package.json` → bootstrap logs `New workspace package(s) detected (...)` and runs `pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile` → the lockfile now references the new importer → `pnpm install --frozen-lockfile` succeeds. This is the structural unblock for [PR #4166](https://github.com/paperclipai/paperclip/pull/4166).
  - **PR modifying an existing manifest** (version bump, dep change, etc.): `--diff-filter=A` does not list it → bootstrap prints the no-op log → `--frozen-lockfile` runs as today. If the PR forgot to land via `chore/refresh-lockfile`, install still fails loudly; the bootstrap is intentionally not used as an escape hatch for stale lockfiles.
- Side-effect check on `verify`'s `Release canary dry run`: that step starts with `git checkout -- pnpm-lock.yaml`, which discards any in-runner lockfile modifications (including a bootstrap), so `./scripts/release.sh canary --skip-verify --dry-run` continues to operate on the committed lockfile. No change in canary behavior.

## Risks

- **Low risk overall.** The bootstrap branch is gated on `--diff-filter=A` against a workspace-scoped glob list, so normal PRs never enter it.
- The bootstrap install adds runtime to PRs that legitimately introduce a new workspace package (extra `pnpm install --lockfile-only --ignore-scripts`). This is unavoidable and rare; benefit is unblocking the workflow entirely.
- `fetch-depth: 0` adds a small clone cost on every `verify` / `e2e` run. Repo history is modest and `pnpm install` already dominates wall time.
- If a future workspace pattern is added beyond depth 4 under `packages/`, the detection patterns will need to be updated. Today's `pnpm-workspace.yaml` (`packages/*`, `packages/adapters/*`, `packages/plugins/*`, `packages/plugins/examples/*`, plus the static `server` / `ui` / `cli` roots — none of which can be "added" via PR) is fully covered.
- The conditional only short-circuits the install-time lockfile mismatch. The `policy` job's pre-existing lockfile-edit guard remains intact: PR authors still cannot commit `pnpm-lock.yaml` themselves.

> Verified that this lives outside the `ROADMAP.md` core feature scope (it is workflow plumbing for repo CI, not product surface).

## Model Used

- Claude (Anthropic) — `claude-opus-4-7` (1M context window), invoked via the Paperclip CTO agent (`837f3e09-…`) in a heartbeat run. No extended thinking mode beyond default tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (workflow is YAML — validated via `yaml.safe_load`; runtime validation will come from this PR's own `verify` / `e2e` jobs, which exercise the no-op branch of the new step)
- [ ] I have added or updated tests where applicable (no automated test surface for workflow YAML; the conditional's no-op path is exercised by this PR's own CI, and the bootstrap path will be exercised by [PR #4166](https://github.com/paperclipai/paperclip/pull/4166) once rebased on top)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — CI workflow only)
- [x] I have updated relevant documentation to reflect my changes (no docs reference the lockfile flow yet; followed the existing comment style in `pr.yml`)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

Refs: GEM-53 (this change), GEM-51 (parent CI plan, decision D1=(a)).