### PR TITLE
fix(openclaw-gateway): remove agentParams.paperclip to satisfy strict schema

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1127,7 +1127,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
   const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
 
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
@@ -1136,7 +1135,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  // openclaw AgentParamsSchema has additionalProperties: false and no paperclip field;
+  // the paperclip wake context is fully embedded in the message text already.
+  delete agentParams.paperclip;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; the openclaw_gateway adapter connects Paperclip to OpenClaw-based agents over WebSocket
> - When Paperclip dispatches a run, `execute.ts` builds an `agentParams` object that is sent to the OpenClaw gateway
> - `agentParams` is validated against OpenClaw's `AgentParamsSchema`, which has `additionalProperties: false`
> - The adapter sets `agentParams.paperclip = buildStandardPaperclipPayload(...)`, but `paperclip` is not a field in `AgentParamsSchema`
> - This causes schema validation failures at the gateway, rejecting the agent invocation
> - The paperclip wake context (runId, issueId, apiUrl, wakeReason, etc.) is already fully serialised into the `message` field via `renderPaperclipWakePrompt` and `stringifyPaperclipWakePayload` — agents receive all necessary context through the message text
> - This PR removes the `buildStandardPaperclipPayload` call and the `agentParams.paperclip` assignment, replacing them with a `delete agentParams.paperclip` guard so any `paperclip` key coming from a `payloadTemplate` spread is also stripped

## What Changed

- **`packages/adapters/openclaw-gateway/src/server/execute.ts`**
  - Removed: `const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);`
  - Removed: `agentParams.paperclip = paperclipPayload;`
  - Added: `delete agentParams.paperclip;` with an explanatory comment (guards against the key arriving via `...payloadTemplate` spread as well)

The `buildStandardPaperclipPayload` function definition is left in place — it may be useful to other adapters or future use cases and is harmless as unused code.

## Verification

1. Spin up a local Paperclip instance with an agent using the `openclaw_gateway` adapter
2. Trigger a heartbeat — previously the gateway rejected the payload with a schema validation error
3. With this fix, the `agentParams` object no longer contains a `paperclip` key and the invocation succeeds

The hotfix of the same change (applied directly to the installed `node_modules` file) has been running in production on at least one instance without regressions.

## Risks

Low risk. The removed assignment was the direct cause of failures. The paperclip context was already duplicated in the `message` field, so agent behaviour is unchanged. The defensive `delete` guard is a no-op when `payloadTemplate` does not contain a `paperclip` key.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context window: 200k tokens
- Tool use enabled (Paperclip agent heartbeat context)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (no tests changed — behaviour-neutral guard)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-side only)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge