### PR TITLE
Add instance-level heartbeat concurrency cap

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -43,6 +43,14 @@ This starts:
 
 `pnpm dev` and `pnpm dev:once` are now idempotent for the current repo and instance: if the matching Paperclip dev runner is already alive, Paperclip reports the existing process instead of starting a duplicate.
 
+Optional safety valve for busy instances:
+
+```sh
+PAPERCLIP_MAX_CONCURRENT_HEARTBEAT_RUNS=4 pnpm dev
+```
+
+When set, Paperclip keeps additional heartbeat runs queued once the instance reaches that many concurrent running heartbeats. This env var is used as a fallback when `Instance Settings > General > Concurrent heartbeat runs` is left unset.
+
 ## Storybook
 
 The board UI Storybook keeps stories and Storybook config under `ui/storybook/` so component review files stay out of the app source routes.

--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -21,6 +21,7 @@ export interface InstanceGeneralSettings {
   keyboardShortcuts: boolean;
   feedbackDataSharingPreference: FeedbackDataSharingPreference;
   backupRetention: BackupRetentionPolicy;
+  maxConcurrentHeartbeatRuns: number | null;
 }
 
 export interface InstanceExperimentalSettings {

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -28,6 +28,7 @@ export const instanceGeneralSettingsSchema = z.object({
     DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
   ),
   backupRetention: backupRetentionPolicySchema.default(DEFAULT_BACKUP_RETENTION),
+  maxConcurrentHeartbeatRuns: z.number().int().min(1).max(1000).nullable().default(null),
 }).strict();
 
 export const patchInstanceGeneralSettingsSchema = instanceGeneralSettingsSchema.partial();

--- a/server/src/__tests__/heartbeat-global-concurrency.test.ts
+++ b/server/src/__tests__/heartbeat-global-concurrency.test.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat global concurrency tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat global concurrency limit", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  const previousGlobalLimit = process.env.PAPERCLIP_MAX_CONCURRENT_HEARTBEAT_RUNS;
+
+  beforeAll(async () => {
+    process.env.PAPERCLIP_MAX_CONCURRENT_HEARTBEAT_RUNS = "1";
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-global-concurrency-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterAll(async () => {
+    if (previousGlobalLimit == null) {
+      delete process.env.PAPERCLIP_MAX_CONCURRENT_HEARTBEAT_RUNS;
+    } else {
+      process.env.PAPERCLIP_MAX_CONCURRENT_HEARTBEAT_RUNS = previousGlobalLimit;
+    }
+    await tempDb?.cleanup();
+  });
+
+  async function waitForStatus(runId: string, status: "queued" | "running", timeoutMs = 3_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      if (run?.status === status) return;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(`Timed out waiting for run ${runId} to reach ${status}`);
+  }
+
+  it("keeps later agent runs queued when the global cap is full", async () => {
+    const companyId = randomUUID();
+    const firstAgentId = randomUUID();
+    const secondAgentId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    for (const [agentId, name] of [
+      [firstAgentId, "AgentOne"],
+      [secondAgentId, "AgentTwo"],
+    ] as const) {
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name,
+        role: "engineer",
+        status: "idle",
+        adapterType: "process",
+        adapterConfig: {
+          command: process.execPath,
+          args: ["-e", "setTimeout(() => process.exit(0), 1500)"],
+        },
+        runtimeConfig: {
+          heartbeat: {
+            wakeOnDemand: true,
+            maxConcurrentRuns: 5,
+          },
+        },
+        permissions: {},
+      });
+    }
+
+    const firstRun = await heartbeat.invoke(firstAgentId, "on_demand", {}, "manual");
+    expect(firstRun).not.toBeNull();
+    await waitForStatus(firstRun!.id, "running");
+
+    const secondRun = await heartbeat.invoke(secondAgentId, "on_demand", {}, "manual");
+    expect(secondRun).not.toBeNull();
+    await waitForStatus(secondRun!.id, "queued");
+
+    const allRuns = await db
+      .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+      .from(heartbeatRuns);
+
+    expect(allRuns.filter((run) => run.status === "running")).toHaveLength(1);
+    expect(allRuns.find((run) => run.id === secondRun!.id)?.status).toBe("queued");
+  });
+});

--- a/server/src/__tests__/instance-settings-routes.test.ts
+++ b/server/src/__tests__/instance-settings-routes.test.ts
@@ -53,6 +53,8 @@ describe("instance settings routes", () => {
       censorUsernameInLogs: false,
       keyboardShortcuts: false,
       feedbackDataSharingPreference: "prompt",
+      backupRetention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+      maxConcurrentHeartbeatRuns: null,
     });
     mockInstanceSettingsService.getExperimental.mockResolvedValue({
       enableIsolatedWorkspaces: false,
@@ -64,6 +66,8 @@ describe("instance settings routes", () => {
         censorUsernameInLogs: true,
         keyboardShortcuts: true,
         feedbackDataSharingPreference: "allowed",
+        backupRetention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+        maxConcurrentHeartbeatRuns: 4,
       },
     });
     mockInstanceSettingsService.updateExperimental.mockResolvedValue({
@@ -134,6 +138,8 @@ describe("instance settings routes", () => {
       censorUsernameInLogs: false,
       keyboardShortcuts: false,
       feedbackDataSharingPreference: "prompt",
+      backupRetention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+      maxConcurrentHeartbeatRuns: null,
     });
 
     const patchRes = await request(app)
@@ -142,6 +148,7 @@ describe("instance settings routes", () => {
         censorUsernameInLogs: true,
         keyboardShortcuts: true,
         feedbackDataSharingPreference: "allowed",
+        maxConcurrentHeartbeatRuns: 4,
       });
 
     expect(patchRes.status).toBe(200);
@@ -149,6 +156,7 @@ describe("instance settings routes", () => {
       censorUsernameInLogs: true,
       keyboardShortcuts: true,
       feedbackDataSharingPreference: "allowed",
+      maxConcurrentHeartbeatRuns: 4,
     });
     expect(mockLogActivity).toHaveBeenCalledTimes(2);
   });
@@ -169,6 +177,8 @@ describe("instance settings routes", () => {
       censorUsernameInLogs: false,
       keyboardShortcuts: false,
       feedbackDataSharingPreference: "prompt",
+      backupRetention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+      maxConcurrentHeartbeatRuns: null,
     });
   });
 

--- a/server/src/services/feedback.ts
+++ b/server/src/services/feedback.ts
@@ -23,6 +23,7 @@ import { claudeConfigDir, parseClaudeStreamJson } from "@paperclipai/adapter-cla
 import { codexHomeDir, parseCodexJsonl } from "@paperclipai/adapter-codex-local/server";
 import { parseOpenCodeJsonl } from "@paperclipai/adapter-opencode-local/server";
 import {
+  DEFAULT_BACKUP_RETENTION,
   DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
   DEFAULT_FEEDBACK_DATA_SHARING_TERMS_VERSION,
   instanceGeneralSettingsSchema,
@@ -156,7 +157,10 @@ function normalizeInstanceGeneralSettings(raw: unknown) {
   if (parsed.success) return parsed.data;
   return {
     censorUsernameInLogs: false,
+    keyboardShortcuts: false,
     feedbackDataSharingPreference: DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
+    backupRetention: DEFAULT_BACKUP_RETENTION,
+    maxConcurrentHeartbeatRuns: null,
   };
 }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -124,6 +124,7 @@ const MAX_RUN_EVENT_PAYLOAD_OBJECT_KEYS = 100;
 const MAX_RUN_EVENT_PAYLOAD_DEPTH = 6;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
+const GLOBAL_HEARTBEAT_RUN_LIMIT_ENV = "PAPERCLIP_MAX_CONCURRENT_HEARTBEAT_RUNS";
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
@@ -134,6 +135,7 @@ const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const startLocksByAgent = new Map<string, Promise<void>>();
+let globalStartLock: Promise<void> | null = null;
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
@@ -739,6 +741,30 @@ function normalizeMaxConcurrentRuns(value: unknown) {
   const parsed = Math.floor(asNumber(value, HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT));
   if (!Number.isFinite(parsed)) return HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT;
   return Math.max(HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
+}
+
+function parseGlobalHeartbeatRunLimit(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const parsed = Math.floor(Number(raw));
+  if (!Number.isFinite(parsed) || parsed < 1) return null;
+  return parsed;
+}
+
+async function withGlobalStartLock<T>(fn: () => Promise<T>) {
+  const previous = globalStartLock ?? Promise.resolve();
+  const run = previous.then(fn);
+  const marker = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  globalStartLock = marker;
+  try {
+    return await run;
+  } finally {
+    if (globalStartLock === marker) {
+      globalStartLock = null;
+    }
+  }
 }
 
 async function withAgentStartLock<T>(agentId: string, fn: () => Promise<T>) {
@@ -1852,6 +1878,12 @@ export function heartbeatService(db: Db) {
   };
   const budgets = budgetService(db, budgetHooks);
   let unsafeTextProjectionPromise: Promise<boolean> | null = null;
+
+  async function getConfiguredGlobalHeartbeatRunLimit() {
+    const settingsLimit = (await instanceSettings.getGeneral()).maxConcurrentHeartbeatRuns;
+    if (settingsLimit != null) return settingsLimit;
+    return parseGlobalHeartbeatRunLimit(process.env[GLOBAL_HEARTBEAT_RUN_LIMIT_ENV]);
+  }
 
   async function hasUnsafeTextProjectionDatabase() {
     if (!unsafeTextProjectionPromise) {
@@ -3475,6 +3507,14 @@ export function heartbeatService(db: Db) {
     return Number(count ?? 0);
   }
 
+  async function countRunningRunsGlobally() {
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.status, "running"));
+    return Number(count ?? 0);
+  }
+
   async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect) {
     if (run.status !== "queued") return run;
     const agent = await getAgent(run.agentId);
@@ -3922,7 +3962,7 @@ export function heartbeatService(db: Db) {
       });
 
       await finalizeAgentStatus(run.agentId, "failed");
-      await startNextQueuedRunForAgent(run.agentId);
+      await resumeQueuedRunsAfterCapacityChange(run.agentId);
       runningProcesses.delete(run.id);
       reaped.push(run.id);
     }
@@ -3943,6 +3983,14 @@ export function heartbeatService(db: Db) {
     for (const agentId of agentIds) {
       await startNextQueuedRunForAgent(agentId);
     }
+  }
+
+  async function resumeQueuedRunsAfterCapacityChange(agentId: string) {
+    if (await getConfiguredGlobalHeartbeatRunLimit() == null) {
+      await startNextQueuedRunForAgent(agentId);
+      return;
+    }
+    await resumeQueuedRuns();
   }
 
   async function getLatestIssueRun(companyId: string, issueId: string) {
@@ -4768,7 +4816,7 @@ export function heartbeatService(db: Db) {
   }
 
   async function startNextQueuedRunForAgent(agentId: string) {
-    return withAgentStartLock(agentId, async () => {
+    return withGlobalStartLock(() => withAgentStartLock(agentId, async () => {
       const agent = await getAgent(agentId);
       if (!agent) return [];
       if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
@@ -4776,7 +4824,17 @@ export function heartbeatService(db: Db) {
       }
       const policy = parseHeartbeatPolicy(agent);
       const runningCount = await countRunningRunsForAgent(agentId);
-      const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
+      const availableAgentSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
+      let availableSlots = availableAgentSlots;
+      const configuredGlobalHeartbeatRunLimit = await getConfiguredGlobalHeartbeatRunLimit();
+      if (configuredGlobalHeartbeatRunLimit != null) {
+        const runningGlobalCount = await countRunningRunsGlobally();
+        const availableGlobalSlots = Math.max(
+          0,
+          configuredGlobalHeartbeatRunLimit - runningGlobalCount,
+        );
+        availableSlots = Math.min(availableSlots, availableGlobalSlots);
+      }
       if (availableSlots <= 0) return [];
 
       const queuedRuns = await db
@@ -4837,7 +4895,7 @@ export function heartbeatService(db: Db) {
         });
       }
       return claimedRuns;
-    });
+    }));
   }
 
   async function executeRun(runId: string) {
@@ -5955,7 +6013,7 @@ export function heartbeatService(db: Db) {
           }
           await releaseRuntimeServicesForRun(run.id).catch(() => undefined);
           activeRunExecutions.delete(run.id);
-          await startNextQueuedRunForAgent(run.agentId);
+          await resumeQueuedRunsAfterCapacityChange(run.agentId);
         }
   }
 
@@ -7073,7 +7131,7 @@ export function heartbeatService(db: Db) {
 
     runningProcesses.delete(run.id);
     await finalizeAgentStatus(run.agentId, "cancelled");
-    await startNextQueuedRunForAgent(run.agentId);
+    await resumeQueuedRunsAfterCapacityChange(run.agentId);
     return cancelled;
   }
 

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -24,6 +24,7 @@ function normalizeGeneralSettings(raw: unknown): InstanceGeneralSettings {
       feedbackDataSharingPreference:
         parsed.data.feedbackDataSharingPreference ?? DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
       backupRetention: parsed.data.backupRetention ?? DEFAULT_BACKUP_RETENTION,
+      maxConcurrentHeartbeatRuns: parsed.data.maxConcurrentHeartbeatRuns ?? null,
     };
   }
   return {
@@ -31,6 +32,7 @@ function normalizeGeneralSettings(raw: unknown): InstanceGeneralSettings {
     keyboardShortcuts: false,
     feedbackDataSharingPreference: DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
     backupRetention: DEFAULT_BACKUP_RETENTION,
+    maxConcurrentHeartbeatRuns: null,
   };
 }
 

--- a/ui/src/pages/InstanceGeneralSettings.tsx
+++ b/ui/src/pages/InstanceGeneralSettings.tsx
@@ -24,6 +24,7 @@ export function InstanceGeneralSettings() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const [actionError, setActionError] = useState<string | null>(null);
+  const [maxConcurrentHeartbeatRunsDraft, setMaxConcurrentHeartbeatRunsDraft] = useState<string>("");
 
   const signOutMutation = useMutation({
     mutationFn: () => authApi.signOut(),
@@ -63,6 +64,11 @@ export function InstanceGeneralSettings() {
     },
   });
 
+  useEffect(() => {
+    const value = generalQuery.data?.maxConcurrentHeartbeatRuns;
+    setMaxConcurrentHeartbeatRunsDraft(value == null ? "" : String(value));
+  }, [generalQuery.data?.maxConcurrentHeartbeatRuns]);
+
   if (generalQuery.isLoading) {
     return <div className="text-sm text-muted-foreground">Loading general settings...</div>;
   }
@@ -81,6 +87,17 @@ export function InstanceGeneralSettings() {
   const keyboardShortcuts = generalQuery.data?.keyboardShortcuts === true;
   const feedbackDataSharingPreference = generalQuery.data?.feedbackDataSharingPreference ?? "prompt";
   const backupRetention: BackupRetentionPolicy = generalQuery.data?.backupRetention ?? DEFAULT_BACKUP_RETENTION;
+  const maxConcurrentHeartbeatRuns = generalQuery.data?.maxConcurrentHeartbeatRuns ?? null;
+
+  const commitMaxConcurrentHeartbeatRuns = () => {
+    const trimmed = maxConcurrentHeartbeatRunsDraft.trim();
+    const nextValue =
+      trimmed.length === 0
+        ? null
+        : Math.max(1, Math.min(1000, Math.floor(Number(trimmed) || 0)));
+    if (nextValue === maxConcurrentHeartbeatRuns) return;
+    updateGeneralMutation.mutate({ maxConcurrentHeartbeatRuns: nextValue });
+  };
 
   return (
     <div className="max-w-4xl space-y-6">
@@ -168,6 +185,59 @@ export function InstanceGeneralSettings() {
             disabled={updateGeneralMutation.isPending}
             aria-label="Toggle keyboard shortcuts"
           />
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-border bg-card p-5">
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <h2 className="text-sm font-semibold">Concurrent heartbeat runs</h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Limit how many heartbeat runs can execute at the same time across the whole instance.
+              When the cap is reached, additional runs stay queued until a slot frees up. Leave blank
+              for no global cap.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="w-40 space-y-1">
+              <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Max running heartbeats
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={1000}
+                step={1}
+                value={maxConcurrentHeartbeatRunsDraft}
+                onChange={(event) => setMaxConcurrentHeartbeatRunsDraft(event.target.value)}
+                className="w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono"
+                placeholder="Unlimited"
+              />
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={updateGeneralMutation.isPending}
+              onClick={() => {
+                setMaxConcurrentHeartbeatRunsDraft("");
+                if (maxConcurrentHeartbeatRuns !== null) {
+                  updateGeneralMutation.mutate({ maxConcurrentHeartbeatRuns: null });
+                }
+              }}
+            >
+              Unlimited
+            </Button>
+            <Button
+              type="button"
+              disabled={updateGeneralMutation.isPending}
+              onClick={commitMaxConcurrentHeartbeatRuns}
+            >
+              Save limit
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Current value: {maxConcurrentHeartbeatRuns == null ? "Unlimited" : maxConcurrentHeartbeatRuns}
+          </p>
         </div>
       </section>
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for AI-agent companies, so scheduler behavior must protect the whole instance, not just a single agent.
> - Heartbeats are the execution path that turns queued work into active agent runs.
> - Before this change, Paperclip only enforced per-agent `maxConcurrentRuns`, which still allowed many different agents to saturate CPU together.
> - That creates operational risk on small hosts: once several agents wake at once, the system can oversubscribe the box and degrade every company on the instance.
> - The right control-plane fix is backpressure at the scheduler layer: cap globally running heartbeats and leave the rest queued.
> - This pull request adds an instance-level concurrency cap, exposes it in Instance Settings, and keeps the existing env var as fallback.
> - The benefit is predictable instance-wide load control without dropping work or changing issue/heartbeat semantics.

## What Changed

- Added `general.maxConcurrentHeartbeatRuns` to the instance settings contract and normalization path.
- Updated the heartbeat scheduler to enforce an instance-wide running heartbeat cap with queued backpressure.
- Added a global scheduler lock so cross-agent claims do not race past the cap.
- Kept `PAPERCLIP_MAX_CONCURRENT_HEARTBEAT_RUNS` as a fallback when the instance setting is unset.
- Added a new General settings control in the UI to configure the cap or leave it unlimited.
- Added a regression test for the global concurrency cap and updated instance settings route tests.
- Documented the new setting and clarified the env var fallback behavior.

## Verification

- `pnpm --dir ~/Documents/dev/paperclip-stack/paperclip test -- --run server/src/__tests__/instance-settings-routes.test.ts server/src/__tests__/heartbeat-global-concurrency.test.ts`
- `pnpm --dir ~/Documents/dev/paperclip-stack/paperclip --filter @paperclipai/server typecheck`
- `pnpm --dir ~/Documents/dev/paperclip-stack/paperclip --filter @paperclipai/ui typecheck`
- In the board UI, open `Instance Settings > General`, set `Concurrent heartbeat runs`, save, and confirm extra runs remain `queued` once the cap is reached.

## Risks

- Scheduler throughput now depends on an extra instance-settings read on claim; low risk, but it is on a hot path.
- The new global lock is intentionally conservative and may slightly reduce parallel claim throughput in exchange for predictable cap enforcement.
- No DB migration is required because instance settings are stored as JSON, but older rows will normalize `maxConcurrentHeartbeatRuns` to `null` until updated.
- UI screenshot not included; this is a small settings-only surface change.

> Checked `ROADMAP.md`: this does not duplicate planned core work. The roadmap mentions queue-style work streams at a higher level, while this PR adds scheduler backpressure for existing heartbeats.

## Model Used

- OpenAI GPT-5 via Codex CLI (tool-using coding agent in terminal mode).
- Exact public model version/context window is not surfaced by the CLI in this session.
- Used repository inspection, patch application, shell commands, and targeted test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
