### PR TITLE
feat(issues): add goalId filter to company issues list endpoint

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -656,6 +656,57 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(projectResult.map((issue) => issue.id).sort()).toEqual([executionLinkedIssueId, projectLinkedIssueId].sort());
   });
 
+  it("filters issues by goalId", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const otherGoalId = randomUUID();
+    const matchingIssueId = randomUUID();
+    const otherGoalIssueId = randomUUID();
+    const noGoalIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(goals).values([
+      { id: goalId, companyId, title: "Target goal", level: "task", status: "active" },
+      { id: otherGoalId, companyId, title: "Other goal", level: "task", status: "active" },
+    ]);
+
+    await db.insert(issues).values([
+      {
+        id: matchingIssueId,
+        companyId,
+        goalId,
+        title: "Matching issue",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: otherGoalIssueId,
+        companyId,
+        goalId: otherGoalId,
+        title: "Other goal issue",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: noGoalIssueId,
+        companyId,
+        title: "No goal issue",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    const result = await svc.list(companyId, { goalId });
+
+    expect(result.map((issue) => issue.id)).toEqual([matchingIssueId]);
+  });
+
   it("hides archived inbox issues until new external activity arrives", async () => {
     const companyId = randomUUID();
     const userId = "user-1";

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -966,6 +966,7 @@ export function issueRoutes(
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
       parentId: req.query.parentId as string | undefined,
       descendantOf: req.query.descendantOf as string | undefined,
+      goalId: req.query.goalId as string | undefined,
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,
       originId: req.query.originId as string | undefined,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -105,6 +105,7 @@ export interface IssueFilters {
   parentId?: string;
   descendantOf?: string;
   labelId?: string;
+  goalId?: string;
   originKind?: string;
   originId?: string;
   includeRoutineExecutions?: boolean;
@@ -2164,6 +2165,7 @@ export function issueService(db: Db) {
         conditions.push(eq(issues.executionWorkspaceId, filters.executionWorkspaceId));
       }
       if (filters?.parentId) conditions.push(eq(issues.parentId, filters.parentId));
+      if (filters?.goalId) conditions.push(eq(issues.goalId, filters.goalId));
       if (filters?.originKind) conditions.push(eq(issues.originKind, filters.originKind));
       if (filters?.originId) conditions.push(eq(issues.originId, filters.originId));
       if (filters?.labelId) {

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -777,7 +777,7 @@ Terminal states: `done`, `cancelled`
 
 | Method | Path                               | Description                                                                              |
 | ------ | ---------------------------------- | ---------------------------------------------------------------------------------------- |
-| GET    | `/api/companies/:companyId/issues` | List issues, sorted by priority. Filters: `?status=`, `?assigneeAgentId=`, `?assigneeUserId=`, `?projectId=`, `?labelId=`, `?q=` (full-text search across title, identifier, description, comments) |
+| GET    | `/api/companies/:companyId/issues` | List issues, sorted by priority. Filters: `?status=`, `?assigneeAgentId=`, `?assigneeUserId=`, `?projectId=`, `?goalId=`, `?labelId=`, `?q=` (full-text search across title, identifier, description, comments) |
 | GET    | `/api/issues/:issueId`             | Issue details + ancestors                                                                |
 | GET    | `/api/issues/:issueId/heartbeat-context` | Compact context for heartbeat: issue state, ancestor summaries, comment cursor  |
 | POST   | `/api/companies/:companyId/issues` | Create issue (supports `blockedByIssueIds: string[]` for dependencies)                   |


### PR DESCRIPTION
## Summary
- Wire `goalId` query parameter through the issues list route, `IssueFilters` interface, and list query builder
- `GET /api/companies/:companyId/issues?goalId={goalId}` now returns only issues matching that goal
- Updated API reference docs to include `goalId` in the filter list
- Added integration test verifying the filter returns only matching issues

## Context
Goal Review routines (running in 5 companies) call this endpoint to list issues under a specific goal, but the `goalId` parameter was silently ignored — returning all company issues instead. This unblocks the weekly "Goals review" routine (step 2).

The `inbox-lite` endpoint uses `svc.list()` with hardcoded agent-specific filters and doesn't expose arbitrary query params, so no change is needed there. The underlying `list()` method now supports `goalId` consistently.

Closes SEC-65

## Test plan
- [x] New integration test: `filters issues by goalId` — creates issues with different goalIds and verifies only the matching one is returned
- [ ] Manual: `curl /api/companies/{id}/issues?goalId={id}` returns filtered results
- [ ] Verify Goal Review routine can now list goal-scoped issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)