### PR TITLE
codex-local: normalize reasoning effort + rebuild prompt per attempt

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-args.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.test.ts
@@ -48,6 +48,40 @@ describe("buildCodexExecArgs", () => {
     ]);
   });
 
+  it("normalizes xhigh modelReasoningEffort to high (Codex CLI alias)", () => {
+    const result = buildCodexExecArgs({
+      model: "gpt-5.4",
+      modelReasoningEffort: "xhigh",
+    });
+    expect(result.args).toContain("model_reasoning_effort=\"high\"");
+    expect(result.reasoningEffortNormalizedReason).toContain(
+      'Normalized modelReasoningEffort "xhigh" to "high"',
+    );
+    expect(result.reasoningEffortIgnoredReason).toBeNull();
+  });
+
+  it("drops unsupported modelReasoningEffort values instead of forwarding", () => {
+    const result = buildCodexExecArgs({
+      model: "gpt-5.4",
+      modelReasoningEffort: "banana",
+    });
+    expect(result.args.some((a) => a.startsWith("model_reasoning_effort"))).toBe(false);
+    expect(result.reasoningEffortIgnoredReason).toContain(
+      'Ignored unsupported modelReasoningEffort "banana"',
+    );
+    expect(result.reasoningEffortNormalizedReason).toBeNull();
+  });
+
+  it("passes supported modelReasoningEffort through unchanged", () => {
+    const result = buildCodexExecArgs({
+      model: "gpt-5.4",
+      modelReasoningEffort: "high",
+    });
+    expect(result.args).toContain("model_reasoning_effort=\"high\"");
+    expect(result.reasoningEffortNormalizedReason).toBeNull();
+    expect(result.reasoningEffortIgnoredReason).toBeNull();
+  });
+
   it("ignores fast mode for unsupported models", () => {
     const result = buildCodexExecArgs({
       model: "gpt-5.3-codex",

--- a/packages/adapters/codex-local/src/server/codex-args.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.ts
@@ -10,6 +10,25 @@ export type BuildCodexExecArgsResult = {
   fastModeRequested: boolean;
   fastModeApplied: boolean;
   fastModeIgnoredReason: string | null;
+  reasoningEffortNormalizedReason: string | null;
+  reasoningEffortIgnoredReason: string | null;
+};
+
+const CODEX_SUPPORTED_REASONING_EFFORTS = new Set([
+  "minimal",
+  "low",
+  "medium",
+  "high",
+]);
+
+const CODEX_REASONING_EFFORT_ALIASES: Record<string, string> = {
+  xhigh: "high",
+};
+
+type NormalizedReasoningEffort = {
+  effort: string;
+  ignoredReason: string | null;
+  normalizedReason: string | null;
 };
 
 function readExtraArgs(config: unknown): string[] {
@@ -28,16 +47,47 @@ function formatFastModeSupportedModels(): string {
   return `${CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS.join(", ")} or manually configured model IDs`;
 }
 
+function normalizeModelReasoningEffort(
+  modelReasoningEffort: string,
+): NormalizedReasoningEffort {
+  if (!modelReasoningEffort) {
+    return { effort: "", ignoredReason: null, normalizedReason: null };
+  }
+  const normalizedInput = modelReasoningEffort.trim().toLowerCase();
+  const aliasedEffort = Object.prototype.hasOwnProperty.call(
+    CODEX_REASONING_EFFORT_ALIASES,
+    normalizedInput,
+  )
+    ? CODEX_REASONING_EFFORT_ALIASES[normalizedInput]
+    : normalizedInput;
+  if (!CODEX_SUPPORTED_REASONING_EFFORTS.has(aliasedEffort)) {
+    return {
+      effort: "",
+      ignoredReason: `Ignored unsupported modelReasoningEffort "${modelReasoningEffort}". Supported values: minimal, low, medium, high.`,
+      normalizedReason: null,
+    };
+  }
+  return {
+    effort: aliasedEffort,
+    ignoredReason: null,
+    normalizedReason:
+      aliasedEffort !== normalizedInput
+        ? `Normalized modelReasoningEffort "${modelReasoningEffort}" to "${aliasedEffort}" for Codex exec compatibility.`
+        : null,
+  };
+}
+
 export function buildCodexExecArgs(
   config: unknown,
   options: { resumeSessionId?: string | null } = {},
 ): BuildCodexExecArgsResult {
   const record = asRecord(config);
   const model = asString(record.model, "").trim();
-  const modelReasoningEffort = asString(
+  const rawModelReasoningEffort = asString(
     record.modelReasoningEffort,
     asString(record.reasoningEffort, ""),
   ).trim();
+  const modelReasoningEffort = normalizeModelReasoningEffort(rawModelReasoningEffort);
   const search = asBoolean(record.search, false);
   const fastModeRequested = asBoolean(record.fastMode, false);
   const fastModeApplied = fastModeRequested && isCodexLocalFastModeSupported(model);
@@ -51,8 +101,8 @@ export function buildCodexExecArgs(
   if (search) args.unshift("--search");
   if (bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
   if (model) args.push("--model", model);
-  if (modelReasoningEffort) {
-    args.push("-c", `model_reasoning_effort=${JSON.stringify(modelReasoningEffort)}`);
+  if (modelReasoningEffort.effort) {
+    args.push("-c", `model_reasoning_effort=${JSON.stringify(modelReasoningEffort.effort)}`);
   }
   if (fastModeApplied) {
     args.push("-c", 'service_tier="fast"', "-c", "features.fast_mode=true");
@@ -70,5 +120,7 @@ export function buildCodexExecArgs(
       fastModeRequested && !fastModeApplied
         ? `Configured fast mode is currently only supported on ${formatFastModeSupportedModels()}; Paperclip will ignore it for model ${model || "(default)"}.`
         : null,
+    reasoningEffortNormalizedReason: modelReasoningEffort.normalizedReason,
+    reasoningEffortIgnoredReason: modelReasoningEffort.ignoredReason,
   };
 }

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -500,7 +500,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   let instructionsPrefix = "";
-  let instructionsChars = 0;
   if (instructionsFilePath) {
     try {
       const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
@@ -508,7 +507,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `${instructionsContents}\n\n` +
         `The above agent instructions were loaded from ${instructionsFilePath}. ` +
         `Resolve any relative file references from ${instructionsDir}.\n\n`;
-      instructionsChars = instructionsPrefix.length;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(
@@ -529,14 +527,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     run: { id: runId, source: "on_demand" },
     context,
   };
-  const renderedBootstrapPrompt =
-    !sessionId && bootstrapPromptTemplate.trim().length > 0
+  const baseRenderedBootstrapPrompt =
+    bootstrapPromptTemplate.trim().length > 0
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
-  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: Boolean(sessionId) });
-  const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
-  const promptInstructionsPrefix = shouldUseResumeDeltaPrompt ? "" : instructionsPrefix;
-  instructionsChars = promptInstructionsPrefix.length;
+  const baseRenderedPrompt = renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const continuationSummary = parseObject(context.paperclipContinuationSummary);
   const continuationSummaryBody = asString(continuationSummary.body, "").trim() || null;
   const codexFallbackHandoffNote =
@@ -547,22 +543,51 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           continuationSummaryBody,
         })
       : "";
-  const commandNotes = (() => {
-    if (!instructionsFilePath) {
-      const notes = [repoAgentsNote];
-      if (forceSaferInvocation) {
-        notes.push("Codex transient fallback requested safer invocation settings for this retry.");
+
+  const buildAttemptPrompt = (resumeSessionId: string | null) => {
+    const resumedSession = Boolean(resumeSessionId);
+    const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession });
+    const shouldUseResumeDeltaPrompt = resumedSession && wakePrompt.length > 0;
+    const promptInstructionsPrefix = shouldUseResumeDeltaPrompt ? "" : instructionsPrefix;
+    const renderedBootstrapPrompt = resumedSession ? "" : baseRenderedBootstrapPrompt;
+    const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : baseRenderedPrompt;
+    const prompt = joinPromptSections([
+      promptInstructionsPrefix,
+      renderedBootstrapPrompt,
+      wakePrompt,
+      codexFallbackHandoffNote,
+      sessionHandoffNote,
+      renderedPrompt,
+    ]);
+    const commandNotes = (() => {
+      if (!instructionsFilePath) {
+        const notes = [repoAgentsNote];
+        if (forceSaferInvocation) {
+          notes.push("Codex transient fallback requested safer invocation settings for this retry.");
+        }
+        if (forceFreshSession) {
+          notes.push("Codex transient fallback forced a fresh session with a continuation handoff.");
+        }
+        return notes;
       }
-      if (forceFreshSession) {
-        notes.push("Codex transient fallback forced a fresh session with a continuation handoff.");
-      }
-      return notes;
-    }
-    if (instructionsPrefix.length > 0) {
-      if (shouldUseResumeDeltaPrompt) {
+      if (instructionsPrefix.length > 0) {
+        if (shouldUseResumeDeltaPrompt) {
+          const notes = [
+            `Loaded agent instructions from ${instructionsFilePath}`,
+            "Skipped stdin instruction reinjection because an existing Codex session is being resumed with a wake delta.",
+            repoAgentsNote,
+          ];
+          if (forceSaferInvocation) {
+            notes.push("Codex transient fallback requested safer invocation settings for this retry.");
+          }
+          if (forceFreshSession) {
+            notes.push("Codex transient fallback forced a fresh session with a continuation handoff.");
+          }
+          return notes;
+        }
         const notes = [
           `Loaded agent instructions from ${instructionsFilePath}`,
-          "Skipped stdin instruction reinjection because an existing Codex session is being resumed with a wake delta.",
+          `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
           repoAgentsNote,
         ];
         if (forceSaferInvocation) {
@@ -574,8 +599,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         return notes;
       }
       const notes = [
-        `Loaded agent instructions from ${instructionsFilePath}`,
-        `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
+        `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
         repoAgentsNote,
       ];
       if (forceSaferInvocation) {
@@ -585,48 +609,38 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         notes.push("Codex transient fallback forced a fresh session with a continuation handoff.");
       }
       return notes;
-    }
-    const notes = [
-      `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
-      repoAgentsNote,
-    ];
-    if (forceSaferInvocation) {
-      notes.push("Codex transient fallback requested safer invocation settings for this retry.");
-    }
-    if (forceFreshSession) {
-      notes.push("Codex transient fallback forced a fresh session with a continuation handoff.");
-    }
-    return notes;
-  })();
-  const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
-  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
-  const prompt = joinPromptSections([
-    promptInstructionsPrefix,
-    renderedBootstrapPrompt,
-    wakePrompt,
-    codexFallbackHandoffNote,
-    sessionHandoffNote,
-    renderedPrompt,
-  ]);
-  const promptMetrics = {
-    promptChars: prompt.length,
-    instructionsChars,
-    bootstrapPromptChars: renderedBootstrapPrompt.length,
-    wakePromptChars: wakePrompt.length,
-    sessionHandoffChars: sessionHandoffNote.length,
-    heartbeatPromptChars: renderedPrompt.length,
+    })();
+    return {
+      prompt,
+      commandNotes,
+      promptMetrics: {
+        promptChars: prompt.length,
+        instructionsChars: promptInstructionsPrefix.length,
+        bootstrapPromptChars: renderedBootstrapPrompt.length,
+        wakePromptChars: wakePrompt.length,
+        sessionHandoffChars: sessionHandoffNote.length,
+        heartbeatPromptChars: renderedPrompt.length,
+      },
+    };
   };
 
   const runAttempt = async (resumeSessionId: string | null) => {
+    const attemptPrompt = buildAttemptPrompt(resumeSessionId);
     const execArgs = buildCodexExecArgs(
       forceSaferInvocation ? { ...config, fastMode: false } : config,
       { resumeSessionId },
     );
     const args = execArgs.args;
-    const commandNotesWithFastMode =
-      execArgs.fastModeIgnoredReason == null
-        ? commandNotes
-        : [...commandNotes, execArgs.fastModeIgnoredReason];
+    const commandNotesWithFastMode = [
+      ...attemptPrompt.commandNotes,
+      ...(execArgs.reasoningEffortNormalizedReason
+        ? [execArgs.reasoningEffortNormalizedReason]
+        : []),
+      ...(execArgs.reasoningEffortIgnoredReason
+        ? [execArgs.reasoningEffortIgnoredReason]
+        : []),
+      ...(execArgs.fastModeIgnoredReason ? [execArgs.fastModeIgnoredReason] : []),
+    ];
     if (onMeta) {
       await onMeta({
         adapterType: "codex_local",
@@ -634,12 +648,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         cwd: effectiveExecutionCwd,
         commandNotes: commandNotesWithFastMode,
         commandArgs: args.map((value, idx) => {
-          if (idx === args.length - 1 && value !== "-") return `<prompt ${prompt.length} chars>`;
+          if (idx === args.length - 1 && value !== "-")
+            return `<prompt ${attemptPrompt.prompt.length} chars>`;
           return value;
         }),
         env: loggedEnv,
-        prompt,
-        promptMetrics,
+        prompt: attemptPrompt.prompt,
+        promptMetrics: attemptPrompt.promptMetrics,
         context,
       });
     }
@@ -647,7 +662,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const proc = await runAdapterExecutionTargetProcess(runId, executionTarget, command, args, {
       cwd,
       env,
-      stdin: prompt,
+      stdin: attemptPrompt.prompt,
       timeoutSec,
       graceSec,
       onSpawn,


### PR DESCRIPTION
## Summary

Two fixes in `@paperclipai/adapter-codex-local`, validated against a live runtime via Paperclip task UPS-2 ("Fix adapter retry reasoning-effort mismatch and stabilize continuation").

### 1. `buildCodexExecArgs`: normalize `modelReasoningEffort`

Codex CLI only accepts `{minimal, low, medium, high}` for `model_reasoning_effort`. Previously the adapter forwarded any configured string verbatim, so a config of `xhigh` produced `-c model_reasoning_effort=\"xhigh\"` and Codex exec rejected the invocation as `adapter_failed` on every heartbeat.

This PR adds a normalizer that:
- aliases `xhigh` → `high` (matches Codex's own startup expansion) and surfaces a `reasoningEffortNormalizedReason` note so the run notes record the substitution
- drops unsupported values instead of forwarding them, surfacing a `reasoningEffortIgnoredReason` note
- passes supported values through unchanged

The adapter result type now exposes both reasons, and `execute` includes them in `commandNotes` alongside the existing `fastModeIgnoredReason`.

### 2. `execute`: rebuild the stdin prompt per attempt

The unknown-session retry path calls `runAttempt(null)` to drop a bad resume sessionId, but the prompt was being constructed once at the outer scope using the original `sessionId`. As a result the fresh-session retry reused the resume-delta prompt (no instructions, no bootstrap) and the agent woke up without context.

Prompt construction is now factored into `buildAttemptPrompt(resumeSessionId)` and called from `runAttempt`, so the fresh-session retry rebuilds the full prompt: instructions + bootstrap + wake + Codex transient handoff + session handoff + heartbeat. Existing behavior on the happy path is preserved (resumed sessions still skip instruction reinjection and the heartbeat body).

`commandNotes` is also computed per attempt so the resume-delta vs. fresh-session note matches the actual attempt.

## Test plan

- [x] Added `codex-args.test.ts` cases: `xhigh` normalization, unsupported value drop, supported passthrough
- [x] `pnpm --filter @paperclipai/adapter-codex-local test` — 24/24 passing locally
- [x] `pnpm --filter @paperclipai/adapter-codex-local build` — clean tsc, dist contains the four patch markers (`xhigh` alias, `reasoningEffortNormalizedReason`, `reasoningEffortIgnoredReason`, `buildAttemptPrompt(resumeSessionId)`)
- [x] Live-runtime smoke from Paperclip UPS-2 closeout:
  - `xhigh` startup variant — effort arg becomes `model_reasoning_effort=\"high\"` with normalized note; unsupported values dropped with ignored note
  - unknown-session retry — `buildAttemptPrompt(null)` rebuilds full prompt context (instructions, bootstrap, wake, handoff) on the fresh-session attempt

## Related

- Paperclip task: UPS-2 "Fix adapter retry reasoning-effort mismatch and stabilize continuation"
- Paperclip task: UPS-9 "Publish codex-local adapter patch and post rollout verification"
- Paperclip task: UPS-10 "CTO: Upstream codex-local publish + verification"

## Notes for maintainers

- npm publish for `@paperclipai/adapter-codex-local` is intentionally not part of this PR. The author does not hold publish credentials for the `@paperclipai` npm scope or write access to this repo (this PR comes from a fork). Once merged, please cut a new release so operators running `npx @paperclipai/...@latest` pick up the fix; current `latest` (2026.427.0) and `canary` (2026.427.1-canary.1) tarballs do not contain these markers.