### PR TITLE
feat(plugins): commit Approvals Menu example source (MYO-22 / MYO-41)

### DIFF
--- a/packages/plugins/examples/plugin-approvals-menu-example/README.md
+++ b/packages/plugins/examples/plugin-approvals-menu-example/README.md
@@ -1,0 +1,54 @@
+# @paperclipai/plugin-approvals-menu-example
+
+Reference plugin that adds an **Approvals** entry to the application sidebar
+(beside Inbox) with a pending-count badge, plus a dedicated pending-approvals
+list page mounted at `/<companyPrefix>/approvals-menu`.
+
+## What It Demonstrates
+
+- a manifest with `sidebar` and `page` UI slots
+- `entrypoints.ui` wiring for plugin UI bundles
+- reading host context (`companyId`, `companyPrefix`) from `PluginSidebarProps` / `PluginPageProps`
+- worker `setup` handler exposing plugin config through `ctx.data.register`
+- reading effective config from the UI side via `usePluginData("plugin-config")`
+- same-origin `fetch` against the host approvals API for read-only data
+
+## Configuration
+
+The instance config schema declares three operator-tunable values:
+
+| Key | Default | Effect |
+|---|---|---|
+| `refreshIntervalSeconds` | `60` | Sidebar badge + list page poll cadence. `0` disables polling. |
+| `showBadge` | `true` | Whether to render the pending-count pill on the sidebar. |
+| `listLimit` | `50` | Max rows rendered on the list page. The host approvals API does not accept a `limit` query parameter, so the cap is applied client-side after the response. |
+
+## Behaviour Notes
+
+- **Sidebar link target.** The sidebar entry navigates to the plugin's own page
+  (`/<companyPrefix>/approvals-menu`), not to the core `/approvals/pending`
+  route. The plugin page slot is the canonical destination for this plugin.
+- **Non-board user fallback.** If the approvals API responds with `401`, `403`
+  or `404` (typical for an authenticated user without board access), the
+  sidebar entry hides itself and the page renders a neutral "not available"
+  state — never a red error alert.
+- **Read-only.** This iteration does not implement inline approve / reject. The
+  list deep-links each row to the core approval detail page where the action
+  buttons live.
+
+## Local Install (Dev)
+
+From the repo root:
+
+```bash
+pnpm --filter @paperclipai/plugin-approvals-menu-example build
+pnpm paperclipai plugin install ./packages/plugins/examples/plugin-approvals-menu-example
+```
+
+**Local development notes:**
+
+- **Build first.** The host resolves the worker from the manifest's `entrypoints.worker` (`./dist/worker.js`). Run `pnpm build` before installing so the worker file exists.
+- **Dev-only install path.** This local-path install flow assumes a source checkout with this example package present on disk. For deployed installs, publish an npm package instead of relying on the monorepo example path.
+- **Reinstall after pulling.** If you installed a plugin by local path before the server stored `package_path`, the plugin may show status **error** (worker not found). Uninstall and install again so the server persists the path and can activate the plugin:
+  `pnpm paperclipai plugin uninstall paperclip.approvals-menu-example --force` then
+  `pnpm paperclipai plugin install ./packages/plugins/examples/plugin-approvals-menu-example`.

--- a/packages/plugins/examples/plugin-approvals-menu-example/package.json
+++ b/packages/plugins/examples/plugin-approvals-menu-example/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@paperclipai/plugin-approvals-menu-example",
+  "version": "0.1.0",
+  "description": "First-party reference plugin that adds an Approvals sidebar entry and a pending-approvals list page",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "scripts": {
+    "prebuild": "node ../../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.3"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/examples/plugin-approvals-menu-example/src/constants.ts
+++ b/packages/plugins/examples/plugin-approvals-menu-example/src/constants.ts
@@ -1,0 +1,31 @@
+/**
+ * Stable plugin identifiers shared between the manifest and runtime code.
+ */
+export const PLUGIN_ID = "paperclip.approvals-menu-example";
+export const PLUGIN_VERSION = "0.1.0";
+
+export const SIDEBAR_SLOT_ID = "approvals-menu-link";
+export const PAGE_SLOT_ID = "approvals-menu-page";
+
+export const EXPORT_NAMES = {
+  sidebar: "ApprovalsMenuLink",
+  page: "ApprovalsMenuPage",
+} as const;
+
+/** Plugin-owned page route, mounted at `/:companyPrefix/approvals-menu`. */
+export const PAGE_ROUTE = "approvals-menu";
+
+export const DEFAULT_CONFIG = {
+  /** Auto-refresh interval for the badge + list view (seconds). 0 disables polling. */
+  refreshIntervalSeconds: 60,
+  /** Whether to surface a numeric pending count badge on the sidebar link. */
+  showBadge: true,
+  /**
+   * Max rows displayed in the pending list page. The host approvals API does
+   * not accept a `limit` query parameter, so this cap is applied client-side
+   * after the response is received.
+   */
+  listLimit: 50,
+};
+
+export type ApprovalsMenuPluginConfig = typeof DEFAULT_CONFIG;

--- a/packages/plugins/examples/plugin-approvals-menu-example/src/index.ts
+++ b/packages/plugins/examples/plugin-approvals-menu-example/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-approvals-menu-example/src/manifest.ts
+++ b/packages/plugins/examples/plugin-approvals-menu-example/src/manifest.ts
@@ -1,0 +1,89 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+import {
+  DEFAULT_CONFIG,
+  EXPORT_NAMES,
+  PAGE_ROUTE,
+  PAGE_SLOT_ID,
+  PLUGIN_ID,
+  PLUGIN_VERSION,
+  SIDEBAR_SLOT_ID,
+} from "./constants.js";
+
+/**
+ * Adds an "Approvals" entry to the application sidebar (next to Inbox) and a
+ * pending-approvals list page at `/:companyPrefix/approvals-menu`.
+ *
+ * Read capabilities are intentionally minimal: the UI reads approvals through
+ * the same-origin board session, so the worker only exposes plugin config and
+ * health. No approve/deny mutations in this iteration — users click through to
+ * the core approval detail page.
+ */
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Approvals Menu (Example)",
+  description:
+    "Adds an Approvals entry to the sidebar with a pending-count badge and a dedicated list page, similar to Inbox.",
+  author: "Paperclip",
+  categories: ["ui"],
+  capabilities: [
+    "companies.read",
+    "plugin.state.read",
+    "ui.sidebar.register",
+    "ui.page.register",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      refreshIntervalSeconds: {
+        type: "number",
+        title: "Refresh Interval (seconds)",
+        description:
+          "How often the sidebar badge and list auto-refresh. 0 disables polling.",
+        default: DEFAULT_CONFIG.refreshIntervalSeconds,
+        minimum: 0,
+        maximum: 3600,
+      },
+      showBadge: {
+        type: "boolean",
+        title: "Show Pending Count Badge",
+        default: DEFAULT_CONFIG.showBadge,
+      },
+      listLimit: {
+        type: "number",
+        title: "List Row Limit",
+        description:
+          "Maximum pending approvals shown on the list page. The host approvals API does not accept a limit parameter, so this cap is applied client-side after the response.",
+        default: DEFAULT_CONFIG.listLimit,
+        minimum: 1,
+        maximum: 500,
+      },
+    },
+  },
+  ui: {
+    slots: [
+      {
+        type: "sidebar",
+        id: SIDEBAR_SLOT_ID,
+        displayName: "Approvals",
+        exportName: EXPORT_NAMES.sidebar,
+        order: 20,
+      },
+      {
+        type: "page",
+        id: PAGE_SLOT_ID,
+        displayName: "Approvals",
+        exportName: EXPORT_NAMES.page,
+        routePath: PAGE_ROUTE,
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-approvals-menu-example/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-approvals-menu-example/src/ui/index.tsx
@@ -1,0 +1,362 @@
+import { useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
+import type { PluginPageProps, PluginSidebarProps } from "@paperclipai/plugin-sdk/ui";
+import { usePluginData } from "@paperclipai/plugin-sdk/ui";
+
+const DEFAULT_CONFIG = {
+  refreshIntervalSeconds: 60,
+  showBadge: true,
+  listLimit: 50,
+};
+
+const PAGE_ROUTE = "approvals-menu";
+
+interface ApprovalRecord {
+  id: string;
+  type: string;
+  status: string;
+  createdAt: string;
+  payload?: { title?: string } | null;
+  requestedByAgentId?: string | null;
+  requestedByUserId?: string | null;
+}
+
+interface PluginConfigShape {
+  refreshIntervalSeconds?: number;
+  showBadge?: boolean;
+  listLimit?: number;
+}
+
+function buildApprovalsUrl(companyId: string): string {
+  const search = new URLSearchParams({ status: "pending" });
+  return `/api/companies/${encodeURIComponent(companyId)}/approvals?${search.toString()}`;
+}
+
+function buildPagePath(companyPrefix: string | null): string {
+  return companyPrefix ? `/${companyPrefix}/${PAGE_ROUTE}` : `/${PAGE_ROUTE}`;
+}
+
+function buildApprovalDetailPath(
+  companyPrefix: string | null,
+  approvalId: string,
+): string {
+  return companyPrefix
+    ? `/${companyPrefix}/approvals/${approvalId}`
+    : `/approvals/${approvalId}`;
+}
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const diff = Math.max(0, Date.now() - then);
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  return `${days}d ago`;
+}
+
+interface UsePendingApprovalsResult {
+  approvals: ApprovalRecord[];
+  loading: boolean;
+  error: string | null;
+  unauthorized: boolean;
+  refresh: () => void;
+}
+
+/**
+ * Polls the pending approvals list using the same-origin board session.
+ *
+ * Treats 401/403/404 as "the current user has no access to this company's
+ * approvals" — a non-board fallback that should render silently rather than
+ * surface a red error banner. Any other failure (network, 5xx, parse) is
+ * reported as a regular error so operators can see real breakage.
+ */
+function usePendingApprovals(
+  companyId: string | null,
+  refreshIntervalSeconds: number,
+  limit: number,
+): UsePendingApprovalsResult {
+  const [approvals, setApprovals] = useState<ApprovalRecord[]>([]);
+  const [loading, setLoading] = useState<boolean>(Boolean(companyId));
+  const [error, setError] = useState<string | null>(null);
+  const [unauthorized, setUnauthorized] = useState<boolean>(false);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!companyId) {
+      setApprovals([]);
+      setLoading(false);
+      setError(null);
+      setUnauthorized(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    fetch(buildApprovalsUrl(companyId), { credentials: "same-origin" })
+      .then(async (res) => {
+        if (cancelled) return;
+        if (res.status === 401 || res.status === 403 || res.status === 404) {
+          setApprovals([]);
+          setError(null);
+          setUnauthorized(true);
+          return;
+        }
+        if (!res.ok) {
+          throw new Error(`Approvals request failed (${res.status})`);
+        }
+        const body = (await res.json()) as ApprovalRecord[];
+        setApprovals(Array.isArray(body) ? body.slice(0, limit) : []);
+        setError(null);
+        setUnauthorized(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setUnauthorized(false);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [companyId, limit, tick]);
+
+  useEffect(() => {
+    if (!companyId || refreshIntervalSeconds <= 0) return;
+    const handle = window.setInterval(
+      () => setTick((t) => t + 1),
+      refreshIntervalSeconds * 1000,
+    );
+    return () => window.clearInterval(handle);
+  }, [companyId, refreshIntervalSeconds]);
+
+  const refresh = useMemo(() => () => setTick((t) => t + 1), []);
+  return { approvals, loading, error, unauthorized, refresh };
+}
+
+function useResolvedConfig() {
+  const { data } = usePluginData<PluginConfigShape>("plugin-config", {});
+  return {
+    refreshIntervalSeconds:
+      typeof data?.refreshIntervalSeconds === "number"
+        ? data.refreshIntervalSeconds
+        : DEFAULT_CONFIG.refreshIntervalSeconds,
+    showBadge: data?.showBadge ?? DEFAULT_CONFIG.showBadge,
+    listLimit:
+      typeof data?.listLimit === "number" && data.listLimit > 0
+        ? data.listLimit
+        : DEFAULT_CONFIG.listLimit,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sidebar entry — mirrors the Inbox nav item with a pending-count badge.
+// Links to the plugin's own page so the sidebar is the canonical entry point
+// for this plugin (do NOT bypass the plugin and link to core /approvals/pending).
+// ---------------------------------------------------------------------------
+
+const SIDEBAR_LINK_STYLE: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.625rem",
+  padding: "0.5rem 0.75rem",
+  fontSize: 13,
+  fontWeight: 500,
+  color: "inherit",
+  textDecoration: "none",
+};
+
+const SIDEBAR_BADGE_STYLE: CSSProperties = {
+  minWidth: 20,
+  padding: "0 6px",
+  borderRadius: 10,
+  background: "var(--accent, rgba(120,120,120,0.2))",
+  fontSize: 11,
+  textAlign: "center",
+  lineHeight: "18px",
+};
+
+export function ApprovalsMenuLink({ context }: PluginSidebarProps) {
+  const config = useResolvedConfig();
+  const { approvals, error, unauthorized } = usePendingApprovals(
+    context.companyId,
+    config.refreshIntervalSeconds,
+    config.listLimit,
+  );
+
+  // Non-board user (or no approvals surface available) — render nothing so the
+  // sidebar stays clean instead of showing a dead link.
+  if (unauthorized) return null;
+
+  const href = buildPagePath(context.companyPrefix);
+  const count = approvals.length;
+  const showBadge = config.showBadge && count > 0 && !error;
+
+  return (
+    <a href={href} aria-label="Approvals" style={SIDEBAR_LINK_STYLE}>
+      <span aria-hidden style={{ width: 16, textAlign: "center" }}>
+        ✓
+      </span>
+      <span style={{ flex: 1 }}>Approvals</span>
+      {showBadge ? (
+        <span style={SIDEBAR_BADGE_STYLE}>{count > 99 ? "99+" : count}</span>
+      ) : null}
+    </a>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page — full list of pending approvals with deep links to the core detail page.
+// ---------------------------------------------------------------------------
+
+const PAGE_ROOT_STYLE: CSSProperties = {
+  padding: "1.5rem",
+  display: "grid",
+  gap: "1rem",
+};
+
+const PAGE_HEADER_STYLE: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.75rem",
+};
+
+const REFRESH_BUTTON_STYLE: CSSProperties = {
+  marginLeft: "auto",
+  padding: "0.25rem 0.75rem",
+  fontSize: 12,
+  borderRadius: 4,
+  border: "1px solid currentColor",
+  background: "transparent",
+  cursor: "pointer",
+};
+
+const TABLE_STYLE: CSSProperties = {
+  width: "100%",
+  borderCollapse: "collapse",
+  fontSize: 13,
+};
+
+const TABLE_HEAD_ROW_STYLE: CSSProperties = {
+  textAlign: "left",
+  borderBottom: "1px solid rgba(128,128,128,0.25)",
+};
+
+const TABLE_BODY_ROW_STYLE: CSSProperties = {
+  borderBottom: "1px solid rgba(128,128,128,0.12)",
+};
+
+const TABLE_CELL_STYLE: CSSProperties = { padding: "0.5rem" };
+const TABLE_CELL_MONO_STYLE: CSSProperties = {
+  padding: "0.5rem",
+  fontFamily: "monospace",
+  fontSize: 12,
+};
+
+export function ApprovalsMenuPage({ context }: PluginPageProps) {
+  const config = useResolvedConfig();
+  const { approvals, loading, error, unauthorized, refresh } = usePendingApprovals(
+    context.companyId,
+    config.refreshIntervalSeconds,
+    config.listLimit,
+  );
+
+  if (!context.companyId) {
+    return (
+      <section style={{ padding: "1.5rem" }}>
+        <h1 style={{ margin: 0 }}>Approvals</h1>
+        <p>Select a company to view its pending approvals.</p>
+      </section>
+    );
+  }
+
+  // Non-board fallback: render a neutral, non-alarming state. Operators see no
+  // red error banner; the page is simply empty for users without access.
+  if (unauthorized) {
+    return (
+      <section style={PAGE_ROOT_STYLE}>
+        <header style={PAGE_HEADER_STYLE}>
+          <h1 style={{ margin: 0, fontSize: 20 }}>Pending Approvals</h1>
+        </header>
+        <div style={{ opacity: 0.7 }}>
+          Approvals are not available for your account in this company.
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section style={PAGE_ROOT_STYLE}>
+      <header style={PAGE_HEADER_STYLE}>
+        <h1 style={{ margin: 0, fontSize: 20 }}>Pending Approvals</h1>
+        <span style={{ fontSize: 13, opacity: 0.7 }}>
+          {loading ? "refreshing…" : `${approvals.length} pending`}
+        </span>
+        <button type="button" onClick={refresh} style={REFRESH_BUTTON_STYLE}>
+          Refresh
+        </button>
+      </header>
+
+      {error ? (
+        <div role="alert" style={{ color: "var(--destructive, #b00020)" }}>
+          Failed to load approvals: {error}
+        </div>
+      ) : null}
+
+      {!loading && approvals.length === 0 && !error ? (
+        <div style={{ opacity: 0.7 }}>No approvals awaiting review.</div>
+      ) : null}
+
+      {approvals.length > 0 ? (
+        <table style={TABLE_STYLE}>
+          <thead>
+            <tr style={TABLE_HEAD_ROW_STYLE}>
+              <th style={TABLE_CELL_STYLE}>Title</th>
+              <th style={TABLE_CELL_STYLE}>Type</th>
+              <th style={TABLE_CELL_STYLE}>Requested by</th>
+              <th style={TABLE_CELL_STYLE}>Created</th>
+              <th style={TABLE_CELL_STYLE}>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {approvals.map((approval) => {
+              const href = buildApprovalDetailPath(context.companyPrefix, approval.id);
+              const title = approval.payload?.title ?? approval.type;
+              const requester =
+                approval.requestedByAgentId ?? approval.requestedByUserId ?? "—";
+              return (
+                <tr key={approval.id} style={TABLE_BODY_ROW_STYLE}>
+                  <td style={TABLE_CELL_STYLE}>
+                    <a href={href} style={{ color: "inherit", textDecoration: "underline" }}>
+                      {title}
+                    </a>
+                  </td>
+                  <td style={TABLE_CELL_MONO_STYLE}>{approval.type}</td>
+                  <td style={TABLE_CELL_MONO_STYLE}>
+                    {typeof requester === "string" ? requester.slice(0, 12) : "—"}
+                  </td>
+                  <td style={TABLE_CELL_STYLE}>{formatRelative(approval.createdAt)}</td>
+                  <td style={TABLE_CELL_STYLE}>
+                    <a href={href}>Review →</a>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      ) : null}
+
+      <footer style={{ fontSize: 12, opacity: 0.6 }}>
+        Auto-refresh:{" "}
+        {config.refreshIntervalSeconds > 0
+          ? `every ${config.refreshIntervalSeconds}s`
+          : "disabled"}
+      </footer>
+    </section>
+  );
+}

--- a/packages/plugins/examples/plugin-approvals-menu-example/src/worker.ts
+++ b/packages/plugins/examples/plugin-approvals-menu-example/src/worker.ts
@@ -1,0 +1,37 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+
+import { DEFAULT_CONFIG, PLUGIN_ID } from "./constants.js";
+
+/**
+ * Worker stays deliberately thin. The approvals list is read via same-origin
+ * board session from the UI side, so we only expose plugin config + health.
+ */
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.logger.info(`${PLUGIN_ID} setup complete`);
+
+    ctx.data.register("plugin-config", async () => {
+      const raw = ((await ctx.config.get()) ?? {}) as Record<string, unknown>;
+      const config = {
+        refreshIntervalSeconds:
+          typeof raw.refreshIntervalSeconds === "number" && raw.refreshIntervalSeconds >= 0
+            ? raw.refreshIntervalSeconds
+            : DEFAULT_CONFIG.refreshIntervalSeconds,
+        showBadge:
+          raw.showBadge === undefined ? DEFAULT_CONFIG.showBadge : Boolean(raw.showBadge),
+        listLimit:
+          typeof raw.listLimit === "number" && raw.listLimit > 0
+            ? Math.min(500, Math.floor(raw.listLimit))
+            : DEFAULT_CONFIG.listLimit,
+      };
+      return config;
+    });
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "Approvals Menu plugin ready" };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-approvals-menu-example/tsconfig.json
+++ b/packages/plugins/examples/plugin-approvals-menu-example/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,31 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/plugins/examples/plugin-approvals-menu-example:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.3
+        version: 19.2.3(@types/react@19.2.14)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/plugins/examples/plugin-authoring-smoke-example:
     dependencies:
       '@paperclipai/plugin-sdk':


### PR DESCRIPTION
## Summary

- Commits the missing source tree for `plugin-approvals-menu-example` (was `dist/` only on disk; pnpm could not resolve the workspace package from a clean checkout).
- Sidebar link target now points at the plugin's own page (`/<companyPrefix>/approvals-menu`) instead of bypassing it for core `/approvals/pending`.
- `listLimit` schema description and constants comment now reflect that the cap is applied client-side (the host approvals API does not accept a `limit` parameter).
- 401 / 403 / 404 from the approvals API are handled as a non-board fallback: sidebar entry hides itself; page renders a neutral "not available" state instead of a red error alert.

## Context

QA verdict on [MYO-41](https://paperclip/MYO/issues/MYO-41) was **FAIL — request changes** because the plugin package source was never committed. This PR addresses that blocker plus the three secondary findings.

Source is reconstructed from the existing `dist/` artefacts and the sibling `plugin-hello-world-example` layout, with the QA-driven fixes applied in the rewrite. No core Paperclip files are modified.

## Test plan

- [x] `pnpm --filter @paperclipai/plugin-approvals-menu-example typecheck` — green from a clean worktree.
- [x] `pnpm --filter @paperclipai/plugin-approvals-menu-example build` — produces `dist/{manifest,worker,index,constants}.js` and `dist/ui/index.js`.
- [ ] QA re-run of the full MYO-41 checklist (sidebar entry, badge, plugin page route, deep links, refresh, `refreshIntervalSeconds`, `listLimit`, fallback states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)