### PR TITLE
fix(docker): always chown /paperclip to node:node on container start

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -6,28 +6,22 @@ PUID=${USER_UID:-1000}
 PGID=${USER_GID:-1000}
 
 # Adjust the node user's UID/GID if they differ from the runtime request
-# and fix volume ownership only when a remap is needed
-changed=0
-
 if [ "$(id -u node)" -ne "$PUID" ]; then
     echo "Updating node UID to $PUID"
     usermod -o -u "$PUID" node
-    changed=1
 fi
 
 if [ "$(id -g node)" -ne "$PGID" ]; then
     echo "Updating node GID to $PGID"
     groupmod -o -g "$PGID" node
     usermod -g "$PGID" node
-    changed=1
 fi
 
 # Always ensure /paperclip is owned by node:node.
-# The volume mount may have been created during build-time by root (e.g. hermes setup
-# creating ~/.hermes/) and subdirectories created by the server at boot (e.g. data/,
-# logs/) inherit the wrong owner when no UID/GID remap is needed.
-# Without this, Paperclip's run-log-store, hermes adapter, and other components
-# fail with EACCES when the node process tries to write to these directories.
+# The volume mount may contain directories created at build-time by root
+# (e.g. hermes setup creating ~/.hermes/) that cause EACCES errors when no
+# UID/GID remap is needed. An unconditional chown -R is the simplest correct
+# fix; on very large volumes startup time increases proportionally.
 chown -R node:node /paperclip
 
 exec gosu node "$@"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -22,8 +22,12 @@ if [ "$(id -g node)" -ne "$PGID" ]; then
     changed=1
 fi
 
-if [ "$changed" = "1" ]; then
-    chown -R node:node /paperclip
-fi
+# Always ensure /paperclip is owned by node:node.
+# The volume mount may have been created during build-time by root (e.g. hermes setup
+# creating ~/.hermes/) and subdirectories created by the server at boot (e.g. data/,
+# logs/) inherit the wrong owner when no UID/GID remap is needed.
+# Without this, Paperclip's run-log-store, hermes adapter, and other components
+# fail with EACCES when the node process tries to write to these directories.
+chown -R node:node /paperclip
 
 exec gosu node "$@"


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The Docker entrypoint (`scripts/docker-entrypoint.sh`) adjusts the node user's UID/GID at container start to match the host
> - When the default UID/GID (1000:1000) already matches, no remap occurs, and the old code skipped `chown -R`
> - However, `hermes setup` during Docker build creates `~/.hermes/` as root, and other runtime directories (`data/`, `logs/`) can be created by root before the node process takes over
> - When UID/GID remap is not needed, those directories remain root-owned, and Paperclip's run-log-store, hermes adapter, and other components fail with EACCES
> - This PR makes `chown -R node:node /paperclip` unconditional, and removes the now-dead `changed` flag

## What Changed

- `scripts/docker-entrypoint.sh`: Removed the `changed` flag (initialization + two assignment blocks — dead code after the conditional was removed). Moved `chown -R node:node /paperclip` outside any conditional so it always runs. Added a comment documenting the root cause and the startup-latency tradeoff.

## Verification

1. **Default UID/GID (no remap)**: Run container without `USER_UID`/`USER_GID` env vars — no EACCES from run-log-store or hermes adapter
2. **Custom UID/GID**: Run with `USER_UID=1001 USER_GID=1001` — owner correctly remapped, no EACCES
3. **CI**: All checks pass (policy ✅, verify ✅ (1 flaky UI test unrelated), e2e ✅, Greptile review ✅, snyk ✅)

## Risks

- **Startup latency**: On very large `/paperclip` volumes (many GB of logs, agent data), `chown -R` will add proportional startup time. This is a correctness-over-performance tradeoff — the previous conditional approach was the root cause of the EACCES bug. A future optimization could use `find /paperclip -not -user node` to limit chown scope, but the current approach is the simplest correct fix.
- Low risk otherwise — the entrypoint script is well-contained and this change is a simplification.

## Model Used

- deepseek-v4-pro (DeepSeek) — used through Hermes Agent for reasoning, code generation, and PR description

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge