### PR TITLE
feat(plugins): allow agent run auth on Plugin SDK tool routes

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -75,6 +75,18 @@ Write tools:
 - `paperclipApprovalDecision`
 - `paperclipAddApprovalComment`
 
+Plugin SDK tools (agent run auth):
+
+- `paperclipPluginListTools`
+- `paperclipPluginExecuteTool`
+- `paperclipPluginApiRequest`
+
+These talk to `/api/plugins/tools*` and `/api/plugins/{pluginId}/api/...` under
+the current agent run's bearer token. `paperclipPluginExecuteTool` defaults the
+`agentId`, `runId`, and `companyId` from the current run; the caller must
+supply the namespaced tool name, `projectId`, and any `parameters` the tool
+declares.
+
 Escape hatch:
 
 - `paperclipApiRequest`

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -161,6 +161,26 @@ const apiRequestSchema = z.object({
   jsonBody: z.string().optional(),
 });
 
+const pluginToolListSchema = z.object({
+  pluginId: z.string().trim().min(1).optional(),
+});
+
+const pluginToolExecuteSchema = z.object({
+  tool: z.string().trim().min(1),
+  parameters: z.unknown().optional(),
+  projectId: z.string().min(1),
+  companyId: companyIdOptional,
+  agentId: agentIdOptional,
+  runId: z.string().uuid().optional().nullable(),
+});
+
+const pluginApiRequestSchema = z.object({
+  method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]),
+  pluginId: z.string().trim().min(1),
+  path: z.string().min(1),
+  jsonBody: z.string().optional(),
+});
+
 const workspaceRuntimeControlTargetSchema = z.object({
   workspaceCommandId: z.string().min(1).optional().nullable(),
   runtimeServiceId: z.string().uuid().optional().nullable(),
@@ -591,6 +611,52 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
         client.requestJson("POST", `/approvals/${encodeURIComponent(approvalId)}/comments`, {
           body: { body },
         }),
+    ),
+    makeTool(
+      "paperclipPluginListTools",
+      "List Plugin SDK tools available to the current agent run, optionally filtered by pluginId",
+      pluginToolListSchema,
+      async ({ pluginId }) => {
+        const qs = pluginId ? `?pluginId=${encodeURIComponent(pluginId)}` : "";
+        return client.requestJson("GET", `/plugins/tools${qs}`);
+      },
+    ),
+    makeTool(
+      "paperclipPluginExecuteTool",
+      "Execute a Plugin SDK tool by its namespaced name (e.g. 'paperclipai.plugin-kb-local:kb_search'). Defaults companyId/agentId/runId from the current run.",
+      pluginToolExecuteSchema,
+      async ({ tool, parameters, projectId, companyId, agentId, runId }) => {
+        const resolvedRunId = runId?.trim() || client.defaults.runId;
+        if (!resolvedRunId) {
+          throw new Error("runId is required because PAPERCLIP_RUN_ID is not set");
+        }
+        return client.requestJson("POST", "/plugins/tools/execute", {
+          body: {
+            tool,
+            parameters: parameters ?? {},
+            runContext: {
+              agentId: client.resolveAgentId(agentId),
+              runId: resolvedRunId,
+              companyId: client.resolveCompanyId(companyId),
+              projectId,
+            },
+          },
+        });
+      },
+    ),
+    makeTool(
+      "paperclipPluginApiRequest",
+      "Make a JSON request to a Plugin SDK scoped API route (/api/plugins/{pluginId}/api/...) for unsupported operations",
+      pluginApiRequestSchema,
+      async ({ method, pluginId, path, jsonBody }) => {
+        if (!path.startsWith("/") || path.includes("..")) {
+          throw new Error("path must start with / and be relative to the plugin scoped API root, and must not contain '..'");
+        }
+        const fullPath = `/plugins/${encodeURIComponent(pluginId)}/api${path}`;
+        return client.requestJson(method, fullPath, {
+          body: parseOptionalJson(jsonBody),
+        });
+      },
     ),
     makeTool(
       "paperclipApiRequest",

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -101,6 +101,18 @@ function boardActor(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function agentActor(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "agent",
+    agentId: agentA,
+    companyId: companyA,
+    runId: runA,
+    source: "agent_jwt",
+    keyId: undefined,
+    ...overrides,
+  };
+}
+
 function readyPlugin() {
   mockRegistry.getById.mockResolvedValue({
     id: pluginId,
@@ -541,5 +553,227 @@ describe.sequential("plugin tool and bridge authz", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ runId: "run-1", jobId: "job-1" });
     expect(scheduler.triggerJob).toHaveBeenCalledWith("job-1", "manual");
+  });
+});
+
+describe.sequential("agent-auth plugin tool access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows agent run auth to list plugin tools", async () => {
+    const tools = [{ name: "paperclipai.plugin-kb-local:kb_search" }];
+    const listToolsForAgent = vi.fn().mockReturnValue(tools);
+    const { app } = await createApp(agentActor(), {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent,
+          getTool: vi.fn(),
+          executeTool: vi.fn(),
+        },
+      },
+    });
+
+    const res = await request(app).get("/api/plugins/tools");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(tools);
+    expect(listToolsForAgent).toHaveBeenCalled();
+  });
+
+  it("rejects unauthenticated callers from listing plugin tools", async () => {
+    const listToolsForAgent = vi.fn();
+    const { app } = await createApp({ type: "none" }, {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent,
+          getTool: vi.fn(),
+          executeTool: vi.fn(),
+        },
+      },
+    });
+
+    const res = await request(app).get("/api/plugins/tools");
+
+    expect(res.status).toBe(401);
+    expect(listToolsForAgent).not.toHaveBeenCalled();
+  });
+
+  it("allows an agent run to execute a tool when runContext matches its identity", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ content: "ok" });
+    const { app } = await createApp(agentActor(), {}, {
+      db: createSelectQueueDb([
+        [{ companyId: companyA }],
+        [{ companyId: companyA, agentId: agentA }],
+        [{ companyId: companyA }],
+      ]),
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclipai.plugin-kb-local:kb_search" })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclipai.plugin-kb-local:kb_search",
+        parameters: { query: "insurance risks" },
+        runContext: {
+          agentId: agentA,
+          runId: runA,
+          companyId: companyA,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(executeTool).toHaveBeenCalledWith(
+      "paperclipai.plugin-kb-local:kb_search",
+      { query: "insurance risks" },
+      {
+        agentId: agentA,
+        runId: runA,
+        companyId: companyA,
+        projectId: projectA,
+      },
+    );
+  });
+
+  it("rejects an agent run when runContext.agentId belongs to a sibling agent", async () => {
+    const otherAgent = "77777777-7777-4777-8777-777777777777";
+    const executeTool = vi.fn();
+    const { app } = await createApp(agentActor(), {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclipai.plugin-kb-local:kb_search" })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclipai.plugin-kb-local:kb_search",
+        parameters: {},
+        runContext: {
+          agentId: otherAgent,
+          runId: runA,
+          companyId: companyA,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("rejects an agent run when runContext.runId differs from the authenticated run", async () => {
+    const otherRun = "88888888-8888-4888-8888-888888888888";
+    const executeTool = vi.fn();
+    const { app } = await createApp(agentActor(), {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclipai.plugin-kb-local:kb_search" })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclipai.plugin-kb-local:kb_search",
+        parameters: {},
+        runContext: {
+          agentId: agentA,
+          runId: otherRun,
+          companyId: companyA,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("rejects an agent run when runContext.companyId differs from the authenticated company", async () => {
+    const executeTool = vi.fn();
+    const { app } = await createApp(agentActor(), {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclipai.plugin-kb-local:kb_search" })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclipai.plugin-kb-local:kb_search",
+        parameters: {},
+        runContext: {
+          agentId: agentA,
+          runId: runA,
+          companyId: companyB,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("requires an agent run id when an agent calls executeTool without one", async () => {
+    const executeTool = vi.fn();
+    const { app } = await createApp(agentActor({ runId: undefined }), {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclipai.plugin-kb-local:kb_search" })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclipai.plugin-kb-local:kb_search",
+        parameters: {},
+        runContext: {
+          agentId: agentA,
+          runId: runA,
+          companyId: companyA,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(401);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("keeps board-only management routes protected from agent run auth", async () => {
+    const { app } = await createApp(agentActor());
+
+    const installRes = await request(app)
+      .post("/api/plugins/install")
+      .send({ packageName: "paperclipai.plugin-kb-local" });
+    expect(installRes.status).toBe(403);
+
+    const listRes = await request(app).get("/api/plugins");
+    expect(listRes.status).toBe(403);
+
+    const upgradeRes = await request(app)
+      .post(`/api/plugins/${pluginId}/upgrade`)
+      .send({});
+    expect(upgradeRes.status).toBe(403);
   });
 });

--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -39,6 +39,27 @@ export function assertInstanceAdmin(req: Request) {
   throw forbidden("Instance admin access required");
 }
 
+/**
+ * Allow either board users with company-or-org access OR authenticated
+ * agent runs. Used by plugin tool discovery and execution routes that
+ * must be reachable from local Codex/Cursor/Claude adapters running under
+ * an agent JWT.
+ *
+ * This helper does NOT compare an actor against any specific company.
+ * Callers must invoke `assertCompanyAccess` separately for any path that
+ * touches per-company state.
+ */
+export function assertBoardOrAgentAccess(req: Request) {
+  assertAuthenticated(req);
+  if (req.actor.type === "agent") {
+    return;
+  }
+  if (req.actor.type === "board" && hasBoardOrgAccess(req)) {
+    return;
+  }
+  throw forbidden("Board or agent access required");
+}
+
 export function assertCompanyAccess(req: Request, companyId: string) {
   assertAuthenticated(req);
   if (req.actor.type === "agent" && req.actor.companyId !== companyId) {

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -60,6 +60,7 @@ import { JsonRpcCallError, PLUGIN_RPC_ERROR_CODES } from "@paperclipai/plugin-sd
 import {
   assertAuthenticated,
   assertBoard,
+  assertBoardOrAgentAccess,
   assertBoardOrgAccess,
   assertCompanyAccess,
   assertInstanceAdmin,
@@ -720,6 +721,13 @@ export function pluginRoutes(
    *
    * List all available plugin-contributed tools in an agent-friendly format.
    *
+   * Authentication:
+   * - Board users with company-or-org access (any active membership or
+   *   instance admin) may list tools across the instance.
+   * - Agent run auth may list tools — the result is the same global set
+   *   because plugin tools are installed instance-wide. Per-call scope
+   *   enforcement happens at execute time via `runContext` validation.
+   *
    * Query params:
    * - `pluginId` (optional): Filter to tools from a specific plugin
    *
@@ -727,7 +735,7 @@ export function pluginRoutes(
    * Errors: 501 if tool dispatcher is not configured
    */
   router.get("/plugins/tools", async (req, res) => {
-    assertBoardOrgAccess(req);
+    assertBoardOrAgentAccess(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
@@ -761,7 +769,7 @@ export function pluginRoutes(
    * - 502 if the plugin worker is unavailable or the RPC call fails
    */
   router.post("/plugins/tools/execute", async (req, res) => {
-    assertBoardOrgAccess(req);
+    assertBoardOrAgentAccess(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
@@ -795,6 +803,26 @@ export function pluginRoutes(
     }
 
     assertCompanyAccess(req, runContext.companyId);
+
+    // For agent callers, the supplied runContext must match the bearer
+    // token's own (companyId, agentId, runId). This prevents an agent run
+    // from impersonating a sibling agent or a different run inside the
+    // same company.
+    if (req.actor.type === "agent") {
+      if (req.actor.agentId && req.actor.agentId !== runContext.agentId) {
+        res.status(403).json({ error: '"runContext.agentId" must match the authenticated agent' });
+        return;
+      }
+      if (req.actor.runId && req.actor.runId !== runContext.runId) {
+        res.status(403).json({ error: '"runContext.runId" must match the authenticated run' });
+        return;
+      }
+      if (!req.actor.runId) {
+        res.status(401).json({ error: "Agent run id required to execute plugin tools" });
+        return;
+      }
+    }
+
     const scopeError = await validateToolRunContextScope(runContext);
     if (scopeError) {
       res.status(403).json({ error: scopeError });


### PR DESCRIPTION
## Summary

Local Codex/Cursor/Claude adapters run under an agent JWT and were rejected by `/api/plugins/tools` and `/api/plugins/tools/execute` with `Board access required`. This blocked agents from discovering and invoking installed Plugin SDK tools (e.g. `paperclipai.plugin-kb-local:kb_search`) inside their heartbeats.

This PR opens the two tool-facing plugin routes to agent run auth, with strict scope enforcement that prevents an agent from impersonating a sibling agent or another run inside the same company. Plugin install/upgrade/enable/disable/config/job-trigger routes remain restricted to instance admins or board users.

It also adds three first-class MCP server tools (`paperclipPluginListTools`, `paperclipPluginExecuteTool`, `paperclipPluginApiRequest`) so adapters that ship the MCP server have a typed entry point instead of relying on `paperclipApiRequest` with hand-built paths.

### Server changes

- New `assertBoardOrAgentAccess` helper in `server/src/routes/authz.ts`.
- `GET /api/plugins/tools` and `POST /api/plugins/tools/execute` now use that helper.
- For agent callers on `executeTool`, `runContext.{agentId,runId,companyId}` must match the bearer token's identity. Existing `validateToolRunContextScope` cross-table checks remain.
- All other plugin lifecycle routes are untouched.

### MCP server changes

- `paperclipPluginListTools` → `GET /api/plugins/tools[?pluginId=...]`
- `paperclipPluginExecuteTool` → `POST /api/plugins/tools/execute`, defaulting `agentId/runId/companyId` from the run.
- `paperclipPluginApiRequest` → escape hatch for plugin-scoped routes under `/api/plugins/{pluginId}/api/...`.
- README updated.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/plugin-routes-authz.test.ts` (server) — 27/27 pass, including 7 new agent-auth cases.
- [x] `pnpm exec vitest run` (mcp-server) — 11/11 pass.
- [x] `pnpm typecheck` (server) — clean.
- [x] `pnpm typecheck` (mcp-server) — clean.
- [ ] Once deployed, run `paperclipPluginExecuteTool` with `paperclipai.plugin-kb-local:kb_search` query `insurance risks` from a real agent run and confirm the API returns the dispatcher result instead of `Board access required`.

## Risk / rollback

- Single-purpose change to two routes plus one new authz helper. Reverting the commit restores the prior behavior with no schema or migration impact.


Made with [Cursor](https://cursor.com)