### PR TITLE
fix(ui): guard against null metadata in IssueChatThread

### DIFF
--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -2635,7 +2635,7 @@ export function IssueChatThread({
       && lastUserId !== lastUserMessageIdRef.current
     ) {
       pendingSubmitScrollRef.current = false;
-      const custom = lastUserMessage?.metadata.custom as { anchorId?: unknown } | undefined;
+      const custom = (lastUserMessage?.metadata?.custom ?? undefined) as { anchorId?: unknown } | undefined;
       const anchorId = typeof custom?.anchorId === "string" ? custom.anchorId : null;
       if (anchorId) {
         const reserve = Math.round(window.innerHeight * SUBMIT_SCROLL_RESERVE_VH);

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -689,7 +689,7 @@ function IssueChatChainOfThought({
   cotParts: readonly IssueChatCoTPart[];
 }) {
   const { agentMap } = useContext(IssueChatCtx);
-  const custom = message.metadata.custom as Record<string, unknown>;
+  const custom = (message.metadata?.custom ?? {}) as Record<string, unknown>;
   const runAgentId = typeof custom.runAgentId === "string" ? custom.runAgentId : null;
   const authorAgentId = typeof custom.authorAgentId === "string" ? custom.authorAgentId : null;
   const agentId = authorAgentId ?? runAgentId;
@@ -1144,7 +1144,7 @@ function IssueChatUserMessage({ message }: { message: ThreadMessage }) {
     currentUserId,
     userProfileMap,
   } = useContext(IssueChatCtx);
-  const custom = message.metadata.custom as Record<string, unknown>;
+  const custom = (message.metadata?.custom ?? {}) as Record<string, unknown>;
   const anchorId = typeof custom.anchorId === "string" ? custom.anchorId : undefined;
   const commentId = typeof custom.commentId === "string" ? custom.commentId : message.id;
   const authorName = typeof custom.authorName === "string" ? custom.authorName : null;
@@ -1301,7 +1301,7 @@ function IssueChatAssistantMessage({ message }: { message: ThreadMessage }) {
     onStopRun,
     stoppingRunId,
   } = useContext(IssueChatCtx);
-  const custom = message.metadata.custom as Record<string, unknown>;
+  const custom = (message.metadata?.custom ?? {}) as Record<string, unknown>;
   const anchorId = typeof custom.anchorId === "string" ? custom.anchorId : undefined;
   const authorName = typeof custom.authorName === "string"
     ? custom.authorName
@@ -1851,7 +1851,7 @@ function IssueChatSystemMessage({ message }: { message: ThreadMessage }) {
     onRejectInteraction,
     onSubmitInteractionAnswers,
   } = useContext(IssueChatCtx);
-  const custom = message.metadata.custom as Record<string, unknown>;
+  const custom = (message.metadata?.custom ?? {}) as Record<string, unknown>;
   const anchorId = typeof custom.anchorId === "string" ? custom.anchorId : undefined;
   const runId = typeof custom.runId === "string" ? custom.runId : null;
   const runAgentId = typeof custom.runAgentId === "string" ? custom.runAgentId : null;


### PR DESCRIPTION
## Summary

Four components in `IssueChatThread.tsx` read `message.metadata.custom` without null-checking `metadata` first. When a message arrives before metadata is populated (streaming, recovery, or edge-case race), this throws a TypeError that crashes the chat thread.

Two other sites in the same file (lines 371, 394) already use the guarded pattern `message.metadata?.custom`. This PR brings the remaining four into alignment:

```ts
// Before
const custom = message.metadata.custom as Record<string, unknown>;

// After
const custom = (message.metadata?.custom ?? {}) as Record<string, unknown>;
```

Supersedes #3309 (same fix, rebased to current master to resolve conflicts).

## Test plan

- [x] All four unguarded sites fixed (lines 692, 1147, 1304, 1854)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
