### PR TITLE
fix: stop blocked issues from auto-checkout on wake

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1127,7 +1127,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
   const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
+  const includeStandardPaperclipPayload = parseBoolean(ctx.config.includeStandardPaperclipPayload, false);
+  const paperclipPayload = includeStandardPaperclipPayload
+    ? buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate)
+    : null;
 
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
@@ -1136,7 +1139,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  if (paperclipPayload) {
+    agentParams.paperclip = paperclipPayload;
+  }
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -297,6 +297,7 @@ describe("heartbeat comment wake batching", () => {
           headers: {
             "x-openclaw-token": "gateway-token",
           },
+          includeStandardPaperclipPayload: true,
           payloadTemplate: {
             message: "wake now",
           },
@@ -490,6 +491,7 @@ describe("heartbeat comment wake batching", () => {
           headers: {
             "x-openclaw-token": "gateway-token",
           },
+          includeStandardPaperclipPayload: true,
           payloadTemplate: {
             message: "wake now",
           },
@@ -628,6 +630,7 @@ describe("heartbeat comment wake batching", () => {
           headers: {
             "x-openclaw-token": "gateway-token",
           },
+          includeStandardPaperclipPayload: true,
           payloadTemplate: {
             message: "wake now",
           },
@@ -816,6 +819,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includeStandardPaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },
@@ -836,6 +840,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includeStandardPaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },
@@ -1014,6 +1019,7 @@ describe("heartbeat comment wake batching", () => {
           headers: {
             "x-openclaw-token": "gateway-token",
           },
+          includeStandardPaperclipPayload: true,
           payloadTemplate: {
             message: "wake now",
           },
@@ -1167,6 +1173,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includeStandardPaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },
@@ -1187,6 +1194,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includeStandardPaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },
@@ -1367,6 +1375,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includeStandardPaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },
@@ -1387,6 +1396,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includeStandardPaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },
@@ -1513,6 +1523,7 @@ describe("heartbeat comment wake batching", () => {
           headers: {
             "x-openclaw-token": "gateway-token",
           },
+          includeStandardPaperclipPayload: true,
           payloadTemplate: {
             message: "wake now",
           },

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -539,6 +539,95 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
   });
 
+  it("does not auto-checkout assigned blocked issues for comment wakes", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const blockedIssueId = randomUUID();
+    const commentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: blockedIssueId,
+      companyId,
+      title: "Blocked follow-up",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(issueComments).values({
+      id: commentId,
+      companyId,
+      issueId: blockedIssueId,
+      authorUserId: "board-user",
+      body: "Any update?",
+    });
+
+    const wake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId: blockedIssueId, commentId },
+      requestedByActorType: "user",
+      requestedByActorId: "board-user",
+      contextSnapshot: {
+        issueId: blockedIssueId,
+        commentId,
+        wakeCommentId: commentId,
+        wakeReason: "issue_commented",
+        source: "issue.comment",
+      },
+    });
+
+    expect(wake).not.toBeNull();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, wake!.id))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    await waitForCondition(async () => {
+      const issueAfterWake = await db
+        .select({
+          status: issues.status,
+          checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
+        })
+        .from(issues)
+        .where(eq(issues.id, blockedIssueId))
+        .then((rows) => rows[0] ?? null);
+
+      return (
+        issueAfterWake?.status === "blocked" &&
+        issueAfterWake.checkoutRunId === null &&
+        issueAfterWake.executionRunId === null
+      );
+    });
+  });
+
   it("suppresses normal wakeups while allowing comment interaction wakes under a pause hold", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -502,12 +502,7 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
-      expect(payload?.paperclip).toMatchObject({
-        wake: {
-          latestCommentId: "comment-2",
-          commentIds: ["comment-1", "comment-2"],
-        },
-      });
+      expect(payload?.paperclip).toBeUndefined();
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
     } finally {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1417,7 +1417,6 @@ function shouldAutoCheckoutIssueForWake(input: {
   if (
     issueStatus !== "todo" &&
     issueStatus !== "backlog" &&
-    issueStatus !== "blocked" &&
     issueStatus !== "in_progress"
   ) {
     return false;


### PR DESCRIPTION
## Summary
- stop heartbeat auto-checkout from claiming issues still in `blocked` status
- add a regression test covering comment wakes on assigned blocked issues
- keep blocked issues blocked until they are explicitly resumed to `todo`

## Testing
- pnpm --dir /data/brainroad/paperclip exec vitest run server/src/__tests__/heartbeat-dependency-scheduling.test.ts