### PR TITLE
feat(plugin-hooks): add runtimeEnvProvider hook (MYO-80 / Phase 1c)

### DIFF
--- a/docs/specs/plugin-hooks-runtime-env-provider.md
+++ b/docs/specs/plugin-hooks-runtime-env-provider.md
@@ -1,0 +1,207 @@
+# Runtime Env Provider plugin hook (MYO-80)
+
+> **Status — Phase 1c.** The hook surface is registered alongside the
+> wake-payload and skill-resolver hooks shipped in MYO-62. No call-site in
+> core uses it yet (MYO-76 Phase 1B is the planned first consumer in
+> `claude_local`). The registry surface is safe to merge in isolation.
+
+## Why
+
+Each new adapter that needs to inject per-run environment variables today
+forks core: `claude_local` for Git identity, `codex_local` for the OpenAI
+key, OpenClaw for whatever credential bundle a future runtime exposes. The
+core-patch authorization template (`MYO-24` → `MYO-50` → `MYO-62`) was
+designed exactly to absorb these one-offs into a hook the next adapter can
+reuse without touching core. `runtimeEnvProvider` is the hook for per-run
+env / runtime files.
+
+## Surface
+
+```ts
+// server/src/services/plugin-hooks/types.ts
+export interface RuntimeEnvProviderContext {
+  readonly issue: PluginHookIssueContext;
+  readonly agentId: string;
+  readonly agentRole?: string;
+  readonly companyId: string;
+  readonly runId: string;
+  readonly adapterType: string;
+  readonly adapterConfig: Readonly<Record<string, unknown>>;
+}
+
+export interface RuntimeFileSpec {
+  readonly path: string;     // relative to <runDir>; absolute / .. paths rejected
+  readonly content: string;
+  readonly mode?: number;    // POSIX octal, defaults to 0o600
+}
+
+export interface RuntimeEnvProviderResult {
+  readonly env: Readonly<Record<string, string>>;
+  readonly runtimeFiles?: readonly RuntimeFileSpec[];
+}
+
+export type RuntimeEnvProvider = (
+  current: RuntimeEnvProviderResult,
+  context: RuntimeEnvProviderContext,
+) => Promise<RuntimeEnvProviderResult> | RuntimeEnvProviderResult;
+```
+
+The chain is invoked once per heartbeat, **before** the adapter spawns the
+agent process:
+
+```ts
+import { applyRuntimeEnvProviderHooks } from "@paperclipai/server/services/plugin-hooks";
+
+const { env, runtimeFiles } = await applyRuntimeEnvProviderHooks(registry, {
+  issue,
+  agentId,
+  agentRole,
+  companyId,
+  runId,
+  adapterType: "claude_local",
+  adapterConfig,
+});
+
+// Adapter then merges `env` into the spawned process env and writes
+// runtimeFiles into <runDir>/<path>.
+```
+
+## Semantics
+
+| Concern | Behaviour |
+| --- | --- |
+| Default budget | `DEFAULT_RUNTIME_ENV_BUDGET_MS = 200`. Wider than wake/skill (50 / 20 ms) because providers may legitimately fetch a fresh PAT. |
+| Per-handler timeout | `10 × budget` by default; configurable via `ApplyOptions.perHandlerTimeoutMs`. |
+| Order | Priority asc, deterministic insertion seq tie-break. Same as the other hooks. |
+| Conflicts (env) | Last-write-wins by priority order. |
+| Conflicts (files) | Keyed by `path`, last-write-wins by priority order. |
+| Predicate gating | Standard `when` predicates supported (`issueFieldEquals`, `agentRoleEquals`, `all/any/not`). |
+| Empty registry | Returns `EMPTY_RUNTIME_ENV_RESULT` (frozen, shared). |
+| Bad env key | Drops the entire hook return with `handler_returned_invalid` telemetry. Other hooks continue. |
+| Bad file path (absolute, `..`, drive letter, NUL) | Drops that file with a `runtime_file_rejected` telemetry record. Other files in the same return are kept. |
+| File mode | Defaults to `0o600`; explicit modes are clamped to the 12 POSIX bits. |
+
+### Why the env-key validation is strict
+
+Spawn implementations on Windows, macOS and Linux all disagree on what
+characters they tolerate in env names. `[A-Za-z_][A-Za-z0-9_]*` is the
+POSIX-portable subset. A plugin that ships a non-portable key is broken on
+some platforms; we'd rather refuse it loudly with telemetry than ship a
+partially-working credential to the spawned process.
+
+### Why the path validation is strict
+
+`<runDir>/<path>` is a host-controlled write. Any traversal lets a plugin
+write arbitrary files into the host filesystem (`/etc/passwd`,
+`~/.ssh/authorized_keys`). The validator rejects:
+
+- absolute POSIX paths (`/...`)
+- absolute Windows paths (`C:\...`, `\\...`)
+- any segment equal to `.` or `..`
+- any segment containing `\0`
+
+Rejections are emitted to `onError({ reason: "runtime_file_rejected" })`
+so plugin authors see them in the dev/CI log.
+
+## Example plugin: `gh-identity-provider`
+
+A plugin that resolves a per-agent GitHub PAT from a secret store and
+exposes it as `GH_TOKEN` + the matching git author identity:
+
+```ts
+// packages/plugins/examples/plugin-gh-identity-provider/src/worker.ts
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+import { resolveGitIdentity } from "./resolve.js";
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.logger.info("gh-identity-provider ready");
+  },
+  hooks: {
+    runtimeEnvProvider: async (_current, context) => {
+      const identity = await resolveGitIdentity({
+        agentId: context.agentId,
+        companyId: context.companyId,
+        adapterType: context.adapterType,
+      });
+      if (!identity) return { env: {} };
+      return {
+        env: {
+          GH_TOKEN: identity.token,
+          GIT_AUTHOR_NAME: identity.userName,
+          GIT_AUTHOR_EMAIL: identity.userEmail,
+          GIT_COMMITTER_NAME: identity.userName,
+          GIT_COMMITTER_EMAIL: identity.userEmail,
+          GIT_CONFIG_GLOBAL: ".gitconfig",
+        },
+        runtimeFiles: [
+          {
+            path: ".gitconfig",
+            content: `[user]\n  name = ${identity.userName}\n  email = ${identity.userEmail}\n`,
+            mode: 0o600,
+          },
+        ],
+      };
+    },
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);
+```
+
+> The `hooks.runtimeEnvProvider` field on `definePlugin()` is part of the
+> SDK surface that lands with MYO-61. Until MYO-61 is merged, plugins
+> register through the registry directly via
+> `registry.register({ kind: "runtimeEnvProvider", … })` (see the
+> `__tests__/plugin-hooks-runtime-env.test.ts` for working snippets).
+
+## Predicate cookbook
+
+Restrict a hook to a single adapter type:
+
+```ts
+{
+  when: { issueFieldEquals: { field: "adapterType", value: "claude_local" } },
+}
+```
+
+Only run for engineer-role agents in fast-action mode:
+
+```ts
+{
+  when: {
+    all: [
+      { agentRoleEquals: "engineer" },
+      { issueFieldEquals: { field: "fastAction", value: true } },
+    ],
+  },
+}
+```
+
+## Phase plan
+
+| Phase | Deliverable | Issue |
+| --- | --- | --- |
+| 1c | Hook surface in registry/apply, types, tests, docs | **MYO-80 (this PR)** |
+| 2 | Wire `applyRuntimeEnvProviderHooks` into the adapter spawn flow (`packages/adapters/*/src/server/execute.ts`) | follow-up |
+| 3 | Migrate `claude_local` Git identity injection (Phase 1B) onto the hook so it stops being adapter-specific | follow-up of MYO-76 |
+| 4 | SDK exposure on `definePlugin({ hooks })` | merges with MYO-61 |
+| 5 | First-party `gh-identity-provider` example plugin | follow-up |
+
+## Acceptance traceability
+
+- [x] Hook `runtimeEnvProvider` registrable via the MYO-62 registry —
+  `register({ kind: "runtimeEnvProvider", ... })` and
+  `registerManifestEntries({ declarations: { runtimeEnvProvider: ... } })`.
+- [ ] `claude_local` consumes the hook instead of inline logic — *deferred
+  to the Phase 2 wiring follow-up; safe in isolation since no call-site in
+  core uses the hook yet.*
+- [x] Plugin authoring doc updated with the hook — this file.
+- [x] Integration test: plugin registers a provider that injects `FOO=bar`
+  → exposed in the merged result. See
+  `server/src/__tests__/plugin-hooks-runtime-env.test.ts` —
+  *registers and merges env from a single hook (FOO=bar acceptance)*.
+- [x] No future adapter needs to patch core to carry per-run env — once
+  Phase 2 lands the hook in the spawn flow, codex_local / OpenClaw / future
+  adapters can stay vanilla.

--- a/server/src/__tests__/plugin-hooks-apply.test.ts
+++ b/server/src/__tests__/plugin-hooks-apply.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applySkillResolverTransformers,
+  applyWakePayloadTransformers,
+  DEFAULT_SKILL_BUDGET_MS,
+  DEFAULT_WAKE_BUDGET_MS,
+} from "../services/plugin-hooks/apply.js";
+import { createPluginHookRegistry } from "../services/plugin-hooks/registry.js";
+import type {
+  PluginHookIssueContext,
+  WakePayload,
+} from "../services/plugin-hooks/types.js";
+
+const issue: PluginHookIssueContext = {
+  issueId: "issue-1",
+  companyId: "company-1",
+  fields: { fastAction: true, mode: "fast" },
+};
+
+interface Recorded {
+  applied: Array<{ pluginId: string; durationMs: number; hook: string }>;
+  skipped: Array<{ pluginId: string; reason: string; hook: string }>;
+  errors: Array<{ pluginId: string; reason: string; hook: string }>;
+}
+
+function recorder(): {
+  sink: Parameters<typeof applyWakePayloadTransformers>[3] extends infer T
+    ? T extends { telemetry?: infer S }
+      ? NonNullable<S>
+      : never
+    : never;
+  recorded: Recorded;
+} {
+  const recorded: Recorded = { applied: [], skipped: [], errors: [] };
+  const sink = {
+    recordApplied(args: { pluginId: string; durationMs: number; hook: string }) {
+      recorded.applied.push({ pluginId: args.pluginId, durationMs: args.durationMs, hook: args.hook });
+    },
+    recordSkipped(args: { pluginId: string; reason: string; hook: string }) {
+      recorded.skipped.push({ pluginId: args.pluginId, reason: args.reason, hook: args.hook });
+    },
+    recordError(args: { pluginId: string; reason: string; hook: string }) {
+      recorded.errors.push({ pluginId: args.pluginId, reason: args.reason, hook: args.hook });
+    },
+  } as never;
+  return { sink, recorded };
+}
+
+describe("applyWakePayloadTransformers", () => {
+  it("returns the input untouched when the registry is empty", async () => {
+    const registry = createPluginHookRegistry();
+    const payload: WakePayload = { issueId: "i" };
+    const out = await applyWakePayloadTransformers(registry, payload, { issue });
+    expect(out).toBe(payload);
+  });
+
+  it("default budget exposed for documentation", () => {
+    expect(DEFAULT_WAKE_BUDGET_MS).toBe(50);
+    expect(DEFAULT_SKILL_BUDGET_MS).toBe(20);
+  });
+
+  it("invokes hooks in priority order and threads the payload", async () => {
+    const registry = createPluginHookRegistry();
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-second",
+      pluginKey: "second",
+      priority: 50,
+      handler: (payload) => ({ ...payload, sequence: [...((payload.sequence as string[]) ?? []), "second"] }),
+    });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-first",
+      pluginKey: "first",
+      priority: 10,
+      handler: (payload) => ({ ...payload, sequence: [...((payload.sequence as string[]) ?? []), "first"] }),
+    });
+    const out = await applyWakePayloadTransformers(registry, { sequence: [] }, { issue });
+    expect(out.sequence).toEqual(["first", "second"]);
+  });
+
+  it("skips hooks whose `when` predicate is false", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-skip",
+      pluginKey: "skip",
+      when: { issueFieldEquals: { field: "fastAction", value: false } },
+      handler: () => ({ shouldNotRun: true }),
+    });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-run",
+      pluginKey: "run",
+      when: { issueHasField: "fastAction" },
+      handler: (payload) => ({ ...payload, ran: true }),
+    });
+    const out = await applyWakePayloadTransformers(registry, {}, { issue }, { telemetry: sink });
+    expect(out).toEqual({ ran: true });
+    expect(recorded.skipped.map((e) => e.pluginId)).toEqual(["p-skip"]);
+    expect(recorded.applied.map((e) => e.pluginId)).toEqual(["p-run"]);
+  });
+
+  it("isolates handler errors and continues the chain", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-throw",
+      pluginKey: "throw",
+      priority: 10,
+      handler: () => {
+        throw new Error("boom");
+      },
+    });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-good",
+      pluginKey: "good",
+      priority: 20,
+      handler: (payload) => ({ ...payload, good: true }),
+    });
+    const out = await applyWakePayloadTransformers(
+      registry,
+      { initial: true },
+      { issue },
+      { telemetry: sink },
+    );
+    expect(out).toEqual({ initial: true, good: true });
+    expect(recorded.errors).toMatchObject([{ pluginId: "p-throw", reason: "handler_threw" }]);
+    expect(recorded.applied.map((e) => e.pluginId)).toEqual(["p-good"]);
+  });
+
+  it("rejects non-object handler returns and records handler_returned_invalid", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-bad",
+      pluginKey: "bad",
+      handler: () => "not an object" as never,
+    });
+    const out = await applyWakePayloadTransformers(
+      registry,
+      { initial: true },
+      { issue },
+      { telemetry: sink },
+    );
+    expect(out).toEqual({ initial: true });
+    expect(recorded.errors[0]?.reason).toBe("handler_returned_invalid");
+  });
+
+  it("stops dispatching once the cumulative budget is exhausted", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    let virtualClock = 0;
+    const tick = (ms: number) => {
+      virtualClock += ms;
+    };
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-slow-1",
+      pluginKey: "slow-1",
+      priority: 10,
+      handler: async (payload) => {
+        tick(40);
+        return { ...payload, slow1: true };
+      },
+    });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-slow-2",
+      pluginKey: "slow-2",
+      priority: 20,
+      handler: async (payload) => {
+        tick(30);
+        return { ...payload, slow2: true };
+      },
+    });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-skipped",
+      pluginKey: "skipped",
+      priority: 30,
+      handler: () => ({ skipped: true }),
+    });
+    const out = await applyWakePayloadTransformers(
+      registry,
+      {},
+      { issue },
+      {
+        telemetry: sink,
+        budgetMs: 50,
+        now: () => virtualClock,
+      },
+    );
+    expect(out).toEqual({ slow1: true, slow2: true });
+    expect(recorded.applied.map((e) => e.pluginId)).toEqual(["p-slow-1", "p-slow-2"]);
+    expect(recorded.skipped[0]).toMatchObject({ pluginId: "p-skipped", reason: "budget_exhausted" });
+  });
+
+  it("times out a handler that exceeds the per-handler timeout", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-stuck",
+      pluginKey: "stuck",
+      handler: () => new Promise<never>(() => {}),
+    });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-recover",
+      pluginKey: "recover",
+      handler: (payload) => ({ ...payload, recover: true }),
+    });
+    const out = await applyWakePayloadTransformers(
+      registry,
+      {},
+      { issue },
+      { telemetry: sink, perHandlerTimeoutMs: 5 },
+    );
+    expect(out).toEqual({ recover: true });
+    expect(recorded.errors[0]?.reason).toBe("handler_timed_out");
+  });
+});
+
+describe("applySkillResolverTransformers", () => {
+  const skillContext = {
+    issue,
+    agentId: "agent-1",
+    agentRole: "founding_engineer",
+  };
+
+  it("respects the 20ms default budget", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    let virtualClock = 0;
+    registry.register({
+      kind: "skillResolverTransformer",
+      pluginId: "p-1",
+      pluginKey: "p-1",
+      priority: 10,
+      handler: (current) => {
+        virtualClock += 15;
+        return { skills: [...current.skills, "alpha"] };
+      },
+    });
+    registry.register({
+      kind: "skillResolverTransformer",
+      pluginId: "p-2",
+      pluginKey: "p-2",
+      priority: 20,
+      handler: (current) => {
+        virtualClock += 10;
+        return { skills: [...current.skills, "beta"] };
+      },
+    });
+    registry.register({
+      kind: "skillResolverTransformer",
+      pluginId: "p-3",
+      pluginKey: "p-3",
+      priority: 30,
+      handler: (current) => ({ skills: [...current.skills, "gamma"] }),
+    });
+    const out = await applySkillResolverTransformers(
+      registry,
+      { skills: ["base"] },
+      skillContext,
+      { telemetry: sink, now: () => virtualClock },
+    );
+    expect(out.skills).toEqual(["base", "alpha", "beta"]);
+    expect(recorded.skipped[0]).toMatchObject({ pluginId: "p-3", reason: "budget_exhausted" });
+  });
+
+  it("normalises array results into SkillResolverResult", async () => {
+    const registry = createPluginHookRegistry();
+    registry.register({
+      kind: "skillResolverTransformer",
+      pluginId: "p-1",
+      pluginKey: "p-1",
+      handler: () => ["override"] as never,
+    });
+    const out = await applySkillResolverTransformers(
+      registry,
+      { skills: ["base"], required: ["base"] },
+      skillContext,
+    );
+    expect(out.skills).toEqual(["override"]);
+    expect(out.required).toEqual(["base"]);
+  });
+
+  it("rejects handler results with non-string entries", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    registry.register({
+      kind: "skillResolverTransformer",
+      pluginId: "p-bad",
+      pluginKey: "bad",
+      handler: () => ({ skills: ["ok", 42 as unknown as string] }),
+    });
+    const out = await applySkillResolverTransformers(
+      registry,
+      { skills: ["base"] },
+      skillContext,
+      { telemetry: sink },
+    );
+    expect(out.skills).toEqual(["base"]);
+    expect(recorded.errors[0]?.reason).toBe("handler_returned_invalid");
+  });
+
+  it("forwards onError callbacks for handler failures", async () => {
+    const registry = createPluginHookRegistry();
+    const onError = vi.fn();
+    registry.register({
+      kind: "skillResolverTransformer",
+      pluginId: "p-err",
+      pluginKey: "err",
+      handler: () => {
+        throw new Error("nope");
+      },
+    });
+    await applySkillResolverTransformers(
+      registry,
+      { skills: ["base"] },
+      skillContext,
+      { onError },
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]![0]).toMatchObject({
+      hook: "skillResolverTransformer",
+      pluginId: "p-err",
+      reason: "handler_threw",
+    });
+  });
+});

--- a/server/src/__tests__/plugin-hooks-predicates.test.ts
+++ b/server/src/__tests__/plugin-hooks-predicates.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { evaluateWhen } from "../services/plugin-hooks/predicates.js";
+import type { PluginHookIssueContext } from "../services/plugin-hooks/types.js";
+
+const issue: PluginHookIssueContext = {
+  issueId: "issue-1",
+  companyId: "company-1",
+  projectId: "project-1",
+  assigneeAgentId: "agent-1",
+  fields: {
+    fastAction: true,
+    priority: "high",
+    label: null,
+  },
+};
+
+describe("evaluateWhen", () => {
+  it("returns true when no predicate is provided", () => {
+    expect(evaluateWhen(null, { issue })).toBe(true);
+    expect(evaluateWhen(undefined, { issue })).toBe(true);
+  });
+
+  it("matches issueHasField only when the field is present", () => {
+    expect(evaluateWhen({ issueHasField: "fastAction" }, { issue })).toBe(true);
+    expect(evaluateWhen({ issueHasField: "missing" }, { issue })).toBe(false);
+  });
+
+  it("matches issueFieldEquals strictly on scalars", () => {
+    expect(
+      evaluateWhen({ issueFieldEquals: { field: "fastAction", value: true } }, { issue }),
+    ).toBe(true);
+    expect(
+      evaluateWhen({ issueFieldEquals: { field: "fastAction", value: false } }, { issue }),
+    ).toBe(false);
+    expect(
+      evaluateWhen({ issueFieldEquals: { field: "priority", value: "high" } }, { issue }),
+    ).toBe(true);
+  });
+
+  it("matches null values explicitly", () => {
+    expect(
+      evaluateWhen({ issueFieldEquals: { field: "label", value: null } }, { issue }),
+    ).toBe(true);
+  });
+
+  it("evaluates agentRoleEquals against the supplied role", () => {
+    expect(
+      evaluateWhen({ agentRoleEquals: "founding_engineer" }, {
+        issue,
+        agentRole: "founding_engineer",
+      }),
+    ).toBe(true);
+    expect(
+      evaluateWhen({ agentRoleEquals: "founding_engineer" }, { issue, agentRole: "ceo" }),
+    ).toBe(false);
+    expect(
+      evaluateWhen({ agentRoleEquals: "founding_engineer" }, { issue }),
+    ).toBe(false);
+  });
+
+  it("supports composite predicates", () => {
+    expect(
+      evaluateWhen(
+        {
+          all: [
+            { issueHasField: "fastAction" },
+            { issueFieldEquals: { field: "priority", value: "high" } },
+          ],
+        },
+        { issue },
+      ),
+    ).toBe(true);
+    expect(
+      evaluateWhen(
+        {
+          any: [
+            { issueFieldEquals: { field: "priority", value: "low" } },
+            { issueFieldEquals: { field: "priority", value: "high" } },
+          ],
+        },
+        { issue },
+      ),
+    ).toBe(true);
+    expect(
+      evaluateWhen(
+        { not: { issueFieldEquals: { field: "fastAction", value: false } } },
+        { issue },
+      ),
+    ).toBe(true);
+  });
+
+  it("treats malformed predicates as non-matches (fail-closed)", () => {
+    expect(evaluateWhen({} as never, { issue })).toBe(false);
+    expect(evaluateWhen({ issueHasField: 5 } as never, { issue })).toBe(false);
+    expect(evaluateWhen({ issueFieldEquals: {} } as never, { issue })).toBe(false);
+    expect(evaluateWhen("nope" as never, { issue })).toBe(false);
+  });
+
+  it("caps recursion depth", () => {
+    let nested: unknown = { issueHasField: "fastAction" };
+    for (let i = 0; i < 64; i += 1) nested = { not: nested };
+    expect(evaluateWhen(nested as never, { issue })).toBe(false);
+  });
+});

--- a/server/src/__tests__/plugin-hooks-registry.test.ts
+++ b/server/src/__tests__/plugin-hooks-registry.test.ts
@@ -1,0 +1,241 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import {
+  createPluginHookRegistry,
+  type PluginLifecycleSubset,
+} from "../services/plugin-hooks/registry.js";
+
+const noopHandler = (payload: Record<string, unknown>) => payload;
+
+function makeLifecycle(): PluginLifecycleSubset & {
+  emit: (event: "plugin.disabled" | "plugin.unloaded" | "plugin.error", payload: { pluginId: string }) => void;
+} {
+  const ee = new EventEmitter();
+  return {
+    on: ee.on.bind(ee) as PluginLifecycleSubset["on"],
+    off: ee.off.bind(ee) as NonNullable<PluginLifecycleSubset["off"]>,
+    emit: ee.emit.bind(ee),
+  };
+}
+
+describe("createPluginHookRegistry", () => {
+  it("registers and lists hook entries sorted by priority then insertion order", async () => {
+    const registry = createPluginHookRegistry();
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-mid",
+      pluginKey: "mid",
+      priority: 50,
+      handler: noopHandler,
+    });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-low",
+      pluginKey: "low",
+      priority: 10,
+      handler: noopHandler,
+    });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-high",
+      pluginKey: "high",
+      priority: 200,
+      handler: noopHandler,
+    });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-mid-2",
+      pluginKey: "mid-2",
+      priority: 50,
+      handler: noopHandler,
+    });
+
+    const list = await registry.list("wakePayloadTransformer", { companyId: "c-1" });
+    expect(list.map((e) => e.pluginId)).toEqual(["p-low", "p-mid", "p-mid-2", "p-high"]);
+  });
+
+  it("falls back to default priority when not provided or invalid", async () => {
+    const registry = createPluginHookRegistry();
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-default",
+      pluginKey: "default",
+      handler: noopHandler,
+    });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-explicit",
+      pluginKey: "explicit",
+      priority: 5,
+      handler: noopHandler,
+    });
+    const list = await registry.list("wakePayloadTransformer", { companyId: "c-1" });
+    expect(list.map((e) => e.pluginId)).toEqual(["p-explicit", "p-default"]);
+    expect(list.find((e) => e.pluginId === "p-default")?.priority).toBe(100);
+  });
+
+  it("filters out plugins not enabled for the company", async () => {
+    const registry = createPluginHookRegistry({
+      isPluginEnabledForCompany: (pluginId) => pluginId !== "p-blocked",
+    });
+    registry.register({
+      kind: "skillResolverTransformer",
+      pluginId: "p-allowed",
+      pluginKey: "allowed",
+      handler: (skills) => skills,
+    });
+    registry.register({
+      kind: "skillResolverTransformer",
+      pluginId: "p-blocked",
+      pluginKey: "blocked",
+      handler: (skills) => skills,
+    });
+    const list = await registry.list("skillResolverTransformer", { companyId: "c-1" });
+    expect(list.map((e) => e.pluginId)).toEqual(["p-allowed"]);
+  });
+
+  it("returns an empty list when the per-company feature flag is off", async () => {
+    const registry = createPluginHookRegistry({
+      isHooksEnabledForCompany: () => false,
+    });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-1",
+      pluginKey: "p-1",
+      handler: noopHandler,
+    });
+    const list = await registry.list("wakePayloadTransformer", { companyId: "c-1" });
+    expect(list).toHaveLength(0);
+  });
+
+  it("becomes a no-op when the registry-level kill switch is off", async () => {
+    const registry = createPluginHookRegistry({ enabled: false });
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-1",
+      pluginKey: "p-1",
+      handler: noopHandler,
+    });
+    expect(registry.size()).toBe(0);
+    expect(await registry.list("wakePayloadTransformer", { companyId: "c-1" })).toHaveLength(0);
+  });
+
+  it("registers manifest-declared hooks when a paired handler is provided", async () => {
+    const registry = createPluginHookRegistry();
+    const accepted = registry.registerManifestEntries({
+      pluginId: "p-decl",
+      pluginKey: "decl",
+      declarations: {
+        wakePayloadTransformer: { priority: 25, when: { issueHasField: "fastAction" } },
+        skillResolverTransformer: { priority: 5 },
+      },
+      handlers: {
+        wakePayloadTransformer: noopHandler,
+        // skillResolverTransformer handler intentionally omitted
+      },
+    });
+    expect(accepted.map((e) => e.kind)).toEqual(["wakePayloadTransformer"]);
+    const list = await registry.list("wakePayloadTransformer", { companyId: "c-1" });
+    expect(list).toHaveLength(1);
+    expect(list[0]!.priority).toBe(25);
+    expect(list[0]!.when).toEqual({ issueHasField: "fastAction" });
+  });
+
+  it("removes all of a plugin's hooks on unregisterPlugin", async () => {
+    const registry = createPluginHookRegistry();
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-1",
+      pluginKey: "p-1",
+      handler: noopHandler,
+    });
+    registry.register({
+      kind: "skillResolverTransformer",
+      pluginId: "p-1",
+      pluginKey: "p-1",
+      handler: (skills) => skills,
+    });
+    registry.register({
+      kind: "skillResolverTransformer",
+      pluginId: "p-2",
+      pluginKey: "p-2",
+      handler: (skills) => skills,
+    });
+    expect(registry.size()).toBe(3);
+    registry.unregisterPlugin("p-1");
+    expect(registry.size()).toBe(1);
+    expect(
+      (await registry.list("skillResolverTransformer", { companyId: "c-1" })).map((e) => e.pluginId),
+    ).toEqual(["p-2"]);
+  });
+
+  it("unregisters hooks when a lifecycle event fires", async () => {
+    const lifecycle = makeLifecycle();
+    const registry = createPluginHookRegistry();
+    registry.attachLifecycle(lifecycle);
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-1",
+      pluginKey: "p-1",
+      handler: noopHandler,
+    });
+    lifecycle.emit("plugin.disabled", { pluginId: "p-1" });
+    expect(registry.size()).toBe(0);
+
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-2",
+      pluginKey: "p-2",
+      handler: noopHandler,
+    });
+    lifecycle.emit("plugin.unloaded", { pluginId: "p-2" });
+    expect(registry.size()).toBe(0);
+
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-3",
+      pluginKey: "p-3",
+      handler: noopHandler,
+    });
+    lifecycle.emit("plugin.error", { pluginId: "p-3" });
+    expect(registry.size()).toBe(0);
+  });
+
+  it("reset() clears entries and detaches lifecycle listeners", async () => {
+    const lifecycle = makeLifecycle();
+    const registry = createPluginHookRegistry();
+    registry.attachLifecycle(lifecycle);
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-1",
+      pluginKey: "p-1",
+      handler: noopHandler,
+    });
+    registry.reset();
+    expect(registry.size()).toBe(0);
+
+    // After reset, lifecycle events must not affect newly registered hooks.
+    registry.register({
+      kind: "wakePayloadTransformer",
+      pluginId: "p-1",
+      pluginKey: "p-1",
+      handler: noopHandler,
+    });
+    lifecycle.emit("plugin.disabled", { pluginId: "p-1" });
+    expect(registry.size()).toBe(1);
+  });
+
+  it("keeps lookup with an empty registry under 1 ms", () => {
+    const registry = createPluginHookRegistry();
+    const iterations = 10_000;
+    const start = performance.now();
+    for (let i = 0; i < iterations; i += 1) {
+      registry.listUnfiltered("wakePayloadTransformer");
+      registry.listUnfiltered("skillResolverTransformer");
+    }
+    const elapsedNs = (performance.now() - start) * 1_000_000;
+    const perCallNs = elapsedNs / iterations;
+    // Documented exit criterion: lookup with no hooks installed < 1 ms.
+    expect(perCallNs).toBeLessThan(1_000_000);
+  });
+});

--- a/server/src/__tests__/plugin-hooks-registry.test.ts
+++ b/server/src/__tests__/plugin-hooks-registry.test.ts
@@ -232,10 +232,45 @@ describe("createPluginHookRegistry", () => {
     for (let i = 0; i < iterations; i += 1) {
       registry.listUnfiltered("wakePayloadTransformer");
       registry.listUnfiltered("skillResolverTransformer");
+      registry.listUnfiltered("runtimeEnvProvider");
     }
     const elapsedNs = (performance.now() - start) * 1_000_000;
     const perCallNs = elapsedNs / iterations;
     // Documented exit criterion: lookup with no hooks installed < 1 ms.
     expect(perCallNs).toBeLessThan(1_000_000);
+  });
+
+  it("supports the runtimeEnvProvider kind end-to-end (register / list / manifest / lifecycle)", async () => {
+    const lifecycle = makeLifecycle();
+    const registry = createPluginHookRegistry();
+    registry.attachLifecycle(lifecycle);
+
+    const accepted = registry.registerManifestEntries({
+      pluginId: "gh-identity-provider",
+      pluginKey: "gh-identity",
+      declarations: {
+        runtimeEnvProvider: { priority: 25, when: { issueHasField: "adapterType" } },
+      },
+      handlers: {
+        runtimeEnvProvider: (current) => current,
+      },
+    });
+    expect(accepted.map((e) => e.kind)).toEqual(["runtimeEnvProvider"]);
+
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-second",
+      pluginKey: "second",
+      priority: 5,
+      handler: (current) => current,
+    });
+
+    const list = await registry.list("runtimeEnvProvider", { companyId: "c-1" });
+    expect(list.map((e) => e.pluginId)).toEqual(["p-second", "gh-identity-provider"]);
+
+    lifecycle.emit("plugin.unloaded", { pluginId: "gh-identity-provider" });
+    expect(
+      (await registry.list("runtimeEnvProvider", { companyId: "c-1" })).map((e) => e.pluginId),
+    ).toEqual(["p-second"]);
   });
 });

--- a/server/src/__tests__/plugin-hooks-runtime-env.test.ts
+++ b/server/src/__tests__/plugin-hooks-runtime-env.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyRuntimeEnvProviderHooks,
+  DEFAULT_RUNTIME_ENV_BUDGET_MS,
+} from "../services/plugin-hooks/apply.js";
+import { createPluginHookRegistry } from "../services/plugin-hooks/registry.js";
+import {
+  EMPTY_RUNTIME_ENV_RESULT,
+  type PluginHookIssueContext,
+  type RuntimeEnvProviderContext,
+} from "../services/plugin-hooks/types.js";
+
+const issue: PluginHookIssueContext = {
+  issueId: "issue-1",
+  companyId: "company-1",
+  fields: { adapterType: "claude_local" },
+};
+
+function makeContext(
+  override: Partial<RuntimeEnvProviderContext> = {},
+): RuntimeEnvProviderContext {
+  return {
+    issue,
+    agentId: "agent-1",
+    agentRole: "engineer",
+    companyId: "company-1",
+    runId: "run-1",
+    adapterType: "claude_local",
+    adapterConfig: {},
+    ...override,
+  };
+}
+
+interface Recorded {
+  applied: Array<{ pluginId: string; durationMs: number; hook: string }>;
+  skipped: Array<{ pluginId: string; reason: string; hook: string }>;
+  errors: Array<{ pluginId: string; reason: string; hook: string }>;
+}
+
+function recorder(): {
+  sink: Parameters<typeof applyRuntimeEnvProviderHooks>[2] extends infer T
+    ? T extends { telemetry?: infer S }
+      ? NonNullable<S>
+      : never
+    : never;
+  recorded: Recorded;
+} {
+  const recorded: Recorded = { applied: [], skipped: [], errors: [] };
+  const sink = {
+    recordApplied(args: { pluginId: string; durationMs: number; hook: string }) {
+      recorded.applied.push({ pluginId: args.pluginId, durationMs: args.durationMs, hook: args.hook });
+    },
+    recordSkipped(args: { pluginId: string; reason: string; hook: string }) {
+      recorded.skipped.push({ pluginId: args.pluginId, reason: args.reason, hook: args.hook });
+    },
+    recordError(args: { pluginId: string; reason: string; hook: string }) {
+      recorded.errors.push({ pluginId: args.pluginId, reason: args.reason, hook: args.hook });
+    },
+  } as never;
+  return { sink, recorded };
+}
+
+describe("applyRuntimeEnvProviderHooks", () => {
+  it("returns the empty result when the registry is empty", async () => {
+    const registry = createPluginHookRegistry();
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext());
+    expect(out).toBe(EMPTY_RUNTIME_ENV_RESULT);
+    expect(out.env).toEqual({});
+    expect(out.runtimeFiles).toBeUndefined();
+  });
+
+  it("default budget exposed for documentation", () => {
+    expect(DEFAULT_RUNTIME_ENV_BUDGET_MS).toBe(200);
+  });
+
+  it("registers and merges env from a single hook (FOO=bar acceptance)", async () => {
+    // MYO-80 acceptance: a third-party plugin injects FOO=bar and the merged
+    // result exposes it to the spawn caller.
+    const registry = createPluginHookRegistry();
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "third-party.gh-identity",
+      pluginKey: "gh-identity",
+      handler: () => ({ env: { FOO: "bar" } }),
+    });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext());
+    expect(out.env).toEqual({ FOO: "bar" });
+  });
+
+  it("threads context (agentId, runId, adapterType) into each handler", async () => {
+    const registry = createPluginHookRegistry();
+    let observed: RuntimeEnvProviderContext | null = null;
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-observe",
+      pluginKey: "observe",
+      handler: (current, ctx) => {
+        observed = ctx;
+        return current;
+      },
+    });
+    await applyRuntimeEnvProviderHooks(
+      registry,
+      makeContext({ agentId: "agent-99", runId: "run-99", adapterType: "codex_local" }),
+    );
+    expect(observed).toMatchObject({
+      agentId: "agent-99",
+      runId: "run-99",
+      adapterType: "codex_local",
+      companyId: "company-1",
+    });
+  });
+
+  it("merges env in priority order with last-write-wins semantics", async () => {
+    const registry = createPluginHookRegistry();
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-low",
+      pluginKey: "low",
+      priority: 10,
+      handler: () => ({ env: { GIT_AUTHOR_NAME: "low-priority" } }),
+    });
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-high",
+      pluginKey: "high",
+      priority: 20,
+      handler: (current) => ({
+        env: { ...current.env, GIT_AUTHOR_NAME: "high-priority" },
+      }),
+    });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext());
+    expect(out.env).toEqual({ GIT_AUTHOR_NAME: "high-priority" });
+  });
+
+  it("skips hooks whose `when` predicate is false", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-only-codex",
+      pluginKey: "only-codex",
+      when: { issueFieldEquals: { field: "adapterType", value: "codex_local" } },
+      handler: () => ({ env: { CODEX_ONLY: "1" } }),
+    });
+    const out = await applyRuntimeEnvProviderHooks(
+      registry,
+      makeContext({ adapterType: "claude_local" }),
+      { telemetry: sink },
+    );
+    expect(out.env).toEqual({});
+    expect(recorded.skipped[0]?.reason).toBe("predicate_false");
+  });
+
+  it("isolates handler errors and continues the chain", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-throw",
+      pluginKey: "throw",
+      priority: 10,
+      handler: () => {
+        throw new Error("boom");
+      },
+    });
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-good",
+      pluginKey: "good",
+      priority: 20,
+      handler: (current) => ({ env: { ...current.env, GOOD: "1" } }),
+    });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext(), { telemetry: sink });
+    expect(out.env).toEqual({ GOOD: "1" });
+    expect(recorded.errors).toMatchObject([{ pluginId: "p-throw", reason: "handler_threw" }]);
+    expect(recorded.applied.map((e) => e.pluginId)).toEqual(["p-good"]);
+  });
+
+  it("rejects invalid env keys (not POSIX-portable) and records handler_returned_invalid", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-bad-key",
+      pluginKey: "bad-key",
+      handler: () => ({ env: { "BAD-KEY!": "value" } }),
+    });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext(), { telemetry: sink });
+    expect(out.env).toEqual({});
+    expect(recorded.errors[0]?.reason).toBe("handler_returned_invalid");
+  });
+
+  it("rejects non-string env values", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-num",
+      pluginKey: "num",
+      handler: () => ({ env: { COUNT: 7 } }) as never,
+    });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext(), { telemetry: sink });
+    expect(out.env).toEqual({});
+    expect(recorded.errors[0]?.reason).toBe("handler_returned_invalid");
+  });
+
+  it("accepts runtimeFiles with relative paths and applies a default 0o600 mode", async () => {
+    const registry = createPluginHookRegistry();
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-files",
+      pluginKey: "files",
+      handler: () => ({
+        env: { GIT_CONFIG_GLOBAL: ".gitconfig" },
+        runtimeFiles: [{ path: ".gitconfig", content: "[user]\n  name = bot" }],
+      }),
+    });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext());
+    expect(out.runtimeFiles).toEqual([
+      { path: ".gitconfig", content: "[user]\n  name = bot", mode: 0o600 },
+    ]);
+  });
+
+  it("rejects absolute paths and parent-traversal segments without aborting the chain", async () => {
+    const registry = createPluginHookRegistry();
+    const errors: Array<{ reason: string; pluginId: string }> = [];
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-escape",
+      pluginKey: "escape",
+      handler: () => ({
+        env: {},
+        runtimeFiles: [
+          { path: "/etc/passwd", content: "rooted" },
+          { path: "../escape", content: "traversal" },
+          { path: "C:\\Windows\\evil.txt", content: "windows" },
+          { path: "ok.txt", content: "kept" },
+        ],
+      }),
+    });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext(), {
+      onError: (event) => errors.push({ reason: event.reason, pluginId: event.pluginId }),
+    });
+    expect(out.runtimeFiles).toEqual([
+      { path: "ok.txt", content: "kept", mode: 0o600 },
+    ]);
+    expect(errors.filter((e) => e.reason === "runtime_file_rejected")).toHaveLength(3);
+  });
+
+  it("normalises file paths and preserves explicit mode bits", async () => {
+    const registry = createPluginHookRegistry();
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-mode",
+      pluginKey: "mode",
+      handler: () => ({
+        env: {},
+        runtimeFiles: [
+          { path: "nested//dir///file.txt", content: "ok", mode: 0o644 },
+          // Non-mode bits (setuid 0o4000) get clamped away by the host.
+          { path: "secret", content: "k", mode: 0o4600 },
+        ],
+      }),
+    });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext());
+    const sorted = (out.runtimeFiles ?? []).slice().sort((a, b) => a.path.localeCompare(b.path));
+    expect(sorted).toEqual([
+      { path: "nested/dir/file.txt", content: "ok", mode: 0o644 },
+      { path: "secret", content: "k", mode: 0o4600 & 0o7777 },
+    ]);
+  });
+
+  it("later runtimeFiles overwrite earlier entries for the same path (last-write-wins)", async () => {
+    const registry = createPluginHookRegistry();
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-first",
+      pluginKey: "first",
+      priority: 10,
+      handler: () => ({
+        env: {},
+        runtimeFiles: [{ path: ".gitconfig", content: "first" }],
+      }),
+    });
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-second",
+      pluginKey: "second",
+      priority: 20,
+      handler: (current) => ({
+        env: current.env,
+        runtimeFiles: [
+          ...(current.runtimeFiles ?? []),
+          { path: ".gitconfig", content: "second" },
+        ],
+      }),
+    });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext());
+    expect(out.runtimeFiles).toEqual([
+      { path: ".gitconfig", content: "second", mode: 0o600 },
+    ]);
+  });
+
+  it("stops dispatching once the cumulative budget is exhausted", async () => {
+    const registry = createPluginHookRegistry();
+    const { sink, recorded } = recorder();
+    let virtualClock = 0;
+    const tick = (ms: number) => {
+      virtualClock += ms;
+    };
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-slow-1",
+      pluginKey: "slow-1",
+      priority: 10,
+      handler: async (current) => {
+        tick(120);
+        return { env: { ...current.env, FIRST: "1" } };
+      },
+    });
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-slow-2",
+      pluginKey: "slow-2",
+      priority: 20,
+      handler: async (current) => {
+        tick(120);
+        return { env: { ...current.env, SECOND: "1" } };
+      },
+    });
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-skipped",
+      pluginKey: "skipped",
+      priority: 30,
+      handler: () => ({ env: { SKIPPED: "1" } }),
+    });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext(), {
+      telemetry: sink,
+      budgetMs: 200,
+      now: () => virtualClock,
+    });
+    expect(out.env).toEqual({ FIRST: "1", SECOND: "1" });
+    expect(recorded.applied.map((e) => e.pluginId)).toEqual(["p-slow-1", "p-slow-2"]);
+    expect(recorded.skipped.map((e) => e.pluginId)).toContain("p-skipped");
+  });
+
+  it("does not call hooks when the registry is globally disabled", async () => {
+    const registry = createPluginHookRegistry({ enabled: false });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext());
+    expect(out).toBe(EMPTY_RUNTIME_ENV_RESULT);
+  });
+
+  it("respects the per-company hook feature flag", async () => {
+    const registry = createPluginHookRegistry({
+      isHooksEnabledForCompany: (companyId) => companyId !== "company-1",
+    });
+    registry.register({
+      kind: "runtimeEnvProvider",
+      pluginId: "p-blocked-company",
+      pluginKey: "blocked",
+      handler: () => ({ env: { LEAK: "should-not-appear" } }),
+    });
+    const out = await applyRuntimeEnvProviderHooks(registry, makeContext());
+    expect(out.env).toEqual({});
+  });
+});

--- a/server/src/services/plugin-hooks/apply.ts
+++ b/server/src/services/plugin-hooks/apply.ts
@@ -1,0 +1,326 @@
+/**
+ * Apply layer for plugin hooks.
+ *
+ * Each hook kind has its own `apply...Transformers()` entry point that:
+ *  1. Pulls the registered entries from the registry (already filtered by
+ *     company eligibility + global feature flag).
+ *  2. Iterates them in priority order, evaluating the `when` predicate.
+ *  3. Runs each handler with a per-call budget; stops dispatching new hooks
+ *     once the cumulative budget is exhausted (in-flight hooks still
+ *     complete).
+ *  4. Isolates handler errors — a thrown / timed-out / invalid-result hook
+ *     drops its contribution but never aborts the chain.
+ *  5. Emits telemetry for applied/skipped/error outcomes.
+ *
+ * No call-site wires this in yet (Phase 2 — MYO-63). The signatures are
+ * shaped so call-sites can drop them in as a tail step:
+ *
+ * ```ts
+ * payload = await applyWakePayloadTransformers(registry, payload, ctx);
+ * ```
+ */
+
+import type {
+  PluginHookEntry,
+  PluginHookErrorReason,
+  PluginHookIssueContext,
+  PluginHookSkipReason,
+  SkillResolverResult,
+  SkillResolverTransformer,
+  SkillResolverTransformerContext,
+  WakePayload,
+  WakePayloadTransformer,
+  WakePayloadTransformerContext,
+} from "./types.js";
+import { evaluateWhen } from "./predicates.js";
+import {
+  NOOP_SINK,
+  createTelemetrySink,
+  type HookTelemetrySink,
+  type MinimalTelemetryClient,
+} from "./metrics.js";
+import type { PluginHookRegistry } from "./registry.js";
+
+/** Default total budget for the wake-payload chain — see issue MYO-62. */
+export const DEFAULT_WAKE_BUDGET_MS = 50;
+/** Default total budget for the skill-resolver chain — see issue MYO-62. */
+export const DEFAULT_SKILL_BUDGET_MS = 20;
+/** Per-handler timeout safety net (10× the per-call budget). */
+const DEFAULT_PER_HANDLER_TIMEOUT_MULTIPLIER = 10;
+
+export interface ApplyOptions {
+  /** Total budget in milliseconds for the whole chain. */
+  budgetMs?: number;
+  /** Per-handler timeout in milliseconds. Defaults to 10× `budgetMs`. */
+  perHandlerTimeoutMs?: number;
+  telemetry?: HookTelemetrySink | MinimalTelemetryClient | null;
+  /** Optional hook-error logger. Defaults to `console.warn`. */
+  onError?: (event: HookErrorEvent) => void;
+  /** Wall-clock source — overridable for tests. */
+  now?: () => number;
+}
+
+export interface HookErrorEvent {
+  hook: PluginHookEntry["kind"];
+  pluginId: string;
+  pluginKey: string;
+  reason: PluginHookErrorReason;
+  durationMs: number;
+  error?: unknown;
+}
+
+export interface HookSkipEvent {
+  hook: PluginHookEntry["kind"];
+  pluginId: string;
+  pluginKey: string;
+  reason: PluginHookSkipReason;
+}
+
+const DEFAULT_NOW = () => performance.now();
+const SILENT_ERROR_LOG: (event: HookErrorEvent) => void = () => {};
+
+function resolveSink(input: ApplyOptions["telemetry"]): HookTelemetrySink {
+  if (!input) return NOOP_SINK;
+  if (typeof (input as HookTelemetrySink).recordApplied === "function") {
+    return input as HookTelemetrySink;
+  }
+  return createTelemetrySink(input as MinimalTelemetryClient);
+}
+
+/**
+ * Apply the wake-payload transformer chain. Returns the (possibly modified)
+ * payload. Never throws — handler errors are isolated.
+ */
+export async function applyWakePayloadTransformers(
+  registry: PluginHookRegistry,
+  payload: WakePayload,
+  context: WakePayloadTransformerContext,
+  options: ApplyOptions = {},
+): Promise<WakePayload> {
+  if (!registry.isEnabled || registry.size() === 0) return payload;
+
+  const entries = await registry.list("wakePayloadTransformer", {
+    companyId: context.issue.companyId,
+  });
+  if (entries.length === 0) return payload;
+
+  return runChain<WakePayload>({
+    entries,
+    initial: payload,
+    runHandler: (entry, current) =>
+      (entry.handler as WakePayloadTransformer)(current, context),
+    validateResult: (result) => (isPlainObject(result) ? (result as WakePayload) : undefined),
+    issue: context.issue,
+    agentRole: context.agentRole,
+    options,
+    defaultBudgetMs: DEFAULT_WAKE_BUDGET_MS,
+  });
+}
+
+/**
+ * Apply the skill-resolver transformer chain. The chain accumulates a
+ * `SkillResolverResult`; call-sites can collapse `result.skills` back to a
+ * `string[]` after.
+ */
+export async function applySkillResolverTransformers(
+  registry: PluginHookRegistry,
+  initial: SkillResolverResult,
+  context: SkillResolverTransformerContext,
+  options: ApplyOptions = {},
+): Promise<SkillResolverResult> {
+  if (!registry.isEnabled || registry.size() === 0) return initial;
+
+  const entries = await registry.list("skillResolverTransformer", {
+    companyId: context.issue.companyId,
+  });
+  if (entries.length === 0) return initial;
+
+  return runChain<SkillResolverResult>({
+    entries,
+    initial,
+    runHandler: (entry, current) =>
+      (entry.handler as SkillResolverTransformer)(current, context),
+    validateResult: (result, current) => normaliseSkillResult(result, current),
+    issue: context.issue,
+    agentRole: context.agentRole,
+    options,
+    defaultBudgetMs: DEFAULT_SKILL_BUDGET_MS,
+  });
+}
+
+interface ChainArgs<T> {
+  entries: readonly PluginHookEntry[];
+  initial: T;
+  runHandler: (entry: PluginHookEntry, current: T) => unknown;
+  validateResult: (result: unknown, current: T) => T | undefined;
+  issue: PluginHookIssueContext;
+  agentRole?: string;
+  options: ApplyOptions;
+  defaultBudgetMs: number;
+}
+
+async function runChain<T>(args: ChainArgs<T>): Promise<T> {
+  const now = args.options.now ?? DEFAULT_NOW;
+  const sink = resolveSink(args.options.telemetry);
+  const onError = args.options.onError ?? SILENT_ERROR_LOG;
+  const budgetMs = clampPositive(args.options.budgetMs, args.defaultBudgetMs);
+  const perHandlerTimeoutMs = clampPositive(
+    args.options.perHandlerTimeoutMs,
+    budgetMs * DEFAULT_PER_HANDLER_TIMEOUT_MULTIPLIER,
+  );
+  const startedAt = now();
+
+  let current = args.initial;
+
+  for (const entry of args.entries) {
+    const elapsed = now() - startedAt;
+    if (elapsed >= budgetMs) {
+      sink.recordSkipped({
+        hook: entry.kind,
+        pluginId: entry.pluginId,
+        pluginKey: entry.pluginKey,
+        reason: "budget_exhausted",
+      });
+      continue;
+    }
+
+    const matches = evaluateWhen(entry.when, {
+      issue: args.issue,
+      agentRole: args.agentRole,
+    });
+    if (!matches) {
+      sink.recordSkipped({
+        hook: entry.kind,
+        pluginId: entry.pluginId,
+        pluginKey: entry.pluginKey,
+        reason: "predicate_false",
+      });
+      continue;
+    }
+
+    const handlerStart = now();
+    let result: unknown;
+    try {
+      result = await raceWithTimeout(
+        () => Promise.resolve(args.runHandler(entry, current)),
+        perHandlerTimeoutMs,
+      );
+    } catch (err) {
+      const reason: PluginHookErrorReason =
+        err instanceof HookTimeoutError ? "handler_timed_out" : "handler_threw";
+      const durationMs = now() - handlerStart;
+      sink.recordError({
+        hook: entry.kind,
+        pluginId: entry.pluginId,
+        pluginKey: entry.pluginKey,
+        reason,
+        durationMs,
+      });
+      onError({
+        hook: entry.kind,
+        pluginId: entry.pluginId,
+        pluginKey: entry.pluginKey,
+        reason,
+        durationMs,
+        error: err,
+      });
+      continue;
+    }
+
+    const next = args.validateResult(result, current);
+    const handlerDuration = now() - handlerStart;
+    if (next === undefined) {
+      sink.recordError({
+        hook: entry.kind,
+        pluginId: entry.pluginId,
+        pluginKey: entry.pluginKey,
+        reason: "handler_returned_invalid",
+        durationMs: handlerDuration,
+      });
+      onError({
+        hook: entry.kind,
+        pluginId: entry.pluginId,
+        pluginKey: entry.pluginKey,
+        reason: "handler_returned_invalid",
+        durationMs: handlerDuration,
+      });
+      continue;
+    }
+    current = next;
+    sink.recordApplied({
+      hook: entry.kind,
+      pluginId: entry.pluginId,
+      pluginKey: entry.pluginKey,
+      durationMs: handlerDuration,
+    });
+  }
+
+  return current;
+}
+
+class HookTimeoutError extends Error {
+  constructor() {
+    super("Plugin hook timed out");
+    this.name = "HookTimeoutError";
+  }
+}
+
+function raceWithTimeout<T>(start: () => Promise<T>, timeoutMs: number): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return start();
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new HookTimeoutError());
+    }, timeoutMs);
+    if (typeof timer.unref === "function") timer.unref();
+    start().then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+function clampPositive(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return fallback;
+  return value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normaliseSkillResult(
+  result: unknown,
+  current: SkillResolverResult,
+): SkillResolverResult | undefined {
+  if (Array.isArray(result)) {
+    if (!result.every((s) => typeof s === "string")) return undefined;
+    return { skills: result.slice() as string[], required: current.required };
+  }
+  if (!isPlainObject(result)) return undefined;
+  const next = result as { skills?: unknown; required?: unknown };
+  if (!Array.isArray(next.skills) || !next.skills.every((s) => typeof s === "string")) {
+    return undefined;
+  }
+  if (next.required !== undefined) {
+    if (!Array.isArray(next.required) || !next.required.every((s) => typeof s === "string")) {
+      return undefined;
+    }
+  }
+  return {
+    skills: (next.skills as string[]).slice(),
+    required: next.required ? (next.required as string[]).slice() : current.required,
+  };
+}

--- a/server/src/services/plugin-hooks/apply.ts
+++ b/server/src/services/plugin-hooks/apply.ts
@@ -25,6 +25,10 @@ import type {
   PluginHookErrorReason,
   PluginHookIssueContext,
   PluginHookSkipReason,
+  RuntimeEnvProvider,
+  RuntimeEnvProviderContext,
+  RuntimeEnvProviderResult,
+  RuntimeFileSpec,
   SkillResolverResult,
   SkillResolverTransformer,
   SkillResolverTransformerContext,
@@ -32,6 +36,7 @@ import type {
   WakePayloadTransformer,
   WakePayloadTransformerContext,
 } from "./types.js";
+import { EMPTY_RUNTIME_ENV_RESULT } from "./types.js";
 import { evaluateWhen } from "./predicates.js";
 import {
   NOOP_SINK,
@@ -45,6 +50,15 @@ import type { PluginHookRegistry } from "./registry.js";
 export const DEFAULT_WAKE_BUDGET_MS = 50;
 /** Default total budget for the skill-resolver chain — see issue MYO-62. */
 export const DEFAULT_SKILL_BUDGET_MS = 20;
+/**
+ * Default total budget for the runtime-env-provider chain — see issue MYO-80.
+ *
+ * Sized larger than the wake/skill chains because runtime env providers may
+ * legitimately fetch a fresh PAT or read a secret store before each spawn.
+ * The host calls this once per heartbeat (not on every wake-payload build),
+ * so a wider budget does not add per-message overhead.
+ */
+export const DEFAULT_RUNTIME_ENV_BUDGET_MS = 200;
 /** Per-handler timeout safety net (10× the per-call budget). */
 const DEFAULT_PER_HANDLER_TIMEOUT_MULTIPLIER = 10;
 
@@ -145,6 +159,45 @@ export async function applySkillResolverTransformers(
     agentRole: context.agentRole,
     options,
     defaultBudgetMs: DEFAULT_SKILL_BUDGET_MS,
+  });
+}
+
+/**
+ * Apply the runtime-env-provider chain. Returns the merged env + runtimeFiles
+ * the host should inject before spawning the agent process.
+ *
+ * Each hook receives the previous result and must return a new
+ * {@link RuntimeEnvProviderResult}. Conflicts on the same env key resolve
+ * last-write-wins. Files are keyed by `path`; later hooks overwrite earlier
+ * entries.
+ *
+ * Hooks that return invalid env keys, absolute paths, or paths that escape
+ * the run directory are dropped with a `runtime_file_rejected` /
+ * `handler_returned_invalid` telemetry record — the chain continues with the
+ * previous result so a single bad plugin cannot break the whole heartbeat.
+ */
+export async function applyRuntimeEnvProviderHooks(
+  registry: PluginHookRegistry,
+  context: RuntimeEnvProviderContext,
+  options: ApplyOptions = {},
+): Promise<RuntimeEnvProviderResult> {
+  if (!registry.isEnabled || registry.size() === 0) return EMPTY_RUNTIME_ENV_RESULT;
+
+  const entries = await registry.list("runtimeEnvProvider", {
+    companyId: context.issue.companyId,
+  });
+  if (entries.length === 0) return EMPTY_RUNTIME_ENV_RESULT;
+
+  return runChain<RuntimeEnvProviderResult>({
+    entries,
+    initial: EMPTY_RUNTIME_ENV_RESULT,
+    runHandler: (entry, current) =>
+      (entry.handler as RuntimeEnvProvider)(current, context),
+    validateResult: (result, current) => mergeRuntimeEnvResult(result, current, options),
+    issue: context.issue,
+    agentRole: context.agentRole,
+    options,
+    defaultBudgetMs: DEFAULT_RUNTIME_ENV_BUDGET_MS,
   });
 }
 
@@ -299,6 +352,105 @@ function clampPositive(value: number | undefined, fallback: number): number {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Allowed characters in a runtime env var name. Mirrors the POSIX-portable
+ * subset (letter / digit / underscore, not starting with a digit) so the
+ * value is safe across spawn implementations on every supported platform.
+ */
+const RUNTIME_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+/** Default file mode applied when a runtimeEnvProvider hook omits it. */
+const DEFAULT_RUNTIME_FILE_MODE = 0o600;
+
+/**
+ * Validate and merge a `runtimeEnvProvider` hook return value into the
+ * accumulated result. Returns `undefined` (treated as "invalid result") when
+ * the shape is wrong; returns the new accumulated result when the shape is
+ * acceptable. Per-key / per-file rejections are silent at this layer — they
+ * are surfaced via `options.onError` so plugin authors can see them in the
+ * dev/CI log without poisoning the chain.
+ */
+function mergeRuntimeEnvResult(
+  result: unknown,
+  current: RuntimeEnvProviderResult,
+  options: ApplyOptions,
+): RuntimeEnvProviderResult | undefined {
+  if (!isPlainObject(result)) return undefined;
+  const next = result as { env?: unknown; runtimeFiles?: unknown };
+  if (next.env !== undefined && !isPlainObject(next.env)) return undefined;
+  if (next.runtimeFiles !== undefined && !Array.isArray(next.runtimeFiles)) {
+    return undefined;
+  }
+
+  const env: Record<string, string> = { ...current.env };
+  if (isPlainObject(next.env)) {
+    for (const [key, value] of Object.entries(next.env)) {
+      if (typeof value !== "string") return undefined;
+      if (!RUNTIME_ENV_KEY_PATTERN.test(key)) return undefined;
+      env[key] = value;
+    }
+  }
+
+  const filesByPath = new Map<string, RuntimeFileSpec>();
+  for (const f of current.runtimeFiles ?? []) filesByPath.set(f.path, f);
+
+  if (Array.isArray(next.runtimeFiles)) {
+    for (const candidate of next.runtimeFiles) {
+      const validated = validateRuntimeFile(candidate);
+      if (!validated) {
+        options.onError?.({
+          hook: "runtimeEnvProvider",
+          pluginId: "<unknown>",
+          pluginKey: "<unknown>",
+          reason: "runtime_file_rejected",
+          durationMs: 0,
+        });
+        continue;
+      }
+      filesByPath.set(validated.path, validated);
+    }
+  }
+
+  const runtimeFiles = filesByPath.size === 0 ? undefined : Array.from(filesByPath.values());
+  return runtimeFiles ? { env, runtimeFiles } : { env };
+}
+
+/**
+ * Reject any path that escapes the run dir. The host writes files at
+ * `<runDir>/<path>`; a hook that hands us `..`, `/etc/passwd`, or a Windows
+ * drive letter must be dropped. The check is intentionally strict because
+ * a single bypass here lets a plugin write arbitrary files into the host.
+ */
+function validateRuntimeFile(candidate: unknown): RuntimeFileSpec | null {
+  if (!isPlainObject(candidate)) return null;
+  const c = candidate as { path?: unknown; content?: unknown; mode?: unknown };
+  if (typeof c.path !== "string" || c.path.length === 0) return null;
+  if (typeof c.content !== "string") return null;
+
+  const path = c.path;
+  // Reject absolute paths (POSIX + Windows) and any backslash-style traversal.
+  if (path.startsWith("/") || path.startsWith("\\")) return null;
+  if (/^[A-Za-z]:[\\/]/.test(path)) return null;
+
+  const segments = path.split(/[\\/]+/).filter((s) => s.length > 0);
+  if (segments.length === 0) return null;
+  for (const segment of segments) {
+    if (segment === "." || segment === "..") return null;
+    if (segment.includes("\0")) return null;
+  }
+
+  let mode: number | undefined = DEFAULT_RUNTIME_FILE_MODE;
+  if (c.mode !== undefined) {
+    if (typeof c.mode !== "number" || !Number.isFinite(c.mode) || c.mode < 0) {
+      return null;
+    }
+    // Clamp to the 12 mode bits a POSIX file can carry. Anything outside is
+    // either a programmer mistake or an attempt to flip setuid/sticky bits.
+    mode = Math.floor(c.mode) & 0o7777;
+  }
+
+  return { path: segments.join("/"), content: c.content, mode };
 }
 
 function normaliseSkillResult(

--- a/server/src/services/plugin-hooks/index.ts
+++ b/server/src/services/plugin-hooks/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Plugin hook registry — Phase 1b. See server/src/services/plugin-hooks for
+ * the per-file responsibilities.
+ *
+ * The module is intentionally side-effect free. No call-site uses these
+ * exports yet (Phase 2 — MYO-63 wires them into `buildPaperclipWakePayload`
+ * and `resolvePaperclipDesiredSkillNames`).
+ */
+
+export {
+  createPluginHookRegistry,
+  type PluginHookRegistry,
+  type PluginHookRegistryOptions,
+  type PluginEnabledForCompanyFn,
+  type HooksEnabledForCompanyFn,
+  type ManifestHookDeclarations,
+  type PluginLifecycleSubset,
+} from "./registry.js";
+
+export {
+  applyWakePayloadTransformers,
+  applySkillResolverTransformers,
+  DEFAULT_WAKE_BUDGET_MS,
+  DEFAULT_SKILL_BUDGET_MS,
+  type ApplyOptions,
+  type HookErrorEvent,
+  type HookSkipEvent,
+} from "./apply.js";
+
+export { evaluateWhen, type PredicateContext } from "./predicates.js";
+
+export {
+  createTelemetrySink,
+  NOOP_SINK,
+  type HookTelemetrySink,
+  type MinimalTelemetryClient,
+} from "./metrics.js";
+
+export type {
+  PluginHookEntry,
+  PluginHookErrorReason,
+  PluginHookHandlerMap,
+  PluginHookIssueContext,
+  PluginHookKind,
+  PluginHookManifestEntry,
+  PluginHookSkipReason,
+  SkillResolverResult,
+  SkillResolverTransformer,
+  SkillResolverTransformerContext,
+  WakePayload,
+  WakePayloadTransformer,
+  WakePayloadTransformerContext,
+  WhenPredicate,
+} from "./types.js";

--- a/server/src/services/plugin-hooks/index.ts
+++ b/server/src/services/plugin-hooks/index.ts
@@ -20,8 +20,10 @@ export {
 export {
   applyWakePayloadTransformers,
   applySkillResolverTransformers,
+  applyRuntimeEnvProviderHooks,
   DEFAULT_WAKE_BUDGET_MS,
   DEFAULT_SKILL_BUDGET_MS,
+  DEFAULT_RUNTIME_ENV_BUDGET_MS,
   type ApplyOptions,
   type HookErrorEvent,
   type HookSkipEvent,
@@ -44,6 +46,10 @@ export type {
   PluginHookKind,
   PluginHookManifestEntry,
   PluginHookSkipReason,
+  RuntimeEnvProvider,
+  RuntimeEnvProviderContext,
+  RuntimeEnvProviderResult,
+  RuntimeFileSpec,
   SkillResolverResult,
   SkillResolverTransformer,
   SkillResolverTransformerContext,
@@ -52,3 +58,5 @@ export type {
   WakePayloadTransformerContext,
   WhenPredicate,
 } from "./types.js";
+
+export { EMPTY_RUNTIME_ENV_RESULT } from "./types.js";

--- a/server/src/services/plugin-hooks/metrics.ts
+++ b/server/src/services/plugin-hooks/metrics.ts
@@ -1,0 +1,87 @@
+/**
+ * Telemetry adapter for plugin-hook execution. Wraps the existing
+ * `TelemetryClient.track()` event surface so the apply layer can emit
+ * `paperclip_plugin_hook_*` style metrics without touching the underlying
+ * client directly.
+ *
+ * Phase 1b deliberately routes through the existing event-based telemetry
+ * (no new prom-style histogram). When/if the host gains a histogram surface
+ * we replace this adapter without touching `apply.ts`.
+ */
+
+import type { PluginHookErrorReason, PluginHookKind, PluginHookSkipReason } from "./types.js";
+
+export interface HookTelemetrySink {
+  recordApplied(args: {
+    hook: PluginHookKind;
+    pluginId: string;
+    pluginKey: string;
+    durationMs: number;
+  }): void;
+  recordSkipped(args: {
+    hook: PluginHookKind;
+    pluginId: string;
+    pluginKey: string;
+    reason: PluginHookSkipReason;
+  }): void;
+  recordError(args: {
+    hook: PluginHookKind;
+    pluginId: string;
+    pluginKey: string;
+    reason: PluginHookErrorReason;
+    durationMs: number;
+  }): void;
+}
+
+/** Minimal subset of the shared `TelemetryClient` we depend on. */
+export interface MinimalTelemetryClient {
+  track(eventName: `plugin.${string}`, dimensions?: Record<string, string | number | boolean>): void;
+}
+
+/**
+ * Default sink that forwards to the running telemetry client (if any). When
+ * telemetry is disabled, every method is a no-op so the apply path stays
+ * allocation-free.
+ */
+export function createTelemetrySink(client: MinimalTelemetryClient | null): HookTelemetrySink {
+  if (!client) return NOOP_SINK;
+  return {
+    recordApplied({ hook, pluginId, pluginKey, durationMs }) {
+      client.track("plugin.hook.applied", {
+        hook,
+        pluginId,
+        pluginKey,
+        durationMs: roundMicros(durationMs),
+      });
+    },
+    recordSkipped({ hook, pluginId, pluginKey, reason }) {
+      client.track("plugin.hook.skipped", {
+        hook,
+        pluginId,
+        pluginKey,
+        reason,
+      });
+    },
+    recordError({ hook, pluginId, pluginKey, reason, durationMs }) {
+      client.track("plugin.hook.error", {
+        hook,
+        pluginId,
+        pluginKey,
+        reason,
+        durationMs: roundMicros(durationMs),
+      });
+    },
+  };
+}
+
+function roundMicros(ms: number): number {
+  // Cap precision at 0.001 ms so the dimension cardinality stays bounded for
+  // downstream aggregation.
+  return Math.round(ms * 1_000) / 1_000;
+}
+
+export const NOOP_SINK: HookTelemetrySink = Object.freeze({
+  recordApplied() {},
+  recordSkipped() {},
+  recordError() {},
+});

--- a/server/src/services/plugin-hooks/predicates.ts
+++ b/server/src/services/plugin-hooks/predicates.ts
@@ -1,0 +1,99 @@
+/**
+ * Safe evaluator for plugin-hook `when` predicates.
+ *
+ * Predicates are pure data structures (no functions, no eval). The evaluator
+ * walks them and returns a boolean. Any structurally invalid predicate is
+ * treated as a non-match so a malformed manifest cannot accidentally enable a
+ * hook in a wider scope than intended (fail-closed).
+ */
+
+import type {
+  PluginHookIssueContext,
+  WhenPredicate,
+} from "./types.js";
+
+export interface PredicateContext {
+  readonly issue: PluginHookIssueContext;
+  readonly agentRole?: string;
+}
+
+/**
+ * Maximum recursion depth allowed inside `all`/`any`/`not` predicates. Caps
+ * cost in case a malicious or buggy manifest ships a deeply nested tree.
+ */
+const MAX_PREDICATE_DEPTH = 32;
+
+/**
+ * Evaluate a `when` predicate. Returns `true` when the predicate matches the
+ * given context. A `null` / `undefined` predicate always matches.
+ *
+ * Predicates that exceed the depth cap fail closed regardless of how many
+ * `not` wrappers surround them — the evaluator throws a sentinel, which the
+ * top level converts to `false`. This prevents a deeply nested manifest from
+ * smuggling a `not(not(...))` pyramid past the cap.
+ */
+export function evaluateWhen(
+  predicate: WhenPredicate | null | undefined,
+  ctx: PredicateContext,
+): boolean {
+  if (predicate == null) return true;
+  try {
+    return evalNode(predicate, ctx, 0);
+  } catch (err) {
+    if (err === DEPTH_EXCEEDED) return false;
+    throw err;
+  }
+}
+
+const DEPTH_EXCEEDED: unique symbol = Symbol("plugin-hooks/predicate-depth-exceeded");
+
+function evalNode(node: unknown, ctx: PredicateContext, depth: number): boolean {
+  if (depth > MAX_PREDICATE_DEPTH) throw DEPTH_EXCEEDED;
+  if (node == null || typeof node !== "object") return false;
+
+  const obj = node as Record<string, unknown>;
+
+  if (typeof obj.issueHasField === "string") {
+    return Object.prototype.hasOwnProperty.call(ctx.issue.fields, obj.issueHasField);
+  }
+
+  if (obj.issueFieldEquals && typeof obj.issueFieldEquals === "object") {
+    const ife = obj.issueFieldEquals as { field?: unknown; value?: unknown };
+    if (typeof ife.field !== "string") return false;
+    if (!Object.prototype.hasOwnProperty.call(ctx.issue.fields, ife.field)) return false;
+    return scalarEquals(ctx.issue.fields[ife.field], ife.value);
+  }
+
+  if (typeof obj.agentRoleEquals === "string") {
+    return ctx.agentRole === obj.agentRoleEquals;
+  }
+
+  if (Array.isArray(obj.all)) {
+    if (obj.all.length === 0) return true;
+    return obj.all.every((child) => evalNode(child, ctx, depth + 1));
+  }
+
+  if (Array.isArray(obj.any)) {
+    if (obj.any.length === 0) return false;
+    return obj.any.some((child) => evalNode(child, ctx, depth + 1));
+  }
+
+  if (obj.not !== undefined) {
+    return !evalNode(obj.not, ctx, depth + 1);
+  }
+
+  return false;
+}
+
+/**
+ * Strict scalar comparison. Predicates only accept JSON scalars to keep
+ * evaluation O(1); unknown / non-scalar shapes return `false`.
+ */
+function scalarEquals(actual: unknown, expected: unknown): boolean {
+  if (actual === expected) return true;
+  // Allow numeric/boolean equality across `null`/`undefined` boundary by
+  // treating both as "missing" — but the caller already verified the field is
+  // present, so this branch is only hit when the stored value itself is null.
+  if (actual === null && expected === null) return true;
+  return false;
+}

--- a/server/src/services/plugin-hooks/registry.ts
+++ b/server/src/services/plugin-hooks/registry.ts
@@ -1,0 +1,342 @@
+/**
+ * Plugin hook registry — collects manifest-declared and worker-registered
+ * hooks, indexes them by kind, sorts by priority, and prunes them when a
+ * plugin is unloaded/disabled.
+ *
+ * Phase 1b only — no call-site wiring inside the core (see MYO-63).
+ */
+
+import type {
+  PluginHookEntry,
+  PluginHookHandlerMap,
+  PluginHookKind,
+  PluginHookManifestEntry,
+  WhenPredicate,
+} from "./types.js";
+
+/**
+ * Plugin lifecycle events the registry reacts to. Kept as a structural
+ * subset of the real `PluginLifecycleEvents` type so the registry does not
+ * import the heavier `plugin-lifecycle` module (and stays test-friendly).
+ */
+export interface PluginLifecycleSubset {
+  on(
+    event: "plugin.disabled" | "plugin.unloaded" | "plugin.error",
+    listener: (payload: { pluginId: string }) => void,
+  ): void;
+  off?(
+    event: "plugin.disabled" | "plugin.unloaded" | "plugin.error",
+    listener: (payload: { pluginId: string }) => void,
+  ): void;
+}
+
+/**
+ * Resolver that decides whether a plugin's hooks are eligible for a given
+ * company. Defaults to "always allowed". The default lookup is a per-company
+ * read against `pluginCompanySettings`, which call-sites inject in MYO-63.
+ */
+export type PluginEnabledForCompanyFn = (
+  pluginId: string,
+  companyId: string,
+) => boolean | Promise<boolean>;
+
+/**
+ * Per-company feature flag for the entire hook system. Default `true`.
+ * Wired up to the operator-facing setting in MYO-63.
+ */
+export type HooksEnabledForCompanyFn = (companyId: string) => boolean | Promise<boolean>;
+
+export interface PluginHookRegistryOptions {
+  /** When false the registry is a no-op (used as a hard kill switch). */
+  enabled?: boolean;
+  isPluginEnabledForCompany?: PluginEnabledForCompanyFn;
+  isHooksEnabledForCompany?: HooksEnabledForCompanyFn;
+}
+
+const DEFAULT_PRIORITY = 100;
+
+const ALWAYS_ENABLED: PluginEnabledForCompanyFn = () => true;
+const ALWAYS_ALLOWED: HooksEnabledForCompanyFn = () => true;
+
+export interface PluginHookRegistry {
+  /** Returns whether the registry is globally enabled (kill-switch off). */
+  readonly isEnabled: boolean;
+
+  /**
+   * Register a single hook handler. Used by the worker bridge once a plugin
+   * worker reports its hook implementations, and by tests to stub plugins.
+   */
+  register<K extends PluginHookKind>(entry: {
+    kind: K;
+    pluginId: string;
+    pluginKey: string;
+    priority?: number;
+    when?: WhenPredicate | null;
+    handler: PluginHookHandlerMap[K];
+  }): void;
+
+  /**
+   * Register all hooks declared in a plugin manifest. Returns the list of
+   * accepted entries (handler-bound). Manifest-only declarations cannot
+   * actually run without a paired `register({ kind, handler })` call from
+   * the worker bridge — we accept them here only for metadata indexing,
+   * never as standalone executables.
+   */
+  registerManifestEntries(args: {
+    pluginId: string;
+    pluginKey: string;
+    declarations: ManifestHookDeclarations;
+    handlers: Partial<PluginHookHandlerMap>;
+  }): PluginHookEntry[];
+
+  /**
+   * Remove all hook entries belonging to a plugin. Idempotent.
+   */
+  unregisterPlugin(pluginId: string): void;
+
+  /**
+   * Subscribe to lifecycle events and remove hooks on disable/unload/error.
+   * Safe to call multiple times — listeners deduplicate.
+   */
+  attachLifecycle(lifecycle: PluginLifecycleSubset): void;
+
+  /**
+   * List entries for a kind. Filtered by company eligibility and the hook
+   * feature flag. Sorted by priority ascending, then plugin id ascending.
+   */
+  list<K extends PluginHookKind>(
+    kind: K,
+    args: { companyId: string },
+  ): Promise<readonly PluginHookEntry<K>[]>;
+
+  /**
+   * Synchronous `list` variant — useful for benchmarks and call-sites that
+   * accept a pre-resolved company allow-list. Skips the eligibility resolver
+   * (the caller is asserting the company is allowed).
+   */
+  listUnfiltered<K extends PluginHookKind>(kind: K): readonly PluginHookEntry<K>[];
+
+  /**
+   * Total number of registered hooks across all kinds and plugins. Used by
+   * call-sites to bail out early before `list()` walks the maps.
+   */
+  size(): number;
+
+  /** Reset the registry. Disposes of any lifecycle subscriptions. */
+  reset(): void;
+}
+
+export interface ManifestHookDeclarations {
+  wakePayloadTransformer?: PluginHookManifestEntry;
+  skillResolverTransformer?: PluginHookManifestEntry;
+}
+
+interface RegistryEntry<K extends PluginHookKind> extends PluginHookEntry<K> {
+  /** Insertion sequence — used as a deterministic tie-breaker. */
+  readonly seq: number;
+}
+
+export function createPluginHookRegistry(
+  options: PluginHookRegistryOptions = {},
+): PluginHookRegistry {
+  const enabled = options.enabled !== false;
+  const isPluginEnabledForCompany = options.isPluginEnabledForCompany ?? ALWAYS_ENABLED;
+  const isHooksEnabledForCompany = options.isHooksEnabledForCompany ?? ALWAYS_ALLOWED;
+
+  const entries: { [K in PluginHookKind]: RegistryEntry<K>[] } = {
+    wakePayloadTransformer: [],
+    skillResolverTransformer: [],
+  };
+
+  /**
+   * Cache of eligibility resolutions per (companyId, pluginId) for the
+   * lifetime of a single `list()` call. Prevents N×M DB reads when a
+   * call-site invokes the registry repeatedly inside the same heartbeat.
+   * Keyed by `companyId:pluginId` because the eligibility may legitimately
+   * change across companies.
+   */
+
+  const lifecycleSubscriptions = new Set<PluginLifecycleSubset>();
+  const lifecycleListeners = new WeakMap<
+    PluginLifecycleSubset,
+    (payload: { pluginId: string }) => void
+  >();
+
+  let seqCounter = 0;
+
+  function pushEntry<K extends PluginHookKind>(
+    kind: K,
+    entry: Omit<RegistryEntry<K>, "seq">,
+  ): RegistryEntry<K> {
+    const stored = { ...entry, seq: seqCounter++ } as RegistryEntry<K>;
+    const list = entries[kind] as RegistryEntry<K>[];
+    // Insertion-sort: keep the array sorted by priority then seq.
+    let i = list.length - 1;
+    while (i >= 0 && comparePriority(stored, list[i]!) < 0) {
+      i -= 1;
+    }
+    list.splice(i + 1, 0, stored);
+    return stored;
+  }
+
+  function register<K extends PluginHookKind>(args: {
+    kind: K;
+    pluginId: string;
+    pluginKey: string;
+    priority?: number;
+    when?: WhenPredicate | null;
+    handler: PluginHookHandlerMap[K];
+  }): void {
+    if (!enabled) return;
+    if (!args.pluginId || !args.pluginKey || typeof args.handler !== "function") {
+      throw new TypeError("register: pluginId, pluginKey and handler are required");
+    }
+    pushEntry(args.kind, {
+      kind: args.kind,
+      pluginId: args.pluginId,
+      pluginKey: args.pluginKey,
+      priority: normalisePriority(args.priority),
+      when: args.when ?? null,
+      handler: args.handler,
+    } as Omit<RegistryEntry<K>, "seq">);
+  }
+
+  function registerManifestEntries(args: {
+    pluginId: string;
+    pluginKey: string;
+    declarations: ManifestHookDeclarations;
+    handlers: Partial<PluginHookHandlerMap>;
+  }): PluginHookEntry[] {
+    if (!enabled) return [];
+    const accepted: PluginHookEntry[] = [];
+    for (const kind of HOOK_KINDS) {
+      const declaration = args.declarations[kind];
+      const handler = args.handlers[kind];
+      if (!declaration || typeof handler !== "function") continue;
+      register({
+        kind,
+        pluginId: args.pluginId,
+        pluginKey: args.pluginKey,
+        priority: declaration.priority,
+        when: declaration.when ?? null,
+        handler: handler as PluginHookHandlerMap[typeof kind],
+      });
+      accepted.push({
+        kind,
+        pluginId: args.pluginId,
+        pluginKey: args.pluginKey,
+        priority: normalisePriority(declaration.priority),
+        when: declaration.when ?? null,
+        handler: handler as PluginHookHandlerMap[typeof kind],
+      });
+    }
+    return accepted;
+  }
+
+  function unregisterPlugin(pluginId: string): void {
+    if (!enabled) return;
+    for (const kind of HOOK_KINDS) {
+      const list = entries[kind];
+      let write = 0;
+      for (let read = 0; read < list.length; read += 1) {
+        const entry = list[read]!;
+        if (entry.pluginId !== pluginId) {
+          if (write !== read) list[write] = entry;
+          write += 1;
+        }
+      }
+      list.length = write;
+    }
+  }
+
+  function attachLifecycle(lifecycle: PluginLifecycleSubset): void {
+    if (!enabled) return;
+    if (lifecycleSubscriptions.has(lifecycle)) return;
+    const handler = (payload: { pluginId: string }) => {
+      if (typeof payload?.pluginId === "string") unregisterPlugin(payload.pluginId);
+    };
+    lifecycle.on("plugin.disabled", handler);
+    lifecycle.on("plugin.unloaded", handler);
+    lifecycle.on("plugin.error", handler);
+    lifecycleSubscriptions.add(lifecycle);
+    lifecycleListeners.set(lifecycle, handler);
+  }
+
+  async function list<K extends PluginHookKind>(
+    kind: K,
+    args: { companyId: string },
+  ): Promise<readonly PluginHookEntry<K>[]> {
+    if (!enabled) return EMPTY;
+    const candidates = entries[kind] as RegistryEntry<K>[];
+    if (candidates.length === 0) return EMPTY;
+    const flagOk = await isHooksEnabledForCompany(args.companyId);
+    if (!flagOk) return EMPTY;
+
+    const eligibilityCache = new Map<string, Promise<boolean>>();
+    const resolved = await Promise.all(
+      candidates.map((entry) => {
+        const cacheKey = entry.pluginId;
+        let pending = eligibilityCache.get(cacheKey);
+        if (!pending) {
+          pending = Promise.resolve(isPluginEnabledForCompany(entry.pluginId, args.companyId));
+          eligibilityCache.set(cacheKey, pending);
+        }
+        return pending.then((ok) => (ok ? entry : null));
+      }),
+    );
+    const out = resolved.filter((entry): entry is RegistryEntry<K> => entry !== null);
+    return out as readonly PluginHookEntry<K>[];
+  }
+
+  function listUnfiltered<K extends PluginHookKind>(
+    kind: K,
+  ): readonly PluginHookEntry<K>[] {
+    if (!enabled) return EMPTY;
+    return entries[kind] as readonly PluginHookEntry<K>[];
+  }
+
+  function size(): number {
+    let total = 0;
+    for (const kind of HOOK_KINDS) total += entries[kind].length;
+    return total;
+  }
+
+  function reset(): void {
+    for (const kind of HOOK_KINDS) entries[kind].length = 0;
+    for (const lifecycle of lifecycleSubscriptions) {
+      const listener = lifecycleListeners.get(lifecycle);
+      if (listener && typeof lifecycle.off === "function") {
+        lifecycle.off("plugin.disabled", listener);
+        lifecycle.off("plugin.unloaded", listener);
+        lifecycle.off("plugin.error", listener);
+      }
+    }
+    lifecycleSubscriptions.clear();
+  }
+
+  return {
+    isEnabled: enabled,
+    register,
+    registerManifestEntries,
+    unregisterPlugin,
+    attachLifecycle,
+    list,
+    listUnfiltered,
+    size,
+    reset,
+  };
+}
+
+const HOOK_KINDS = ["wakePayloadTransformer", "skillResolverTransformer"] as const;
+
+const EMPTY: readonly never[] = Object.freeze([]);
+
+function normalisePriority(p: number | undefined): number {
+  if (typeof p !== "number" || !Number.isFinite(p)) return DEFAULT_PRIORITY;
+  return p;
+}
+
+function comparePriority(a: { priority: number; seq: number }, b: { priority: number; seq: number }): number {
+  if (a.priority !== b.priority) return a.priority - b.priority;
+  return a.seq - b.seq;
+}

--- a/server/src/services/plugin-hooks/registry.ts
+++ b/server/src/services/plugin-hooks/registry.ts
@@ -129,6 +129,7 @@ export interface PluginHookRegistry {
 export interface ManifestHookDeclarations {
   wakePayloadTransformer?: PluginHookManifestEntry;
   skillResolverTransformer?: PluginHookManifestEntry;
+  runtimeEnvProvider?: PluginHookManifestEntry;
 }
 
 interface RegistryEntry<K extends PluginHookKind> extends PluginHookEntry<K> {
@@ -146,6 +147,7 @@ export function createPluginHookRegistry(
   const entries: { [K in PluginHookKind]: RegistryEntry<K>[] } = {
     wakePayloadTransformer: [],
     skillResolverTransformer: [],
+    runtimeEnvProvider: [],
   };
 
   /**
@@ -327,7 +329,11 @@ export function createPluginHookRegistry(
   };
 }
 
-const HOOK_KINDS = ["wakePayloadTransformer", "skillResolverTransformer"] as const;
+const HOOK_KINDS = [
+  "wakePayloadTransformer",
+  "skillResolverTransformer",
+  "runtimeEnvProvider",
+] as const;
 
 const EMPTY: readonly never[] = Object.freeze([]);
 

--- a/server/src/services/plugin-hooks/types.ts
+++ b/server/src/services/plugin-hooks/types.ts
@@ -1,0 +1,139 @@
+/**
+ * Internal plugin-hook contract types.
+ *
+ * These mirror the shape that {@link MYO-61}/Phase 1a will export from
+ * `@paperclipai/plugin-sdk`. Until that ships, the registry/apply layer uses
+ * these locally so MYO-62 can land in isolation. When the SDK contract lands,
+ * this file will narrow to a `re-export from "@paperclipai/plugin-sdk"`.
+ *
+ * Phase 1b only — no call-sites in the core yet (see MYO-63 for integration).
+ */
+
+/**
+ * Compact, read-only projection of an issue exposed to plugin hooks.
+ *
+ * The full issue record is intentionally not handed to plugins so that a hook
+ * cannot mutate or leak fields the host did not opt-in to share.
+ */
+export interface PluginHookIssueContext {
+  readonly issueId: string;
+  readonly companyId: string;
+  readonly projectId?: string | null;
+  readonly assigneeAgentId?: string | null;
+  /**
+   * Subset of issue scalar fields the host has opted to expose. Hooks read
+   * field values via `issueFieldEquals` predicates; the registry never lets a
+   * hook see fields outside this map.
+   */
+  readonly fields: Readonly<Record<string, unknown>>;
+}
+
+export interface WakePayloadTransformerContext {
+  readonly issue: PluginHookIssueContext;
+  readonly agentId?: string;
+  readonly agentRole?: string;
+}
+
+export interface SkillResolverTransformerContext {
+  readonly issue: PluginHookIssueContext;
+  readonly agentId: string;
+  readonly agentRole?: string;
+}
+
+/**
+ * Normalised return shape of a skill-resolver hook so additive/subtractive
+ * intent is explicit. The default mapping from `string[]` to this shape is
+ * `{ skills, required: [] }`.
+ */
+export interface SkillResolverResult {
+  /** The full ordered skill list after this hook runs. */
+  readonly skills: readonly string[];
+  /** Subset of `skills` the hook is asserting as required. May be empty. */
+  readonly required?: readonly string[];
+}
+
+export type WakePayload = Record<string, unknown>;
+
+export type WakePayloadTransformer = (
+  payload: WakePayload,
+  context: WakePayloadTransformerContext,
+) => Promise<WakePayload> | WakePayload;
+
+export type SkillResolverTransformer = (
+  current: SkillResolverResult,
+  context: SkillResolverTransformerContext,
+) => Promise<SkillResolverResult> | SkillResolverResult;
+
+/**
+ * Declarative `when` predicate. Plugins describe predicates in their manifest;
+ * the registry evaluates them safely without running plugin code (see
+ * `predicates.ts`).
+ *
+ * Supported leaf forms:
+ * - `{ issueHasField: "myField" }` — field exists in the exposed projection.
+ * - `{ issueFieldEquals: { field, value } }` — strict equality on a scalar.
+ * - `{ agentRoleEquals: "founding_engineer" }` — agent role match.
+ *
+ * Composite forms (all supported recursively):
+ * - `{ all: WhenPredicate[] }` — logical AND
+ * - `{ any: WhenPredicate[] }` — logical OR
+ * - `{ not: WhenPredicate }` — logical NOT
+ */
+export type WhenPredicate =
+  | { readonly issueHasField: string }
+  | { readonly issueFieldEquals: { readonly field: string; readonly value: unknown } }
+  | { readonly agentRoleEquals: string }
+  | { readonly all: readonly WhenPredicate[] }
+  | { readonly any: readonly WhenPredicate[] }
+  | { readonly not: WhenPredicate };
+
+/** Symbolic name for the supported hook kinds. */
+export type PluginHookKind = "wakePayloadTransformer" | "skillResolverTransformer";
+
+/**
+ * Map from {@link PluginHookKind} to the handler signature. Used to keep the
+ * registry strongly typed without resorting to per-kind APIs.
+ */
+export interface PluginHookHandlerMap {
+  wakePayloadTransformer: WakePayloadTransformer;
+  skillResolverTransformer: SkillResolverTransformer;
+}
+
+/**
+ * Manifest-declared hook entry. Plugins surface these inside
+ * `manifestJson.hooks.{wakePayloadTransformer,skillResolverTransformer}` —
+ * MYO-61 finalises the SDK shape; we match it structurally here.
+ */
+export interface PluginHookManifestEntry {
+  /** Lower number = earlier execution. Must be a finite number. */
+  readonly priority?: number;
+  /** Optional safe predicate gating the hook. */
+  readonly when?: WhenPredicate;
+}
+
+/**
+ * In-memory hook entry stored by the registry.
+ */
+export interface PluginHookEntry<K extends PluginHookKind = PluginHookKind> {
+  readonly kind: K;
+  readonly pluginId: string;
+  readonly pluginKey: string;
+  readonly priority: number;
+  readonly when: WhenPredicate | null;
+  readonly handler: PluginHookHandlerMap[K];
+}
+
+/**
+ * Reason a hook invocation was skipped or aborted. Used by the apply layer to
+ * emit precise telemetry without leaking internal state to plugins.
+ */
+export type PluginHookSkipReason =
+  | "predicate_false"
+  | "company_disabled"
+  | "feature_flag_disabled"
+  | "budget_exhausted";
+
+export type PluginHookErrorReason =
+  | "handler_threw"
+  | "handler_returned_invalid"
+  | "handler_timed_out";

--- a/server/src/services/plugin-hooks/types.ts
+++ b/server/src/services/plugin-hooks/types.ts
@@ -41,6 +41,65 @@ export interface SkillResolverTransformerContext {
 }
 
 /**
+ * Inputs available to a `runtimeEnvProvider` hook. Exposed to plugins right
+ * before an adapter spawns the agent process for a heartbeat. The host calls
+ * the chain once per run; the resulting env is injected into the spawned
+ * process and runtimeFiles are written into `<runDir>/`.
+ *
+ * Only the fields needed by adapters to derive a per-run identity / secret
+ * are exposed. `adapterConfig` is forwarded as an opaque, read-only view so
+ * plugins can branch on adapter-specific settings without mutating them.
+ */
+export interface RuntimeEnvProviderContext {
+  readonly issue: PluginHookIssueContext;
+  readonly agentId: string;
+  readonly agentRole?: string;
+  readonly companyId: string;
+  readonly runId: string;
+  readonly adapterType: string;
+  readonly adapterConfig: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Per-file artifact a `runtimeEnvProvider` hook may stage in the run dir.
+ *
+ * The host writes the file at `<runDir>/<path>` before the process spawns.
+ * Plugins return paths relative to the run dir; the apply layer rejects
+ * absolute paths and any path that escapes the run dir (e.g. contains `..`).
+ *
+ * `mode` is an octal POSIX mode (e.g. `0o600` for secrets). Defaults to
+ * `0o600` to keep credentials private by default. The host may further
+ * tighten this on platforms that do not support the requested bits.
+ */
+export interface RuntimeFileSpec {
+  readonly path: string;
+  readonly content: string;
+  readonly mode?: number;
+}
+
+/**
+ * Aggregated contribution of the `runtimeEnvProvider` chain. Each hook is
+ * given the previous result and returns a new one — chain semantics mirror
+ * the wake-payload chain so plugins compose deterministically.
+ *
+ * `env` keys must be valid POSIX env names (see `RUNTIME_ENV_KEY_PATTERN`
+ * in `apply.ts`). Conflicts are resolved last-write-wins by priority order.
+ *
+ * `runtimeFiles` is keyed by `path`; later hooks overwrite earlier entries
+ * for the same path. Files staged by reserved or invalid paths are dropped
+ * with telemetry, never silently merged into a parent path.
+ */
+export interface RuntimeEnvProviderResult {
+  readonly env: Readonly<Record<string, string>>;
+  readonly runtimeFiles?: readonly RuntimeFileSpec[];
+}
+
+export type RuntimeEnvProvider = (
+  current: RuntimeEnvProviderResult,
+  context: RuntimeEnvProviderContext,
+) => Promise<RuntimeEnvProviderResult> | RuntimeEnvProviderResult;
+
+/**
  * Normalised return shape of a skill-resolver hook so additive/subtractive
  * intent is explicit. The default mapping from `string[]` to this shape is
  * `{ skills, required: [] }`.
@@ -63,6 +122,14 @@ export type SkillResolverTransformer = (
   current: SkillResolverResult,
   context: SkillResolverTransformerContext,
 ) => Promise<SkillResolverResult> | SkillResolverResult;
+
+/**
+ * Empty seed used by the apply layer when starting a `runtimeEnvProvider`
+ * chain. Exported so call-sites and tests share the exact same identity.
+ */
+export const EMPTY_RUNTIME_ENV_RESULT: RuntimeEnvProviderResult = Object.freeze({
+  env: Object.freeze({}) as Readonly<Record<string, string>>,
+});
 
 /**
  * Declarative `when` predicate. Plugins describe predicates in their manifest;
@@ -88,7 +155,10 @@ export type WhenPredicate =
   | { readonly not: WhenPredicate };
 
 /** Symbolic name for the supported hook kinds. */
-export type PluginHookKind = "wakePayloadTransformer" | "skillResolverTransformer";
+export type PluginHookKind =
+  | "wakePayloadTransformer"
+  | "skillResolverTransformer"
+  | "runtimeEnvProvider";
 
 /**
  * Map from {@link PluginHookKind} to the handler signature. Used to keep the
@@ -97,11 +167,12 @@ export type PluginHookKind = "wakePayloadTransformer" | "skillResolverTransforme
 export interface PluginHookHandlerMap {
   wakePayloadTransformer: WakePayloadTransformer;
   skillResolverTransformer: SkillResolverTransformer;
+  runtimeEnvProvider: RuntimeEnvProvider;
 }
 
 /**
  * Manifest-declared hook entry. Plugins surface these inside
- * `manifestJson.hooks.{wakePayloadTransformer,skillResolverTransformer}` —
+ * `manifestJson.hooks.{wakePayloadTransformer,skillResolverTransformer,runtimeEnvProvider}` —
  * MYO-61 finalises the SDK shape; we match it structurally here.
  */
 export interface PluginHookManifestEntry {
@@ -136,4 +207,5 @@ export type PluginHookSkipReason =
 export type PluginHookErrorReason =
   | "handler_threw"
   | "handler_returned_invalid"
-  | "handler_timed_out";
+  | "handler_timed_out"
+  | "runtime_file_rejected";


### PR DESCRIPTION
## Summary

Generalises per-run env injection so adapters stop needing core patches to carry a Git identity, an OpenAI key, or any other per-run credential. New `runtimeEnvProvider` plugin hook is registered next to the wake-payload and skill-resolver transformers shipped in [MYO-62](/MYO/issues/MYO-62) and follows the same [MYO-50](/MYO/issues/MYO-50) pattern: priority-ordered, predicate-gated, budget-bounded, error-isolated.

**No call-site in core uses the hook yet.** Phase 2 wires it into the adapter spawn flow (`packages/adapters/*/src/server/execute.ts`); Phase 3 migrates the `claude_local` Git identity injection ([MYO-76](/MYO/issues/MYO-76) Phase 1B) onto it. The registry surface is therefore safe to merge in isolation — with no call-site it has no observable effect.

## What ships

- New `RuntimeEnvProvider` / `RuntimeEnvProviderContext` / `RuntimeEnvProviderResult` / `RuntimeFileSpec` types alongside `EMPTY_RUNTIME_ENV_RESULT`.
- `applyRuntimeEnvProviderHooks` with `DEFAULT_RUNTIME_ENV_BUDGET_MS = 200`, env key validation (POSIX-portable subset), runtime file path validation (rejects absolute paths, `..`, drive letters, NUL), default `0o600` mode, mode bit clamping. Per-key / per-file rejections drop with telemetry without aborting the chain.
- Registry entries map + `HOOK_KINDS` + `ManifestHookDeclarations` extended with the new kind. Existing lifecycle / unregister / list paths already iterate `HOOK_KINDS`, so they pick up the new kind for free.
- 16-test suite covering: empty result identity, **FOO=bar acceptance**, context threading, priority ordering with last-write-wins env, predicate gating, error isolation, invalid env keys / values, default file mode, path validation (absolute / `..` / Windows drive / NUL), path normalisation, mode clamp, file last-write-wins by path, budget exhaustion, kill switch, per-company hook flag.
- Doc: `docs/specs/plugin-hooks-runtime-env-provider.md` — surface, semantics, example `gh-identity-provider` plugin, predicate cookbook, phase plan, MYO-80 acceptance traceability.

## Scope

Strictly under `server/src/services/plugin-hooks/**`, `server/src/__tests__/plugin-hooks-*`, and `docs/specs/`. Zero call-site touches, mirroring the [MYO-62](/MYO/issues/MYO-62) Phase 1b posture.

## Test plan

- [x] `pnpm --filter @paperclipai/server vitest run src/__tests__/plugin-hooks-runtime-env.test.ts src/__tests__/plugin-hooks-registry.test.ts src/__tests__/plugin-hooks-apply.test.ts src/__tests__/plugin-hooks-predicates.test.ts` → 47/47 passing.
- [x] `tsc --noEmit` (server) clean.
- [ ] Phase 2 wiring follow-up: adapter spawn flow consumes `applyRuntimeEnvProviderHooks` before exec (separate PR).
- [ ] Phase 3 follow-up: migrate `claude_local` Git identity injection ([MYO-76](/MYO/issues/MYO-76) Phase 1B) off the inline path.

## Acceptance ([MYO-80](/MYO/issues/MYO-80))

- [x] Hook `runtimeEnvProvider` registrable via the [MYO-62](/MYO/issues/MYO-62) registry.
- [ ] `claude_local` consumes the hook instead of inline logic — *deferred to Phase 2/3 wiring follow-up; see doc for rationale.*
- [x] Plugin authoring doc updated with the hook.
- [x] Integration test: plugin registers a provider that injects `FOO=bar` → exposed in the merged result (`registers and merges env from a single hook (FOO=bar acceptance)`).
- [x] No future adapter needs to patch core to carry per-run env — once Phase 2 lands the spawn-flow wiring, codex_local / OpenClaw / future adapters reuse the hook.

Refs [MYO-80](/MYO/issues/MYO-80), [MYO-76](/MYO/issues/MYO-76), [MYO-62](/MYO/issues/MYO-62), [MYO-50](/MYO/issues/MYO-50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)