### PR TITLE
Fix status-filtered global Issues fetch

### DIFF
--- a/ui/src/components/IssuesList.test.tsx
+++ b/ui/src/components/IssuesList.test.tsx
@@ -783,6 +783,55 @@ describe("IssuesList", () => {
     });
   });
 
+  it("loads list issues from the server when status filters are applied", async () => {
+    localStorage.setItem(
+      "paperclip:test-issues:company-1",
+      JSON.stringify({ statuses: ["blocked"] }),
+    );
+
+    const staleLocalIssue = createIssue({
+      id: "issue-local",
+      title: "Local todo issue",
+      status: "todo",
+    });
+    const blockedServerIssue = createIssue({
+      id: "issue-server-blocked",
+      title: "Blocked server issue outside default slice",
+      status: "blocked",
+    });
+
+    mockIssuesApi.list.mockImplementation((_companyId, filters) => {
+      if (filters?.status === "blocked") return Promise.resolve([blockedServerIssue]);
+      return Promise.resolve([]);
+    });
+
+    const { root } = renderWithQueryClient(
+      <IssuesList
+        issues={[staleLocalIssue]}
+        agents={[]}
+        projects={[]}
+        viewStateKey="paperclip:test-issues"
+        enableRoutineVisibilityFilter
+        remoteStatusFiltering
+        onUpdateIssue={() => undefined}
+      />,
+      container,
+    );
+
+    await waitForAssertion(() => {
+      expect(mockIssuesApi.list).toHaveBeenCalledWith("company-1", expect.objectContaining({
+        status: "blocked",
+        includeRoutineExecutions: true,
+      }));
+      expect(container.textContent).toContain("Blocked server issue outside default slice");
+      expect(container.textContent).not.toContain("Local todo issue");
+    });
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
   it("shows a refinement hint when a board column hits its server cap", async () => {
     localStorage.setItem(
       "paperclip:test-issues:company-1",

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -70,6 +70,7 @@ import { ISSUE_STATUSES, type Issue, type IssueStatus, type Project } from "@pap
 const ISSUE_SEARCH_DEBOUNCE_MS = 250;
 const ISSUE_SEARCH_RESULT_LIMIT = 200;
 const ISSUE_BOARD_COLUMN_RESULT_LIMIT = 200;
+const ISSUE_STATUS_FILTER_RESULT_LIMIT = 1000;
 const INITIAL_ISSUE_ROW_RENDER_LIMIT = 100;
 const ISSUE_ROW_RENDER_BATCH_SIZE = 150;
 const ISSUE_ROW_RENDER_BATCH_DELAY_MS = 0;
@@ -306,6 +307,7 @@ interface IssuesListProps {
   defaultSortField?: IssueSortField;
   showProgressSummary?: boolean;
   enableRoutineVisibilityFilter?: boolean;
+  remoteStatusFiltering?: boolean;
   mutedIssueIds?: Set<string>;
   issueBadgeById?: Map<string, string>;
   onSearchChange?: (search: string) => void;
@@ -475,6 +477,7 @@ export function IssuesList({
   defaultSortField,
   showProgressSummary = false,
   enableRoutineVisibilityFilter = false,
+  remoteStatusFiltering = false,
   mutedIssueIds,
   issueBadgeById,
   onSearchChange,
@@ -574,6 +577,34 @@ export function IssuesList({
       }),
     enabled: !!selectedCompanyId && normalizedIssueSearch.length > 0 && !searchWithinLoadedIssues,
     placeholderData: (previousData) => previousData,
+  });
+  const remoteStatusFilter = viewState.statuses.length > 0 ? viewState.statuses.join(",") : null;
+  const { data: statusFilteredIssues = [] } = useQuery({
+    queryKey: [
+      ...queryKeys.issues.list(selectedCompanyId ?? "__no-company__"),
+      "status-filter",
+      remoteStatusFilter ?? "__all-statuses__",
+      projectId ?? "__all-projects__",
+      searchFilters ?? {},
+      ISSUE_STATUS_FILTER_RESULT_LIMIT,
+      enableRoutineVisibilityFilter ? "with-routine-executions" : "without-routine-executions",
+    ],
+    queryFn: () =>
+      issuesApi.list(selectedCompanyId!, {
+        ...searchFilters,
+        projectId,
+        status: remoteStatusFilter ?? undefined,
+        limit: ISSUE_STATUS_FILTER_RESULT_LIMIT,
+        ...(enableRoutineVisibilityFilter ? { includeRoutineExecutions: true } : {}),
+      }),
+    enabled:
+      !!selectedCompanyId
+      && remoteStatusFiltering
+      && viewState.viewMode === "list"
+      && !searchWithinLoadedIssues
+      && normalizedIssueSearch.length === 0
+      && remoteStatusFilter != null,
+    placeholderData: (previousData: Issue[] | undefined) => previousData,
   });
   const boardIssueQueries = useQueries({
     queries: boardIssueStatuses.map((status) => ({
@@ -813,7 +844,16 @@ export function IssuesList({
 
   const filtered = useMemo(() => {
     const useRemoteSearch = normalizedIssueSearch.length > 0 && !searchWithinLoadedIssues;
-    const sourceIssues = boardIssues ?? (useRemoteSearch ? searchedIssues : issues);
+    const useRemoteStatusFilter =
+      remoteStatusFiltering
+      && viewState.viewMode === "list"
+      && !searchWithinLoadedIssues
+      && normalizedIssueSearch.length === 0
+      && viewState.statuses.length > 0;
+    const sourceIssues = boardIssues
+      ?? (useRemoteSearch
+        ? searchedIssues
+        : (useRemoteStatusFilter ? statusFilteredIssues : issues));
     const searchScopedIssues = normalizedIssueSearch.length > 0 && searchWithinLoadedIssues
       ? sourceIssues.filter((issue) => issueMatchesLocalSearch(issue, normalizedIssueSearch))
       : sourceIssues;
@@ -830,7 +870,9 @@ export function IssuesList({
     boardIssues,
     issues,
     searchedIssues,
+    statusFilteredIssues,
     searchWithinLoadedIssues,
+    remoteStatusFiltering,
     viewState,
     normalizedIssueSearch,
     currentUserId,

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -127,6 +127,7 @@ export function Issues() {
       initialSearch={initialSearch}
       onSearchChange={handleSearchChange}
       enableRoutineVisibilityFilter
+      remoteStatusFiltering
       onUpdateIssue={(id, data) => updateIssue.mutate({ id, data })}
       searchFilters={participantAgentId || workspaceIdFilter ? { participantAgentId, workspaceId: workspaceIdFilter } : undefined}
     />


### PR DESCRIPTION
## Summary
- Add opt-in remote status filtering for the global Issues list view.
- Enable remote status filtering on the global Issues page so blocked/active filters do not run only against the default capped issue slice.
- Add a regression covering a blocked issue returned only by the server-side status request.

## Validation
- pnpm exec vitest run ui/src/pages/Issues.test.tsx ui/src/components/IssuesList.test.tsx
- pnpm --filter @paperclipai/ui typecheck

## Review
- Pravin review required before merge.