### PR TITLE
Release Manager approval inbox UI/UX (SKY-170)

### DIFF
--- a/ui/src/components/ApprovalCard.tsx
+++ b/ui/src/components/ApprovalCard.tsx
@@ -5,10 +5,7 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { Identity } from "./Identity";
 import {
   approvalSubject,
-  typeIcon,
-  defaultTypeIcon,
   ApprovalPayloadRenderer,
-  typeLabel,
   isReleaseApproval,
   resolvedTypeLabel,
   resolvedTypeIcon,

--- a/ui/src/components/ApprovalCard.tsx
+++ b/ui/src/components/ApprovalCard.tsx
@@ -9,6 +9,9 @@ import {
   defaultTypeIcon,
   ApprovalPayloadRenderer,
   typeLabel,
+  isReleaseApproval,
+  resolvedTypeLabel,
+  resolvedTypeIcon,
 } from "./ApprovalPayload";
 import { timeAgo } from "../lib/timeAgo";
 import type { Approval, Agent } from "@paperclipai/shared";
@@ -42,8 +45,9 @@ export function ApprovalCard({
   pendingAction?: "approve" | "reject" | null;
 }) {
   const payload = approval.payload as Record<string, unknown> | null;
-  const Icon = typeIcon[approval.type] ?? defaultTypeIcon;
-  const kindLabel = typeLabel[approval.type] ?? approval.type;
+  const Icon = resolvedTypeIcon(approval);
+  const kindLabel = resolvedTypeLabel(approval);
+  const isRelease = isReleaseApproval(approval);
   const subject = approvalSubject(payload);
   const showResolutionButtons =
     Boolean(onApprove && onReject) &&
@@ -118,7 +122,7 @@ export function ApprovalCard({
                   onClick={onApprove}
                   disabled={isPending}
                 >
-                  {pendingAction === "approve" ? "Approving..." : "Approve"}
+                  {pendingAction === "approve" ? "Approving..." : isRelease ? "Approve release" : "Approve"}
                 </Button>
                 <Button
                   variant="destructive"
@@ -126,7 +130,7 @@ export function ApprovalCard({
                   onClick={onReject}
                   disabled={isPending}
                 >
-                  {pendingAction === "reject" ? "Rejecting..." : "Reject"}
+                  {pendingAction === "reject" ? (isRelease ? "Holding..." : "Rejecting...") : isRelease ? "Hold" : "Reject"}
                 </Button>
               </>
             )}

--- a/ui/src/components/ApprovalPayload.test.tsx
+++ b/ui/src/components/ApprovalPayload.test.tsx
@@ -3,7 +3,8 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { ApprovalPayloadRenderer, approvalLabel } from "./ApprovalPayload";
+import { ApprovalPayloadRenderer, approvalLabel, isReleaseApproval, resolvedApprovalLabel, RELEASE_MANAGER_AGENT_ID } from "./ApprovalPayload";
+import type { Approval } from "@paperclipai/shared";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -84,5 +85,90 @@ describe("ApprovalPayloadRenderer", () => {
     act(() => {
       root.unmount();
     });
+  });
+});
+
+function makeTestApproval(overrides: Partial<Approval> = {}): Approval {
+  return {
+    id: "approval-test",
+    companyId: "company-1",
+    type: "request_board_approval",
+    requestedByAgentId: null,
+    requestedByUserId: null,
+    status: "pending",
+    payload: {},
+    decisionNote: null,
+    decidedByUserId: null,
+    decidedAt: null,
+    createdAt: new Date("2026-04-01"),
+    updatedAt: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+describe("isReleaseApproval", () => {
+  it("returns false for hire_agent type", () => {
+    expect(isReleaseApproval(makeTestApproval({ type: "hire_agent" }))).toBe(false);
+  });
+
+  it("returns false for request_board_approval with empty payload", () => {
+    expect(isReleaseApproval(makeTestApproval({ payload: {} }))).toBe(false);
+  });
+
+  it("returns true when payload.approvalCategory is 'release'", () => {
+    expect(
+      isReleaseApproval(makeTestApproval({ payload: { approvalCategory: "release" } })),
+    ).toBe(true);
+  });
+
+  it("returns true when payload.releaseAction is a non-empty string", () => {
+    expect(
+      isReleaseApproval(makeTestApproval({ payload: { releaseAction: "approve_release" } })),
+    ).toBe(true);
+  });
+
+  it("returns true when requestedByAgentId matches RELEASE_MANAGER_AGENT_ID", () => {
+    expect(
+      isReleaseApproval(makeTestApproval({ requestedByAgentId: RELEASE_MANAGER_AGENT_ID })),
+    ).toBe(true);
+  });
+
+  it("returns false when requestedByAgentId is a different UUID", () => {
+    expect(
+      isReleaseApproval(makeTestApproval({ requestedByAgentId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" })),
+    ).toBe(false);
+  });
+
+  it("returns true when both discriminator and agent ID match", () => {
+    expect(
+      isReleaseApproval(
+        makeTestApproval({
+          requestedByAgentId: RELEASE_MANAGER_AGENT_ID,
+          payload: { approvalCategory: "release" },
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("resolvedApprovalLabel", () => {
+  it("returns 'Release Approval: [title]' for release approval", () => {
+    expect(
+      resolvedApprovalLabel(
+        makeTestApproval({
+          payload: { approvalCategory: "release", title: "v2.1.0 hotfix" },
+        }),
+      ),
+    ).toBe("Release Approval: v2.1.0 hotfix");
+  });
+
+  it("returns 'Board Approval: [title]' for non-release board approval", () => {
+    expect(
+      resolvedApprovalLabel(
+        makeTestApproval({
+          payload: { title: "Reply with an ASCII frog" },
+        }),
+      ),
+    ).toBe("Board Approval: Reply with an ASCII frog");
   });
 });

--- a/ui/src/components/ApprovalPayload.tsx
+++ b/ui/src/components/ApprovalPayload.tsx
@@ -1,5 +1,35 @@
-import { UserPlus, Lightbulb, ShieldAlert, ShieldCheck } from "lucide-react";
+import { UserPlus, Lightbulb, ShieldAlert, ShieldCheck, Rocket } from "lucide-react";
 import { formatCents } from "../lib/utils";
+import type { Approval } from "@paperclipai/shared";
+
+export const RELEASE_MANAGER_AGENT_ID = "9532afbd-33aa-4b27-82e1-9a031773af60";
+
+export function isReleaseApproval(approval: Approval): boolean {
+  if (approval.type !== "request_board_approval") return false;
+  const payload = approval.payload as Record<string, unknown> | null;
+  if (!payload) return false;
+  if (payload.approvalCategory === "release") return true;
+  if (typeof payload.releaseAction === "string" && payload.releaseAction.trim().length > 0) return true;
+  if (approval.requestedByAgentId === RELEASE_MANAGER_AGENT_ID) return true;
+  return false;
+}
+
+export function resolvedTypeLabel(approval: Approval): string {
+  if (isReleaseApproval(approval)) return "Release Approval";
+  return typeLabel[approval.type] ?? approval.type;
+}
+
+export function resolvedTypeIcon(approval: Approval): typeof UserPlus {
+  if (isReleaseApproval(approval)) return Rocket;
+  return typeIcon[approval.type] ?? defaultTypeIcon;
+}
+
+export function resolvedApprovalLabel(approval: Approval): string {
+  const base = resolvedTypeLabel(approval);
+  const subject = approvalSubject(approval.payload as Record<string, unknown> | null);
+  if (subject) return `${base}: ${subject}`;
+  return base;
+}
 
 export const typeLabel: Record<string, string> = {
   hire_agent: "Hire Agent",

--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -8,7 +8,7 @@ import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { StatusBadge } from "../components/StatusBadge";
 import { Identity } from "../components/Identity";
-import { approvalLabel, typeIcon, defaultTypeIcon, ApprovalPayloadRenderer } from "../components/ApprovalPayload";
+import { approvalLabel, typeIcon, defaultTypeIcon, ApprovalPayloadRenderer, isReleaseApproval, resolvedTypeIcon, resolvedApprovalLabel } from "../components/ApprovalPayload";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -148,7 +148,8 @@ export function ApprovalDetail() {
   const linkedAgentId = typeof payload.agentId === "string" ? payload.agentId : null;
   const isActionable = approval.status === "pending" || approval.status === "revision_requested";
   const isBudgetApproval = approval.type === "budget_override_required";
-  const TypeIcon = typeIcon[approval.type] ?? defaultTypeIcon;
+  const TypeIcon = resolvedTypeIcon(approval);
+  const isRelease = isReleaseApproval(approval);
   const showApprovedBanner = searchParams.get("resolved") === "approved" && approval.status === "approved";
   const primaryLinkedIssue = linkedIssues?.[0] ?? null;
   const resolvedCta =
@@ -183,7 +184,9 @@ export function ApprovalDetail() {
               <div>
                 <p className="text-sm text-green-800 dark:text-green-100 font-medium">Approval confirmed</p>
                 <p className="text-xs text-green-700 dark:text-green-200/90">
-                  Requesting agent was notified to review this approval and linked issues.
+                  {isRelease
+                    ? "The Release Manager was notified. No code was merged or deployed."
+                    : "Requesting agent was notified to review this approval and linked issues."}
                 </p>
               </div>
             </div>
@@ -203,7 +206,7 @@ export function ApprovalDetail() {
           <div className="flex items-center gap-2">
             <TypeIcon className="h-5 w-5 text-muted-foreground shrink-0" />
             <div>
-              <h2 className="text-lg font-semibold">{approvalLabel(approval.type, approval.payload as Record<string, unknown> | null)}</h2>
+              <h2 className="text-lg font-semibold">{resolvedApprovalLabel(approval)}</h2>
               <p className="text-xs text-muted-foreground font-mono">{approval.id}</p>
             </div>
           </div>
@@ -256,9 +259,16 @@ export function ApprovalDetail() {
               ))}
             </div>
             <p className="text-[11px] text-muted-foreground mt-2">
-              Linked issues remain open until the requesting agent follows up and closes them.
+              {isRelease
+                ? "Linked issues remain open. The Release Manager will proceed with the release workflow separately."
+                : "Linked issues remain open until the requesting agent follows up and closes them."}
             </p>
           </div>
+        )}
+        {isRelease && isActionable && (
+          <p className="text-xs text-muted-foreground italic">
+            Approval records your decision and notifies the Release Manager. It does not merge code, deploy, publish, or activate spend.
+          </p>
         )}
         <div className="flex flex-wrap items-center gap-2">
           {isActionable && !isBudgetApproval && (
@@ -269,7 +279,7 @@ export function ApprovalDetail() {
                 onClick={() => approveMutation.mutate()}
                 disabled={approveMutation.isPending}
               >
-                Approve
+                {isRelease ? "Approve release request" : "Approve"}
               </Button>
               <Button
                 variant="destructive"
@@ -277,7 +287,7 @@ export function ApprovalDetail() {
                 onClick={() => rejectMutation.mutate()}
                 disabled={rejectMutation.isPending}
               >
-                Reject
+                {isRelease ? "Hold or request changes" : "Reject"}
               </Button>
             </>
           )}

--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -8,7 +8,7 @@ import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { StatusBadge } from "../components/StatusBadge";
 import { Identity } from "../components/Identity";
-import { approvalLabel, typeIcon, defaultTypeIcon, ApprovalPayloadRenderer, isReleaseApproval, resolvedTypeIcon, resolvedApprovalLabel } from "../components/ApprovalPayload";
+import { ApprovalPayloadRenderer, isReleaseApproval, resolvedTypeIcon, resolvedApprovalLabel } from "../components/ApprovalPayload";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -58,7 +58,7 @@ import { SwipeToArchive } from "../components/SwipeToArchive";
 import { StatusIcon } from "../components/StatusIcon";
 import { cn } from "../lib/utils";
 import { StatusBadge } from "../components/StatusBadge";
-import { approvalLabel, defaultTypeIcon, typeIcon, isReleaseApproval, resolvedTypeIcon, resolvedApprovalLabel } from "../components/ApprovalPayload";
+import { approvalLabel, isReleaseApproval, resolvedTypeIcon, resolvedApprovalLabel } from "../components/ApprovalPayload";
 import { timeAgo } from "../lib/timeAgo";
 import { Button } from "@/components/ui/button";
 import {

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -58,7 +58,7 @@ import { SwipeToArchive } from "../components/SwipeToArchive";
 import { StatusIcon } from "../components/StatusIcon";
 import { cn } from "../lib/utils";
 import { StatusBadge } from "../components/StatusBadge";
-import { approvalLabel, defaultTypeIcon, typeIcon } from "../components/ApprovalPayload";
+import { approvalLabel, defaultTypeIcon, typeIcon, isReleaseApproval, resolvedTypeIcon, resolvedApprovalLabel } from "../components/ApprovalPayload";
 import { timeAgo } from "../lib/timeAgo";
 import { Button } from "@/components/ui/button";
 import {
@@ -407,8 +407,9 @@ function ApprovalInboxRow({
   selected?: boolean;
   className?: string;
 }) {
-  const Icon = typeIcon[approval.type] ?? defaultTypeIcon;
-  const label = approvalLabel(approval.type, approval.payload as Record<string, unknown> | null);
+  const Icon = resolvedTypeIcon(approval);
+  const label = resolvedApprovalLabel(approval);
+  const isRelease = isReleaseApproval(approval);
   const showResolutionButtons =
     approval.type !== "budget_override_required" &&
     ACTIONABLE_APPROVAL_STATUSES.has(approval.status);
@@ -463,7 +464,7 @@ function ApprovalInboxRow({
         >
           {!showUnreadSlot && <span className="hidden h-2 w-2 shrink-0 sm:inline-flex" aria-hidden="true" />}
           <span className="hidden h-3.5 w-3.5 shrink-0 sm:inline-flex" aria-hidden="true" />
-          <span className="mt-0.5 shrink-0 rounded-md bg-muted p-1.5 sm:mt-0">
+          <span className={cn("mt-0.5 shrink-0 rounded-md p-1.5 sm:mt-0", isRelease ? "bg-purple-500/10" : "bg-muted")}>
             <Icon className="h-4 w-4 text-muted-foreground" />
           </span>
           <span className="min-w-0 flex-1">
@@ -485,7 +486,7 @@ function ApprovalInboxRow({
               onClick={onApprove}
               disabled={isPending}
             >
-              Approve
+              {isRelease ? "Approve release" : "Approve"}
             </Button>
             <Button
               variant="destructive"
@@ -494,7 +495,7 @@ function ApprovalInboxRow({
               onClick={onReject}
               disabled={isPending}
             >
-              Reject
+              {isRelease ? "Hold" : "Reject"}
             </Button>
           </div>
         ) : null}
@@ -507,7 +508,7 @@ function ApprovalInboxRow({
             onClick={onApprove}
             disabled={isPending}
           >
-            Approve
+            {isRelease ? "Approve release" : "Approve"}
           </Button>
           <Button
             variant="destructive"
@@ -516,7 +517,7 @@ function ApprovalInboxRow({
             onClick={onReject}
             disabled={isPending}
           >
-            Reject
+            {isRelease ? "Hold" : "Reject"}
           </Button>
         </div>
       ) : null}


### PR DESCRIPTION
## Thinking Path
Release Manager approval requests arrive as `request_board_approval` since SKY-169 (backend type) hasn't landed yet. Implemented a layered detection heuristic: (1) `payload.approvalCategory === "release"`, (2) `payload.releaseAction` non-empty, (3) `requestedByAgentId` matches known Release Manager agent. This forward-compatible approach works with existing payloads via agent ID fallback and will automatically upgrade when SKY-169 ships discriminator fields.

## What Changed
- **Detection**: Added `isReleaseApproval()` with 3-layer heuristic, plus `resolvedTypeLabel()`, `resolvedTypeIcon()`, `resolvedApprovalLabel()` helpers in `ApprovalPayload.tsx`
- **Inbox row**: Release approvals show Rocket icon with purple tint, "Approve release" / "Hold" action labels (desktop + mobile)
- **Approval card**: Conditional button labels matching inbox pattern
- **Approval detail**: "Approve release request" / "Hold or request changes" buttons, disclaimer ("does not merge, deploy, publish, or activate spend"), release-specific banner and linked issues copy
- **Tests**: 9 new test cases for detection logic and label generation; all 67 existing tests pass (regression green)

## Verification
- [x] `npx tsc --noEmit` — clean, zero errors
- [x] `npx vitest run src/components/ApprovalPayload.test.tsx` — 12/12 pass (3 existing + 9 new)
- [x] `npx vitest run src/pages/Inbox.test.tsx` — 8/8 pass (regression)
- [x] `npx vitest run src/lib/inbox.test.ts` — 47/47 pass (regression)
- [x] Code review: PASS (0 P0, 0 P1)
- [x] Security review: PASS (no new API endpoints, no auth changes, no XSS vectors, STRIDE clear)

## Risks
- Release Manager agent ID (`9532afbd...`) is hardcoded for fallback detection. If the agent is recreated with a new UUID, this fallback breaks — but discriminator field checks (layers 1-2) remain unaffected.
- Backend shape from SKY-169 may differ from assumed `approvalCategory`/`releaseAction` fields — a one-line update in `isReleaseApproval()` would adapt.

## SKY-169 Backend Dependency
SKY-169 is still in progress with no PR. This PR implements UI-side detection that works with the existing `request_board_approval` type and is designed to transparently upgrade when SKY-169 ships payload discriminator fields. No backend changes are required for this PR.

## Model Used
Claude Opus 4.6 (orchestrator + architect + web-builder + code-reviewer + security-sentinel)

## Checklist
- [x] No new API endpoints or backend changes
- [x] No deployment, merge, publish, TestFlight, App Store, or spend triggered by approval
- [x] Existing hire/join/budget/CEO strategy approvals unchanged
- [x] TypeScript build clean
- [x] Tests pass with regression coverage
- [x] Security review passed
- [x] Release-gate note: hand off to Sky Duty Release Manager, do NOT merge or deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)