### PR TITLE
feat(claude_local): per-agent Git/GitHub identity (MYO-79)

### DIFF
--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -217,6 +217,82 @@ export function registerAgentCommands(program: Command): void {
 
   addCommonClientOptions(
     agent
+      .command("set-git-identity")
+      .description(
+        "Set per-agent Git/GitHub identity (claude_local). Updates adapterConfig.git fields without touching other settings.",
+      )
+      .argument("<agentId>", "Agent ID")
+      .requiredOption("--user-name <name>", "Git author/committer name")
+      .requiredOption("--user-email <email>", "Git author/committer email")
+      .option(
+        "--token-ref <ref>",
+        "Token reference (env:NAME or file:/abs/path). Resolved at heartbeat time. Omit to clear.",
+      )
+      .option("--clear", "Remove the git identity from adapterConfig.git", false)
+      .action(
+        async (
+          agentId: string,
+          opts: BaseClientOptions & {
+            userName?: string;
+            userEmail?: string;
+            tokenRef?: string;
+            clear?: boolean;
+          },
+        ) => {
+          try {
+            const ctx = resolveCommandContext(opts);
+            if (opts.clear) {
+              const result = await ctx.api.patch<Agent>(`/api/agents/${agentId}`, {
+                adapterConfig: { git: null },
+              });
+              if (ctx.json) {
+                printOutput(result, { json: true });
+                return;
+              }
+              console.log(`Cleared adapterConfig.git on agent ${agentId}`);
+              return;
+            }
+            const userName = opts.userName?.trim();
+            const userEmail = opts.userEmail?.trim();
+            if (!userName || !userEmail) {
+              throw new Error("--user-name and --user-email are required (use --clear to remove)");
+            }
+            if (!userEmail.includes("@")) {
+              throw new Error(`--user-email must look like an email address (got: ${userEmail})`);
+            }
+            const tokenRef = opts.tokenRef?.trim() ?? "";
+            if (tokenRef && !/^env:[A-Za-z_][A-Za-z0-9_]*$/.test(tokenRef) && !tokenRef.startsWith("file:/")) {
+              throw new Error(
+                `--token-ref must use env:NAME (e.g. env:PAPERCLIP_GH_TOKEN_FOO) or file:/abs/path (got: ${tokenRef})`,
+              );
+            }
+            const gitFields: Record<string, string> = {
+              userName,
+              userEmail,
+            };
+            if (tokenRef) gitFields.tokenSecretRef = tokenRef;
+            const result = await ctx.api.patch<Agent>(`/api/agents/${agentId}`, {
+              adapterConfig: { git: gitFields },
+            });
+            if (ctx.json) {
+              printOutput(result, { json: true });
+              return;
+            }
+            console.log(
+              `Updated adapterConfig.git on agent ${agentId}: name="${userName}" email="${userEmail}" tokenSecretRef=${tokenRef ? `"${tokenRef}"` : "(unset)"}`,
+            );
+            console.log(
+              "Note: feature flag PAPERCLIP_ADAPTER_GIT_IDENTITY=true must be set on the Paperclip server for this to take effect.",
+            );
+          } catch (err) {
+            handleCommandError(err);
+          }
+        },
+      ),
+  );
+
+  addCommonClientOptions(
+    agent
       .command("local-cli")
       .description(
         "Create an agent API key, install local Paperclip skills for Codex/Claude, and print shell exports",

--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -22,6 +22,47 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 | `graceSec` | number | No | Grace period before force-kill |
 | `maxTurnsPerRun` | number | No | Max agentic turns per heartbeat (defaults to `300`) |
 | `dangerouslySkipPermissions` | boolean | No | Skip permission prompts (default: `true`); required for headless runs where interactive approval is impossible |
+| `git` | object | No | Per-agent Git/GitHub identity (off by default — gated by `PAPERCLIP_ADAPTER_GIT_IDENTITY=true`). See [Per-agent Git identity](#per-agent-git-identity). |
+
+## Per-agent Git identity
+
+When the host feature flag `PAPERCLIP_ADAPTER_GIT_IDENTITY=true` is set on the Paperclip server, `claude_local` agents can carry their own Git/GitHub identity per agent. The adapter writes a per-run `.gitconfig` and exports `GIT_AUTHOR_NAME/EMAIL`, `GIT_COMMITTER_NAME/EMAIL`, `GIT_CONFIG_GLOBAL`, and (if a token resolves) `GH_TOKEN`. The host `~/.gitconfig` is **never** modified.
+
+```jsonc
+{
+  "adapterType": "claude_local",
+  "adapterConfig": {
+    "git": {
+      "userName": "paperclip-foundingeng",
+      "userEmail": "paperclip+foundingeng@openstudio.fr",
+      "tokenSecretRef": "env:PAPERCLIP_GH_TOKEN_FOUNDINGENG"
+    }
+  }
+}
+```
+
+Supported `tokenSecretRef` schemes:
+
+- `env:VAR_NAME` — read from the Paperclip server process environment.
+- `file:/abs/path` — read the token from a chmod-600 file.
+
+CLI helper (preferred for managing identities):
+
+```sh
+pnpm paperclipai agent set-git-identity <agentId> \
+  --user-name paperclip-foundingeng \
+  --user-email paperclip+foundingeng@openstudio.fr \
+  --token-ref env:PAPERCLIP_GH_TOKEN_FOUNDINGENG
+```
+
+The CLI never persists the token — only the indirection ref. The actual PAT is supplied to the Paperclip server out-of-band (env var or secure file). Recommended PAT scopes (fine-grained): `contents:write`, `pull_requests:write`.
+
+Mandatory operational notes:
+
+- Feature flag `PAPERCLIP_ADAPTER_GIT_IDENTITY` must be `true` on the server. Otherwise the field is ignored and the adapter inherits host Git config (legacy behavior).
+- Per-run `.gitconfig` files are written under `os.tmpdir()/paperclip-claude-git-identity/<agentId>/<runId>/.gitconfig` and removed at the end of each `execute()` call.
+- The credential helper in the per-run `.gitconfig` references `$GH_TOKEN` — the literal PAT is never embedded in the file.
+- PAT values are redacted from logs by Paperclip's redaction layer (regex covers both `ghp_*` classic and `github_pat_*` fine-grained tokens).
 
 ## Prompt Templates
 

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -28,6 +28,11 @@ Core fields:
 - env (object, optional): KEY=VALUE environment variables
 - workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
 - workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
+- git (object, optional, off by default): per-agent Git/GitHub identity. Gated by the host feature flag PAPERCLIP_ADAPTER_GIT_IDENTITY=true (or context.paperclipAdapterGitIdentity.enabledOverride). Fields:
+  - userName (string, required when git is set): commit author/committer name
+  - userEmail (string, required when git is set): commit author/committer email
+  - tokenSecretRef (string, optional): token reference resolved at heartbeat time. Supported schemes: "env:VAR" (read from process env), "file:/abs/path" (read from a chmod 600 file). Resolved value is exported as GH_TOKEN and wired into a per-run .gitconfig credential helper for github.com.
+  When applied, the adapter writes a per-run isolated .gitconfig and exports GIT_AUTHOR_NAME/EMAIL, GIT_COMMITTER_NAME/EMAIL, GIT_CONFIG_GLOBAL, and (if a token resolved) GH_TOKEN — the host ~/.gitconfig is never modified.
 
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -48,6 +48,13 @@ import {
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
+import {
+  isClaudeLocalGitIdentityEnabled,
+  parseClaudeLocalGitConfig,
+  prepareGitIdentityRuntime,
+  type ClaudeLocalGitConfigParseError,
+  type TokenResolver,
+} from "./git-identity.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -58,6 +65,18 @@ interface ClaudeExecutionInput {
   context: Record<string, unknown>;
   executionTarget?: ReturnType<typeof readAdapterExecutionTarget>;
   authToken?: string;
+  gitIdentity?: {
+    /**
+     * Override the host env-var feature flag check. When provided, this takes
+     * precedence over PAPERCLIP_ADAPTER_GIT_IDENTITY. Server-side callers can
+     * use this to plug a per-company feature flag.
+     */
+    enabledOverride?: boolean;
+    /** Override the default token resolver (used by tests). */
+    resolveToken?: TokenResolver;
+    /** Override the per-run gitconfig root directory (used by tests). */
+    runtimeRoot?: string;
+  };
 }
 
 interface ClaudeRuntimeConfig {
@@ -72,6 +91,13 @@ interface ClaudeRuntimeConfig {
   timeoutSec: number;
   graceSec: number;
   extraArgs: string[];
+  gitIdentity: {
+    applied: boolean;
+    gitConfigPath: string | null;
+    warnings: string[];
+    parseErrors: ClaudeLocalGitConfigParseError[];
+    cleanup: (() => Promise<void>) | null;
+  };
 }
 
 function buildLoginResult(input: {
@@ -107,7 +133,7 @@ function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscri
 }
 
 async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {
-  const { runId, agent, config, context, executionTarget, authToken } = input;
+  const { runId, agent, config, context, executionTarget, authToken, gitIdentity } = input;
 
   const command = asString(config.command, "claude");
   const workspaceContext = parseObject(context.paperclipWorkspace);
@@ -230,6 +256,37 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     env.PAPERCLIP_API_KEY = authToken;
   }
 
+  const gitIdentityRuntime: ClaudeRuntimeConfig["gitIdentity"] = {
+    applied: false,
+    gitConfigPath: null,
+    warnings: [],
+    parseErrors: [],
+    cleanup: null,
+  };
+  const gitIdentityEnabled =
+    gitIdentity?.enabledOverride ?? isClaudeLocalGitIdentityEnabled(process.env);
+  if (gitIdentityEnabled) {
+    const parsed = parseClaudeLocalGitConfig((config as Record<string, unknown>).git);
+    gitIdentityRuntime.parseErrors = parsed.errors;
+    if (parsed.config !== null) {
+      const prepared = await prepareGitIdentityRuntime({
+        runId,
+        agentId: agent.id,
+        cwd,
+        config: parsed.config,
+        resolveToken: gitIdentity?.resolveToken,
+        runtimeRoot: gitIdentity?.runtimeRoot,
+      });
+      for (const [key, value] of Object.entries(prepared.env)) {
+        env[key] = value;
+      }
+      gitIdentityRuntime.applied = true;
+      gitIdentityRuntime.gitConfigPath = prepared.gitConfigPath;
+      gitIdentityRuntime.warnings = prepared.warnings;
+      gitIdentityRuntime.cleanup = prepared.cleanup;
+    }
+  }
+
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
   await ensureAdapterExecutionTargetCommandResolvable(command, executionTarget, cwd, runtimeEnv);
   const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(command, executionTarget, cwd, runtimeEnv);
@@ -259,6 +316,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     timeoutSec,
     graceSec,
     extraArgs,
+    gitIdentity: gitIdentityRuntime,
   };
 }
 
@@ -325,6 +383,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     context,
     executionTarget,
     authToken,
+    gitIdentity: readGitIdentityOverridesFromContext(context),
   });
   const {
     command,
@@ -344,6 +403,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     0,
     asNumber(config.terminalResultCleanupGraceMs, 5_000),
   );
+  if (runtimeConfig.gitIdentity.applied) {
+    await onLog(
+      "stdout",
+      `[paperclip] claude_local git identity applied: GIT_CONFIG_GLOBAL=${runtimeConfig.gitIdentity.gitConfigPath} (run-scoped)\n`,
+    );
+  }
+  for (const warning of runtimeConfig.gitIdentity.warnings) {
+    await onLog("stderr", `[paperclip] ${warning}\n`);
+  }
+  for (const parseError of runtimeConfig.gitIdentity.parseErrors) {
+    await onLog(
+      "stderr",
+      `[paperclip] adapterConfig.git ignored: ${parseError.message}\n`,
+    );
+  }
   const effectiveEnv = Object.fromEntries(
     Object.entries({ ...process.env, ...env }).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string",
@@ -773,5 +847,29 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       );
       await restoreRemoteWorkspace();
     }
+    if (runtimeConfig.gitIdentity.cleanup) {
+      await runtimeConfig.gitIdentity.cleanup();
+    }
   }
+}
+
+function readGitIdentityOverridesFromContext(
+  context: Record<string, unknown> | undefined,
+): ClaudeExecutionInput["gitIdentity"] | undefined {
+  if (!context || typeof context !== "object") return undefined;
+  const raw = (context as Record<string, unknown>).paperclipAdapterGitIdentity;
+  if (!raw || typeof raw !== "object") return undefined;
+  const record = raw as Record<string, unknown>;
+  const out: NonNullable<ClaudeExecutionInput["gitIdentity"]> = {};
+  if (typeof record.enabledOverride === "boolean") {
+    out.enabledOverride = record.enabledOverride;
+  }
+  if (typeof record.runtimeRoot === "string" && record.runtimeRoot.trim().length > 0) {
+    out.runtimeRoot = record.runtimeRoot;
+  }
+  if (typeof record.resolveToken === "function") {
+    out.resolveToken = record.resolveToken as TokenResolver;
+  }
+  if (Object.keys(out).length === 0) return undefined;
+  return out;
 }

--- a/packages/adapters/claude-local/src/server/git-identity.ts
+++ b/packages/adapters/claude-local/src/server/git-identity.ts
@@ -1,0 +1,254 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export interface ClaudeLocalGitConfig {
+  userName: string;
+  userEmail: string;
+  tokenSecretRef: string | null;
+}
+
+export interface ClaudeLocalGitConfigParseError {
+  field: "userName" | "userEmail" | "tokenSecretRef";
+  message: string;
+}
+
+export interface ClaudeLocalGitConfigParseResult {
+  config: ClaudeLocalGitConfig | null;
+  errors: ClaudeLocalGitConfigParseError[];
+}
+
+const FEATURE_FLAG_ENV = "PAPERCLIP_ADAPTER_GIT_IDENTITY";
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+
+export function isClaudeLocalGitIdentityEnabled(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): boolean {
+  const raw = env[FEATURE_FLAG_ENV];
+  if (typeof raw !== "string") return false;
+  return TRUE_VALUES.has(raw.trim().toLowerCase());
+}
+
+export function parseClaudeLocalGitConfig(value: unknown): ClaudeLocalGitConfigParseResult {
+  if (value === null || value === undefined) {
+    return { config: null, errors: [] };
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    return {
+      config: null,
+      errors: [{ field: "userName", message: "adapterConfig.git must be an object" }],
+    };
+  }
+  const record = value as Record<string, unknown>;
+  const errors: ClaudeLocalGitConfigParseError[] = [];
+
+  const userName = readNonEmptyString(record.userName);
+  if (userName === null) {
+    errors.push({
+      field: "userName",
+      message: "adapterConfig.git.userName must be a non-empty string",
+    });
+  }
+  const userEmail = readNonEmptyString(record.userEmail);
+  if (userEmail === null) {
+    errors.push({
+      field: "userEmail",
+      message: "adapterConfig.git.userEmail must be a non-empty string",
+    });
+  } else if (!userEmail.includes("@")) {
+    errors.push({
+      field: "userEmail",
+      message: "adapterConfig.git.userEmail must look like an email address",
+    });
+  }
+  let tokenSecretRef: string | null = null;
+  if (record.tokenSecretRef !== undefined && record.tokenSecretRef !== null) {
+    const raw = readNonEmptyString(record.tokenSecretRef);
+    if (raw === null) {
+      errors.push({
+        field: "tokenSecretRef",
+        message: "adapterConfig.git.tokenSecretRef must be a non-empty string when provided",
+      });
+    } else if (!isSupportedTokenSecretRef(raw)) {
+      errors.push({
+        field: "tokenSecretRef",
+        message:
+          "adapterConfig.git.tokenSecretRef must use a supported scheme (env:NAME, file:/abs/path)",
+      });
+    } else {
+      tokenSecretRef = raw;
+    }
+  }
+  if (errors.length > 0 || userName === null || userEmail === null) {
+    return { config: null, errors };
+  }
+  return {
+    config: { userName, userEmail, tokenSecretRef },
+    errors,
+  };
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isSupportedTokenSecretRef(ref: string): boolean {
+  if (ref.startsWith("env:")) return ref.slice(4).trim().length > 0;
+  if (ref.startsWith("file:")) return ref.slice(5).trim().length > 0;
+  return false;
+}
+
+export interface TokenResolver {
+  (ref: string): Promise<string | null>;
+}
+
+export const defaultTokenResolver: TokenResolver = async (ref) => {
+  if (ref.startsWith("env:")) {
+    const name = ref.slice(4).trim();
+    if (!name) return null;
+    const value = process.env[name];
+    if (typeof value !== "string" || value.length === 0) return null;
+    return value;
+  }
+  if (ref.startsWith("file:")) {
+    const filePath = ref.slice(5).trim();
+    if (!filePath) return null;
+    const absolute = path.isAbsolute(filePath) ? filePath : path.resolve(filePath);
+    try {
+      const raw = await fs.readFile(absolute, "utf8");
+      const trimmed = raw.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+};
+
+export interface PrepareGitIdentityRuntimeInput {
+  runId: string;
+  agentId: string;
+  cwd: string;
+  config: ClaudeLocalGitConfig;
+  resolveToken?: TokenResolver;
+  runtimeRoot?: string;
+}
+
+export interface PrepareGitIdentityRuntimeResult {
+  env: Record<string, string>;
+  gitConfigPath: string;
+  cleanup: () => Promise<void>;
+  resolvedTokenLength: number;
+  warnings: string[];
+}
+
+export async function prepareGitIdentityRuntime(
+  input: PrepareGitIdentityRuntimeInput,
+): Promise<PrepareGitIdentityRuntimeResult> {
+  const warnings: string[] = [];
+  const resolveToken = input.resolveToken ?? defaultTokenResolver;
+  const runtimeRoot = input.runtimeRoot
+    ? input.runtimeRoot
+    : path.join(os.tmpdir(), "paperclip-claude-git-identity");
+  const runDir = path.join(runtimeRoot, sanitizePathSegment(input.agentId), sanitizePathSegment(input.runId));
+  await fs.mkdir(runDir, { recursive: true, mode: 0o700 });
+  try {
+    await fs.chmod(runDir, 0o700);
+  } catch {
+    // Best-effort: chmod may fail on Windows or unusual filesystems.
+  }
+  const gitConfigPath = path.join(runDir, ".gitconfig");
+  let resolvedToken: string | null = null;
+  if (input.config.tokenSecretRef) {
+    try {
+      resolvedToken = await resolveToken(input.config.tokenSecretRef);
+    } catch (err) {
+      warnings.push(
+        `Failed to resolve adapter git tokenSecretRef "${input.config.tokenSecretRef}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      resolvedToken = null;
+    }
+    if (resolvedToken === null) {
+      warnings.push(
+        `Adapter git tokenSecretRef "${input.config.tokenSecretRef}" did not resolve to a value; ` +
+          "skipping GH_TOKEN injection.",
+      );
+    }
+  }
+  const gitConfigBody = buildGitConfigBody({
+    userName: input.config.userName,
+    userEmail: input.config.userEmail,
+    includeCredentialHelper: resolvedToken !== null,
+  });
+  await fs.writeFile(gitConfigPath, gitConfigBody, { encoding: "utf8", mode: 0o600 });
+  try {
+    await fs.chmod(gitConfigPath, 0o600);
+  } catch {
+    // Best-effort: chmod may fail on Windows or unusual filesystems.
+  }
+  const env: Record<string, string> = {
+    GIT_AUTHOR_NAME: input.config.userName,
+    GIT_AUTHOR_EMAIL: input.config.userEmail,
+    GIT_COMMITTER_NAME: input.config.userName,
+    GIT_COMMITTER_EMAIL: input.config.userEmail,
+    GIT_CONFIG_GLOBAL: gitConfigPath,
+  };
+  if (resolvedToken !== null) {
+    env.GH_TOKEN = resolvedToken;
+  }
+  return {
+    env,
+    gitConfigPath,
+    resolvedTokenLength: resolvedToken?.length ?? 0,
+    warnings,
+    cleanup: async () => {
+      try {
+        await fs.rm(runDir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    },
+  };
+}
+
+interface BuildGitConfigBodyInput {
+  userName: string;
+  userEmail: string;
+  includeCredentialHelper: boolean;
+}
+
+function buildGitConfigBody(input: BuildGitConfigBodyInput): string {
+  const lines = [
+    `# Generated by Paperclip claude_local adapter. Per-run, do not edit.`,
+    `[user]`,
+    `\tname = ${quoteIniValue(input.userName)}`,
+    `\temail = ${quoteIniValue(input.userEmail)}`,
+  ];
+  if (input.includeCredentialHelper) {
+    lines.push(
+      `[credential "https://github.com"]`,
+      `\thelper = !f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function quoteIniValue(value: string): string {
+  const sanitized = value.replace(/[\r\n]+/g, " ").trim();
+  const escaped = sanitized.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 64) || "default";
+}
+
+export const __testing = {
+  FEATURE_FLAG_ENV,
+  buildGitConfigBody,
+};

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -1,4 +1,14 @@
 export { execute, runClaudeLogin } from "./execute.js";
+export {
+  isClaudeLocalGitIdentityEnabled,
+  parseClaudeLocalGitConfig,
+  prepareGitIdentityRuntime,
+  defaultTokenResolver,
+  type ClaudeLocalGitConfig,
+  type ClaudeLocalGitConfigParseError,
+  type ClaudeLocalGitConfigParseResult,
+  type TokenResolver,
+} from "./git-identity.js";
 export { listClaudeSkills, syncClaudeSkills } from "./skills.js";
 export { listClaudeModels } from "./models.js";
 export { testEnvironment } from "./test.js";

--- a/server/src/__tests__/claude-local-git-identity.test.ts
+++ b/server/src/__tests__/claude-local-git-identity.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  execute,
+  isClaudeLocalGitIdentityEnabled,
+  parseClaudeLocalGitConfig,
+  prepareGitIdentityRuntime,
+} from "@paperclipai/adapter-claude-local/server";
+import { redactSensitiveText } from "../redaction.js";
+
+async function writeGitInspectingClaudeCommand(commandPath: string): Promise<void> {
+  // The fake claude binary writes the git-related env vars + the contents of
+  // the per-run .gitconfig back to a capture file so the test can assert on
+  // what the agent process would actually see.
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+let gitconfigContents = null;
+if (process.env.GIT_CONFIG_GLOBAL) {
+  try {
+    gitconfigContents = fs.readFileSync(process.env.GIT_CONFIG_GLOBAL, "utf8");
+  } catch (err) {
+    gitconfigContents = "ERROR:" + err.message;
+  }
+}
+const payload = {
+  argv: process.argv.slice(2),
+  env: {
+    GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? null,
+    GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? null,
+    GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? null,
+    GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? null,
+    GIT_CONFIG_GLOBAL: process.env.GIT_CONFIG_GLOBAL ?? null,
+    GH_TOKEN: process.env.GH_TOKEN ?? null,
+  },
+  gitconfigContents,
+  pid: process.pid,
+};
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-1", model: "claude-sonnet" }));
+console.log(JSON.stringify({ type: "assistant", session_id: "claude-session-1", message: { content: [{ type: "text", text: "hello" }] } }));
+console.log(JSON.stringify({ type: "result", session_id: "claude-session-1", result: "hello", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+interface ExecHarness {
+  workspace: string;
+  commandPath: string;
+  capturePath: string;
+  hostGitconfig: string;
+  hostGitconfigSentinel: string;
+  runtimeRoot: string;
+  restore: () => void;
+}
+
+async function setupExecuteEnv(root: string): Promise<ExecHarness> {
+  const workspace = path.join(root, "workspace");
+  const binDir = path.join(root, "bin");
+  const commandPath = path.join(binDir, "claude");
+  const capturePath = path.join(root, "capture.json");
+  const hostHome = path.join(root, "home");
+  const hostGitconfig = path.join(hostHome, ".gitconfig");
+  const hostGitconfigSentinel = "[user]\n\tname = host-original\n\temail = host@example.com\n";
+  const runtimeRoot = path.join(root, "git-identity-runtime");
+  await fs.mkdir(workspace, { recursive: true });
+  await fs.mkdir(binDir, { recursive: true });
+  await fs.mkdir(hostHome, { recursive: true });
+  await fs.writeFile(hostGitconfig, hostGitconfigSentinel, "utf8");
+  await writeGitInspectingClaudeCommand(commandPath);
+  const previousHome = process.env.HOME;
+  const previousPath = process.env.PATH;
+  const previousFlag = process.env.PAPERCLIP_ADAPTER_GIT_IDENTITY;
+  process.env.HOME = hostHome;
+  process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+  return {
+    workspace,
+    commandPath,
+    capturePath,
+    hostGitconfig,
+    hostGitconfigSentinel,
+    runtimeRoot,
+    restore: () => {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      if (previousFlag === undefined) delete process.env.PAPERCLIP_ADAPTER_GIT_IDENTITY;
+      else process.env.PAPERCLIP_ADAPTER_GIT_IDENTITY = previousFlag;
+    },
+  };
+}
+
+describe("claude_local git identity feature flag", () => {
+  it("isClaudeLocalGitIdentityEnabled defaults to false", () => {
+    expect(isClaudeLocalGitIdentityEnabled({})).toBe(false);
+    expect(isClaudeLocalGitIdentityEnabled({ PAPERCLIP_ADAPTER_GIT_IDENTITY: "false" })).toBe(false);
+    expect(isClaudeLocalGitIdentityEnabled({ PAPERCLIP_ADAPTER_GIT_IDENTITY: "0" })).toBe(false);
+    expect(isClaudeLocalGitIdentityEnabled({ PAPERCLIP_ADAPTER_GIT_IDENTITY: "" })).toBe(false);
+  });
+
+  it("isClaudeLocalGitIdentityEnabled is true for truthy values", () => {
+    for (const value of ["true", "1", "yes", "on", "TRUE"]) {
+      expect(isClaudeLocalGitIdentityEnabled({ PAPERCLIP_ADAPTER_GIT_IDENTITY: value })).toBe(true);
+    }
+  });
+});
+
+describe("claude_local git identity schema", () => {
+  it("rejects non-object values", () => {
+    const result = parseClaudeLocalGitConfig("paperclip-foundingeng");
+    expect(result.config).toBeNull();
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("rejects missing or invalid email", () => {
+    const result = parseClaudeLocalGitConfig({
+      userName: "paperclip-foundingeng",
+      userEmail: "not-an-email",
+    });
+    expect(result.config).toBeNull();
+    expect(result.errors.find((e) => e.field === "userEmail")).toBeDefined();
+  });
+
+  it("rejects unsupported tokenSecretRef schemes", () => {
+    const result = parseClaudeLocalGitConfig({
+      userName: "x",
+      userEmail: "x@y.com",
+      tokenSecretRef: "vault://secret",
+    });
+    expect(result.config).toBeNull();
+    expect(result.errors.find((e) => e.field === "tokenSecretRef")).toBeDefined();
+  });
+
+  it("accepts a valid config with env: token ref", () => {
+    const result = parseClaudeLocalGitConfig({
+      userName: "paperclip-foundingeng",
+      userEmail: "paperclip+foundingeng@openstudio.fr",
+      tokenSecretRef: "env:PAPERCLIP_GH_TOKEN_FOUNDINGENG",
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.config).toEqual({
+      userName: "paperclip-foundingeng",
+      userEmail: "paperclip+foundingeng@openstudio.fr",
+      tokenSecretRef: "env:PAPERCLIP_GH_TOKEN_FOUNDINGENG",
+    });
+  });
+
+  it("accepts an absent tokenSecretRef", () => {
+    const result = parseClaudeLocalGitConfig({
+      userName: "x",
+      userEmail: "x@y.com",
+    });
+    expect(result.config).toEqual({
+      userName: "x",
+      userEmail: "x@y.com",
+      tokenSecretRef: null,
+    });
+  });
+});
+
+describe("claude_local prepareGitIdentityRuntime isolation", () => {
+  it("writes a per-run .gitconfig and never touches the host ~/.gitconfig", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-identity-iso-"));
+    const hostHome = path.join(root, "home");
+    const hostGitconfig = path.join(hostHome, ".gitconfig");
+    const hostSentinel = "[user]\n\tname = host-original\n\temail = host@example.com\n";
+    await fs.mkdir(hostHome, { recursive: true });
+    await fs.writeFile(hostGitconfig, hostSentinel, "utf8");
+    try {
+      const result = await prepareGitIdentityRuntime({
+        runId: "run-1",
+        agentId: "agent-A",
+        cwd: root,
+        config: {
+          userName: "paperclip-foundingeng",
+          userEmail: "paperclip+foundingeng@openstudio.fr",
+          tokenSecretRef: "env:GH_TOK_AGENT_A",
+        },
+        resolveToken: async (ref) => (ref === "env:GH_TOK_AGENT_A" ? "ghp_agentApat0000000000000000" : null),
+        runtimeRoot: path.join(root, "runtime"),
+      });
+      expect(result.env.GIT_AUTHOR_NAME).toBe("paperclip-foundingeng");
+      expect(result.env.GIT_AUTHOR_EMAIL).toBe("paperclip+foundingeng@openstudio.fr");
+      expect(result.env.GIT_COMMITTER_NAME).toBe("paperclip-foundingeng");
+      expect(result.env.GIT_COMMITTER_EMAIL).toBe("paperclip+foundingeng@openstudio.fr");
+      expect(result.env.GH_TOKEN).toBe("ghp_agentApat0000000000000000");
+      expect(result.env.GIT_CONFIG_GLOBAL).toBe(result.gitConfigPath);
+      const gitconfigBody = await fs.readFile(result.gitConfigPath, "utf8");
+      expect(gitconfigBody).toContain('name = "paperclip-foundingeng"');
+      expect(gitconfigBody).toContain("https://github.com");
+      expect(gitconfigBody).toContain("password=$GH_TOKEN");
+      // Host ~/.gitconfig must remain unchanged.
+      const hostBodyAfter = await fs.readFile(hostGitconfig, "utf8");
+      expect(hostBodyAfter).toBe(hostSentinel);
+      // The PAT itself must not appear inside the per-run .gitconfig — the helper
+      // shells out to $GH_TOKEN, never embeds the literal token.
+      expect(gitconfigBody).not.toContain("ghp_agentApat0000000000000000");
+      // chmod 600 on the file (best-effort, skipped on platforms without it).
+      const stat = await fs.stat(result.gitConfigPath);
+      if (process.platform !== "win32") {
+        expect(stat.mode & 0o777).toBe(0o600);
+      }
+      await result.cleanup();
+      await expect(fs.stat(result.gitConfigPath)).rejects.toBeDefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("isolates two parallel agents — distinct GH_TOKEN values and distinct GIT_CONFIG_GLOBAL paths", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-identity-cross-"));
+    try {
+      const runtimeRoot = path.join(root, "runtime");
+      const [a, b] = await Promise.all([
+        prepareGitIdentityRuntime({
+          runId: "run-A",
+          agentId: "agent-A",
+          cwd: root,
+          config: {
+            userName: "agent-a",
+            userEmail: "a@x.com",
+            tokenSecretRef: "env:GH_TOK_A",
+          },
+          resolveToken: async (ref) => (ref === "env:GH_TOK_A" ? "ghp_AAAAAAAAAAAAAAAAAAAAAA" : null),
+          runtimeRoot,
+        }),
+        prepareGitIdentityRuntime({
+          runId: "run-B",
+          agentId: "agent-B",
+          cwd: root,
+          config: {
+            userName: "agent-b",
+            userEmail: "b@x.com",
+            tokenSecretRef: "env:GH_TOK_B",
+          },
+          resolveToken: async (ref) => (ref === "env:GH_TOK_B" ? "ghp_BBBBBBBBBBBBBBBBBBBBBB" : null),
+          runtimeRoot,
+        }),
+      ]);
+      expect(a.gitConfigPath).not.toBe(b.gitConfigPath);
+      expect(a.env.GH_TOKEN).toBe("ghp_AAAAAAAAAAAAAAAAAAAAAA");
+      expect(b.env.GH_TOKEN).toBe("ghp_BBBBBBBBBBBBBBBBBBBBBB");
+      const aBody = await fs.readFile(a.gitConfigPath, "utf8");
+      const bBody = await fs.readFile(b.gitConfigPath, "utf8");
+      expect(aBody).toContain('name = "agent-a"');
+      expect(bBody).toContain('name = "agent-b"');
+      // Cross-agent sanitizer: the gitconfig of agent A must not embed the PAT of B (or its own).
+      expect(aBody).not.toContain("ghp_BBBBBBBBBBBBBBBBBBBBBB");
+      expect(aBody).not.toContain("ghp_AAAAAAAAAAAAAAAAAAAAAA");
+      expect(bBody).not.toContain("ghp_AAAAAAAAAAAAAAAAAAAAAA");
+      expect(bBody).not.toContain("ghp_BBBBBBBBBBBBBBBBBBBBBB");
+      await Promise.all([a.cleanup(), b.cleanup()]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("warns and skips GH_TOKEN injection when tokenSecretRef does not resolve", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-identity-noresolve-"));
+    try {
+      const result = await prepareGitIdentityRuntime({
+        runId: "run-noresolve",
+        agentId: "agent-noresolve",
+        cwd: root,
+        config: {
+          userName: "x",
+          userEmail: "x@y.com",
+          tokenSecretRef: "env:DOES_NOT_EXIST_ABC",
+        },
+        resolveToken: async () => null,
+        runtimeRoot: path.join(root, "runtime"),
+      });
+      expect(result.env.GH_TOKEN).toBeUndefined();
+      expect(result.warnings.length).toBeGreaterThan(0);
+      const body = await fs.readFile(result.gitConfigPath, "utf8");
+      // Without a resolved token, the credential helper section is omitted.
+      expect(body).not.toContain("https://github.com");
+      await result.cleanup();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("claude_local execute git identity end-to-end", () => {
+  it("does not inject git env when feature flag is off, even with adapterConfig.git present", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-git-off-"));
+    const harness = await setupExecuteEnv(root);
+    delete process.env.PAPERCLIP_ADAPTER_GIT_IDENTITY;
+    try {
+      await execute({
+        runId: "run-off",
+        agent: { id: "agent-off", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: harness.commandPath,
+          cwd: harness.workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: harness.capturePath },
+          promptTemplate: "Do work.",
+          git: {
+            userName: "paperclip-foundingeng",
+            userEmail: "paperclip+foundingeng@openstudio.fr",
+            tokenSecretRef: "env:GH_TOK_OFF",
+          },
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+        onMeta: async () => {},
+      });
+      const captured = JSON.parse(await fs.readFile(harness.capturePath, "utf8"));
+      expect(captured.env.GIT_AUTHOR_NAME).toBeNull();
+      expect(captured.env.GIT_CONFIG_GLOBAL).toBeNull();
+      expect(captured.env.GH_TOKEN).toBeNull();
+      // Host ~/.gitconfig is untouched.
+      expect(await fs.readFile(harness.hostGitconfig, "utf8")).toBe(harness.hostGitconfigSentinel);
+    } finally {
+      harness.restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("injects per-run gitconfig + GH_TOKEN when feature flag is on, isolating from host ~/.gitconfig", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-git-on-"));
+    const harness = await setupExecuteEnv(root);
+    process.env.PAPERCLIP_ADAPTER_GIT_IDENTITY = "true";
+    process.env.GH_TOK_AGENT_FE = "ghp_pat_inject0000000000000000";
+    try {
+      await execute({
+        runId: "run-on",
+        agent: {
+          id: "agent-fe",
+          companyId: "co-1",
+          name: "Founding Engineer",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: harness.commandPath,
+          cwd: harness.workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: harness.capturePath },
+          promptTemplate: "Do work.",
+          git: {
+            userName: "paperclip-foundingeng",
+            userEmail: "paperclip+foundingeng@openstudio.fr",
+            tokenSecretRef: "env:GH_TOK_AGENT_FE",
+          },
+        },
+        context: {
+          paperclipAdapterGitIdentity: { runtimeRoot: harness.runtimeRoot },
+        },
+        authToken: "tok",
+        onLog: async () => {},
+        onMeta: async () => {},
+      });
+      const captured = JSON.parse(await fs.readFile(harness.capturePath, "utf8"));
+      expect(captured.env.GIT_AUTHOR_NAME).toBe("paperclip-foundingeng");
+      expect(captured.env.GIT_AUTHOR_EMAIL).toBe("paperclip+foundingeng@openstudio.fr");
+      expect(captured.env.GIT_COMMITTER_NAME).toBe("paperclip-foundingeng");
+      expect(captured.env.GIT_COMMITTER_EMAIL).toBe("paperclip+foundingeng@openstudio.fr");
+      expect(captured.env.GH_TOKEN).toBe("ghp_pat_inject0000000000000000");
+      expect(typeof captured.env.GIT_CONFIG_GLOBAL).toBe("string");
+      expect(captured.env.GIT_CONFIG_GLOBAL.startsWith(harness.runtimeRoot)).toBe(true);
+      expect(captured.gitconfigContents).toContain('name = "paperclip-foundingeng"');
+      expect(captured.gitconfigContents).toContain("https://github.com");
+      expect(captured.gitconfigContents).not.toContain("ghp_pat_inject0000000000000000");
+      // Host ~/.gitconfig still untouched.
+      expect(await fs.readFile(harness.hostGitconfig, "utf8")).toBe(harness.hostGitconfigSentinel);
+    } finally {
+      delete process.env.GH_TOK_AGENT_FE;
+      harness.restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("redaction: GitHub PATs are never echoed in logs", () => {
+  it("redacts ghp_ classic and github_pat_ fine-grained tokens via redactSensitiveText", () => {
+    const classic = "ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789";
+    const fineGrained =
+      "github_pat_11ABCDEF0123456789_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH";
+    const sample = `Pushing with token ${classic} and fine-grained ${fineGrained} should never appear in logs.`;
+    const redacted = redactSensitiveText(sample);
+    expect(redacted).not.toContain(classic);
+    expect(redacted).not.toContain(fineGrained);
+    expect(redacted).toContain("***REDACTED***");
+  });
+});

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -4,6 +4,7 @@ const JWT_VALUE_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-
 const JWT_TEXT_RE = /\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?\b/g;
 const OPENAI_KEY_TEXT_RE = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
 const GITHUB_TOKEN_TEXT_RE = /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g;
+const GITHUB_FINE_GRAINED_PAT_TEXT_RE = /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g;
 const AUTHORIZATION_BEARER_TEXT_RE = /(\bAuthorization\s*:\s*Bearer\s+)[^\s"'`]+/gi;
 const ENV_SECRET_ASSIGNMENT_TEXT_RE =
   /(\b[A-Za-z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|AUTHORIZATION|JWT)[A-Za-z0-9_]*\s*=\s*)[^\s"'`]+/gi;
@@ -76,5 +77,6 @@ export function redactSensitiveText(input: string): string {
     .replace(ENV_SECRET_ASSIGNMENT_TEXT_RE, `$1${REDACTED_EVENT_VALUE}`)
     .replace(OPENAI_KEY_TEXT_RE, REDACTED_EVENT_VALUE)
     .replace(GITHUB_TOKEN_TEXT_RE, REDACTED_EVENT_VALUE)
+    .replace(GITHUB_FINE_GRAINED_PAT_TEXT_RE, REDACTED_EVENT_VALUE)
     .replace(JWT_TEXT_RE, REDACTED_EVENT_VALUE);
 }


### PR DESCRIPTION
## Summary

- Introduce opt-in per-agent Git/GitHub identity for `claude_local` agents.
- Strictly scoped to `claude_local` per CEO authorization on MYO-76 (paired with parallel hook-refactor follow-up — see issue MYO-79).
- Gated by host feature flag `PAPERCLIP_ADAPTER_GIT_IDENTITY=true` (off by default).
- Per-run `.gitconfig` is written under `os.tmpdir()` and removed at end of `execute()`. Host `~/.gitconfig` is never modified.
- Token resolution via `tokenSecretRef`: `env:VAR_NAME` or `file:/abs/path`. The literal PAT never lands on disk in the per-run `.gitconfig` (credential helper shells out to `\$GH_TOKEN`).
- New CLI helper: `paperclipai agent set-git-identity <agentId> --user-name X --user-email Y --token-ref Z` (uses standard PATCH /api/agents/:id, only writes the indirection ref).
- Extends Paperclip log redaction to cover `github_pat_*` fine-grained tokens (was only matching `gh[pousr]_*` classic).

## Files

- `packages/adapters/claude-local/src/server/git-identity.ts` — schema, resolver, gitconfig writer (no new runtime deps).
- `packages/adapters/claude-local/src/server/execute.ts` — wires the prep step into `buildClaudeRuntimeConfig`, logs warnings, cleans up.
- `packages/adapters/claude-local/src/server/index.ts` — exports public API for tests.
- `packages/adapters/claude-local/src/index.ts` — `agentConfigurationDoc` updated.
- `cli/src/commands/client/agent.ts` — new `set-git-identity` subcommand.
- `server/src/redaction.ts` — adds `github_pat_*` regex.
- `docs/adapters/claude-local.md` — adds the per-agent Git identity section.
- `server/src/__tests__/claude-local-git-identity.test.ts` — 13 integration tests.

## Test plan

- [x] `pnpm -C server vitest run claude-local-git-identity` → 13/13 green.
- [x] `pnpm -C server vitest run claude-local-execute claude-local-adapter redaction` → 20/20 green (no regression).
- [x] `pnpm -C packages/adapters/claude-local exec tsc --noEmit` → clean.
- [x] Server typecheck: no new errors introduced (pre-existing errors in `services/environment-runtime.ts` and `services/plugin-environment-driver.ts` are unrelated to this PR).
- [ ] Manual smoke: hire a `paperclip-foundingeng` bot, set `PAPERCLIP_ADAPTER_GIT_IDENTITY=true` + `PAPERCLIP_GH_TOKEN_FOUNDINGENG`, run a heartbeat that pushes a PR, verify commit author = `paperclip-foundingeng`. (Phase 2, follow-up MYO ticket.)

## Acceptance (MYO-79)

- [x] `adapterConfig.git` schema validated at runtime
- [x] Feature flag `PAPERCLIP_ADAPTER_GIT_IDENTITY` operational (off → legacy behavior)
- [x] CLI `paperclipai agent set-git-identity <agentId> --user-name X --user-email Y --token-ref Z`
- [x] Integration tests for isolation `GIT_CONFIG_GLOBAL`, cross-agent, PAT sanitizer
- [x] PAT never in DB (only `tokenSecretRef`); never in logs (regex covers both `ghp_*` and `github_pat_*`)
- [x] PR opened with stopgap board approval (Phase 1A bot identity not yet provisioned for DevOps)
- [x] Doc updated

## Related

- Parent: MYO-76 (CEO option-1 scoped patch)
- Pattern: MYO-24 / MYO-62 (scoped core patch + parallel hook-refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)