### PR TITLE
feat: add heartbeat instance affinity gating

### DIFF
--- a/server/src/__tests__/heartbeat-instance-affinity.test.ts
+++ b/server/src/__tests__/heartbeat-instance-affinity.test.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockAdapterExecute = vi.hoisted(() => vi.fn(async () => ({
+  exitCode: 0,
+  signal: null,
+  timedOut: false,
+  errorMessage: null,
+  summary: "ok",
+  provider: "test",
+  model: "test-model",
+})));
+const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
+const mockTrackAgentFirstHeartbeat = vi.hoisted(() => vi.fn());
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+vi.mock("../telemetry.ts", () => ({
+  getTelemetryClient: () => mockTelemetryClient,
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: mockTrackAgentFirstHeartbeat,
+  };
+});
+
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function waitForRunStatus(
+  heartbeat: ReturnType<typeof heartbeatService>,
+  runId: string,
+  status: string,
+  timeoutMs = 3_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const run = await heartbeat.getRun(runId);
+    if (run?.status === status) return run;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return heartbeat.getRun(runId);
+}
+
+async function seedQueuedRun(db: ReturnType<typeof createDb>, input?: {
+  heartbeat?: Record<string, unknown>;
+}) {
+  const companyId = randomUUID();
+  const agentId = randomUUID();
+  const runId = randomUUID();
+  const wakeupRequestId = randomUUID();
+  const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+  const now = new Date("2026-03-19T00:00:00.000Z");
+
+  await db.insert(companies).values({
+    id: companyId,
+    name: "Paperclip",
+    issuePrefix,
+    requireBoardApprovalForNewAgents: false,
+  });
+
+  await db.insert(agents).values({
+    id: agentId,
+    companyId,
+    name: "AffinityAgent",
+    role: "engineer",
+    status: "idle",
+    adapterType: "codex_local",
+    adapterConfig: {},
+    runtimeConfig: {
+      heartbeat: {
+        wakeOnDemand: true,
+        maxConcurrentRuns: 1,
+        ...input?.heartbeat,
+      },
+    },
+    permissions: {},
+  });
+
+  await db.insert(agentWakeupRequests).values({
+    id: wakeupRequestId,
+    companyId,
+    agentId,
+    source: "assignment",
+    triggerDetail: "system",
+    reason: "issue_assigned",
+    payload: {},
+    status: "queued",
+    runId,
+    requestedAt: now,
+    updatedAt: now,
+  });
+
+  await db.insert(heartbeatRuns).values({
+    id: runId,
+    companyId,
+    agentId,
+    invocationSource: "assignment",
+    triggerDetail: "system",
+    status: "queued",
+    wakeupRequestId,
+    contextSnapshot: {},
+    updatedAt: now,
+    createdAt: now,
+  });
+
+  return { companyId, agentId, runId, wakeupRequestId };
+}
+
+describeEmbeddedPostgres("heartbeat instance affinity", () => {
+  beforeEach(() => {
+    mockAdapterExecute.mockClear();
+  });
+  it("runs queued work when no heartbeat instance affinity is configured", async () => {
+    const started = await startEmbeddedPostgresTestDatabase("heartbeat-instance-affinity-default-");
+    const db = createDb(started.connectionString);
+    try {
+      const { agentId, runId } = await seedQueuedRun(db);
+      const heartbeat = heartbeatService(db, { instanceId: "macbook" });
+
+      const claimed = await heartbeat.resumeQueuedRuns();
+      expect(claimed.map((run) => run.id)).toEqual([runId]);
+
+      const settled = await waitForRunStatus(heartbeat, runId, "succeeded");
+      expect(settled?.status).toBe("succeeded");
+      expect(mockAdapterExecute).toHaveBeenCalled();
+
+      const agent = await db.select().from(agents).where(eq(agents.id, agentId)).then((rows) => rows[0]);
+      expect(agent?.status).toBe("idle");
+    } finally {
+      await started.cleanup();
+    }
+  });
+
+  it("runs queued work when heartbeat instance affinity matches this instance", async () => {
+    const started = await startEmbeddedPostgresTestDatabase("heartbeat-instance-affinity-match-");
+    const db = createDb(started.connectionString);
+    try {
+      const { runId } = await seedQueuedRun(db, { heartbeat: { instanceId: "gex44" } });
+      const heartbeat = heartbeatService(db, { instanceId: "gex44" });
+
+      const claimed = await heartbeat.resumeQueuedRuns();
+      expect(claimed.map((run) => run.id)).toEqual([runId]);
+
+      const settled = await waitForRunStatus(heartbeat, runId, "succeeded");
+      expect(settled?.status).toBe("succeeded");
+      expect(mockAdapterExecute).toHaveBeenCalled();
+    } finally {
+      await started.cleanup();
+    }
+  });
+
+  it("leaves queued work untouched when heartbeat instance affinity targets another instance", async () => {
+    const started = await startEmbeddedPostgresTestDatabase("heartbeat-instance-affinity-mismatch-");
+    const db = createDb(started.connectionString);
+    try {
+      const { runId, wakeupRequestId } = await seedQueuedRun(db, { heartbeat: { instanceId: "gex44" } });
+      const heartbeat = heartbeatService(db, { instanceId: "macbook" });
+
+      const claimed = await heartbeat.resumeQueuedRuns();
+      expect(claimed).toEqual([]);
+
+      const run = await heartbeat.getRun(runId);
+      expect(run?.status).toBe("queued");
+      const wakeup = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null);
+      expect(wakeup?.status).toBe("queued");
+      expect(mockAdapterExecute).not.toHaveBeenCalled();
+    } finally {
+      await started.cleanup();
+    }
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1975,9 +1975,11 @@ export type HeartbeatEnvironmentRuntime = ReturnType<typeof environmentRuntimeSe
 export interface HeartbeatServiceOptions {
   pluginWorkerManager?: PluginWorkerManager;
   environmentRuntime?: HeartbeatEnvironmentRuntime;
+  instanceId?: string;
 }
 
 export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) {
+  const instanceId = readNonEmptyString(options.instanceId ?? process.env.PAPERCLIP_INSTANCE_ID);
   const instanceSettings = instanceSettingsService(db);
   const getCurrentUserRedactionOptions = async () => ({
     enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
@@ -3691,6 +3693,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      instanceId: readNonEmptyString(heartbeat.instanceId) ?? readNonEmptyString(heartbeat.affinityInstanceId),
     };
   }
 
@@ -3722,6 +3725,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return new Map<string, Awaited<ReturnType<typeof issuesSvc.getDependencyReadiness>>>();
     }
     return issuesSvc.listDependencyReadiness(companyId, issueIds);
+  }
+
+  function heartbeatInstanceAffinityMatches(policy: ReturnType<typeof parseHeartbeatPolicy>) {
+    return !policy.instanceId || !instanceId || policy.instanceId === instanceId;
   }
 
   async function countRunningRunsForAgent(agentId: string) {
@@ -4468,9 +4475,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .where(eq(heartbeatRuns.status, "queued"));
 
     const agentIds = [...new Set(queuedRuns.map((r) => r.agentId))];
+    const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
     for (const agentId of agentIds) {
-      await startNextQueuedRunForAgent(agentId);
+      claimedRuns.push(...await startNextQueuedRunForAgent(agentId));
     }
+    return claimedRuns;
   }
 
   async function reconcileStrandedAssignedIssues() {
@@ -4579,6 +4588,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return [];
       }
       const policy = parseHeartbeatPolicy(agent);
+      if (!heartbeatInstanceAffinityMatches(policy)) {
+        logger.debug(
+          { agentId, instanceId, affinityInstanceId: policy.instanceId },
+          "skipping queued heartbeat runs for non-matching instance affinity",
+        );
+        return [];
+      }
       const runningCount = await countRunningRunsForAgent(agentId);
       const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
       if (availableSlots <= 0) return [];
@@ -6410,6 +6426,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     if (source === "timer" && !policy.enabled) {
       await writeSkippedRequest("heartbeat.disabled");
+      return null;
+    }
+    if (!heartbeatInstanceAffinityMatches(policy)) {
+      await writeSkippedRequest("heartbeat.instance_affinity.mismatch");
       return null;
     }
     if (source !== "timer" && !policy.wakeOnDemand) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies and can run heartbeat work from multiple server processes.
> - Heartbeat runners currently claim queued work from shared `heartbeat_runs` state without knowing which Paperclip instance is intended to execute it.
> - In a multi-instance fleet, this can let the wrong server steal a run and produce false negatives during canary or lifecycle smoke tests.
> - Paperclip already has process-level `PAPERCLIP_INSTANCE_ID` plumbing, but heartbeat scheduling did not use agent-level affinity to gate claims.
> - This pull request adds an optional, backward-compatible heartbeat affinity gate keyed by the current instance id.
> - The benefit is safer canary rollout: one selected instance can run a heartbeat agent while other instances leave that queued work untouched.

## What Changed

- Added optional `instanceId` support to `heartbeatService`, falling back to `process.env.PAPERCLIP_INSTANCE_ID`.
- Extended heartbeat runtime policy parsing to read `runtimeConfig.heartbeat.instanceId`, with `affinityInstanceId` as a compatibility alias.
- Added an affinity gate before queued heartbeat runs are claimed for execution.
- Added an affinity gate for wake-on-demand/manual wake requests; mismatches are recorded as skipped requests instead of executing on the wrong instance.
- Made `resumeQueuedRuns()` return the claimed runs it starts, which preserves existing callers and improves test/observability ergonomics.
- Added embedded-Postgres tests for unset affinity, matching affinity, and non-matching affinity.

## Verification

- `pnpm install --frozen-lockfile`
  - Passed, with existing plugin-sdk bin symlink warnings.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-instance-affinity.test.ts`
  - Passed: 3/3 tests.
- `pnpm --filter @paperclipai/server typecheck`
  - Passed.

## Risks

- Low risk when affinity is unset: behavior remains backward-compatible and any instance can continue claiming queued heartbeat work.
- If an operator sets `runtimeConfig.heartbeat.instanceId` incorrectly, that agent's heartbeat work will remain queued/skipped on non-matching instances until a matching instance is running.
- This does not enable heartbeat anywhere by itself and does not mutate deploy/env configuration.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Claude Code 2.1.121 / Claude Sonnet 4.6 via `claude -p` was used for initial investigation but hit `max_turns` before completing the implementation.
- HermesResearcher (OpenAI GPT-5.5 via Hermes CLI, tool-assisted code editing and terminal verification) completed the implementation, tests, typecheck, and PR preparation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
