### PR TITLE
fix(ui): support generic Git repo URLs

### DIFF
--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -9,6 +9,7 @@ import { goalsApi } from "../api/goals";
 import { assetsApi } from "../api/assets";
 import { buildMarkdownMentionOptions } from "../lib/company-members";
 import { queryKeys } from "../lib/queryKeys";
+import { deriveRepoNameFromUrl, isGitRepoUrl, isPlainHttpGitRepoUrl } from "../lib/git-repo-url";
 import {
   Dialog,
   DialogContent,
@@ -115,32 +116,10 @@ export function NewProjectDialog() {
 
   const isAbsolutePath = (value: string) => value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
 
-  const looksLikeRepoUrl = (value: string) => {
-    try {
-      const parsed = new URL(value);
-      if (parsed.protocol !== "https:") return false;
-      const segments = parsed.pathname.split("/").filter(Boolean);
-      return segments.length >= 2;
-    } catch {
-      return false;
-    }
-  };
-
   const deriveWorkspaceNameFromPath = (value: string) => {
     const normalized = value.trim().replace(/[\\/]+$/, "");
     const segments = normalized.split(/[\\/]/).filter(Boolean);
     return segments[segments.length - 1] ?? "Local folder";
-  };
-
-  const deriveWorkspaceNameFromRepo = (value: string) => {
-    try {
-      const parsed = new URL(value);
-      const segments = parsed.pathname.split("/").filter(Boolean);
-      const repo = segments[segments.length - 1]?.replace(/\.git$/i, "") ?? "";
-      return repo || "GitHub repo";
-    } catch {
-      return "GitHub repo";
-    }
   };
 
   async function handleSubmit() {
@@ -152,8 +131,8 @@ export function NewProjectDialog() {
       setWorkspaceError("Local folder must be a full absolute path.");
       return;
     }
-    if (repoUrl && !looksLikeRepoUrl(repoUrl)) {
-      setWorkspaceError("Repo must use a valid GitHub or GitHub Enterprise repo URL.");
+    if (repoUrl && !isGitRepoUrl(repoUrl)) {
+      setWorkspaceError("Repo must use a valid HTTP or HTTPS Git remote URL.");
       return;
     }
 
@@ -173,7 +152,7 @@ export function NewProjectDialog() {
         const workspacePayload: Record<string, unknown> = {
           name: localPath
             ? deriveWorkspaceNameFromPath(localPath)
-            : deriveWorkspaceNameFromRepo(repoUrl),
+            : deriveRepoNameFromUrl(repoUrl),
           ...(localPath ? { cwd: localPath } : {}),
           ...(repoUrl ? { repoUrl } : {}),
         };
@@ -289,7 +268,7 @@ export function NewProjectDialog() {
                   <HelpCircle className="h-3 w-3 text-muted-foreground/50 cursor-help" />
                 </TooltipTrigger>
                 <TooltipContent side="top" className="max-w-(--sz-240px) text-xs">
-                  Link a GitHub repository so agents can clone, read, and push code for this project.
+                  Link a Git repository so agents can clone, read, and push code for this project.
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -297,8 +276,13 @@ export function NewProjectDialog() {
               className="w-full rounded border border-border bg-transparent px-2 py-1 text-xs outline-none"
               value={workspaceRepoUrl}
               onChange={(e) => { setWorkspaceRepoUrl(e.target.value); setWorkspaceError(null); }}
-              placeholder="https://github.com/org/repo"
+              placeholder="https://git.example.com/org/repo"
             />
+            {isPlainHttpGitRepoUrl(workspaceRepoUrl) && (
+              <p className="mt-1 text-xs text-amber-600 dark:text-amber-300">
+                This URL uses an unencrypted connection. Use HTTPS if your Git server supports it.
+              </p>
+            )}
           </div>
 
           <div>

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -9,6 +9,7 @@ import { goalsApi } from "../api/goals";
 import { assetsApi } from "../api/assets";
 import { buildMarkdownMentionOptions } from "../lib/company-members";
 import { queryKeys } from "../lib/queryKeys";
+import { deriveRepoNameFromUrl, isGitRepoUrl, isPlainHttpGitRepoUrl } from "../lib/git-repo-url";
 import {
   Dialog,
   DialogContent,
@@ -116,32 +117,10 @@ export function NewProjectDialog() {
 
   const isAbsolutePath = (value: string) => value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
 
-  const looksLikeRepoUrl = (value: string) => {
-    try {
-      const parsed = new URL(value);
-      if (parsed.protocol !== "https:") return false;
-      const segments = parsed.pathname.split("/").filter(Boolean);
-      return segments.length >= 2;
-    } catch {
-      return false;
-    }
-  };
-
   const deriveWorkspaceNameFromPath = (value: string) => {
     const normalized = value.trim().replace(/[\\/]+$/, "");
     const segments = normalized.split(/[\\/]/).filter(Boolean);
     return segments[segments.length - 1] ?? "Local folder";
-  };
-
-  const deriveWorkspaceNameFromRepo = (value: string) => {
-    try {
-      const parsed = new URL(value);
-      const segments = parsed.pathname.split("/").filter(Boolean);
-      const repo = segments[segments.length - 1]?.replace(/\.git$/i, "") ?? "";
-      return repo || "GitHub repo";
-    } catch {
-      return "GitHub repo";
-    }
   };
 
   async function handleSubmit() {
@@ -153,8 +132,8 @@ export function NewProjectDialog() {
       setWorkspaceError("Local folder must be a full absolute path.");
       return;
     }
-    if (repoUrl && !looksLikeRepoUrl(repoUrl)) {
-      setWorkspaceError("Repo must use a valid GitHub or GitHub Enterprise repo URL.");
+    if (repoUrl && !isGitRepoUrl(repoUrl)) {
+      setWorkspaceError("Repo must use a valid HTTP or HTTPS Git remote URL.");
       return;
     }
 
@@ -174,7 +153,7 @@ export function NewProjectDialog() {
         const workspacePayload: Record<string, unknown> = {
           name: localPath
             ? deriveWorkspaceNameFromPath(localPath)
-            : deriveWorkspaceNameFromRepo(repoUrl),
+            : deriveRepoNameFromUrl(repoUrl),
           ...(localPath ? { cwd: localPath } : {}),
           ...(repoUrl ? { repoUrl } : {}),
         };
@@ -290,7 +269,7 @@ export function NewProjectDialog() {
                   <HelpCircle className="h-3 w-3 text-muted-foreground/50 cursor-help" />
                 </TooltipTrigger>
                 <TooltipContent side="top" className="max-w-[240px] text-xs">
-                  Link a GitHub repository so agents can clone, read, and push code for this project.
+                  Link a Git repository so agents can clone, read, and push code for this project.
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -298,8 +277,13 @@ export function NewProjectDialog() {
               className="w-full rounded border border-border bg-transparent px-2 py-1 text-xs outline-none"
               value={workspaceRepoUrl}
               onChange={(e) => { setWorkspaceRepoUrl(e.target.value); setWorkspaceError(null); }}
-              placeholder="https://github.com/org/repo"
+              placeholder="https://git.example.com/org/repo"
             />
+            {isPlainHttpGitRepoUrl(workspaceRepoUrl) && (
+              <p className="mt-1 text-xs text-amber-600 dark:text-amber-300">
+                This URL uses an unencrypted connection. Use HTTPS if your Git server supports it.
+              </p>
+            )}
           </div>
 
           <div>

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -9,6 +9,7 @@ import { goalsApi } from "../api/goals";
 import { instanceSettingsApi } from "../api/instanceSettings";
 import { projectsApi } from "../api/projects";
 import { secretsApi } from "../api/secrets";
+import { formatGitRepoUrl, isGitRepoUrl, isPlainHttpGitRepoUrl } from "../lib/git-repo-url";
 import { useCompany } from "../context/CompanyContext";
 import { queryKeys } from "../lib/queryKeys";
 import { statusBadge, statusBadgeDefault } from "../lib/status-colors";
@@ -16,7 +17,7 @@ import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { AlertCircle, Archive, ArchiveRestore, Check, ExternalLink, Github, Loader2, Plus, Trash2, X } from "lucide-react";
+import { AlertCircle, Archive, ArchiveRestore, Check, ExternalLink, GitBranch, Loader2, Plus, Trash2, X } from "lucide-react";
 import { ChoosePathButton } from "./PathInstructionsModal";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { DraftInput } from "./agent-config-primitives";
@@ -378,17 +379,6 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
 
   const isAbsolutePath = (value: string) => value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
 
-  const looksLikeRepoUrl = (value: string) => {
-    try {
-      const parsed = new URL(value);
-      if (parsed.protocol !== "https:") return false;
-      const segments = parsed.pathname.split("/").filter(Boolean);
-      return segments.length >= 2;
-    } catch {
-      return false;
-    }
-  };
-
   const isSafeExternalUrl = (value: string | null | undefined) => {
     if (!value) return false;
     try {
@@ -396,20 +386,6 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
       return parsed.protocol === "http:" || parsed.protocol === "https:";
     } catch {
       return false;
-    }
-  };
-
-  const formatRepoUrl = (value: string) => {
-    try {
-      const parsed = new URL(value);
-      const segments = parsed.pathname.split("/").filter(Boolean);
-      if (segments.length < 2) return parsed.host;
-      const owner = segments[0];
-      const repo = segments[1]?.replace(/\.git$/i, "");
-      if (!owner || !repo) return parsed.host;
-      return `${parsed.host}/${owner}/${repo}`;
-    } catch {
-      return value;
     }
   };
 
@@ -466,8 +442,8 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
       persistCodebase({ repoUrl: null });
       return;
     }
-    if (!looksLikeRepoUrl(repoUrl)) {
-      setWorkspaceError("Repo must use a valid GitHub or GitHub Enterprise repo URL.");
+    if (!isGitRepoUrl(repoUrl)) {
+      setWorkspaceError("Repo must use a valid HTTP or HTTPS Git remote URL.");
       return;
     }
     setWorkspaceError(null);
@@ -682,13 +658,13 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                       rel="noreferrer"
                       className="inline-flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground hover:underline"
                     >
-                      <Github className="h-3 w-3 shrink-0" />
-                      <span className="break-all min-w-0">{formatRepoUrl(codebase.repoUrl)}</span>
+                      <GitBranch className="h-3 w-3 shrink-0" />
+                      <span className="break-all min-w-0">{formatGitRepoUrl(codebase.repoUrl)}</span>
                       <ExternalLink className="h-3 w-3 shrink-0" />
                     </a>
                   ) : (
                     <div className="inline-flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
-                      <Github className="h-3 w-3 shrink-0" />
+                      <GitBranch className="h-3 w-3 shrink-0" />
                       <span className="break-all min-w-0">{codebase.repoUrl}</span>
                     </div>
                   )}
@@ -866,8 +842,13 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                 className="w-full rounded border border-border bg-transparent px-2 py-1 text-xs outline-none"
                 value={workspaceRepoUrl}
                 onChange={(e) => setWorkspaceRepoUrl(e.target.value)}
-                placeholder="https://github.com/org/repo"
+                placeholder="https://git.example.com/org/repo"
               />
+              {isPlainHttpGitRepoUrl(workspaceRepoUrl) && (
+                <p className="text-xs text-amber-600 dark:text-amber-300">
+                  This URL uses an unencrypted connection. Use HTTPS if your Git server supports it.
+                </p>
+              )}
               <div className="flex items-center gap-2">
                 <Button
                   variant="outline"

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -9,6 +9,7 @@ import { goalsApi } from "../api/goals";
 import { instanceSettingsApi } from "../api/instanceSettings";
 import { projectsApi } from "../api/projects";
 import { secretsApi } from "../api/secrets";
+import { formatGitRepoUrl, isGitRepoUrl, isPlainHttpGitRepoUrl } from "../lib/git-repo-url";
 import { useCompany } from "../context/CompanyContext";
 import { queryKeys } from "../lib/queryKeys";
 import { statusBadge, statusBadgeDefault } from "../lib/status-colors";
@@ -16,7 +17,7 @@ import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { AlertCircle, Archive, ArchiveRestore, Check, ExternalLink, Github, Loader2, Plus, Trash2, X } from "lucide-react";
+import { AlertCircle, Archive, ArchiveRestore, Check, ExternalLink, GitBranch, Loader2, Plus, Trash2, X } from "lucide-react";
 import { ChoosePathButton } from "./PathInstructionsModal";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { DraftInput } from "./agent-config-primitives";
@@ -387,17 +388,6 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
 
   const isAbsolutePath = (value: string) => value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
 
-  const looksLikeRepoUrl = (value: string) => {
-    try {
-      const parsed = new URL(value);
-      if (parsed.protocol !== "https:") return false;
-      const segments = parsed.pathname.split("/").filter(Boolean);
-      return segments.length >= 2;
-    } catch {
-      return false;
-    }
-  };
-
   const isSafeExternalUrl = (value: string | null | undefined) => {
     if (!value) return false;
     try {
@@ -405,20 +395,6 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
       return parsed.protocol === "http:" || parsed.protocol === "https:";
     } catch {
       return false;
-    }
-  };
-
-  const formatRepoUrl = (value: string) => {
-    try {
-      const parsed = new URL(value);
-      const segments = parsed.pathname.split("/").filter(Boolean);
-      if (segments.length < 2) return parsed.host;
-      const owner = segments[0];
-      const repo = segments[1]?.replace(/\.git$/i, "");
-      if (!owner || !repo) return parsed.host;
-      return `${parsed.host}/${owner}/${repo}`;
-    } catch {
-      return value;
     }
   };
 
@@ -475,8 +451,8 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
       persistCodebase({ repoUrl: null });
       return;
     }
-    if (!looksLikeRepoUrl(repoUrl)) {
-      setWorkspaceError("Repo must use a valid GitHub or GitHub Enterprise repo URL.");
+    if (!isGitRepoUrl(repoUrl)) {
+      setWorkspaceError("Repo must use a valid HTTP or HTTPS Git remote URL.");
       return;
     }
     setWorkspaceError(null);
@@ -692,13 +668,13 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                       rel="noreferrer"
                       className="inline-flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground hover:underline"
                     >
-                      <Github className="h-3 w-3 shrink-0" />
-                      <span className="break-all min-w-0">{formatRepoUrl(codebase.repoUrl)}</span>
+                      <GitBranch className="h-3 w-3 shrink-0" />
+                      <span className="break-all min-w-0">{formatGitRepoUrl(codebase.repoUrl)}</span>
                       <ExternalLink className="h-3 w-3 shrink-0" />
                     </a>
                   ) : (
                     <div className="inline-flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
-                      <Github className="h-3 w-3 shrink-0" />
+                      <GitBranch className="h-3 w-3 shrink-0" />
                       <span className="break-all min-w-0">{codebase.repoUrl}</span>
                     </div>
                   )}
@@ -876,8 +852,13 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                 className="w-full rounded border border-border bg-transparent px-2 py-1 text-xs outline-none"
                 value={workspaceRepoUrl}
                 onChange={(e) => setWorkspaceRepoUrl(e.target.value)}
-                placeholder="https://github.com/org/repo"
+                placeholder="https://git.example.com/org/repo"
               />
+              {isPlainHttpGitRepoUrl(workspaceRepoUrl) && (
+                <p className="mt-1 text-xs text-amber-600 dark:text-amber-300">
+                  This URL uses an unencrypted connection. Use HTTPS if your Git server supports it.
+                </p>
+              )}
               <div className="flex items-center gap-2">
                 <Button
                   variant="outline"

--- a/ui/src/lib/git-repo-url.test.ts
+++ b/ui/src/lib/git-repo-url.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { deriveRepoNameFromUrl, formatGitRepoUrl, isGitRepoUrl, isPlainHttpGitRepoUrl } from "./git-repo-url";
+
+describe("isGitRepoUrl", () => {
+  it("accepts GitHub HTTPS remotes", () => {
+    expect(isGitRepoUrl("https://github.com/org/repo")).toBe(true);
+    expect(isGitRepoUrl("https://github.com/org/repo.git")).toBe(true);
+  });
+
+  it("accepts self-hosted HTTP and HTTPS remotes", () => {
+    expect(isGitRepoUrl("https://git.example.com/org/repo")).toBe(true);
+    expect(isGitRepoUrl("http://git.local/org/repo.git")).toBe(true);
+    expect(isGitRepoUrl("http://gitea.lan/repo.git")).toBe(true);
+  });
+
+  it("rejects empty, non-URL, non-HTTP, and host-only values", () => {
+    expect(isGitRepoUrl("")).toBe(false);
+    expect(isGitRepoUrl("not a url")).toBe(false);
+    expect(isGitRepoUrl("git@github.com:org/repo.git")).toBe(false);
+    expect(isGitRepoUrl("https://git.example.com")).toBe(false);
+  });
+});
+
+describe("deriveRepoNameFromUrl", () => {
+  it("uses the final path segment without a .git suffix", () => {
+    expect(deriveRepoNameFromUrl("https://gitlab.com/org/project.git")).toBe("project");
+  });
+
+  it("falls back to a generic label for invalid input", () => {
+    expect(deriveRepoNameFromUrl("not a url")).toBe("Git repo");
+  });
+});
+
+describe("isPlainHttpGitRepoUrl", () => {
+  it("only identifies valid plain HTTP Git repo URLs", () => {
+    expect(isPlainHttpGitRepoUrl("http://gitea.lan/repo.git")).toBe(true);
+    expect(isPlainHttpGitRepoUrl("https://git.example.com/org/repo.git")).toBe(false);
+    expect(isPlainHttpGitRepoUrl("http://gitea.lan")).toBe(false);
+  });
+});
+
+describe("formatGitRepoUrl", () => {
+  it("formats nested repo paths without a trailing .git suffix", () => {
+    expect(formatGitRepoUrl("https://gitlab.com/group/subgroup/project.git")).toBe("gitlab.com/group/subgroup/project");
+  });
+
+  it("keeps single-segment self-hosted repo paths visible", () => {
+    expect(formatGitRepoUrl("http://gitea.lan/repo.git")).toBe("gitea.lan/repo");
+  });
+});

--- a/ui/src/lib/git-repo-url.test.ts
+++ b/ui/src/lib/git-repo-url.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { deriveRepoNameFromUrl, formatGitRepoUrl, isGitRepoUrl, isPlainHttpGitRepoUrl } from "./git-repo-url";
+
+describe("isGitRepoUrl", () => {
+  it("accepts GitHub HTTPS remotes", () => {
+    expect(isGitRepoUrl("https://github.com/org/repo")).toBe(true);
+    expect(isGitRepoUrl("https://github.com/org/repo.git")).toBe(true);
+  });
+
+  it("accepts self-hosted HTTP and HTTPS remotes", () => {
+    expect(isGitRepoUrl("https://git.example.com/org/repo")).toBe(true);
+    expect(isGitRepoUrl("http://git.local/org/repo.git")).toBe(true);
+    expect(isGitRepoUrl("http://gitea.lan/repo.git")).toBe(true);
+    expect(isGitRepoUrl("https://git.example.com/repo")).toBe(true);
+  });
+
+  it("rejects empty, non-URL, non-HTTP, and host-only values", () => {
+    expect(isGitRepoUrl("")).toBe(false);
+    expect(isGitRepoUrl("not a url")).toBe(false);
+    expect(isGitRepoUrl("git@github.com:org/repo.git")).toBe(false);
+    expect(isGitRepoUrl("https://git.example.com")).toBe(false);
+  });
+
+  it("rejects public host profile URLs without a repo segment", () => {
+    expect(isGitRepoUrl("https://github.com/myorg")).toBe(false);
+    expect(isGitRepoUrl("https://gitlab.com/mygroup")).toBe(false);
+    expect(isGitRepoUrl("https://bitbucket.org/workspace")).toBe(false);
+  });
+});
+
+describe("deriveRepoNameFromUrl", () => {
+  it("uses the final path segment without a .git suffix", () => {
+    expect(deriveRepoNameFromUrl("https://gitlab.com/org/project.git")).toBe("project");
+  });
+
+  it("falls back to a generic label for invalid input", () => {
+    expect(deriveRepoNameFromUrl("not a url")).toBe("Git repo");
+  });
+});
+
+describe("isPlainHttpGitRepoUrl", () => {
+  it("only identifies valid plain HTTP Git repo URLs", () => {
+    expect(isPlainHttpGitRepoUrl("http://gitea.lan/repo.git")).toBe(true);
+    expect(isPlainHttpGitRepoUrl("https://git.example.com/org/repo.git")).toBe(false);
+    expect(isPlainHttpGitRepoUrl("http://gitea.lan")).toBe(false);
+  });
+});
+
+describe("formatGitRepoUrl", () => {
+  it("formats nested repo paths without a trailing .git suffix", () => {
+    expect(formatGitRepoUrl("https://gitlab.com/group/subgroup/project.git")).toBe("gitlab.com/group/subgroup/project");
+  });
+
+  it("keeps single-segment self-hosted repo paths visible", () => {
+    expect(formatGitRepoUrl("http://gitea.lan/repo.git")).toBe("gitea.lan/repo");
+  });
+});

--- a/ui/src/lib/git-repo-url.ts
+++ b/ui/src/lib/git-repo-url.ts
@@ -1,0 +1,43 @@
+export function isGitRepoUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+    if (!parsed.hostname) return false;
+    return parsed.pathname.split("/").filter(Boolean).length >= 1;
+  } catch {
+    return false;
+  }
+}
+
+export function isPlainHttpGitRepoUrl(value: string): boolean {
+  try {
+    return new URL(value.trim()).protocol === "http:" && isGitRepoUrl(value);
+  } catch {
+    return false;
+  }
+}
+
+export function deriveRepoNameFromUrl(value: string): string {
+  try {
+    const parsed = new URL(value.trim());
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    const repo = segments[segments.length - 1]?.replace(/\.git$/i, "") ?? "";
+    return repo || "Git repo";
+  } catch {
+    return "Git repo";
+  }
+}
+
+export function formatGitRepoUrl(value: string): string {
+  try {
+    const parsed = new URL(value.trim());
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length === 0) return parsed.host;
+    const displaySegments = [...segments];
+    displaySegments[displaySegments.length - 1] =
+      displaySegments[displaySegments.length - 1]?.replace(/\.git$/i, "") ?? "";
+    return [parsed.host, ...displaySegments.filter(Boolean)].join("/");
+  } catch {
+    return value;
+  }
+}

--- a/ui/src/lib/git-repo-url.ts
+++ b/ui/src/lib/git-repo-url.ts
@@ -1,0 +1,50 @@
+const PUBLIC_GIT_HOSTS_REQUIRING_OWNER = new Set(["github.com", "gitlab.com", "bitbucket.org"]);
+
+function requiredPathSegmentsForHost(hostname: string): number {
+  return PUBLIC_GIT_HOSTS_REQUIRING_OWNER.has(hostname.toLowerCase()) ? 2 : 1;
+}
+
+export function isGitRepoUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+    if (!parsed.hostname) return false;
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    return segments.length >= requiredPathSegmentsForHost(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function isPlainHttpGitRepoUrl(value: string): boolean {
+  try {
+    return new URL(value.trim()).protocol === "http:" && isGitRepoUrl(value);
+  } catch {
+    return false;
+  }
+}
+
+export function deriveRepoNameFromUrl(value: string): string {
+  try {
+    const parsed = new URL(value.trim());
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    const repo = segments[segments.length - 1]?.replace(/\.git$/i, "") ?? "";
+    return repo || "Git repo";
+  } catch {
+    return "Git repo";
+  }
+}
+
+export function formatGitRepoUrl(value: string): string {
+  try {
+    const parsed = new URL(value.trim());
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length === 0) return parsed.host;
+    const displaySegments = [...segments];
+    displaySegments[displaySegments.length - 1] =
+      displaySegments[displaySegments.length - 1]?.replace(/\.git$/i, "") ?? "";
+    return [parsed.host, ...displaySegments.filter(Boolean)].join("/");
+  } catch {
+    return value;
+  }
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Project workspace configuration lets agents connect a project to source code.
> - The backend can store arbitrary repository URLs, but the project creation and project properties UI still presents the flow as GitHub-specific.
> - Issue #1052 asks for generic Git provider support so GitLab, Gitea, Forgejo, Codeberg, and self-hosted/internal Git servers can be used.
> - PR #1053 covers the same issue but is stale and merge-conflicted; it also left follow-up feedback around duplicated helpers, plain HTTP visibility, and nested path display.
> - This PR keeps the change UI-only, extracts shared URL helpers, accepts valid HTTP/HTTPS Git remotes, and surfaces a non-blocking warning for plain HTTP.
> - The benefit is broader self-hosted Git support with less duplicated validation logic and focused tests for the URL behavior.

## Linked Issues or Issue Description

Refs #1052.

Related PR: #1053. This is a refreshed alternative/follow-up because #1053 is stale and currently merge-conflicted. It incorporates the follow-up feedback from #1053 by extracting shared helpers, preserving nested paths in display labels, and warning on plain HTTP without blocking internal Git server workflows.

## What Changed

- Added shared `git-repo-url` helpers for validation, display formatting, repo name derivation, and plain-HTTP detection.
- Updated project creation and project properties repo inputs to use the shared helpers and provider-neutral copy/icons.
- Allowed valid `http://` Git remotes for internal/self-hosted servers while showing a non-blocking warning recommending HTTPS when available.
- Preserved nested Git path display instead of truncating GitLab subgroup paths to only two segments.
- Added focused unit tests for GitHub, self-hosted HTTPS, local HTTP, invalid values, repo naming, and display formatting.

## Verification

June 18, 2026 refresh after rebasing onto current `origin/master`:

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run ui/src/lib/git-repo-url.test.ts`
- `pnpm --filter @paperclipai/ui typecheck`
- `git diff --check origin/master...HEAD`
- Storybook/browser verification at `product-dialogs-modals--new-project-empty`: provider-neutral repo placeholder is present and a plain HTTP Gitea URL shows the unencrypted-connection warning.
- Storybook/browser verification at `product-projects-goals-workspaces--surface-matrix`: project repo editor uses the provider-neutral placeholder and a plain HTTP Forgejo URL shows the same warning.
- GitHub PR checks are green on head `774e2261`.

Earlier pre-refresh verification also included `pnpm test`.

Screenshots: static screenshot capture timed out in this local browser environment, so I verified the changed UI states through Storybook/browser DOM checks instead of attaching image files.

## Risks

- Low risk: UI-only validation/copy/helper extraction; no backend or persistence changes.
- Plain HTTP remotes are intentionally accepted for private/internal Git servers, but users now receive a visible warning.
- This overlaps with #1053. I am happy to close this if maintainers prefer continuing that PR instead.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex based on GPT-5, used through the Codex desktop coding environment on April 26, June 15, and June 18, 2026.
- Tool-assisted code editing, local command execution, GitHub CLI workflows, Storybook/browser verification, rebase/refresh, and CI monitoring were used.
- Exact context window and internal reasoning mode are not surfaced by the environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
