### PR TITLE
feat: add company-wide pause/resume for all agents

### DIFF
--- a/server/src/__tests__/companies-route-path-guard.test.ts
+++ b/server/src/__tests__/companies-route-path-guard.test.ts
@@ -35,6 +35,9 @@ vi.mock("../services/index.js", () => ({
     getFeedbackTraceById: vi.fn(),
     saveIssueVote: vi.fn(),
   }),
+  heartbeatService: () => ({
+    cancelActiveForAgent: vi.fn(),
+  }),
   logActivity: vi.fn(),
 }));
 

--- a/server/src/__tests__/company-branding-route.test.ts
+++ b/server/src/__tests__/company-branding-route.test.ts
@@ -46,6 +46,9 @@ vi.mock("../services/index.js", () => ({
   companyPortabilityService: () => mockCompanyPortabilityService,
   companyService: () => mockCompanyService,
   feedbackService: () => mockFeedbackService,
+  heartbeatService: () => ({
+    cancelActiveForAgent: vi.fn(),
+  }),
   logActivity: mockLogActivity,
 }));
 

--- a/server/src/__tests__/company-pause-resume-routes.test.ts
+++ b/server/src/__tests__/company-pause-resume-routes.test.ts
@@ -1,0 +1,289 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "../errors.js";
+import { errorHandler } from "../middleware/index.js";
+import { companyRoutes } from "../routes/companies.js";
+
+const mockCompanyService = vi.hoisted(() => ({
+  pause: vi.fn(),
+  resume: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  ensureMembership: vi.fn(),
+}));
+
+const mockBudgetService = vi.hoisted(() => ({
+  upsertPolicy: vi.fn(),
+}));
+
+const mockCompanyPortabilityService = vi.hoisted(() => ({
+  exportBundle: vi.fn(),
+  previewExport: vi.fn(),
+  previewImport: vi.fn(),
+  importBundle: vi.fn(),
+}));
+
+const mockFeedbackService = vi.hoisted(() => ({
+  listIssueVotesForUser: vi.fn(),
+  listFeedbackTraces: vi.fn(),
+  getFeedbackTraceById: vi.fn(),
+  saveIssueVote: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  cancelActiveForAgent: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/companies.js", () => ({
+  companyService: () => mockCompanyService,
+}));
+
+vi.mock("../services/agents.js", () => ({
+  agentService: () => mockAgentService,
+}));
+
+vi.mock("../services/access.js", () => ({
+  accessService: () => mockAccessService,
+}));
+
+vi.mock("../services/budgets.js", () => ({
+  budgetService: () => mockBudgetService,
+}));
+
+vi.mock("../services/company-portability.js", () => ({
+  companyPortabilityService: () => mockCompanyPortabilityService,
+}));
+
+vi.mock("../services/feedback.js", () => ({
+  feedbackService: () => mockFeedbackService,
+}));
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
+  budgetService: () => mockBudgetService,
+  companyPortabilityService: () => mockCompanyPortabilityService,
+  companyService: () => mockCompanyService,
+  feedbackService: () => mockFeedbackService,
+  heartbeatService: () => mockHeartbeatService,
+  logActivity: mockLogActivity,
+}));
+
+async function createApp(actor: Record<string, unknown>) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api/companies", companyRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+const companyId = "11111111-1111-4111-8111-111111111111";
+
+describe.sequential("company pause/resume routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe.sequential("POST /:companyId/pause", () => {
+    it.sequential("requires board access", async () => {
+      const app = await createApp({
+        type: "agent",
+        agentId: "22222222-2222-4222-8222-222222222222",
+        companyId,
+        source: "agent_key",
+        runId: "run-1",
+      });
+
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/pause`)
+        .send({});
+
+      expect(res.status).toBe(403);
+      expect(mockCompanyService.pause).not.toHaveBeenCalled();
+    });
+
+    it.sequential("requires company access", async () => {
+      const app = await createApp({
+        type: "board",
+        userId: "user-1",
+        companyIds: ["other-company"],
+        source: "session",
+        isInstanceAdmin: false,
+      });
+
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/pause`)
+        .send({});
+
+      expect(res.status).toBe(403);
+      expect(mockCompanyService.pause).not.toHaveBeenCalled();
+    });
+
+    it.sequential("returns 404 when company not found", async () => {
+      const app = await createApp({
+        type: "board",
+        userId: "user-1",
+        companyIds: [companyId],
+        source: "session",
+        isInstanceAdmin: false,
+      });
+      mockCompanyService.pause.mockResolvedValue(null);
+
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/pause`)
+        .send({});
+
+      expect(res.status).toBe(404);
+    });
+
+    it.sequential("pauses company and cancels active runs for paused agents", async () => {
+      const app = await createApp({
+        type: "board",
+        userId: "user-1",
+        companyIds: [companyId],
+        source: "session",
+        isInstanceAdmin: false,
+      });
+      const pausedAgentIds = ["agent-1", "agent-2"];
+      mockCompanyService.pause.mockImplementation(async (
+        _companyId: string,
+        _reason: string,
+        options: { cancelActiveForAgent: (agentId: string) => Promise<unknown> },
+      ) => {
+        for (const agentId of pausedAgentIds) {
+          await options.cancelActiveForAgent(agentId);
+        }
+        return {
+          id: companyId,
+          status: "paused",
+          pausedAgentIds,
+        };
+      });
+      mockHeartbeatService.cancelActiveForAgent.mockResolvedValue(null);
+
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/pause`)
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("paused");
+      expect(mockCompanyService.pause).toHaveBeenCalledWith(companyId, "manual", {
+        cancelActiveForAgent: mockHeartbeatService.cancelActiveForAgent,
+      });
+      expect(mockHeartbeatService.cancelActiveForAgent).toHaveBeenCalledWith("agent-1");
+      expect(mockHeartbeatService.cancelActiveForAgent).toHaveBeenCalledWith("agent-2");
+      expect(mockLogActivity).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: "company.paused",
+          entityType: "company",
+          entityId: companyId,
+          details: { pausedAgentCount: 2 },
+        }),
+      );
+    });
+
+    it.sequential("returns 422 when company is already paused", async () => {
+      const app = await createApp({
+        type: "board",
+        userId: "user-1",
+        companyIds: [companyId],
+        source: "session",
+        isInstanceAdmin: false,
+      });
+      mockCompanyService.pause.mockRejectedValue(new HttpError(422, "Company is already paused"));
+
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/pause`)
+        .send({});
+
+      expect(res.status).toBe(422);
+      expect(res.body.error).toBe("Company is already paused");
+    });
+  });
+
+  describe.sequential("POST /:companyId/resume", () => {
+    it.sequential("requires board access", async () => {
+      const app = await createApp({
+        type: "agent",
+        agentId: "22222222-2222-4222-8222-222222222222",
+        companyId,
+        source: "agent_key",
+        runId: "run-1",
+      });
+
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/resume`)
+        .send({});
+
+      expect(res.status).toBe(403);
+      expect(mockCompanyService.resume).not.toHaveBeenCalled();
+    });
+
+    it.sequential("returns 404 when company not found", async () => {
+      const app = await createApp({
+        type: "board",
+        userId: "user-1",
+        companyIds: [companyId],
+        source: "session",
+        isInstanceAdmin: false,
+      });
+      mockCompanyService.resume.mockResolvedValue(null);
+
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/resume`)
+        .send({});
+
+      expect(res.status).toBe(404);
+    });
+
+    it.sequential("resumes company and logs activity", async () => {
+      const app = await createApp({
+        type: "board",
+        userId: "user-1",
+        companyIds: [companyId],
+        source: "session",
+        isInstanceAdmin: false,
+      });
+      const resumedAgentIds = ["agent-1", "agent-2"];
+      mockCompanyService.resume.mockResolvedValue({
+        id: companyId,
+        status: "active",
+        resumedAgentIds,
+      });
+
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/resume`)
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("active");
+      expect(mockCompanyService.resume).toHaveBeenCalledWith(companyId);
+      expect(mockLogActivity).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: "company.resumed",
+          entityType: "company",
+          entityId: companyId,
+          details: { resumedAgentCount: 2 },
+        }),
+      );
+    });
+  });
+});

--- a/server/src/__tests__/company-pause-resume-service.test.ts
+++ b/server/src/__tests__/company-pause-resume-service.test.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { agents, companies, createDb } from "@paperclipai/db";
+import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
 import { eq } from "drizzle-orm";
 import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
 import { companyService } from "../services/companies.js";
+import { heartbeatService } from "../services/heartbeat.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEP = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -52,6 +53,7 @@ describeEP("companyService pause/resume", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -193,5 +195,27 @@ describeEP("companyService pause/resume", () => {
     const companyId = await insertCompany(db, { status: "paused", pauseReason: "manual", pausedAt: new Date() });
     const svc = companyService(db);
     await expect(svc.pause(companyId)).rejects.toThrow("already paused");
+  });
+
+  it("skips timer heartbeats for agents in paused companies", async () => {
+    const companyId = await insertCompany(db, { status: "paused", pauseReason: "manual", pausedAt: new Date() });
+    const dueCreatedAt = new Date("2026-01-01T00:00:00.000Z");
+    await insertAgent(db, companyId, {
+      status: "idle",
+      createdAt: dueCreatedAt,
+      runtimeConfig: { heartbeat: { enabled: true, intervalSec: 30 } },
+    });
+    await insertAgent(db, companyId, {
+      status: "running",
+      createdAt: dueCreatedAt,
+      runtimeConfig: { heartbeat: { enabled: true, intervalSec: 30 } },
+    });
+
+    const result = await heartbeatService(db).tickTimers(new Date("2026-01-01T00:01:00.000Z"));
+
+    expect(result.checked).toBe(0);
+    expect(result.enqueued).toBe(0);
+    const runs = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+    expect(runs).toHaveLength(0);
   });
 });

--- a/server/src/__tests__/company-pause-resume-service.test.ts
+++ b/server/src/__tests__/company-pause-resume-service.test.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { agents, companies, createDb } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
+import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
+import { companyService } from "../services/companies.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEP = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(`Skipping: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`);
+}
+
+async function insertCompany(db: ReturnType<typeof createDb>, overrides: Record<string, unknown> = {}) {
+  const id = overrides.id as string ?? randomUUID();
+  const prefix = `T${id.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+  await db.insert(companies).values({
+    id,
+    name: `Company-${id.slice(0, 4)}`,
+    issuePrefix: prefix,
+    requireBoardApprovalForNewAgents: false,
+    ...overrides,
+  });
+  return id;
+}
+
+async function insertAgent(db: ReturnType<typeof createDb>, companyId: string, overrides: Record<string, unknown> = {}) {
+  const id = overrides.id as string ?? randomUUID();
+  await db.insert(agents).values({
+    id,
+    companyId,
+    name: `Agent-${id.slice(0, 4)}`,
+    role: "engineer",
+    status: "idle",
+    adapterType: "codex_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    permissions: {},
+    ...overrides,
+  });
+  return id;
+}
+
+describeEP("companyService pause/resume", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-company-pause-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("pauses only active agents when pausing a company", async () => {
+    const companyId = await insertCompany(db);
+    const idleAgent = await insertAgent(db, companyId, { status: "idle" });
+    const runningAgent = await insertAgent(db, companyId, { status: "running" });
+    const manuallyPausedAgent = await insertAgent(db, companyId, { status: "paused", pauseReason: "manual" });
+    const budgetPausedAgent = await insertAgent(db, companyId, { status: "paused", pauseReason: "budget" });
+    const terminatedAgent = await insertAgent(db, companyId, { status: "terminated" });
+
+    const svc = companyService(db);
+    const result = await svc.pause(companyId);
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("paused");
+    expect(result!.pausedAgentIds).toHaveLength(2);
+    expect(result!.pausedAgentIds).toContain(idleAgent);
+    expect(result!.pausedAgentIds).toContain(runningAgent);
+    expect(result!.pausedAgentIds).not.toContain(manuallyPausedAgent);
+    expect(result!.pausedAgentIds).not.toContain(budgetPausedAgent);
+    expect(result!.pausedAgentIds).not.toContain(terminatedAgent);
+
+    const idleRow = await db.select({ status: agents.status, pauseReason: agents.pauseReason }).from(agents).where(eq(agents.id, idleAgent)).then(r => r[0]);
+    expect(idleRow.status).toBe("paused");
+    expect(idleRow.pauseReason).toBe("company_paused");
+
+    const runningRow = await db.select({ status: agents.status, pauseReason: agents.pauseReason }).from(agents).where(eq(agents.id, runningAgent)).then(r => r[0]);
+    expect(runningRow.status).toBe("paused");
+    expect(runningRow.pauseReason).toBe("company_paused");
+
+    const terminatedRow = await db.select({ status: agents.status }).from(agents).where(eq(agents.id, terminatedAgent)).then(r => r[0]);
+    expect(terminatedRow.status).toBe("terminated");
+
+    const manualStill = await db.select({ status: agents.status, pauseReason: agents.pauseReason }).from(agents).where(eq(agents.id, manuallyPausedAgent)).then(r => r[0]);
+    expect(manualStill.status).toBe("paused");
+    expect(manualStill.pauseReason).toBe("manual");
+
+    const budgetStill = await db.select({ status: agents.status, pauseReason: agents.pauseReason }).from(agents).where(eq(agents.id, budgetPausedAgent)).then(r => r[0]);
+    expect(budgetStill.status).toBe("paused");
+    expect(budgetStill.pauseReason).toBe("budget");
+  });
+
+  it("resumes only agents paused by the company", async () => {
+    const companyId = await insertCompany(db, { status: "paused", pauseReason: "manual", pausedAt: new Date() });
+    const companyPausedAgent = await insertAgent(db, companyId, { status: "paused", pauseReason: "company_paused" });
+    const manuallyPausedAgent = await insertAgent(db, companyId, { status: "paused", pauseReason: "manual" });
+    const budgetPausedAgent = await insertAgent(db, companyId, { status: "paused", pauseReason: "budget" });
+
+    const svc = companyService(db);
+    const result = await svc.resume(companyId);
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("active");
+    expect(result!.resumedAgentIds).toHaveLength(1);
+    expect(result!.resumedAgentIds).toContain(companyPausedAgent);
+    expect(result!.resumedAgentIds).not.toContain(manuallyPausedAgent);
+    expect(result!.resumedAgentIds).not.toContain(budgetPausedAgent);
+
+    const resumed = await db.select({ status: agents.status, pauseReason: agents.pauseReason }).from(agents).where(eq(agents.id, companyPausedAgent)).then(r => r[0]);
+    expect(resumed.status).toBe("idle");
+    expect(resumed.pauseReason).toBeNull();
+
+    const manualStill = await db.select({ status: agents.status, pauseReason: agents.pauseReason }).from(agents).where(eq(agents.id, manuallyPausedAgent)).then(r => r[0]);
+    expect(manualStill.status).toBe("paused");
+    expect(manualStill.pauseReason).toBe("manual");
+
+    const budgetStill = await db.select({ status: agents.status, pauseReason: agents.pauseReason }).from(agents).where(eq(agents.id, budgetPausedAgent)).then(r => r[0]);
+    expect(budgetStill.status).toBe("paused");
+    expect(budgetStill.pauseReason).toBe("budget");
+  });
+
+  it("does not pause agents from other companies", async () => {
+    const companyA = await insertCompany(db);
+    const companyB = await insertCompany(db);
+    const agentA = await insertAgent(db, companyA, { status: "idle" });
+    const agentB = await insertAgent(db, companyB, { status: "idle" });
+
+    const svc = companyService(db);
+    const result = await svc.pause(companyA);
+
+    expect(result!.pausedAgentIds).toContain(agentA);
+    expect(result!.pausedAgentIds).not.toContain(agentB);
+
+    const otherAgent = await db.select({ status: agents.status }).from(agents).where(eq(agents.id, agentB)).then(r => r[0]);
+    expect(otherAgent.status).toBe("idle");
+  });
+
+  it("sets company pauseReason and pausedAt", async () => {
+    const companyId = await insertCompany(db);
+    const svc = companyService(db);
+    const result = await svc.pause(companyId, "manual");
+
+    expect(result!.pauseReason).toBe("manual");
+    expect(result!.pausedAt).not.toBeNull();
+  });
+
+  it("cancels active work for agents that will be paused", async () => {
+    const companyId = await insertCompany(db);
+    const runningAgent = await insertAgent(db, companyId, { status: "running" });
+    const manuallyPausedAgent = await insertAgent(db, companyId, { status: "paused", pauseReason: "manual" });
+    const cancelActiveForAgent = vi.fn(async () => undefined);
+
+    const svc = companyService(db);
+    await svc.pause(companyId, "manual", { cancelActiveForAgent });
+
+    expect(cancelActiveForAgent).toHaveBeenCalledWith(runningAgent);
+    expect(cancelActiveForAgent).not.toHaveBeenCalledWith(manuallyPausedAgent);
+  });
+
+  it("clears company pauseReason and pausedAt on resume", async () => {
+    const companyId = await insertCompany(db);
+    const svc = companyService(db);
+    await svc.pause(companyId);
+    const result = await svc.resume(companyId);
+
+    expect(result!.pauseReason).toBeNull();
+    expect(result!.pausedAt).toBeNull();
+  });
+
+  it("returns null for non-existent company on pause", async () => {
+    const svc = companyService(db);
+    const result = await svc.pause(randomUUID());
+    expect(result).toBeNull();
+  });
+
+  it("refuses to resume a company that is not paused", async () => {
+    const companyId = await insertCompany(db);
+    const svc = companyService(db);
+    await expect(svc.resume(companyId)).rejects.toThrow("not paused");
+  });
+
+  it("refuses to pause a company that is already paused", async () => {
+    const companyId = await insertCompany(db, { status: "paused", pauseReason: "manual", pausedAt: new Date() });
+    const svc = companyService(db);
+    await expect(svc.pause(companyId)).rejects.toThrow("already paused");
+  });
+});

--- a/server/src/__tests__/company-portability-routes.test.ts
+++ b/server/src/__tests__/company-portability-routes.test.ts
@@ -74,6 +74,9 @@ vi.mock("../services/index.js", () => ({
   companyPortabilityService: () => mockCompanyPortabilityService,
   companyService: () => mockCompanyService,
   feedbackService: () => mockFeedbackService,
+  heartbeatService: () => ({
+    cancelActiveForAgent: vi.fn(),
+  }),
   logActivity: mockLogActivity,
 }));
 
@@ -85,6 +88,9 @@ function registerCompanyRouteMocks() {
     companyPortabilityService: () => mockCompanyPortabilityService,
     companyService: () => mockCompanyService,
     feedbackService: () => mockFeedbackService,
+    heartbeatService: () => ({
+      cancelActiveForAgent: vi.fn(),
+    }),
     logActivity: mockLogActivity,
   }));
 }

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -383,13 +383,12 @@ export function companyRoutes(db: Db, storage?: StorageService) {
     assertBoard(req);
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    const result = await svc.pause(companyId);
+    const result = await svc.pause(companyId, "manual", {
+      cancelActiveForAgent: heartbeat.cancelActiveForAgent,
+    });
     if (!result) {
       res.status(404).json({ error: "Company not found" });
       return;
-    }
-    for (const agentId of result.pausedAgentIds) {
-      await heartbeat.cancelActiveForAgent(agentId);
     }
     await logActivity(db, {
       companyId,

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -21,6 +21,7 @@ import {
   companyPortabilityService,
   companyService,
   feedbackService,
+  heartbeatService,
   logActivity,
 } from "../services/index.js";
 import type { StorageService } from "../storage/types.js";
@@ -34,6 +35,7 @@ export function companyRoutes(db: Db, storage?: StorageService) {
   const access = accessService(db);
   const budgets = budgetService(db);
   const feedback = feedbackService(db);
+  const heartbeat = heartbeatService(db);
 
   function parseBooleanQuery(value: unknown) {
     return value === true || value === "true" || value === "1";
@@ -375,6 +377,51 @@ export function companyRoutes(db: Db, storage?: StorageService) {
       details: req.body,
     });
     res.json(company);
+  });
+
+  router.post("/:companyId/pause", async (req, res) => {
+    assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const result = await svc.pause(companyId);
+    if (!result) {
+      res.status(404).json({ error: "Company not found" });
+      return;
+    }
+    for (const agentId of result.pausedAgentIds) {
+      await heartbeat.cancelActiveForAgent(agentId);
+    }
+    await logActivity(db, {
+      companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: "company.paused",
+      entityType: "company",
+      entityId: companyId,
+      details: { pausedAgentCount: result.pausedAgentIds.length },
+    });
+    res.json(result);
+  });
+
+  router.post("/:companyId/resume", async (req, res) => {
+    assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const result = await svc.resume(companyId);
+    if (!result) {
+      res.status(404).json({ error: "Company not found" });
+      return;
+    }
+    await logActivity(db, {
+      companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: "company.resumed",
+      entityType: "company",
+      entityId: companyId,
+      details: { resumedAgentCount: result.resumedAgentIds.length },
+    });
+    res.json(result);
   });
 
   router.post("/:companyId/archive", async (req, res) => {

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -280,11 +280,12 @@ export function companyService(db: Db) {
           .then((rows) => rows[0] ?? null);
         if (!updated) return null;
 
-        for (const agent of companyAgents) {
+        const companyAgentIds = companyAgents.map((agent) => agent.id);
+        if (companyAgentIds.length > 0) {
           await tx
             .update(agents)
             .set({ status: "paused", pauseReason: "company_paused", pausedAt: new Date(), updatedAt: new Date() })
-            .where(eq(agents.id, agent.id));
+            .where(inArray(agents.id, companyAgentIds));
         }
 
         const row = await getCompanyQuery(tx)
@@ -292,7 +293,7 @@ export function companyService(db: Db) {
           .then((rows) => rows[0] ?? null);
         if (!row) return null;
         const [hydrated] = await hydrateCompanySpend([row], tx);
-        return { ...enrichCompany(hydrated), pausedAgentIds: companyAgents.map((a) => a.id) };
+        return { ...enrichCompany(hydrated), pausedAgentIds: companyAgentIds };
       }),
 
     resume: (id: string) =>
@@ -317,11 +318,12 @@ export function companyService(db: Db) {
           .select({ id: agents.id })
           .from(agents)
           .where(and(eq(agents.companyId, id), eq(agents.pauseReason, "company_paused")));
-        for (const agent of pausedAgents) {
+        const pausedAgentIds = pausedAgents.map((agent) => agent.id);
+        if (pausedAgentIds.length > 0) {
           await tx
             .update(agents)
             .set({ status: "idle", pauseReason: null, pausedAt: null, updatedAt: new Date() })
-            .where(eq(agents.id, agent.id));
+            .where(inArray(agents.id, pausedAgentIds));
         }
 
         const row = await getCompanyQuery(tx)
@@ -329,7 +331,7 @@ export function companyService(db: Db) {
           .then((rows) => rows[0] ?? null);
         if (!row) return null;
         const [hydrated] = await hydrateCompanySpend([row], tx);
-        return { ...enrichCompany(hydrated), resumedAgentIds: pausedAgents.map((a) => a.id) };
+        return { ...enrichCompany(hydrated), resumedAgentIds: pausedAgentIds };
       }),
 
     archive: (id: string) =>

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -246,7 +246,11 @@ export function companyService(db: Db) {
         return enrichCompany(hydrated);
       }),
 
-    pause: (id: string, reason: string = "manual") =>
+    pause: (
+      id: string,
+      reason: string = "manual",
+      options: { cancelActiveForAgent?: (agentId: string) => Promise<unknown> } = {},
+    ) =>
       db.transaction(async (tx) => {
         const existing = await tx
           .select({ status: companies.status })
@@ -255,6 +259,18 @@ export function companyService(db: Db) {
           .then((rows) => rows[0] ?? null);
         if (!existing) return null;
         if (existing.status === "archived") throw unprocessable("Cannot pause an archived company");
+        if (existing.status === "paused") throw unprocessable("Company is already paused");
+
+        const companyAgents = await tx
+          .select({ id: agents.id, status: agents.status })
+          .from(agents)
+          .where(and(eq(agents.companyId, id), notInArray(agents.status, ["terminated", "pending_approval", "paused"])));
+
+        if (options.cancelActiveForAgent) {
+          for (const agent of companyAgents) {
+            await options.cancelActiveForAgent(agent.id);
+          }
+        }
 
         const updated = await tx
           .update(companies)
@@ -264,10 +280,6 @@ export function companyService(db: Db) {
           .then((rows) => rows[0] ?? null);
         if (!updated) return null;
 
-        const companyAgents = await tx
-          .select({ id: agents.id, status: agents.status })
-          .from(agents)
-          .where(and(eq(agents.companyId, id), notInArray(agents.status, ["terminated", "pending_approval"])));
         for (const agent of companyAgents) {
           await tx
             .update(agents)

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, gte, inArray, lt, sql } from "drizzle-orm";
+import { and, count, eq, gte, inArray, lt, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   companies,
@@ -41,6 +41,8 @@ export function companyService(db: Db) {
     name: companies.name,
     description: companies.description,
     status: companies.status,
+    pauseReason: companies.pauseReason,
+    pausedAt: companies.pausedAt,
     issuePrefix: companies.issuePrefix,
     issueCounter: companies.issueCounter,
     budgetMonthlyCents: companies.budgetMonthlyCents,
@@ -242,6 +244,80 @@ export function companyService(db: Db) {
         }], tx);
 
         return enrichCompany(hydrated);
+      }),
+
+    pause: (id: string, reason: string = "manual") =>
+      db.transaction(async (tx) => {
+        const existing = await tx
+          .select({ status: companies.status })
+          .from(companies)
+          .where(eq(companies.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!existing) return null;
+        if (existing.status === "archived") throw unprocessable("Cannot pause an archived company");
+
+        const updated = await tx
+          .update(companies)
+          .set({ status: "paused", pauseReason: reason, pausedAt: new Date(), updatedAt: new Date() })
+          .where(eq(companies.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!updated) return null;
+
+        const companyAgents = await tx
+          .select({ id: agents.id, status: agents.status })
+          .from(agents)
+          .where(and(eq(agents.companyId, id), notInArray(agents.status, ["terminated", "pending_approval"])));
+        for (const agent of companyAgents) {
+          await tx
+            .update(agents)
+            .set({ status: "paused", pauseReason: "company_paused", pausedAt: new Date(), updatedAt: new Date() })
+            .where(eq(agents.id, agent.id));
+        }
+
+        const row = await getCompanyQuery(tx)
+          .where(eq(companies.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!row) return null;
+        const [hydrated] = await hydrateCompanySpend([row], tx);
+        return { ...enrichCompany(hydrated), pausedAgentIds: companyAgents.map((a) => a.id) };
+      }),
+
+    resume: (id: string) =>
+      db.transaction(async (tx) => {
+        const existing = await tx
+          .select({ status: companies.status })
+          .from(companies)
+          .where(eq(companies.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!existing) return null;
+        if (existing.status !== "paused") throw unprocessable("Company is not paused");
+
+        const updated = await tx
+          .update(companies)
+          .set({ status: "active", pauseReason: null, pausedAt: null, updatedAt: new Date() })
+          .where(eq(companies.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!updated) return null;
+
+        const pausedAgents = await tx
+          .select({ id: agents.id })
+          .from(agents)
+          .where(and(eq(agents.companyId, id), eq(agents.pauseReason, "company_paused")));
+        for (const agent of pausedAgents) {
+          await tx
+            .update(agents)
+            .set({ status: "idle", pauseReason: null, pausedAt: null, updatedAt: new Date() })
+            .where(eq(agents.id, agent.id));
+        }
+
+        const row = await getCompanyQuery(tx)
+          .where(eq(companies.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!row) return null;
+        const [hydrated] = await hydrateCompanySpend([row], tx);
+        return { ...enrichCompany(hydrated), resumedAgentIds: pausedAgents.map((a) => a.id) };
       }),
 
     archive: (id: string) =>

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -21,6 +21,7 @@ import {
   agentTaskSessions,
   agentWakeupRequests,
   activityLog,
+  companies,
   companySkills as companySkillsTable,
   documentRevisions,
   issueDocuments,
@@ -7498,12 +7499,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     tickTimers: async (now = new Date()) => {
       const allAgents = await db.select().from(agents);
+      const pausedCompanyRows = await db
+        .select({ id: companies.id })
+        .from(companies)
+        .where(eq(companies.status, "paused"));
+      const pausedCompanyIds = new Set(pausedCompanyRows.map((r) => r.id));
       let checked = 0;
       let enqueued = 0;
       let skipped = 0;
 
       for (const agent of allAgents) {
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
+        if (pausedCompanyIds.has(agent.companyId)) continue;
         const policy = parseHeartbeatPolicy(agent);
         if (!policy.enabled || policy.intervalSec <= 0) continue;
 

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -42,6 +42,8 @@ export const companiesApi = {
   updateBranding: (companyId: string, data: UpdateCompanyBranding) =>
     api.patch<Company>(`/companies/${companyId}/branding`, data),
   archive: (companyId: string) => api.post<Company>(`/companies/${companyId}/archive`, {}),
+  pause: (companyId: string) => api.post<Company>(`/companies/${companyId}/pause`, {}),
+  resume: (companyId: string) => api.post<Company>(`/companies/${companyId}/resume`, {}),
   remove: (companyId: string) => api.delete<{ ok: true }>(`/companies/${companyId}`),
   exportBundle: (
     companyId: string,

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -18,7 +18,7 @@ import { instanceSettingsApi } from "../api/instanceSettings";
 import { secretsApi } from "../api/secrets";
 import { queryKeys } from "../lib/queryKeys";
 import { Button } from "@/components/ui/button";
-import { Settings, Check, Download, Upload } from "lucide-react";
+import { Settings, Check, Download, Upload, PauseCircle, PlayCircle } from "lucide-react";
 import { CompanyPatternIcon } from "../components/CompanyPatternIcon";
 import { JsonSchemaForm, getDefaultValues, validateJsonSchemaForm } from "@/components/JsonSchemaForm";
 import {
@@ -456,6 +456,30 @@ export function CompanySettings() {
         queryKey: queryKeys.companies.stats
       });
     }
+  });
+
+  const pauseMutation = useMutation({
+    mutationFn: () => companiesApi.pause(selectedCompanyId!),
+    onSuccess: async () => {
+      pushToast({ tone: "success", title: "Company paused", body: "All agents have been paused." });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.companies.stats });
+    },
+    onError: (err) => {
+      pushToast({ tone: "error", title: "Failed to pause company", body: err instanceof Error ? err.message : "Unknown error" });
+    },
+  });
+
+  const resumeMutation = useMutation({
+    mutationFn: () => companiesApi.resume(selectedCompanyId!),
+    onSuccess: async () => {
+      pushToast({ tone: "success", title: "Company resumed", body: "Agents are back online." });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.companies.stats });
+    },
+    onError: (err) => {
+      pushToast({ tone: "error", title: "Failed to resume company", body: err instanceof Error ? err.message : "Unknown error" });
+    },
   });
 
   useEffect(() => {
@@ -1252,6 +1276,76 @@ export function CompanySettings() {
         <div className="text-xs font-medium text-destructive uppercase tracking-wide">
           Danger Zone
         </div>
+        <div className="space-y-3 rounded-md border border-destructive/40 bg-destructive/5 px-4 py-4">
+          {selectedCompany.status === "paused" ? (
+            <>
+              <p className="text-sm text-muted-foreground">
+                This company is paused. All agents are stopped and no new work will be started.
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={resumeMutation.isPending}
+                  onClick={() => {
+                    if (!selectedCompanyId) return;
+                    const confirmed = window.confirm(
+                      `Resume company "${selectedCompany.name}"? All agents will be reactivated and resume their work.`
+                    );
+                    if (!confirmed) return;
+                    resumeMutation.mutate();
+                  }}
+                >
+                  <PlayCircle className="mr-1.5 h-4 w-4" />
+                  {resumeMutation.isPending ? "Resuming..." : "Resume company"}
+                </Button>
+                {resumeMutation.isError && (
+                  <span className="text-xs text-destructive">
+                    {resumeMutation.error instanceof Error
+                      ? resumeMutation.error.message
+                      : "Failed to resume company"}
+                  </span>
+                )}
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">
+                Pause this company to immediately stop all agents. No work will be
+                started until you resume. Nothing is lost — agents pick up where they left off.
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={
+                    pauseMutation.isPending ||
+                    selectedCompany.status === "archived"
+                  }
+                  onClick={() => {
+                    if (!selectedCompanyId) return;
+                    const confirmed = window.confirm(
+                      `Pause company "${selectedCompany.name}"? All agents will be stopped immediately.`
+                    );
+                    if (!confirmed) return;
+                    pauseMutation.mutate();
+                  }}
+                >
+                  <PauseCircle className="mr-1.5 h-4 w-4" />
+                  {pauseMutation.isPending ? "Pausing..." : "Pause company"}
+                </Button>
+                {pauseMutation.isError && (
+                  <span className="text-xs text-destructive">
+                    {pauseMutation.error instanceof Error
+                      ? pauseMutation.error.message
+                      : "Failed to pause company"}
+                  </span>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+
         <div className="space-y-3 rounded-md border border-destructive/40 bg-destructive/5 px-4 py-4">
           <p className="text-sm text-muted-foreground">
             Archive this company to hide it from the sidebar. This persists in


### PR DESCRIPTION
Adds POST /api/companies/:id/pause and /resume endpoints that stop or restart all agents at once. The pause sets company status to paused, pauses all non-terminated agents, cancels active runs and kills child processes. tickTimers() skips agents in paused companies. Resume restores only agents that were paused by the company (preserving manually or budget-paused agents). UI button added to Company Settings > Danger Zone.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies
> - company is involved
> - Multiple agents working with many tasks is overwhelming, sometimes you need to pull the trigger and stop to see what's going on
> - You need to go 1 by 1 while the others are working
> - This pull request implements the new button
> - The benefit is you can pause all company operations at once without going 1 by 1 agent.

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

- Added a button to pause all company agents from company settings. Manually paused agents are not affected after resume.

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

  **After: default state**
<img width="719" height="291" alt="image" src="https://github.com/user-attachments/assets/e8e0a9bc-2866-40ab-b9b2-01ad9ad6984c" />

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used


<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

- GLM 5.1 (OpenCode)
- GPT 5.5 (Codex)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
