### PR TITLE
fix(openclaw-gateway): abort remote runs when Paperclip stops waiting

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -5,6 +5,7 @@ export type {
   AdapterBillingType,
   AdapterRuntimeServiceReport,
   AdapterExecutionResult,
+  AdapterCancelRunContext,
   AdapterInvocationMeta,
   AdapterExecutionContext,
   AdapterEnvironmentCheckLevel,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -139,6 +139,15 @@ export interface AdapterExecutionContext {
   authToken?: string;
 }
 
+export interface AdapterCancelRunContext {
+  runId: string;
+  agent: AdapterAgent;
+  config: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  reason?: string;
+  onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+}
+
 export interface AdapterModel {
   id: string;
   label: string;
@@ -307,6 +316,7 @@ export interface AdapterConfigSchema {
 export interface ServerAdapterModule {
   type: string;
   execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult>;
+  cancelRun?: (ctx: AdapterCancelRunContext) => Promise<void>;
   testEnvironment(ctx: AdapterEnvironmentTestContext): Promise<AdapterEnvironmentTestResult>;
   listSkills?: (ctx: AdapterSkillContext) => Promise<AdapterSkillSnapshot>;
   syncSkills?: (ctx: AdapterSkillContext, desiredSkills: string[]) => Promise<AdapterSkillSnapshot>;

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1,4 +1,5 @@
 import type {
+  AdapterCancelRunContext,
   AdapterExecutionContext,
   AdapterExecutionResult,
   AdapterRuntimeServiceReport,
@@ -833,6 +834,136 @@ class GatewayWsClient {
   }
 }
 
+async function abortAcceptedRun(params: {
+  client: GatewayWsClient;
+  runId: string;
+  sessionKey: string | undefined;
+  timeoutMs: number;
+  reason?: string;
+  onLog: AdapterExecutionContext["onLog"];
+}) {
+  const reason = params.reason ? ` (${params.reason})` : "";
+  try {
+    await params.client.request<Record<string, unknown>>(
+      "chat.abort",
+      {
+        runId: params.runId,
+        ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+      },
+      { timeoutMs: Math.max(1_000, Math.min(params.timeoutMs, 10_000)) },
+    );
+    await params.onLog("stderr", `[openclaw-gateway] aborted gateway run${reason} runId=${params.runId}\n`);
+  } catch (err) {
+    await params.onLog(
+      "stderr",
+      `[openclaw-gateway] failed to abort gateway run${reason} runId=${params.runId}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+export async function cancelRun(ctx: AdapterCancelRunContext): Promise<void> {
+  const onLog = ctx.onLog ?? (async () => {});
+  const urlValue = nonEmpty(ctx.config.url);
+  if (!urlValue) return;
+
+  const parsedUrl = normalizeUrl(urlValue);
+  if (!parsedUrl || (parsedUrl.protocol !== "ws:" && parsedUrl.protocol !== "wss:")) return;
+
+  const headers = toStringRecord(ctx.config.headers);
+  const authToken = resolveAuthToken(parseObject(ctx.config), headers);
+  const password = nonEmpty(ctx.config.password);
+  const deviceToken = nonEmpty(ctx.config.deviceToken);
+
+  if (authToken && !headerMapHasIgnoreCase(headers, "authorization")) {
+    headers.authorization = toAuthorizationHeaderValue(authToken);
+  }
+
+  const clientId = nonEmpty(ctx.config.clientId) ?? DEFAULT_CLIENT_ID;
+  const clientMode = nonEmpty(ctx.config.clientMode) ?? DEFAULT_CLIENT_MODE;
+  const clientVersion = nonEmpty(ctx.config.clientVersion) ?? DEFAULT_CLIENT_VERSION;
+  const role = nonEmpty(ctx.config.role) ?? DEFAULT_ROLE;
+  const scopes = normalizeScopes(ctx.config.scopes);
+  const deviceFamily = nonEmpty(ctx.config.deviceFamily);
+  const disableDeviceAuth = parseBoolean(ctx.config.disableDeviceAuth, false);
+  const configuredDevicePrivateKey = nonEmpty(ctx.config.devicePrivateKeyPem);
+  const configuredAgentId = nonEmpty(ctx.config.agentId);
+  const issueId = nonEmpty(ctx.context?.issueId) ?? nonEmpty(ctx.context?.taskId);
+  const sessionKey = resolveSessionKey({
+    strategy: normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy),
+    configuredSessionKey: nonEmpty(ctx.config.sessionKey),
+    runId: ctx.runId,
+    issueId,
+    agentId: configuredAgentId ?? ctx.agent.id,
+  });
+
+  const client = new GatewayWsClient({
+    url: parsedUrl.toString(),
+    headers,
+    onEvent: () => {},
+    onLog,
+  });
+
+  try {
+    const deviceIdentity =
+      !disableDeviceAuth && configuredDevicePrivateKey
+        ? resolveDeviceIdentity(parseObject(ctx.config))
+        : null;
+    await client.connect((nonce) => {
+      const connectParams: Record<string, unknown> = {
+        minProtocol: PROTOCOL_VERSION,
+        maxProtocol: PROTOCOL_VERSION,
+        client: {
+          id: clientId,
+          version: clientVersion,
+          platform: process.platform,
+          mode: clientMode,
+        },
+        auth: {
+          ...(authToken ? { token: authToken } : {}),
+          ...(password ? { password } : {}),
+          ...(deviceToken ? { deviceToken } : {}),
+          role,
+          scopes,
+        },
+      };
+      if (deviceIdentity) {
+        const signedAtMs = Date.now();
+        const payload = buildDeviceAuthPayloadV3({
+          deviceId: deviceIdentity.deviceId,
+          nonce,
+          clientId,
+          clientMode,
+          role,
+          scopes,
+          signedAtMs,
+          token: authToken,
+          platform: process.platform,
+          deviceFamily,
+        });
+        connectParams.device = {
+          id: deviceIdentity.deviceId,
+          publicKey: deviceIdentity.publicKeyRawBase64Url,
+          signature: signDevicePayload(deviceIdentity.privateKeyPem, payload),
+          signedAt: signedAtMs,
+          nonce,
+        };
+      }
+      return connectParams;
+    }, 10_000);
+
+    await abortAcceptedRun({
+      client,
+      runId: ctx.runId,
+      sessionKey,
+      timeoutMs: 10_000,
+      reason: ctx.reason,
+      onLog,
+    });
+  } finally {
+    client.close();
+  }
+}
+
 async function autoApproveDevicePairing(params: {
   url: string;
   headers: Record<string, string>;
@@ -1349,6 +1480,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
         const waitStatus = nonEmpty(waitPayload?.status)?.toLowerCase() ?? "";
         if (waitStatus === "timeout") {
+          await abortAcceptedRun({
+            client,
+            runId: acceptedRunId,
+            sessionKey: typeof agentParams.sessionKey === "string" ? agentParams.sessionKey : undefined,
+            timeoutMs: connectTimeoutMs,
+            reason: "agent.wait timeout",
+            onLog: ctx.onLog,
+          });
           return {
             exitCode: 1,
             signal: null,

--- a/packages/adapters/openclaw-gateway/src/server/index.ts
+++ b/packages/adapters/openclaw-gateway/src/server/index.ts
@@ -1,2 +1,2 @@
-export { execute } from "./execute.js";
+export { cancelRun, execute } from "./execute.js";
 export { testEnvironment } from "./test.js";

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -46,6 +46,7 @@ async function createMockGatewayServer(options?: {
   const wss = new WebSocketServer({ server });
 
   let agentPayload: Record<string, unknown> | null = null;
+  const requests: Array<{ method: string; params?: Record<string, unknown> }> = [];
 
   wss.on("connection", (socket) => {
     socket.send(
@@ -66,6 +67,7 @@ async function createMockGatewayServer(options?: {
       };
 
       if (frame.type !== "req") return;
+      requests.push({ method: frame.method, params: frame.params });
 
       if (frame.method === "connect") {
         socket.send(
@@ -150,6 +152,20 @@ async function createMockGatewayServer(options?: {
           }),
         );
       }
+
+      if (frame.method === "chat.abort") {
+        socket.send(
+          JSON.stringify({
+            type: "res",
+            id: frame.id,
+            ok: true,
+            payload: {
+              ok: true,
+              runIds: [frame.params?.runId],
+            },
+          }),
+        );
+      }
     });
   });
 
@@ -165,6 +181,7 @@ async function createMockGatewayServer(options?: {
   return {
     url: `ws://127.0.0.1:${address.port}`,
     getAgentPayload: () => agentPayload,
+    getRequests: () => requests,
     close: async () => {
       await new Promise<void>((resolve) => wss.close(() => resolve()));
       await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -564,6 +581,53 @@ describe("openclaw gateway adapter execute", () => {
           status: "running",
         }),
       ]);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("aborts the accepted gateway run when agent.wait times out", async () => {
+    const gateway = await createMockGatewayServer({
+      waitPayload: {
+        runId: "run-123",
+        status: "timeout",
+      },
+    });
+    const logs: string[] = [];
+
+    try {
+      const result = await execute(
+        buildContext(
+          {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            waitTimeoutMs: 2000,
+          },
+          {
+            onLog: async (_stream, chunk) => {
+              logs.push(chunk);
+            },
+          },
+        ),
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.timedOut).toBe(true);
+      expect(result.errorCode).toBe("openclaw_gateway_wait_timeout");
+      expect(gateway.getRequests()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            method: "chat.abort",
+            params: expect.objectContaining({
+              runId: "run-123",
+              sessionKey: "paperclip:issue:issue-123",
+            }),
+          }),
+        ]),
+      );
+      expect(logs.some((entry) => entry.includes("aborted gateway run (agent.wait timeout) runId=run-123"))).toBe(true);
     } finally {
       await gateway.close();
     }

--- a/server/src/adapters/index.ts
+++ b/server/src/adapters/index.ts
@@ -14,6 +14,7 @@ export type {
   ServerAdapterModule,
   AdapterExecutionContext,
   AdapterExecutionResult,
+  AdapterCancelRunContext,
   AdapterInvocationMeta,
   AdapterEnvironmentCheckLevel,
   AdapterEnvironmentCheck,

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -48,6 +48,7 @@ import {
   models as openCodeModels,
 } from "@paperclipai/adapter-opencode-local";
 import {
+  cancelRun as openclawGatewayCancelRun,
   execute as openclawGatewayExecute,
   testEnvironment as openclawGatewayTestEnvironment,
 } from "@paperclipai/adapter-openclaw-gateway/server";
@@ -190,6 +191,7 @@ const geminiLocalAdapter: ServerAdapterModule = {
 const openclawGatewayAdapter: ServerAdapterModule = {
   type: "openclaw_gateway",
   execute: openclawGatewayExecute,
+  cancelRun: openclawGatewayCancelRun,
   testEnvironment: openclawGatewayTestEnvironment,
   models: openclawGatewayModels,
   supportsLocalAgentJwt: false,

--- a/server/src/adapters/types.ts
+++ b/server/src/adapters/types.ts
@@ -7,6 +7,7 @@ export type {
   AdapterRuntime,
   UsageSummary,
   AdapterExecutionResult,
+  AdapterCancelRunContext,
   AdapterInvocationMeta,
   AdapterExecutionContext,
   AdapterEnvironmentCheckLevel,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4339,6 +4339,47 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
+  async function cancelAdapterRunIfSupported(
+    run: typeof heartbeatRuns.$inferSelect,
+    agent: typeof agents.$inferSelect | null,
+    reason: string,
+  ) {
+    if (!agent) return;
+    const adapter = getServerAdapter(agent.adapterType);
+    if (!adapter.cancelRun) return;
+
+    try {
+      await adapter.cancelRun({
+        runId: run.id,
+        agent: {
+          id: agent.id,
+          companyId: agent.companyId,
+          name: agent.name,
+          adapterType: agent.adapterType,
+          adapterConfig: parseObject(agent.adapterConfig),
+        },
+        config: parseObject(agent.adapterConfig),
+        context: parseObject(run.contextSnapshot),
+        reason,
+        onLog: async (stream, chunk) => {
+          const message = chunk.trim();
+          if (!message) return;
+          await appendRunEvent(run, await nextRunEventSeq(run.id), {
+            eventType: "lifecycle",
+            stream,
+            level: stream === "stderr" ? "warn" : "info",
+            message,
+          });
+        },
+      });
+    } catch (err) {
+      logger.warn(
+        { err, runId: run.id, adapterType: agent.adapterType },
+        "adapter run cancellation hook failed",
+      );
+    }
+  }
+
   async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
@@ -4401,6 +4442,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
       const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const agent = await getAgent(run.agentId);
+      await cancelAdapterRunIfSupported(run, agent, shouldRetry ? `${baseMessage}; retrying once` : baseMessage);
 
       let finalizedRun = await setRunStatus(run.id, "failed", {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
@@ -4426,7 +4469,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       let retriedRun: typeof heartbeatRuns.$inferSelect | null = null;
       if (shouldRetry) {
-        const agent = await getAgent(run.agentId);
         if (agent) {
           retriedRun = await enqueueProcessLossRetry(finalizedRun, agent, now);
         }
@@ -7126,6 +7168,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         processGroupId: run.processGroupId,
       });
     }
+    await cancelAdapterRunIfSupported(run, agent ?? null, reason);
 
     const cancelled = await setRunStatus(run.id, "cancelled", {
       finishedAt: new Date(),
@@ -7169,6 +7212,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .where(and(eq(heartbeatRuns.agentId, agentId), inArray(heartbeatRuns.status, [...CANCELLABLE_HEARTBEAT_RUN_STATUSES])));
 
     for (const run of runs) {
+      await cancelAdapterRunIfSupported(run, agent ?? null, reason);
+
       await setRunStatus(run.id, "cancelled", {
         finishedAt: new Date(),
         error: reason,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent companies and heartbeat runs are the control-plane record for delegated work.
> - The affected subsystem is the server heartbeat lifecycle plus the `openclaw_gateway` adapter that hands work to a remote OpenClaw gateway.
> - Existing upstream reports show `openclaw_gateway` can leave Paperclip and OpenClaw out of sync: Paperclip marks a run timed out, cancelled, or process-lost while the remote accepted task keeps running.
> - I reproduced the same class of failure locally: Paperclip finalized runs with `openclaw_gateway_wait_timeout` / `process_lost`, while OpenClaw still showed active tasks and later runs hit stale session lock contention.
> - Upstream currently returns `openclaw_gateway_wait_timeout` after `agent.wait` timeout without sending `chat.abort`, and the shared adapter surface has no way for heartbeat cancellation to ask a remote adapter to stop work.
> - This pull request adds a best-effort adapter cancellation hook and implements it for OpenClaw by sending `chat.abort` for accepted remote runs.
> - The benefit is that Paperclip finalization now attempts to clean up the corresponding OpenClaw task instead of leaving remote work running after the control plane has stopped waiting.

## What Changed

- Added optional `ServerAdapterModule.cancelRun(ctx)` / `AdapterCancelRunContext` types and exports.
- Wired heartbeat orphan reaping and explicit cancellation paths to call the adapter cancellation hook before finalizing the run.
- Implemented `openclaw_gateway` cancellation by reconnecting to the gateway and issuing `chat.abort` with the Paperclip run id and resolved session key.
- Updated the `agent.wait` timeout path to abort the accepted OpenClaw run over the existing gateway connection before returning `openclaw_gateway_wait_timeout`.
- Added a focused regression test asserting that an accepted timed-out gateway run sends `chat.abort`.

## Verification

- `pnpm vitest run server/src/__tests__/openclaw-gateway-adapter.test.ts`
- `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `git diff --check`

## Risks

- Moderate risk because this touches heartbeat finalization and adapter interfaces.
- The hook is intentionally best-effort: remote abort failure logs a warning but must not block Paperclip from finalizing or retrying a run.
- External adapter packages that do not implement `cancelRun` keep current behavior because the hook is optional.
- This complements, but does not replace, false `process_lost` reaper fixes such as #2687.

Related upstream reports: #1804, #3305, #2224.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.
>
> Checked `ROADMAP.md`; this is a tightly scoped bug fix for existing OpenClaw gateway lifecycle behavior, not a new roadmap-level feature.

## Model Used

- OpenAI Codex
- Model ID: `gpt-5.4`
- Reasoning mode: high
- Capabilities used: repository inspection, GitHub issue/PR triage with `gh`, code editing, shell execution, and focused tests/typechecks.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

No UI changes; screenshots are not applicable. No user-facing docs changed because this is runtime lifecycle behavior.
