### PR TITLE
feat: productize local Hermes workflow

### DIFF
--- a/doc/PAPERCLIP_HERMES_CHECKLIST.md
+++ b/doc/PAPERCLIP_HERMES_CHECKLIST.md
@@ -1,0 +1,56 @@
+# Paperclip 本地使用清单（Hermes 版）
+
+## 每次启动
+
+1. 启动 Paperclip
+2. 打开对应实例 UI（默认常见为 <http://127.0.0.1:3100>）
+3. 如果当前实例不在 `3100`，先设置：`export PAPERCLIP_API_BASE="http://127.0.0.1:<port>/api"`
+4. 先运行：`pnpm hermes:verify`
+5. 确认 `/api/adapters` 里有 `hermes_local`
+
+## 创建一个新 Hermes agent 时
+
+- 优先使用 `doc/templates/hermes-local-agent.json`
+- 先把模板中的 `REPLACE_PAPERCLIP_API_BASE` 改成当前实例 API 地址
+- 默认不要显式写 `model`
+- 默认不要显式写 `provider`
+- 先给 `toolsets: terminal,file`
+- 先把 `persistSession` 设成 `false`
+
+## 做最小 demo 时
+
+- 临时模式：直接运行 `pnpm hermes:demo`
+- 回归模式：`pnpm hermes:demo -- --company-id <company-id> --agent-id <agent-id>`
+- 如果手动做：用 `doc/templates/hermes-demo-issue.json`
+- 替换 `assigneeAgentId`
+- 创建 issue 后等待 assignment wakeup 自动触发
+- 查看：
+  - issue 状态
+  - issue comments
+  - heartbeat runs
+  - run log
+
+## 观察结果的 4 个 API
+
+```bash
+GET /api/issues/{issueId}
+GET /api/issues/{issueId}/comments
+GET /api/companies/{companyId}/heartbeat-runs?agentId={agentId}&limit=20
+GET /api/heartbeat-runs/{runId}/log
+```
+
+## 一键入口
+
+```bash
+pnpm hermes:verify
+pnpm hermes:demo
+pnpm hermes:demo -- --company-id <company-id> --agent-id <agent-id>
+```
+
+## 已知本机特性
+
+- 启动入口使用 `cli/node_modules/tsx/dist/cli.mjs`
+- 当前分支的 Hermes 接入以 **plugin-only** 模式为准，可通过 Adapter manager 或 `~/.paperclip/adapter-plugins.json` 的 `file:` 路径做本地开发接入
+- 当前 adapter 已修复：
+  - Python 检测误报
+  - 默认模型错误绑到 Anthropic

--- a/doc/PAPERCLIP_HERMES_LOCAL_WORKFLOW.md
+++ b/doc/PAPERCLIP_HERMES_LOCAL_WORKFLOW.md
@@ -1,0 +1,378 @@
+# Paperclip + Hermes 本地工作流（已在本机验证）
+
+> 环境：`/Users/neo/projects/paperclip` + `/Users/neo/projects/hermes-paperclip-adapter`
+>
+> 本文档记录一套在这台机器上已经实跑成功的最小可用工作流：启动 Paperclip、本地接入 Hermes、创建 agent、下发 issue、观察执行结果。
+
+---
+
+## 0. 新增：一键入口
+
+在 `paperclip` repo 根目录现在可直接运行：
+
+```bash
+pnpm hermes:verify
+pnpm hermes:demo
+```
+
+如果当前实例不在默认 `3100`，先显式指定 API base：
+
+```bash
+export PAPERCLIP_API_BASE="http://127.0.0.1:<port>/api"
+```
+
+### `pnpm hermes:verify`
+
+用途：
+- 检查 Hermes CLI 是否可运行
+- 检查 `/api/adapters` 中是否存在 `hermes_local`
+- 调用 `test-environment`
+- 列出当前实例中的 companies
+
+适合场景：
+- 每次启动后先做环境体检
+- 更新 adapter 后确认修复仍生效
+
+### `pnpm hermes:demo`
+
+用途：
+- 默认模式：自动创建临时 company + agent + demo issue
+- 回归模式：复用已有 company / agent，仅创建新的 demo issue
+- 自动轮询 execution run
+- 自动校验：
+  - issue 最终为 `done`
+  - comment 中包含 `DEMO_DONE`
+  - heartbeat run 最终 `succeeded`
+
+注意：
+- 这两个脚本默认会优先读取 `PAPERCLIP_API_BASE`
+- 若未设置，则回退读取 `.paperclip/config.json` 中的 `server.port`
+- 只有在两者都拿不到时，才回退到 `http://127.0.0.1:3100/api`
+
+可选参数：
+
+```bash
+pnpm hermes:demo -- --company-name "Hermes Demo Co"
+pnpm hermes:demo -- --issue-title "Custom demo issue"
+pnpm hermes:demo -- --timeout-sec 240 --poll-sec 5
+pnpm hermes:demo -- --company-id <company-id> --agent-id <agent-id>
+```
+
+### 回归模式（复用已有 company / agent）
+
+当你已经有一个稳定的 Hermes company / agent，希望重复做回归验证时，推荐直接：
+
+```bash
+pnpm hermes:demo -- \
+  --company-id 5206167d-028f-4f9a-9efe-a29f5ce6d7b3 \
+  --agent-id 7dd59715-9ac3-4943-ac2c-eab2659d4592 \
+  --issue-title "Hermes regression issue"
+```
+
+此模式下脚本会：
+- 复用已有 company
+- 复用已有 `hermes_local` agent
+- 只创建一条新的 demo / regression issue
+- 等待该 agent 自动处理并验证结果
+
+适合做：
+- 每次升级 adapter 后的回归测试
+- 每次更新 Hermes 配置后的烟雾验证
+- 长期保留同一公司/同一 agent 的稳定回归入口
+
+---
+
+## 1. 当前本机已验证的前提
+
+- Paperclip 仓库：`/Users/neo/projects/paperclip`
+- Hermes adapter 仓库：`/Users/neo/projects/hermes-paperclip-adapter`
+- Paperclip config：`/Users/neo/projects/paperclip/.paperclip/config.json`
+- Paperclip instance id：`paperclip-local`
+- Paperclip API / UI：`http://127.0.0.1:3100`
+- Hermes CLI：本机可运行
+- Hermes 实际运行 Python：`3.14.3`
+
+---
+
+## 2. 启动 Paperclip
+
+在 Paperclip repo 根目录运行：
+
+```bash
+cd /Users/neo/projects/paperclip
+PAPERCLIP_CONFIG=/Users/neo/projects/paperclip/.paperclip/config.json \
+PAPERCLIP_INSTANCE_ID=paperclip-local \
+node cli/node_modules/tsx/dist/cli.mjs cli/src/index.ts run
+```
+
+启动后：
+
+- UI：<http://127.0.0.1:3100>
+- API：<http://127.0.0.1:3100/api>
+
+快速检查：
+
+```bash
+curl -sS http://127.0.0.1:3100/api/adapters
+```
+
+预期能看到：
+
+- `hermes_local`
+
+---
+
+## 3. 更新 Hermes adapter 到本地源码版本
+
+本 fork/分支当前应优先按 **plugin-only** 模式接入 Hermes，不建议在 `server/` 里直接添加内联依赖。
+
+推荐做法：
+- 通过 **Board → Adapter manager** 注册 Hermes adapter
+- 或在本地开发时通过 `~/.paperclip/adapter-plugins.json` 配置 `file:` 路径
+
+### 3.1 重新 build adapter
+
+```bash
+cd /Users/neo/projects/hermes-paperclip-adapter
+export PATH="$HOME/.bun/bin:$PATH"
+npm run build
+```
+
+### 3.2 以本地插件方式接入 adapter
+
+在 `~/.paperclip/adapter-plugins.json` 中为 Hermes adapter 配置本地 `file:` 路径，然后重启 Paperclip。
+
+> 说明：当前这份产品化文档聚焦的是 **verify/demo 回归流程**；adapter 的具体插件注册步骤应以本仓库 `AGENTS.md` 的 plugin-only 说明为准。
+
+### 3.3 重启 Paperclip
+
+重启后再检查：
+
+```bash
+curl -sS "$PAPERCLIP_API_BASE/adapters"
+```
+
+---
+
+## 4. 运行环境检测
+
+### 推荐：直接运行一键验证
+
+```bash
+cd /Users/neo/projects/paperclip
+pnpm hermes:verify
+```
+
+### 底层 API 等价命令
+
+```bash
+curl -sS -X POST \
+  http://127.0.0.1:3100/api/companies/test-co/adapters/hermes_local/test-environment \
+  -H 'Content-Type: application/json' \
+  -d '{"adapterConfig":{}}'
+```
+
+本机当前预期结果：
+
+- `status: "warn"` 或更好
+- 不应再出现系统 `python3 3.9.6` 的误报
+
+说明：
+
+- 当前 adapter 已修正为优先读取 `hermes --version` 报告的 Python 版本
+- 默认不再强制写死 `anthropic/claude-sonnet-4`
+- 如果未显式指定 `model`，Paperclip 中的 Hermes agent 会回退到本机 Hermes 默认配置
+
+---
+
+## 5. 创建 company
+
+如果还没有测试 company，可以用：
+
+```bash
+curl -sS -X POST http://127.0.0.1:3100/api/companies \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Hermes Paperclip Test Co",
+    "description": "Temporary local company for Hermes adapter verification",
+    "budgetMonthlyCents": 0
+  }'
+```
+
+列出 company：
+
+```bash
+curl -sS http://127.0.0.1:3100/api/companies
+```
+
+---
+
+## 6. 创建 Hermes agent
+
+推荐最小配置：
+
+- 不显式指定 `model`
+- 不显式指定 `provider`
+- 先给 `terminal,file`
+- `persistSession` 先关掉，方便演示和排障
+
+示例 payload 见：
+
+- `doc/templates/hermes-local-agent.json`
+
+其中 `paperclipApiUrl` 使用 `REPLACE_PAPERCLIP_API_BASE` 占位；在实际创建前请替换成当前实例的 API base（例如 `http://127.0.0.1:3100/api`）。
+
+创建命令示例：
+
+```bash
+COMPANY_ID="<your-company-id>"
+
+python - <<'PY' >/tmp/hermes-local-agent.filled.json
+import json
+from pathlib import Path
+p = Path('/Users/neo/projects/paperclip/doc/templates/hermes-local-agent.json')
+data = json.loads(p.read_text())
+data['adapterConfig']['paperclipApiUrl'] = 'http://127.0.0.1:3100/api'
+print(json.dumps(data))
+PY
+
+curl -sS -X POST "http://127.0.0.1:3100/api/companies/$COMPANY_ID/agents" \
+  -H 'Content-Type: application/json' \
+  --data @/tmp/hermes-local-agent.filled.json
+```
+
+列出 agent：
+
+```bash
+curl -sS "http://127.0.0.1:3100/api/companies/$COMPANY_ID/agents"
+```
+
+---
+
+## 7. 下发 demo issue 给 Hermes agent
+
+### 推荐：直接运行一键 demo
+
+```bash
+cd /Users/neo/projects/paperclip
+pnpm hermes:demo
+```
+
+### 回归模式：复用已有 company / agent
+
+```bash
+cd /Users/neo/projects/paperclip
+pnpm hermes:demo -- \
+  --company-id <company-id> \
+  --agent-id <agent-id> \
+  --issue-title "Regression issue"
+```
+
+示例 payload 仍可参考：
+
+- `doc/templates/hermes-demo-issue.json`
+
+创建命令示例：
+
+```bash
+COMPANY_ID="<your-company-id>"
+AGENT_ID="<your-agent-id>"
+
+python - <<'PY'
+import json
+from pathlib import Path
+p = Path('/Users/neo/projects/paperclip/doc/templates/hermes-demo-issue.json')
+data = json.loads(p.read_text())
+data['assigneeAgentId'] = 'REPLACE_AGENT_ID'
+print(json.dumps(data))
+PY
+```
+
+更直接的方式：把模板里的 `REPLACE_AGENT_ID` 替换掉后执行：
+
+```bash
+curl -sS -X POST "http://127.0.0.1:3100/api/companies/$COMPANY_ID/issues" \
+  -H 'Content-Type: application/json' \
+  --data @/path/to/hermes-demo-issue.filled.json
+```
+
+### 自动行为
+
+当 issue 被分配给 agent 后，Paperclip 会自动：
+
+- 把 issue 派给该 agent
+- 触发 `assignment` 类型 wakeup
+- 创建 heartbeat run
+- 拉起 Hermes 执行
+
+---
+
+## 8. 观察运行结果
+
+### 看 issue 列表
+
+```bash
+curl -sS "http://127.0.0.1:3100/api/companies/$COMPANY_ID/issues"
+```
+
+### 看某个 issue 详情
+
+```bash
+ISSUE_ID="<issue-id>"
+curl -sS "http://127.0.0.1:3100/api/issues/$ISSUE_ID"
+```
+
+### 看 comments
+
+```bash
+curl -sS "http://127.0.0.1:3100/api/issues/$ISSUE_ID/comments"
+```
+
+### 看 heartbeat runs
+
+```bash
+curl -sS "http://127.0.0.1:3100/api/companies/$COMPANY_ID/heartbeat-runs?agentId=$AGENT_ID&limit=20"
+```
+
+### 看某次 run 的详情 / 事件 / 日志
+
+```bash
+RUN_ID="<run-id>"
+
+curl -sS "http://127.0.0.1:3100/api/heartbeat-runs/$RUN_ID"
+curl -sS "http://127.0.0.1:3100/api/heartbeat-runs/$RUN_ID/events"
+curl -sS "http://127.0.0.1:3100/api/heartbeat-runs/$RUN_ID/log"
+```
+
+---
+
+## 9. 本机已验证成功的 demo 闭环
+
+本机已经实测成功的链路：
+
+1. 创建测试 company
+2. 创建 `hermes_local` agent
+3. 创建并分配一个 issue 给该 agent
+4. Paperclip 自动触发 assignment wakeup
+5. Hermes 读取 issue 内容
+6. Hermes 在 issue 下发评论（包含 `DEMO_DONE`）
+7. Hermes 将 issue 状态改为 `done`
+8. 对应 heartbeat run 最终 `status = succeeded`
+
+回归模式下则是：
+
+1. 复用已有 company
+2. 复用已有 `hermes_local` agent
+3. 创建并分配一个新的 regression issue
+4. 观察同样的自动闭环是否继续成立
+
+---
+
+## 10. 配置建议
+
+### 推荐默认项
+
+- `toolsets: "terminal,file"`
+- `timeoutSec: 120` 或 `300`
+- `persistSession: false`（先演示再调优）
+- **不要显式写 `model` / `provider`**，先继承本机 Hermes 默认配置

--- a/doc/templates/hermes-demo-issue.json
+++ b/doc/templates/hermes-demo-issue.json
@@ -1,0 +1,7 @@
+{
+  "title": "Paperclip Hermes demo issue",
+  "description": "这是一个本地演示任务。请完成以下动作：\n1. 在此 issue 下发表评论，正文里必须包含 `DEMO_DONE`\n2. 然后把这个 issue 标记为 done\n3. 评论里用中文简要说明你完成了什么\n",
+  "status": "todo",
+  "priority": "medium",
+  "assigneeAgentId": "REPLACE_AGENT_ID"
+}

--- a/doc/templates/hermes-local-agent.json
+++ b/doc/templates/hermes-local-agent.json
@@ -1,0 +1,16 @@
+{
+  "name": "Hermes Worker",
+  "role": "general",
+  "title": "Hermes execution agent",
+  "adapterType": "hermes_local",
+  "adapterConfig": {
+    "paperclipApiUrl": "REPLACE_PAPERCLIP_API_BASE",
+    "toolsets": "terminal,file",
+    "timeoutSec": 120,
+    "graceSec": 10,
+    "persistSession": false,
+    "verbose": false
+  },
+  "runtimeConfig": {},
+  "budgetMonthlyCents": 0
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "type": "module",
   "scripts": {
     "preflight:workspace-links": "node cli/node_modules/tsx/dist/cli.mjs scripts/ensure-workspace-package-links.ts",
+    "hermes:verify": "node cli/node_modules/tsx/dist/cli.mjs scripts/hermes-local-verify.ts",
+    "hermes:demo": "node cli/node_modules/tsx/dist/cli.mjs scripts/hermes-local-demo.ts",
     "dev": "pnpm --filter @paperclipai/server exec tsx ../scripts/dev-runner.ts watch",
     "dev:watch": "pnpm --filter @paperclipai/server exec tsx ../scripts/dev-runner.ts watch",
     "dev:once": "pnpm --filter @paperclipai/server exec tsx ../scripts/dev-runner.ts dev",

--- a/scripts/hermes-local-common.ts
+++ b/scripts/hermes-local-common.ts
@@ -1,0 +1,378 @@
+#!/usr/bin/env -S node --import tsx
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const FALLBACK_API_BASE = "http://127.0.0.1:3100/api";
+const DEFAULT_CONFIG_PATH = path.resolve(process.cwd(), ".paperclip/config.json");
+const DEFAULT_INSTANCE_ID = process.env.PAPERCLIP_INSTANCE_ID ?? "paperclip-local";
+const DEFAULT_AUTH_STORE_PATH = path.join(os.homedir(), ".paperclip", "auth.json");
+const DEFAULT_PAPERCLIP_START_COMMAND = [
+  "cd /Users/neo/projects/paperclip",
+  `PAPERCLIP_CONFIG=${process.env.PAPERCLIP_CONFIG ?? DEFAULT_CONFIG_PATH} \\`,
+  `PAPERCLIP_INSTANCE_ID=${DEFAULT_INSTANCE_ID} \\`,
+  "node cli/node_modules/tsx/dist/cli.mjs cli/src/index.ts run",
+].join("\n");
+
+export const API_BASE = resolveApiBase();
+export const API_ORIGIN = resolveApiOrigin(API_BASE);
+export const BOARD_AUTH_TOKEN = resolveBoardAuthToken(API_ORIGIN);
+
+export interface AdapterSummary {
+  type: string;
+  label?: string;
+  source?: string;
+  modelsCount?: number;
+  loaded?: boolean;
+  disabled?: boolean;
+  overridePaused?: boolean;
+}
+
+export interface TestEnvironmentCheck {
+  level: "info" | "warn" | "error";
+  message: string;
+  hint?: string;
+  code?: string;
+}
+
+export interface TestEnvironmentResult {
+  adapterType: string;
+  status: "ok" | "warn" | "fail";
+  checks: TestEnvironmentCheck[];
+  testedAt?: string;
+}
+
+export interface CompanyRecord {
+  id: string;
+  name: string;
+  description?: string | null;
+  issuePrefix?: string | null;
+  status?: string;
+}
+
+export interface AgentRecord {
+  id: string;
+  companyId: string;
+  name: string;
+  adapterType: string;
+  status?: string;
+}
+
+export interface IssueRecord {
+  id: string;
+  companyId: string;
+  identifier?: string;
+  title: string;
+  description?: string | null;
+  status: string;
+  assigneeAgentId?: string | null;
+  executionRunId?: string | null;
+  checkoutRunId?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface IssueCommentRecord {
+  id: string;
+  issueId: string;
+  body: string;
+  authorAgentId?: string | null;
+  createdAt?: string;
+}
+
+export interface HeartbeatRunRecord {
+  id: string;
+  companyId: string;
+  agentId: string;
+  status: string;
+  invocationSource?: string | null;
+  triggerDetail?: string | null;
+  createdAt?: string;
+  startedAt?: string | null;
+  finishedAt?: string | null;
+  contextSnapshot?: Record<string, unknown> | null;
+}
+
+export interface HeartbeatLogResult {
+  content: string;
+  nextOffset: number;
+  truncated?: boolean;
+}
+
+export interface HermesVersionInfo {
+  raw: string;
+  versionLine: string;
+  pythonVersion: string | null;
+}
+
+function normalizeApiBase(apiBase: string): string {
+  return apiBase.replace(/\/$/, "");
+}
+
+function normalizeConfigHost(host: string): string {
+  return host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+}
+
+function resolveApiBase(): string {
+  if (process.env.PAPERCLIP_API_BASE) {
+    return normalizeApiBase(process.env.PAPERCLIP_API_BASE);
+  }
+
+  const configPath = process.env.PAPERCLIP_CONFIG ?? DEFAULT_CONFIG_PATH;
+  try {
+    if (fs.existsSync(configPath)) {
+      const raw = fs.readFileSync(configPath, "utf8");
+      const parsed = JSON.parse(raw) as {
+        server?: { host?: string; port?: number };
+      };
+      const host = normalizeConfigHost(parsed.server?.host || "127.0.0.1");
+      const port = parsed.server?.port;
+      if (typeof port === "number" && Number.isInteger(port) && port > 0) {
+        return normalizeApiBase(`http://${host}:${port}/api`);
+      }
+    }
+  } catch {
+    // Fall through to the stable fallback.
+  }
+
+  return normalizeApiBase(FALLBACK_API_BASE);
+}
+
+function resolveApiOrigin(apiBase: string): string {
+  try {
+    const url = new URL(apiBase);
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return apiBase.replace(/\/api\/?$/, "");
+  }
+}
+
+function resolveBoardAuthToken(apiOrigin: string): string | null {
+  if (process.env.PAPERCLIP_API_KEY?.trim()) return process.env.PAPERCLIP_API_KEY.trim();
+  if (process.env.PAPERCLIP_BOARD_AUTH_TOKEN?.trim()) return process.env.PAPERCLIP_BOARD_AUTH_TOKEN.trim();
+
+  const storePath = process.env.PAPERCLIP_AUTH_STORE?.trim() || DEFAULT_AUTH_STORE_PATH;
+  try {
+    if (!fs.existsSync(storePath)) return null;
+    const raw = fs.readFileSync(storePath, "utf8");
+    const parsed = JSON.parse(raw) as {
+      credentials?: Record<string, { apiBase?: string; token?: string }>;
+    };
+    const credentials = parsed.credentials ?? {};
+    const normalizedOrigin = normalizeApiBase(apiOrigin);
+    const candidates = new Set<string>([
+      normalizedOrigin,
+      normalizedOrigin.replace("127.0.0.1", "localhost"),
+      normalizedOrigin.replace("localhost", "127.0.0.1"),
+    ]);
+
+    for (const key of candidates) {
+      const token = credentials[key]?.token;
+      if (typeof token === "string" && token.trim()) return token.trim();
+    }
+
+    for (const value of Object.values(credentials)) {
+      const base = typeof value.apiBase === "string" ? normalizeApiBase(value.apiBase) : "";
+      const token = value.token;
+      if (candidates.has(base) && typeof token === "string" && token.trim()) return token.trim();
+    }
+  } catch {
+    // Continue unauthenticated; the API will return a clear authorization error.
+  }
+  return null;
+}
+
+export function section(title: string): void {
+  console.log(`\n=== ${title} ===`);
+}
+
+export function step(message: string): void {
+  console.log(`• ${message}`);
+}
+
+export function success(message: string): void {
+  console.log(`✅ ${message}`);
+}
+
+export function warn(message: string): void {
+  console.warn(`⚠️  ${message}`);
+}
+
+export function fail(message: string): never {
+  console.error(`❌ ${message}`);
+  process.exit(1);
+}
+
+export function summarizeCheck(check: TestEnvironmentCheck): string {
+  const hint = check.hint ? ` | hint: ${check.hint}` : "";
+  const code = check.code ? ` (${check.code})` : "";
+  return `[${check.level}]${code} ${check.message}${hint}`;
+}
+
+export function extractCheckMessages(result: TestEnvironmentResult, level: TestEnvironmentCheck["level"]): string[] {
+  return result.checks.filter((check) => check.level === level).map(summarizeCheck);
+}
+
+export async function apiRequest<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const url = path.startsWith("http://") || path.startsWith("https://") ? path : `${API_BASE}${path}`;
+  const headers = new Headers(init.headers ?? {});
+  if (BOARD_AUTH_TOKEN && !headers.has("Authorization") && !headers.has("authorization")) {
+    headers.set("Authorization", `Bearer ${BOARD_AUTH_TOKEN}`);
+  }
+  if (init.body !== undefined && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, { ...init, headers });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to reach Paperclip API at ${API_BASE}. Start Paperclip first, e.g.\n\n${DEFAULT_PAPERCLIP_START_COMMAND}\n\nOriginal error: ${detail}`,
+    );
+  }
+
+  const rawText = await response.text();
+  const data = parseMaybeJson(rawText);
+  if (!response.ok) {
+    const detail = formatErrorDetail(data, rawText);
+    throw new Error(`Paperclip API ${response.status} ${response.statusText} for ${url}${detail ? `: ${detail}` : ""}`);
+  }
+  return data as T;
+}
+
+export async function getAdapters(): Promise<AdapterSummary[]> {
+  return await apiRequest<AdapterSummary[]>("/adapters");
+}
+
+export async function getHermesTestEnvironment(companyId: string, adapterConfig: Record<string, unknown> = {}): Promise<TestEnvironmentResult> {
+  return await apiRequest<TestEnvironmentResult>(`/companies/${companyId}/adapters/hermes_local/test-environment`, {
+    method: "POST",
+    body: JSON.stringify({ adapterConfig }),
+  });
+}
+
+export async function getCompanies(): Promise<CompanyRecord[]> {
+  return await apiRequest<CompanyRecord[]>("/companies");
+}
+
+export async function getAgents(companyId: string): Promise<AgentRecord[]> {
+  return await apiRequest<AgentRecord[]>(`/companies/${companyId}/agents`);
+}
+
+export async function getHeartbeatRuns(companyId: string, agentId: string, limit = 20): Promise<HeartbeatRunRecord[]> {
+  const query = new URLSearchParams({ agentId, limit: String(limit) });
+  return await apiRequest<HeartbeatRunRecord[]>(`/companies/${companyId}/heartbeat-runs?${query.toString()}`);
+}
+
+export async function getHeartbeatRun(runId: string): Promise<HeartbeatRunRecord> {
+  return await apiRequest<HeartbeatRunRecord>(`/heartbeat-runs/${runId}`);
+}
+
+export async function getHeartbeatRunEvents(runId: string): Promise<unknown[]> {
+  return await apiRequest<unknown[]>(`/heartbeat-runs/${runId}/events`);
+}
+
+export async function getHeartbeatRunLog(runId: string, limitBytes = 12000): Promise<HeartbeatLogResult> {
+  return await apiRequest<HeartbeatLogResult>(`/heartbeat-runs/${runId}/log?limitBytes=${limitBytes}`);
+}
+
+export async function getIssue(issueId: string): Promise<IssueRecord> {
+  return await apiRequest<IssueRecord>(`/issues/${issueId}`);
+}
+
+export async function getIssueComments(issueId: string): Promise<IssueCommentRecord[]> {
+  return await apiRequest<IssueCommentRecord[]>(`/issues/${issueId}/comments`);
+}
+
+export async function createCompany(payload: Record<string, unknown>): Promise<CompanyRecord> {
+  return await apiRequest<CompanyRecord>("/companies", { method: "POST", body: JSON.stringify(payload) });
+}
+
+export async function createAgent(companyId: string, payload: Record<string, unknown>): Promise<AgentRecord> {
+  return await apiRequest<AgentRecord>(`/companies/${companyId}/agents`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function createAgentHire(companyId: string, payload: Record<string, unknown>): Promise<{ agent: AgentRecord; approval?: { id: string; status: string } | null }> {
+  return await apiRequest<{ agent: AgentRecord; approval?: { id: string; status: string } | null }>(`/companies/${companyId}/agent-hires`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function approveApproval(approvalId: string, decisionNote = "Approved by local Hermes demo automation."): Promise<unknown> {
+  return await apiRequest<unknown>(`/approvals/${approvalId}/approve`, {
+    method: "POST",
+    body: JSON.stringify({ decisionNote }),
+  });
+}
+
+export async function createIssue(companyId: string, payload: Record<string, unknown>): Promise<IssueRecord> {
+  return await apiRequest<IssueRecord>(`/companies/${companyId}/issues`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function getHermesVersion(): Promise<HermesVersionInfo> {
+  try {
+    const { stdout, stderr } = await execFileAsync("hermes", ["--version"], { timeout: 20_000 });
+    const combined = `${stdout ?? ""}\n${stderr ?? ""}`.trim();
+    const versionLine = combined.split(/\r?\n/).find((line) => line.trim().length > 0) ?? combined;
+    const pythonMatch = combined.match(/Python:\s*([0-9]+\.[0-9]+(?:\.[0-9]+)?)/i);
+    return {
+      raw: combined,
+      versionLine,
+      pythonVersion: pythonMatch?.[1] ?? null,
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to run 'hermes --version': ${detail}`);
+  }
+}
+
+export async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function formatJson(data: unknown): string {
+  return JSON.stringify(data, null, 2);
+}
+
+export function truncate(text: string, maxLength = 1200): string {
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength)}\n...<truncated>`;
+}
+
+export function makeTimestampSlug(date = new Date()): string {
+  const iso = date.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  return iso.replace(/T/, "-").replace(/Z$/, "").toLowerCase();
+}
+
+export function parseMaybeJson(rawText: string): unknown {
+  if (!rawText) return null;
+  try {
+    return JSON.parse(rawText);
+  } catch {
+    return rawText;
+  }
+}
+
+function formatErrorDetail(data: unknown, rawText: string): string {
+  if (typeof data === "string" && data.trim()) return data.trim();
+  if (data && typeof data === "object") {
+    const errorValue = (data as Record<string, unknown>).error;
+    if (typeof errorValue === "string" && errorValue.trim()) return errorValue.trim();
+    return truncate(JSON.stringify(data));
+  }
+  return rawText.trim();
+}

--- a/scripts/hermes-local-demo.ts
+++ b/scripts/hermes-local-demo.ts
@@ -1,0 +1,371 @@
+#!/usr/bin/env -S node --import tsx
+import process from "node:process";
+import {
+  API_BASE,
+  approveApproval,
+  createAgent,
+  createAgentHire,
+  createCompany,
+  createIssue,
+  formatJson,
+  getAgents,
+  getCompanies,
+  getHeartbeatRun,
+  getHeartbeatRunEvents,
+  getHeartbeatRunLog,
+  getHeartbeatRuns,
+  getIssue,
+  getIssueComments,
+  makeTimestampSlug,
+  section,
+  sleep,
+  step,
+  success,
+  truncate,
+  warn,
+  fail,
+} from "./hermes-local-common.ts";
+
+interface DemoOptions {
+  companyName: string;
+  issueTitle: string;
+  timeoutMs: number;
+  pollIntervalMs: number;
+  companyId: string | null;
+  agentId: string | null;
+  agentName: string;
+}
+
+interface ResolvedCompany {
+  id: string;
+  name: string;
+  mode: "created" | "reused";
+}
+
+interface ResolvedAgent {
+  id: string;
+  name: string;
+  mode: "created" | "reused";
+}
+
+function parseArgs(argv: string[]): DemoOptions {
+  const timestamp = makeTimestampSlug();
+  const options: DemoOptions = {
+    companyName: `Hermes Paperclip Demo ${timestamp}`,
+    issueTitle: `Paperclip Hermes demo issue ${timestamp}`,
+    timeoutMs: 180_000,
+    pollIntervalMs: 5_000,
+    companyId: null,
+    agentId: null,
+    agentName: "Hermes Worker",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--company-name" && next) {
+      options.companyName = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--issue-title" && next) {
+      options.issueTitle = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--company-id" && next) {
+      options.companyId = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--agent-id" && next) {
+      options.agentId = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--agent-name" && next) {
+      options.agentName = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--timeout-sec" && next) {
+      options.timeoutMs = Number(next) * 1000;
+      index += 1;
+      continue;
+    }
+    if (arg === "--poll-sec" && next) {
+      options.pollIntervalMs = Number(next) * 1000;
+      index += 1;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+
+  if (options.agentId && !options.companyId) {
+    fail("使用 --agent-id 时必须同时提供 --company-id。");
+  }
+  if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
+    fail("--timeout-sec 必须是正数。");
+  }
+  if (!Number.isFinite(options.pollIntervalMs) || options.pollIntervalMs <= 0) {
+    fail("--poll-sec 必须是正数。");
+  }
+  return options;
+}
+
+function printHelp(): void {
+  console.log(`Paperclip + Hermes 一键 demo
+
+默认模式：创建临时 company + agent，再创建 demo issue。
+回归模式：传入既有 company/agent，复用既有环境只创建 demo issue。
+
+Options:
+  --company-id <id>       复用已有 company
+  --agent-id <id>         复用已有 agent（需与 --company-id 一起使用）
+  --company-name <name>   临时创建 company 时使用的名称
+  --agent-name <name>     创建新 agent 时使用的名称，默认 Hermes Worker
+  --issue-title <title>   指定 demo issue 标题
+  --timeout-sec <sec>     最大等待秒数，默认 180
+  --poll-sec <sec>        轮询间隔秒数，默认 5
+`);
+}
+
+async function resolveCompany(options: DemoOptions): Promise<ResolvedCompany> {
+  if (!options.companyId) {
+    step("创建临时 demo company");
+    const company = await createCompany({
+      name: options.companyName,
+      description: "Temporary local company for Paperclip + Hermes one-click demo",
+      budgetMonthlyCents: 0,
+    });
+    success(`company 已创建：${company.name} (${company.id})`);
+    return { id: company.id, name: company.name, mode: "created" };
+  }
+
+  step(`复用已有 company：${options.companyId}`);
+  const companies = await getCompanies();
+  const company = companies.find((item) => item.id === options.companyId);
+  if (!company) {
+    fail(`未找到 company：${options.companyId}`);
+  }
+  success(`company 已复用：${company.name} (${company.id})`);
+  return { id: company.id, name: company.name, mode: "reused" };
+}
+
+async function resolveAgent(companyId: string, options: DemoOptions): Promise<ResolvedAgent> {
+  if (!options.agentId) {
+    step("创建 hermes_local demo agent");
+    const agentPayload = {
+      name: options.agentName,
+      role: "general",
+      title: "One-click local Paperclip/Hermes demo agent",
+      adapterType: "hermes_local",
+      adapterConfig: {
+        paperclipApiUrl: API_BASE,
+        toolsets: "terminal,file",
+        timeoutSec: 120,
+        graceSec: 10,
+        persistSession: false,
+        verbose: false,
+        promptTemplate:
+          'You are "{{agentName}}", an AI agent employee in a Paperclip-managed company.\n\n' +
+          'IMPORTANT: Use `terminal` tool for Paperclip API calls because web_extract and browser cannot access localhost. Do not use `curl | python3`, `curl | node`, or any pipe-to-interpreter command. If you need to read JSON, use Python urllib.request directly.\n\n' +
+          'Your Paperclip identity:\n' +
+          '  Agent ID: {{agentId}}\n' +
+          '  Company ID: {{companyId}}\n' +
+          '  API Base: {{paperclipApiUrl}}\n\n' +
+          '{{#taskId}}\n' +
+          '## Assigned Task\n\n' +
+          'Issue ID: {{taskId}}\n' +
+          'Title: {{taskTitle}}\n\n' +
+          '{{taskBody}}\n\n' +
+          '## Workflow\n\n' +
+          '1. Work on the task using your tools.\n' +
+          '2. When done, mark the issue as completed with a safe local command such as `python3 -c` using urllib.request. Include `Authorization: Bearer $PAPERCLIP_API_KEY` and `X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID`.\n' +
+          '3. Post a completion comment on the issue. The comment body must include `DEMO_DONE`.\n' +
+          '{{/taskId}}\n' +
+          '{{#noTask}}\n' +
+          '## Heartbeat Wake — Check for Work\n' +
+          'Check assigned open issues first, then unassigned backlog. Use Python urllib.request directly; do not pipe curl output into an interpreter.\n' +
+          '{{/noTask}}',
+      },
+      runtimeConfig: {},
+      budgetMonthlyCents: 0,
+    };
+    try {
+      const agent = await createAgent(companyId, agentPayload);
+      success(`agent 已创建：${agent.name} (${agent.id})`);
+      return { id: agent.id, name: agent.name, mode: "created" };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      if (!detail.includes("Direct agent creation requires board approval")) throw error;
+      warn("当前 company 要求 Board approval，改用 agent-hires 创建 pending hire 并自动批准。只用于本地一键 demo。");
+      const hire = await createAgentHire(companyId, agentPayload);
+      const approvalId = hire.approval?.id;
+      if (approvalId) {
+        await approveApproval(approvalId);
+      }
+      const agents = await getAgents(companyId);
+      const approvedAgent = agents.find((item) => item.id === hire.agent.id) ?? hire.agent;
+      success(`agent hire 已批准：${approvedAgent.name} (${approvedAgent.id})`);
+      return { id: approvedAgent.id, name: approvedAgent.name, mode: "created" };
+    }
+  }
+
+  step(`复用已有 agent：${options.agentId}`);
+  const agents = await getAgents(companyId);
+  const agent = agents.find((item) => item.id === options.agentId);
+  if (!agent) {
+    fail(`在 company ${companyId} 下未找到 agent：${options.agentId}`);
+  }
+  if (agent.adapterType !== "hermes_local") {
+    fail(`agent ${agent.id} 的 adapterType 不是 hermes_local，而是 ${agent.adapterType}`);
+  }
+  success(`agent 已复用：${agent.name} (${agent.id})`);
+  return { id: agent.id, name: agent.name, mode: "reused" };
+}
+
+async function waitForExecutionRun(companyId: string, agentId: string, issueId: string, timeoutMs: number, pollMs: number) {
+  const start = Date.now();
+  let lastSeenRunId: string | null = null;
+
+  while (Date.now() - start < timeoutMs) {
+    const issue = await getIssue(issueId);
+    if (issue.executionRunId) {
+      return { issue, runId: issue.executionRunId };
+    }
+
+    const runs = await getHeartbeatRuns(companyId, agentId, 20);
+    const matchingRun = runs.find((run) => {
+      const contextIssueId = typeof run.contextSnapshot?.issueId === "string" ? run.contextSnapshot.issueId : null;
+      return contextIssueId === issueId;
+    });
+    if (matchingRun) {
+      return { issue, runId: matchingRun.id };
+    }
+
+    if (runs.length > 0 && runs[0]?.id !== lastSeenRunId) {
+      lastSeenRunId = runs[0]?.id ?? null;
+      step(`已观察到最近 heartbeat run：${lastSeenRunId}，继续等待其与 issue 绑定...`);
+    }
+    await sleep(pollMs);
+  }
+
+  fail(`在 ${Math.round(timeoutMs / 1000)} 秒内未等到 issue 绑定 execution run。`);
+}
+
+async function waitForRunCompletion(runId: string, timeoutMs: number, pollMs: number) {
+  const start = Date.now();
+  let previousStatus: string | null = null;
+
+  while (Date.now() - start < timeoutMs) {
+    const run = await getHeartbeatRun(runId);
+    if (run.status !== previousStatus) {
+      previousStatus = run.status;
+      step(`run ${runId} 当前状态：${run.status}`);
+    }
+    if (!["queued", "running"].includes(run.status)) {
+      return run;
+    }
+    await sleep(pollMs);
+  }
+
+  fail(`在 ${Math.round(timeoutMs / 1000)} 秒内 run 仍未结束：${runId}`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  section("Paperclip + Hermes 一键 demo");
+  step(`API base: ${API_BASE}`);
+  step(`Demo issue title: ${options.issueTitle}`);
+  if (options.companyId) {
+    step(`回归模式：复用 company ${options.companyId}${options.agentId ? ` / agent ${options.agentId}` : ""}`);
+  } else {
+    step(`临时模式：将创建 company ${options.companyName}`);
+  }
+
+  const company = await resolveCompany(options);
+  const agent = await resolveAgent(company.id, options);
+
+  step("创建并分配 demo issue（将自动触发 assignment wakeup）");
+  const issue = await createIssue(company.id, {
+    title: options.issueTitle,
+    description:
+      "这是一个本地一键演示/回归任务。请完成以下动作：\n1. 在此 issue 下发表评论，正文里必须包含 `DEMO_DONE`\n2. 然后把这个 issue 标记为 done\n3. 评论里用中文简要说明你完成了什么\n\n执行约束：\n- 可以访问本地 Paperclip API，但不要使用 `curl | python3`、`curl | node` 或任何把网络输出直接 pipe 给解释器的命令。\n- 如需读取 API JSON，请使用 Python 标准库 `urllib.request` 获取响应后再 `json.loads` 解析，或使用单独的 `curl` 输出人工检查。\n- 不要输出任何 token、API key 或 Authorization header。\n",
+    status: "todo",
+    priority: "medium",
+    assigneeAgentId: agent.id,
+  });
+  success(`issue 已创建：${issue.identifier ?? issue.id} (${issue.id})`);
+
+  step("等待 Paperclip 为该 issue 建立 execution run");
+  const runBinding = await waitForExecutionRun(company.id, agent.id, issue.id, options.timeoutMs, options.pollIntervalMs);
+  success(`已绑定 execution run：${runBinding.runId}`);
+
+  step("等待 run 执行完成");
+  const finalRun = await waitForRunCompletion(runBinding.runId, options.timeoutMs, options.pollIntervalMs);
+  const finalIssue = await getIssue(issue.id);
+  const comments = await getIssueComments(issue.id);
+  const log = await getHeartbeatRunLog(finalRun.id, 20000);
+  const events = await getHeartbeatRunEvents(finalRun.id);
+
+  const demoComment = comments.find((comment) => comment.body.includes("DEMO_DONE"));
+
+  section("Demo 结果摘要");
+  console.log(
+    formatJson({
+      mode: {
+        company: company.mode,
+        agent: agent.mode,
+      },
+      company: { id: company.id, name: company.name },
+      agent: { id: agent.id, name: agent.name },
+      issue: {
+        id: finalIssue.id,
+        identifier: finalIssue.identifier,
+        status: finalIssue.status,
+        executionRunId: finalIssue.executionRunId,
+      },
+      run: {
+        id: finalRun.id,
+        status: finalRun.status,
+        triggerDetail: finalRun.triggerDetail,
+        invocationSource: finalRun.invocationSource,
+      },
+      commentFound: Boolean(demoComment),
+      commentId: demoComment?.id ?? null,
+      commentsCount: comments.length,
+      eventsCount: events.length,
+    }),
+  );
+
+  section("Issue comments");
+  for (const comment of comments) {
+    console.log(`- ${comment.id}: ${truncate(comment.body, 400)}`);
+  }
+
+  section("Run log（截断预览）");
+  console.log(truncate(log.content, 4000));
+
+  if (finalRun.status !== "succeeded") {
+    warn(`run 未成功结束：${finalRun.status}`);
+    fail("一键 demo 失败：heartbeat run 未达到 succeeded。");
+  }
+  if (finalIssue.status !== "done") {
+    fail(`一键 demo 失败：issue 最终状态不是 done，而是 ${finalIssue.status}`);
+  }
+  if (!demoComment) {
+    fail("一键 demo 失败：未发现包含 DEMO_DONE 的评论。");
+  }
+
+  success("一键 demo 成功：Hermes 已在 Paperclip 中完成 issue 评论并标记 done。");
+}
+
+main().catch((error) => {
+  const detail = error instanceof Error ? error.message : String(error);
+  fail(detail);
+});

--- a/scripts/hermes-local-verify.ts
+++ b/scripts/hermes-local-verify.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env -S node --import tsx
+import process from "node:process";
+import {
+  API_BASE,
+  getAdapters,
+  getCompanies,
+  getHermesTestEnvironment,
+  getHermesVersion,
+  section,
+  step,
+  success,
+  summarizeCheck,
+  warn,
+  fail,
+  formatJson,
+} from "./hermes-local-common.ts";
+
+async function main() {
+  section("Paperclip + Hermes 本地一键验证");
+  step("API base: " + API_BASE);
+
+  step("检查 Hermes CLI 版本");
+  const hermes = await getHermesVersion();
+  success(`Hermes 可执行：${hermes.versionLine}`);
+  if (hermes.pythonVersion) {
+    step(`Hermes runtime Python: ${hermes.pythonVersion}`);
+  }
+
+  step("检查 Paperclip adapters 列表");
+  const adapters = await getAdapters();
+  const hermesAdapter = adapters.find((adapter) => adapter.type === "hermes_local");
+  if (!hermesAdapter) {
+    fail("/api/adapters 中未发现 hermes_local；请先确认 Paperclip 已启动且 adapter 已正确接入。");
+  }
+  success(
+    `发现 hermes_local（loaded=${String(hermesAdapter.loaded)}, disabled=${String(hermesAdapter.disabled)}, modelsCount=${String(hermesAdapter.modelsCount ?? 0)}）`,
+  );
+
+  step("列出现有 companies（用于选择可访问 company 并确认当前实例是否可读写）");
+  const companies = await getCompanies();
+  if (companies.length === 0) {
+    fail("当前实例还没有 company；请先在 Board 创建 company，或使用 demo 命令创建临时 company。");
+  }
+  for (const company of companies) {
+    console.log(`  - ${company.name} (${company.id}) [${company.status ?? "unknown"}]`);
+  }
+
+  const companyId = process.env.PAPERCLIP_COMPANY_ID?.trim() || companies[0].id;
+  const company = companies.find((item) => item.id === companyId);
+  if (!company) {
+    fail(`PAPERCLIP_COMPANY_ID=${companyId} 不在当前账号可访问 companies 中。`);
+  }
+  step(`运行 hermes_local test-environment：${company.name} (${company.id})`);
+  const envResult = await getHermesTestEnvironment(company.id, {});
+  console.log(formatJson(envResult));
+
+  const errorChecks = envResult.checks.filter((check) => check.level === "error");
+  const warnChecks = envResult.checks.filter((check) => check.level === "warn");
+  const infoChecks = envResult.checks.filter((check) => check.level === "info");
+
+  if (infoChecks.length > 0) {
+    step("Info checks:");
+    for (const line of infoChecks.map(summarizeCheck)) console.log(`  ${line}`);
+  }
+  if (warnChecks.length > 0) {
+    warn("存在 warning checks：");
+    for (const line of warnChecks.map(summarizeCheck)) console.log(`  ${line}`);
+  }
+  if (envResult.status === "fail" || errorChecks.length > 0) {
+    console.error("Error checks:");
+    for (const line of errorChecks.map(summarizeCheck)) console.error(`  ${line}`);
+    fail("test-environment 返回 fail/error；本地一键验证失败。请先修复上述问题。");
+  }
+
+  success("一键验证通过：Paperclip API、hermes_local adapter、Hermes CLI 与 test-environment 均已可用。");
+}
+
+main().catch((error) => {
+  const detail = error instanceof Error ? error.message : String(error);
+  fail(detail);
+});


### PR DESCRIPTION
## Summary
- Adds repo-local one-command Hermes workflow scripts:
  - `pnpm hermes:verify`
  - `pnpm hermes:demo`
- Resolves local Board auth without printing secrets, using environment variables or the local Paperclip auth store.
- Uses a real accessible company for adapter test-environment checks instead of a hardcoded company id.
- Supports the Board approval path for local demo agent creation through `agent-hires` + local approval.
- Adds demo safety constraints and prompt override for the local Hermes agent path.

## Scope
This is intentionally separated from PR #3812's docs-only scope. PR #3812 now contains only documentation/templates; this PR contains the executable local workflow productization.

## Test Plan
- `PAPERCLIP_API_BASE=http://127.0.0.1:3100/api pnpm hermes:verify`
- `PAPERCLIP_API_BASE=http://127.0.0.1:3100/api pnpm hermes:demo -- --company-id 0869822b-812e-462b-a3fc-f5d3245dc578 --timeout-sec 300 --poll-sec 5`
- `git diff --check`
