### PR TITLE
Upstream adapter wake guardrails into codex/opencode sources

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -356,4 +356,46 @@ describe("codex remote execution", () => {
     expect(call?.[3].env.CODEX_HOME).toBe("/remote/workspace/.paperclip-runtime/codex/home");
     expect(call?.[3].remoteExecution?.remoteCwd).toBe("/remote/workspace");
   });
+
+  it("skips initialization when wake issue status is blocked", async () => {
+    const onLog = vi.fn(async () => {});
+    const result = await execute({
+      runId: "run-blocked",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: { command: "codex" },
+      context: { paperclipWake: { issue: { status: "blocked" } } },
+      onLog,
+    });
+
+    expect(runChildProcess).not.toHaveBeenCalled();
+    expect(result.summary).toContain("wake issue is blocked");
+    expect(onLog).toHaveBeenCalledWith("stdout", "[paperclip][init] blocked issue detected; skipping adapter initialization\n");
+  });
+
+  it("clamps timeoutSec to 110 seconds", async () => {
+    await execute({
+      runId: "run-timeout-clamp",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: { command: "codex", timeoutSec: 600 },
+      context: {},
+      onLog: async () => {},
+    });
+
+    const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[], { timeoutSec?: number }] | undefined;
+    expect(call?.[3].timeoutSec).toBe(110);
+  });
 });

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -87,6 +87,14 @@ function resolveCodexBiller(env: Record<string, string>, billingType: "api" | "s
   return billingType === "subscription" ? "chatgpt" : openAiCompatibleBiller ?? "openai";
 }
 
+function resolveWakeIssueStatus(context: Record<string, unknown>): string {
+  const wake = parseObject(context.paperclipWake);
+  const issue = parseObject(wake.issue);
+  const fromWake = asString(issue.status, "").trim();
+  if (fromWake) return fromWake;
+  return asString(context.issueStatus, "").trim();
+}
+
 async function isLikelyPaperclipRepoRoot(candidate: string): Promise<boolean> {
   const [hasWorkspace, hasPackageJson, hasServerDir, hasAdapterUtilsDir] = await Promise.all([
     pathExists(path.join(candidate, "pnpm-workspace.yaml")),
@@ -278,6 +286,25 @@ export async function ensureCodexSkillsInjected(
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  await onLog("stdout", "[paperclip][init] wake received\n");
+  const wakeIssueStatus = resolveWakeIssueStatus(context).toLowerCase();
+  await onLog("stdout", `[paperclip][init] issue status check: ${wakeIssueStatus || "unknown"}\n`);
+  if (wakeIssueStatus === "blocked") {
+    await onLog("stdout", "[paperclip][init] blocked issue detected; skipping adapter initialization\n");
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      summary: "Skipped run because the wake issue is blocked.",
+      resultJson: {
+        stdout: "",
+        stderr: "",
+      },
+      clearSession: false,
+    };
+  }
+  await onLog("stdout", "[paperclip][init] adapter init start\n");
 
   const promptTemplate = asString(
     config.promptTemplate,
@@ -471,7 +498,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     resolvedCommand,
   });
 
-  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const configuredTimeoutSec = asNumber(config.timeoutSec, 0);
+  const timeoutSec = configuredTimeoutSec > 0 ? Math.min(configuredTimeoutSec, 110) : 110;
+  if (configuredTimeoutSec !== timeoutSec) {
+    await onLog("stdout", `[paperclip][init] adjusted timeoutSec from ${configuredTimeoutSec} to ${timeoutSec}\n`);
+  }
   const graceSec = asNumber(config.graceSec, 20);
 
   const runtimeSessionParams = parseObject(runtime.sessionParams);
@@ -618,6 +649,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const runAttempt = async (resumeSessionId: string | null) => {
+    await onLog("stdout", "[paperclip][init] work start\n");
     const execArgs = buildCodexExecArgs(
       forceSaferInvocation ? { ...config, fastMode: false } : config,
       { resumeSessionId },

--- a/packages/adapters/opencode-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.remote.test.ts
@@ -222,4 +222,68 @@ describe("opencode remote execution", () => {
     expect(call?.[2]).toContain("--session");
     expect(call?.[2]).toContain("session-123");
   });
+
+  it("skips initialization when wake issue status is blocked", async () => {
+    const onLog = vi.fn(async () => {});
+    const result = await execute({
+      runId: "run-blocked",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Builder",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: { command: "opencode", model: "opencode/gpt-5-nano" },
+      context: { paperclipWake: { issue: { status: "blocked" } } },
+      onLog,
+    });
+
+    expect(runChildProcess).not.toHaveBeenCalled();
+    expect(result.summary).toContain("wake issue is blocked");
+    expect(onLog).toHaveBeenCalledWith("stdout", "[paperclip][init] blocked issue detected; skipping adapter initialization\n");
+  });
+
+  it("clamps timeoutSec to 110 seconds", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-remote-timeout-clamp-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+
+    await execute({
+      runId: "run-timeout-clamp",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Builder",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: { command: "opencode", model: "opencode/gpt-5-nano", timeoutSec: 600 },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async () => {},
+    });
+
+    const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[], { timeoutSec?: number }] | undefined;
+    expect(call?.[3].timeoutSec).toBe(110);
+  });
 });

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -70,6 +70,14 @@ function claudeSkillsHome(): string {
   return path.join(os.homedir(), ".claude", "skills");
 }
 
+function resolveWakeIssueStatus(context: Record<string, unknown>): string {
+  const wake = parseObject(context.paperclipWake);
+  const issue = parseObject(wake.issue);
+  const fromWake = asString(issue.status, "").trim();
+  if (fromWake) return fromWake;
+  return asString(context.issueStatus, "").trim();
+}
+
 async function ensureOpenCodeSkillsInjected(
   onLog: AdapterExecutionContext["onLog"],
   skillsEntries: Array<{ key: string; runtimeName: string; source: string }>,
@@ -123,6 +131,25 @@ async function buildOpenCodeSkillsDir(config: Record<string, unknown>): Promise<
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  await onLog("stdout", "[paperclip][init] wake received\n");
+  const wakeIssueStatus = resolveWakeIssueStatus(context).toLowerCase();
+  await onLog("stdout", `[paperclip][init] issue status check: ${wakeIssueStatus || "unknown"}\n`);
+  if (wakeIssueStatus === "blocked") {
+    await onLog("stdout", "[paperclip][init] blocked issue detected; skipping adapter initialization\n");
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      summary: "Skipped run because the wake issue is blocked.",
+      resultJson: {
+        stdout: "",
+        stderr: "",
+      },
+      clearSession: false,
+    };
+  }
+  await onLog("stdout", "[paperclip][init] adapter init start\n");
   const executionTarget = readAdapterExecutionTarget({
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
@@ -249,7 +276,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       });
     }
 
-    const timeoutSec = asNumber(config.timeoutSec, 0);
+    const configuredTimeoutSec = asNumber(config.timeoutSec, 0);
+    const timeoutSec = configuredTimeoutSec > 0 ? Math.min(configuredTimeoutSec, 110) : 110;
+    if (configuredTimeoutSec !== timeoutSec) {
+      await onLog("stdout", `[paperclip][init] adjusted timeoutSec from ${configuredTimeoutSec} to ${timeoutSec}\n`);
+    }
     const graceSec = asNumber(config.graceSec, 20);
     const extraArgs = (() => {
       const fromExtraArgs = asStringArray(config.extraArgs);
@@ -414,6 +445,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
 
     const runAttempt = async (resumeSessionId: string | null) => {
+      await onLog("stdout", "[paperclip][init] work start\n");
       const args = buildArgs(resumeSessionId);
       if (onMeta) {
         await onMeta({


### PR DESCRIPTION
## Summary\n- upstream blocked-wake init guardrails from installed dist into canonical adapter source\n- add deterministic timeout clamp/default (110s) in codex-local and opencode-local execute paths\n- add execute.remote tests for blocked wake early exit and timeout clamp behavior\n\n## Verification\n- corepack pnpm --filter @paperclipai/adapter-codex-local exec vitest run src/server/execute.remote.test.ts\n- corepack pnpm --filter @paperclipai/adapter-opencode-local exec vitest run src/server/execute.remote.test.ts\n- corepack pnpm --filter @paperclipai/adapter-codex-local build\n- corepack pnpm --filter @paperclipai/adapter-opencode-local build\n\n## Context\nFollow-up to HYM-83/HYM-85 to ensure fixes survive dependency refreshes by living in source + build path.