### PR TITLE
feat(server): wake approval requester when a comment is added

### DIFF
--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -356,6 +356,74 @@ export function approvalRoutes(
       details: { commentId: comment.id },
     });
 
+    // Wake the approval requester so they see the new comment — mirrors the
+    // issue_commented behaviour in routes/issues.ts. Skip self-wake when the
+    // commenter is the requester themselves (matches the issue-comment pattern).
+    if (
+      approval.requestedByAgentId &&
+      approval.requestedByAgentId !== actor.agentId
+    ) {
+      try {
+        const primaryIssueId = approval.linkedIssueIds?.[0] ?? null;
+        const wakeRun = await heartbeat.wakeup(approval.requestedByAgentId, {
+          source: "automation",
+          triggerDetail: "system",
+          reason: "approval_commented",
+          payload: {
+            approvalId: approval.id,
+            approvalStatus: approval.status,
+            commentId: comment.id,
+            issueId: primaryIssueId,
+          },
+          requestedByActorType: actor.actorType,
+          requestedByActorId: actor.actorId,
+          contextSnapshot: {
+            source: "approval.comment_added",
+            approvalId: approval.id,
+            approvalStatus: approval.status,
+            commentId: comment.id,
+            issueId: primaryIssueId,
+            taskId: primaryIssueId,
+            wakeReason: "approval_commented",
+            wakeCommentId: comment.id,
+          },
+        });
+
+        await logActivity(db, {
+          companyId: approval.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          action: "approval.requester_wakeup_queued",
+          entityType: "approval",
+          entityId: approval.id,
+          details: {
+            requesterAgentId: approval.requestedByAgentId,
+            wakeRunId: wakeRun?.id ?? null,
+            commentId: comment.id,
+            wakeReason: "approval_commented",
+          },
+        });
+      } catch (err) {
+        logger.warn(
+          { err, approvalId: approval.id, commentId: comment.id },
+          "failed to queue requester wakeup after approval comment",
+        );
+        await logActivity(db, {
+          companyId: approval.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          action: "approval.requester_wakeup_failed",
+          entityType: "approval",
+          entityId: approval.id,
+          details: {
+            requesterAgentId: approval.requestedByAgentId,
+            commentId: comment.id,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+      }
+    }
+
     res.status(201).json(comment);
   });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and routes inter-agent + human-to-agent state changes via a heartbeat / wakeup primitive
> - The two main user-visible objects that carry comments are issues and approvals
> - `routes/issues.ts` already wakes the assignee when a comment is added (`wakeReason: "issue_commented"`, exposes `PAPERCLIP_WAKE_COMMENT_ID` in env)
> - `routes/approvals.ts` does NOT wake the requester on comment-add — only on `approve` / `reject` / `request_revision`
> - This means feedback left as a comment on a pending approval is invisible to the requesting agent until the approval is decided, which often defeats the purpose of leaving the comment in the first place
> - This pull request mirrors the existing `issue_commented` wake into the approval-comment route, with the same self-wake skip and failure-isolation pattern as the existing handlers
> - The benefit is symmetry between the two comment-add surfaces and a routing edge that today requires a manual out-of-band wake call to traverse

## What Changed

- `server/src/routes/approvals.ts`: in the `POST /approvals/:id/comments` handler, after the comment is added and `approval.comment_added` is logged, call `heartbeat.wakeup(approval.requestedByAgentId, ...)` with `wakeReason: "approval_commented"` — provided the requester is set and is not the same agent as the commenter.
- `contextSnapshot` includes `commentId`, `wakeCommentId`, `approvalId`, and `taskId` (set to the primary linked issue if any), mirroring the existing `approval.approved` wakeup at lines 192–201.
- New activity log entries `approval.requester_wakeup_queued` and `approval.requester_wakeup_failed`, symmetric with the existing `approval.approved` wakeup logging.

## Verification

- File an approval as agent A. Post a comment as agent B (or as a user). Inspect activity log + agent A's runs — a new heartbeat run should be queued with `wakeReason: "approval_commented"` and the comment id in `contextSnapshot.wakeCommentId`.
- Post a comment on the same approval as the requester (agent A). No new wake should be queued (self-wake skip).
- Mock `heartbeat.wakeup` to throw. Comment-add should still return 201; activity log should contain `approval.requester_wakeup_failed` with the error message.

## Risks

- **Low risk.** The change is additive and gated on `approval.requestedByAgentId` being set + not equal to the commenter. Wakeup failures are caught and logged, never propagated to the comment-add response (mirrors existing handler). No schema change. No new dependency.
- One behavioural shift to flag: agents that file approvals will now receive a wake every time a non-self comment lands. Consumers that assumed quiet between approval-add and approval-decide may need to handle the extra wake gracefully — though the standard pattern is to read `PAPERCLIP_WAKE_REASON` and switch behaviour, so this should be a no-op for well-behaved agents.

> For core feature work, check `ROADMAP.md` first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (1M context)
- Model ID: `claude-opus-4-7[1m]`
- Reasoning mode: standard
- Used to: investigate the source-level cause of an observed asymmetry, write the patch mirroring the existing `issue_commented` and `approval.approved` wakeup handlers, and draft this PR description.

## Checklist

- [x] Mirrors existing patterns in the codebase (`approval.approved` wakeup + `issue_commented` wake)
- [x] Adds no new dependency
- [x] Adds no schema change
- [x] Self-wake skip is in place (matches issue-comment behaviour)
- [x] Wakeup failure does not fail the comment-add response (try/catch + activity log)
- [x] Activity log entries added for both success + failure paths
- [ ] Maintainer to confirm `wakeReason: "approval_commented"` doesn't collide with anything elsewhere in the wake-reason taxonomy
