### PR TITLE
모델 티어 라우팅: wake payload 기반 Haiku/Sonnet/Opus 선택 (WOR-36)

### DIFF
--- a/server/src/__tests__/model-tier-routing.test.ts
+++ b/server/src/__tests__/model-tier-routing.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyModelTierSelection,
+  selectHeartbeatModelTier,
+} from "../services/model-tier-routing.js";
+
+const FULL_PROFILE = {
+  default: "sonnet",
+  haiku: "claude-haiku-4-5",
+  sonnet: "claude-sonnet-4-6",
+  opus: "claude-opus-4-7",
+};
+
+function configWithProfile(profile: unknown = FULL_PROFILE) {
+  return { modelTierProfile: profile, model: "claude-opus-4-7" };
+}
+
+describe("selectHeartbeatModelTier", () => {
+  it("returns null when the agent has no modelTierProfile", () => {
+    const result = selectHeartbeatModelTier({
+      config: { model: "claude-opus-4-7" },
+      context: {},
+      wakePayload: { issue: { status: "in_progress" }, comments: [{ body: "hi" }] },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the profile is disabled", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile({ ...FULL_PROFILE, enabled: false }),
+      context: {},
+      wakePayload: { issue: { status: "in_progress" }, comments: [] },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("routes blocked status with no new comments to haiku (dedup)", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile(),
+      context: { wakeReason: "issue_assigned" },
+      wakePayload: { issue: { status: "blocked" }, comments: [], commentIds: [] },
+    });
+    expect(result).toEqual({
+      tier: "haiku",
+      model: "claude-haiku-4-5",
+      reason: "blocked_no_new_context",
+    });
+  });
+
+  it("routes dependency-blocked interactions to haiku", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile(),
+      context: {},
+      wakePayload: {
+        issue: { status: "in_progress" },
+        comments: [{ body: "no-op" }],
+        dependencyBlockedInteraction: true,
+      },
+    });
+    expect(result?.tier).toBe("haiku");
+    expect(result?.reason).toBe("dependency_blocked_interaction");
+  });
+
+  it("routes system retry wakes with no new context to haiku", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile(),
+      context: { wakeReason: "transient_failure_retry" },
+      wakePayload: {
+        issue: { status: "in_progress" },
+        reason: "transient_failure_retry",
+        comments: [],
+        commentIds: [],
+      },
+    });
+    expect(result?.tier).toBe("haiku");
+    expect(result?.reason).toBe("system_retry:transient_failure_retry");
+  });
+
+  it("routes no-context wakes to haiku", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile(),
+      context: {},
+      wakePayload: {
+        issue: { status: "in_progress" },
+        comments: [],
+        commentIds: [],
+        executionStage: null,
+        continuationSummary: null,
+      },
+    });
+    expect(result?.tier).toBe("haiku");
+    expect(result?.reason).toBe("no_context_wake");
+  });
+
+  it("routes umbrellas with 3+ in-flight children to opus", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile(),
+      context: { wakeReason: "issue_commented" },
+      wakePayload: {
+        issue: { status: "in_progress" },
+        comments: [{ body: "ping" }],
+        childIssueSummaries: [
+          { id: "a", status: "in_progress" },
+          { id: "b", status: "todo" },
+          { id: "c", status: "in_review" },
+          { id: "d", status: "done" },
+        ],
+      },
+    });
+    expect(result?.tier).toBe("opus");
+    expect(result?.reason).toBe("umbrella_children:3");
+    expect(result?.model).toBe("claude-opus-4-7");
+  });
+
+  it("does NOT escalate when most children are done/cancelled", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile(),
+      context: { wakeReason: "issue_commented" },
+      wakePayload: {
+        issue: { status: "in_progress" },
+        comments: [{ body: "ping" }],
+        childIssueSummaries: [
+          { id: "a", status: "done" },
+          { id: "b", status: "cancelled" },
+          { id: "c", status: "in_progress" },
+        ],
+      },
+    });
+    expect(result?.tier).toBe("sonnet");
+  });
+
+  it("escalates to opus on plan-mode keyword in description", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile(),
+      context: {
+        wakeReason: "issue_assigned",
+        paperclipIssue: { description: "이번 heartbeat에서 mode=plan 으로 설계만 부탁" },
+      },
+      wakePayload: {
+        issue: { status: "in_progress", title: "라우팅 설계" },
+        comments: [{ body: "내용" }],
+      },
+    });
+    expect(result?.tier).toBe("opus");
+    expect(result?.reason).toBe("plan_mode_keyword");
+  });
+
+  it("escalates to opus on Korean plan keywords (기획/설계/검토)", () => {
+    for (const kw of ["기획안", "설계 검토", "검토 부탁"]) {
+      const result = selectHeartbeatModelTier({
+        config: configWithProfile(),
+        context: { wakeReason: "issue_commented" },
+        wakePayload: {
+          issue: { status: "in_progress", title: kw },
+          comments: [{ body: "..." }],
+        },
+      });
+      expect(result?.tier).toBe("opus");
+      expect(result?.reason).toBe("plan_mode_keyword");
+    }
+  });
+
+  it("escalates to opus when an execution review/approval stage is active", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile(),
+      context: { wakeReason: "execution_review_requested" },
+      wakePayload: {
+        issue: { status: "in_review" },
+        comments: [{ body: "리뷰 부탁드립니다" }],
+        executionStage: { currentStageType: "execution_review" },
+      },
+    });
+    expect(result?.tier).toBe("opus");
+    expect(result?.reason).toBe("execution_stage");
+  });
+
+  it("falls back to sonnet for ordinary in-progress wakes", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile(),
+      context: { wakeReason: "issue_commented" },
+      wakePayload: {
+        issue: { status: "in_progress", title: "단일 파일 버그 수정" },
+        comments: [{ body: "이 함수에서 NPE가 발생합니다" }],
+      },
+    });
+    expect(result?.tier).toBe("sonnet");
+    expect(result?.reason).toBe("default");
+    expect(result?.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("falls back to a lower tier model when the requested tier is missing", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile({ default: "sonnet", opus: "claude-opus-4-7" }),
+      context: { wakeReason: "issue_commented" },
+      wakePayload: {
+        issue: { status: "in_progress" },
+        comments: [{ body: "..." }],
+      },
+    });
+    expect(result?.tier).toBe("sonnet");
+    expect(result?.model).toBe("claude-opus-4-7");
+  });
+
+  it("respects an explicit non-default tier in the profile", () => {
+    const result = selectHeartbeatModelTier({
+      config: configWithProfile({ ...FULL_PROFILE, default: "haiku" }),
+      context: { wakeReason: "issue_commented" },
+      wakePayload: {
+        issue: { status: "in_progress" },
+        comments: [{ body: "..." }],
+      },
+    });
+    expect(result?.tier).toBe("haiku");
+    expect(result?.model).toBe("claude-haiku-4-5");
+  });
+});
+
+describe("applyModelTierSelection", () => {
+  it("returns the config unchanged when selection is null", () => {
+    const config = { model: "claude-opus-4-7" };
+    expect(applyModelTierSelection(config, null)).toBe(config);
+  });
+
+  it("overrides model and records the selection", () => {
+    const out = applyModelTierSelection(
+      { model: "claude-opus-4-7", other: "x" },
+      { tier: "haiku", model: "claude-haiku-4-5", reason: "blocked_no_new_context" },
+    );
+    expect(out).toEqual({
+      model: "claude-haiku-4-5",
+      other: "x",
+      modelTierSelection: {
+        tier: "haiku",
+        model: "claude-haiku-4-5",
+        reason: "blocked_no_new_context",
+      },
+    });
+  });
+
+  it("preserves the original model when the selected tier has no resolved model", () => {
+    const out = applyModelTierSelection(
+      { model: "claude-opus-4-7" },
+      { tier: "haiku", model: null, reason: "blocked_no_new_context" },
+    );
+    expect(out.model).toBe("claude-opus-4-7");
+    expect(out.modelTierSelection).toEqual({
+      tier: "haiku",
+      model: null,
+      reason: "blocked_no_new_context",
+    });
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -125,6 +125,10 @@ import { extractSkillMentionIds } from "@paperclipai/shared";
 import { environmentService } from "./environments.js";
 import { environmentRuntimeService } from "./environment-runtime.js";
 import { environmentRunOrchestrator } from "./environment-run-orchestrator.js";
+import {
+  applyModelTierSelection,
+  selectHeartbeatModelTier,
+} from "./model-tier-routing.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
@@ -4914,10 +4918,34 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       runScopedMentionedSkillKeys,
     );
     const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId);
-    let runtimeConfig = {
+    let runtimeConfig: Record<string, unknown> = {
       ...effectiveResolvedConfig,
       paperclipRuntimeSkills: runtimeSkillEntries,
     };
+    const modelTierSelection = selectHeartbeatModelTier({
+      config: runtimeConfig,
+      context,
+      wakePayload: paperclipWakePayload,
+    });
+    if (modelTierSelection) {
+      runtimeConfig = applyModelTierSelection(runtimeConfig, modelTierSelection);
+      context.paperclipModelTierSelection = {
+        tier: modelTierSelection.tier,
+        model: modelTierSelection.model,
+        reason: modelTierSelection.reason,
+      };
+      logger.info(
+        {
+          companyId: agent.companyId,
+          agentId: agent.id,
+          runId: run.id,
+          tier: modelTierSelection.tier,
+          model: modelTierSelection.model,
+          reason: modelTierSelection.reason,
+        },
+        "model tier routed",
+      );
+    }
     const workspaceOperationRecorder = workspaceOperationsSvc.createRecorder({
       companyId: agent.companyId,
       heartbeatRunId: run.id,

--- a/server/src/services/model-tier-routing.ts
+++ b/server/src/services/model-tier-routing.ts
@@ -1,0 +1,288 @@
+/**
+ * Wake-time model tier routing.
+ *
+ * Picks Haiku/Sonnet/Opus per heartbeat from the wake payload alone (no
+ * additional DB calls). Opt-in via `agent.adapterConfig.modelTierProfile` —
+ * agents without a profile keep their existing `config.model` untouched.
+ *
+ * Rule (v1, see WOR-36):
+ *   trivial → haiku   (blocked-task dedup, no-context wake, system-only retries)
+ *   heavy   → opus    (umbrella with ≥3 in-flight children, plan/기획/설계/검토,
+ *                      review/approval execution stage)
+ *   else    → sonnet
+ */
+
+export type ModelTier = "haiku" | "sonnet" | "opus";
+
+export interface ModelTierProfile {
+  /** Tier to use when none of the rules match. Defaults to "sonnet". */
+  default?: ModelTier;
+  /** Model id for the haiku tier (e.g. "claude-haiku-4-5"). Optional. */
+  haiku?: string | null;
+  /** Model id for the sonnet tier (e.g. "claude-sonnet-4-6"). Optional. */
+  sonnet?: string | null;
+  /** Model id for the opus tier (e.g. "claude-opus-4-7"). Optional. */
+  opus?: string | null;
+  /** Disable routing without removing the profile. Defaults to true. */
+  enabled?: boolean;
+}
+
+export interface ModelTierSelection {
+  tier: ModelTier;
+  /** Resolved model id, or null when the tier has no model in the profile. */
+  model: string | null;
+  /** Short reason — surfaced to telemetry / agent env for debugging. */
+  reason: string;
+}
+
+export interface ModelTierRoutingInput {
+  config: Record<string, unknown>;
+  context: Record<string, unknown> | null | undefined;
+  wakePayload: Record<string, unknown> | null | undefined;
+}
+
+const PLAN_MODE_KEYWORDS = [
+  "mode=plan",
+  "mode: plan",
+  "plan-only",
+  "기획",
+  "설계",
+  "검토",
+];
+
+const SYSTEM_RETRY_WAKE_REASONS = new Set([
+  "process_lost_retry",
+  "transient_failure_retry",
+  "retry_failed_run",
+  "missing_issue_comment",
+  "issue_tree_restored",
+]);
+
+const TERMINAL_CHILD_STATUSES = new Set(["done", "cancelled"]);
+
+const UMBRELLA_IN_FLIGHT_THRESHOLD = 3;
+
+const HEAVY_EXECUTION_STAGE_TYPES = new Set([
+  "execution_review",
+  "execution_approval",
+  "execution_changes_requested",
+]);
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function readModelTierProfile(config: Record<string, unknown>): ModelTierProfile | null {
+  const raw = config.modelTierProfile;
+  if (!raw || typeof raw !== "object") return null;
+  const profile = raw as Record<string, unknown>;
+  const enabled = profile.enabled !== false;
+  if (!enabled) return null;
+  const defaultTier = asString(profile.default).toLowerCase();
+  const normalizedDefault: ModelTier =
+    defaultTier === "haiku" || defaultTier === "sonnet" || defaultTier === "opus"
+      ? defaultTier
+      : "sonnet";
+  return {
+    default: normalizedDefault,
+    haiku: typeof profile.haiku === "string" ? profile.haiku : null,
+    sonnet: typeof profile.sonnet === "string" ? profile.sonnet : null,
+    opus: typeof profile.opus === "string" ? profile.opus : null,
+    enabled: true,
+  };
+}
+
+function countInFlightChildren(wakePayload: Record<string, unknown>): number {
+  const summaries = asArray(wakePayload.childIssueSummaries);
+  let count = 0;
+  for (const entry of summaries) {
+    if (!entry || typeof entry !== "object") continue;
+    const status = asString((entry as Record<string, unknown>).status).toLowerCase();
+    if (status && !TERMINAL_CHILD_STATUSES.has(status)) count += 1;
+  }
+  return count;
+}
+
+function collectKeywordHaystack(
+  context: Record<string, unknown>,
+  wakePayload: Record<string, unknown>,
+): string {
+  const parts: string[] = [];
+  const issue = asObject(wakePayload.issue);
+  if (issue.title) parts.push(asString(issue.title));
+  const continuation = asObject(wakePayload.continuationSummary);
+  if (continuation.body) parts.push(asString(continuation.body));
+  for (const comment of asArray(wakePayload.comments)) {
+    if (comment && typeof comment === "object") {
+      const body = asString((comment as Record<string, unknown>).body);
+      if (body) parts.push(body);
+    }
+  }
+  const paperclipIssue = asObject(context.paperclipIssue);
+  if (paperclipIssue.description) parts.push(asString(paperclipIssue.description));
+  const wakeComment = asObject(context.paperclipWakeComment);
+  if (wakeComment.body) parts.push(asString(wakeComment.body));
+  return parts.join("\n").toLowerCase();
+}
+
+function hasPlanModeKeyword(haystack: string): boolean {
+  if (!haystack) return false;
+  return PLAN_MODE_KEYWORDS.some((kw) => haystack.includes(kw));
+}
+
+function isHeavyExecutionStage(wakePayload: Record<string, unknown>): boolean {
+  const stage = wakePayload.executionStage;
+  if (!stage || typeof stage !== "object") return false;
+  const stageObj = stage as Record<string, unknown>;
+  const type = asString(stageObj.currentStageType).toLowerCase();
+  if (type && HEAVY_EXECUTION_STAGE_TYPES.has(type)) return true;
+  return Object.keys(stageObj).length > 0 && asString(stageObj.currentStageType).length > 0;
+}
+
+interface TrivialReason {
+  trivial: boolean;
+  reason: string;
+}
+
+function classifyTrivial(
+  context: Record<string, unknown>,
+  wakePayload: Record<string, unknown>,
+): TrivialReason {
+  const issue = asObject(wakePayload.issue);
+  const status = asString(issue.status).toLowerCase();
+  const wakeReason = asString(wakePayload.reason) || asString(context.wakeReason);
+  const comments = asArray(wakePayload.comments);
+  const commentIds = asArray(wakePayload.commentIds);
+  const hasNewComments = comments.length > 0 || commentIds.length > 0;
+  const wakeCommentContext = asObject(context.paperclipWakeComment);
+  const hasWakeCommentContext = Object.keys(wakeCommentContext).length > 0;
+  const continuationSummary = asObject(wakePayload.continuationSummary);
+  const executionStage = wakePayload.executionStage;
+  const hasExecutionStage =
+    executionStage !== null && typeof executionStage === "object" &&
+    Object.keys(executionStage as Record<string, unknown>).length > 0;
+
+  if (wakePayload.dependencyBlockedInteraction === true) {
+    return { trivial: true, reason: "dependency_blocked_interaction" };
+  }
+
+  if (status === "blocked" && !hasNewComments && !hasWakeCommentContext) {
+    return { trivial: true, reason: "blocked_no_new_context" };
+  }
+
+  if (
+    SYSTEM_RETRY_WAKE_REASONS.has(wakeReason) &&
+    !hasNewComments &&
+    !hasWakeCommentContext
+  ) {
+    return { trivial: true, reason: `system_retry:${wakeReason}` };
+  }
+
+  if (
+    !hasNewComments &&
+    !hasWakeCommentContext &&
+    Object.keys(continuationSummary).length === 0 &&
+    !hasExecutionStage &&
+    !wakeReason
+  ) {
+    return { trivial: true, reason: "no_context_wake" };
+  }
+
+  return { trivial: false, reason: "" };
+}
+
+interface HeavyReason {
+  heavy: boolean;
+  reason: string;
+}
+
+function classifyHeavy(
+  context: Record<string, unknown>,
+  wakePayload: Record<string, unknown>,
+): HeavyReason {
+  const inFlightChildren = countInFlightChildren(wakePayload);
+  if (inFlightChildren >= UMBRELLA_IN_FLIGHT_THRESHOLD) {
+    return { heavy: true, reason: `umbrella_children:${inFlightChildren}` };
+  }
+  if (isHeavyExecutionStage(wakePayload)) {
+    return { heavy: true, reason: "execution_stage" };
+  }
+  const haystack = collectKeywordHaystack(context, wakePayload);
+  if (hasPlanModeKeyword(haystack)) {
+    return { heavy: true, reason: "plan_mode_keyword" };
+  }
+  return { heavy: false, reason: "" };
+}
+
+function pickModelForTier(profile: ModelTierProfile, tier: ModelTier): string | null {
+  if (tier === "haiku") return profile.haiku ?? profile.sonnet ?? profile.opus ?? null;
+  if (tier === "opus") return profile.opus ?? profile.sonnet ?? profile.haiku ?? null;
+  return profile.sonnet ?? profile.opus ?? profile.haiku ?? null;
+}
+
+/**
+ * Decide which model tier to use for this heartbeat.
+ *
+ * Returns null when the agent has no `modelTierProfile` (or it is disabled),
+ * meaning the caller should leave `config.model` untouched.
+ */
+export function selectHeartbeatModelTier(
+  input: ModelTierRoutingInput,
+): ModelTierSelection | null {
+  const profile = readModelTierProfile(input.config);
+  if (!profile) return null;
+
+  const context = input.context ?? {};
+  const wakePayload = input.wakePayload ?? {};
+
+  const trivial = classifyTrivial(context, wakePayload);
+  if (trivial.trivial) {
+    const tier: ModelTier = "haiku";
+    return { tier, model: pickModelForTier(profile, tier), reason: trivial.reason };
+  }
+
+  const heavy = classifyHeavy(context, wakePayload);
+  if (heavy.heavy) {
+    const tier: ModelTier = "opus";
+    return { tier, model: pickModelForTier(profile, tier), reason: heavy.reason };
+  }
+
+  const tier: ModelTier = profile.default ?? "sonnet";
+  return { tier, model: pickModelForTier(profile, tier), reason: "default" };
+}
+
+/**
+ * Apply a routing decision to an adapter `config` object. Returns a new config
+ * with `config.model` overridden when the selection produced a model id.
+ *
+ * The routing selection is also recorded under `modelTierSelection` so the
+ * adapter can surface it in env / telemetry.
+ */
+export function applyModelTierSelection(
+  config: Record<string, unknown>,
+  selection: ModelTierSelection | null,
+): Record<string, unknown> {
+  if (!selection) return config;
+  const next: Record<string, unknown> = {
+    ...config,
+    modelTierSelection: {
+      tier: selection.tier,
+      model: selection.model,
+      reason: selection.reason,
+    },
+  };
+  if (selection.model) {
+    next.model = selection.model;
+  }
+  return next;
+}


### PR DESCRIPTION
## Summary

- heartbeat 직전 wakePayload 신호만 보고 모델 티어를 선택하는 라우팅 레이어 추가 (`server/src/services/model-tier-routing.ts`)
- 에이전트 `adapterConfig.modelTierProfile`이 설정된 경우에만 활성화 (opt-in). 미설정 에이전트는 기존 `config.model` 그대로 사용
- runtimeConfig가 빌드된 직후 라우팅 함수를 호출하고, 결과를 `config.model`에 머지 + `context.paperclipModelTierSelection`에 기록 → 이후 어댑터 env / 텔레메트리에서 추적 가능 (`server/src/services/heartbeat.ts:4920-4951`)

## 라우팅 규칙 (v1)

| 분류 | 신호 | 모델 |
|---|---|---|
| trivial | blocked + 신규 코멘트 없음 / dependency-blocked interaction / 시스템 retry wake + 신규 컨텍스트 없음 / no-context wake | **Haiku** |
| heavy | 우산(자식 in-flight ≥ 3) / 플랜 모드 키워드 (`mode=plan`, `기획`, `설계`, `검토`) / execution review·approval 스테이지 | **Opus** |
| 그 외 | — | **Sonnet** (default) |

## 어댑터 변경 없음

`claude_local`(`packages/adapters/claude-local/src/server/execute.ts:504`)과 `codex_local`(`packages/adapters/codex-local/src/server/codex-args.ts:53`) 모두 이미 `config.model`을 읽어 `--model` 옵션을 전달하므로 어댑터 패치는 불필요.

## 활성화 방법 (rollout)

```jsonc
// agent.adapterConfig
{
  \"modelTierProfile\": {
    \"default\": \"sonnet\",
    \"haiku\": \"claude-haiku-4-5\",
    \"sonnet\": \"claude-sonnet-4-6\",
    \"opus\": \"claude-opus-4-7\"
  }
}
```

`enabled: false`를 명시하거나 필드를 제거하면 라우팅이 꺼지고 기존 `config.model`이 그대로 사용됨.

## Test plan

- [x] 신규 단위 테스트 17개 통과: \`pnpm --filter @paperclipai/server exec vitest run src/__tests__/model-tier-routing.test.ts\`
- [x] 회귀 확인: \`heartbeat-context-summary.test.ts\`, \`heartbeat-comment-wake-batching.test.ts\` 통과
- [x] \`pnpm --filter @paperclipai/server typecheck\` 통과
- [ ] 도입 후 7일 모니터링: trivial 분류 비율 ≥ 30%, 사후 escalation ≤ 5%, 토큰비용/머지된 PR 30% 이상 절감 (Acceptance Criteria)
- [ ] Sonnet 다운그레이드로 인한 코드 회귀 0건 검증 (회귀 발견 시 룰 보정)

## Issue

- [WOR-36](/WOR/issues/WOR-36) — 본 PR
- 우산 [WOR-29](/WOR/issues/WOR-29) v2 plan: [/WOR/issues/WOR-29#document-plan](/WOR/issues/WOR-29#document-plan)