### PR TITLE
fix(config): log schema validation errors instead of silent fallback

### DIFF
--- a/server/src/config-file.ts
+++ b/server/src/config-file.ts
@@ -10,7 +10,11 @@ export function readConfigFile(): PaperclipConfig | null {
   try {
     const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
     return paperclipConfigSchema.parse(raw);
-  } catch {
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[paperclip] Failed to load config at ${configPath}, falling back to defaults: ${message}`,
+    );
     return null;
   }
 }


### PR DESCRIPTION
## Summary

`readConfigFile()` currently swallows every schema-parse error via `} catch { return null; }` ([config-file.ts](https://github.com/paperclipai/paperclip/blob/master/server/src/config-file.ts#L11-L14)) and falls back to defaults silently. This makes misconfigured `config.json` files extremely hard to diagnose — the symptom is just "my config edits don't take effect."

## Repro

Set `$meta.source` to any value outside its Zod enum (`"onboard" | "configure" | "doctor"`) — or violate any other schema constraint — and `readConfigFile()` returns `null`. The whole `server`, `auth`, `storage`, etc. blocks then fall back to defaults, so:

- Custom `server.host` silently ignored
- `server.allowedHostnames` silently empty (private hostname gate effectively disabled)
- `auth.publicBaseUrl` silently dropped

…with no log output. The user has no idea what failed.

## Fix

Add a single `console.error` in the catch arm with the validation message. Behavior is otherwise identical — still falls back to defaults — but now users see exactly which field was rejected.

## Test plan

- [x] `pnpm -r build` passes
- [x] Manual repro: introduce a schema violation in `config.json` → log line now appears with the Zod issue path/message → defaults still applied (no behavior change)