### PR TITLE
fix(adapter-claude-local): parse compact usage status line

### DIFF
--- a/packages/adapters/claude-local/src/server/quota.test.ts
+++ b/packages/adapters/claude-local/src/server/quota.test.ts
@@ -29,4 +29,20 @@ describe("parseClaudeCliUsageText", () => {
       { label: "Current week (all models)", usedPercent: 88 },
     ]);
   });
+
+  it("merges compact status-line windows into a partial usage panel", () => {
+    const rendered = [
+      "Settings:",
+      "Usage",
+      "Current session",
+      "42% used",
+      "Resets Apr 27 at 5pm",
+      "Opus 4.6 | 5h: 52% | 7d: 23%",
+    ].join("\n");
+
+    expect(parseClaudeCliUsageText(rendered).map(({ label, usedPercent }) => ({ label, usedPercent }))).toEqual([
+      { label: "Current session", usedPercent: 42 },
+      { label: "Current week (all models)", usedPercent: 23 },
+    ]);
+  });
 });

--- a/packages/adapters/claude-local/src/server/quota.test.ts
+++ b/packages/adapters/claude-local/src/server/quota.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { parseClaudeCliUsageText } from "./quota.js";
+
+describe("parseClaudeCliUsageText", () => {
+  it("parses compact Claude status-line usage windows", () => {
+    expect(parseClaudeCliUsageText("Opus 4.6 | 5h: 42% | 7d: 23%")).toEqual([
+      {
+        label: "Current session",
+        usedPercent: 42,
+        resetsAt: null,
+        valueLabel: null,
+        detail: null,
+      },
+      {
+        label: "Current week (all models)",
+        usedPercent: 23,
+        resetsAt: null,
+        valueLabel: null,
+        detail: null,
+      },
+    ]);
+  });
+
+  it("parses compact usage windows from ANSI-rendered terminal output", () => {
+    const rendered = "\u001b[2K\r\u001b[36mSonnet 4.6\u001b[0m | 5h: 7.6% | 7d: 88.4%";
+
+    expect(parseClaudeCliUsageText(rendered).map(({ label, usedPercent }) => ({ label, usedPercent }))).toEqual([
+      { label: "Current session", usedPercent: 8 },
+      { label: "Current week (all models)", usedPercent: 88 },
+    ]);
+  });
+});

--- a/packages/adapters/claude-local/src/server/quota.ts
+++ b/packages/adapters/claude-local/src/server/quota.ts
@@ -278,6 +278,7 @@ function usageOutputLooksRelevant(text: string): boolean {
   const normalized = normalizeForLabelSearch(text);
   return normalized.includes("currentsession")
     || normalized.includes("currentweek")
+    || statusLineUsageWindows(text).length > 0
     || normalized.includes("loadingusage")
     || normalized.includes("failedtoloadusagedata")
     || normalized.includes("tokenexpired")
@@ -287,6 +288,9 @@ function usageOutputLooksRelevant(text: string): boolean {
 
 function usageOutputLooksComplete(text: string): boolean {
   const normalized = normalizeForLabelSearch(text);
+  if (statusLineUsageWindows(text).length > 0) {
+    return true;
+  }
   if (
     normalized.includes("failedtoloadusagedata")
     || normalized.includes("tokenexpired")
@@ -329,6 +333,33 @@ function percentFromLine(line: string): number | null {
     return Math.max(0, Math.min(100, Math.round(100 - clamped)));
   }
   return Math.round(clamped);
+}
+
+function statusLineUsageWindows(text: string): QuotaWindow[] {
+  const cleaned = cleanTerminalText(text);
+  const match = cleaned.match(
+    /\b5h\s*:\s*([0-9]{1,3}(?:\.[0-9]+)?)\s*%\s*(?:[|,;/]\s*)?7d\s*:\s*([0-9]{1,3}(?:\.[0-9]+)?)\s*%/i,
+  );
+  if (!match) return [];
+  const fiveHourPercent = Number(match[1]);
+  const sevenDayPercent = Number(match[2]);
+  if (!Number.isFinite(fiveHourPercent) || !Number.isFinite(sevenDayPercent)) return [];
+  return [
+    {
+      label: "Current session",
+      usedPercent: Math.min(100, Math.max(0, Math.round(fiveHourPercent))),
+      resetsAt: null,
+      valueLabel: null,
+      detail: null,
+    },
+    {
+      label: "Current week (all models)",
+      usedPercent: Math.min(100, Math.max(0, Math.round(sevenDayPercent))),
+      resetsAt: null,
+      valueLabel: null,
+      detail: null,
+    },
+  ];
 }
 
 function isQuotaLabel(line: string): boolean {
@@ -385,7 +416,8 @@ function formatClaudeCliDetail(label: string, lines: string[]): string | null {
 }
 
 export function parseClaudeCliUsageText(text: string): QuotaWindow[] {
-  const cleaned = trimToLatestUsagePanel(cleanTerminalText(text)) ?? cleanTerminalText(text);
+  const fullCleaned = cleanTerminalText(text);
+  const cleaned = trimToLatestUsagePanel(fullCleaned) ?? fullCleaned;
   const usageError = extractUsageError(cleaned);
   if (usageError) throw new Error(usageError);
 
@@ -418,8 +450,16 @@ export function parseClaudeCliUsageText(text: string): QuotaWindow[] {
     };
   });
 
+  const statusLineWindows = statusLineUsageWindows(fullCleaned);
   if (!windows.some((window) => normalizeForLabelSearch(window.label) === "currentsession")) {
+    if (statusLineWindows.length > 0) return statusLineWindows;
     throw new Error("Could not parse Claude CLI usage output.");
+  }
+  const labels = new Set(windows.map((window) => normalizeForLabelSearch(window.label)));
+  for (const window of statusLineWindows) {
+    if (!labels.has(normalizeForLabelSearch(window.label))) {
+      windows.push(window);
+    }
   }
   return windows;
 }

--- a/packages/adapters/claude-local/src/server/quota.ts
+++ b/packages/adapters/claude-local/src/server/quota.ts
@@ -278,7 +278,7 @@ function usageOutputLooksRelevant(text: string): boolean {
   const normalized = normalizeForLabelSearch(text);
   return normalized.includes("currentsession")
     || normalized.includes("currentweek")
-    || statusLineUsageWindows(text).length > 0
+    || statusLineUsageWindowsFromCleanedText(text).length > 0
     || normalized.includes("loadingusage")
     || normalized.includes("failedtoloadusagedata")
     || normalized.includes("tokenexpired")
@@ -288,7 +288,7 @@ function usageOutputLooksRelevant(text: string): boolean {
 
 function usageOutputLooksComplete(text: string): boolean {
   const normalized = normalizeForLabelSearch(text);
-  if (statusLineUsageWindows(text).length > 0) {
+  if (statusLineUsageWindowsFromCleanedText(text).length > 0) {
     return true;
   }
   if (
@@ -335,9 +335,8 @@ function percentFromLine(line: string): number | null {
   return Math.round(clamped);
 }
 
-function statusLineUsageWindows(text: string): QuotaWindow[] {
-  const cleaned = cleanTerminalText(text);
-  const match = cleaned.match(
+function statusLineUsageWindowsFromCleanedText(cleanedText: string): QuotaWindow[] {
+  const match = cleanedText.match(
     /\b5h\s*:\s*([0-9]{1,3}(?:\.[0-9]+)?)\s*%\s*(?:[|,;/]\s*)?7d\s*:\s*([0-9]{1,3}(?:\.[0-9]+)?)\s*%/i,
   );
   if (!match) return [];
@@ -450,7 +449,7 @@ export function parseClaudeCliUsageText(text: string): QuotaWindow[] {
     };
   });
 
-  const statusLineWindows = statusLineUsageWindows(fullCleaned);
+  const statusLineWindows = statusLineUsageWindowsFromCleanedText(fullCleaned);
   if (!windows.some((window) => normalizeForLabelSearch(window.label) === "currentsession")) {
     if (statusLineWindows.length > 0) return statusLineWindows;
     throw new Error("Could not parse Claude CLI usage output.");


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Local adapters report model/provider quota so operators can understand whether an agent can keep working.
> - The Claude local adapter first tries the Anthropic OAuth usage endpoint, then falls back to probing the Claude CLI `/usage` panel for subscription sessions.
> - Recent Claude Code output can show compact status-line quota values like `5h: 42% | 7d: 23%` before the full usage panel renders.
> - Without parsing that compact line, Paperclip can report `quota polling failed` even though the CLI already exposed the useful quota values.
> - This pull request teaches the fallback parser to treat the compact status line as quota data and keeps the behavior covered with focused tests.
> - The benefit is fewer false quota-polling failures for Claude Max users while preserving the existing full-panel parser.

## What Changed

- Parse compact Claude Code quota status-line output such as `5h: 42% | 7d: 23%` as the current session and current week quota windows.
- Treat compact status-line output as complete/relevant during the CLI `/usage` probe so Paperclip does not discard useful quota output while waiting for the full panel.
- Clarified the status-line helper contract so it only accepts already-cleaned terminal text.
- Added tests for plain compact output, ANSI-rendered compact output, and merging compact weekly usage into a partially parsed full usage panel.

## Verification

- `pnpm --filter @paperclipai/adapter-claude-local exec vitest run`
- `pnpm --filter @paperclipai/adapter-claude-local typecheck`

## Risks

- Low risk: parsing is limited to the Claude local adapter quota probe and only recognizes the specific compact `5h` / `7d` percent format.
- The compact status line does not include reset timestamps, so generated fallback windows keep `resetsAt`, `valueLabel`, and `detail` as `null`.
- `ROADMAP.md` checked: this is a tightly scoped bug fix and does not duplicate planned core feature work.

## GitHub issue/PR check

Searched existing GitHub issues/PRs for this exact failure and parser surface:

- `"quota polling failed"`
- `"Claude CLI /usage"`
- `"5h:" "7d:"`
- `"Could not parse Claude CLI usage output"`

Related but not duplicate work found: #498, #3320, #3406, #3425, and #2505. None fixes compact `5h` / `7d` status-line parsing in `packages/adapters/claude-local/src/server/quota.ts`.

## Model Used

- OpenAI Codex coding agent using GPT-5 with shell and GitHub CLI tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable: no UI change)
- [x] I have updated relevant documentation to reflect my changes (not applicable: no documentation surface affected)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge