### PR TITLE
Fix codex-local git discovery ceiling for managed workspaces

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.test.ts
@@ -1,0 +1,150 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  runChildProcess,
+  ensureCommandResolvable,
+  resolveCommandForLogs,
+} = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async () => ({
+    exitCode: 1,
+    signal: null,
+    timedOut: false,
+    stdout: "",
+    stderr: "local failure",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async () => "/usr/bin/codex"),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+describe("codex local execution", () => {
+  const cleanupDirs: string[] = [];
+  const originalGitDiscoveryCeiling = process.env.GIT_CEILING_DIRECTORIES;
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    if (typeof originalGitDiscoveryCeiling === "string") {
+      process.env.GIT_CEILING_DIRECTORIES = originalGitDiscoveryCeiling;
+    } else {
+      delete process.env.GIT_CEILING_DIRECTORIES;
+    }
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("bounds git discovery to the workspace parent when no explicit ceiling is configured", async () => {
+    delete process.env.GIT_CEILING_DIRECTORIES;
+
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-local-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const codexHomeDir = path.join(rootDir, "codex-home");
+    await mkdir(workspaceDir, { recursive: true });
+    await mkdir(codexHomeDir, { recursive: true });
+
+    await execute({
+      runId: "run-local-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+        env: {
+          CODEX_HOME: codexHomeDir,
+        },
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    const call = runChildProcess.mock.calls[0] as unknown as
+      | [string, string, string[], { env: Record<string, string> }]
+      | undefined;
+    expect(call?.[3].env.GIT_CEILING_DIRECTORIES).toBe(path.dirname(workspaceDir));
+  });
+
+  it("preserves an explicit git discovery ceiling from adapter config", async () => {
+    delete process.env.GIT_CEILING_DIRECTORIES;
+
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-local-explicit-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const codexHomeDir = path.join(rootDir, "codex-home");
+    await mkdir(workspaceDir, { recursive: true });
+    await mkdir(codexHomeDir, { recursive: true });
+
+    await execute({
+      runId: "run-local-2",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+        env: {
+          CODEX_HOME: codexHomeDir,
+          GIT_CEILING_DIRECTORIES: "C:\\explicit-ceiling",
+        },
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    const call = runChildProcess.mock.calls[0] as unknown as
+      | [string, string, string[], { env: Record<string, string> }]
+      | undefined;
+    expect(call?.[3].env.GIT_CEILING_DIRECTORIES).toBe("C:\\explicit-ceiling");
+  });
+});

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -71,9 +71,18 @@ function firstNonEmptyLine(text: string): string {
   );
 }
 
-function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
+function hasNonEmptyEnvValue(env: Record<string, unknown>, key: string): boolean {
   const raw = env[key];
   return typeof raw === "string" && raw.trim().length > 0;
+}
+
+function resolveGitDiscoveryCeiling(workspaceCwd: string): string | null {
+  const trimmed = workspaceCwd.trim();
+  if (!trimmed) return null;
+
+  const resolvedWorkspaceCwd = path.resolve(trimmed);
+  const parentDir = path.dirname(resolvedWorkspaceCwd);
+  return parentDir !== resolvedWorkspaceCwd ? parentDir : null;
 }
 
 function resolveCodexBillingType(env: Record<string, string>): "api" | "subscription" {
@@ -296,6 +305,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceBranch = asString(workspaceContext.branchName, "");
   const workspaceWorktreePath = asString(workspaceContext.worktreePath, "");
   const agentHome = asString(workspaceContext.agentHome, "");
+  const gitDiscoveryCeiling = resolveGitDiscoveryCeiling(workspaceCwd);
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
         (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
@@ -444,6 +454,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   if (runtimePrimaryUrl) {
     env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
+  }
+  if (
+    gitDiscoveryCeiling &&
+    !hasNonEmptyEnvValue(process.env as Record<string, string>, "GIT_CEILING_DIRECTORIES") &&
+    !hasNonEmptyEnvValue(envConfig, "GIT_CEILING_DIRECTORIES")
+  ) {
+    env.GIT_CEILING_DIRECTORIES = gitDiscoveryCeiling;
   }
   const targetPaperclipApiUrl = adapterExecutionTargetPaperclipApiUrl(executionTarget);
   if (targetPaperclipApiUrl) {


### PR DESCRIPTION
## Summary\n- derive GIT_CEILING_DIRECTORIES from the parent of the managed Paperclip workspace when Codex runs locally\n- preserve explicit or host-provided GIT_CEILING_DIRECTORIES values\n- add local execution tests covering the default and explicit ceiling behaviors\n\n## Verification\n- pnpm --filter @paperclipai/adapter-codex-local typecheck\n- pnpm --filter @paperclipai/adapter-codex-local exec vitest run src/server/execute.test.ts src/server/execute.remote.test.ts\n- pnpm --filter @paperclipai/adapter-codex-local build\n