### PR TITLE
Fix GET /issues?identifier= filter returning same record regardless of input

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -859,3 +859,96 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
   });
 });
+
+describeEmbeddedPostgres("issueService.list identifier filter", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-identifier-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("returns only the issue matching the identifier filter", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const issueAId = randomUUID();
+    const issueBId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: issueAId,
+        companyId,
+        identifier: "RPAA-100",
+        title: "First issue",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: issueBId,
+        companyId,
+        identifier: "RPAA-200",
+        title: "Second issue",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    const result = await svc.list(companyId, { identifier: "RPAA-100" });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(issueAId);
+    expect(result[0].identifier).toBe("RPAA-100");
+  });
+
+  it("is case-insensitive for the identifier filter", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      identifier: "RPAA-300",
+      title: "Case test issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const result = await svc.list(companyId, { identifier: "rpaa-300" });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(issueId);
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -376,6 +376,7 @@ export function issueRoutes(
       includeRoutineExecutions:
         req.query.includeRoutineExecutions === "true" || req.query.includeRoutineExecutions === "1",
       q: req.query.q as string | undefined,
+      identifier: req.query.identifier as string | undefined,
     });
     res.json(result);
   });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -78,6 +78,7 @@ export interface IssueFilters {
   originId?: string;
   includeRoutineExecutions?: boolean;
   q?: string;
+  identifier?: string;
 }
 
 type IssueRow = typeof issues.$inferSelect;
@@ -778,6 +779,7 @@ export function issueService(db: Db) {
       if (filters?.parentId) conditions.push(eq(issues.parentId, filters.parentId));
       if (filters?.originKind) conditions.push(eq(issues.originKind, filters.originKind));
       if (filters?.originId) conditions.push(eq(issues.originId, filters.originId));
+      if (filters?.identifier) conditions.push(eq(issues.identifier, filters.identifier.toUpperCase()));
       if (filters?.labelId) {
         const labeledIssueIds = await db
           .select({ issueId: issueLabels.issueId })


### PR DESCRIPTION
## Problem

`GET /api/companies/:companyId/issues?identifier=RPAA-NNN` returned an arbitrary issue regardless of the `identifier` value passed. Every request was effectively an unfiltered list query.

**Root cause:** Two-layer gap:

1. `IssueFilters` (services/issues.ts) had no `identifier` field.
2. The route handler (routes/issues.ts) never passed `req.query.identifier` to `svc.list()`.

So the `identifier` param was silently dropped before reaching the SQL WHERE clause.

## Reproducer (before fix)

```
# Returns RPAA-650 regardless of what identifier you pass:
curl http://localhost:3100/api/companies/<cid>/issues?identifier=RPAA-869
curl http://localhost:3100/api/companies/<cid>/issues?identifier=RPAA-1
```

## Fix

- Add `identifier?: string` to `IssueFilters`
- Add `eq(issues.identifier, filters.identifier.toUpperCase())` condition in `list()`, following the same pattern as `originId`, `parentId`, etc.
- Pass `req.query.identifier as string | undefined` from route handler to `svc.list()`

## Tests

Two new embedded-Postgres tests in `issues-service.test.ts`:
- Exact-match: `?identifier=RPAA-100` returns only that issue from a two-issue fixture
- Case-insensitive: `?identifier=rpaa-300` matches `RPAA-300` in DB (`.toUpperCase()` normalisation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)