### PR TITLE
Fix plugin tool routing after activation

### DIFF
--- a/server/src/__tests__/plugin-tool-dispatcher.test.ts
+++ b/server/src/__tests__/plugin-tool-dispatcher.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { createPluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
+
+describe("plugin tool dispatcher", () => {
+  it("routes manifest-key namespaced tools to the installed plugin worker UUID", async () => {
+    const calls: Array<{ pluginId: string; method: string; params: unknown }> = [];
+    const workerManager = {
+      isRunning(pluginId: string) {
+        return pluginId === "plugin-db-id";
+      },
+      async call(pluginId: string, method: string, params: unknown) {
+        calls.push({ pluginId, method, params });
+        return { content: "ok" };
+      },
+    } as unknown as PluginWorkerManager;
+
+    const dispatcher = createPluginToolDispatcher({ workerManager });
+    const manifest = {
+      id: "acme.example",
+      name: "Example",
+      version: "1.0.0",
+      tools: [
+        {
+          name: "lookup",
+          displayName: "Lookup",
+          description: "Look up a record",
+          parametersSchema: { type: "object", properties: {} },
+        },
+      ],
+    } as unknown as PaperclipPluginManifestV1;
+
+    dispatcher.registerPluginTools("acme.example", manifest, "plugin-db-id");
+
+    expect(dispatcher.listToolsForAgent()).toMatchObject([
+      {
+        name: "acme.example:lookup",
+        pluginId: "plugin-db-id",
+      },
+    ]);
+
+    await expect(
+      dispatcher.executeTool(
+        "acme.example:lookup",
+        { query: "customer" },
+        { agentId: "agent-1", runId: "run-1", companyId: "company-1" },
+      ),
+    ).resolves.toMatchObject({
+      pluginId: "acme.example",
+      toolName: "lookup",
+      result: { content: "ok" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      pluginId: "plugin-db-id",
+      method: "executeTool",
+    });
+  });
+});

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1826,7 +1826,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,14 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin key used for tool namespacing
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - The installed plugin database UUID used for worker routing
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +431,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Summary
- pass the installed plugin database UUID through `registerPluginTools` during plugin activation
- preserve manifest-key namespacing while routing execution to the worker UUID
- add a regression test covering list/execute behavior for tools registered through the activation path

Fixes #4094.

## Verification
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/plugin-tool-dispatcher.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Local validation
Applied the equivalent dist patch locally and verified `/api/plugins/tools` reports the installed plugin UUID and `/api/plugins/tools/execute` reaches the Company Knowledge plugin worker.