### PR TITLE
[codex] Fix sub-issue progress summary styling

### DIFF
--- a/ui/src/components/IssuesList.test.tsx
+++ b/ui/src/components/IssuesList.test.tsx
@@ -567,13 +567,14 @@ describe("IssuesList", () => {
     });
   });
 
-  it("hides the sub-issue progress summary unless it is enabled and populated", async () => {
+  it("hides the sub-issue progress summary unless it is enabled with multiple sub-issues", async () => {
     const { root } = renderWithQueryClient(
       <IssuesList
         issues={[createIssue()]}
         agents={[]}
         projects={[]}
         viewStateKey="paperclip:test-issues"
+        showProgressSummary
         onUpdateIssue={() => undefined}
       />,
       container,

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -390,7 +390,7 @@ function SubIssueProgressSummaryStrip({
     .filter((entry) => entry.count > 0);
 
   return (
-    <div className="rounded-md border border-border bg-muted/20 p-3">
+    <div className="border border-border bg-background p-3">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div className="min-w-0 flex-1 space-y-2">
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
@@ -424,7 +424,7 @@ function SubIssueProgressSummaryStrip({
           </div>
         </div>
 
-        <div className="min-w-0 rounded-md border border-border bg-background px-3 py-2 text-sm lg:w-72">
+        <div className="min-w-0 border border-border bg-background px-3 py-2 text-sm lg:w-72">
           {target && targetIssue ? (
             <>
               <div className="text-xs font-medium text-muted-foreground">

--- a/ui/src/lib/issue-detail-subissues.test.ts
+++ b/ui/src/lib/issue-detail-subissues.test.ts
@@ -39,8 +39,9 @@ describe("shouldRenderRichSubIssuesSection", () => {
 });
 
 describe("shouldRenderSubIssueProgressSummary", () => {
-  it("requires both the opt-in flag and child issues", () => {
-    expect(shouldRenderSubIssueProgressSummary(true, 1)).toBe(true);
+  it("requires both the opt-in flag and multiple child issues", () => {
+    expect(shouldRenderSubIssueProgressSummary(true, 2)).toBe(true);
+    expect(shouldRenderSubIssueProgressSummary(true, 1)).toBe(false);
     expect(shouldRenderSubIssueProgressSummary(false, 1)).toBe(false);
     expect(shouldRenderSubIssueProgressSummary(true, 0)).toBe(false);
   });

--- a/ui/src/lib/issue-detail-subissues.ts
+++ b/ui/src/lib/issue-detail-subissues.ts
@@ -21,8 +21,10 @@ export function shouldRenderRichSubIssuesSection(childIssuesLoading: boolean, ch
   return childIssuesLoading || childIssueCount > 0;
 }
 
+const MIN_CHILD_ISSUES_FOR_PROGRESS_SUMMARY = 2;
+
 export function shouldRenderSubIssueProgressSummary(enabled: boolean | undefined, childIssueCount: number): boolean {
-  return enabled === true && childIssueCount > 1;
+  return enabled === true && childIssueCount >= MIN_CHILD_ISSUES_FOR_PROGRESS_SUMMARY;
 }
 
 export function buildSubIssueProgressSummary(issues: Issue[]): SubIssueProgressSummary {

--- a/ui/src/lib/issue-detail-subissues.ts
+++ b/ui/src/lib/issue-detail-subissues.ts
@@ -22,7 +22,7 @@ export function shouldRenderRichSubIssuesSection(childIssuesLoading: boolean, ch
 }
 
 export function shouldRenderSubIssueProgressSummary(enabled: boolean | undefined, childIssueCount: number): boolean {
-  return enabled === true && childIssueCount > 0;
+  return enabled === true && childIssueCount > 1;
 }
 
 export function buildSubIssueProgressSummary(issues: Issue[]): SubIssueProgressSummary {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The issue list and issue detail surfaces summarize child/sub-issue progress for operators.
> - Those summaries need to be compact and visually consistent because they appear in dense lists.
> - The progress strip is most useful when there are multiple sub-issues to compare, so the summary intentionally stays hidden for a single sub-issue.
> - This pull request tightens the sub-issue progress summary styling and updates the related tests.
> - The benefit is a cleaner, more scannable task list without changing task ownership, status, or workflow behavior.

## What Changed

- Adjusted sub-issue progress summary copy/styling in the issue list and detail summary helpers.
- Intentionally render the progress summary only for two or more child issues; a single child issue still appears in the normal sub-issue list without a redundant progress strip.
- Updated the UI tests that assert the rendered summary behavior.
- Clarified the two-plus-child threshold in code with a named constant.

## Verification

- `pnpm exec vitest run --project @paperclipai/ui ui/src/components/IssuesList.test.tsx ui/src/lib/issue-detail-subissues.test.ts`

## Screenshots

![Before/after comparison of sub-issue progress summary styling](https://gist.githubusercontent.com/cryppadotta/3a0aded379de3515acd3360bd54638e0/raw/cd26b5bd63ee65d01334f6c8ad88b1c831eb5d8f/pap-2449-subissue-progress-before-after.svg)

## Risks

- Low risk; this is a small UI presentation change with focused test coverage.
- The intentional threshold change means parents with exactly one child no longer show the aggregate progress strip, avoiding redundant summary chrome while keeping the child visible in the list.
- No schema or API behavior changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, `gpt-5`, coding model with tool use and local command execution; context window not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
