### PR TITLE
fix(routines): self-heal from orphaned routine_execution issues

### DIFF
--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -963,31 +963,91 @@ export function routineService(
           }
 
           const existingIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint);
-          if (!existingIssue) throw error;
-          const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
-          if (manualRunnerUserId) {
-            await touchIssueForUserInbox(txDb, {
-              companyId: input.routine.companyId,
-              issueId: existingIssue.id,
-              userId: manualRunnerUserId,
-              touchedAt: triggeredAt,
+          if (!existingIssue) {
+            // Constraint hit but no live execution found: the prior routine_execution
+            // issue is orphaned (its heartbeat run terminated without reconciling the
+            // issue — typically after a server SIGKILL or an adapter timeout).
+            // Look up the orphan directly, hide it, and retry the create so the
+            // routine can self-heal instead of failing every subsequent dispatch.
+            const orphan = await txDb
+              .select({
+                id: issues.id,
+                identifier: issues.identifier,
+                status: issues.status,
+                updatedAt: issues.updatedAt,
+              })
+              .from(issues)
+              .where(
+                and(
+                  eq(issues.companyId, input.routine.companyId),
+                  eq(issues.originKind, "routine_execution"),
+                  eq(issues.originId, input.routine.id),
+                  isNull(issues.hiddenAt),
+                ),
+              )
+              .orderBy(desc(issues.updatedAt))
+              .limit(1)
+              .then((rows) => rows[0] ?? null);
+            if (!orphan) throw error;
+            logger.warn(
+              {
+                routineId: input.routine.id,
+                orphanIssueId: orphan.id,
+                orphanIdentifier: orphan.identifier,
+                orphanStatus: orphan.status,
+                orphanUpdatedAt: orphan.updatedAt,
+              },
+              "auto-hiding orphaned routine_execution issue with no live heartbeat run",
+            );
+            await txDb
+              .update(issues)
+              .set({ hiddenAt: new Date() })
+              .where(eq(issues.id, orphan.id));
+            createdIssue = await issueSvc.create(input.routine.companyId, {
+              projectId,
+              goalId: input.routine.goalId,
+              parentId: input.routine.parentIssueId,
+              title,
+              description,
+              status: "todo",
+              priority: input.routine.priority,
+              assigneeAgentId,
+              createdByAgentId: input.source === "manual" ? input.actor?.agentId ?? null : null,
+              createdByUserId: manualRunnerUserId,
+              originKind: "routine_execution",
+              originId: input.routine.id,
+              originRunId: createdRun.id,
+              originFingerprint: dispatchFingerprint,
+              executionWorkspaceId: input.executionWorkspaceId ?? null,
+              executionWorkspacePreference: input.executionWorkspacePreference ?? null,
+              executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
             });
+          } else {
+            const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
+            if (manualRunnerUserId) {
+              await touchIssueForUserInbox(txDb, {
+                companyId: input.routine.companyId,
+                issueId: existingIssue.id,
+                userId: manualRunnerUserId,
+                touchedAt: triggeredAt,
+              });
+            }
+            const updated = await finalizeRun(createdRun.id, {
+              status,
+              linkedIssueId: existingIssue.id,
+              coalescedIntoRunId: existingIssue.originRunId,
+              completedAt: triggeredAt,
+            }, txDb);
+            await updateRoutineTouchedState({
+              routineId: input.routine.id,
+              triggerId: input.trigger?.id ?? null,
+              triggeredAt,
+              status,
+              issueId: existingIssue.id,
+              nextRunAt,
+            }, txDb);
+            return updated ?? createdRun;
           }
-          const updated = await finalizeRun(createdRun.id, {
-            status,
-            linkedIssueId: existingIssue.id,
-            coalescedIntoRunId: existingIssue.originRunId,
-            completedAt: triggeredAt,
-          }, txDb);
-          await updateRoutineTouchedState({
-            routineId: input.routine.id,
-            triggerId: input.trigger?.id ?? null,
-            triggeredAt,
-            status,
-            issueId: existingIssue.id,
-            nextRunAt,
-          }, txDb);
-          return updated ?? createdRun;
         }
 
         // Keep the dispatch lock until the issue is linked to a queued heartbeat run.


### PR DESCRIPTION
## What

When a routine's dispatch hits the `issues_open_routine_execution_uq` unique constraint, the recovery path calls `findLiveExecutionIssue()`, which inner-joins `heartbeat_runs` and filters to `LIVE_HEARTBEAT_RUN_STATUSES` (`queued` / `running` / `scheduled_retry`). If the previous run died abnormally (server SIGKILL, adapter timeout, `process_lost`) without reconciling its `routine_execution` issue, that issue is left with `hidden_at IS NULL` but no live heartbeat run linking to it. The join returns null, the original Postgres conflict is rethrown, and the routine fails every subsequent dispatch with `adapter_failed` until someone manually hides the orphan.

This patch teaches the catch block to look up the orphan directly — without the heartbeat join — when `findLiveExecutionIssue` returns null but the constraint genuinely fired. It hides the orphan and retries the create within the same transaction. The routine self-heals, a warning is logged for visibility, and downstream agents can resume work.

## How it was hit

Observed on a self-hosted instance after a Paperclip server SIGKILL left a `Review handoff notifier` issue stranded in `backlog` for 19+ hours. Every subsequent dispatch of that routine failed with:

\`\`\`
duplicate key value violates unique constraint \"issues_open_routine_execution_uq\"
\`\`\`

bubbling up as `adapter_failed` on every assigned agent. Manual remediation: `PATCH /api/issues/<id>` with `{\"hiddenAt\": now()}` to clear the slot. Not great as a recovery story.

## Behavior change

| Before | After |
| --- | --- |
| Orphan blocks routine forever; every fire = `adapter_failed` | Routine self-heals on next fire; orphan auto-hidden, new issue created |
| `findLiveExecutionIssue` returns null → rethrow | Returns null → look up orphan directly → hide → retry create |
| `coalesce_if_active` and `skip_if_active` policies stuck | Both policies recover |
| `always_enqueue` (which already rethrows by design) | Unchanged |

The orphan-hide path is gated on the same `isOpenExecutionConflict` check as the existing coalesce/skip path — if the constraint did not fire, we still rethrow.

## Notes

- The lookup uses `(companyId, originKind = routine_execution, originId, hiddenAt IS NULL)` which is the exact predicate of the unique index — guaranteed to find the orphan if the constraint fired.
- Did not add a test in this PR because the existing test seed pattern always sets `executionRunId` to a live heartbeat run, and synthesizing a true orphan in the test DB needs a second seam I did not want to introduce in a fix-only PR. Happy to add coverage in a follow-up if you have a preferred fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)