### PR TITLE
feat(adapters): add custom LLM adapter and refresh local model choices

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -42,6 +42,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-custom-llm-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -2,6 +2,7 @@ import type { CLIAdapterModule } from "@paperclipai/adapter-utils";
 import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
 import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
+import { printCustomLlmLocalStreamEvent } from "@paperclipai/adapter-custom-llm-local/cli";
 import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
@@ -34,6 +35,11 @@ const cursorLocalCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printCursorStreamEvent,
 };
 
+const customLlmLocalCLIAdapter: CLIAdapterModule = {
+  type: "custom_llm_local",
+  formatStdoutEvent: printCustomLlmLocalStreamEvent,
+};
+
 const geminiLocalCLIAdapter: CLIAdapterModule = {
   type: "gemini_local",
   formatStdoutEvent: printGeminiStreamEvent,
@@ -51,6 +57,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     openCodeLocalCLIAdapter,
     piLocalCLIAdapter,
     cursorLocalCLIAdapter,
+    customLlmLocalCLIAdapter,
     geminiLocalCLIAdapter,
     openclawGatewayCLIAdapter,
     processCLIAdapter,

--- a/docs/adapters/codex-local.md
+++ b/docs/adapters/codex-local.md
@@ -23,6 +23,18 @@ The `codex_local` adapter runs OpenAI's Codex CLI locally. It supports session p
 | `fastMode` | boolean | No | Enables Codex Fast mode. Currently supported on `gpt-5.4` only and burns credits faster |
 | `dangerouslyBypassApprovalsAndSandbox` | boolean | No | Skip safety checks (dev only) |
 
+## Selectable Models
+
+The built-in dropdown lists model IDs verified against the Codex CLI `--model` chat path for ChatGPT subscription auth:
+
+- `gpt-5.5` — flagship model; can invoke Codex image generation tools, including GPT Image 2, from the agent workflow.
+- `gpt-5.4` — supports Codex Fast mode.
+- `gpt-5.4-mini`
+- `gpt-5.3-codex`
+- `gpt-5.3-codex-spark`
+
+Do not set `model` to `gpt-image-2`. GPT Image 2 is a media-generation tool/model surface, not a Codex CLI chat model value; configure a supported Codex chat model such as `gpt-5.5` and let the agent call the image generation tool.
+
 ## Session Persistence
 
 Codex uses `previous_response_id` for session continuity. The adapter serializes and restores this across heartbeats, allowing the agent to maintain conversation context.

--- a/docs/adapters/gemini-local.md
+++ b/docs/adapters/gemini-local.md
@@ -23,6 +23,20 @@ The `gemini_local` adapter runs Google's Gemini CLI locally. It supports session
 | `graceSec` | number | No | Grace period before force-kill |
 | `yolo` | boolean | No | Pass `--approval-mode yolo` for unattended operation |
 
+## Selectable Models
+
+The built-in dropdown lists model IDs verified against the Gemini CLI `--model` chat path:
+
+- `auto`
+- `gemini-3.1-pro-preview`
+- `gemini-3-flash-preview`
+- `gemini-3.1-flash-lite-preview`
+- `gemini-2.5-pro`
+- `gemini-2.5-flash`
+- `gemini-2.5-flash-lite`
+
+Image and video generation IDs are intentionally not selectable here. The standard Gemini CLI non-interactive chat route rejects `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview`, and `veo-3.1-generate-preview`; use a dedicated Gemini media-generation API or extension route for Nano Banana / Veo workflows instead.
+
 ## Session Persistence
 
 The adapter persists Gemini session IDs between heartbeats. On the next wake, it resumes the existing conversation with `--resume` so the agent retains context.

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -12,16 +12,11 @@ export function isCodexLocalFastModeSupported(model: string | null | undefined):
 }
 
 export const models = [
-  { id: "gpt-5.4", label: "gpt-5.4" },
+  { id: "gpt-5.5", label: "gpt-5.5 (supports image generation tools)" },
+  { id: "gpt-5.4", label: "gpt-5.4 (Fast mode supported)" },
+  { id: "gpt-5.4-mini", label: "gpt-5.4-mini" },
   { id: DEFAULT_CODEX_LOCAL_MODEL, label: DEFAULT_CODEX_LOCAL_MODEL },
   { id: "gpt-5.3-codex-spark", label: "gpt-5.3-codex-spark" },
-  { id: "gpt-5", label: "gpt-5" },
-  { id: "o3", label: "o3" },
-  { id: "o4-mini", label: "o4-mini" },
-  { id: "gpt-5-mini", label: "gpt-5-mini" },
-  { id: "gpt-5-nano", label: "gpt-5-nano" },
-  { id: "o3-mini", label: "o3-mini" },
-  { id: "codex-mini-latest", label: "Codex Mini" },
 ];
 
 export const agentConfigurationDoc = `# codex_local agent configuration
@@ -55,5 +50,6 @@ Notes:
 - Unless explicitly overridden in adapter config, Paperclip runs Codex with a per-company managed CODEX_HOME under the active Paperclip instance and seeds auth/config from the shared Codex home (the CODEX_HOME env var, when set, or ~/.codex).
 - Some model/tool combinations reject certain effort levels (for example minimal with web search enabled).
 - Fast mode is currently supported on GPT-5.4 only. When enabled, Paperclip applies \`service_tier="fast"\` and \`features.fast_mode=true\`.
+- GPT Image 2 is available through Codex's image generation tool surface on supported ChatGPT subscription models such as gpt-5.5; do not configure \`gpt-image-2\` as the Codex \`--model\` value because the CLI rejects that direct chat model selection.
 - When Paperclip realizes a workspace/runtime for a run, it injects PAPERCLIP_WORKSPACE_* and PAPERCLIP_RUNTIME_* env vars for agent-side tooling.
 `;

--- a/packages/adapters/custom-llm-local/package.json
+++ b/packages/adapters/custom-llm-local/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@paperclipai/adapter-custom-llm-local",
+  "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/custom-llm-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/custom-llm-local/src/cli/index.ts
+++ b/packages/adapters/custom-llm-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export function printCustomLlmLocalStreamEvent(_line: string, _debug: boolean): void {}

--- a/packages/adapters/custom-llm-local/src/errors.ts
+++ b/packages/adapters/custom-llm-local/src/errors.ts
@@ -1,0 +1,68 @@
+import type { AdapterExecutionResult } from "@paperclipai/adapter-utils";
+
+export type ErrorCode =
+  | "CONFIG_INVALID"
+  | "AUTH_FAILED"
+  | "ENDPOINT_UNREACHABLE"
+  | "TIMEOUT"
+  | "MODEL_REJECTED"
+  | "UPSTREAM_ERROR"
+  | "BAD_RESPONSE";
+
+export interface CustomLlmError {
+  code: ErrorCode;
+  message: string;
+  meta?: Record<string, unknown>;
+}
+
+export function buildErrorResult(err: CustomLlmError): AdapterExecutionResult {
+  return {
+    exitCode: 1,
+    signal: null,
+    timedOut: err.code === "TIMEOUT",
+    errorMessage: err.message,
+    errorCode: err.code,
+    errorMeta: err.meta,
+  };
+}
+
+/**
+ * Map a fetch error (ECONNREFUSED, ENOTFOUND, etc.) to the correct error code.
+ * Must be called before reading the response body.
+ */
+export function classifyFetchError(err: unknown): CustomLlmError {
+  const msg = err instanceof Error ? err.message : String(err);
+
+  if (
+    msg.includes("ECONNREFUSED") ||
+    msg.includes("ENOTFOUND") ||
+    msg.includes("ETIMEDOUT") ||
+    msg.includes("fetch failed") ||
+    msg.includes("Failed to fetch") ||
+    msg.includes("NetworkError")
+  ) {
+    return { code: "ENDPOINT_UNREACHABLE", message: `Endpoint unreachable: ${msg}` };
+  }
+
+  if (msg.includes("AbortError") || msg.includes("The operation was aborted")) {
+    return { code: "TIMEOUT", message: msg };
+  }
+
+  return { code: "ENDPOINT_UNREACHABLE", message: `Fetch error: ${msg}` };
+}
+
+/**
+ * Map an HTTP status code to the correct error code.
+ */
+export function classifyHttpStatus(status: number, body: string): CustomLlmError {
+  if (status === 401 || status === 403) {
+    return { code: "AUTH_FAILED", message: `Authentication failed (HTTP ${status})`, meta: { status, body: body.slice(0, 500) } };
+  }
+  if (status >= 400 && status < 500) {
+    return { code: "MODEL_REJECTED", message: `Request rejected by endpoint (HTTP ${status})`, meta: { status, body: body.slice(0, 500) } };
+  }
+  if (status >= 500) {
+    return { code: "UPSTREAM_ERROR", message: `Upstream server error (HTTP ${status})`, meta: { status, body: body.slice(0, 500) } };
+  }
+  return { code: "BAD_RESPONSE", message: `Unexpected HTTP status ${status}`, meta: { status } };
+}

--- a/packages/adapters/custom-llm-local/src/index.ts
+++ b/packages/adapters/custom-llm-local/src/index.ts
@@ -1,0 +1,25 @@
+export { getConfigSchema } from "./schema.js";
+
+export const agentConfigurationDoc = `
+# Custom LLM (Local) Adapter
+
+Calls local or proxy LLM endpoints directly via OpenAI-compatible or Anthropic-compatible HTTP APIs.
+No provider inference — model ID is passed verbatim to the endpoint.
+
+## Required fields
+- **model** — model ID sent verbatim (e.g. \`or-llama-4-scout\`)
+- **baseUrl** — endpoint base URL (e.g. \`http://127.0.0.1:8317/v1\`)
+- **transport** — \`openai_chat_completions\` or \`anthropic_messages\`
+
+## Optional fields
+- **apiKeyEnv** — name of the env var holding the API key
+- **instructionsFilePath** — absolute path to AGENTS.md
+- **timeoutSec** / **graceSec** — timeout control
+- **modelAlias** — canonical model ID for display/records
+- **extraHeaders** — additional HTTP headers
+
+## Security
+Never put raw API keys in adapterConfig. Use \`apiKeyEnv\` to reference a server environment variable.
+`.trim();
+
+export const models = [];

--- a/packages/adapters/custom-llm-local/src/instructions.ts
+++ b/packages/adapters/custom-llm-local/src/instructions.ts
@@ -1,0 +1,21 @@
+import fs from "node:fs/promises";
+import { CustomLlmError } from "./errors.js";
+
+/**
+ * Read the instructions file per-request (no caching).
+ * Throws a CONFIG_INVALID error if the path is provided but the file cannot be read.
+ */
+export async function loadInstructions(instructionsFilePath: string): Promise<string> {
+  try {
+    const content = await fs.readFile(instructionsFilePath, "utf-8");
+    return content;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    const error: CustomLlmError = {
+      code: "CONFIG_INVALID",
+      message: `Cannot read instructions file "${instructionsFilePath}": ${reason}`,
+      meta: { path: instructionsFilePath, reason },
+    };
+    throw error;
+  }
+}

--- a/packages/adapters/custom-llm-local/src/redact.ts
+++ b/packages/adapters/custom-llm-local/src/redact.ts
@@ -1,0 +1,13 @@
+const SENSITIVE_HEADER_RE = /auth|key|token|secret/i;
+
+/**
+ * Return a copy of `headers` with values redacted for headers whose names
+ * match the sensitive pattern. NEVER log raw headers without calling this first.
+ */
+export function redactSensitive(headers: Record<string, string>): Record<string, string> {
+  const safe: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    safe[name] = SENSITIVE_HEADER_RE.test(name) ? "[REDACTED]" : value;
+  }
+  return safe;
+}

--- a/packages/adapters/custom-llm-local/src/schema.ts
+++ b/packages/adapters/custom-llm-local/src/schema.ts
@@ -27,7 +27,14 @@ export function parseConfig(raw: Record<string, unknown>): CustomLlmLocalConfig 
 
   const baseUrl = asString(raw.baseUrl, "").trim();
   if (!baseUrl) throw new Error("CONFIG_INVALID: baseUrl is required");
-  if (!/^https?:\/\//i.test(baseUrl)) throw new Error("CONFIG_INVALID: baseUrl must be an absolute http/https URL");
+  try {
+    const parsedBaseUrl = new URL(baseUrl);
+    if ((parsedBaseUrl.protocol !== "http:" && parsedBaseUrl.protocol !== "https:") || !parsedBaseUrl.host) {
+      throw new Error("invalid protocol or host");
+    }
+  } catch {
+    throw new Error("CONFIG_INVALID: baseUrl must be an absolute http/https URL");
+  }
 
   const transport = asString(raw.transport, "") as Transport;
   if (!VALID_TRANSPORTS.includes(transport)) {

--- a/packages/adapters/custom-llm-local/src/schema.ts
+++ b/packages/adapters/custom-llm-local/src/schema.ts
@@ -1,0 +1,115 @@
+import type { AdapterConfigSchema } from "@paperclipai/adapter-utils";
+import { asString, asNumber, parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+export type Transport = "openai_chat_completions" | "anthropic_messages";
+const VALID_TRANSPORTS: Transport[] = ["openai_chat_completions", "anthropic_messages"];
+
+export interface CustomLlmLocalConfig {
+  model: string;
+  baseUrl: string;
+  apiKeyEnv: string | null;
+  transport: Transport;
+  timeoutSec: number;
+  graceSec: number;
+  instructionsFilePath: string | null;
+  extraHeaders: Record<string, string>;
+  modelAlias: string | null;
+}
+
+export function parseConfig(raw: Record<string, unknown>): CustomLlmLocalConfig {
+  // Reject raw apiKey per plan §5.2 — hard reject, no compat shim
+  if ("apiKey" in raw && raw.apiKey != null && raw.apiKey !== "") {
+    throw new Error("CONFIG_INVALID: raw apiKey is not supported; use apiKeyEnv instead");
+  }
+
+  const model = asString(raw.model, "").trim();
+  if (!model) throw new Error("CONFIG_INVALID: model is required");
+
+  const baseUrl = asString(raw.baseUrl, "").trim();
+  if (!baseUrl) throw new Error("CONFIG_INVALID: baseUrl is required");
+  if (!/^https?:\/\//i.test(baseUrl)) throw new Error("CONFIG_INVALID: baseUrl must be an absolute http/https URL");
+
+  const transport = asString(raw.transport, "") as Transport;
+  if (!VALID_TRANSPORTS.includes(transport)) {
+    throw new Error(
+      `CONFIG_INVALID: transport must be one of ${VALID_TRANSPORTS.join(", ")} — got "${transport}"`,
+    );
+  }
+
+  const apiKeyEnv = asString(raw.apiKeyEnv, "").trim() || null;
+  const instructionsFilePath = asString(raw.instructionsFilePath, "").trim() || null;
+  const modelAlias = asString(raw.modelAlias, "").trim() || null;
+  const timeoutSec = asNumber(raw.timeoutSec, 300);
+  const graceSec = asNumber(raw.graceSec, 30);
+
+  const rawHeaders = parseObject(raw.extraHeaders);
+  const extraHeaders: Record<string, string> = {};
+  for (const [k, v] of Object.entries(rawHeaders)) {
+    if (typeof v === "string") extraHeaders[k] = v;
+  }
+
+  return { model, baseUrl, apiKeyEnv, transport, timeoutSec, graceSec, instructionsFilePath, extraHeaders, modelAlias };
+}
+
+export function getConfigSchema(): AdapterConfigSchema {
+  return {
+    fields: [
+      {
+        key: "model",
+        label: "Model ID",
+        type: "text",
+        required: true,
+        hint: "Sent verbatim to the endpoint (e.g. synthetic/hf:nvidia/Kimi-K2.5-NVFP4)",
+      },
+      {
+        key: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        hint: "Absolute endpoint URL (e.g. http://127.0.0.1:8317/v1)",
+      },
+      {
+        key: "transport",
+        label: "Transport",
+        type: "select",
+        required: true,
+        options: [
+          { value: "openai_chat_completions", label: "OpenAI Chat Completions" },
+          { value: "anthropic_messages", label: "Anthropic Messages" },
+        ],
+        hint: "API format used by the endpoint",
+      },
+      {
+        key: "apiKeyEnv",
+        label: "API Key Env Var",
+        type: "text",
+        hint: "Name of the environment variable holding the API key (e.g. CLIPROXY_API_KEY)",
+      },
+      {
+        key: "modelAlias",
+        label: "Model Alias",
+        type: "text",
+        hint: "Optional display/canonical model ID stored in run records",
+      },
+      {
+        key: "instructionsFilePath",
+        label: "Instructions File Path",
+        type: "text",
+        hint: "Absolute path to AGENTS.md injected as system instructions",
+      },
+      {
+        key: "timeoutSec",
+        label: "Timeout (seconds)",
+        type: "number",
+        default: 300,
+      },
+      {
+        key: "graceSec",
+        label: "Grace Period (seconds)",
+        type: "number",
+        default: 30,
+        hint: "Wait after timeout before hard abort",
+      },
+    ],
+  };
+}

--- a/packages/adapters/custom-llm-local/src/server/execute.ts
+++ b/packages/adapters/custom-llm-local/src/server/execute.ts
@@ -1,0 +1,105 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asString,
+  renderPaperclipWakePrompt,
+  renderTemplate,
+  joinPromptSections,
+} from "@paperclipai/adapter-utils/server-utils";
+import { parseConfig } from "../schema.js";
+import { loadInstructions } from "../instructions.js";
+import { buildErrorResult, type CustomLlmError } from "../errors.js";
+import { callOpenAiChatCompletions } from "../transports/openai-chat-completions.js";
+import { callAnthropicMessages } from "../transports/anthropic-messages.js";
+
+const DEFAULT_PROMPT_TEMPLATE =
+  "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.";
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime: _runtime, config: rawConfig, context, onLog, onMeta } = ctx;
+
+  let config;
+  try {
+    config = parseConfig(rawConfig as Record<string, unknown>);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return buildErrorResult({ code: "CONFIG_INVALID", message: msg });
+  }
+
+  let apiKey = "";
+  if (config.apiKeyEnv) {
+    apiKey = process.env[config.apiKeyEnv] ?? "";
+    if (!apiKey) {
+      return buildErrorResult({
+        code: "AUTH_FAILED",
+        message: `apiKeyEnv "${config.apiKeyEnv}" is not set or empty in server process environment`,
+        meta: { apiKeyEnv: config.apiKeyEnv },
+      });
+    }
+  }
+
+  let systemPrompt: string | null = null;
+  if (config.instructionsFilePath) {
+    try {
+      systemPrompt = await loadInstructions(config.instructionsFilePath);
+    } catch (err) {
+      const e = err as CustomLlmError;
+      return buildErrorResult(e);
+    }
+  }
+
+  const promptTemplate = asString(rawConfig.promptTemplate, DEFAULT_PROMPT_TEMPLATE);
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake);
+  const renderedPrompt = renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const userPrompt = joinPromptSections([wakePrompt, sessionHandoffNote, renderedPrompt]);
+
+  if (onMeta) {
+    await onMeta({
+      adapterType: "custom_llm_local",
+      command: config.baseUrl,
+      cwd: undefined,
+      commandNotes: [
+        `transport=${config.transport}`,
+        `model=${config.model}`,
+        ...(config.modelAlias ? [`modelAlias=${config.modelAlias}`] : []),
+        ...(config.instructionsFilePath ? [`instructions=${config.instructionsFilePath}`] : []),
+        ...(config.apiKeyEnv ? [`apiKeyEnv=${config.apiKeyEnv}`] : []),
+      ],
+      context,
+    });
+  }
+
+  const controller = new AbortController();
+  let graceTimer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutTimer = setTimeout(() => {
+    graceTimer = setTimeout(() => controller.abort(), config.graceSec * 1000);
+  }, config.timeoutSec * 1000);
+
+  try {
+    const callInput = {
+      config,
+      apiKey,
+      systemPrompt,
+      userPrompt,
+      onLog,
+      signal: controller.signal,
+    };
+
+    if (config.transport === "openai_chat_completions") {
+      return await callOpenAiChatCompletions(callInput);
+    }
+    return await callAnthropicMessages(callInput);
+  } finally {
+    clearTimeout(timeoutTimer);
+    if (graceTimer) clearTimeout(graceTimer);
+  }
+}

--- a/packages/adapters/custom-llm-local/src/server/index.ts
+++ b/packages/adapters/custom-llm-local/src/server/index.ts
@@ -1,0 +1,2 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test-environment.js";

--- a/packages/adapters/custom-llm-local/src/server/test-environment.ts
+++ b/packages/adapters/custom-llm-local/src/server/test-environment.ts
@@ -1,0 +1,44 @@
+import type { AdapterEnvironmentCheck, AdapterEnvironmentTestContext, AdapterEnvironmentTestResult } from "@paperclipai/adapter-utils";
+import { parseConfig } from "../schema.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
+  return "pass";
+}
+
+export async function testEnvironment(ctx: AdapterEnvironmentTestContext): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+
+  let config;
+  try {
+    config = parseConfig(ctx.config as Record<string, unknown>);
+  } catch (err) {
+    checks.push({
+      code: "custom_llm_local_config_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return { adapterType: ctx.adapterType, status: "fail", checks, testedAt: new Date().toISOString() };
+  }
+
+  checks.push({ code: "custom_llm_local_config_valid", level: "info", message: `Config valid: transport=${config.transport}, baseUrl=${config.baseUrl}, model=${config.model}` });
+
+  if (config.apiKeyEnv) {
+    const keyValue = process.env[config.apiKeyEnv] ?? "";
+    if (!keyValue) {
+      checks.push({
+        code: "custom_llm_local_api_key_missing",
+        level: "warn",
+        message: `apiKeyEnv "${config.apiKeyEnv}" is not set in server environment`,
+        hint: `Set ${config.apiKeyEnv} in the server process environment before running agents`,
+      });
+    } else {
+      checks.push({ code: "custom_llm_local_api_key_present", level: "info", message: `apiKeyEnv "${config.apiKeyEnv}" is set` });
+    }
+  } else {
+    checks.push({ code: "custom_llm_local_no_api_key_env", level: "info", message: "No apiKeyEnv configured — endpoint will be called without Authorization header" });
+  }
+
+  return { adapterType: ctx.adapterType, status: summarizeStatus(checks), checks, testedAt: new Date().toISOString() };
+}

--- a/packages/adapters/custom-llm-local/src/transports/anthropic-messages.ts
+++ b/packages/adapters/custom-llm-local/src/transports/anthropic-messages.ts
@@ -1,0 +1,123 @@
+import type { UsageSummary, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { redactSensitive } from "../redact.js";
+import {
+  classifyFetchError,
+  classifyHttpStatus,
+  buildErrorResult,
+  type CustomLlmError,
+} from "../errors.js";
+import type { CustomLlmLocalConfig } from "../schema.js";
+
+const ANTHROPIC_VERSION = "2023-06-01";
+
+export interface AnthropicCallInput {
+  config: CustomLlmLocalConfig;
+  apiKey: string;
+  systemPrompt: string | null;
+  userPrompt: string;
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  signal: AbortSignal;
+}
+
+interface AnthropicResponse {
+  model?: string;
+  content?: Array<{ type?: string; text?: string }>;
+  stop_reason?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+}
+
+export async function callAnthropicMessages(input: AnthropicCallInput): Promise<AdapterExecutionResult> {
+  const { config, apiKey, systemPrompt, userPrompt, onLog, signal } = input;
+
+  const url = `${config.baseUrl.replace(/\/$/, "")}/messages`;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+    "anthropic-version": ANTHROPIC_VERSION,
+    ...config.extraHeaders,
+  };
+
+  const safeHeaders = redactSensitive(headers);
+  await onLog("stdout", `[custom-llm-local] POST ${url} (transport=anthropic_messages, model=${config.model}, headers=${JSON.stringify(safeHeaders)})\n`);
+
+  const body: Record<string, unknown> = {
+    model: config.model,
+    max_tokens: 8192,
+    messages: [{ role: "user", content: userPrompt }],
+  };
+  if (systemPrompt) {
+    body.system = systemPrompt;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal,
+    });
+  } catch (err) {
+    if (signal.aborted) {
+      const e: CustomLlmError = { code: "TIMEOUT", message: `Request timed out after ${config.timeoutSec}s` };
+      return buildErrorResult(e);
+    }
+    return buildErrorResult(classifyFetchError(err));
+  }
+
+  let responseBody: string;
+  try {
+    responseBody = await response.text();
+  } catch {
+    return buildErrorResult({ code: "BAD_RESPONSE", message: "Failed to read response body" });
+  }
+
+  if (!response.ok) {
+    return buildErrorResult(classifyHttpStatus(response.status, responseBody));
+  }
+
+  let parsed: AnthropicResponse;
+  try {
+    parsed = JSON.parse(responseBody) as AnthropicResponse;
+  } catch {
+    return buildErrorResult({ code: "BAD_RESPONSE", message: "Response body is not valid JSON", meta: { body: responseBody.slice(0, 500) } });
+  }
+
+  const textBlock = parsed.content?.find((b) => b.type === "text");
+  const text = textBlock?.text ?? "";
+  if (typeof text !== "string") {
+    return buildErrorResult({ code: "BAD_RESPONSE", message: "Unexpected response shape: missing content[0].text", meta: { body: responseBody.slice(0, 500) } });
+  }
+
+  const upstreamModel = typeof parsed.model === "string" ? parsed.model : null;
+  const resolvedModel = upstreamModel || config.model;
+
+  const usage: UsageSummary | undefined = parsed.usage
+    ? {
+        inputTokens: parsed.usage.input_tokens ?? 0,
+        outputTokens: parsed.usage.output_tokens ?? 0,
+      }
+    : undefined;
+
+  const finishReason = parsed.stop_reason ?? null;
+
+  const resultJson: Record<string, unknown> = { text, finishReason };
+  if (config.modelAlias) resultJson.modelAlias = config.modelAlias;
+
+  await onLog("stdout", `[custom-llm-local] succeeded (model=${resolvedModel}, inputTokens=${usage?.inputTokens ?? "?"},outputTokens=${usage?.outputTokens ?? "?"})\n`);
+
+  return {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    provider: "custom-llm-local",
+    model: resolvedModel,
+    usage,
+    summary: `anthropic_messages @ ${new URL(url).host} → succeeded`,
+    resultJson,
+  };
+}

--- a/packages/adapters/custom-llm-local/src/transports/anthropic-messages.ts
+++ b/packages/adapters/custom-llm-local/src/transports/anthropic-messages.ts
@@ -36,10 +36,12 @@ export async function callAnthropicMessages(input: AnthropicCallInput): Promise<
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    "x-api-key": apiKey,
     "anthropic-version": ANTHROPIC_VERSION,
     ...config.extraHeaders,
   };
+  if (apiKey.trim()) {
+    headers["x-api-key"] = apiKey;
+  }
 
   const safeHeaders = redactSensitive(headers);
   await onLog("stdout", `[custom-llm-local] POST ${url} (transport=anthropic_messages, model=${config.model}, headers=${JSON.stringify(safeHeaders)})\n`);

--- a/packages/adapters/custom-llm-local/src/transports/openai-chat-completions.ts
+++ b/packages/adapters/custom-llm-local/src/transports/openai-chat-completions.ts
@@ -43,9 +43,11 @@ export async function callOpenAiChatCompletions(input: OAICallInput): Promise<Ad
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
     ...config.extraHeaders,
   };
+  if (apiKey.trim()) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
 
   const safeHeaders = redactSensitive(headers);
   await onLog("stdout", `[custom-llm-local] POST ${url} (transport=openai_chat_completions, model=${config.model}, headers=${JSON.stringify(safeHeaders)})\n`);

--- a/packages/adapters/custom-llm-local/src/transports/openai-chat-completions.ts
+++ b/packages/adapters/custom-llm-local/src/transports/openai-chat-completions.ts
@@ -1,0 +1,124 @@
+import type { UsageSummary, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { redactSensitive } from "../redact.js";
+import {
+  classifyFetchError,
+  classifyHttpStatus,
+  buildErrorResult,
+  type CustomLlmError,
+} from "../errors.js";
+import type { CustomLlmLocalConfig } from "../schema.js";
+
+export interface OAICallInput {
+  config: CustomLlmLocalConfig;
+  apiKey: string;
+  systemPrompt: string | null;
+  userPrompt: string;
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  signal: AbortSignal;
+}
+
+interface OAIResponse {
+  model?: string;
+  choices?: Array<{
+    message?: { content?: string };
+    finish_reason?: string;
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+}
+
+export async function callOpenAiChatCompletions(input: OAICallInput): Promise<AdapterExecutionResult> {
+  const { config, apiKey, systemPrompt, userPrompt, onLog, signal } = input;
+
+  const url = `${config.baseUrl.replace(/\/$/, "")}/chat/completions`;
+
+  const messages: Array<{ role: string; content: string }> = [];
+  if (systemPrompt) {
+    messages.push({ role: "system", content: systemPrompt });
+  }
+  messages.push({ role: "user", content: userPrompt });
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+    ...config.extraHeaders,
+  };
+
+  const safeHeaders = redactSensitive(headers);
+  await onLog("stdout", `[custom-llm-local] POST ${url} (transport=openai_chat_completions, model=${config.model}, headers=${JSON.stringify(safeHeaders)})\n`);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: config.model,
+        stream: false,
+        messages,
+      }),
+      signal,
+    });
+  } catch (err) {
+    // Check if it was an abort (timeout)
+    if (signal.aborted) {
+      const e: CustomLlmError = { code: "TIMEOUT", message: `Request timed out after ${config.timeoutSec}s` };
+      return buildErrorResult(e);
+    }
+    return buildErrorResult(classifyFetchError(err));
+  }
+
+  let body: string;
+  try {
+    body = await response.text();
+  } catch {
+    return buildErrorResult({ code: "BAD_RESPONSE", message: "Failed to read response body" });
+  }
+
+  if (!response.ok) {
+    return buildErrorResult(classifyHttpStatus(response.status, body));
+  }
+
+  let parsed: OAIResponse;
+  try {
+    parsed = JSON.parse(body) as OAIResponse;
+  } catch {
+    return buildErrorResult({ code: "BAD_RESPONSE", message: "Response body is not valid JSON", meta: { body: body.slice(0, 500) } });
+  }
+
+  const text = parsed.choices?.[0]?.message?.content ?? "";
+  if (typeof text !== "string") {
+    return buildErrorResult({ code: "BAD_RESPONSE", message: "Unexpected response shape: missing choices[0].message.content", meta: { body: body.slice(0, 500) } });
+  }
+
+  const upstreamModel = typeof parsed.model === "string" ? parsed.model : null;
+  const resolvedModel = upstreamModel || config.model;
+
+  const usage: UsageSummary | undefined = parsed.usage
+    ? {
+        inputTokens: parsed.usage.prompt_tokens ?? 0,
+        outputTokens: parsed.usage.completion_tokens ?? 0,
+      }
+    : undefined;
+
+  const finishReason = parsed.choices?.[0]?.finish_reason ?? null;
+
+  const resultJson: Record<string, unknown> = { text, finishReason };
+  if (config.modelAlias) resultJson.modelAlias = config.modelAlias;
+
+  await onLog("stdout", `[custom-llm-local] succeeded (model=${resolvedModel}, inputTokens=${usage?.inputTokens ?? "?"},outputTokens=${usage?.outputTokens ?? "?"})\n`);
+
+  return {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    provider: "custom-llm-local",
+    model: resolvedModel,
+    usage,
+    summary: `openai_chat_completions @ ${new URL(url).host} → succeeded`,
+    resultJson,
+  };
+}

--- a/packages/adapters/custom-llm-local/src/ui/index.ts
+++ b/packages/adapters/custom-llm-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export const type = "custom_llm_local";
+export const label = "Custom LLM (Local)";

--- a/packages/adapters/custom-llm-local/tests/errors.test.ts
+++ b/packages/adapters/custom-llm-local/tests/errors.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildErrorResult, classifyFetchError, classifyHttpStatus } from "../src/errors.js";
+
+describe("classifyFetchError", () => {
+  it.each(["connect ECONNREFUSED 127.0.0.1:1", "getaddrinfo ENOTFOUND llm.local"])(
+    "maps %s to ENDPOINT_UNREACHABLE",
+    (message) => {
+      expect(classifyFetchError(new Error(message))).toMatchObject({ code: "ENDPOINT_UNREACHABLE" });
+    },
+  );
+
+  it("maps AbortError to TIMEOUT", () => {
+    expect(classifyFetchError(new Error("AbortError: The operation was aborted"))).toMatchObject({
+      code: "TIMEOUT",
+    });
+  });
+});
+
+describe("classifyHttpStatus", () => {
+  it.each([401, 403])("maps HTTP %s to AUTH_FAILED", (status) => {
+    expect(classifyHttpStatus(status, "nope")).toMatchObject({ code: "AUTH_FAILED" });
+  });
+
+  it.each([400, 404, 429])("maps HTTP %s to MODEL_REJECTED", (status) => {
+    expect(classifyHttpStatus(status, "bad model")).toMatchObject({ code: "MODEL_REJECTED" });
+  });
+
+  it.each([500, 502, 503])("maps HTTP %s to UPSTREAM_ERROR", (status) => {
+    expect(classifyHttpStatus(status, "upstream down")).toMatchObject({ code: "UPSTREAM_ERROR" });
+  });
+});
+
+describe("buildErrorResult", () => {
+  it("creates a failed AdapterExecutionResult shape", () => {
+    expect(
+      buildErrorResult({
+        code: "TIMEOUT",
+        message: "too slow",
+        meta: { timeoutSec: 2 },
+      }),
+    ).toEqual({
+      exitCode: 1,
+      signal: null,
+      timedOut: true,
+      errorMessage: "too slow",
+      errorCode: "TIMEOUT",
+      errorMeta: { timeoutSec: 2 },
+    });
+  });
+});

--- a/packages/adapters/custom-llm-local/tests/instructions.test.ts
+++ b/packages/adapters/custom-llm-local/tests/instructions.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadInstructions } from "../src/instructions.js";
+
+const cleanupPaths = new Set<string>();
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all([...cleanupPaths].map((target) => fs.rm(target, { recursive: true, force: true })));
+  cleanupPaths.clear();
+});
+
+async function makeTempDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-custom-llm-local-"));
+  cleanupPaths.add(dir);
+  return dir;
+}
+
+describe("loadInstructions", () => {
+  it("successfully reads file content", async () => {
+    const dir = await makeTempDir();
+    const file = path.join(dir, "AGENTS.md");
+    await fs.writeFile(file, "You are focused.\n", "utf8");
+
+    await expect(loadInstructions(file)).resolves.toBe("You are focused.\n");
+  });
+
+  it("throws CONFIG_INVALID for ENOENT", async () => {
+    const dir = await makeTempDir();
+    await expect(loadInstructions(path.join(dir, "missing.md"))).rejects.toMatchObject({
+      code: "CONFIG_INVALID",
+    });
+  });
+
+  it("throws CONFIG_INVALID for permission errors", async () => {
+    vi.spyOn(fs, "readFile").mockRejectedValueOnce(new Error("EACCES: permission denied"));
+
+    await expect(loadInstructions("/private/AGENTS.md")).rejects.toMatchObject({
+      code: "CONFIG_INVALID",
+    });
+  });
+});

--- a/packages/adapters/custom-llm-local/tests/redact.test.ts
+++ b/packages/adapters/custom-llm-local/tests/redact.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { redactSensitive } from "../src/redact.js";
+
+describe("redactSensitive", () => {
+  it("redacts headers whose names match auth, key, token, or secret", () => {
+    expect(
+      redactSensitive({
+        Authorization: "Bearer secret",
+        "x-api-key": "key",
+        "session-token": "token",
+        "client-secret": "secret",
+      }),
+    ).toEqual({
+      Authorization: "[REDACTED]",
+      "x-api-key": "[REDACTED]",
+      "session-token": "[REDACTED]",
+      "client-secret": "[REDACTED]",
+    });
+  });
+
+  it("passes through non-sensitive headers unchanged", () => {
+    expect(redactSensitive({ "Content-Type": "application/json", Accept: "application/json" })).toEqual({
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    });
+  });
+
+  it("matches sensitive header names case-insensitively", () => {
+    expect(redactSensitive({ AUTHORIZATION: "a", ApiKey: "b", TOKEN: "c", Secret: "d" })).toEqual({
+      AUTHORIZATION: "[REDACTED]",
+      ApiKey: "[REDACTED]",
+      TOKEN: "[REDACTED]",
+      Secret: "[REDACTED]",
+    });
+  });
+});

--- a/packages/adapters/custom-llm-local/tests/schema.test.ts
+++ b/packages/adapters/custom-llm-local/tests/schema.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { getConfigSchema, parseConfig } from "../src/schema.js";
+
+describe("parseConfig", () => {
+  it("parses a valid config with all fields", () => {
+    expect(
+      parseConfig({
+        model: "or-llama-4-scout",
+        baseUrl: "http://127.0.0.1:8317/v1",
+        apiKeyEnv: "CLIPROXY_API_KEY",
+        transport: "openai_chat_completions",
+        timeoutSec: 120,
+        graceSec: 5,
+        instructionsFilePath: "/tmp/AGENTS.md",
+        extraHeaders: { "x-extra": "yes", ignored: 7 },
+        modelAlias: "scout",
+      }),
+    ).toEqual({
+      model: "or-llama-4-scout",
+      baseUrl: "http://127.0.0.1:8317/v1",
+      apiKeyEnv: "CLIPROXY_API_KEY",
+      transport: "openai_chat_completions",
+      timeoutSec: 120,
+      graceSec: 5,
+      instructionsFilePath: "/tmp/AGENTS.md",
+      extraHeaders: { "x-extra": "yes" },
+      modelAlias: "scout",
+    });
+  });
+
+  it.each([
+    ["model", { baseUrl: "https://example.test/v1", transport: "openai_chat_completions" }],
+    ["baseUrl", { model: "m", transport: "openai_chat_completions" }],
+    ["transport", { model: "m", baseUrl: "https://example.test/v1" }],
+  ])("throws CONFIG_INVALID when %s is missing", (_field, config) => {
+    expect(() => parseConfig(config)).toThrow(/CONFIG_INVALID/);
+  });
+
+  it("throws CONFIG_INVALID for an invalid transport enum", () => {
+    expect(() =>
+      parseConfig({ model: "m", baseUrl: "https://example.test/v1", transport: "responses" }),
+    ).toThrow(/CONFIG_INVALID/);
+  });
+
+  it("throws CONFIG_INVALID when a raw apiKey is provided", () => {
+    expect(() =>
+      parseConfig({
+        model: "m",
+        baseUrl: "https://example.test/v1",
+        transport: "openai_chat_completions",
+        apiKey: "secret",
+      }),
+    ).toThrow(/CONFIG_INVALID/);
+  });
+
+  it.each(["/v1", "example.test/v1", "ftp://example.test/v1", "http://"])(
+    "throws CONFIG_INVALID when baseUrl is not an absolute http/https URL: %s",
+    (baseUrl) => {
+      expect(() =>
+        parseConfig({ model: "m", baseUrl, transport: "openai_chat_completions" }),
+      ).toThrow(/CONFIG_INVALID/);
+    },
+  );
+});
+
+describe("getConfigSchema", () => {
+  it("returns required fields and transport options", () => {
+    const schema = getConfigSchema();
+
+    expect(schema.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "model", required: true }),
+        expect.objectContaining({ key: "baseUrl", required: true }),
+        expect.objectContaining({ key: "transport", required: true }),
+      ]),
+    );
+    expect(schema.fields.find((field) => field.key === "transport")?.options).toEqual([
+      { value: "openai_chat_completions", label: "OpenAI Chat Completions" },
+      { value: "anthropic_messages", label: "Anthropic Messages" },
+    ]);
+    expect(schema.fields.some((field) => field.key === "apiKey")).toBe(false);
+  });
+});

--- a/packages/adapters/custom-llm-local/tests/transports/anthropic.test.ts
+++ b/packages/adapters/custom-llm-local/tests/transports/anthropic.test.ts
@@ -23,10 +23,14 @@ function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 }
 
-async function call(signal = new AbortController().signal, overrides: Partial<CustomLlmLocalConfig> = {}) {
+async function call(
+  signal = new AbortController().signal,
+  overrides: Partial<CustomLlmLocalConfig> = {},
+  apiKey = "secret-key",
+) {
   return callAnthropicMessages({
     config: config(overrides),
-    apiKey: "secret-key",
+    apiKey,
     systemPrompt: "system rules",
     userPrompt: "hello",
     onLog,
@@ -65,6 +69,22 @@ describe("callAnthropicMessages", () => {
       system: "system rules",
       messages: [{ role: "user", content: "hello" }],
     });
+  });
+
+  it("omits x-api-key when no API key is configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        model: "upstream-model",
+        content: [{ type: "text", text: "pong" }],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await call(undefined, {}, "");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({ "anthropic-version": "2023-06-01" });
+    expect(init.headers).not.toHaveProperty("x-api-key");
   });
 
   it("parses text content and usage from the response", async () => {

--- a/packages/adapters/custom-llm-local/tests/transports/anthropic.test.ts
+++ b/packages/adapters/custom-llm-local/tests/transports/anthropic.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { callAnthropicMessages } from "../../src/transports/anthropic-messages.js";
+import type { CustomLlmLocalConfig } from "../../src/schema.js";
+
+const onLog = vi.fn(async () => undefined);
+
+function config(overrides: Partial<CustomLlmLocalConfig> = {}): CustomLlmLocalConfig {
+  return {
+    model: "anthropic/claude-sonnet-4-6",
+    baseUrl: "http://127.0.0.1:8317/v1",
+    apiKeyEnv: "CLIPROXY_API_KEY",
+    transport: "anthropic_messages",
+    timeoutSec: 30,
+    graceSec: 1,
+    instructionsFilePath: null,
+    extraHeaders: {},
+    modelAlias: null,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+async function call(signal = new AbortController().signal, overrides: Partial<CustomLlmLocalConfig> = {}) {
+  return callAnthropicMessages({
+    config: config(overrides),
+    apiKey: "secret-key",
+    systemPrompt: "system rules",
+    userPrompt: "hello",
+    onLog,
+    signal,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  onLog.mockClear();
+});
+
+describe("callAnthropicMessages", () => {
+  it("sends a Messages request with system, x-api-key, and anthropic-version", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        model: "upstream-model",
+        content: [{ type: "text", text: "pong" }],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await call();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:8317/v1/messages");
+    expect(init.headers).toMatchObject({
+      "x-api-key": "secret-key",
+      "anthropic-version": "2023-06-01",
+    });
+    expect(JSON.parse(init.body as string)).toEqual({
+      model: "anthropic/claude-sonnet-4-6",
+      max_tokens: 8192,
+      system: "system rules",
+      messages: [{ role: "user", content: "hello" }],
+    });
+  });
+
+  it("parses text content and usage from the response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          model: "upstream-model",
+          content: [{ type: "text", text: "pong" }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 13, output_tokens: 5 },
+        }),
+      ),
+    );
+
+    await expect(call()).resolves.toMatchObject({
+      exitCode: 0,
+      timedOut: false,
+      model: "upstream-model",
+      usage: { inputTokens: 13, outputTokens: 5 },
+      resultJson: { text: "pong", finishReason: "end_turn" },
+    });
+  });
+
+  it("maps 401 responses to AUTH_FAILED", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: "unauthorized" }, 401)));
+
+    await expect(call()).resolves.toMatchObject({ errorCode: "AUTH_FAILED", exitCode: 1 });
+  });
+
+  it("maps ECONNREFUSED fetch failures to ENDPOINT_UNREACHABLE", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:1")));
+
+    await expect(call()).resolves.toMatchObject({ errorCode: "ENDPOINT_UNREACHABLE", exitCode: 1 });
+  });
+
+  it("maps aborted requests to TIMEOUT", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("AbortError: The operation was aborted")));
+
+    await expect(call(controller.signal)).resolves.toMatchObject({ errorCode: "TIMEOUT", timedOut: true });
+  });
+});

--- a/packages/adapters/custom-llm-local/tests/transports/openai.test.ts
+++ b/packages/adapters/custom-llm-local/tests/transports/openai.test.ts
@@ -23,10 +23,14 @@ function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 }
 
-async function call(signal = new AbortController().signal, overrides: Partial<CustomLlmLocalConfig> = {}) {
+async function call(
+  signal = new AbortController().signal,
+  overrides: Partial<CustomLlmLocalConfig> = {},
+  apiKey = "secret-key",
+) {
   return callOpenAiChatCompletions({
     config: config(overrides),
-    apiKey: "secret-key",
+    apiKey,
     systemPrompt: "system rules",
     userPrompt: "hello",
     onLog,
@@ -64,6 +68,21 @@ describe("callOpenAiChatCompletions", () => {
         { role: "user", content: "hello" },
       ],
     });
+  });
+
+  it("omits Authorization when no API key is configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        model: "upstream-model",
+        choices: [{ message: { content: "pong" }, finish_reason: "stop" }],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await call(undefined, {}, "");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).not.toHaveProperty("Authorization");
   });
 
   it("parses assistant content and usage from the response", async () => {

--- a/packages/adapters/custom-llm-local/tests/transports/openai.test.ts
+++ b/packages/adapters/custom-llm-local/tests/transports/openai.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { callOpenAiChatCompletions } from "../../src/transports/openai-chat-completions.js";
+import type { CustomLlmLocalConfig } from "../../src/schema.js";
+
+const onLog = vi.fn(async () => undefined);
+
+function config(overrides: Partial<CustomLlmLocalConfig> = {}): CustomLlmLocalConfig {
+  return {
+    model: "or-llama-4-scout",
+    baseUrl: "http://127.0.0.1:8317/v1",
+    apiKeyEnv: "CLIPROXY_API_KEY",
+    transport: "openai_chat_completions",
+    timeoutSec: 30,
+    graceSec: 1,
+    instructionsFilePath: null,
+    extraHeaders: {},
+    modelAlias: null,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+async function call(signal = new AbortController().signal, overrides: Partial<CustomLlmLocalConfig> = {}) {
+  return callOpenAiChatCompletions({
+    config: config(overrides),
+    apiKey: "secret-key",
+    systemPrompt: "system rules",
+    userPrompt: "hello",
+    onLog,
+    signal,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  onLog.mockClear();
+});
+
+describe("callOpenAiChatCompletions", () => {
+  it("sends a buffered chat completions request with Authorization bearer header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        model: "upstream-model",
+        choices: [{ message: { content: "pong" }, finish_reason: "stop" }],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await call();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:8317/v1/chat/completions");
+    expect(init.headers).toMatchObject({ Authorization: "Bearer secret-key" });
+    expect(JSON.parse(init.body as string)).toEqual({
+      model: "or-llama-4-scout",
+      stream: false,
+      messages: [
+        { role: "system", content: "system rules" },
+        { role: "user", content: "hello" },
+      ],
+    });
+  });
+
+  it("parses assistant content and usage from the response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          model: "upstream-model",
+          choices: [{ message: { content: "pong" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+        }),
+      ),
+    );
+
+    await expect(call()).resolves.toMatchObject({
+      exitCode: 0,
+      timedOut: false,
+      model: "upstream-model",
+      usage: { inputTokens: 11, outputTokens: 7 },
+      resultJson: { text: "pong", finishReason: "stop" },
+    });
+  });
+
+  it("maps 401 responses to AUTH_FAILED", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: "unauthorized" }, 401)));
+
+    await expect(call()).resolves.toMatchObject({ errorCode: "AUTH_FAILED", exitCode: 1 });
+  });
+
+  it("maps ECONNREFUSED fetch failures to ENDPOINT_UNREACHABLE", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:1")));
+
+    await expect(call()).resolves.toMatchObject({ errorCode: "ENDPOINT_UNREACHABLE", exitCode: 1 });
+  });
+
+  it("maps aborted requests to TIMEOUT", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("AbortError: The operation was aborted")));
+
+    await expect(call(controller.signal)).resolves.toMatchObject({ errorCode: "TIMEOUT", timedOut: true });
+  });
+});

--- a/packages/adapters/custom-llm-local/tsconfig.json
+++ b/packages/adapters/custom-llm-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/custom-llm-local/vitest.config.ts
+++ b/packages/adapters/custom-llm-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -4,11 +4,12 @@ export const DEFAULT_GEMINI_LOCAL_MODEL = "auto";
 
 export const models = [
   { id: DEFAULT_GEMINI_LOCAL_MODEL, label: "Auto" },
+  { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
+  { id: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" },
+  { id: "gemini-3.1-flash-lite-preview", label: "Gemini 3.1 Flash Lite Preview" },
   { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
   { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },
-  { id: "gemini-2.0-flash", label: "Gemini 2.0 Flash" },
-  { id: "gemini-2.0-flash-lite", label: "Gemini 2.0 Flash Lite" },
 ];
 
 export const agentConfigurationDoc = `# gemini_local agent configuration
@@ -44,4 +45,5 @@ Notes:
 - Sessions resume with --resume when stored session cwd matches the current cwd.
 - Paperclip auto-injects local skills into \`~/.gemini/skills/\` via symlinks, so the CLI can discover both credentials and skills in their natural location.
 - Authentication can use GEMINI_API_KEY / GOOGLE_API_KEY or local Gemini CLI login.
+- The standard Gemini CLI chat path only lists models that accept \`--model\` for non-interactive text turns. Image and video generation model ids such as \`gemini-3.1-flash-image-preview\`, \`gemini-3-pro-image-preview\`, and \`veo-3.1-generate-preview\` require a dedicated media-generation API or extension route and are intentionally not exposed as chat model dropdown choices.
 `;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -29,6 +29,7 @@ export const AGENT_ADAPTER_TYPES = [
   "http",
   "claude_local",
   "codex_local",
+  "custom_llm_local",
   "gemini_local",
   "opencode_local",
   "pi_local",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
+      '@paperclipai/adapter-custom-llm-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/custom-llm-local
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
@@ -145,6 +148,19 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/custom-llm-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
     devDependencies:
       '@types/node':
         specifier: ^24.6.0
@@ -474,6 +490,9 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
+      '@paperclipai/adapter-custom-llm-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/custom-llm-local
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
@@ -631,6 +650,9 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
+      '@paperclipai/adapter-custom-llm-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/custom-llm-local
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local

--- a/server/package.json
+++ b/server/package.json
@@ -50,6 +50,7 @@
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-custom-llm-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -28,6 +28,9 @@ describe("adapter model listing", () => {
     const models = await listAdapterModels("codex_local");
 
     expect(models).toEqual(codexFallbackModels);
+    expect(models.some((model) => model.id === "gpt-5.5")).toBe(true);
+    expect(models.some((model) => model.id === "gpt-image-2")).toBe(false);
+    expect(models.some((model) => model.id === "codex-mini-latest")).toBe(false);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -49,7 +52,17 @@ describe("adapter model listing", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(first).toEqual(second);
     expect(first.some((model) => model.id === "gpt-5-pro")).toBe(true);
-    expect(first.some((model) => model.id === "codex-mini-latest")).toBe(true);
+    expect(first.some((model) => model.id === "gpt-5.5")).toBe(true);
+  });
+
+  it("returns Gemini CLI fallback models verified for the chat model flag", async () => {
+    const models = await listAdapterModels("gemini_local");
+
+    expect(models.some((model) => model.id === "gemini-3.1-pro-preview")).toBe(true);
+    expect(models.some((model) => model.id === "gemini-3-flash-preview")).toBe(true);
+    expect(models.some((model) => model.id === "gemini-3.1-flash-image-preview")).toBe(false);
+    expect(models.some((model) => model.id === "veo-3.1-generate-preview")).toBe(false);
+    expect(models.some((model) => model.id === "gemini-2.0-flash")).toBe(false);
   });
 
   it("falls back to static codex models when OpenAI model discovery fails", async () => {

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -10,6 +10,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "opencode_local",
   "pi_local",
   "hermes_local",
+  "custom_llm_local",
   "process",
   "http",
 ]);

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -85,6 +85,28 @@ import { buildExternalAdapters } from "./plugin-loader.js";
 import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
+import {
+  execute as customLlmLocalExecute,
+  testEnvironment as customLlmLocalTestEnvironment,
+} from "@paperclipai/adapter-custom-llm-local/server";
+import {
+  agentConfigurationDoc as customLlmLocalAgentConfigurationDoc,
+  models as customLlmLocalModels,
+  getConfigSchema as customLlmLocalGetConfigSchema,
+} from "@paperclipai/adapter-custom-llm-local";
+
+const customLlmLocalAdapter: ServerAdapterModule = {
+  type: "custom_llm_local",
+  execute: customLlmLocalExecute,
+  testEnvironment: customLlmLocalTestEnvironment,
+  models: customLlmLocalModels,
+  supportsLocalAgentJwt: false,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: customLlmLocalAgentConfigurationDoc,
+  getConfigSchema: customLlmLocalGetConfigSchema,
+};
 
 const claudeLocalAdapter: ServerAdapterModule = {
   type: "claude_local",
@@ -237,6 +259,7 @@ function registerBuiltInAdapters() {
     geminiLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,
+    customLlmLocalAdapter,
     processAdapter,
     httpAdapter,
   ]) {

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,7 @@
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-custom-llm-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/shared": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -108,6 +108,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     icon: Cpu,
     comingSoon: true,
   },
+  custom_llm_local: {
+    label: "Custom LLM",
+    description: "Direct local/proxy LLM endpoint",
+    icon: Cpu,
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/ui/src/adapters/custom-llm-local/index.ts
+++ b/ui/src/adapters/custom-llm-local/index.ts
@@ -1,0 +1,10 @@
+import type { UIAdapterModule } from "../types";
+import { SchemaConfigFields, buildSchemaAdapterConfig } from "../schema-config-fields";
+
+export const customLlmLocalUIAdapter: UIAdapterModule = {
+  type: "custom_llm_local",
+  label: "Custom LLM (Local)",
+  parseStdoutLine: () => [],
+  ConfigFields: SchemaConfigFields,
+  buildAdapterConfig: buildSchemaAdapterConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -9,6 +9,7 @@ import { openClawGatewayUIAdapter } from "./openclaw-gateway";
 import { hermesLocalUIAdapter } from "./hermes-local";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
+import { customLlmLocalUIAdapter } from "./custom-llm-local";
 import { loadDynamicParser, invalidateDynamicParser } from "./dynamic-loader";
 import { SchemaConfigFields, buildSchemaAdapterConfig } from "./schema-config-fields";
 
@@ -57,6 +58,7 @@ function registerBuiltInUIAdapters() {
     openClawGatewayUIAdapter,
     processUIAdapter,
     httpUIAdapter,
+    customLlmLocalUIAdapter,
   ]) {
     builtinTypes.add(adapter.type);
     builtinAdaptersByType.set(adapter.type, adapter);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     projects: [
       "packages/db",
       "packages/adapters/codex-local",
+      "packages/adapters/custom-llm-local",
       "packages/adapters/opencode-local",
       "server",
       "ui",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Adapter configuration is the boundary where operators choose which local CLI or local/proxy model surface an agent uses.
> - The branch adds `custom_llm_local` for direct local/proxy LLM endpoints and tightens local CLI model dropdowns for Codex and Gemini.
> - The model dropdowns previously exposed stale or unsupported IDs that fail under the current subscription/OAuth CLI paths.
> - Multimedia generation also needs clear routing: GPT Image 2 works through Codex image-generation tools, while Gemini image/video IDs are not valid Gemini CLI chat `--model` values.
> - This pull request keeps selectable model values aligned with verified CLI behavior and documents where media-generation models belong.
> - The benefit is safer agent setup with fewer unsupported runtime choices and clearer operator guidance.

## What Changed

- Added the `custom_llm_local` adapter package with OpenAI-compatible and Anthropic Messages transports, schema validation, redaction, environment checks, and tests.
- Registered `custom_llm_local` across CLI/server/shared/UI adapter registries.
- Fixed custom LLM transports so auth headers are omitted when no API key is configured, preserving unauthenticated local/proxy endpoints.
- Refreshed `codex_local` fallback model choices to verified Codex CLI chat models and documented GPT Image 2 as a tool surface rather than a direct `--model` value.
- Refreshed `gemini_local` fallback model choices to verified Gemini CLI chat models and documented Nano Banana / Veo as dedicated media-generation routes, not chat dropdown values.
- Added adapter model listing and transport tests for the refreshed fallback/auth behavior.

## Verification

- `pnpm vitest run server/src/__tests__/adapter-models.test.ts`
- `pnpm vitest run packages/adapters/custom-llm-local/tests/transports/openai.test.ts packages/adapters/custom-llm-local/tests/transports/anthropic.test.ts`
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `pnpm --filter @paperclipai/adapter-gemini-local typecheck`
- `pnpm --filter @paperclipai/adapter-custom-llm-local typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm build`
- Manual CLI smoke checks on local host:
  - Codex `--model` success: `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`
  - Gemini `--model` success: `gemini-3.1-pro-preview`, `gemini-3-flash-preview`, `gemini-3.1-flash-lite-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`
- UI smoke on local preview (`PORT=3123 PAPERCLIP_HOME=/tmp/paperclip-pr4649 pnpm dev:once`): onboarding adapter selector expanded and shows `Custom LLM — Direct local/proxy LLM endpoint`.

## UI Evidence

Playwright smoke verified the Custom LLM adapter appears in the onboarding adapter selector after expanding "More Agent Adapter Types":

```text
button "Custom LLM Direct local/proxy LLM endpoint"
  Custom LLM
  Direct local/proxy LLM endpoint
```

Screenshot artifact: https://gist.github.com/codeg-dev/3ae72e0a62577f7d104d80f89395cecf

The local full-page screenshot was captured with Playwright as `pr-4649-custom-llm-onboarding.png`; the gist wraps the PNG in HTML because `gh gist create` does not accept raw binary uploads.

## Risks

- Low-to-medium risk: operators who intentionally selected removed stale IDs will need to enter custom values manually or use an API/extension route.
- Codex/OpenAI and Gemini model availability can vary by account, CLI version, and auth surface; the fallback list intentionally reflects models verified on the current subscription/OAuth CLI paths.
- Existing unrelated local change `cli/esbuild.config.mjs` was not included in this PR.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 via OpenCode (`openai/gpt-5.5`), tool-enabled coding session with shell, LSP, browser automation, and repository search. External context gathered with specialized explore/librarian/oracle agents.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge