### PR TITLE
skill(paperclip-dev): add Hard Rules 6-7 to prevent autonomous package installation

### DIFF
--- a/skills/paperclip-dev/SKILL.md
+++ b/skills/paperclip-dev/SKILL.md
@@ -204,6 +204,16 @@ These rules exist because agents have caused real damage by improvising around C
 
 5. **Seeding is a CLI operation.** When asked to seed a worktree database from the main instance, use `worktree reseed` or recreate with `worktree:make --seed-mode full`. Read `doc/DEVELOPING.md` for the full option tables. Never attempt manual database copying.
 
+6. **Never install system packages.** If a required tool (e.g. `tmux`, `pnpm`,
+   `bfg`) is missing, STOP immediately. Set the task to `blocked`, report the
+   missing tool name in a comment, and do NOT run `brew install`, `npm install -g`,
+   `pip install`, `apt install`, or any other package manager. Ask the board to
+   install it manually.
+
+7. **Verify tool availability before use.** Before running any command that
+   depends on an external tool, check with `which <tool>`. If the tool is absent,
+   apply rule 6 — do NOT attempt to install it.
+
 ## Persistent Dev Servers (for Manual Testing)
 
 When an agent needs to start a dev server that outlives the current heartbeat — for example, so a human or QA agent can manually test against it — the server process **must** be launched in a detached session. A process started directly from a heartbeat shell is killed when the heartbeat exits.


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies using Claude Code as the runtime
> - The `paperclip-dev` skill guides agents on how to develop and operate a local Paperclip instance
> - The skill's "Persistent Dev Servers" section instructs agents to use `tmux` for detached server processes
> - When `tmux` is not installed, agents encounter a `command not found` error — but the skill provides no guidance for this failure mode
> - Without explicit guidance, agents autonomously ran `brew install tmux` (and in other cases `brew install bfg`) to resolve missing tools, triggering multi-hour builds that blocked system resources
> - The existing Hard Rules section already establishes the pattern: "if a CLI command fails, stop and report" — but this principle was not applied to missing system tools
> - This PR extends that pattern with two new Hard Rules that close the gap

## What Changed

- Added **Hard Rule 6**: If a required system tool is missing, set the task to `blocked` and report it to the board. Explicitly prohibits running `brew install`, `npm install -g`, `pip install`, `apt install`, or any other package manager autonomously.
- Added **Hard Rule 7**: Always verify tool availability with `which <tool>` before use. If absent, apply Rule 6.

## Verification

1. Read the updated `skills/paperclip-dev/SKILL.md` — Hard Rules section now has rules 6 and 7 after rule 5.
2. No code changes — documentation only, no tests required.
3. Behavioral verification: an agent following this skill and encountering `command not found: tmux` should now set the task to `blocked` rather than running `brew install tmux`.

## Risks

Low risk — documentation-only change. Adds explicit prohibition that was previously implied but not enforced. Agents that were already well-behaved are unaffected. Agents that were autonomously installing packages will now block and report instead, which is the intended behavior.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Mode: tool use / agentic (Claude Code CLI)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] What Changed section lists concrete changes
- [x] Verification section explains how to confirm the change works
- [x] Risks section addresses what could go wrong
- [x] Model Used section identifies the AI model

Fixes #4633