### PR TITLE
DIG-922: fix authenticated full-seed worktree restore fidelity

### DIFF
--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
@@ -7,10 +8,12 @@ import { eq } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   agents,
+  applyPendingMigrations,
   authUsers,
   companyMemberships,
   companies,
   createDb,
+  ensurePostgresDatabase,
   instanceUserRoles,
   issueComments,
   issues,
@@ -132,6 +135,25 @@ function buildSourceConfig(): PaperclipConfig {
       },
     },
   };
+}
+
+async function allocateTestPort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to allocate test port")));
+        return;
+      }
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(address.port);
+      });
+    });
+  });
 }
 
 describe("worktree helpers", () => {
@@ -819,6 +841,210 @@ describe("worktree helpers", () => {
         await liveDbClient.$client?.end?.({ timeout: 5 }).catch(() => undefined);
         await liveDb.cleanup();
         await staleDb.cleanup();
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+      }
+    },
+    30000,
+  );
+
+  itEmbeddedPostgres(
+    "uses home-prefixed embedded postgres source paths for full-seed worktree clones",
+    async () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-worktree-auth-full-seed-home-"));
+      const fakeHome = path.join(tempRoot, "home");
+      const sourceConfigDir = path.join(fakeHome, ".paperclip", "instances", "default");
+      const sourceConfigPath = path.join(sourceConfigDir, "config.json");
+      const sourceDbDir = path.join(sourceConfigDir, "db");
+      const sourceKeyPath = path.join(sourceConfigDir, "secrets", "master.key");
+      const worktreeRoot = path.join(tempRoot, "PAP-1000-auth-full-seed-home");
+      const worktreeHome = path.join(tempRoot, ".paperclip-worktrees");
+      const originalCwd = process.cwd();
+      const sourcePort = await allocateTestPort();
+      const companyId = randomUUID();
+      const agentId = randomUUID();
+      const issueId = randomUUID();
+      const userId = "user-home-admin";
+      const homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
+      const { default: EmbeddedPostgres } = await import("embedded-postgres");
+      const sourcePg = new EmbeddedPostgres({
+        databaseDir: sourceDbDir,
+        user: "paperclip",
+        password: "paperclip",
+        port: sourcePort,
+        persistent: true,
+        initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
+        onLog: () => {},
+        onError: () => {},
+      });
+
+      try {
+        fs.mkdirSync(path.dirname(sourceKeyPath), { recursive: true });
+        fs.mkdirSync(worktreeRoot, { recursive: true });
+
+        await sourcePg.initialise();
+        await sourcePg.start();
+
+        const sourceAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${sourcePort}/postgres`;
+        await ensurePostgresDatabase(sourceAdminConnectionString, "paperclip");
+        const sourceConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${sourcePort}/paperclip`;
+        await applyPendingMigrations(sourceConnectionString);
+        const sourceDb = createDb(sourceConnectionString);
+
+        try {
+          await sourceDb.insert(authUsers).values({
+            id: userId,
+            email: "admin-home@paperclip.ing",
+            name: "Admin Home User",
+            emailVerified: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          });
+          await sourceDb.insert(instanceUserRoles).values({
+            userId,
+            role: "instance_admin",
+          });
+          await sourceDb.insert(companies).values({
+            id: companyId,
+            name: "Paperclip",
+            issuePrefix: "PAPH",
+            issueCounter: 1,
+            requireBoardApprovalForNewAgents: false,
+          });
+          await sourceDb.insert(agents).values({
+            id: agentId,
+            companyId,
+            name: "HomePathCoder",
+            role: "engineer",
+            status: "running",
+            adapterType: "codex_local",
+            adapterConfig: {},
+            runtimeConfig: {
+              heartbeat: { enabled: true, intervalSec: 60 },
+            },
+            permissions: {},
+          });
+          await sourceDb.insert(companyMemberships).values({
+            companyId,
+            principalType: "user",
+            principalId: userId,
+            status: "active",
+            membershipRole: "owner",
+          });
+          await sourceDb.insert(issues).values({
+            id: issueId,
+            companyId,
+            title: "Copied home-path issue",
+            status: "in_progress",
+            priority: "medium",
+            assigneeAgentId: agentId,
+            issueNumber: 1,
+            identifier: "PAPH-1",
+            executionAgentNameKey: "homepathcoder",
+            executionLockedAt: new Date("2026-04-30T00:00:00.000Z"),
+          });
+
+          const sourceConfig = buildSourceConfig();
+          sourceConfig.database = {
+            mode: "embedded-postgres",
+            embeddedPostgresDataDir: "~/.paperclip/instances/default/db",
+            embeddedPostgresPort: sourcePort,
+            backup: {
+              enabled: true,
+              intervalMinutes: 60,
+              retentionDays: 30,
+              dir: "~/.paperclip/instances/default/data/backups",
+            },
+          };
+          sourceConfig.logging.logDir = "~/.paperclip/instances/default/logs";
+          sourceConfig.storage.localDisk.baseDir = "~/.paperclip/instances/default/data/storage";
+          sourceConfig.secrets.localEncrypted.keyFilePath = "~/.paperclip/instances/default/secrets/master.key";
+
+          fs.writeFileSync(sourceConfigPath, JSON.stringify(sourceConfig, null, 2) + "\n", "utf8");
+          fs.writeFileSync(sourceKeyPath, "source-master-key", "utf8");
+
+          process.chdir(worktreeRoot);
+          await worktreeInitCommand({
+            name: "PAP-1000-auth-full-seed-home",
+            home: worktreeHome,
+            fromInstance: "default",
+            force: true,
+            seedMode: "full",
+          });
+
+          const seedDir = path.join(
+            worktreeHome,
+            "instances",
+            "pap-1000-auth-full-seed-home",
+            "data",
+            "backups",
+            "seed",
+          );
+          const seedFiles = fs.readdirSync(seedDir).filter((entry) => entry.endsWith(".sql.gz"));
+          expect(seedFiles).toHaveLength(1);
+          expect(fs.statSync(path.join(seedDir, seedFiles[0]!)).size).toBeGreaterThan(1000);
+
+          const targetConfig = JSON.parse(
+            fs.readFileSync(path.join(worktreeRoot, ".paperclip", "config.json"), "utf8"),
+          ) as PaperclipConfig;
+          const targetPg = new EmbeddedPostgres({
+            databaseDir: targetConfig.database.embeddedPostgresDataDir,
+            user: "paperclip",
+            password: "paperclip",
+            port: targetConfig.database.embeddedPostgresPort,
+            persistent: true,
+            initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
+            onLog: () => {},
+            onError: () => {},
+          });
+
+          await targetPg.start();
+          try {
+            const targetDb = createDb(
+              `postgres://paperclip:paperclip@127.0.0.1:${targetConfig.database.embeddedPostgresPort}/paperclip`,
+            );
+
+            const seededCompanies = await targetDb.select().from(companies);
+            expect(seededCompanies).toHaveLength(1);
+            expect(seededCompanies[0]?.id).toBe(companyId);
+
+            const seededRoles = await targetDb.select().from(instanceUserRoles);
+            expect(seededRoles).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  userId,
+                  role: "instance_admin",
+                }),
+              ]),
+            );
+
+            const memberships = await targetDb.select().from(companyMemberships);
+            expect(memberships).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  companyId,
+                  principalId: userId,
+                }),
+              ]),
+            );
+
+            const [seededAgent] = await targetDb.select().from(agents).where(eq(agents.id, agentId));
+            expect(seededAgent?.status).toBe("idle");
+
+            const [seededIssue] = await targetDb.select().from(issues).where(eq(issues.id, issueId));
+            expect(seededIssue?.status).toBe("blocked");
+            expect(seededIssue?.assigneeAgentId).toBeNull();
+
+            await targetDb.$client?.end?.({ timeout: 5 }).catch(() => undefined);
+          } finally {
+            await targetPg.stop();
+          }
+        } finally {
+          await sourceDb.$client?.end?.({ timeout: 5 }).catch(() => undefined);
+        }
+      } finally {
+        homedirSpy.mockRestore();
+        process.chdir(originalCwd);
+        await sourcePg.stop().catch(() => undefined);
         fs.rmSync(tempRoot, { recursive: true, force: true });
       }
     },

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -8,8 +8,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   agents,
   authUsers,
+  companyMemberships,
   companies,
   createDb,
+  instanceUserRoles,
   issueComments,
   issues,
   projects,
@@ -597,6 +599,226 @@ describe("worktree helpers", () => {
       } finally {
         process.chdir(originalCwd);
         await sourceDb.cleanup();
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+      }
+    },
+    30000,
+  );
+
+  itEmbeddedPostgres(
+    "uses the current runtime DATABASE_URL for authenticated full-seed worktree clones",
+    async () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-worktree-auth-full-seed-"));
+      const worktreeRoot = path.join(tempRoot, "PAP-999-auth-full-seed");
+      const sourceHome = path.join(tempRoot, "source-home");
+      const sourceConfigDir = path.join(sourceHome, "instances", "source");
+      const sourceConfigPath = path.join(sourceConfigDir, "config.json");
+      const sourceEnvPath = path.join(sourceConfigDir, ".env");
+      const sourceKeyPath = path.join(sourceConfigDir, "secrets", "master.key");
+      const worktreeHome = path.join(tempRoot, ".paperclip-worktrees");
+      const originalCwd = process.cwd();
+      const liveDb = await startEmbeddedPostgresTestDatabase("paperclip-worktree-auth-live-source-");
+      const staleDb = await startEmbeddedPostgresTestDatabase("paperclip-worktree-auth-stale-source-");
+      const companyId = randomUUID();
+      const agentId = randomUUID();
+      const inProgressIssueId = randomUUID();
+      const todoIssueId = randomUUID();
+      const reviewIssueId = randomUUID();
+      const userId = "user-live-admin";
+      const liveDbClient = createDb(liveDb.connectionString);
+
+      try {
+        await liveDbClient.insert(authUsers).values({
+          id: userId,
+          email: "admin@paperclip.ing",
+          name: "Admin User",
+          emailVerified: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        });
+        await liveDbClient.insert(instanceUserRoles).values({
+          userId,
+          role: "instance_admin",
+        });
+        await liveDbClient.insert(companies).values({
+          id: companyId,
+          name: "Paperclip",
+          issuePrefix: "PAP",
+          issueCounter: 3,
+          requireBoardApprovalForNewAgents: false,
+        });
+        await liveDbClient.insert(agents).values({
+          id: agentId,
+          companyId,
+          name: "CodexCoder",
+          role: "engineer",
+          status: "running",
+          adapterType: "codex_local",
+          adapterConfig: {},
+          runtimeConfig: {
+            heartbeat: { enabled: true, intervalSec: 60 },
+          },
+          permissions: {},
+        });
+        await liveDbClient.insert(companyMemberships).values({
+          companyId,
+          principalType: "user",
+          principalId: userId,
+          status: "active",
+          membershipRole: "owner",
+        });
+        await liveDbClient.insert(issues).values([
+          {
+            id: inProgressIssueId,
+            companyId,
+            title: "Copied in-flight issue",
+            status: "in_progress",
+            priority: "medium",
+            assigneeAgentId: agentId,
+            issueNumber: 1,
+            identifier: "PAP-1",
+            executionAgentNameKey: "codexcoder",
+            executionLockedAt: new Date("2026-04-28T00:00:00.000Z"),
+          },
+          {
+            id: todoIssueId,
+            companyId,
+            title: "Copied todo issue",
+            status: "todo",
+            priority: "medium",
+            assigneeAgentId: agentId,
+            issueNumber: 2,
+            identifier: "PAP-2",
+          },
+          {
+            id: reviewIssueId,
+            companyId,
+            title: "Copied review issue",
+            status: "in_review",
+            priority: "medium",
+            assigneeAgentId: agentId,
+            issueNumber: 3,
+            identifier: "PAP-3",
+          },
+        ]);
+
+        fs.mkdirSync(path.dirname(sourceKeyPath), { recursive: true });
+        fs.mkdirSync(worktreeRoot, { recursive: true });
+
+        const sourceConfig = buildSourceConfig();
+        sourceConfig.database = {
+          mode: "postgres",
+          embeddedPostgresDataDir: path.join(sourceConfigDir, "db"),
+          embeddedPostgresPort: 54329,
+          backup: {
+            enabled: true,
+            intervalMinutes: 60,
+            retentionDays: 30,
+            dir: path.join(sourceConfigDir, "backups"),
+          },
+          connectionString: staleDb.connectionString,
+        };
+        sourceConfig.logging.logDir = path.join(sourceConfigDir, "logs");
+        sourceConfig.storage.localDisk.baseDir = path.join(sourceConfigDir, "storage");
+        sourceConfig.secrets.localEncrypted.keyFilePath = sourceKeyPath;
+
+        fs.writeFileSync(sourceConfigPath, JSON.stringify(sourceConfig, null, 2) + "\n", "utf8");
+        fs.writeFileSync(sourceEnvPath, `DATABASE_URL=${JSON.stringify(staleDb.connectionString)}\n`, "utf8");
+        fs.writeFileSync(sourceKeyPath, "source-master-key", "utf8");
+
+        process.env.PAPERCLIP_CONFIG = sourceConfigPath;
+        process.env.DATABASE_URL = liveDb.connectionString;
+        process.chdir(worktreeRoot);
+
+        await worktreeInitCommand({
+          name: "PAP-999-auth-full-seed",
+          home: worktreeHome,
+          fromConfig: sourceConfigPath,
+          force: true,
+          seedMode: "full",
+        });
+
+        const targetConfig = JSON.parse(
+          fs.readFileSync(path.join(worktreeRoot, ".paperclip", "config.json"), "utf8"),
+        ) as PaperclipConfig;
+        const { default: EmbeddedPostgres } = await import("embedded-postgres");
+        const targetPg = new EmbeddedPostgres({
+          databaseDir: targetConfig.database.embeddedPostgresDataDir,
+          user: "paperclip",
+          password: "paperclip",
+          port: targetConfig.database.embeddedPostgresPort,
+          persistent: true,
+          initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
+          onLog: () => {},
+          onError: () => {},
+        });
+
+        await targetPg.start();
+        try {
+          const targetDb = createDb(
+            `postgres://paperclip:paperclip@127.0.0.1:${targetConfig.database.embeddedPostgresPort}/paperclip`,
+          );
+
+          const seededCompanies = await targetDb.select().from(companies);
+          expect(seededCompanies).toHaveLength(1);
+          expect(seededCompanies[0]?.id).toBe(companyId);
+
+          const seededUsers = await targetDb.select().from(authUsers);
+          expect(seededUsers.some((row) => row.id === userId)).toBe(true);
+
+          const seededRoles = await targetDb.select().from(instanceUserRoles);
+          expect(seededRoles).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                userId,
+                role: "instance_admin",
+              }),
+            ]),
+          );
+
+          const memberships = await targetDb.select().from(companyMemberships);
+          expect(memberships).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                companyId,
+                principalType: "user",
+                principalId: userId,
+              }),
+            ]),
+          );
+
+          const [seededAgent] = await targetDb.select().from(agents).where(eq(agents.id, agentId));
+          expect(seededAgent?.companyId).toBe(companyId);
+          expect(seededAgent?.status).toBe("idle");
+          expect(seededAgent?.runtimeConfig).toMatchObject({
+            heartbeat: { enabled: false, intervalSec: 60 },
+          });
+
+          const [inProgressIssue] = await targetDb.select().from(issues).where(eq(issues.id, inProgressIssueId));
+          expect(inProgressIssue?.status).toBe("blocked");
+          expect(inProgressIssue?.assigneeAgentId).toBeNull();
+
+          const [todoIssue] = await targetDb.select().from(issues).where(eq(issues.id, todoIssueId));
+          expect(todoIssue?.status).toBe("todo");
+          expect(todoIssue?.assigneeAgentId).toBeNull();
+
+          const [reviewIssue] = await targetDb.select().from(issues).where(eq(issues.id, reviewIssueId));
+          expect(reviewIssue?.status).toBe("in_review");
+          expect(reviewIssue?.assigneeAgentId).toBeNull();
+
+          const comments = await targetDb.select().from(issueComments).where(eq(issueComments.issueId, inProgressIssueId));
+          expect(comments).toHaveLength(1);
+          expect(comments[0]?.body).toContain("Quarantined during worktree seed");
+
+          await targetDb.$client?.end?.({ timeout: 5 }).catch(() => undefined);
+        } finally {
+          await targetPg.stop();
+        }
+      } finally {
+        process.chdir(originalCwd);
+        await liveDbClient.$client?.end?.({ timeout: 5 }).catch(() => undefined);
+        await liveDb.cleanup();
+        await staleDb.cleanup();
         fs.rmSync(tempRoot, { recursive: true, force: true });
       }
     },

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -211,6 +211,10 @@ function isCurrentSourceConfigPath(sourceConfigPath: string): boolean {
   return path.resolve(currentConfigPath) === path.resolve(sourceConfigPath);
 }
 
+function resolveEmbeddedPostgresDataDir(dataDir: string, configPath: string): string {
+  return resolveRuntimeLikePath(dataDir, configPath);
+}
+
 function formatSeededWorktreeExecutionQuarantineSummary(
   summary: SeededWorktreeExecutionQuarantineSummary,
 ): string {
@@ -1308,7 +1312,10 @@ async function seedWorktreeDatabase(input: {
   try {
     if (input.sourceConfig.database.mode === "embedded-postgres") {
       sourceHandle = await ensureEmbeddedPostgres(
-        input.sourceConfig.database.embeddedPostgresDataDir,
+        resolveEmbeddedPostgresDataDir(
+          input.sourceConfig.database.embeddedPostgresDataDir,
+          input.sourceConfigPath,
+        ),
         input.sourceConfig.database.embeddedPostgresPort,
       );
       const sourceAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${sourceHandle.port}/postgres`;
@@ -1332,7 +1339,10 @@ async function seedWorktreeDatabase(input: {
     });
 
     targetHandle = await ensureEmbeddedPostgres(
-      input.targetConfig.database.embeddedPostgresDataDir,
+      resolveEmbeddedPostgresDataDir(
+        input.targetConfig.database.embeddedPostgresDataDir,
+        input.targetPaths.configPath,
+      ),
       input.targetConfig.database.embeddedPostgresPort,
     );
 
@@ -1941,7 +1951,7 @@ async function openConfiguredDb(configPath: string): Promise<OpenDbHandle> {
   try {
     if (config.database.mode === "embedded-postgres") {
       embeddedHandle = await ensureEmbeddedPostgres(
-        config.database.embeddedPostgresDataDir,
+        resolveEmbeddedPostgresDataDir(config.database.embeddedPostgresDataDir, configPath),
         config.database.embeddedPostgresPort,
       );
     }
@@ -2124,11 +2134,16 @@ function renderMergePlan(plan: Awaited<ReturnType<typeof collectMergePlan>>["pla
   return lines.join("\n");
 }
 
-function resolveRunningEmbeddedPostgresPid(config: PaperclipConfig): number | null {
+function resolveRunningEmbeddedPostgresPid(config: PaperclipConfig, configPath: string): number | null {
   if (config.database.mode !== "embedded-postgres") {
     return null;
   }
-  return readRunningPostmasterPid(path.resolve(config.database.embeddedPostgresDataDir, "postmaster.pid"));
+  return readRunningPostmasterPid(
+    path.resolve(
+      resolveEmbeddedPostgresDataDir(config.database.embeddedPostgresDataDir, configPath),
+      "postmaster.pid",
+    ),
+  );
 }
 
 async function collectMergePlan(input: {
@@ -3103,7 +3118,7 @@ async function runWorktreeReseed(opts: WorktreeReseedOptions): Promise<void> {
     configPath: targetEndpoint.configPath,
     rootPath: targetEndpoint.rootPath,
   });
-  const runningTargetPid = resolveRunningEmbeddedPostgresPid(targetConfig);
+  const runningTargetPid = resolveRunningEmbeddedPostgresPid(targetConfig, target.configPath);
   if (runningTargetPid && !opts.allowLiveTarget) {
     throw new Error(
       `Target worktree database appears to be running (pid ${runningTargetPid}). Stop Paperclip in ${targetEndpoint.rootPath} before reseeding, or re-run with --allow-live-target if you want to override this guard.`,

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -984,15 +984,28 @@ async function ensureRepairTargetWorktree(input: {
   };
 }
 
-function resolveSourceConnectionString(config: PaperclipConfig, envEntries: Record<string, string>, portOverride?: number): string {
-  if (config.database.mode === "postgres") {
-    const connectionString = nonEmpty(envEntries.DATABASE_URL) ?? nonEmpty(config.database.connectionString);
-    if (!connectionString) {
-      throw new Error(
-        "Source instance uses postgres mode but has no connection string in config or adjacent .env.",
-      );
-    }
+function resolveSourceConnectionString(
+  sourceConfigPath: string,
+  config: PaperclipConfig,
+  envEntries: Record<string, string>,
+  portOverride?: number,
+): string {
+  const runtimeEnvConnectionString = isCurrentSourceConfigPath(sourceConfigPath)
+    ? nonEmpty(process.env.DATABASE_URL)
+    : null;
+  const fileEnvConnectionString = nonEmpty(envEntries.DATABASE_URL);
+  const configConnectionString =
+    config.database.mode === "postgres" ? nonEmpty(config.database.connectionString) : null;
+  const connectionString = runtimeEnvConnectionString ?? fileEnvConnectionString ?? configConnectionString;
+
+  if (connectionString) {
     return connectionString;
+  }
+
+  if (config.database.mode === "postgres") {
+    throw new Error(
+      "Source instance uses postgres mode but has no connection string in runtime env, config, or adjacent .env.",
+    );
   }
 
   const port = portOverride ?? config.database.embeddedPostgresPort;
@@ -1302,6 +1315,7 @@ async function seedWorktreeDatabase(input: {
       await ensurePostgresDatabase(sourceAdminConnectionString, "paperclip");
     }
     const sourceConnectionString = resolveSourceConnectionString(
+      input.sourceConfigPath,
       input.sourceConfig,
       sourceEnvEntries,
       sourceHandle?.port,
@@ -1931,7 +1945,7 @@ async function openConfiguredDb(configPath: string): Promise<OpenDbHandle> {
         config.database.embeddedPostgresPort,
       );
     }
-    const connectionString = resolveSourceConnectionString(config, envEntries, embeddedHandle?.port);
+    const connectionString = resolveSourceConnectionString(configPath, config, envEntries, embeddedHandle?.port);
     const migrationState = await inspectMigrations(connectionString);
     if (migrationState.status !== "upToDate") {
       const pending =


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Its worktree CLI clones isolated Paperclip instances so contributors can debug issues against realistic state without mutating the source instance.
> - Authenticated deployments can source their live database from runtime `DATABASE_URL`, and `--from-instance default` can also point embedded Postgres at home-prefixed runtime paths like `~/.paperclip/...`.
> - The original full-seed restore bug came from the seed path resolving a different source database than the running instance, which produced the observed `215B` dump and dropped company, agent, issue, and membership state.
> - This pull request aligns worktree source selection with the real runtime path for both authenticated `DATABASE_URL` deployments and `fromInstance: "default"` embedded Postgres configs.
> - The benefit is that full-seed authenticated worktrees preserve real relational state before quarantine, and the staged replay no longer falls back to `bootstrap_pending` on copied production data.

## What Changed

- Updated `cli/src/commands/worktree.ts` so full-seed worktree creation resolves the current source database in runtime order: live `process.env.DATABASE_URL` for the current source config, then source `.env`, then explicit Postgres config, otherwise embedded Postgres.
- Normalized home-prefixed embedded Postgres data dirs before seed backup, merge-history DB access, and running-PID checks so `--from-instance default` uses the real source instance instead of opening an empty path literal.
- Added regression coverage in `cli/src/__tests__/worktree.test.ts` for both authenticated runtime-`DATABASE_URL` clones and `fromInstance: "default"` clones with `~/.paperclip/...` source paths.

## Verification

- `pnpm exec vitest run cli/src/__tests__/worktree.test.ts -t "uses home-prefixed embedded postgres source paths for full-seed worktree clones|uses the current runtime DATABASE_URL for authenticated full-seed worktree clones"`
- Exact staged replay from the failing drill:
  - `pnpm paperclipai worktree:make dig-922-auth-full-seed-rerun-20260430 --start-point deploy/default/20260428-6940f34d --seed-mode full --from-instance default`
- Observed replay results after the fix:
  - seed artifact grew from `215B` to `145.7M`
  - restored clone counts: `companies=1`, `agents=11`, `issues=965`, `company_memberships=12`, `instance_user_roles=2`
  - cloned server health: `{"status":"ok","deploymentMode":"authenticated","bootstrapStatus":"ready","bootstrapInviteActive":false}`

## Risks

- Low to medium: this changes which source database wins when runtime env, source `.env`, and file config disagree, but it intentionally matches the running server/runtime behavior instead of the stale config path.
- The change is scoped to worktree source resolution and is covered by targeted regressions plus the exact previously failing deploy drill replay.
- I did not rerun a full local `pnpm -r typecheck` / `pnpm test:run` in this handoff heartbeat; CI on this PR should be treated as the full-gate verification.

## Model Used

- OpenAI Codex coding agent in the local Codex runtime, GPT-5-family backend, terminal tool use enabled, medium-reasoning workflow.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
