### PR TITLE
fix(recovery): generic guard against recovery-of-recovery cascade (STO-259)

### DIFF
--- a/server/src/__tests__/recovery-classifiers.test.ts
+++ b/server/src/__tests__/recovery-classifiers.test.ts
@@ -4,12 +4,14 @@ import { decideRunLivenessContinuation as decideRunLivenessContinuationCompat } 
 import {
   RECOVERY_KEY_PREFIXES,
   RECOVERY_ORIGIN_KINDS,
+  RECOVERY_ORIGIN_KIND_VALUES,
   RECOVERY_REASON_KINDS,
   buildIssueGraphLivenessIncidentKey,
   buildIssueGraphLivenessLeafKey,
   buildRunLivenessContinuationIdempotencyKey,
   classifyIssueGraphLiveness,
   decideRunLivenessContinuation,
+  isRecoveryOriginKind,
   isStrandedIssueRecoveryOriginKind,
   parseIssueGraphLivenessIncidentKey,
 } from "../services/recovery/index.ts";
@@ -150,5 +152,22 @@ describe("recovery classifier boundary", () => {
     expect(isStrandedIssueRecoveryOriginKind("harness_liveness_escalation")).toBe(false);
     expect(isStrandedIssueRecoveryOriginKind("manual")).toBe(false);
     expect(isStrandedIssueRecoveryOriginKind(null)).toBe(false);
+  });
+
+  it("flags every recovery origin so the cascade guard catches all watchdog kinds", () => {
+    // Cascade guard for incident 2026-04-25: any origin kind that marks an
+    // issue as a recovery artifact must never itself spawn another recovery
+    // issue. Keep this set in sync with RECOVERY_ORIGIN_KINDS — adding a new
+    // recovery origin without flipping this assertion will break the guard.
+    expect([...RECOVERY_ORIGIN_KIND_VALUES].sort()).toEqual(
+      Object.values(RECOVERY_ORIGIN_KINDS).sort(),
+    );
+    for (const kind of RECOVERY_ORIGIN_KIND_VALUES) {
+      expect(isRecoveryOriginKind(kind)).toBe(true);
+    }
+    expect(isRecoveryOriginKind("manual")).toBe(false);
+    expect(isRecoveryOriginKind(null)).toBe(false);
+    expect(isRecoveryOriginKind(undefined)).toBe(false);
+    expect(isRecoveryOriginKind("")).toBe(false);
   });
 });

--- a/server/src/services/recovery/index.ts
+++ b/server/src/services/recovery/index.ts
@@ -1,9 +1,11 @@
 export {
   RECOVERY_KEY_PREFIXES,
   RECOVERY_ORIGIN_KINDS,
+  RECOVERY_ORIGIN_KIND_VALUES,
   RECOVERY_REASON_KINDS,
   buildIssueGraphLivenessIncidentKey,
   buildIssueGraphLivenessLeafKey,
+  isRecoveryOriginKind,
   isStrandedIssueRecoveryOriginKind,
   parseIssueGraphLivenessIncidentKey,
 } from "./origins.js";

--- a/server/src/services/recovery/origins.ts
+++ b/server/src/services/recovery/origins.ts
@@ -4,6 +4,17 @@ export const RECOVERY_ORIGIN_KINDS = {
   staleActiveRunEvaluation: "stale_active_run_evaluation",
 } as const;
 
+// Set of all origin kinds that mark an issue as itself a recovery artifact.
+// Watchdog code paths must refuse to spawn a recovery issue *for* any issue
+// whose originKind is in this set — otherwise a single stuck recovery issue
+// can cascade into unbounded self-replicating recovery rows (incident
+// 2026-04-25: 17,786 self-replicating "Recover stalled issue ..." rows).
+export const RECOVERY_ORIGIN_KIND_VALUES = [
+  RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation,
+  RECOVERY_ORIGIN_KINDS.strandedIssueRecovery,
+  RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation,
+] as const;
+
 export const RECOVERY_REASON_KINDS = {
   runLivenessContinuation: "run_liveness_continuation",
 } as const;
@@ -19,6 +30,14 @@ export type RecoveryKeyPrefix = typeof RECOVERY_KEY_PREFIXES[keyof typeof RECOVE
 
 export function isStrandedIssueRecoveryOriginKind(originKind: string | null | undefined) {
   return originKind === RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
+}
+
+// Returns true when the originKind marks the issue as a recovery artifact
+// (any of the kinds in `RECOVERY_ORIGIN_KIND_VALUES`). Use this — not the
+// stranded-only check — when deciding whether to *spawn* a recovery issue.
+export function isRecoveryOriginKind(originKind: string | null | undefined) {
+  if (!originKind) return false;
+  return (RECOVERY_ORIGIN_KIND_VALUES as readonly string[]).includes(originKind);
 }
 
 export function buildIssueGraphLivenessIncidentKey(input: {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -35,6 +35,7 @@ import { getRunLogStore } from "../run-log-store.js";
 import {
   RECOVERY_ORIGIN_KINDS,
   buildIssueGraphLivenessLeafKey,
+  isRecoveryOriginKind,
   isStrandedIssueRecoveryOriginKind,
   parseIssueGraphLivenessIncidentKey,
 } from "./origins.js";
@@ -1312,6 +1313,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     previousStatus: "todo" | "in_progress";
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) return null;
+    // Defense-in-depth against the recovery-cascade pattern (incident
+    // 2026-04-25). The reconcile loop already filters stranded recovery issues
+    // out at the candidate-classification step, but additional callers should
+    // also refuse to spawn a stranded-recovery issue *for* any kind of
+    // recovery-origin issue (stranded, harness liveness, stale active run) —
+    // those issues are themselves recovery artefacts and must escalate
+    // in-place if they get stuck.
+    if (isRecoveryOriginKind(input.issue.originKind)) return null;
 
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
     if (existing) return existing;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The recovery subsystem watches for "stranded" assigned issues — assigned but with no live execution path — and creates a `stranded_issue_recovery` issue so a human (or recovery owner) can intervene.
> - Incident 2026-04-25: this watchdog created **17,786 self-replicating** "Recover stalled issue …" rows in ~3h, blowing the STO counter from ~200 to 18,047. Root cause was that recovery-origin issues (themselves stranded) re-entered the same watchdog and spawned more recovery issues — recovery-of-recovery cascade.
> - The current in-tree guard is a single helper, `isStrandedIssueRecoveryIssue`, which only matches the `strandedIssueRecovery` origin kind. The other recovery origins (`issue_graph_liveness_escalation`, `stale_active_run_evaluation`) don't currently feed the same watchdog, but the safety guarantee depends on that contingency holding forever.
> - This pull request adds a generic `isRecoveryOriginKind(originKind)` helper plus an explicit `RECOVERY_ORIGIN_KIND_VALUES` registry and uses it as a defense-in-depth gate inside `ensureStrandedIssueRecoveryIssue`. The behavior is invisible under current call graphs — but adding any future recovery origin to `RECOVERY_ORIGIN_KINDS` will inherit cascade protection automatically, instead of silently bypassing it.
> - The benefit is a single source of truth ("which origin kinds count as recovery artifacts?") that the cascade guard mechanically consumes, removing a class of foot-gun where a future contributor adds a recovery origin and forgets to extend the guard.

## What Changed

- `server/src/services/recovery/origins.ts`: add `RECOVERY_ORIGIN_KIND_VALUES` (frozen list of every recovery origin) and `isRecoveryOriginKind(originKind)` predicate.
- `server/src/services/recovery/index.ts`: re-export both new symbols alongside the existing `isStrandedIssueRecoveryOriginKind`.
- `server/src/services/recovery/service.ts`: in `ensureStrandedIssueRecoveryIssue`, refuse to spawn a stranded-recovery issue when the source's `originKind` matches **any** entry in `RECOVERY_ORIGIN_KIND_VALUES` (not only the stranded kind).
- `server/src/__tests__/recovery-classifiers.test.ts`: assert `RECOVERY_ORIGIN_KIND_VALUES` stays in sync with `Object.values(RECOVERY_ORIGIN_KINDS)`, so future origin additions cannot silently bypass the guard.

## Verification

```sh
cd server && pnpm vitest run src/__tests__/recovery-classifiers.test.ts
# 5/5 pass (incl. new "flags every recovery origin" test)
```

Behavioral check (no change expected today):

- Existing `isStrandedIssueRecoveryIssue` already short-circuits the only known cascade hot path. New `isRecoveryOriginKind` gate inside `ensureStrandedIssueRecoveryIssue` is redundant **today** — that's the point. Future-proofing only.

Failure mode the test catches: someone adds `RECOVERY_ORIGIN_KINDS.fooBar = "foo_bar"` without appending to `RECOVERY_ORIGIN_KIND_VALUES` → the sync assertion fails in CI before the regression can ship.

## Risks

Low.

- The new predicate's value set is identical to `Object.values(RECOVERY_ORIGIN_KINDS)`, so under current callers the gate matches the same issues as before.
- No schema, no migration, no UI surface change.
- Does not address the **other** STO-259 requirements (per-source cap, recoveryAttempts counter, cap-reached emergency notification). Those are deferred and tracked in STO-259's body — this PR is the smallest in-tree hardening that stands alone.
- Does not stop the cascade currently observed at 2026-04-28T13:09–13:36 (12 stranded_recovery rows for STO-245/259). That cascade goes through a different path (live retries flipping status to in_progress momentarily) — separate fix, not in scope.

## Model Used

Claude Opus 4-7 (Anthropic, ~1M context, extended-thinking off). Used for code drafting, test design, and PR composition. Code reviewed by author before commit.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have listed concrete changes in "What Changed"
- [x] I have explained how a reviewer can verify this works
- [x] I have identified risks (or stated low risk)
- [x] I have specified the AI model used (or stated "None — human-authored")
- [x] Tests pass locally
- [x] Typecheck passes locally for the changed package
- [x] No DB migrations introduced
- [x] PR is scoped to a single logical change
