### PR TITLE
fix: classify pre-spawn orphaned heartbeat runs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run script unit tests
+        run: pnpm test:scripts
+
       - name: Typecheck
         run: pnpm -r typecheck
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "pnpm run test:run",
     "test:watch": "pnpm run preflight:workspace-links && vitest",
     "test:run": "pnpm run preflight:workspace-links && node scripts/run-vitest-stable.mjs",
+    "test:scripts": "node --test scripts/*.test.mjs",
     "db:generate": "pnpm --filter @paperclipai/db generate",
     "db:migrate": "pnpm --filter @paperclipai/db migrate",
     "issue-references:backfill": "pnpm run preflight:workspace-links && tsx scripts/backfill-issue-reference-mentions.ts",

--- a/scripts/ensure-plugin-build-deps-lib.mjs
+++ b/scripts/ensure-plugin-build-deps-lib.mjs
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const IGNORED_INPUT_DIRS = new Set([".git", "dist", "node_modules"]);
+
+function newestMtimeMs(filePath) {
+  const stats = fs.statSync(filePath);
+  if (stats.isFile()) {
+    return stats.mtimeMs;
+  }
+  if (!stats.isDirectory()) {
+    return 0;
+  }
+
+  let newest = stats.mtimeMs;
+  for (const entry of fs.readdirSync(filePath, { withFileTypes: true })) {
+    if (entry.isDirectory() && IGNORED_INPUT_DIRS.has(entry.name)) {
+      continue;
+    }
+    newest = Math.max(newest, newestMtimeMs(path.join(filePath, entry.name)));
+  }
+  return newest;
+}
+
+function oldestMtimeMs(filePaths) {
+  let oldest = Number.POSITIVE_INFINITY;
+  for (const filePath of filePaths) {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    const stats = fs.statSync(filePath);
+    if (!stats.isFile()) {
+      return null;
+    }
+    oldest = Math.min(oldest, stats.mtimeMs);
+  }
+  return oldest;
+}
+
+export function isBuildTargetStale({ inputPaths, outputPaths }) {
+  const oldestOutput = oldestMtimeMs(outputPaths);
+  if (oldestOutput === null) {
+    return true;
+  }
+
+  let newestInput = 0;
+  for (const inputPath of inputPaths) {
+    if (!fs.existsSync(inputPath)) {
+      continue;
+    }
+    newestInput = Math.max(newestInput, newestMtimeMs(inputPath));
+  }
+
+  return newestInput > oldestOutput;
+}
+
+export function areBuildTargetsFresh(buildTargets) {
+  return buildTargets.every((target) => !isBuildTargetStale(target));
+}

--- a/scripts/ensure-plugin-build-deps-lib.test.mjs
+++ b/scripts/ensure-plugin-build-deps-lib.test.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+import test from "node:test";
+import { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { isBuildTargetStale } from "./ensure-plugin-build-deps-lib.mjs";
+
+const fixtures = [];
+
+afterEach(() => {
+  for (const dir of fixtures.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function touch(file, mtimeMs) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${path.basename(file)}\n`);
+  const time = new Date(mtimeMs);
+  fs.utimesSync(file, time, time);
+}
+
+function fixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-build-deps-test-"));
+  fixtures.push(dir);
+  return dir;
+}
+
+test("build target is fresh when every declared output is newer than every input", () => {
+  const root = fixture();
+  const input = path.join(root, "src", "index.ts");
+  const output = path.join(root, "dist", "index.d.ts");
+  touch(input, 1_000);
+  touch(output, 2_000);
+
+  assert.equal(
+    isBuildTargetStale({
+      rootDir: root,
+      inputPaths: [input],
+      outputPaths: [output],
+    }),
+    false,
+  );
+});
+
+test("build target is stale when any input is newer than the oldest declared output", () => {
+  const root = fixture();
+  const input = path.join(root, "src", "protocol.ts");
+  const output = path.join(root, "dist", "protocol.d.ts");
+  touch(output, 1_000);
+  touch(input, 2_000);
+
+  assert.equal(
+    isBuildTargetStale({
+      rootDir: root,
+      inputPaths: [input],
+      outputPaths: [output],
+    }),
+    true,
+  );
+});
+
+test("build target is stale when a declared output is missing", () => {
+  const root = fixture();
+  const input = path.join(root, "src", "index.ts");
+  touch(input, 1_000);
+
+  assert.equal(
+    isBuildTargetStale({
+      rootDir: root,
+      inputPaths: [input],
+      outputPaths: [path.join(root, "dist", "index.d.ts")],
+    }),
+    true,
+  );
+});
+
+test("directory inputs are scanned recursively and ignore dist and node_modules", () => {
+  const root = fixture();
+  const output = path.join(root, "dist", "index.d.ts");
+  touch(path.join(root, "src", "index.ts"), 1_000);
+  touch(path.join(root, "src", "nested", "types.ts"), 3_000);
+  touch(path.join(root, "src", "nested", "dist", "generated.ts"), 9_000);
+  touch(path.join(root, "src", "node_modules", "ignored.ts"), 9_000);
+  touch(output, 2_000);
+
+  assert.equal(
+    isBuildTargetStale({
+      rootDir: root,
+      inputPaths: [path.join(root, "src")],
+      outputPaths: [output],
+    }),
+    true,
+  );
+});

--- a/scripts/ensure-plugin-build-deps.mjs
+++ b/scripts/ensure-plugin-build-deps.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { areBuildTargetsFresh, isBuildTargetStale } from "./ensure-plugin-build-deps-lib.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(scriptDir, "..");
@@ -11,16 +12,44 @@ const tscCliPath = path.join(rootDir, "node_modules", "typescript", "bin", "tsc"
 const lockDir = path.join(rootDir, "node_modules", ".cache", "paperclip-plugin-build-deps.lock");
 const lockTimeoutMs = 60_000;
 const lockPollMs = 100;
+const rootTsconfig = path.join(rootDir, "tsconfig.base.json");
 
 const buildTargets = [
   {
     name: "@paperclipai/shared",
-    output: path.join(rootDir, "packages/shared/dist/index.js"),
+    outputPaths: [
+      path.join(rootDir, "packages/shared/dist/index.js"),
+      path.join(rootDir, "packages/shared/dist/index.d.ts"),
+    ],
+    inputPaths: [
+      path.join(rootDir, "packages/shared/src"),
+      path.join(rootDir, "packages/shared/package.json"),
+      path.join(rootDir, "packages/shared/tsconfig.json"),
+      rootTsconfig,
+    ],
     tsconfig: path.join(rootDir, "packages/shared/tsconfig.json"),
   },
   {
     name: "@paperclipai/plugin-sdk",
-    output: path.join(rootDir, "packages/plugins/sdk/dist/index.js"),
+    outputPaths: [
+      path.join(rootDir, "packages/plugins/sdk/dist/index.js"),
+      path.join(rootDir, "packages/plugins/sdk/dist/index.d.ts"),
+      path.join(rootDir, "packages/plugins/sdk/dist/protocol.d.ts"),
+      path.join(rootDir, "packages/plugins/sdk/dist/types.d.ts"),
+      path.join(rootDir, "packages/plugins/sdk/dist/testing.d.ts"),
+      path.join(rootDir, "packages/plugins/sdk/dist/bundlers.d.ts"),
+      path.join(rootDir, "packages/plugins/sdk/dist/dev-server.d.ts"),
+      path.join(rootDir, "packages/plugins/sdk/dist/ui/index.d.ts"),
+      path.join(rootDir, "packages/plugins/sdk/dist/ui/hooks.d.ts"),
+      path.join(rootDir, "packages/plugins/sdk/dist/ui/types.d.ts"),
+    ],
+    inputPaths: [
+      path.join(rootDir, "packages/plugins/sdk/src"),
+      path.join(rootDir, "packages/plugins/sdk/package.json"),
+      path.join(rootDir, "packages/plugins/sdk/tsconfig.json"),
+      path.join(rootDir, "packages/shared/dist/index.d.ts"),
+      rootTsconfig,
+    ],
     tsconfig: path.join(rootDir, "packages/plugins/sdk/tsconfig.json"),
   },
 ];
@@ -29,12 +58,12 @@ if (!fs.existsSync(tscCliPath)) {
   throw new Error(`TypeScript CLI not found at ${tscCliPath}`);
 }
 
-function allOutputsExist() {
-  return buildTargets.every((target) => fs.existsSync(target.output));
-}
-
 function sleep(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function allTargetsFresh() {
+  return areBuildTargetsFresh(buildTargets);
 }
 
 function waitForLockRelease() {
@@ -43,7 +72,7 @@ function waitForLockRelease() {
     if (!fs.existsSync(lockDir)) {
       return;
     }
-    if (allOutputsExist()) {
+    if (allTargetsFresh()) {
       return;
     }
     sleep(lockPollMs);
@@ -52,7 +81,7 @@ function waitForLockRelease() {
   throw new Error(`Timed out waiting for plugin build dependency lock at ${lockDir}`);
 }
 
-if (allOutputsExist()) {
+if (allTargetsFresh()) {
   process.exit(0);
 }
 
@@ -60,6 +89,7 @@ fs.mkdirSync(path.dirname(lockDir), { recursive: true });
 
 let holdsLock = false;
 let exitCode = 0;
+let rebuiltDependency = false;
 try {
   try {
     fs.mkdirSync(lockDir);
@@ -67,8 +97,8 @@ try {
   } catch (error) {
     if (error && typeof error === "object" && "code" in error && error.code === "EEXIST") {
       waitForLockRelease();
-      if (!allOutputsExist()) {
-        throw new Error("Plugin build dependency lock released before all outputs were created");
+      if (!allTargetsFresh()) {
+        throw new Error("Plugin build dependency lock released before build outputs became fresh");
       }
       process.exit(0);
     }
@@ -76,7 +106,7 @@ try {
   }
 
   for (const target of buildTargets) {
-    if (fs.existsSync(target.output)) {
+    if (!rebuiltDependency && !isBuildTargetStale(target)) {
       continue;
     }
 
@@ -93,6 +123,8 @@ try {
       exitCode = result.status ?? 1;
       break;
     }
+
+    rebuiltDependency = true;
   }
 } finally {
   if (holdsLock) {
@@ -102,4 +134,8 @@ try {
 
 if (exitCode !== 0) {
   process.exit(exitCode);
+}
+
+if (!allTargetsFresh()) {
+  throw new Error("Plugin build dependency outputs are still stale after rebuild");
 }

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -600,7 +600,7 @@ describe("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("promotes deferred comment wakes after the active run closes the issue", async () => {
+  it("does not promote deferred comment wakes after the active run closes the issue", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -741,16 +741,29 @@ describe("heartbeat comment wake batching", () => {
 
       gateway.releaseFirstWait();
 
-      await waitFor(() => gateway.getAgentPayloads().length === 2, 90_000);
       await waitFor(async () => {
         const runs = await db
           .select()
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.agentId, agentId));
-        return runs.length === 2 && runs.every((run) => run.status === "succeeded");
+        return runs.length === 1 && runs[0]?.status === "succeeded";
+      }, 90_000);
+      await waitFor(async () => {
+        const deferred = await db
+          .select({ status: agentWakeupRequests.status })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.status, "cancelled"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return deferred?.status === "cancelled";
       }, 90_000);
 
-      const reopenedIssue = await db
+      const finishedIssue = await db
         .select({
           status: issues.status,
           completedAt: issues.completedAt,
@@ -759,27 +772,15 @@ describe("heartbeat comment wake batching", () => {
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
 
-      expect(reopenedIssue).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
-      });
+      expect(finishedIssue?.status).toBe("done");
+      expect(finishedIssue?.completedAt).not.toBeNull();
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
 
-      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_commented",
-          commentIds: [comment2.id],
-          latestCommentId: comment2.id,
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Reopen after deferred comment",
-            status: "in_progress",
-            priority: "medium",
-          },
-        },
-      });
-      expect(String(secondPayload.message ?? "")).toContain("Please handle this follow-up after you finish");
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId));
+      expect(runs).toHaveLength(1);
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();
@@ -941,13 +942,19 @@ describe("heartbeat comment wake batching", () => {
 
       gateway.releaseFirstWait();
 
-      await waitFor(() => gateway.getAgentPayloads().length === 2, 90_000);
       await waitFor(async () => {
-        const runs = await db
-          .select()
-          .from(heartbeatRuns)
-          .where(eq(heartbeatRuns.companyId, companyId));
-        return runs.length === 2 && runs.every((run) => run.status === "succeeded");
+        const deferred = await db
+          .select({ status: agentWakeupRequests.status })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, mentionedAgentId),
+              eq(agentWakeupRequests.status, "cancelled"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return deferred?.status === "cancelled";
       }, 90_000);
 
       const issueAfterPromotion = await db
@@ -963,23 +970,13 @@ describe("heartbeat comment wake batching", () => {
         status: "done",
       });
       expect(issueAfterPromotion?.completedAt).not.toBeNull();
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
 
-      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_comment_mentioned",
-          commentIds: [comment.id],
-          latestCommentId: comment.id,
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Do not reopen from agent mention",
-            status: "done",
-            priority: "medium",
-          },
-        },
-      });
-      expect(String(secondPayload.message ?? "")).toContain("please review after I finish");
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.companyId, companyId));
+      expect(runs).toHaveLength(1);
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -389,6 +389,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     includeIssue?: boolean;
     runErrorCode?: string | null;
     runError?: string | null;
+    logStore?: string | null;
+    logRef?: string | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -442,6 +444,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       processPid: input?.processPid ?? null,
       processGroupId: input?.processGroupId ?? null,
       processLossRetryCount: input?.processLossRetryCount ?? 0,
+      logStore: input?.logStore ?? null,
+      logRef: input?.logRef ?? null,
       errorCode: input?.runErrorCode ?? null,
       error: input?.runError ?? null,
       startedAt: now,
@@ -914,8 +918,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
   });
 
-  it("classifies orphaned local runs with no process or log metadata as pre-spawn startup failures", async () => {
-    const { agentId, runId, issueId } = await seedRunFixture({
+  it("classifies no-log/no-pid external orphans as adapter startup failures without retry", async () => {
+    const { agentId, runId, issueId, wakeupRequestId } = await seedRunFixture({
+      adapterType: "litellm_proxy",
       processPid: null,
       processGroupId: null,
     });
@@ -933,20 +938,32 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const failedRun = runs[0];
     expect(failedRun?.status).toBe("failed");
-    expect(failedRun?.errorCode).toBe("spawn_not_started");
-    expect(failedRun?.error).toContain("No process or log metadata was persisted");
+    expect(failedRun?.errorCode).toBe("adapter_not_started");
+    expect(failedRun?.error).toContain("Adapter/log initialization did not complete");
+    expect(failedRun?.resultJson).toMatchObject({
+      timeoutConfigured: false,
+      timeoutFired: false,
+    });
     expect(failedRun?.processPid).toBeNull();
     expect(failedRun?.processGroupId).toBeNull();
     expect(failedRun?.processStartedAt).toBeNull();
     expect(failedRun?.logStore).toBeNull();
     expect(failedRun?.logRef).toBeNull();
 
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("failed");
+    expect(wakeup?.error).toContain("Adapter/log initialization did not complete");
+
     const events = await db
       .select()
       .from(heartbeatRunEvents)
       .where(eq(heartbeatRunEvents.runId, runId));
     expect(events).toHaveLength(1);
-    expect(events[0]?.message).toContain("No process or log metadata was persisted");
+    expect(events[0]?.message).toContain("Adapter/log initialization did not complete");
 
     const issue = await db
       .select()
@@ -955,6 +972,37 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBeNull();
     expect(issue?.checkoutRunId).toBeNull();
+  });
+
+  it("classifies external orphans with initialized logs as adapter incomplete", async () => {
+    const { agentId, runId } = await seedRunFixture({
+      adapterType: "litellm_proxy",
+      processPid: null,
+      processGroupId: null,
+      logStore: "file",
+      logRef: "heartbeat/test-run.log",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+
+    const failedRun = runs[0];
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("adapter_not_completed");
+    expect(failedRun?.errorCode).not.toBe("process_lost");
+    expect(failedRun?.error).toContain("Adapter initialized logging");
+    expect(failedRun?.resultJson).toMatchObject({
+      timeoutConfigured: false,
+      timeoutFired: false,
+    });
   });
 
   it("blocks the issue when process-loss retry is exhausted and the immediate continuation recovery also fails", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -914,6 +914,49 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
   });
 
+  it("classifies orphaned local runs with no process or log metadata as pre-spawn startup failures", async () => {
+    const { agentId, runId, issueId } = await seedRunFixture({
+      processPid: null,
+      processGroupId: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+
+    const failedRun = runs[0];
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("spawn_not_started");
+    expect(failedRun?.error).toContain("No process or log metadata was persisted");
+    expect(failedRun?.processPid).toBeNull();
+    expect(failedRun?.processGroupId).toBeNull();
+    expect(failedRun?.processStartedAt).toBeNull();
+    expect(failedRun?.logStore).toBeNull();
+    expect(failedRun?.logRef).toBeNull();
+
+    const events = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(events).toHaveLength(1);
+    expect(events[0]?.message).toContain("No process or log metadata was persisted");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
+  });
+
   it("blocks the issue when process-loss retry is exhausted and the immediate continuation recovery also fails", async () => {
     mockAdapterExecute.mockRejectedValueOnce(new Error("continuation recovery failed"));
 

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -338,7 +338,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
+  it("keeps closed issues inert via the PATCH comment path even when reassigning to an agent", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
@@ -354,22 +354,22 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({
         assigneeAgentId: "33333333-3333-4333-8333-333333333333",
-        status: "todo",
         actorAgentId: null,
         actorUserId: "local-board",
       }),
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         action: "issue.updated",
-        details: expect.objectContaining({
-          reopened: true,
-          reopenedFrom: "done",
-          status: "todo",
-        }),
+        details: expect.not.objectContaining({ reopened: true }),
       }),
     );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("resolves assignee shortnames before updating an issue", async () => {
@@ -450,7 +450,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via POST comments when an agent is assigned", async () => {
+  it("keeps assigned closed issues inert via generic POST comments", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
@@ -462,19 +462,8 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "hello" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
-    );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          reopenedFrom: "done",
-        }),
-      }),
-    ));
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("does not implicitly reopen closed issues via POST comments for agent-authored comments", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -191,10 +191,10 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   actorType: "agent" | "user";
   actorId: string;
 }) {
-  // Only human comments should implicitly reopen finished work.
-  // Agent-authored comments remain communicative unless reopen was explicit.
+  // Only human comments on active blocked work should implicitly resume an agent.
+  // Closed historical issues must stay inert unless reopen/resume is explicit.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  if (input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }
@@ -2459,7 +2459,12 @@ export function issueRoutes(
 
       if (executionStageWakeup) {
         addWakeup(executionStageWakeup.agentId, executionStageWakeup.wakeup);
-      } else if (assigneeChanged && issue.assigneeAgentId && issue.status !== "backlog") {
+      } else if (
+        assigneeChanged &&
+        issue.assigneeAgentId &&
+        issue.status !== "backlog" &&
+        !isClosedIssueStatus(issue.status)
+      ) {
         addWakeup(issue.assigneeAgentId, {
           source: "assignment",
           triggerDetail: "system",
@@ -2558,6 +2563,7 @@ export function issueRoutes(
         }
 
         for (const mentionedId of mentionedIds) {
+          if (isClosed && !reopened) continue;
           if (actor.actorType === "agent" && actor.actorId === mentionedId) continue;
           addWakeup(mentionedId, {
             source: "automation",
@@ -3536,6 +3542,7 @@ export function issueRoutes(
       }
 
       for (const mentionedId of mentionedIds) {
+        if (isClosed && !reopened) continue;
         if (wakeups.has(mentionedId)) continue;
         if (actorIsAgent && actor.actorId === mentionedId) continue;
         wakeups.set(mentionedId, {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6087,58 +6087,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           };
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
-        const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
-        // Only human/comment-reopen interactions should revive completed issues;
-        // system follow-ups such as retry or cleanup wakes must not reopen closed work.
-        const shouldReopenDeferredCommentWake =
-          deferredCommentIds.length > 0 &&
-          (issue.status === "done" || issue.status === "cancelled") &&
-          (
-            deferred.requestedByActorType === "user" ||
-            deferredWakeReason === "issue_reopened_via_comment"
-          );
-        let reopenedActivity: LogActivityInput | null = null;
-
-        if (shouldReopenDeferredCommentWake) {
-          const reopenedFromStatus = issue.status;
-          const reopenedIssue = await issuesSvc.update(
-            issue.id,
-            {
-              status: "todo",
-              executionState: null,
-            },
-            tx,
-          );
-          if (reopenedIssue) {
-            issue = {
-              ...issue,
-              identifier: reopenedIssue.identifier,
-              status: reopenedIssue.status,
-              executionRunId: reopenedIssue.executionRunId,
-            };
-            if (!readNonEmptyString(promotedContextSeed.reopenedFrom)) {
-              promotedContextSeed.reopenedFrom = reopenedFromStatus;
-            }
-            reopenedActivity = {
-              companyId: issue.companyId,
-              actorType: "system",
-              actorId: "heartbeat",
-              agentId: deferred.agentId,
-              runId: run.id,
-              action: "issue.updated",
-              entityType: "issue",
-              entityId: issue.id,
-              details: {
-                status: "todo",
-                reopened: true,
-                reopenedFrom: reopenedFromStatus,
-                source: "deferred_comment_wake",
-                identifier: issue.identifier,
-              },
-            };
-          }
+        // A deferred comment is only a follow-up while the issue remains open. If the
+        // active run closed/cancelled the issue, drop the deferred wake instead of
+        // resurrecting completed historical work.
+        if (deferredCommentIds.length > 0 && (issue.status === "done" || issue.status === "cancelled")) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "cancelled",
+              finishedAt: new Date(),
+              error: `Deferred comment wake suppressed because issue reached terminal status (${issue.status})`,
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
         }
-
         const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
         const promotedSource =
           (readNonEmptyString(deferred.source) as WakeupOptions["source"]) ?? "automation";
@@ -6208,7 +6171,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return {
           kind: "promoted" as const,
           run: newRun,
-          reopenedActivity,
         };
       }
 
@@ -6346,10 +6308,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const promotedRun = promotionResult?.run ?? null;
     if (!promotedRun) return;
-
-    if (promotionResult?.kind === "promoted" && promotionResult.reopenedActivity) {
-      await logActivity(db, promotionResult.reopenedActivity);
-    }
 
     publishLiveEvent({
       companyId: promotedRun.companyId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -145,6 +145,7 @@ const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
 const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+const SPAWN_NOT_STARTED_ERROR_CODE = "spawn_not_started";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
@@ -1873,6 +1874,28 @@ function buildProcessLossMessage(run: {
     return `Process lost -- process group ${run.processGroupId} is no longer running`;
   }
   return "Process lost -- server may have restarted";
+}
+
+function hasNoPersistedExecutionMetadata(run: {
+  processPid: number | null;
+  processGroupId: number | null;
+  processStartedAt?: Date | string | null;
+  logStore?: string | null;
+  logRef?: string | null;
+  stdoutExcerpt?: string | null;
+  stderrExcerpt?: string | null;
+}) {
+  return !run.processPid &&
+    !run.processGroupId &&
+    !run.processStartedAt &&
+    !run.logStore &&
+    !run.logRef &&
+    !run.stdoutExcerpt &&
+    !run.stderrExcerpt;
+}
+
+function buildSpawnNotStartedMessage() {
+  return "No process or log metadata was persisted before the server lost this run; adapter spawn likely did not start";
 }
 
 function truncateDisplayId(value: string | null | undefined, max = 128) {
@@ -4400,11 +4423,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
-      const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const missingExecutionMetadata = tracksLocalChild && hasNoPersistedExecutionMetadata(run);
+      const baseMessage = missingExecutionMetadata
+        ? buildSpawnNotStartedMessage()
+        : buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const errorCode = missingExecutionMetadata ? SPAWN_NOT_STARTED_ERROR_CODE : "process_lost";
 
       let finalizedRun = await setRunStatus(run.id, "failed", {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
-        errorCode: "process_lost",
+        errorCode,
         finishedAt: now,
         resultJson: mergeRunStopMetadataForAgent(
           { adapterType, adapterConfig },

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -145,7 +145,8 @@ const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
 const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
-const SPAWN_NOT_STARTED_ERROR_CODE = "spawn_not_started";
+const ADAPTER_NOT_STARTED_ERROR_CODE = "adapter_not_started";
+const ADAPTER_NOT_COMPLETED_ERROR_CODE = "adapter_not_completed";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
@@ -1894,8 +1895,12 @@ function hasNoPersistedExecutionMetadata(run: {
     !run.stderrExcerpt;
 }
 
-function buildSpawnNotStartedMessage() {
-  return "No process or log metadata was persisted before the server lost this run; adapter spawn likely did not start";
+function buildAdapterNotStartedMessage() {
+  return "Adapter/log initialization did not complete before the server lost this run; no process or log metadata was persisted";
+}
+
+function buildAdapterNotCompletedMessage() {
+  return "Adapter initialized logging but did not terminalize before the server lost this run";
 }
 
 function truncateDisplayId(value: string | null | undefined, max = 128) {
@@ -4422,12 +4427,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         });
       }
 
-      const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
-      const missingExecutionMetadata = tracksLocalChild && hasNoPersistedExecutionMetadata(run);
-      const baseMessage = missingExecutionMetadata
-        ? buildSpawnNotStartedMessage()
-        : buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
-      const errorCode = missingExecutionMetadata ? SPAWN_NOT_STARTED_ERROR_CODE : "process_lost";
+      const missingExecutionMetadata = hasNoPersistedExecutionMetadata(run);
+      const hasProcessEvidence = !!run.processPid || !!run.processGroupId;
+      const hasLogEvidence = !!run.logStore || !!run.logRef;
+      // Tactical PER-2753 classification until lifecycle_phase makes the
+      // initialization boundary explicit. Public heartbeat_runs.status stays
+      // unchanged; only diagnostic errorCode/message changes here.
+      const orphanError = missingExecutionMetadata
+        ? {
+          code: ADAPTER_NOT_STARTED_ERROR_CODE,
+          message: buildAdapterNotStartedMessage(),
+        }
+        : !tracksLocalChild && !hasProcessEvidence && hasLogEvidence
+        ? {
+          code: ADAPTER_NOT_COMPLETED_ERROR_CODE,
+          message: buildAdapterNotCompletedMessage(),
+        }
+        : {
+          code: "process_lost",
+          message: buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined),
+        };
+      const shouldRetry = orphanError.code === "process_lost" && tracksLocalChild && hasProcessEvidence && (run.processLossRetryCount ?? 0) < 1;
+      const baseMessage = orphanError.message;
+      const errorCode = orphanError.code;
 
       let finalizedRun = await setRunStatus(run.id, "failed", {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
@@ -4438,7 +4460,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           "failed",
           {
             resultJson: parseObject(run.resultJson),
-            errorCode: "process_lost",
+            errorCode,
             errorMessage: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
           },
         ),


### PR DESCRIPTION
## Summary
- add regressions for external/non-local heartbeat runs orphaned before adapter/log/process metadata is initialized
- classify no-log/no-pid pre-spawn/pre-initialization orphans as `adapter_not_started`, not opaque `process_lost`
- classify external runs with initialized logs but no terminal adapter result as `adapter_not_completed`, not `process_lost`
- preserve public heartbeat run statuses (`queued | running | succeeded | failed | cancelled | timed_out`); this PR does not add `starting`
- preserve existing `process_lost` retry behavior for tracked local child-process runs with persisted pid/process-group evidence

## Scope / non-goals
- Tactical PER-2753 classification only
- No DB migration
- No `lifecycle_phase`
- No public status expansion
- No PER-2754/#4658 instance-affinity changes
- Structural lifecycle boundary work remains a separate follow-up

## Test Plan
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `gh pr checks` (CI running after latest push)

Linear: PER-2753
