### PR TITLE
claude-local: retry 403 'organization does not have access' during seat-rotator switching window (PER-41)

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -42,12 +42,14 @@ import {
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeMaxTurnsResult,
+  isClaudeSeatRotationAccessError,
   isClaudeTransientUpstreamError,
   isClaudeUnknownSessionError,
 } from "./parse.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
+import { retryDuringSeatRotation } from "./seat-rotation.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -747,8 +749,27 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   };
 
+  type ClaudeAttempt = Awaited<ReturnType<typeof runAttempt>>;
+
+  const isSeatRotationAccessAttempt = (attempt: ClaudeAttempt): boolean => {
+    if (attempt.proc.timedOut) return false;
+    if ((attempt.proc.exitCode ?? 0) === 0) return false;
+    return isClaudeSeatRotationAccessError({
+      parsed: attempt.parsed,
+      stdout: attempt.proc.stdout,
+      stderr: attempt.proc.stderr,
+    });
+  };
+
+  const runWithSeatRotationRetry = (resumeSessionId: string | null) =>
+    runAttempt(resumeSessionId).then((initial) =>
+      retryDuringSeatRotation(initial, isSeatRotationAccessAttempt, () => runAttempt(resumeSessionId), {
+        onLog: (message) => onLog("stdout", `${message}\n`),
+      }),
+    );
+
   try {
-    const initial = await runAttempt(sessionId ?? null);
+    const initial = await runWithSeatRotationRetry(sessionId ?? null);
     if (
       sessionId &&
       !initial.proc.timedOut &&
@@ -760,7 +781,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         "stdout",
         `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
       );
-      const retry = await runAttempt(null);
+      const retry = await runWithSeatRotationRetry(null);
       return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
     }
 

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   extractClaudeRetryNotBefore,
+  isClaudeSeatRotationAccessError,
   isClaudeTransientUpstreamError,
 } from "./parse.js";
 
@@ -119,5 +120,65 @@ describe("extractClaudeRetryNotBefore", () => {
     expect(
       extractClaudeRetryNotBefore({ errorMessage: "Overloaded. Try again later." }, new Date()),
     ).toBeNull();
+  });
+});
+
+describe("isClaudeSeatRotationAccessError", () => {
+  it("classifies the seat-rotator 403 body as a seat-rotation access error", () => {
+    expect(
+      isClaudeSeatRotationAccessError({
+        errorMessage: "API Error: 403 Your organization does not have access to Claude.",
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeSeatRotationAccessError({
+        parsed: {
+          is_error: true,
+          result:
+            "Anthropic API Error: HTTP 403 — Your organization does not have access to Claude.",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("matches the shorter 'organization does not have access' phrasing in stderr", () => {
+    expect(
+      isClaudeSeatRotationAccessError({
+        stderr: "Error from API: organization does not have access\n",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not classify generic transient-upstream messages as seat-rotation errors", () => {
+    expect(
+      isClaudeSeatRotationAccessError({
+        errorMessage: "Server overloaded (529). Try again later.",
+      }),
+    ).toBe(false);
+    expect(
+      isClaudeSeatRotationAccessError({
+        errorMessage: "rate_limit_error: 429 Too Many Requests",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not classify login-required errors as seat-rotation access errors", () => {
+    expect(
+      isClaudeSeatRotationAccessError({
+        errorMessage: "Please run `claude login` to authenticate.",
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores deterministic max-turns / unknown-session results", () => {
+    expect(
+      isClaudeSeatRotationAccessError({
+        parsed: {
+          is_error: true,
+          subtype: "error_max_turns",
+          result: "Reached max turns",
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -11,6 +11,15 @@ const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
   /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+
+// 403 from `api.anthropic.com` during a `claude-seat-rotator` swap. The body
+// always contains the literal phrase "organization does not have access" (full
+// upstream message: "Your organization does not have access to Claude.").
+// Distinct from the transient-upstream pattern because we want to retry it
+// internally with a marker-aware budget instead of bubbling it up as a generic
+// transient error.
+const CLAUDE_SEAT_ROTATION_ACCESS_RE =
+  /organization\s+does\s+not\s+have\s+access(?:\s+to\s+claude)?/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
@@ -380,4 +389,26 @@ export function isClaudeTransientUpstreamError(input: {
   const haystack = buildClaudeTransientHaystack(input);
   if (!haystack) return false;
   return CLAUDE_TRANSIENT_UPSTREAM_RE.test(haystack);
+}
+
+export function isClaudeSeatRotationAccessError(input: {
+  parsed?: Record<string, unknown> | null;
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+}): boolean {
+  const parsed = input.parsed ?? null;
+  if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed))) {
+    return false;
+  }
+  const loginMeta = detectClaudeLoginRequired({
+    parsed,
+    stdout: input.stdout ?? "",
+    stderr: input.stderr ?? "",
+  });
+  if (loginMeta.requiresLogin) return false;
+
+  const haystack = buildClaudeTransientHaystack(input);
+  if (!haystack) return false;
+  return CLAUDE_SEAT_ROTATION_ACCESS_RE.test(haystack);
 }

--- a/packages/adapters/claude-local/src/server/seat-rotation.test.ts
+++ b/packages/adapters/claude-local/src/server/seat-rotation.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  retryDuringSeatRotation,
+  type SeatRotationMarker,
+} from "./seat-rotation.js";
+
+interface FakeAttempt {
+  ok: boolean;
+}
+
+function makeFakeMarker(overrides: Partial<SeatRotationMarker> = {}): SeatRotationMarker {
+  return {
+    from: "acct-a",
+    to: "acct-b",
+    startedAt: new Date().toISOString(),
+    expectedDurationMs: 30_000,
+    pid: 12345,
+    ...overrides,
+  };
+}
+
+describe("retryDuringSeatRotation", () => {
+  it("returns the initial attempt unchanged when it is not an access error", async () => {
+    const initial: FakeAttempt = { ok: true };
+    const runAttempt = async (): Promise<FakeAttempt> => {
+      throw new Error("runAttempt should not be called when initial succeeded");
+    };
+    const result = await retryDuringSeatRotation(initial, (a) => !a.ok, runAttempt);
+    expect(result).toBe(initial);
+  });
+
+  it("retries until the next attempt succeeds, while marker is live", async () => {
+    const attempts: FakeAttempt[] = [
+      { ok: false },
+      { ok: false },
+      { ok: true },
+    ];
+    let nextIndex = 1;
+    const runAttempt = async (): Promise<FakeAttempt> => {
+      const attempt = attempts[nextIndex];
+      nextIndex += 1;
+      if (!attempt) throw new Error("Exhausted scripted attempts");
+      return attempt;
+    };
+
+    let virtualNow = 0;
+    const sleeps: number[] = [];
+    const result = await retryDuringSeatRotation<FakeAttempt>(
+      attempts[0]!,
+      (a) => !a.ok,
+      runAttempt,
+      {
+        totalBudgetMs: 45_000,
+        baseBackoffMs: 3_000,
+        isInProgress: () => ({ inProgress: true, marker: makeFakeMarker() }),
+        sleep: async (ms) => {
+          sleeps.push(ms);
+          virtualNow += ms;
+        },
+        now: () => virtualNow,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(sleeps).toEqual([3_000, 6_000]);
+  });
+
+  it("stops retrying once the budget is exhausted, even with live marker", async () => {
+    const failing: FakeAttempt = { ok: false };
+    let calls = 0;
+    const runAttempt = async (): Promise<FakeAttempt> => {
+      calls += 1;
+      return failing;
+    };
+
+    let virtualNow = 0;
+    const sleeps: number[] = [];
+    const result = await retryDuringSeatRotation<FakeAttempt>(
+      failing,
+      (a) => !a.ok,
+      runAttempt,
+      {
+        totalBudgetMs: 10_000,
+        baseBackoffMs: 3_000,
+        isInProgress: () => ({ inProgress: true, marker: makeFakeMarker() }),
+        sleep: async (ms) => {
+          sleeps.push(ms);
+          virtualNow += ms;
+        },
+        now: () => virtualNow,
+      },
+    );
+
+    expect(result).toBe(failing);
+    // 3s, 6s. Third attempt would compute remaining=10_000-9_000=1_000 and sleep 1_000ms
+    // before the final retry; loop then exits because budget exhausted.
+    expect(sleeps).toEqual([3_000, 6_000, 1_000]);
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("retries at most once when the marker is absent (no rotator in progress)", async () => {
+    const failing: FakeAttempt = { ok: false };
+    let calls = 0;
+    const runAttempt = async (): Promise<FakeAttempt> => {
+      calls += 1;
+      return failing;
+    };
+
+    let virtualNow = 0;
+    const sleeps: number[] = [];
+    const result = await retryDuringSeatRotation<FakeAttempt>(
+      failing,
+      (a) => !a.ok,
+      runAttempt,
+      {
+        totalBudgetMs: 45_000,
+        baseBackoffMs: 3_000,
+        isInProgress: () => ({ inProgress: false, marker: null }),
+        sleep: async (ms) => {
+          sleeps.push(ms);
+          virtualNow += ms;
+        },
+        now: () => virtualNow,
+      },
+    );
+
+    expect(result).toBe(failing);
+    expect(calls).toBe(1);
+    expect(sleeps).toEqual([3_000]);
+  });
+
+  it("retries at most once when the marker is stale", async () => {
+    const failing: FakeAttempt = { ok: false };
+    let calls = 0;
+    const runAttempt = async (): Promise<FakeAttempt> => {
+      calls += 1;
+      return failing;
+    };
+
+    let virtualNow = 0;
+    const sleeps: number[] = [];
+    const staleMarker = makeFakeMarker({ startedAt: "2020-01-01T00:00:00Z" });
+    const result = await retryDuringSeatRotation<FakeAttempt>(
+      failing,
+      (a) => !a.ok,
+      runAttempt,
+      {
+        totalBudgetMs: 45_000,
+        baseBackoffMs: 3_000,
+        isInProgress: () => ({ inProgress: false, marker: staleMarker }),
+        sleep: async (ms) => {
+          sleeps.push(ms);
+          virtualNow += ms;
+        },
+        now: () => virtualNow,
+      },
+    );
+
+    expect(result).toBe(failing);
+    expect(calls).toBe(1);
+    expect(sleeps).toEqual([3_000]);
+  });
+});

--- a/packages/adapters/claude-local/src/server/seat-rotation.ts
+++ b/packages/adapters/claude-local/src/server/seat-rotation.ts
@@ -1,0 +1,174 @@
+/**
+ * Seat-rotation retry support for the `claude-seat-rotator` watchdog.
+ *
+ * The seat rotator (https://github.com/.../claude-seat-rotator) moves a single
+ * Claude Team Premium seat between accounts. During the ~5-25 s seat-swap
+ * window, `api.anthropic.com` returns HTTP 403 with a body matching
+ * `Your organization does not have access to Claude` for any in-flight
+ * Claude CLI call, because the active account briefly holds no Premium seat.
+ *
+ * The watchdog mitigates the window by writing a marker file at
+ * `~/.claude/seat-rotator-switching.json` before starting a swap and clearing
+ * it after completion. This module reads that marker and exposes a liveness
+ * helper so the adapter can retry the spawned Claude CLI with linear backoff
+ * instead of bubbling the 403 up as a hard failure.
+ *
+ * Marker schema is mirrored from `claude-seat-rotator/src/switch-marker.ts`.
+ * Treat the schema as a stable contract — bump `SEAT_ROTATION_MARKER_PATH` or
+ * the parser if the rotator changes its on-disk format.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const SEAT_ROTATION_MARKER_PATH = join(
+  homedir(),
+  ".claude",
+  "seat-rotator-switching.json",
+);
+
+export interface SeatRotationMarker {
+  from: string;
+  to: string;
+  startedAt: string;
+  expectedDurationMs: number;
+  pid: number;
+}
+
+export function readSeatRotationMarker(
+  path: string = SEAT_ROTATION_MARKER_PATH,
+): SeatRotationMarker | null {
+  if (!existsSync(path)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  if (
+    typeof obj.from !== "string" ||
+    typeof obj.to !== "string" ||
+    typeof obj.startedAt !== "string" ||
+    typeof obj.expectedDurationMs !== "number" ||
+    typeof obj.pid !== "number"
+  ) {
+    return null;
+  }
+  return {
+    from: obj.from,
+    to: obj.to,
+    startedAt: obj.startedAt,
+    expectedDurationMs: obj.expectedDurationMs,
+    pid: obj.pid,
+  };
+}
+
+export function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as { code?: string } | undefined)?.code;
+    // EPERM means the pid exists but is owned by another user — still alive.
+    if (code === "EPERM") return true;
+    return false;
+  }
+}
+
+/**
+ * "Alive" = marker present, pid alive, and not older than 2× the rotator's
+ * own expected duration. Older markers are treated as stale leftovers from a
+ * crashed watchdog.
+ */
+export function isSeatRotationInProgress(
+  now: Date = new Date(),
+  reader: () => SeatRotationMarker | null = readSeatRotationMarker,
+  pidLivenessCheck: (pid: number) => boolean = isPidAlive,
+): { inProgress: boolean; marker: SeatRotationMarker | null } {
+  const marker = reader();
+  if (!marker) return { inProgress: false, marker: null };
+  if (!pidLivenessCheck(marker.pid)) return { inProgress: false, marker };
+
+  const startedAt = Date.parse(marker.startedAt);
+  if (Number.isFinite(startedAt)) {
+    const ageMs = now.getTime() - startedAt;
+    const staleAfterMs = Math.max(marker.expectedDurationMs * 2, 60_000);
+    if (ageMs > staleAfterMs) return { inProgress: false, marker };
+  }
+  return { inProgress: true, marker };
+}
+
+export const SEAT_ROTATION_RETRY_DEFAULT_BUDGET_MS = 45_000;
+export const SEAT_ROTATION_RETRY_DEFAULT_BASE_BACKOFF_MS = 3_000;
+
+export interface SeatRotationRetryConfig {
+  totalBudgetMs?: number;
+  baseBackoffMs?: number;
+  isInProgress?: () => { inProgress: boolean; marker: SeatRotationMarker | null };
+  onLog?: (message: string) => void | Promise<void>;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+/**
+ * Retry `runAttempt` while `isAccessError(attempt)` is true and we are inside
+ * the seat-rotation switching window. Caps total wall-clock at
+ * `totalBudgetMs` (~45 s by default, sized for 2× the rotator's own 30 s
+ * expected duration). When the marker is absent or stale, retry once at most
+ * — covers the small race where the 403 surfaces before the rotator has
+ * written its marker file, but doesn't wait forever on unrelated 403s.
+ */
+export async function retryDuringSeatRotation<T>(
+  initial: T,
+  isAccessError: (attempt: T) => boolean,
+  runAttempt: () => Promise<T>,
+  config?: SeatRotationRetryConfig,
+): Promise<T> {
+  if (!isAccessError(initial)) return initial;
+
+  const totalBudgetMs = config?.totalBudgetMs ?? SEAT_ROTATION_RETRY_DEFAULT_BUDGET_MS;
+  const baseBackoffMs = config?.baseBackoffMs ?? SEAT_ROTATION_RETRY_DEFAULT_BASE_BACKOFF_MS;
+  const isInProgress = config?.isInProgress ?? (() => isSeatRotationInProgress());
+  const sleep = config?.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const onLog = config?.onLog ?? (() => undefined);
+  const now = config?.now ?? (() => Date.now());
+
+  const startedAt = now();
+  let attempt = initial;
+  let retries = 0;
+
+  while (isAccessError(attempt)) {
+    const elapsed = now() - startedAt;
+    const remaining = totalBudgetMs - elapsed;
+    if (remaining <= 0) break;
+
+    const liveness = isInProgress();
+    if (!liveness.inProgress && retries >= 1) break;
+
+    const backoff = Math.min(baseBackoffMs * (retries + 1), remaining);
+    const markerNote = liveness.inProgress
+      ? `live (pid ${liveness.marker?.pid ?? "?"})`
+      : liveness.marker
+      ? "stale"
+      : "absent";
+    await onLog(
+      `[paperclip] seat-rotation 403 detected (marker ${markerNote}); retrying in ${backoff} ms (attempt ${retries + 1}).`,
+    );
+
+    await sleep(backoff);
+    attempt = await runAttempt();
+    retries += 1;
+  }
+
+  return attempt;
+}


### PR DESCRIPTION
## Summary

Closes the propagation gap between the `claude-seat-rotator` watchdog rotation (PER-34) and parallel `claude --print` sessions. When the watchdog briefly leaves the team without a Premium seat (~5–25 s), `api.anthropic.com` returns HTTP 403 with body `Your organization does not have access to Claude`. This change makes the `claude_local` adapter detect that exact 403 and retry with linear backoff during the switching window.

## What changed

- `packages/adapters/claude-local/src/server/seat-rotation.ts` (new, 174 LoC) — mirrors the PER-34 marker schema (`SeatRotationMarker`), reads `~/.claude/seat-rotator-switching.json`, checks pid liveness via `kill -0` (`EPERM` counts as alive), treats markers older than 2× `expectedDurationMs` as stale, and exposes `retryDuringSeatRotation()` as the generic retry wrapper.
- `packages/adapters/claude-local/src/server/parse.ts` — new `isClaudeSeatRotationAccessError()` with a dedicated regex `/organization\s+does\s+not\s+have\s+access(?:\s+to\s+claude)?/i`. Explicitly excludes `login-required`, `max-turns`, and `unknown-session` so existing fast-fail paths stay intact.
- `packages/adapters/claude-local/src/server/execute.ts` — wraps both the initial run and the fresh-session retry path with `retryDuringSeatRotation()`. Logs `[paperclip] seat-rotation 403 detected (marker live (pid …)); retrying in 3000 ms (attempt 1).` to the stream.

Retry rule:
- Marker live (pid alive, age < 2× expected) → linear backoff (3 s, 6 s, 9 s, …) until budget exhausted.
- Marker absent or stale → exactly one retry. Covers the race where the 403 fires before the rotator writes the marker, without retrying generic 403s forever.

Defaults: `SEAT_ROTATION_RETRY_DEFAULT_BUDGET_MS = 45_000` (1.5× `SWITCH_EXPECTED_DURATION_MS`), `SEAT_ROTATION_RETRY_DEFAULT_BASE_BACKOFF_MS = 3_000`.

## Acceptance mapping (PER-41)

| Acceptance | Status |
|---|---|
| Adapter retries 403 with body `organization does not have access` | done — `isClaudeSeatRotationAccessError` |
| Linear backoff | done — 3 s, 6 s, 9 s, … |
| Cap retries ~30–45 s | done — 45 s budget |
| Marker-aware (pid alive, otherwise retry-once) | done — `isSeatRotationInProgress` |
| Manual smoke test (long-running run survives a rotation) | open — needs human-driven smoke test once this PR is merged |

## Test plan

- [x] Unit: `pnpm exec vitest run packages/adapters/claude-local/src/server/seat-rotation.test.ts packages/adapters/claude-local/src/server/parse.test.ts` — 19/19 green (5 new in `seat-rotation.test.ts`, 5 new in `parse.test.ts`). Tests use a virtual marker/timer; no real `setTimeout` waits.
- [x] Typecheck: `pnpm -F @paperclipai/adapter-claude-local typecheck` — clean.
- [ ] Manual smoke test post-merge: stop server, run `claude-rotator watchdog` from `claude-seat-rotator`, restart server, drive a long heartbeat-backed agent run, trigger a watchdog swap mid-turn. Expect `[paperclip] seat-rotation 403 detected (marker live (pid <pid>)); retrying in 3000 ms (attempt 1).` and successful completion. Owner: Senior Engineer or DevOps.

## References

- Tracked in Paperclip issue PER-41 (parent: PER-34 — watchdog mid-switch protection).
- PER-34 marker contract: `claude-seat-rotator/src/switch-marker.ts` (commit `7ec250d` on `feat/per-34-mid-switch-protection`).
- CTO architecture sign-off in PER-41 thread (2026-04-28T05:59Z).

🤖 Generated with [Claude Code](https://claude.com/claude-code)