### PR TITLE
Auto-prune ~/.paperclip-worktrees instance dirs after merge (NODA-188)

### DIFF
--- a/cli/src/__tests__/gc.test.ts
+++ b/cli/src/__tests__/gc.test.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { findOrphanScratchDirs } from "../commands/gc.js";
+
+const KNOWN_COMPANY_ID = "11111111-1111-1111-1111-111111111111";
+const ORPHAN_COMPANY_ID = "22222222-2222-2222-2222-222222222222";
+
+type StubDb = {
+  select: (cols: unknown) => {
+    from: (table: unknown) => {
+      where: (cond: unknown) => Promise<Array<{ id: string }>>;
+    };
+  };
+};
+
+function makeStubDb(knownIds: string[]): StubDb {
+  return {
+    select: () => ({
+      from: () => ({
+        where: async () => knownIds.map((id) => ({ id })),
+      }),
+    }),
+  };
+}
+
+function mkInstanceRoot(): { instanceRoot: string; cleanupRoot: string } {
+  const cleanupRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-gc-"));
+  const instanceRoot = path.join(cleanupRoot, ".paperclip", "instances", "test");
+  fs.mkdirSync(path.join(instanceRoot, "projects", KNOWN_COMPANY_ID, "p"), { recursive: true });
+  fs.mkdirSync(path.join(instanceRoot, "projects", ORPHAN_COMPANY_ID, "x"), { recursive: true });
+  fs.mkdirSync(path.join(instanceRoot, "companies", KNOWN_COMPANY_ID, "codex-home"), { recursive: true });
+  fs.mkdirSync(path.join(instanceRoot, "companies", ORPHAN_COMPANY_ID, "codex-home"), { recursive: true });
+  fs.mkdirSync(path.join(instanceRoot, "projects", "not-a-uuid"), { recursive: true });
+  return { instanceRoot, cleanupRoot };
+}
+
+const cleanupDirs: string[] = [];
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    const dir = cleanupDirs.pop()!;
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+});
+
+describe("findOrphanScratchDirs", () => {
+  it("flags only company-id dirs absent from the DB", async () => {
+    const { instanceRoot, cleanupRoot } = mkInstanceRoot();
+    cleanupDirs.push(cleanupRoot);
+
+    const result = await findOrphanScratchDirs({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db: makeStubDb([KNOWN_COMPANY_ID]) as any,
+      projectsRoot: path.join(instanceRoot, "projects"),
+      companiesRoot: path.join(instanceRoot, "companies"),
+    });
+
+    const ids = result.orphans.map((o) => o.companyId).sort();
+    expect(ids).toEqual([ORPHAN_COMPANY_ID, ORPHAN_COMPANY_ID].sort());
+
+    const kinds = new Set(result.orphans.map((o) => o.kind));
+    expect(kinds).toEqual(new Set(["projects", "companies"]));
+    expect(result.scanned).toBe(4); // 2 projects + 2 companies, "not-a-uuid" is skipped
+  });
+
+  it("returns no orphans when every UUID dir is in the DB", async () => {
+    const { instanceRoot, cleanupRoot } = mkInstanceRoot();
+    cleanupDirs.push(cleanupRoot);
+
+    const result = await findOrphanScratchDirs({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db: makeStubDb([KNOWN_COMPANY_ID, ORPHAN_COMPANY_ID]) as any,
+      projectsRoot: path.join(instanceRoot, "projects"),
+      companiesRoot: path.join(instanceRoot, "companies"),
+    });
+
+    expect(result.orphans).toHaveLength(0);
+  });
+
+  it("handles missing instance roots gracefully", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-gc-empty-"));
+    cleanupDirs.push(tmp);
+
+    const result = await findOrphanScratchDirs({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db: makeStubDb([]) as any,
+      projectsRoot: path.join(tmp, "nonexistent-projects"),
+      companiesRoot: path.join(tmp, "nonexistent-companies"),
+    });
+
+    expect(result.scanned).toBe(0);
+    expect(result.orphans).toHaveLength(0);
+  });
+});

--- a/cli/src/commands/gc.ts
+++ b/cli/src/commands/gc.ts
@@ -1,0 +1,262 @@
+import { existsSync, promises as fsPromises } from "node:fs";
+import path from "node:path";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { inArray } from "drizzle-orm";
+import { companies, createDb, type Db } from "@paperclipai/db";
+import {
+  resolvePaperclipHomeDir,
+  resolvePaperclipInstanceId,
+  resolvePaperclipInstanceRoot,
+} from "../config/home.js";
+import { readConfig } from "../config/store.js";
+import { printPaperclipCliBanner } from "../utils/banner.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type OrphanScratchKind = "projects" | "companies";
+
+export interface OrphanScratchDir {
+  kind: OrphanScratchKind;
+  companyId: string;
+  path: string;
+}
+
+export interface ProjectsGcSummary {
+  scanned: number;
+  orphans: OrphanScratchDir[];
+  quarantined: Array<{ kind: OrphanScratchKind; companyId: string; from: string; to: string }>;
+  swept: string[];
+  errors: Array<{ phase: "quarantine" | "sweep"; path: string; message: string }>;
+  dryRun: boolean;
+}
+
+type ProjectsGcOptions = {
+  config?: string;
+  dataDir?: string;
+  instance?: string;
+  apply?: boolean;
+  dryRun?: boolean;
+  retentionDays?: number;
+  json?: boolean;
+};
+
+function resolveConnectionString(configPath?: string): { value: string; source: string } | null {
+  const envUrl = process.env.DATABASE_URL?.trim();
+  if (envUrl) return { value: envUrl, source: "DATABASE_URL" };
+
+  const config = readConfig(configPath);
+  if (config?.database.mode === "postgres" && config.database.connectionString?.trim()) {
+    return {
+      value: config.database.connectionString.trim(),
+      source: "config.database.connectionString",
+    };
+  }
+  if (config?.database.mode === "embedded-postgres") {
+    const port = config.database.embeddedPostgresPort ?? 54329;
+    return {
+      value: `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`,
+      source: `embedded-postgres@${port}`,
+    };
+  }
+  return null;
+}
+
+function defaultRetentionDays(): number {
+  const fromEnv = Number(process.env.PAPERCLIP_PROJECTS_GC_RETENTION_DAYS);
+  if (Number.isFinite(fromEnv) && fromEnv >= 0) return Math.trunc(fromEnv);
+  return 14;
+}
+
+function resolveInstanceRoot(instance?: string): string {
+  if (!instance) return resolvePaperclipInstanceRoot();
+  return path.resolve(resolvePaperclipHomeDir(), "instances", resolvePaperclipInstanceId(instance));
+}
+
+async function listSubdirs(dir: string): Promise<string[]> {
+  if (!existsSync(dir)) return [];
+  const entries = await fsPromises.readdir(dir, { withFileTypes: true });
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+}
+
+async function loadKnownCompanyIds(db: Db, candidateIds: string[]): Promise<Set<string>> {
+  if (candidateIds.length === 0) return new Set();
+  const rows = await db
+    .select({ id: companies.id })
+    .from(companies)
+    .where(inArray(companies.id, candidateIds));
+  return new Set(rows.map((row) => row.id));
+}
+
+export async function findOrphanScratchDirs(input: {
+  db: Db;
+  projectsRoot: string;
+  companiesRoot: string;
+}): Promise<{ scanned: number; orphans: OrphanScratchDir[] }> {
+  const candidates: OrphanScratchDir[] = [];
+
+  for (const [root, kind] of [
+    [input.projectsRoot, "projects" as const],
+    [input.companiesRoot, "companies" as const],
+  ] satisfies Array<[string, OrphanScratchKind]>) {
+    const names = await listSubdirs(root);
+    for (const name of names) {
+      if (!UUID_RE.test(name)) continue;
+      candidates.push({ kind, companyId: name, path: path.resolve(root, name) });
+    }
+  }
+
+  const known = await loadKnownCompanyIds(
+    input.db,
+    Array.from(new Set(candidates.map((c) => c.companyId))),
+  );
+  const orphans = candidates.filter((c) => !known.has(c.companyId));
+  return { scanned: candidates.length, orphans };
+}
+
+function timestampSlug(now: Date): string {
+  return now.toISOString().replace(/[:.]/g, "-");
+}
+
+async function quarantineOrphan(
+  orphan: OrphanScratchDir,
+  trashRoot: string,
+  now: Date,
+) {
+  const bucket = path.resolve(trashRoot, orphan.kind);
+  await fsPromises.mkdir(bucket, { recursive: true });
+  const target = path.resolve(bucket, `${orphan.companyId}-${timestampSlug(now)}`);
+  await fsPromises.rename(orphan.path, target);
+  return { kind: orphan.kind, companyId: orphan.companyId, from: orphan.path, to: target };
+}
+
+async function sweepBucket(bucketDir: string, cutoffMs: number) {
+  if (!existsSync(bucketDir)) return { swept: [] as string[], errors: [] as Array<{ path: string; message: string }> };
+  const swept: string[] = [];
+  const errors: Array<{ path: string; message: string }> = [];
+  const entries = await fsPromises.readdir(bucketDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.resolve(bucketDir, entry.name);
+    try {
+      const stat = await fsPromises.stat(entryPath);
+      if (stat.mtimeMs > cutoffMs) continue;
+      await fsPromises.rm(entryPath, { recursive: true, force: true });
+      swept.push(entryPath);
+    } catch (err) {
+      errors.push({ path: entryPath, message: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return { swept, errors };
+}
+
+export async function projectsGcCommand(opts: ProjectsGcOptions): Promise<void> {
+  const isJson = Boolean(opts.json);
+  if (!isJson) {
+    printPaperclipCliBanner();
+    p.intro(pc.bgCyan(pc.black(" paperclipai projects:gc ")));
+  }
+
+  const connection = resolveConnectionString(opts.config);
+  if (!connection) {
+    throw new Error("Could not resolve a database connection (no DATABASE_URL and no embedded-postgres config).");
+  }
+
+  const dryRun = opts.apply !== true;
+  const retentionDays =
+    opts.retentionDays !== undefined && Number.isFinite(opts.retentionDays)
+      ? Math.max(0, Math.trunc(opts.retentionDays))
+      : defaultRetentionDays();
+
+  const instanceRoot = resolveInstanceRoot(opts.instance);
+  const projectsRoot = path.resolve(instanceRoot, "projects");
+  const companiesRoot = path.resolve(instanceRoot, "companies");
+  const trashRoot = path.resolve(instanceRoot, "_trash");
+
+  if (!isJson) {
+    p.log.message(pc.dim(`Instance root: ${instanceRoot}`));
+    p.log.message(pc.dim(`DB source: ${connection.source}`));
+    p.log.message(pc.dim(`Retention: ${retentionDays} day(s)`));
+    p.log.message(pc.dim(`Mode: ${dryRun ? "dry-run" : "apply (quarantine + sweep)"}`));
+  }
+
+  const db = createDb(connection.value);
+  const result: ProjectsGcSummary = {
+    scanned: 0,
+    orphans: [],
+    quarantined: [],
+    swept: [],
+    errors: [],
+    dryRun,
+  };
+  try {
+    const found = await findOrphanScratchDirs({ db, projectsRoot, companiesRoot });
+    result.scanned = found.scanned;
+    result.orphans = found.orphans;
+
+    const now = new Date();
+    if (!dryRun) {
+      for (const orphan of found.orphans) {
+        try {
+          const moved = await quarantineOrphan(orphan, trashRoot, now);
+          result.quarantined.push(moved);
+        } catch (err) {
+          result.errors.push({
+            phase: "quarantine",
+            path: orphan.path,
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      const cutoffMs = now.getTime() - retentionDays * 24 * 60 * 60 * 1000;
+      for (const kind of ["projects", "companies"] as const) {
+        const sweep = await sweepBucket(path.resolve(trashRoot, kind), cutoffMs);
+        result.swept.push(...sweep.swept);
+        for (const err of sweep.errors) {
+          result.errors.push({ phase: "sweep", path: err.path, message: err.message });
+        }
+      }
+    }
+
+    if (isJson) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    if (result.orphans.length === 0 && result.swept.length === 0) {
+      p.outro(pc.green(`Nothing to clean (scanned ${result.scanned}).`));
+      return;
+    }
+
+    if (result.orphans.length > 0) {
+      p.log.message(pc.yellow(`Found ${result.orphans.length} orphan${result.orphans.length === 1 ? "" : "s"}:`));
+      for (const orphan of result.orphans) {
+        p.log.message(`  • [${orphan.kind}] ${orphan.companyId}  ${pc.dim(orphan.path)}`);
+      }
+    }
+    if (dryRun) {
+      p.log.info("Dry-run only. Re-run with --apply to quarantine the directories above (and sweep older trash).");
+      p.outro("Done.");
+      return;
+    }
+    if (result.quarantined.length > 0) {
+      p.log.message(pc.cyan(`Quarantined ${result.quarantined.length}:`));
+      for (const entry of result.quarantined) {
+        p.log.message(`  • [${entry.kind}] ${entry.companyId} → ${pc.dim(entry.to)}`);
+      }
+    }
+    if (result.swept.length > 0) {
+      p.log.message(pc.cyan(`Swept ${result.swept.length} expired trash entr${result.swept.length === 1 ? "y" : "ies"}.`));
+    }
+    if (result.errors.length > 0) {
+      for (const err of result.errors) {
+        p.log.error(`[${err.phase}] ${err.path}: ${err.message}`);
+      }
+    }
+    p.outro(pc.green("Done."));
+  } finally {
+    await (db as unknown as { $client?: { end?: (opts?: { timeout?: number }) => Promise<void> } }).$client
+      ?.end?.({ timeout: 5 })
+      .catch(() => undefined);
+  }
+}

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -68,6 +68,10 @@ import {
   type WorktreeLocalPaths,
 } from "./worktree-lib.js";
 import {
+  DEFAULT_WORKTREE_GC_MIN_AGE_MS,
+  runWorktreeGc,
+} from "@paperclipai/shared/worktree-gc";
+import {
   buildWorktreeMergePlan,
   parseWorktreeMergeScopes,
   type IssueAttachmentRow,
@@ -1845,6 +1849,72 @@ export async function worktreeCleanupCommand(nameArg: string, opts: WorktreeClea
   p.outro(pc.green("Cleanup complete."));
 }
 
+type WorktreeGcOptionsCli = {
+  home?: string;
+  dryRun?: boolean;
+  force?: boolean;
+  minAgeMs?: string;
+};
+
+export async function worktreeGcCommand(opts: WorktreeGcOptionsCli): Promise<void> {
+  printPaperclipCliBanner();
+  p.intro(pc.bgCyan(pc.black(" paperclipai worktree:gc ")));
+
+  const homeDir = path.resolve(expandHomePrefix(resolveWorktreeHome(opts.home)));
+  const minAgeMs =
+    opts.minAgeMs !== undefined && opts.minAgeMs !== ""
+      ? Math.max(0, Number(opts.minAgeMs))
+      : DEFAULT_WORKTREE_GC_MIN_AGE_MS;
+
+  if (!Number.isFinite(minAgeMs)) {
+    throw new Error(`Invalid --min-age-ms: ${opts.minAgeMs}`);
+  }
+
+  p.log.info(
+    `Scanning ${homeDir}/instances/ — pruning instances whose branch is gone (min-age: ${Math.round(minAgeMs / 1000)}s)${
+      opts.dryRun ? " [dry-run]" : ""
+    }.`,
+  );
+
+  const result = runWorktreeGc({
+    repoCwd: process.cwd(),
+    homeDir,
+    minAgeMs,
+    dryRun: opts.dryRun,
+    force: opts.force,
+    logger: {
+      info: (msg, meta) => {
+        if (meta && Object.keys(meta).length > 0) {
+          p.log.info(`${msg} ${JSON.stringify(meta)}`);
+        } else {
+          p.log.info(msg);
+        }
+      },
+      warn: (msg, meta) => {
+        if (meta && Object.keys(meta).length > 0) {
+          p.log.warning(`${msg} ${JSON.stringify(meta)}`);
+        } else {
+          p.log.warning(msg);
+        }
+      },
+    },
+  });
+
+  for (const skip of result.skipped) {
+    p.log.warning(`skipped ${skip.instanceId}: ${skip.reason}`);
+  }
+  for (const err of result.errors) {
+    p.log.error(`error ${err.instanceId}: ${err.error}`);
+  }
+
+  const verb = opts.dryRun ? "would prune" : "pruned";
+  p.outro(
+    pc.green(
+      `Scanned ${result.scanned} candidate${result.scanned === 1 ? "" : "s"}; ${verb} ${result.pruned.length}.`,
+    ),
+  );
+}
+
 export async function worktreeEnvCommand(opts: WorktreeEnvOptions): Promise<void> {
   const configPath = resolveConfigPath(opts.config);
   const envPath = resolvePaperclipEnvFile(configPath);
@@ -3339,4 +3409,25 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--home <path>", `Home root for worktree instances (env: PAPERCLIP_WORKTREES_DIR, default: ${DEFAULT_WORKTREE_HOME})`)
     .option("--force", "Bypass safety checks (uncommitted changes, unique commits)", false)
     .action(worktreeCleanupCommand);
+
+  program
+    .command("worktree:gc")
+    .description(
+      "Prune orphaned ~/.paperclip-worktrees/instances/<id>/ directories whose branch is gone",
+    )
+    .option(
+      "--home <path>",
+      `Home root for worktree instances (env: PAPERCLIP_WORKTREES_DIR, default: ${DEFAULT_WORKTREE_HOME})`,
+    )
+    .option("--dry-run", "Show what would be pruned without deleting anything", false)
+    .option(
+      "--force",
+      "Prune even when the linked checkout has uncommitted changes",
+      false,
+    )
+    .option(
+      "--min-age-ms <ms>",
+      `Skip instance dirs younger than this (default: ${DEFAULT_WORKTREE_GC_MIN_AGE_MS})`,
+    )
+    .action(worktreeGcCommand);
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,6 +9,7 @@ import { runCommand } from "./commands/run.js";
 import { bootstrapCeoInvite } from "./commands/auth-bootstrap-ceo.js";
 import { dbBackupCommand } from "./commands/db-backup.js";
 import { registerEnvLabCommands } from "./commands/env-lab.js";
+import { projectsGcCommand } from "./commands/gc.js";
 import { registerContextCommands } from "./commands/client/context.js";
 import { registerCompanyCommands } from "./commands/client/company.js";
 import { registerIssueCommands } from "./commands/client/issue.js";
@@ -137,6 +138,25 @@ heartbeat
   .option("--json", "Output raw JSON where applicable")
   .option("--debug", "Show raw adapter stdout/stderr JSON chunks")
   .action(heartbeatRun);
+
+program
+  .command("projects:gc")
+  .description(
+    "Quarantine orphaned <instance-root>/{projects,companies}/<companyId>/ scratch dirs (whose company is gone) into <instance-root>/_trash/, and sweep trash older than the retention window",
+  )
+  .option("-c, --config <path>", "Path to config file")
+  .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
+  .option("-i, --instance <id>", "Instance id to scan (defaults to current PAPERCLIP_INSTANCE_ID or 'default')")
+  .option("--apply", "Actually quarantine orphans and sweep expired trash (default is dry-run)", false)
+  .option(
+    "--retention-days <days>",
+    "Retention window for trash before final deletion (default: env PAPERCLIP_PROJECTS_GC_RETENTION_DAYS or 14)",
+    (value) => Number(value),
+  )
+  .option("--json", "Print results as JSON (skips banner and prompts)", false)
+  .action(async (opts) => {
+    await projectsGcCommand(opts);
+  });
 
 registerContextCommands(program);
 registerCompanyCommands(program);

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -19,6 +19,8 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` | Runtime mode override |
 | `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` | Exposure policy when deployment mode is `authenticated` |
 | `PAPERCLIP_API_URL` | (auto-derived) | Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful for deployments where the public-facing URL differs from the local bind address. |
+| `PAPERCLIP_WORKTREE_AUTOPRUNE` | `true` | When the primary instance's heartbeat scans `~/.paperclip-worktrees/instances/` and prunes orphaned ticket worktrees whose branch is gone. Set to `false` to disable. |
+| `PAPERCLIP_WORKTREE_AUTOPRUNE_INTERVAL_MS` | `3600000` | Minimum interval between worktree auto-prune sweeps. Floor: 5 minutes. |
 
 ## Secrets
 

--- a/docs/deploy/file-layout.md
+++ b/docs/deploy/file-layout.md
@@ -1,0 +1,89 @@
+---
+title: On-Disk File Layout
+summary: Where Paperclip stores data, runtime scratch, and per-user state on disk
+---
+
+Paperclip writes to two parallel "homes" by design: a **repo-scoped instance home** for the running server's data and runtime artifacts, and a **user-scoped home** for CLI/dev-runner state. This page maps every Paperclip-adjacent folder so it's clear which are authoritative, which are scratch, and which are stale.
+
+## TL;DR
+
+- Authoritative data: embedded Postgres at `<instance-home>/db/`. Nothing else on disk is a source of truth.
+- Folders named after companies or agents (e.g. `companies/<companyId>/`, `workspaces/<agentId>/`) are **runtime scratch** keyed by UUID — adding or removing them by hand does not create or delete records.
+- The legacy `services/paperclip/companies/` directory in the repo checkout is unrelated old scratch and is not read by the server.
+
+## Roots
+
+### 1. `<instance-home>/` — primary runtime home (authoritative)
+
+The instance home is either repo-scoped (`<repo>/.paperclip-home/instances/<instance>/`) or user-scoped (`~/.paperclip/instances/<instance>/`), depending on the workspace strategy chosen at onboarding. Everything the server reads and writes for a running instance lives here.
+
+| Path | Purpose | Authoritative? |
+|---|---|---|
+| `db/` | Embedded Postgres data dir | **Yes — source of truth** |
+| `data/backups/` | Hourly Postgres dumps (default 30-day retention) | Derived |
+| `data/storage/` | Blob/attachment bytes when `storage.provider = local_disk` | **Yes** |
+| `data/run-logs/` | Per-heartbeat run transcripts and structured logs | Derived |
+| `logs/` | Server process logs | Derived |
+| `secrets/master.key` | Local encryption key for secret values stored in the DB | **Yes — back this up** |
+| `config.json` | Instance config: ports, storage provider, backup policy | **Yes** |
+| `companies/<companyId>/` | Per-company adapter scratch (e.g. `claude-prompt-cache/`, `agents/`) | Scratch |
+| `workspaces/<agentId>/` | Per-agent git worktree where the agent does code work | Scratch (regenerable from git) |
+| `projects/<companyId>/<projectId>/` | Per-project scratch | Scratch |
+| `runtime-services/` | Worker/runtime-service state | Scratch |
+| `telemetry/` | Local telemetry spool | Scratch |
+| `_trash/{projects,companies}/` | Quarantine for orphaned scratch awaiting final deletion (see "Stale state") | Scratch |
+
+If you need to inspect, move, or remove a company, use the API or CLI — not the disk. Renaming the UUID-named folders desyncs the cache without changing the DB.
+
+### 2. `~/.paperclip/instances/<instance>/` — user-scoped state
+
+This exists even when the instance home is repo-scoped, because the CLI and dev-runner write user-level state regardless of which checkout you're in. Typical contents:
+
+| Path | Purpose |
+|---|---|
+| `runtime-services/paperclip-dev-*.json` | Dev-runner pid/port/process-group bookkeeping so `pnpm dev` can reuse or restart watch processes |
+| `telemetry/state.json` | Anonymous install ID + salt |
+| `projects/<companyId>/<projectId>/...` | Old per-project scratch (see "Stale state" below) |
+
+This is **not** a second copy of the database. It's separate state owned by the CLI/dev-runner.
+
+### 3. `~/.paperclip-worktrees/instances/<instance>/<branch-or-ticket-slug>/` — ticket worktrees
+
+Created when an agent needs an isolated worktree for a long-running ticket. Folder names are branch/ticket slugs (e.g. `pap-552-install-without-moved-symlinks`).
+
+These are **auto-pruned** when the corresponding branch no longer exists locally or on any remote (typical signal: branch merged and deleted). The sweep runs on the primary checkout's server heartbeat (default: hourly, gated by `PAPERCLIP_WORKTREE_AUTOPRUNE_INTERVAL_MS`) and only inspects directories at least one hour old whose embedded postgres is not running. Set `PAPERCLIP_WORKTREE_AUTOPRUNE=false` to disable. Run `paperclipai worktree:gc --dry-run` to preview, or `paperclipai worktree:gc` to prune on demand (use `--force` to bypass uncommitted-change checks in the linked checkout).
+
+### 4. Repo-root untracked dirs
+
+The following are local-only dev scratch and **not** part of Paperclip runtime state:
+
+- `services/paperclip/companies/` — legacy research bundles from a pre-DB workflow. Untracked, not read by the server.
+- `services/paperclip/state/`, `services/paperclip/temp/`, `custom-skills/` — local dev scratch.
+
+## Stale state
+
+These folders are scratch and safe to delete:
+
+- `<instance-home>/projects/<companyId>/` and `<instance-home>/companies/<companyId>/` where `<companyId>` is no longer present in the DB. Happens when a company is deleted or re-imported under a new UUID. **Auto-collected**: the server runs a daily sweep on startup and at `PAPERCLIP_PROJECTS_GC_INTERVAL_HOURS` (default 24h), moving orphans to `<instance-home>/_trash/{projects,companies}/<companyId>-<timestamp>/`. Quarantined entries older than `PAPERCLIP_PROJECTS_GC_RETENTION_DAYS` (default 14d) are then permanently deleted. Set `PAPERCLIP_PROJECTS_GC_ENABLED=false` to disable.
+- `~/.paperclip-worktrees/instances/<instance>/<slug>/` for branches/tickets that are merged and gone. **Auto-collected**: the primary instance's heartbeat sweeps these (gated by `PAPERCLIP_WORKTREE_AUTOPRUNE`).
+- `services/paperclip/companies/` in older checkouts. Not read by the server.
+
+Manual GC commands:
+
+- `paperclipai projects:gc [--apply] [--retention-days <n>]` — preview (default) or apply the same scan the server's auto-sweep runs: quarantine orphaned project & company scratch into `_trash/`, then delete trash older than the retention window.
+- `paperclipai worktree:gc [--dry-run] [--force]` — list / delete orphaned worktree instance directories under `~/.paperclip-worktrees/`.
+
+## Cheat sheet
+
+| You want… | Where to look |
+|---|---|
+| List of all companies | API: `GET /api/companies` (DB-backed) |
+| An issue's content, comments, attachment metadata | Postgres (via API), not disk |
+| Raw attachment bytes | `<instance-home>/data/storage/` |
+| An agent's working git worktree | `<instance-home>/workspaces/<agentId>/` |
+| Adapter prompt cache for a company | `<instance-home>/companies/<companyId>/claude-prompt-cache/` |
+| Server logs / run transcripts | `<instance-home>/logs/` + `data/run-logs/` |
+| Instance config (ports, storage, backups) | `<instance-home>/config.json` |
+| Encryption key for secrets in the DB | `<instance-home>/secrets/master.key` |
+
+See also: [Storage](./storage.md), [Database](./database.md), [Secrets](./secrets.md).

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -956,6 +956,21 @@ export {
 } from "./routine-variables.js";
 
 export {
+  DEFAULT_WORKTREE_GC_HOME,
+  DEFAULT_WORKTREE_GC_MIN_AGE_MS,
+  WORKTREE_NAME_PREFIX,
+  findStaleWorktreeInstances,
+  pruneStaleWorktreeInstance,
+  runWorktreeGc,
+  type StaleWorktreeCandidate,
+  type StaleWorktreeReason,
+  type WorktreeGcLogger,
+  type WorktreeGcOptions,
+  type WorktreeGcRunOptions,
+  type WorktreeGcRunResult,
+} from "./worktree-gc.js";
+
+export {
   paperclipConfigSchema,
   configMetaSchema,
   llmConfigSchema,

--- a/packages/shared/src/worktree-gc.test.ts
+++ b/packages/shared/src/worktree-gc.test.ts
@@ -1,0 +1,147 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_WORKTREE_GC_MIN_AGE_MS,
+  findStaleWorktreeInstances,
+  runWorktreeGc,
+} from "./worktree-gc.js";
+
+function createTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function initRepo(repoCwd: string): void {
+  execFileSync("git", ["init", "--initial-branch=main"], { cwd: repoCwd, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "gc-test@example.com"], {
+    cwd: repoCwd,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.name", "GC Test"], { cwd: repoCwd, stdio: "ignore" });
+  execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repoCwd, stdio: "ignore" });
+  fs.writeFileSync(path.join(repoCwd, "README.md"), "seed\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repoCwd, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "seed"], { cwd: repoCwd, stdio: "ignore" });
+}
+
+function makeInstanceDir(homeDir: string, instanceId: string): string {
+  const instanceRoot = path.join(homeDir, "instances", instanceId);
+  fs.mkdirSync(path.join(instanceRoot, "secrets"), { recursive: true });
+  fs.mkdirSync(path.join(instanceRoot, "data", "storage"), { recursive: true });
+  return instanceRoot;
+}
+
+function backdate(targetPath: string, msInPast: number): void {
+  const t = (Date.now() - msInPast) / 1000;
+  fs.utimesSync(targetPath, t, t);
+}
+
+const cleanupDirs: string[] = [];
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    const dir = cleanupDirs.pop()!;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("findStaleWorktreeInstances", () => {
+  let repoCwd: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    repoCwd = createTempDir("paperclip-gc-repo-");
+    cleanupDirs.push(repoCwd);
+    homeDir = createTempDir("paperclip-gc-home-");
+    cleanupDirs.push(homeDir);
+    initRepo(repoCwd);
+  });
+
+  it("returns empty when no instances directory exists", () => {
+    expect(findStaleWorktreeInstances({ repoCwd, homeDir })).toEqual([]);
+  });
+
+  it("flags an instance whose branch is gone", () => {
+    const instanceRoot = makeInstanceDir(homeDir, "pap-552-merged-and-gone");
+    backdate(instanceRoot, DEFAULT_WORKTREE_GC_MIN_AGE_MS + 60_000);
+
+    const found = findStaleWorktreeInstances({ repoCwd, homeDir });
+    expect(found).toHaveLength(1);
+    expect(found[0]!.instanceId).toBe("pap-552-merged-and-gone");
+    expect(found[0]!.reason).toBe("branch_missing");
+  });
+
+  it("preserves an instance whose branch still exists locally", () => {
+    execFileSync("git", ["branch", "paperclip-pap-700-active"], { cwd: repoCwd, stdio: "ignore" });
+    const instanceRoot = makeInstanceDir(homeDir, "pap-700-active");
+    backdate(instanceRoot, DEFAULT_WORKTREE_GC_MIN_AGE_MS + 60_000);
+
+    expect(findStaleWorktreeInstances({ repoCwd, homeDir })).toEqual([]);
+  });
+
+  it("preserves recent instances even when no branch exists yet", () => {
+    makeInstanceDir(homeDir, "pap-just-created");
+    const found = findStaleWorktreeInstances({
+      repoCwd,
+      homeDir,
+      minAgeMs: 10 * 60 * 1000,
+    });
+    expect(found).toEqual([]);
+  });
+
+  it("matches branches with and without the paperclip- prefix", () => {
+    execFileSync("git", ["branch", "pap-noprefix-active"], { cwd: repoCwd, stdio: "ignore" });
+    const instanceRoot = makeInstanceDir(homeDir, "pap-noprefix-active");
+    backdate(instanceRoot, DEFAULT_WORKTREE_GC_MIN_AGE_MS + 60_000);
+
+    expect(findStaleWorktreeInstances({ repoCwd, homeDir })).toEqual([]);
+  });
+});
+
+describe("runWorktreeGc", () => {
+  let repoCwd: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    repoCwd = createTempDir("paperclip-gc-repo-");
+    cleanupDirs.push(repoCwd);
+    homeDir = createTempDir("paperclip-gc-home-");
+    cleanupDirs.push(homeDir);
+    initRepo(repoCwd);
+  });
+
+  it("removes stale instance directories", () => {
+    const staleInstanceRoot = makeInstanceDir(homeDir, "pap-stale-001");
+    backdate(staleInstanceRoot, DEFAULT_WORKTREE_GC_MIN_AGE_MS + 60_000);
+
+    const result = runWorktreeGc({ repoCwd, homeDir });
+    expect(result.pruned).toEqual(["pap-stale-001"]);
+    expect(fs.existsSync(staleInstanceRoot)).toBe(false);
+  });
+
+  it("dry-run does not delete anything", () => {
+    const staleInstanceRoot = makeInstanceDir(homeDir, "pap-stale-002");
+    backdate(staleInstanceRoot, DEFAULT_WORKTREE_GC_MIN_AGE_MS + 60_000);
+
+    const result = runWorktreeGc({ repoCwd, homeDir, dryRun: true });
+    expect(result.pruned).toEqual(["pap-stale-002"]);
+    expect(fs.existsSync(staleInstanceRoot)).toBe(true);
+  });
+
+  it("skips pruning when a postmaster.pid exists for a live process", () => {
+    const instanceRoot = makeInstanceDir(homeDir, "pap-stale-live-pg");
+    const dbDir = path.join(instanceRoot, "db");
+    fs.mkdirSync(dbDir, { recursive: true });
+    fs.writeFileSync(path.join(dbDir, "postmaster.pid"), `${process.pid}\n`);
+    backdate(instanceRoot, DEFAULT_WORKTREE_GC_MIN_AGE_MS + 60_000);
+
+    const result = runWorktreeGc({ repoCwd, homeDir });
+    expect(result.pruned).toEqual([]);
+    expect(result.skipped).toEqual([
+      { instanceId: "pap-stale-live-pg", reason: "postmaster_alive" },
+    ]);
+    expect(fs.existsSync(instanceRoot)).toBe(true);
+  });
+});

--- a/packages/shared/src/worktree-gc.ts
+++ b/packages/shared/src/worktree-gc.ts
@@ -1,0 +1,308 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+export const DEFAULT_WORKTREE_GC_HOME = "~/.paperclip-worktrees";
+export const WORKTREE_NAME_PREFIX = "paperclip-";
+export const DEFAULT_WORKTREE_GC_MIN_AGE_MS = 60 * 60 * 1000;
+
+export type WorktreeGcLogger = {
+  info: (msg: string, meta?: Record<string, unknown>) => void;
+  warn: (msg: string, meta?: Record<string, unknown>) => void;
+  debug?: (msg: string, meta?: Record<string, unknown>) => void;
+};
+
+export type StaleWorktreeReason = "branch_missing";
+
+export type StaleWorktreeCandidate = {
+  instanceId: string;
+  instanceRoot: string;
+  candidateBranchNames: string[];
+  worktreeCheckoutPath: string | null;
+  reason: StaleWorktreeReason;
+  ageMs: number;
+};
+
+export type WorktreeGcOptions = {
+  repoCwd: string;
+  homeDir?: string;
+  minAgeMs?: number;
+  now?: Date;
+  logger?: WorktreeGcLogger;
+};
+
+export type WorktreeGcRunOptions = WorktreeGcOptions & {
+  dryRun?: boolean;
+  force?: boolean;
+};
+
+export type WorktreeGcRunResult = {
+  scanned: number;
+  pruned: string[];
+  skipped: { instanceId: string; reason: string }[];
+  errors: { instanceId: string; error: string }[];
+};
+
+function expandHome(value: string): string {
+  if (value === "~") return os.homedir();
+  if (value.startsWith("~/")) return path.resolve(os.homedir(), value.slice(2));
+  return value;
+}
+
+function resolveHomeDir(homeDir: string | undefined): string {
+  return path.resolve(expandHome(homeDir ?? DEFAULT_WORKTREE_GC_HOME));
+}
+
+function listInstanceDirectories(homeDir: string): string[] {
+  const instancesDir = path.resolve(homeDir, "instances");
+  if (!fs.existsSync(instancesDir)) return [];
+  try {
+    return fs
+      .readdirSync(instancesDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+}
+
+function instanceCandidateBranchNames(instanceId: string): string[] {
+  const candidates = new Set<string>();
+  candidates.add(instanceId);
+  if (!instanceId.startsWith(WORKTREE_NAME_PREFIX)) {
+    candidates.add(`${WORKTREE_NAME_PREFIX}${instanceId}`);
+  } else {
+    candidates.add(instanceId.slice(WORKTREE_NAME_PREFIX.length));
+  }
+  return [...candidates].filter((value) => value.length > 0);
+}
+
+function gitOutput(args: string[], cwd: string): string | null {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function listLocalAndRemoteBranchTips(repoCwd: string): Set<string> | null {
+  const out = gitOutput(
+    ["for-each-ref", "--format=%(refname:short)", "refs/heads", "refs/remotes"],
+    repoCwd,
+  );
+  if (out === null) return null;
+  const refs = new Set<string>();
+  for (const rawLine of out.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line === "HEAD" || line.endsWith("/HEAD")) continue;
+    refs.add(line);
+    const slashIndex = line.indexOf("/");
+    if (slashIndex > 0) {
+      const withoutRemote = line.slice(slashIndex + 1);
+      if (withoutRemote.length > 0) refs.add(withoutRemote);
+    }
+  }
+  return refs;
+}
+
+function pickWorktreeCheckoutPath(candidateBranchNames: string[]): string | null {
+  const home = os.homedir();
+  for (const candidate of candidateBranchNames) {
+    const guess = path.resolve(home, candidate);
+    if (fs.existsSync(guess) && fs.statSync(guess).isDirectory()) {
+      return guess;
+    }
+  }
+  return null;
+}
+
+function instanceMtimeMs(instanceRoot: string): number {
+  try {
+    return fs.statSync(instanceRoot).mtimeMs;
+  } catch {
+    return Date.now();
+  }
+}
+
+function postmasterAlive(instanceRoot: string): boolean {
+  const pidFile = path.resolve(instanceRoot, "db", "postmaster.pid");
+  if (!fs.existsSync(pidFile)) return false;
+  try {
+    const lines = fs.readFileSync(pidFile, "utf8").split(/\r?\n/);
+    const pid = Number.parseInt(lines[0]?.trim() ?? "", 10);
+    if (!Number.isFinite(pid) || pid <= 0) return false;
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EPERM") return true;
+      return false;
+    }
+  } catch {
+    return false;
+  }
+}
+
+function checkoutHasUncommittedChanges(checkoutPath: string): boolean {
+  const out = gitOutput(["status", "--porcelain"], checkoutPath);
+  if (out === null) return false;
+  return out.trim().length > 0;
+}
+
+export function findStaleWorktreeInstances(opts: WorktreeGcOptions): StaleWorktreeCandidate[] {
+  const homeDir = resolveHomeDir(opts.homeDir);
+  const instanceIds = listInstanceDirectories(homeDir);
+  if (instanceIds.length === 0) return [];
+
+  const minAgeMs = opts.minAgeMs ?? DEFAULT_WORKTREE_GC_MIN_AGE_MS;
+  const nowMs = (opts.now ?? new Date()).getTime();
+  const liveBranches = listLocalAndRemoteBranchTips(opts.repoCwd);
+  if (liveBranches === null) {
+    opts.logger?.warn?.("worktree gc skipped: git ref enumeration unavailable", {
+      repoCwd: opts.repoCwd,
+    });
+    return [];
+  }
+
+  const candidates: StaleWorktreeCandidate[] = [];
+
+  for (const instanceId of instanceIds) {
+    const instanceRoot = path.resolve(homeDir, "instances", instanceId);
+    const ageMs = nowMs - instanceMtimeMs(instanceRoot);
+    if (ageMs < minAgeMs) continue;
+
+    const candidateBranchNames = instanceCandidateBranchNames(instanceId);
+    const hasLiveBranch = candidateBranchNames.some((name) => liveBranches.has(name));
+    if (hasLiveBranch) continue;
+
+    const worktreeCheckoutPath = pickWorktreeCheckoutPath(candidateBranchNames);
+
+    candidates.push({
+      instanceId,
+      instanceRoot,
+      candidateBranchNames,
+      worktreeCheckoutPath,
+      reason: "branch_missing",
+      ageMs,
+    });
+  }
+
+  return candidates;
+}
+
+export function pruneStaleWorktreeInstance(
+  candidate: StaleWorktreeCandidate,
+  opts: { repoCwd: string; force?: boolean; logger?: WorktreeGcLogger; dryRun?: boolean },
+): { pruned: boolean; skipped?: string; error?: string } {
+  const logger = opts.logger;
+  const dryRun = opts.dryRun === true;
+
+  if (postmasterAlive(candidate.instanceRoot)) {
+    return { pruned: false, skipped: "postmaster_alive" };
+  }
+
+  if (
+    candidate.worktreeCheckoutPath !== null &&
+    fs.existsSync(candidate.worktreeCheckoutPath) &&
+    !opts.force &&
+    checkoutHasUncommittedChanges(candidate.worktreeCheckoutPath)
+  ) {
+    return { pruned: false, skipped: "uncommitted_changes_in_checkout" };
+  }
+
+  if (dryRun) {
+    logger?.info?.("worktree gc would prune (dry-run)", {
+      instanceId: candidate.instanceId,
+      instanceRoot: candidate.instanceRoot,
+      worktreeCheckoutPath: candidate.worktreeCheckoutPath,
+      reason: candidate.reason,
+    });
+    return { pruned: true };
+  }
+
+  if (candidate.worktreeCheckoutPath && fs.existsSync(candidate.worktreeCheckoutPath)) {
+    try {
+      const args = ["worktree", "remove", candidate.worktreeCheckoutPath];
+      if (opts.force) args.push("--force");
+      execFileSync("git", args, { cwd: opts.repoCwd, stdio: ["ignore", "pipe", "pipe"] });
+    } catch (err) {
+      logger?.warn?.("git worktree remove failed; will fall back to filesystem cleanup", {
+        instanceId: candidate.instanceId,
+        worktreeCheckoutPath: candidate.worktreeCheckoutPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  try {
+    execFileSync("git", ["worktree", "prune"], {
+      cwd: opts.repoCwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch {
+    // Pruning broken refs is best-effort.
+  }
+
+  if (candidate.worktreeCheckoutPath && fs.existsSync(candidate.worktreeCheckoutPath)) {
+    try {
+      fs.rmSync(candidate.worktreeCheckoutPath, { recursive: true, force: true });
+    } catch (err) {
+      return {
+        pruned: false,
+        error: `failed to remove worktree checkout: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  try {
+    fs.rmSync(candidate.instanceRoot, { recursive: true, force: true });
+  } catch (err) {
+    return {
+      pruned: false,
+      error: `failed to remove instance root: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  logger?.info?.("worktree gc pruned stale instance", {
+    instanceId: candidate.instanceId,
+    instanceRoot: candidate.instanceRoot,
+    worktreeCheckoutPath: candidate.worktreeCheckoutPath,
+    reason: candidate.reason,
+  });
+
+  return { pruned: true };
+}
+
+export function runWorktreeGc(opts: WorktreeGcRunOptions): WorktreeGcRunResult {
+  const candidates = findStaleWorktreeInstances(opts);
+  const result: WorktreeGcRunResult = {
+    scanned: candidates.length,
+    pruned: [],
+    skipped: [],
+    errors: [],
+  };
+
+  for (const candidate of candidates) {
+    const outcome = pruneStaleWorktreeInstance(candidate, {
+      repoCwd: opts.repoCwd,
+      force: opts.force,
+      logger: opts.logger,
+      dryRun: opts.dryRun,
+    });
+    if (outcome.pruned) {
+      result.pruned.push(candidate.instanceId);
+    } else if (outcome.skipped) {
+      result.skipped.push({ instanceId: candidate.instanceId, reason: outcome.skipped });
+    } else if (outcome.error) {
+      result.errors.push({ instanceId: candidate.instanceId, error: outcome.error });
+    }
+  }
+
+  return result;
+}

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -85,6 +85,9 @@ export interface Config {
   feedbackExportBackendToken: string | undefined;
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
+  projectsGcEnabled: boolean;
+  projectsGcIntervalHours: number;
+  projectsGcRetentionDays: number;
   companyDeletionEnabled: boolean;
   telemetryEnabled: boolean;
 }
@@ -331,6 +334,15 @@ export function loadConfig(): Config {
     feedbackExportBackendToken,
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
+    projectsGcEnabled: process.env.PAPERCLIP_PROJECTS_GC_ENABLED !== "false",
+    projectsGcIntervalHours: Math.max(
+      1,
+      Number(process.env.PAPERCLIP_PROJECTS_GC_INTERVAL_HOURS) || 24,
+    ),
+    projectsGcRetentionDays: Math.max(
+      0,
+      Number(process.env.PAPERCLIP_PROJECTS_GC_RETENTION_DAYS) || 14,
+    ),
     companyDeletionEnabled,
     telemetryEnabled: fileConfig?.telemetry?.enabled ?? true,
   };

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -54,6 +54,18 @@ export function resolveDefaultBackupDir(): string {
   return path.resolve(resolvePaperclipInstanceRoot(), "data", "backups");
 }
 
+export function resolveProjectScratchRoot(): string {
+  return path.resolve(resolvePaperclipInstanceRoot(), "projects");
+}
+
+export function resolveCompanyScratchRoot(): string {
+  return path.resolve(resolvePaperclipInstanceRoot(), "companies");
+}
+
+export function resolvePaperclipTrashRoot(): string {
+  return path.resolve(resolvePaperclipInstanceRoot(), "_trash");
+}
+
 export function resolveDefaultAgentWorkspaceDir(agentId: string): string {
   const trimmed = agentId.trim();
   if (!PATH_SEGMENT_RE.test(trimmed)) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,6 +34,7 @@ import {
   instanceSettingsService,
   reconcilePersistedRuntimeServicesOnStartup,
   routineService,
+  runProjectsGc,
 } from "./services/index.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
 import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
@@ -42,6 +43,7 @@ import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
 import { maybePersistWorktreeRuntimePorts } from "./worktree-config.js";
+import { runWorktreeGc } from "@paperclipai/shared/worktree-gc";
 import { initTelemetry, getTelemetryClient } from "./telemetry.js";
 import { conflict } from "./errors.js";
 import type {
@@ -668,11 +670,54 @@ export async function startServer(): Promise<StartedServer> {
     .catch((err) => {
       logger.error({ err }, "startup reconciliation of persisted runtime services failed");
     });
-  
+
+  if (config.projectsGcEnabled) {
+    const runProjectsGcSweep = async (trigger: "startup" | "scheduled") => {
+      try {
+        const result = await runProjectsGc({
+          db: db as any,
+          retentionDays: config.projectsGcRetentionDays,
+        });
+        if (result.orphans.length > 0 || result.swept.length > 0 || result.errors.length > 0) {
+          logger.info(
+            {
+              trigger,
+              scanned: result.scanned,
+              quarantined: result.quarantined.length,
+              swept: result.swept.length,
+              errors: result.errors.length,
+              retentionDays: config.projectsGcRetentionDays,
+            },
+            "projects GC sweep ran",
+          );
+          for (const err of result.errors) {
+            logger.warn({ err, phase: err.phase, path: err.path }, "projects GC sweep error");
+          }
+        }
+      } catch (err) {
+        logger.error({ err, trigger }, "projects GC sweep failed");
+      }
+    };
+    void runProjectsGcSweep("startup");
+    const intervalMs = Math.max(1, config.projectsGcIntervalHours) * 60 * 60 * 1000;
+    setInterval(() => {
+      void runProjectsGcSweep("scheduled");
+    }, intervalMs);
+  }
+
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any, { pluginWorkerManager });
     const routines = routineService(db as any, { pluginWorkerManager });
-  
+    let lastWorktreeGcAtMs = 0;
+    const worktreeGcEnabled =
+      process.env.PAPERCLIP_IN_WORKTREE !== "true" &&
+      process.env.PAPERCLIP_WORKTREE_AUTOPRUNE !== "false";
+    const worktreeGcIntervalMs = Math.max(
+      5 * 60 * 1000,
+      Number(process.env.PAPERCLIP_WORKTREE_AUTOPRUNE_INTERVAL_MS) || 60 * 60 * 1000,
+    );
+    const worktreeGcRepoCwd = process.cwd();
+
     // Reap orphaned running runs at startup while in-memory execution state is empty,
     // then resume any persisted queued runs that were waiting on the previous process.
     void heartbeat
@@ -780,6 +825,37 @@ export async function startServer(): Promise<StartedServer> {
         .catch((err) => {
           logger.error({ err }, "periodic heartbeat recovery failed");
         });
+
+      const tickNow = new Date();
+      if (
+        worktreeGcEnabled &&
+        tickNow.getTime() - lastWorktreeGcAtMs >= worktreeGcIntervalMs
+      ) {
+        lastWorktreeGcAtMs = tickNow.getTime();
+        try {
+          const result = runWorktreeGc({
+            repoCwd: worktreeGcRepoCwd,
+            now: tickNow,
+            logger: {
+              info: (msg, meta) => logger.info(meta ?? {}, msg),
+              warn: (msg, meta) => logger.warn(meta ?? {}, msg),
+            },
+          });
+          if (result.pruned.length > 0 || result.errors.length > 0) {
+            logger.info(
+              {
+                pruned: result.pruned,
+                skipped: result.skipped,
+                errors: result.errors,
+                scanned: result.scanned,
+              },
+              "worktree gc sweep ran",
+            );
+          }
+        } catch (err) {
+          logger.error({ err }, "worktree gc sweep failed");
+        }
+      }
     }, config.heartbeatSchedulerIntervalMs);
   }
   

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -53,4 +53,12 @@ export { logActivity, type LogActivityInput } from "./activity-log.js";
 export { notifyHireApproved, type NotifyHireApprovedInput } from "./hire-hook.js";
 export { publishLiveEvent, subscribeCompanyLiveEvents } from "./live-events.js";
 export { reconcilePersistedRuntimeServicesOnStartup, restartDesiredRuntimeServicesOnStartup } from "./workspace-runtime.js";
+export {
+  findOrphanScratchDirs,
+  runProjectsGc,
+  type OrphanScratchDir,
+  type OrphanScratchKind,
+  type ProjectsGcOptions,
+  type ProjectsGcResult,
+} from "./projects-gc.js";
 export { createStorageServiceFromConfig, getStorageService } from "../storage/index.js";

--- a/server/src/services/projects-gc.test.ts
+++ b/server/src/services/projects-gc.test.ts
@@ -1,0 +1,184 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Db } from "@paperclipai/db";
+import { runProjectsGc } from "./projects-gc.js";
+
+const ALIVE_COMPANY_ID = "11111111-1111-1111-1111-111111111111";
+const DEAD_COMPANY_ID_A = "22222222-2222-2222-2222-222222222222";
+const DEAD_COMPANY_ID_B = "33333333-3333-3333-3333-333333333333";
+
+function makeFakeDb(activeIds: Set<string>): Db {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () =>
+          Promise.resolve(Array.from(activeIds).map((id) => ({ id }))),
+      }),
+    }),
+  } as unknown as Db;
+}
+
+async function touchDir(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, "marker"), "x");
+}
+
+async function setMtime(target: string, ms: number): Promise<void> {
+  const t = new Date(ms);
+  await fs.utimes(target, t, t);
+}
+
+describe("runProjectsGc", () => {
+  let tempRoot: string;
+  let projectsRoot: string;
+  let companiesRoot: string;
+  let trashRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = mkdtempSync(path.join(os.tmpdir(), "paperclip-gc-"));
+    projectsRoot = path.join(tempRoot, "projects");
+    companiesRoot = path.join(tempRoot, "companies");
+    trashRoot = path.join(tempRoot, "_trash");
+    await fs.mkdir(projectsRoot, { recursive: true });
+    await fs.mkdir(companiesRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("ignores directories whose company id is still in the DB", async () => {
+    await touchDir(path.join(projectsRoot, ALIVE_COMPANY_ID, "project-1"));
+    await touchDir(path.join(companiesRoot, ALIVE_COMPANY_ID));
+
+    const result = await runProjectsGc({
+      db: makeFakeDb(new Set([ALIVE_COMPANY_ID])),
+      retentionDays: 14,
+      projectsRoot,
+      companiesRoot,
+      trashRoot,
+    });
+
+    expect(result.scanned).toBe(2);
+    expect(result.orphans).toEqual([]);
+    expect(result.quarantined).toEqual([]);
+    expect(existsSync(path.join(projectsRoot, ALIVE_COMPANY_ID))).toBe(true);
+    expect(existsSync(path.join(companiesRoot, ALIVE_COMPANY_ID))).toBe(true);
+  });
+
+  it("ignores non-UUID directory names", async () => {
+    await touchDir(path.join(projectsRoot, "_default"));
+    await touchDir(path.join(projectsRoot, "scratchpad"));
+
+    const result = await runProjectsGc({
+      db: makeFakeDb(new Set()),
+      retentionDays: 14,
+      projectsRoot,
+      companiesRoot,
+      trashRoot,
+    });
+
+    expect(result.scanned).toBe(0);
+    expect(result.orphans).toEqual([]);
+    expect(existsSync(path.join(projectsRoot, "_default"))).toBe(true);
+  });
+
+  it("quarantines orphaned company directories from both projects and companies roots", async () => {
+    await touchDir(path.join(projectsRoot, DEAD_COMPANY_ID_A, "p1"));
+    await touchDir(path.join(companiesRoot, DEAD_COMPANY_ID_B));
+    await touchDir(path.join(projectsRoot, ALIVE_COMPANY_ID, "p2"));
+
+    const now = new Date("2026-04-27T12:00:00Z");
+    const result = await runProjectsGc({
+      db: makeFakeDb(new Set([ALIVE_COMPANY_ID])),
+      retentionDays: 14,
+      projectsRoot,
+      companiesRoot,
+      trashRoot,
+      now,
+    });
+
+    expect(result.scanned).toBe(3);
+    expect(result.orphans.map((o) => o.companyId).sort()).toEqual(
+      [DEAD_COMPANY_ID_A, DEAD_COMPANY_ID_B].sort(),
+    );
+    expect(result.quarantined).toHaveLength(2);
+
+    expect(existsSync(path.join(projectsRoot, DEAD_COMPANY_ID_A))).toBe(false);
+    expect(existsSync(path.join(companiesRoot, DEAD_COMPANY_ID_B))).toBe(false);
+    expect(existsSync(path.join(projectsRoot, ALIVE_COMPANY_ID))).toBe(true);
+
+    const projectsTrashEntries = await fs.readdir(path.join(trashRoot, "projects"));
+    expect(projectsTrashEntries).toHaveLength(1);
+    expect(projectsTrashEntries[0]).toContain(DEAD_COMPANY_ID_A);
+
+    const companiesTrashEntries = await fs.readdir(path.join(trashRoot, "companies"));
+    expect(companiesTrashEntries).toHaveLength(1);
+    expect(companiesTrashEntries[0]).toContain(DEAD_COMPANY_ID_B);
+  });
+
+  it("does nothing destructive in dry-run mode", async () => {
+    await touchDir(path.join(projectsRoot, DEAD_COMPANY_ID_A));
+
+    const result = await runProjectsGc({
+      db: makeFakeDb(new Set()),
+      retentionDays: 14,
+      dryRun: true,
+      projectsRoot,
+      companiesRoot,
+      trashRoot,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.orphans).toHaveLength(1);
+    expect(result.quarantined).toHaveLength(0);
+    expect(result.swept).toEqual([]);
+    expect(existsSync(path.join(projectsRoot, DEAD_COMPANY_ID_A))).toBe(true);
+  });
+
+  it("sweeps quarantine entries older than retentionDays", async () => {
+    const now = new Date("2026-04-27T00:00:00Z");
+    const oldDir = path.join(trashRoot, "projects", `${DEAD_COMPANY_ID_A}-old`);
+    const recentDir = path.join(trashRoot, "companies", `${DEAD_COMPANY_ID_B}-recent`);
+    await touchDir(oldDir);
+    await touchDir(recentDir);
+    await setMtime(oldDir, now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    await setMtime(recentDir, now.getTime() - 1 * 24 * 60 * 60 * 1000);
+
+    const result = await runProjectsGc({
+      db: makeFakeDb(new Set()),
+      retentionDays: 14,
+      projectsRoot,
+      companiesRoot,
+      trashRoot,
+      now,
+    });
+
+    expect(result.swept).toHaveLength(1);
+    expect(result.swept[0]).toBe(oldDir);
+    expect(existsSync(oldDir)).toBe(false);
+    expect(existsSync(recentDir)).toBe(true);
+  });
+
+  it("retentionDays=0 sweeps quarantine immediately", async () => {
+    const now = new Date("2026-04-27T00:00:00Z");
+    const dir = path.join(trashRoot, "projects", `${DEAD_COMPANY_ID_A}-x`);
+    await touchDir(dir);
+    await setMtime(dir, now.getTime() - 60 * 1000);
+
+    const result = await runProjectsGc({
+      db: makeFakeDb(new Set()),
+      retentionDays: 0,
+      projectsRoot,
+      companiesRoot,
+      trashRoot,
+      now,
+    });
+
+    expect(result.swept).toContain(dir);
+    expect(existsSync(dir)).toBe(false);
+  });
+});

--- a/server/src/services/projects-gc.ts
+++ b/server/src/services/projects-gc.ts
@@ -1,0 +1,171 @@
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { inArray } from "drizzle-orm";
+import { companies, type Db } from "@paperclipai/db";
+import {
+  resolveCompanyScratchRoot,
+  resolvePaperclipTrashRoot,
+  resolveProjectScratchRoot,
+} from "../home-paths.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type OrphanScratchKind = "projects" | "companies";
+
+export interface OrphanScratchDir {
+  kind: OrphanScratchKind;
+  companyId: string;
+  path: string;
+}
+
+export interface ProjectsGcResult {
+  scanned: number;
+  orphans: OrphanScratchDir[];
+  quarantined: Array<{ kind: OrphanScratchKind; companyId: string; from: string; to: string }>;
+  swept: string[];
+  errors: Array<{ phase: "quarantine" | "sweep"; path: string; message: string }>;
+  dryRun: boolean;
+}
+
+export interface ProjectsGcOptions {
+  db: Db;
+  retentionDays: number;
+  dryRun?: boolean;
+  projectsRoot?: string;
+  companiesRoot?: string;
+  trashRoot?: string;
+  now?: Date;
+}
+
+async function listSubdirs(dir: string): Promise<string[]> {
+  if (!existsSync(dir)) return [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+}
+
+async function loadKnownCompanyIds(db: Db, candidateIds: string[]): Promise<Set<string>> {
+  if (candidateIds.length === 0) return new Set();
+  const rows = await db
+    .select({ id: companies.id })
+    .from(companies)
+    .where(inArray(companies.id, candidateIds));
+  return new Set(rows.map((row) => row.id));
+}
+
+export async function findOrphanScratchDirs(input: {
+  db: Db;
+  projectsRoot: string;
+  companiesRoot: string;
+}): Promise<{ scanned: number; orphans: OrphanScratchDir[] }> {
+  const candidates: Array<{ kind: OrphanScratchKind; companyId: string; path: string }> = [];
+
+  for (const [root, kind] of [
+    [input.projectsRoot, "projects" as const],
+    [input.companiesRoot, "companies" as const],
+  ] satisfies Array<[string, OrphanScratchKind]>) {
+    const names = await listSubdirs(root);
+    for (const name of names) {
+      if (!UUID_RE.test(name)) continue;
+      candidates.push({ kind, companyId: name, path: path.resolve(root, name) });
+    }
+  }
+
+  const known = await loadKnownCompanyIds(
+    input.db,
+    Array.from(new Set(candidates.map((c) => c.companyId))),
+  );
+  const orphans = candidates.filter((c) => !known.has(c.companyId));
+  return { scanned: candidates.length, orphans };
+}
+
+function timestampSlug(now: Date): string {
+  // 2026-04-27T15-55-24-129Z (filesystem-safe, monotonic)
+  return now.toISOString().replace(/[:.]/g, "-");
+}
+
+async function quarantineOrphan(
+  orphan: OrphanScratchDir,
+  trashRoot: string,
+  now: Date,
+): Promise<{ kind: OrphanScratchKind; companyId: string; from: string; to: string }> {
+  const bucket = path.resolve(trashRoot, orphan.kind);
+  await fs.mkdir(bucket, { recursive: true });
+  const target = path.resolve(bucket, `${orphan.companyId}-${timestampSlug(now)}`);
+  await fs.rename(orphan.path, target);
+  return { kind: orphan.kind, companyId: orphan.companyId, from: orphan.path, to: target };
+}
+
+async function sweepBucket(
+  bucketDir: string,
+  cutoffMs: number,
+): Promise<{ swept: string[]; errors: Array<{ path: string; message: string }> }> {
+  if (!existsSync(bucketDir)) return { swept: [], errors: [] };
+  const swept: string[] = [];
+  const errors: Array<{ path: string; message: string }> = [];
+  const entries = await fs.readdir(bucketDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.resolve(bucketDir, entry.name);
+    try {
+      const stat = await fs.stat(entryPath);
+      if (stat.mtimeMs > cutoffMs) continue;
+      await fs.rm(entryPath, { recursive: true, force: true });
+      swept.push(entryPath);
+    } catch (err) {
+      errors.push({ path: entryPath, message: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return { swept, errors };
+}
+
+export async function runProjectsGc(opts: ProjectsGcOptions): Promise<ProjectsGcResult> {
+  const dryRun = opts.dryRun === true;
+  const now = opts.now ?? new Date();
+  const projectsRoot = opts.projectsRoot ?? resolveProjectScratchRoot();
+  const companiesRoot = opts.companiesRoot ?? resolveCompanyScratchRoot();
+  const trashRoot = opts.trashRoot ?? resolvePaperclipTrashRoot();
+  const retentionDays = Math.max(0, Math.trunc(opts.retentionDays));
+
+  const { scanned, orphans } = await findOrphanScratchDirs({
+    db: opts.db,
+    projectsRoot,
+    companiesRoot,
+  });
+
+  const result: ProjectsGcResult = {
+    scanned,
+    orphans,
+    quarantined: [],
+    swept: [],
+    errors: [],
+    dryRun,
+  };
+
+  if (!dryRun) {
+    for (const orphan of orphans) {
+      try {
+        const moved = await quarantineOrphan(orphan, trashRoot, now);
+        result.quarantined.push(moved);
+      } catch (err) {
+        result.errors.push({
+          phase: "quarantine",
+          path: orphan.path,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  const cutoffMs = now.getTime() - retentionDays * 24 * 60 * 60 * 1000;
+  for (const kind of ["projects", "companies"] as const) {
+    const bucket = path.resolve(trashRoot, kind);
+    if (dryRun) continue;
+    const sweep = await sweepBucket(bucket, cutoffMs);
+    result.swept.push(...sweep.swept);
+    for (const err of sweep.errors) {
+      result.errors.push({ phase: "sweep", path: err.path, message: err.message });
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- **NODA-188**: Auto-prune `~/.paperclip-worktrees/instances/<id>/` entries whose branch no longer exists locally or on any remote. Adds `worktree:gc` CLI command and periodic heartbeat sweep (opt-out via `PAPERCLIP_WORKTREE_AUTOPRUNE=false`).
- **NODA-189**: GC orphaned `~/.paperclip/instances/<instance>/projects/<companyId>/` directories whose company UUID no longer exists in the DB. Quarantine-then-delete with configurable retention (`PAPERCLIP_PROJECTS_GC_RETENTION_DAYS`, default 14d). Adds `projects:gc` CLI command and automatic startup/periodic sweep.

## Changes

- `packages/shared/src/worktree-gc.ts` — shared worktree GC library
- `packages/shared/src/worktree-gc.test.ts` — vitest coverage
- `server/src/services/projects-gc.ts` — server-side project scratch GC
- `server/src/services/projects-gc.test.ts` — vitest coverage
- `cli/src/commands/worktree.ts` — `worktree:gc` subcommand
- `cli/src/commands/gc.ts` — `projects:gc` CLI command
- `server/src/index.ts` — heartbeat integration for both GC sweeps
- `docs/deploy/file-layout.md` — documents disk layout

## Rebased

Rebased onto current `master` (d6d7a7ce) on 2026-05-05 to resolve merge conflicts. Dropped unrelated NOD-451 heartbeat commits that were previously stacked on this branch. Clean 2-commit history.

## Test plan

- [x] TypeScript compilation passes (server, shared, cli)
- [ ] Snyk re-check after rebase
- [ ] Manual verification of worktree GC on a host with stale worktrees
- [ ] Manual verification of projects GC with orphaned company dirs