### PR TITLE
feat(adapter-utils): add fetchWithRetry helper for adapter HTTP calls

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   applyPaperclipWorkspaceEnv,
   appendWithByteCap,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  fetchWithRetry,
   renderPaperclipWakePrompt,
   runningProcesses,
   runChildProcess,
@@ -477,5 +478,172 @@ describe("appendWithByteCap", () => {
     expect(output).not.toContain("\uFFFD");
     expect(Buffer.from(output, "utf8").toString("utf8")).toBe(output);
     expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(7);
+  });
+});
+
+describe("fetchWithRetry", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function makeResponse(status: number, headers: Record<string, string> = {}) {
+    return new Response("", { status, headers });
+  }
+
+  it("returns the first successful response without retrying", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await fetchWithRetry("https://example.test", {});
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 429 and returns the eventual 200", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(429))
+      .mockResolvedValueOnce(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { baseDelayMs: 1, maxDelayMs: 1 },
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the last failed response after exhausting retries", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(503));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 1 },
+    );
+
+    expect(res.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry on non-retryable status codes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(400));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { baseDelayMs: 1, maxDelayMs: 1 },
+    );
+
+    expect(res.status).toBe(400);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onRetry with attempt metadata before each wait", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(429, { "retry-after": "0" }))
+      .mockResolvedValueOnce(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const onRetry = vi.fn();
+
+    await fetchWithRetry(
+      "https://example.test",
+      {},
+      {
+        baseDelayMs: 1,
+        maxDelayMs: 1,
+        onRetry,
+      },
+    );
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 1,
+        maxRetries: 3,
+        status: 429,
+        retryAfterHeader: "0",
+      }),
+    );
+  });
+
+  it("treats custom retryableStatuses as retryable (e.g. 403)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(403))
+      .mockResolvedValueOnce(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { baseDelayMs: 1, maxDelayMs: 1, retryableStatuses: [403, 429] },
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("caps Retry-After header value at maxDelayMs", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(429, { "retry-after": "60" }))
+      .mockResolvedValueOnce(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const onRetry = vi.fn();
+    const start = Date.now();
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { baseDelayMs: 1, maxDelayMs: 5, onRetry },
+    );
+
+    const elapsed = Date.now() - start;
+
+    expect(res.status).toBe(200);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ delayMs: 5 }),
+    );
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  it("aborts the request when the per-attempt timeout fires", async () => {
+    const fetchMock = vi.fn((_url: string | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        if (signal) {
+          signal.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      fetchWithRetry(
+        "https://example.test",
+        {},
+        { maxRetries: 0, timeoutMs: 5 },
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -577,8 +577,30 @@ describe("fetchWithRetry", () => {
         attempt: 1,
         maxRetries: 3,
         status: 429,
+        delayMs: 0,
         retryAfterHeader: "0",
       }),
+    );
+  });
+
+  it("treats Retry-After: 0 as 'retry immediately' (delayMs: 0)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(429, { "retry-after": "0" }))
+      .mockResolvedValueOnce(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const onRetry = vi.fn();
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { baseDelayMs: 60_000, maxDelayMs: 60_000, onRetry },
+    );
+
+    expect(res.status).toBe(200);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ delayMs: 0, retryAfterHeader: "0" }),
     );
   });
 

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -2687,6 +2687,8 @@ describe("buildPaperclipEnv", () => {
       const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
       expect(env.PAPERCLIP_API_URL).toBe("http://localhost:3200");
     });
+  });
+});
 
 describe("fetchWithRetry", () => {
   let originalFetch: typeof fetch;
@@ -2784,8 +2786,30 @@ describe("fetchWithRetry", () => {
         attempt: 1,
         maxRetries: 3,
         status: 429,
+        delayMs: 0,
         retryAfterHeader: "0",
       }),
+    );
+  });
+
+  it("treats Retry-After: 0 as 'retry immediately' (delayMs: 0)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(429, { "retry-after": "0" }))
+      .mockResolvedValueOnce(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const onRetry = vi.fn();
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { baseDelayMs: 60_000, maxDelayMs: 60_000, onRetry },
+    );
+
+    expect(res.status).toBe(200);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ delayMs: 0, retryAfterHeader: "0" }),
     );
   });
 

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   applyPaperclipWorkspaceEnv,
   appendWithByteCap,
@@ -12,6 +12,7 @@ import {
   buildInvocationEnvForLogs,
   buildPaperclipEnv,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  fetchWithRetry,
   materializePaperclipSkillCopy,
   refreshPaperclipWorkspaceEnvForExecution,
   renderPaperclipWakePrompt,
@@ -2686,5 +2687,170 @@ describe("buildPaperclipEnv", () => {
       const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
       expect(env.PAPERCLIP_API_URL).toBe("http://localhost:3200");
     });
+
+describe("fetchWithRetry", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function makeResponse(status: number, headers: Record<string, string> = {}) {
+    return new Response("", { status, headers });
+  }
+
+  it("returns the first successful response without retrying", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await fetchWithRetry("https://example.test", {});
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 429 and returns the eventual 200", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(429))
+      .mockResolvedValueOnce(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { baseDelayMs: 1, maxDelayMs: 1 },
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the last failed response after exhausting retries", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(503));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 1 },
+    );
+
+    expect(res.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry on non-retryable status codes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(400));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { baseDelayMs: 1, maxDelayMs: 1 },
+    );
+
+    expect(res.status).toBe(400);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onRetry with attempt metadata before each wait", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(429, { "retry-after": "0" }))
+      .mockResolvedValueOnce(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const onRetry = vi.fn();
+
+    await fetchWithRetry(
+      "https://example.test",
+      {},
+      {
+        baseDelayMs: 1,
+        maxDelayMs: 1,
+        onRetry,
+      },
+    );
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 1,
+        maxRetries: 3,
+        status: 429,
+        retryAfterHeader: "0",
+      }),
+    );
+  });
+
+  it("treats custom retryableStatuses as retryable (e.g. 403)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(403))
+      .mockResolvedValueOnce(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { baseDelayMs: 1, maxDelayMs: 1, retryableStatuses: [403, 429] },
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("caps Retry-After header value at maxDelayMs", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(429, { "retry-after": "60" }))
+      .mockResolvedValueOnce(makeResponse(200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const onRetry = vi.fn();
+    const start = Date.now();
+
+    const res = await fetchWithRetry(
+      "https://example.test",
+      {},
+      { baseDelayMs: 1, maxDelayMs: 5, onRetry },
+    );
+
+    const elapsed = Date.now() - start;
+
+    expect(res.status).toBe(200);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ delayMs: 5 }),
+    );
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  it("aborts the request when the per-attempt timeout fires", async () => {
+    const fetchMock = vi.fn((_url: string | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        if (signal) {
+          signal.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      fetchWithRetry(
+        "https://example.test",
+        {},
+        { maxRetries: 0, timeoutMs: 5 },
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1758,7 +1758,7 @@ export async function fetchWithRetry(
 
     if (retryAfter) {
       const parsed = Number(retryAfter);
-      if (!Number.isNaN(parsed) && parsed > 0) {
+      if (!Number.isNaN(parsed) && parsed >= 0) {
         delayMs = parsed * 1000;
       } else {
         const date = new Date(retryAfter).getTime();

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1667,3 +1667,123 @@ export async function runChildProcess(
       .catch(reject);
   });
 }
+
+/**
+ * Options for `fetchWithRetry`.
+ */
+export interface FetchRetryOptions {
+  /** Maximum number of retry attempts (default: 3). 0 = no retries. */
+  maxRetries?: number;
+  /** Base delay in ms before first retry — doubles each attempt (default: 2000). */
+  baseDelayMs?: number;
+  /** Maximum delay cap in ms (default: 30000). */
+  maxDelayMs?: number;
+  /** HTTP status codes that trigger a retry (default: [429, 502, 503, 504]).
+   *  403 is NOT included by default — pass it explicitly for APIs like Copilot
+   *  that use 403 for TPM rate limits. */
+  retryableStatuses?: number[];
+  /** Optional callback for retry logging. Called before each retry wait. */
+  onRetry?: (info: {
+    attempt: number;
+    maxRetries: number;
+    status: number;
+    delayMs: number;
+    retryAfterHeader?: string | null;
+  }) => void | Promise<void>;
+  /** Request timeout in ms per attempt (default: no timeout). */
+  timeoutMs?: number;
+}
+
+const DEFAULT_RETRYABLE_STATUSES = [429, 502, 503, 504];
+
+/**
+ * Fetch with automatic retry on rate-limit / transient server errors.
+ *
+ * - Respects `Retry-After` header (seconds or HTTP-date) when present.
+ * - Falls back to exponential backoff: baseDelay * 2^attempt, capped at maxDelay.
+ * - Returns the final Response (successful or last failed attempt).
+ * - Throws only on network/abort errors, never on HTTP status codes.
+ *
+ * Adapters that call external HTTP APIs (e.g. provider model-discovery or
+ * token-introspection endpoints) should use this instead of bare `fetch()`
+ * to handle transient rate-limit and server errors gracefully.
+ */
+export async function fetchWithRetry(
+  url: string | URL,
+  init: RequestInit,
+  options: FetchRetryOptions = {},
+): Promise<Response> {
+  const {
+    maxRetries = 3,
+    baseDelayMs = 2000,
+    maxDelayMs = 30_000,
+    retryableStatuses = DEFAULT_RETRYABLE_STATUSES,
+    onRetry,
+    timeoutMs,
+  } = options;
+
+  let lastResponse: Response | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let controller: AbortController | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (timeoutMs && timeoutMs > 0) {
+      controller = new AbortController();
+      timer = setTimeout(() => controller!.abort(), timeoutMs);
+    }
+
+    const signals: AbortSignal[] = [];
+    if (controller?.signal) signals.push(controller.signal);
+    if (init.signal) signals.push(init.signal as AbortSignal);
+    const signal =
+      signals.length > 1
+        ? AbortSignal.any(signals)
+        : signals[0] ?? undefined;
+
+    try {
+      lastResponse = await fetch(url, { ...init, signal });
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+
+    if (lastResponse.ok) return lastResponse;
+
+    if (!retryableStatuses.includes(lastResponse.status) || attempt >= maxRetries) {
+      return lastResponse;
+    }
+
+    const retryAfter = lastResponse.headers.get("retry-after");
+    let delayMs = baseDelayMs * Math.pow(2, attempt);
+
+    if (retryAfter) {
+      const parsed = Number(retryAfter);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        delayMs = parsed * 1000;
+      } else {
+        const date = new Date(retryAfter).getTime();
+        if (!Number.isNaN(date)) {
+          delayMs = Math.max(0, date - Date.now());
+        }
+      }
+    }
+
+    delayMs = Math.min(delayMs, maxDelayMs);
+
+    try { await lastResponse.text(); } catch { /* drain body to free connection */ }
+
+    if (onRetry) {
+      await onRetry({
+        attempt: attempt + 1,
+        maxRetries,
+        status: lastResponse.status,
+        delayMs,
+        retryAfterHeader: retryAfter,
+      });
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  return lastResponse!;
+}

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3529,3 +3529,123 @@ export async function runChildProcess(
       .catch(reject);
   });
 }
+
+/**
+ * Options for `fetchWithRetry`.
+ */
+export interface FetchRetryOptions {
+  /** Maximum number of retry attempts (default: 3). 0 = no retries. */
+  maxRetries?: number;
+  /** Base delay in ms before first retry — doubles each attempt (default: 2000). */
+  baseDelayMs?: number;
+  /** Maximum delay cap in ms (default: 30000). */
+  maxDelayMs?: number;
+  /** HTTP status codes that trigger a retry (default: [429, 502, 503, 504]).
+   *  403 is NOT included by default — pass it explicitly for APIs like Copilot
+   *  that use 403 for TPM rate limits. */
+  retryableStatuses?: number[];
+  /** Optional callback for retry logging. Called before each retry wait. */
+  onRetry?: (info: {
+    attempt: number;
+    maxRetries: number;
+    status: number;
+    delayMs: number;
+    retryAfterHeader?: string | null;
+  }) => void | Promise<void>;
+  /** Request timeout in ms per attempt (default: no timeout). */
+  timeoutMs?: number;
+}
+
+const DEFAULT_RETRYABLE_STATUSES = [429, 502, 503, 504];
+
+/**
+ * Fetch with automatic retry on rate-limit / transient server errors.
+ *
+ * - Respects `Retry-After` header (seconds or HTTP-date) when present.
+ * - Falls back to exponential backoff: baseDelay * 2^attempt, capped at maxDelay.
+ * - Returns the final Response (successful or last failed attempt).
+ * - Throws only on network/abort errors, never on HTTP status codes.
+ *
+ * Adapters that call external HTTP APIs (e.g. provider model-discovery or
+ * token-introspection endpoints) should use this instead of bare `fetch()`
+ * to handle transient rate-limit and server errors gracefully.
+ */
+export async function fetchWithRetry(
+  url: string | URL,
+  init: RequestInit,
+  options: FetchRetryOptions = {},
+): Promise<Response> {
+  const {
+    maxRetries = 3,
+    baseDelayMs = 2000,
+    maxDelayMs = 30_000,
+    retryableStatuses = DEFAULT_RETRYABLE_STATUSES,
+    onRetry,
+    timeoutMs,
+  } = options;
+
+  let lastResponse: Response | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let controller: AbortController | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (timeoutMs && timeoutMs > 0) {
+      controller = new AbortController();
+      timer = setTimeout(() => controller!.abort(), timeoutMs);
+    }
+
+    const signals: AbortSignal[] = [];
+    if (controller?.signal) signals.push(controller.signal);
+    if (init.signal) signals.push(init.signal as AbortSignal);
+    const signal =
+      signals.length > 1
+        ? AbortSignal.any(signals)
+        : signals[0] ?? undefined;
+
+    try {
+      lastResponse = await fetch(url, { ...init, signal });
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+
+    if (lastResponse.ok) return lastResponse;
+
+    if (!retryableStatuses.includes(lastResponse.status) || attempt >= maxRetries) {
+      return lastResponse;
+    }
+
+    const retryAfter = lastResponse.headers.get("retry-after");
+    let delayMs = baseDelayMs * Math.pow(2, attempt);
+
+    if (retryAfter) {
+      const parsed = Number(retryAfter);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        delayMs = parsed * 1000;
+      } else {
+        const date = new Date(retryAfter).getTime();
+        if (!Number.isNaN(date)) {
+          delayMs = Math.max(0, date - Date.now());
+        }
+      }
+    }
+
+    delayMs = Math.min(delayMs, maxDelayMs);
+
+    try { await lastResponse.text(); } catch { /* drain body to free connection */ }
+
+    if (onRetry) {
+      await onRetry({
+        attempt: attempt + 1,
+        maxRetries,
+        status: lastResponse.status,
+        delayMs,
+        retryAfterHeader: retryAfter,
+      });
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  return lastResponse!;
+}

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3620,7 +3620,7 @@ export async function fetchWithRetry(
 
     if (retryAfter) {
       const parsed = Number(retryAfter);
-      if (!Number.isNaN(parsed) && parsed > 0) {
+      if (!Number.isNaN(parsed) && parsed >= 0) {
         delayMs = parsed * 1000;
       } else {
         const date = new Date(retryAfter).getTime();


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The `@paperclipai/adapter-utils` package is the runtime contract every external/in-tree adapter depends on
> - Adapters that hit external HTTP APIs (provider model-discovery, token-introspection, BYOK endpoints) currently each roll their own ad-hoc retry — or skip retry entirely and die on transient 429/503
> - `fetchWithRetry` was first written by @HearthCore inside #3629 (the copilot_local adapter port) and proven in that context against Copilot's `/copilot_internal/user` and `/models` endpoints — but #3629 was a large bundle including the full adapter, so the helper never landed on its own merit
> - This pull request extracts just the helper + tests so it can be reviewed and shipped independently of the larger adapter port
> - The benefit is that any adapter — codex, gemini, claude, copilot, or future community adapters — can drop ad-hoc retry code in favor of one well-tested helper

## Linked Issues or Issue Description

No open issue covers this. Description per `.github/ISSUE_TEMPLATE/enhancement.yml`:

**What existing behavior does this improve?**

HTTP calls from adapters to external provider APIs. Today each adapter implements its own retry, or none.

**Subsystem affected**

`packages/adapter-utils` (shared adapter runtime utilities).

**Current behavior**

Transient provider errors (429, 502, 503, 504) make adapter HTTP calls fail immediately, or hit ad-hoc per-adapter retry code with inconsistent behavior. `Retry-After` headers are not honored consistently. Callers cannot combine cancellation with per-attempt timeouts.

**Proposed behavior**

One shared `fetchWithRetry` helper in `adapter-utils`: configurable retryable statuses, exponential backoff with cap, `Retry-After` support (seconds and HTTP-date), failed-body draining, and per-attempt timeout combined with caller `AbortSignal` via `AbortSignal.any()`.

**Reason and benefit**

Adapters stop dying on transient provider errors. Ad-hoc retry code gets replaced by one tested implementation. Future adapter PRs shrink.

**Breaking changes**

None. Pure addition; no existing export changes.

Related PRs found while searching for duplicates: Refs #3629 (origin of the helper, closed), Refs #1880 (rate-limit backoff helpers `sleep`/`rateLimitBackoffMs` — adjacent, no symbol collision, see Risks), Refs #3231 (opencode-local ad-hoc retry backoff — a potential future consumer of this helper). No duplicate shared-helper PR exists.

## What Changed

- `packages/adapter-utils/src/server-utils.ts`: new `fetchWithRetry(url, init, options)` plus `FetchRetryOptions` interface. Defaults: 3 retries, 2s base delay, 30s cap, retryable on `[429, 502, 503, 504]`. Honors `Retry-After` (seconds or HTTP-date), falls back to exponential backoff, drains failed-response bodies, and combines a per-attempt timeout signal with any caller-provided `AbortSignal` via `AbortSignal.any()` so external cancellation is respected.
- `packages/adapter-utils/src/server-utils.test.ts`: 9 tests covering happy path, retry-then-success on 429, exhaustion (returns last failed response, never throws), non-retryable status pass-through, `onRetry` callback shape, custom `retryableStatuses` (e.g. opt-in 403 for Copilot TPM limits), `Retry-After` cap at `maxDelayMs`, `Retry-After: 0` retry-immediately regression, and per-attempt `timeoutMs` aborting the in-flight request.

## Verification

```bash
pnpm --filter @paperclipai/adapter-utils typecheck
pnpm --filter @paperclipai/adapter-utils build
pnpm exec vitest run --project @paperclipai/adapter-utils packages/adapter-utils/src/server-utils.test.ts
```

All clean locally after the rebase onto `4ffa8de4e`: full file suite 101/101 passing.

## Risks

- **Low risk.** Pure addition — no existing exports renamed or behavior changed. The helper has no module-level side effects and lives in a leaf utility file.
- `AbortSignal.any()` requires Node 20.3+; the workspace already pins `engines.node: ">=20"` and existing code in this file relies on equivalent runtime features.
- Test suite uses `globalThis.fetch` swaps with `vi.fn()` and restores in `afterEach`, scoped to the new `describe` block — does not affect sibling suites.
- Adjacency with #1880 (rate-limit backoff helpers `sleep` / `rateLimitBackoffMs`): no symbol collisions; the two PRs can land in either order. If #1880 merges first, `fetchWithRetry`'s inline `setTimeout`-promise wait can be refactored to consume `sleep` as a follow-up.

## Model Used

- Claude Opus 4.7 (model id `claude-opus-4-7`, 1M-context variant), via Claude Code CLI, with extended thinking enabled at **xhigh** effort tier — multi-step reasoning blocks ran before each tool call and before this PR body. Rebase + Greptile-P1 fix + this template-compliance update: Claude Fable 5 (`claude-fable-5`), extended thinking.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — grepped for `retry`, `fetch`, `adapter-util`, `http`; no matches, no overlap with planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above — searched `retry`, `backoff`, `fetchWithRetry` across open and closed PRs; no duplicate shared-helper PR; related: #1880, #3629, #3231 (linked in the issue-description section)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template — (b), enhancement template, plus `Refs` links to related PRs
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`feat/adapter-utils-fetch-with-retry`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — JSDoc on the exported symbols; no separate doc file in this package
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — Build, Canary Dry Run, all General tests, Greptile Review, Socket Security all pass; the `review` template-compliance check is the one this update addresses and re-runs on the next push
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — Confidence Score 5/5, "The PR appears safe to merge"; the earlier P1 (`Retry-After: 0`) was fixed with a regression test
- [x] I will address all Greptile and reviewer comments before requesting merge

---

Origin: extracted from #3629 by @HearthCore. Splitting it out so the helper can be reviewed in isolation; the full `copilot_local` adapter port stays with #3629's lineage (or the published `@superbiche/copilot-paperclip-adapter` external adapter — already shipped on npm).

Wrote extended thinking at xhigh effort — verify before merge.

---
<sub><em>**[@superbiche](https://github.com/superbiche)** · contributor · drafted with Claude Opus 4.7; rebase and template-compliance update drafted with Claude Fable 5.</em></sub>
