### PR TITLE
fix: bump drizzle-orm to ^0.41.0 to satisfy better-auth peer dep

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -48,7 +48,7 @@
     "@paperclipai/db": "workspace:*",
     "@paperclipai/server": "workspace:*",
     "@paperclipai/shared": "workspace:*",
-    "drizzle-orm": "0.38.4",
+    "drizzle-orm": "^0.41.0",
     "dotenv": "^17.0.1",
     "commander": "^13.1.0",
     "embedded-postgres": "^18.1.0-beta.16",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@paperclipai/shared": "workspace:*",
-    "drizzle-orm": "^0.38.4",
+    "drizzle-orm": "^0.41.0",
     "embedded-postgres": "^18.1.0-beta.16",
     "postgres": "^3.4.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,8 +77,8 @@ importers:
         specifier: ^17.0.1
         version: 17.3.1
       drizzle-orm:
-        specifier: 0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        specifier: ^0.41.0
+        version: 0.41.0(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -229,8 +229,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       drizzle-orm:
-        specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        specifier: ^0.41.0
+        version: 0.41.0(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -522,7 +522,7 @@ importers:
         version: 3.0.1(ajv@8.18.0)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.41.0(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -536,8 +536,8 @@ importers:
         specifier: ^17.0.1
         version: 17.3.1
       drizzle-orm:
-        specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        specifier: ^0.41.0
+        version: 0.41.0(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -4444,8 +4444,8 @@ packages:
     resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
     hasBin: true
 
-  drizzle-orm@0.38.4:
-    resolution: {integrity: sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q==}
+  drizzle-orm@0.41.0:
+    resolution: {integrity: sha512-7A4ZxhHk9gdlXmTdPj/lREtP+3u8KvZ4yEN6MYVxBzZGex5Wtdc+CWSbu7btgF6TB0N+MNPrvW7RKBbxJchs/Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -4460,20 +4460,19 @@ packages:
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
-      '@types/react': '>=18'
       '@types/sql.js': '*'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
+      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
       prisma: '*'
-      react: '>=18'
       sql.js: '>=1'
       sqlite3: '>=5'
     peerDependenciesMeta:
@@ -4503,8 +4502,6 @@ packages:
         optional: true
       '@types/pg':
         optional: true
-      '@types/react':
-        optional: true
       '@types/sql.js':
         optional: true
       '@vercel/postgres':
@@ -4517,6 +4514,8 @@ packages:
         optional: true
       expo-sqlite:
         optional: true
+      gel:
+        optional: true
       knex:
         optional: true
       kysely:
@@ -4528,8 +4527,6 @@ packages:
       postgres:
         optional: true
       prisma:
-        optional: true
-      react:
         optional: true
       sql.js:
         optional: true
@@ -10204,7 +10201,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
+  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.41.0(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -10220,7 +10217,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+      drizzle-orm: 0.41.0(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -10748,14 +10745,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4):
+  drizzle-orm@0.41.0(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
-      '@types/react': 19.2.14
       kysely: 0.28.11
       pg: 8.18.0
       postgres: 3.4.8
-      react: 19.2.4
 
   dunder-proto@1.0.1:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -62,7 +62,7 @@
     "detect-port": "^2.1.0",
     "dompurify": "^3.3.2",
     "dotenv": "^17.0.1",
-    "drizzle-orm": "^0.38.4",
+    "drizzle-orm": "^0.41.0",
     "embedded-postgres": "^18.1.0-beta.16",
     "express": "^5.1.0",
     "hermes-paperclip-adapter": "^0.2.0",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The CLI is distributed as `paperclipai` on npm and is intended to be runnable via `npx paperclipai run`
> - `paperclipai`, `@paperclipai/server`, and `@paperclipai/db` all declare `drizzle-orm` at version `0.38.4` (the cli pins exactly; the others use `^0.38.4`, which under semver caret rules for 0.x stays inside `0.38.x`)
> - `better-auth@1.4.18` (a transitive runtime dep via `@paperclipai/server`) declares `drizzle-orm: >=0.41.0` as an optional peer dependency — and that peer becomes required as soon as its `drizzle-adapter` module is imported, which Paperclip's auth setup does at server start
> - When installed via `npx`, npm hoists the only available version (`0.38.4`) under each Paperclip workspace package's nested `node_modules`, leaving the top of the tree empty for `drizzle-orm`. better-auth's adapter then fails ESM resolution with `Cannot find package 'drizzle-orm' imported from .../better-auth/dist/adapters/drizzle-adapter/drizzle-adapter.mjs` and `npx paperclipai run` exits before booting the server
> - This pull request bumps the three `drizzle-orm` declarations to `^0.41.0`, satisfying better-auth's peer constraint while keeping the API surface Paperclip uses untouched
> - The benefit is that `npx paperclipai run` works out of the box again — no wrapper, no manual `drizzle-orm` install alongside

## What Changed

- `cli/package.json`: `drizzle-orm` `0.38.4` → `^0.41.0`
- `server/package.json`: `drizzle-orm` `^0.38.4` → `^0.41.0`
- `packages/db/package.json`: `drizzle-orm` `^0.38.4` → `^0.41.0`

No source changes — Paperclip's drizzle-orm API surface (basic operators, pg-core column types, `postgres-js` driver and migrator) is unchanged across `0.38 → 0.41`.

## Verification

Audited the drizzle-orm `0.39 / 0.40 / 0.41` release notes against Paperclip's actual usage:

| Release | Notable change | Impact on Paperclip |
| --- | --- | --- |
| 0.39.0 | Bun SQL driver, `WITH` + INSERT/UPDATE/DELETE, `getViewName` util | None — additive |
| 0.39.1–0.39.3 | SQLite onConflict fix, neon schema rename, peer-dep cleanup | None |
| 0.40.0 | New `Gel` dialect | None — additive |
| 0.40.1 | `@neondatabase/serverless@1.0` compat | None |
| 0.41.0 | Removed in-driver mapping for postgres `numeric[]`, `timestamp[]`, `timestamp_with_timezone[]`, `interval[]`, `date[]`; added `bigint`/`number` modes for `decimal`/`numeric` | **None** — Paperclip's schema uses only `text/uuid/timestamp/jsonb/integer/boolean/bigint/date/bigserial`, no array variants of the affected types, no `decimal`/`numeric`/`interval` columns |
| 0.41.0 | Fix for custom-schema RQBv1 queries (#4060) | None — Paperclip's two `db.query.*` call sites (`userSidebarPreferences`, `companyUserSidebarPreferences`) use the default schema |

Local checks on this branch (Node 25.9.0, pnpm 9.15.4, macOS arm64):

```sh
pnpm install                           # single resolved drizzle-orm@0.41.0, no drizzle-related peer warnings
pnpm run typecheck                     # all 21 workspace projects pass
pnpm run paperclipai                   # CLI loads full module graph (better-auth's drizzle-adapter resolves) and prints help

npx vitest run \
  packages/db/src/runtime-config.test.ts \
  packages/db/src/embedded-postgres-error.test.ts \
  server/src/__tests__/better-auth.test.ts \
  server/src/__tests__/access-validators.test.ts \
  server/src/__tests__/feedback-service.test.ts
# 5 files, 28 tests passed
```

`feedback-service.test.ts` exercises real drizzle queries against the embedded postgres, so this is a runtime check, not just a typecheck.

Reproduction of the original failure (before this change) and the working path after, documented for reference:

```sh
# before — fails
npx -y paperclipai@2026.427.0 run
# Cannot find package 'drizzle-orm' imported from .../better-auth/dist/adapters/drizzle-adapter/drizzle-adapter.mjs

# manual workaround that confirms the same diagnosis (only drizzle-orm@^0.41 added at top level)
mkdir runner && cd runner
npm install paperclipai drizzle-orm@^0.41
./node_modules/.bin/paperclipai run    # boots cleanly
```

After this PR, the manual `drizzle-orm@^0.41` step is no longer needed.

## Risks

Low risk. This is a deps-only bump confined to three `package.json` files. The drizzle-orm minor jump introduces no breaking changes in the API surface Paperclip uses (verified by changelog audit and full workspace typecheck). The runtime tests covering both better-auth integration and a representative DB-backed service pass on the bumped version.

If a downstream package surfaces a regression I missed, reverting is a one-line change per file.

## Model Used

Claude Opus 4.7 (1M context), `claude-opus-4-7[1m]`, with tool use (Read, Edit, Bash, WebFetch). Investigation, changelog audit, version bump, and verification commands were authored by the model and run locally; the human contributor reviewed each step before the commit.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable — N/A, deps-only change covered by existing tests
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [ ] I have updated relevant documentation to reflect my changes — N/A, no docs reference the pinned drizzle-orm version
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
