### PR TITLE
fix(adapters): strip host-managed Claude Desktop OAuth token from spawned env

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1484,11 +1484,22 @@ export async function runChildProcess(
     // These vars leak in when the Paperclip server itself is started from
     // within a Claude Code session (e.g. `npx paperclipai run` in a terminal
     // owned by Claude Code) or when cron inherits a contaminated shell env.
+    //
+    // Also strip the host-managed OAuth token + provider flag injected by
+    // Claude Desktop when its terminal launches Paperclip. That token is
+    // scoped to the desktop session and rejected with HTTP 401
+    // ("Invalid authentication credentials") when used by an out-of-process
+    // child. Removing it lets `claude` fall back to the user's persisted
+    // login (keychain / ~/.claude credentials) and use subscription credits
+    // normally — and lets ANTHROPIC_API_KEY take precedence cleanly when the
+    // user later opts into API-credit billing.
     const CLAUDE_CODE_NESTING_VARS = [
       "CLAUDECODE",
       "CLAUDE_CODE_ENTRYPOINT",
       "CLAUDE_CODE_SESSION",
       "CLAUDE_CODE_PARENT_SESSION",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
     ] as const;
     for (const key of CLAUDE_CODE_NESTING_VARS) {
       delete rawMerged[key];


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The `claude_local` adapter is how those agents reach Anthropic — `runChildProcess` spawns the `claude` CLI with a merged env (`{ ...process.env, ...opts.env }`)
> - When a user starts the Paperclip server from a Claude Desktop terminal, Claude Desktop has already injected `CLAUDE_CODE_OAUTH_TOKEN` and `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST` into the shell to manage *its own* in-app session
> - Those vars then leak into every spawned `claude` subprocess. The desktop OAuth token is scoped to the desktop's runtime and is rejected with HTTP 401 ("Invalid authentication credentials") when used by an out-of-process child that the host can't refresh for
> - Result observed locally: every `claude_local` agent (CEO, CTO, SMM, Scheduling Assistant, Research Specialist, Personal Assistant) entered `error` status with `Claude run failed: ... 401 ... authentication_error / Invalid authentication credentials (adapter_failed)`
> - The adapter already strips four `CLAUDECODE*` nesting-guard vars in the same code path for the same class of reason; these two were just missing from the list
> - This pull request adds `CLAUDE_CODE_OAUTH_TOKEN` and `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST` to that strip list
> - The benefit is `claude` falls back to the user's persisted login (macOS Keychain / `~/.claude` credentials) and uses subscription credits normally; `ANTHROPIC_API_KEY` (when set) cleanly takes precedence per the documented Claude Code auth order, restoring the intended "subscription first, API key when used up" workflow without users having to manually launch Paperclip from a clean shell

## What Changed

- `packages/adapter-utils/src/server-utils.ts`: extend `CLAUDE_CODE_NESTING_VARS` in `runChildProcess` to also strip `CLAUDE_CODE_OAUTH_TOKEN` and `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST` before spawning child processes; expand the surrounding comment to document why.

## Verification

Reproduction (before fix):

1. Start Paperclip server from a terminal launched by Claude Desktop (which injects `CLAUDE_CODE_OAUTH_TOKEN`).
2. Trigger a heartbeat for any `claude_local` agent.
3. Observe `Claude run failed: subtype=success: Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}, ...} (adapter_failed)` and the agent transitioning to `error`.

After fix:

1. Same setup, restart the Paperclip server so the patched `runChildProcess` is loaded.
2. Trigger a heartbeat for the same agent.
3. The spawned `claude` no longer sees the host-managed token; it authenticates via the user's persisted login and the heartbeat completes normally.

Sanity check the env diff for one spawn (e.g. via `onMeta` log of the adapter): `CLAUDE_CODE_OAUTH_TOKEN` and `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST` should now be absent from the child env when they were present in the parent server's env.

## Risks

Low risk.

- The change is additive to an existing strip list whose rationale already covers Claude-Code-launched-from-Claude-Code scenarios. No behavior change for any path where these vars were not set.
- Anyone who was *intentionally* relying on `CLAUDE_CODE_OAUTH_TOKEN` flowing into the child `claude` would lose that — but in practice that token is only valid inside the host that issued it, so relying on it across a process boundary was already broken (this PR exists *because* it's broken). Users who want a specific OAuth token for a child can still set it explicitly in the agent's `adapterConfig.env`, which is layered on top of the strip step.
- No public API, schema, or migration change. No test changes required (no existing tests assert presence of these vars in spawned env).

## Model Used

- Claude (Anthropic), `claude-opus-4-6`, 1M-context Claude Code session, extended thinking + tool-use (Read/Edit/Bash/Grep). Diagnosis included reading the live Paperclip server's process env to confirm the host-injected vars and tracing them through `packages/adapters/claude-local/src/server/execute.ts` → `packages/adapter-utils/src/server-utils.ts::runChildProcess`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass — single-line addition to an existing strip list with no test coverage on this code path; verified manually via reproduction above. Happy to add a regression test if reviewers prefer.
- [ ] I have added or updated tests where applicable — see above.
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, no UI changes.
- [x] I have updated relevant documentation to reflect my changes — inline comment expanded to document the new strip rationale.
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge