### PR TITLE
Fix stale detached heartbeat run cleanup

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -767,6 +767,52 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("claimed");
   });
 
+  it("reaps a detached local pid after the stale threshold expires", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { agentId, runId, issueId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      runErrorCode: "process_detached",
+      runError: `Lost in-memory process handle, but child pid ${child.pid} is still alive`,
+    });
+    const heartbeat = heartbeatService(db);
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        updatedAt: new Date("2026-03-18T23:50:00.000Z"),
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 });
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+    expect(await waitForPidExit(child.pid ?? -1, 2_000)).toBe(true);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+
+    const failedRun = runs.find((row) => row.id === runId);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_lost");
+    expect(failedRun?.error).toContain("stale threshold");
+    expect(retryRun?.status).toBe("queued");
+    expect(retryRun?.retryOfRunId).toBe(runId);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
+  });
+
   it("queues exactly one retry when the recorded local pid is dead", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       processPid: 999_999_999,

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -802,8 +802,16 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(failedRun?.status).toBe("failed");
     expect(failedRun?.errorCode).toBe("process_lost");
     expect(failedRun?.error).toContain("stale threshold");
+    expect(failedRun?.livenessState).toBe("failed");
+    expect(failedRun?.livenessReason).toContain("process_lost");
+    expect(failedRun?.resultJson).toMatchObject({
+      stopReason: "process_lost",
+      timeoutConfigured: false,
+      timeoutFired: false,
+    });
     expect(retryRun?.status).toBe("queued");
     expect(retryRun?.retryOfRunId).toBe(runId);
+    expect(retryRun?.processLossRetryCount).toBe(1);
 
     const issue = await db
       .select()
@@ -811,6 +819,63 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
+    expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it.skipIf(process.platform === "win32")("reaps a detached local process group after the stale threshold expires when the pid is already gone", async () => {
+    const orphan = await spawnOrphanedProcessGroup();
+    cleanupPids.add(orphan.descendantPid);
+    expect(isPidAlive(orphan.descendantPid)).toBe(true);
+
+    const { agentId, runId, issueId } = await seedRunFixture({
+      processPid: orphan.processPid,
+      processGroupId: orphan.processGroupId,
+      runErrorCode: "process_detached",
+      runError: `Lost in-memory process handle, but detached process group ${orphan.processGroupId} is still alive`,
+    });
+    const heartbeat = heartbeatService(db);
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        updatedAt: new Date("2026-03-18T23:50:00.000Z"),
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 });
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+    expect(await waitForPidExit(orphan.descendantPid, 2_000)).toBe(true);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+
+    const failedRun = runs.find((row) => row.id === runId);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_lost");
+    expect(failedRun?.error).toContain("detached process group");
+    expect(failedRun?.livenessState).toBe("failed");
+    expect(failedRun?.livenessReason).toContain("process_lost");
+    expect(failedRun?.resultJson).toMatchObject({
+      stopReason: "process_lost",
+      timeoutConfigured: false,
+      timeoutFired: false,
+    });
+    expect(retryRun?.status).toBe("queued");
+    expect(retryRun?.retryOfRunId).toBe(runId);
+    expect(retryRun?.processLossRetryCount).toBe(1);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
+    expect(issue?.checkoutRunId).toBe(runId);
   });
 
   it("queues exactly one retry when the recorded local pid is dead", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1860,9 +1860,15 @@ async function terminateHeartbeatRunProcess(input: {
 function buildProcessLossMessage(run: {
   processPid: number | null;
   processGroupId: number | null;
-}, options?: { descendantOnly?: boolean }) {
+}, options?: { descendantOnly?: boolean; detachedStale?: boolean }) {
   if (options?.descendantOnly && run.processGroupId) {
     return `Process lost -- parent pid ${run.processPid ?? "unknown"} exited, but descendant process group ${run.processGroupId} was still alive and was terminated`;
+  }
+  if (options?.detachedStale && run.processPid) {
+    return `Process lost -- detached child pid ${run.processPid} stayed alive past the stale threshold and was terminated`;
+  }
+  if (options?.detachedStale && run.processGroupId) {
+    return `Process lost -- detached process group ${run.processGroupId} stayed alive past the stale threshold and was terminated`;
   }
   if (run.processPid) {
     return `Process lost -- child pid ${run.processPid} is no longer running`;
@@ -4357,16 +4363,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     for (const { run, adapterType, adapterConfig } of activeRuns) {
       if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
 
+      const refTime = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
+      const isStale = staleThresholdMs <= 0 || now.getTime() - refTime >= staleThresholdMs;
+
       // Apply staleness threshold to avoid false positives
-      if (staleThresholdMs > 0) {
-        const refTime = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
-        if (now.getTime() - refTime < staleThresholdMs) continue;
-      }
+      if (!isStale) continue;
 
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
-      if (processPidAlive) {
+      const detachedRunExceededThreshold =
+        staleThresholdMs > 0 &&
+        run.errorCode === DETACHED_PROCESS_ERROR_CODE &&
+        (Boolean(processPidAlive) || Boolean(processGroupAlive));
+
+      if (processPidAlive && !detachedRunExceededThreshold) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
           const detachedRun = await setRunStatus(run.id, "running", {
@@ -4389,7 +4400,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       let descendantOnlyCleanup = false;
-      if (processGroupAlive) {
+      if (detachedRunExceededThreshold) {
+        await terminateHeartbeatRunProcess({
+          pid: run.processPid,
+          processGroupId: run.processGroupId,
+        });
+      } else if (processGroupAlive) {
         descendantOnlyCleanup = true;
         await terminateHeartbeatRunProcess({
           pid: run.processPid,
@@ -4398,7 +4414,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
-      const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const baseMessage = buildProcessLossMessage(
+        run,
+        descendantOnlyCleanup
+          ? { descendantOnly: true }
+          : detachedRunExceededThreshold
+            ? { detachedStale: true }
+            : undefined,
+      );
 
       let finalizedRun = await setRunStatus(run.id, "failed", {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1860,14 +1860,14 @@ async function terminateHeartbeatRunProcess(input: {
 function buildProcessLossMessage(run: {
   processPid: number | null;
   processGroupId: number | null;
-}, options?: { descendantOnly?: boolean; detachedStale?: boolean }) {
+}, options?: { descendantOnly?: boolean; detachedStaleTarget?: "pid" | "group" }) {
   if (options?.descendantOnly && run.processGroupId) {
     return `Process lost -- parent pid ${run.processPid ?? "unknown"} exited, but descendant process group ${run.processGroupId} was still alive and was terminated`;
   }
-  if (options?.detachedStale && run.processPid) {
+  if (options?.detachedStaleTarget === "pid" && run.processPid) {
     return `Process lost -- detached child pid ${run.processPid} stayed alive past the stale threshold and was terminated`;
   }
-  if (options?.detachedStale && run.processGroupId) {
+  if (options?.detachedStaleTarget === "group" && run.processGroupId) {
     return `Process lost -- detached process group ${run.processGroupId} stayed alive past the stale threshold and was terminated`;
   }
   if (run.processPid) {
@@ -4419,7 +4419,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         descendantOnlyCleanup
           ? { descendantOnly: true }
           : detachedRunExceededThreshold
-            ? { detachedStale: true }
+            ? { detachedStaleTarget: processPidAlive ? "pid" : "group" }
             : undefined,
       );
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates agent heartbeats and issue execution, so stale heartbeat ownership can block real work even after the original task is operationally done.
> - The relevant subsystem here is the heartbeat runtime recovery path that reaps orphaned local child processes and decides whether to retry, fail, or release issue ownership.
> - `MYC-79` exists because a detached heartbeat run for `MYC-76` stayed marked as alive long after useful execution had stopped, leaving `executionRunId` pinned.
> - The original fix taught `reapOrphanedRuns` to treat detached local processes that outlive the stale threshold as recoverable process-loss cases instead of leaving them stranded forever.
> - Review on `#4605` surfaced two gaps in that first pass: the stale-detached message could be inaccurate when only the process group survived, and the regression coverage did not fully exercise that branch.
> - This pull request now tightens that message path, expands the regression assertions, and adds the missing process-group-only detached-stale test so the stale-run recovery behavior is explicit and reviewable.
> - The benefit is a cleaner, better-specified self-healing path for detached heartbeat runs without leaving misleading diagnostics behind.

## What Changed

- Replaced the boolean `detachedStale` message flag with an explicit detached stale target so `buildProcessLossMessage(...)` can distinguish between a surviving detached child pid and a surviving detached process group.
- Updated the detached-local-pid stale-threshold regression test to assert the same liveness and retry metadata that the neighboring process-loss tests already verify.
- Added a regression test for the detached process-group-only case where the recorded pid is already gone but the descendant process group is still alive past the stale threshold.
- Addressed the PR template requirements directly in this PR body so the upstream review handoff matches repository policy.

## Verification

- `PATH=/opt/homebrew/bin:$PATH pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`
- Result: `22 passed`

## Risks

- Low risk. The behavior change is limited to the detached-stale process-loss messaging branch and its associated regression coverage.
- The runtime effect remains the same for the existing stale-detached cleanup path: terminate the surviving local process resource and route through the standard fail-and-retry logic.

## Model Used

- OpenAI Codex running via `codex_local`
- Model: `gpt-5.4`
- Reasoning mode: default Codex agent reasoning with tool use, shell execution, and code editing

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
