### PR TITLE
[codex] Guard external instruction roots

### DIFF
--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -121,27 +121,92 @@ describe("agent instructions service", () => {
     await expect(fs.readFile(path.join(externalRoot, "docs", "AGENTS.md"), "utf8")).resolves.toBe("# Managed Agent\n");
   });
 
-  it("filters junk files, dependency bundles, and python caches from bundle listings and exports", async () => {
-    const externalRoot = await makeTempDir("paperclip-agent-instructions-ignore-");
-    cleanupDirs.add(externalRoot);
+  it("filters junk files, dependency bundles, and python caches from managed bundle listings and exports", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-ignore-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
 
-    await fs.writeFile(path.join(externalRoot, "AGENTS.md"), "# External Agent\n", "utf8");
-    await fs.writeFile(path.join(externalRoot, ".gitignore"), "node_modules/\n", "utf8");
-    await fs.writeFile(path.join(externalRoot, ".DS_Store"), "junk", "utf8");
-    await fs.mkdir(path.join(externalRoot, "docs"), { recursive: true });
-    await fs.writeFile(path.join(externalRoot, "docs", "TOOLS.md"), "## Tools\n", "utf8");
-    await fs.writeFile(path.join(externalRoot, "docs", "module.pyc"), "compiled", "utf8");
-    await fs.writeFile(path.join(externalRoot, "docs", "._TOOLS.md"), "appledouble", "utf8");
-    await fs.mkdir(path.join(externalRoot, "node_modules", "pkg"), { recursive: true });
-    await fs.writeFile(path.join(externalRoot, "node_modules", "pkg", "index.js"), "export {};\n", "utf8");
-    await fs.mkdir(path.join(externalRoot, "python", "__pycache__"), { recursive: true });
+    const managedRoot = path.join(
+      paperclipHome,
+      "instances",
+      "test-instance",
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+    await fs.mkdir(managedRoot, { recursive: true });
+
+    await fs.writeFile(path.join(managedRoot, "AGENTS.md"), "# External Agent\n", "utf8");
+    await fs.writeFile(path.join(managedRoot, ".gitignore"), "node_modules/\n", "utf8");
+    await fs.writeFile(path.join(managedRoot, ".DS_Store"), "junk", "utf8");
+    await fs.mkdir(path.join(managedRoot, "docs"), { recursive: true });
+    await fs.writeFile(path.join(managedRoot, "docs", "TOOLS.md"), "## Tools\n", "utf8");
+    await fs.writeFile(path.join(managedRoot, "docs", "module.pyc"), "compiled", "utf8");
+    await fs.writeFile(path.join(managedRoot, "docs", "._TOOLS.md"), "appledouble", "utf8");
+    await fs.mkdir(path.join(managedRoot, "node_modules", "pkg"), { recursive: true });
+    await fs.writeFile(path.join(managedRoot, "node_modules", "pkg", "index.js"), "export {};\n", "utf8");
+    await fs.mkdir(path.join(managedRoot, "python", "__pycache__"), { recursive: true });
     await fs.writeFile(
-      path.join(externalRoot, "python", "__pycache__", "module.cpython-313.pyc"),
+      path.join(managedRoot, "python", "__pycache__", "module.cpython-313.pyc"),
       "compiled",
       "utf8",
     );
-    await fs.mkdir(path.join(externalRoot, ".pytest_cache"), { recursive: true });
-    await fs.writeFile(path.join(externalRoot, ".pytest_cache", "README.md"), "cache", "utf8");
+    await fs.mkdir(path.join(managedRoot, ".pytest_cache"), { recursive: true });
+    await fs.writeFile(path.join(managedRoot, ".pytest_cache", "README.md"), "cache", "utf8");
+
+    const svc = agentInstructionsService();
+    const agent = makeAgent({
+      instructionsBundleMode: "managed",
+      instructionsRootPath: managedRoot,
+      instructionsEntryFile: "AGENTS.md",
+      instructionsFilePath: path.join(managedRoot, "AGENTS.md"),
+    });
+
+    const bundle = await svc.getBundle(agent);
+    const exported = await svc.exportFiles(agent);
+
+    expect(bundle.files.map((file) => file.path)).toEqual([".gitignore", "AGENTS.md", "docs/TOOLS.md"]);
+    expect(Object.keys(exported.files).sort((left, right) => left.localeCompare(right))).toEqual([
+      ".gitignore",
+      "AGENTS.md",
+      "docs/TOOLS.md",
+    ]);
+  });
+
+  it("rejects external instruction roots that look like repository roots before listing files", async () => {
+    const externalRoot = await makeTempDir("paperclip-agent-instructions-repo-root-");
+    cleanupDirs.add(externalRoot);
+
+    await fs.mkdir(path.join(externalRoot, ".git"), { recursive: true });
+    await fs.writeFile(path.join(externalRoot, "package.json"), "{\"private\":true}\n", "utf8");
+    await fs.writeFile(path.join(externalRoot, "AGENTS.md"), "# External Agent\n", "utf8");
+
+    const svc = agentInstructionsService();
+    const agent = makeAgent({
+      instructionsBundleMode: "external",
+      instructionsRootPath: externalRoot,
+      instructionsEntryFile: "AGENTS.md",
+      instructionsFilePath: path.join(externalRoot, "AGENTS.md"),
+    });
+
+    await expect(svc.getBundle(agent)).rejects.toThrow(
+      "External instructions root is not allowed to point at a repository or application root",
+    );
+    await expect(svc.exportFiles(agent)).rejects.toThrow(
+      "External instructions root is not allowed to point at a repository or application root",
+    );
+  });
+
+  it("keeps narrow external instruction directories working", async () => {
+    const externalRoot = await makeTempDir("paperclip-agent-instructions-narrow-");
+    cleanupDirs.add(externalRoot);
+
+    await fs.writeFile(path.join(externalRoot, "AGENTS.md"), "# External Agent\n", "utf8");
+    await fs.mkdir(path.join(externalRoot, "docs"), { recursive: true });
+    await fs.writeFile(path.join(externalRoot, "docs", "TOOLS.md"), "## Tools\n", "utf8");
 
     const svc = agentInstructionsService();
     const agent = makeAgent({
@@ -154,12 +219,11 @@ describe("agent instructions service", () => {
     const bundle = await svc.getBundle(agent);
     const exported = await svc.exportFiles(agent);
 
-    expect(bundle.files.map((file) => file.path)).toEqual([".gitignore", "AGENTS.md", "docs/TOOLS.md"]);
-    expect(Object.keys(exported.files).sort((left, right) => left.localeCompare(right))).toEqual([
-      ".gitignore",
-      "AGENTS.md",
-      "docs/TOOLS.md",
-    ]);
+    expect(bundle.files.map((file) => file.path)).toEqual(["AGENTS.md", "docs/TOOLS.md"]);
+    expect(exported.files).toEqual({
+      "AGENTS.md": "# External Agent\n",
+      "docs/TOOLS.md": "## Tools\n",
+    });
   });
 
   it("recovers a managed bundle from disk when bundle config metadata is missing", async () => {

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -24,6 +24,31 @@ const IGNORED_INSTRUCTIONS_DIRECTORY_NAMES = new Set([
   "node_modules",
   "venv",
 ]);
+const EXTERNAL_ROOT_REJECTED_FILE_NAMES = new Set([
+  ".git",
+  "composer.json",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "yarn.lock",
+]);
+const EXTERNAL_ROOT_REJECTED_DIRECTORY_NAMES = new Set([
+  ".git",
+  ".next",
+  ".nuxt",
+  ".turbo",
+  ".vite",
+  "build",
+  "cache",
+  "coverage",
+  "data",
+  "dist",
+  "node_modules",
+  "storage",
+  "tmp",
+  "uploads",
+  "vendor",
+]);
 
 type BundleMode = "managed" | "external";
 
@@ -154,6 +179,29 @@ function resolveLegacyInstructionsPath(candidatePath: string, config: Record<str
 
 async function statIfExists(targetPath: string) {
   return fs.stat(targetPath).catch(() => null);
+}
+
+async function assertExternalInstructionsRootSafe(rootPath: string): Promise<void> {
+  const entries = await fs.readdir(rootPath, { withFileTypes: true }).catch(() => null);
+  if (!entries) return;
+
+  for (const entry of entries) {
+    if (EXTERNAL_ROOT_REJECTED_FILE_NAMES.has(entry.name)) {
+      throw unprocessable(
+        `External instructions root is not allowed to point at a repository or application root: found ${entry.name}`,
+      );
+    }
+    if (entry.isDirectory() && EXTERNAL_ROOT_REJECTED_DIRECTORY_NAMES.has(entry.name)) {
+      throw unprocessable(
+        `External instructions root is not allowed to include restricted runtime directory: ${entry.name}`,
+      );
+    }
+  }
+}
+
+async function assertBundleRootSafeForMode(state: BundleState): Promise<void> {
+  if (state.mode !== "external" || !state.rootPath) return;
+  await assertExternalInstructionsRootSafe(state.rootPath);
 }
 
 function shouldIgnoreInstructionsEntry(entry: { name: string; isDirectory(): boolean; isFile(): boolean }) {
@@ -462,6 +510,7 @@ export function agentInstructionsService() {
         warnings: [...state.warnings, `Instructions root does not exist: ${state.rootPath}`],
       }, []);
     }
+    await assertBundleRootSafeForMode(state);
     const files = await listFilesRecursive(state.rootPath);
     const summaries = await Promise.all(files.map((relativePath) => readFileSummary(state.rootPath!, relativePath, state.entryFile)));
     return toBundle(agent, state, summaries);
@@ -485,6 +534,7 @@ export function agentInstructionsService() {
       };
     }
     if (!state.rootPath) throw notFound("Agent instructions bundle is not configured");
+    await assertBundleRootSafeForMode(state);
     const absolutePath = resolvePathWithinRoot(state.rootPath, relativePath);
     const [content, stat] = await Promise.all([
       fs.readFile(absolutePath, "utf8").catch(() => null),
@@ -512,6 +562,7 @@ export function agentInstructionsService() {
     const derived = deriveBundleState(agent);
     const current = await recoverManagedBundleState(agent, derived);
     if (current.rootPath && current.mode) {
+      await assertBundleRootSafeForMode(current);
       const adapterConfig = buildPersistedBundleConfig(derived, current, options);
       return {
         adapterConfig,
@@ -574,6 +625,9 @@ export function agentInstructionsService() {
     }
 
     await fs.mkdir(nextRootPath, { recursive: true });
+    if (nextMode === "external") {
+      await assertExternalInstructionsRootSafe(nextRootPath);
+    }
 
     const existingFiles = await listFilesRecursive(nextRootPath);
     const exported = await exportFiles(agent);
@@ -642,6 +696,7 @@ export function agentInstructionsService() {
       throw unprocessable("Cannot delete the legacy promptTemplate pseudo-file");
     }
     if (!state.rootPath) throw notFound("Agent instructions bundle is not configured");
+    await assertBundleRootSafeForMode(state);
     const normalizedPath = normalizeRelativeFilePath(relativePath);
     if (normalizedPath === state.entryFile) {
       throw unprocessable("Cannot delete the bundle entry file");
@@ -662,6 +717,7 @@ export function agentInstructionsService() {
     if (state.rootPath) {
       const stat = await statIfExists(state.rootPath);
       if (stat?.isDirectory()) {
+        await assertBundleRootSafeForMode(state);
         const relativePaths = await listFilesRecursive(state.rootPath);
         const files = Object.fromEntries(await Promise.all(relativePaths.map(async (relativePath) => {
           const absolutePath = resolvePathWithinRoot(state.rootPath!, relativePath);


### PR DESCRIPTION
## Summary

- Reject external instruction bundle roots that look like repository, app, or heavy runtime roots before recursive scans.
- Keep managed instruction bundles compatible with the existing ignore/filter behavior.
- Add tests for rejected repo-like external roots and narrow external instruction directories that should continue to work.

## Context

Fitzi GitHub issue: https://github.com/vinileonardo/academia/issues/47
Paperclip task: VLT-7

## Validation

- `pnpm run preflight:workspace-links && pnpm vitest run server/src/__tests__/agent-instructions-service.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --cached --check`

## Scope note

This PR intentionally includes only:
- `server/src/services/agent-instructions.ts`
- `server/src/__tests__/agent-instructions-service.test.ts`

It intentionally excludes concurrent local changes for #51/VLT-42:
- `server/src/routes/agents.ts`
- `server/src/__tests__/agent-live-runs-route.test.ts`