### PR TITLE
fix: add 'starting' lifecycle state between queued and running

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -98,7 +98,7 @@ async function waitForRunToSettle(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const run = await heartbeat.getRun(runId);
-    if (!run || (run.status !== "queued" && run.status !== "running")) return run;
+    if (!run || (run.status !== "queued" && run.status !== "starting" && run.status !== "running")) return run;
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   return heartbeat.getRun(runId);
@@ -172,7 +172,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     cleanupPids.clear();
     for (let attempt = 0; attempt < 10; attempt += 1) {
       const runs = await db.select({ status: heartbeatRuns.status }).from(heartbeatRuns);
-      if (runs.every((run) => run.status !== "queued" && run.status !== "running")) {
+      if (runs.every((run) => run.status !== "queued" && run.status !== "starting" && run.status !== "running")) {
         break;
       }
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -219,7 +219,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   async function seedRunFixture(input?: {
     adapterType?: string;
     agentStatus?: "paused" | "idle" | "running";
-    runStatus?: "running" | "queued" | "failed";
+    runStatus?: "running" | "starting" | "queued" | "failed";
     processPid?: number | null;
     processGroupId?: number | null;
     processLossRetryCount?: number;
@@ -648,6 +648,30 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("retried continuation");
     expect(comments[0]?.body).toContain("Latest retry failure: `process_lost` - run failed before issue advanced.");
+  });
+
+  it("fails a stale 'starting' run with start_timeout after the 60s grace period", async () => {
+    const { runId, wakeupRequestId } = await seedRunFixture({
+      runStatus: "starting",
+      includeIssue: false,
+      // updatedAt is seeded to 2026-03-19T00:00:00Z which is well past 60s ago
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("start_timeout");
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("failed");
   });
 
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import type { BillingType, ExecutionWorkspace, ExecutionWorkspaceConfig } from "@paperclipai/shared";
 import {
@@ -2631,9 +2631,8 @@ export function heartbeatService(db: Db) {
     const claimed = await db
       .update(heartbeatRuns)
       .set({
-        status: "running",
+        status: "starting",
         startedAt: run.startedAt ?? claimedAt,
-        updatedAt: claimedAt,
       })
       .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
       .returning()
@@ -2798,9 +2797,21 @@ export function heartbeatService(db: Db) {
       const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
       const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
 
+      // For non-local-child adapters (litellm_proxy, external API adapters):
+      // distinguish "adapter never started" from "process was lost".
+      // This avoids treating a pre-spawn lifecycle dropout as process_lost
+      // (PER-2753: LiteCoder-review assignment race).
+      let errorCode: string;
+      if (!tracksLocalChild && !run.processPid && !run.processGroupId) {
+        const hasLog = !!run.logStore && !!run.logRef;
+        errorCode = hasLog ? "adapter_not_completed" : "adapter_not_started";
+      } else {
+        errorCode = "process_lost";
+      }
+
       let finalizedRun = await setRunStatus(run.id, "failed", {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
-        errorCode: "process_lost",
+        errorCode,
         finishedAt: now,
       });
       await setWakeupStatus(run.wakeupRequestId, "failed", {
@@ -2844,6 +2855,53 @@ export function heartbeatService(db: Db) {
     if (reaped.length > 0) {
       logger.warn({ reapedCount: reaped.length, runIds: reaped }, "reaped orphaned heartbeat runs");
     }
+
+    // Reap stale 'starting' runs — runs that stayed in initialization too long
+    // (PER-2760: state machine for run lifecycle).
+    const STARTING_GRACE_MS = 60_000;
+    const staleStarting = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.status, "starting"),
+          sql`${heartbeatRuns.updatedAt} < ${new Date(Date.now() - STARTING_GRACE_MS).toISOString()}`,
+        ),
+      );
+
+    for (const run of staleStarting) {
+      if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
+
+      const finalizedRun = await setRunStatus(run.id, "failed", {
+        error: "Run stayed in starting state for too long — initialization never completed",
+        errorCode: "start_timeout",
+        finishedAt: now,
+      });
+      if (!finalizedRun) continue;
+
+      await setWakeupStatus(run.wakeupRequestId, "failed", {
+        finishedAt: now,
+        error: "start_timeout",
+      });
+
+      await releaseIssueExecutionAndPromote(finalizedRun);
+
+      await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "error",
+        message: "start_timeout — initialization never completed",
+        payload: {
+          staleThresholdMs: STARTING_GRACE_MS,
+        },
+      });
+
+      await finalizeAgentStatus(run.agentId, "failed");
+      await startNextQueuedRunForAgent(run.agentId);
+      runningProcesses.delete(run.id);
+      reaped.push(run.id);
+    }
+
     return { reaped: reaped.length, runIds: reaped };
   }
 
@@ -3215,7 +3273,7 @@ export function heartbeatService(db: Db) {
   async function executeRun(runId: string) {
     let run = await getRun(runId);
     if (!run) return;
-    if (run.status !== "queued" && run.status !== "running") return;
+    if (run.status !== "queued" && run.status !== "starting" && run.status !== "running") return;
 
     if (run.status === "queued") {
       const claimed = await claimQueuedRun(run);
@@ -3719,14 +3777,9 @@ export function heartbeatService(db: Db) {
         });
       }
 
-      const currentRun = run;
-      await appendRunEvent(currentRun, seq++, {
-        eventType: "lifecycle",
-        stream: "system",
-        level: "info",
-        message: "run started",
-      });
-
+      // Persist log_ref before the run becomes reaper-visible, so the
+      // reaper never encounters a "running" run without any diagnostic
+      // metadata (PER-2753: LiteCoder-review process_lost race).
       handle = await runLogStore.begin({
         companyId: run.companyId,
         agentId: run.agentId,
@@ -3741,6 +3794,25 @@ export function heartbeatService(db: Db) {
           updatedAt: new Date(),
         })
         .where(eq(heartbeatRuns.id, runId));
+
+      // Transition from starting to running now that log is initialized
+      // (PER-2760: state machine for run lifecycle).
+      await db
+        .update(heartbeatRuns)
+        .set({ status: "running", updatedAt: new Date() })
+        .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.status, "starting")))
+        .returning()
+        .then((rows) => {
+          if (rows[0]) run = rows[0];
+        });
+
+      const currentRun = run;
+      await appendRunEvent(currentRun, seq++, {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "info",
+        message: "run started",
+      });
 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, managing the full lifecycle of agent runs via heartbeat_runs
> - The runner/reaper subsystem manages run state transitions — currently `status='running'` means too many things simultaneously
> - This caused production incidents (PER-5948) where a run was classified as opaque `process_lost` with NO diagnostic metadata
> - A surgical fix (PR #4639) adds tactical classification for pre-spawn orphaned runs, but doesn't fix the architecture
> - This PR is a follow-up to #4639. It sketches the structural fix: making the run lifecycle state machine explicit
> - ⚠️ **This is a Draft/RFC prototype, not a production-ready implementation. Do not merge as-is.**

## What Changed (Prototype)

This draft demonstrates the lifecycle boundary idea using the existing `status` column:

- **claimQueuedRun**: sets `status="starting"` instead of `"running"`
- **executeRun**: accepts `"starting"` as valid from-status, transitions to `"running"` after `logStore.begin()`
- **reapOrphanedRuns**: grace period 60s for `"starting"` runs, fail with `start_timeout`
- **Tests**: 12/12 pass including new `start_timeout` test

## ⚠️ Architectural Review: Failed — Requires Rework

**Current approach:** overloads existing `heartbeat_runs.status` with a new value `"starting"`.

**Why this fails architectural bar:**

- `status` is a **public API surface** consumed by UI, API clients, test fixtures, metrics dashboards, and downstream filters
- Adding a 5th value without a full contract audit risks breaking all consumers silently
- No schema migration, no CHECK constraint — this is string soup in a public enum
- Naming: `"starting"` implies process already running; `"initializing"` is more accurate

### Required Rework Before Ready for Review

This draft must be rewritten **before** it can be promoted from Draft to Ready for Review. The correct production shape is:

**1. New additive column (status untouched):**

```sql
ALTER TABLE heartbeat_runs 
  ADD COLUMN lifecycle_phase TEXT NOT NULL DEFAULT 'running'
  CHECK (lifecycle_phase IN ('queued', 'initializing', 'running', 'succeeded', 'failed'));
```

`status` remains: `queued/running/succeeded/failed` — unchanged, no public contract expansion.
`lifecycle_phase` tracks the finer-grained transition: `queued → initializing → running → succeeded/failed`.

**2. DEFAULT `'running'` ensures backward compatibility** for all existing runs. Old code paths work if `lifecycle_phase` is absent/defaulted.

**3. Reaper switches on `lifecycle_phase`**, not on nullable pid/logRef forensic analysis.

**4. Rename:** `"initializing"` (log setup/spawn metadata boundary) instead of `"starting"`.

## Current State: Do Not Deploy

This is a Draft/RFC/prototype only. No production use. No GEX44 deploy. No canary heartbeat smoke test. Instance affinity (PAPERCLIP_INSTANCE_ID) must be in place before any heartbeat enablement, regardless of this PR's status.

## Model Used

- **Architecture plan, investigation:** HermesResearcher (deepseek-v4-flash, ollama-cloud, 272K context)
- **Implementation (prototype):** Claude Code 2.1.121 (claude-sonnet-4-6 via `claude -p` print mode, 15 max turns). Cost: $0.36
- **Post-implementation fix:** HermesResearcher — caught Date → ISO string bug in postgres driver
- **Tests:** Vitest 3.2.4 with embedded PGlite
- **Architectural review:** HermesResearcher — identified status overload, requested rework to additive lifecycle_phase

## Checklist

- [x] Thinking path included
- [x] Model used specified with exact versions
- [x] Targeted tests pass (heartbeat-process-recovery, 12/12)
- [x] New test added
- [x] No UI changes
- [x] Architectural failure documented (status overload, no migration, no CHECK)
- [x] Rework plan documented (additive lifecycle_phase + CHECK + migration)
- [ ] **Do NOT merge in current shape — requires rework before Ready for Review**
