### PR TITLE
Fix heartbeat run concurrency limit

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3807,18 +3807,38 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
     }
 
-    const claimedAt = new Date();
-    const claimed = await db
-      .update(heartbeatRuns)
-      .set({
-        status: "running",
-        startedAt: run.startedAt ?? claimedAt,
-        updatedAt: claimedAt,
-      })
-      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
-      .returning()
-      .then((rows) => rows[0] ?? null);
-    if (!claimed) return null;
+    const claimResult = await db.transaction(async (tx) => {
+      await tx.execute(sql`select id from agents where id = ${run.agentId} for update`);
+
+      const txAgent = await tx
+        .select()
+        .from(agents)
+        .where(eq(agents.id, run.agentId))
+        .then((rows) => rows[0] ?? null);
+      if (!txAgent) return null;
+
+      const policy = parseHeartbeatPolicy(txAgent);
+      const [{ count }] = await tx
+        .select({ count: sql<string>`count(*)` })
+        .from(heartbeatRuns)
+        .where(and(eq(heartbeatRuns.agentId, run.agentId), eq(heartbeatRuns.status, "running")));
+      if (Number(count ?? 0) >= policy.maxConcurrentRuns) return null;
+
+      const claimedAt = new Date();
+      const claimed = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "running",
+          startedAt: run.startedAt ?? claimedAt,
+          updatedAt: claimedAt,
+        })
+        .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      return claimed ? { claimed, claimedAt } : null;
+    });
+    if (!claimResult) return null;
+    const { claimed, claimedAt } = claimResult;
 
     publishLiveEvent({
       companyId: claimed.companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Heartbeat scheduling controls when agents receive and execute work.
> - Agent run policy includes `maxConcurrentRuns`, which is intended to cap simultaneous heartbeat runs per agent.
> - The scheduler checked available slots before starting queued runs, but the actual `queued` to `running` claim did not enforce that limit atomically.
> - Concurrent wakeups or multiple server processes could therefore observe free capacity and claim more runs than allowed.
> - This pull request moves the concurrency gate into the run-claim transaction.
> - The benefit is that `maxConcurrentRuns: 1` reliably prevents an agent from starting multiple runs in parallel.

## What Changed

- Revalidated `maxConcurrentRuns` inside `claimQueuedRun()` immediately before transitioning a run from `queued` to `running`.
- Serialized concurrent claims for the same agent with a database row lock on the agent record.
- Kept existing queued-run ordering and dependency checks intact; only the final claim path now enforces the per-agent concurrency limit atomically.

## Verification

- `pnpm --filter @paperclipai/server exec tsc --noEmit`
- `pnpm exec vitest run server/src/__tests__/heartbeat-dependency-scheduling.test.ts`

The targeted Vitest suite includes the existing regression case: `honors maxConcurrentRuns 1 by leaving a second assignment wake queued`.

-- Previous Status with 1 Max concurrent -- 

<img width="334" height="249" alt="image" src="https://github.com/user-attachments/assets/6d0ef509-b899-4458-8452-390b994be1c5" />

-- Current Status with 1 Max concurrent  -- 

<img width="501" height="631" alt="image" src="https://github.com/user-attachments/assets/545b7670-9665-434f-9390-30a77d171b5c" />


## Risks

- Low risk: this changes only the heartbeat run claim path.
- A queued run may remain queued when capacity is full, which is the intended behavior for `maxConcurrentRuns`.
- The transaction now takes a short row lock on the agent during claim; this should be brief because it only counts running runs and updates one queued run.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex coding agent based on GPT-5, with repository file access, shell command execution, git operations, and patch editing tools. Exact context window size was not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
