### PR TITLE
Add route regression for security agent role

### DIFF
--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -436,6 +436,39 @@ describe.sequential("agent skill routes", () => {
     );
   });
 
+  it("accepts the security role on direct agent creation and preserves it in telemetry", async () => {
+    mockAgentService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeAgent("claude_local"),
+      role: "security",
+      ...patch,
+      adapterConfig: patch.adapterConfig ?? {},
+    }));
+
+    const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
+      .post("/api/companies/company-1/agents")
+      .send({
+        name: "Security Engineer",
+        role: "security",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      }));
+
+    expect([200, 201], JSON.stringify(res.body)).toContain(res.status);
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        role: "security",
+      }),
+    );
+    expect(mockTrackAgentCreated).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        agentId: "11111111-1111-4111-8111-111111111111",
+        agentRole: "security",
+      }),
+    );
+  });
+
   it("materializes a managed AGENTS.md for directly created local agents", async () => {
     const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
       .post("/api/companies/company-1/agents")


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a control plane for autonomous AI companies, so agent metadata needs to remain trustworthy across creation, storage, UI, and telemetry.
> - The agent lifecycle and creation API are the relevant subsystem because role values are captured when agents are hired or created directly.
> - The `security` taxonomy value has already landed in shared constants and validation, but the API route still benefits from explicit coverage for the direct creation path.
> - The original broader regression PR was closed to split out smaller pulls, so this PR keeps only the route-level test.
> - This pull request proves `POST /api/companies/:companyId/agents` accepts `role: "security"` and passes it through to telemetry as `agentRole: "security"`.
> - The benefit is durable regression coverage for the exact path that previously collapsed Security Engineer evidence into the generic engineer role.

## What Changed

- Added a server route regression in `server/src/__tests__/agent-skills-routes.test.ts` for direct agent creation with `role: "security"`.
- Asserted that the create-agent service receives `role: "security"` through the validated API path.
- Asserted that `trackAgentCreated(...)` emits `agentRole: "security"`, preserving the taxonomy value in telemetry.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run server/src/__tests__/agent-skills-routes.test.ts packages/shared/src/adapter-types.test.ts`

## Risks

- Low risk. This PR is test-only and does not change production behavior.
- Residual risk: historical benchmark rows or previously persisted agent records that were already misclassified remain unchanged; this only locks the current create-agent path going forward.

> I checked [`ROADMAP.md`](ROADMAP.md); this does not duplicate planned core feature work and instead adds regression coverage for an already-landed taxonomy fix.

## Model Used

- OpenAI Codex using GPT-5 (`gpt-5`) with local tool use and code execution. Context window size was not surfaced in-session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
