### PR TITLE
fix(heartbeat): orphan-grandchild zombie runs (force-resolve runChildProcess + PID-validate reaper)

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -249,6 +249,91 @@ describe("runChildProcess", () => {
       }
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "force-resolves when child exits but a grandchild keeps stdio open (MISA-545)",
+    async () => {
+      // Repro of the orphan-grandchild zombie: the immediate child exits
+      // cleanly, but a grandchild it spawned with inherited stdout keeps the
+      // pipe open. Without the exit→close fallback, runChildProcess hangs
+      // forever, locking the agent slot. With the fallback armed at 200ms,
+      // we expect the promise to resolve under ~2s and the run-id entry to
+      // be cleared from runningProcesses.
+      const runId = randomUUID();
+      const startedAt = Date.now();
+      const resultPromise = runChildProcess(
+        runId,
+        process.execPath,
+        [
+          "-e",
+          [
+            "const { spawn } = require('node:child_process');",
+            // Grandchild inherits stdout — it will hold the pipe open and
+            // print 'noise' every 100ms long after the immediate child exits.
+            "const g = spawn(process.execPath, ['-e', \"setInterval(() => process.stdout.write('noise\\\\n'), 100)\"], { stdio: ['ignore', 'inherit', 'ignore'] });",
+            "process.stdout.write(`grandchild:${g.pid}\\n`);",
+            // Immediate child exits 50ms in.
+            "setTimeout(() => process.exit(0), 50);",
+          ].join(" "),
+        ],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          onLog: async () => {},
+          exitCloseFallbackMs: 200,
+        },
+      );
+
+      const result = await resultPromise;
+      const elapsedMs = Date.now() - startedAt;
+
+      // Resolved well under 5s — without the fallback, this would never
+      // settle.
+      expect(elapsedMs).toBeLessThan(5_000);
+      expect(result.exitCode).toBe(0);
+
+      // runningProcesses entry must be cleared so reapOrphanedRuns will
+      // process the run normally and the agent slot is released.
+      expect(runningProcesses.has(runId)).toBe(false);
+
+      // Grandchild should be killed (SIGKILL via process group fired in the
+      // fallback path).
+      const grandchildPid = Number.parseInt(
+        result.stdout.match(/grandchild:(\d+)/)?.[1] ?? "",
+        10,
+      );
+      if (Number.isInteger(grandchildPid) && grandchildPid > 0) {
+        expect(await waitForPidExit(grandchildPid, 2_000)).toBe(true);
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "still resolves via the close handler when grandchildren behave normally",
+    async () => {
+      // Sanity check: when nothing holds stdio open, the normal close path
+      // fires before the exit-fallback timer. Behaviour matches pre-MISA-545.
+      const runId = randomUUID();
+      const result = await runChildProcess(
+        runId,
+        process.execPath,
+        ["-e", "process.stdout.write('done\\n');"],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          onLog: async () => {},
+          exitCloseFallbackMs: 5_000,
+        },
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("done\n");
+      expect(runningProcesses.has(runId)).toBe(false);
+    },
+  );
 });
 
 describe("renderPaperclipWakePrompt", () => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1470,6 +1470,13 @@ export async function runChildProcess(
     terminalResultCleanup?: TerminalResultCleanupOptions;
     stdin?: string;
     remoteExecution?: RemoteExecutionSpec | null;
+    /**
+     * Override the delay after the child's `exit` event before forcing
+     * resolution if `close` hasn't fired (because grandchildren held stdio
+     * open). Defaults to 30s. Set lower in tests; set 0 to disable. See
+     * MISA-545 for the orphan-grandchild zombie scenario.
+     */
+    exitCloseFallbackMs?: number;
   },
 ): Promise<RunProcessResult> {
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
@@ -1625,9 +1632,31 @@ export async function runChildProcess(
           });
         }
 
+        // Fallback for the orphan-grandchild zombie case: when the spawned
+        // child exits but its grandchildren (e.g. MCP servers, tool sub-shells)
+        // inherited stdio and keep the pipes open, node never fires 'close' on
+        // the parent. Without this fallback, the promise never resolves, the
+        // dispatcher's await hangs forever, and runningProcesses never gets
+        // cleared — locking the agent slot until the 60-min silence watchdog.
+        // See MISA-545.
+        let exitFallbackTimer: NodeJS.Timeout | null = null;
+        let exitFallbackKillTimer: NodeJS.Timeout | null = null;
+        let lastExitCode: number | null = null;
+        let lastExitSignal: NodeJS.Signals | null = null;
+        const EXIT_CLOSE_FALLBACK_MS = Math.max(0, opts.exitCloseFallbackMs ?? 30_000);
+        const EXIT_CLOSE_FALLBACK_KILL_MS = 1_000;
+
+        const clearExitFallbackTimers = () => {
+          if (exitFallbackTimer) clearTimeout(exitFallbackTimer);
+          if (exitFallbackKillTimer) clearTimeout(exitFallbackKillTimer);
+          exitFallbackTimer = null;
+          exitFallbackKillTimer = null;
+        };
+
         child.on("error", (err: Error) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearExitFallbackTimers();
           runningProcesses.delete(runId);
           void target.cleanup?.();
           const errno = (err as NodeJS.ErrnoException).code;
@@ -1639,13 +1668,53 @@ export async function runChildProcess(
           reject(new Error(msg));
         });
 
-        child.on("exit", () => {
+        child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
+          lastExitCode = code;
+          lastExitSignal = signal;
           maybeArmTerminalResultCleanup();
+          if (EXIT_CLOSE_FALLBACK_MS === 0 || exitFallbackTimer) return;
+          exitFallbackTimer = setTimeout(() => {
+            exitFallbackTimer = null;
+            // 'close' already fired? runningProcesses.delete in close handler.
+            if (!runningProcesses.has(runId)) return;
+            // Kick lingering grandchildren out of the inherited stdio pipes.
+            try {
+              signalRunningProcess({ child, processGroupId }, "SIGKILL");
+            } catch {
+              // best-effort
+            }
+            // Give SIGKILL a moment to take effect; if 'close' still doesn't
+            // fire, force-resolve from the exit-event data so the dispatcher
+            // can release the agent slot.
+            exitFallbackKillTimer = setTimeout(() => {
+              exitFallbackKillTimer = null;
+              if (!runningProcesses.has(runId)) return;
+              if (timeout) clearTimeout(timeout);
+              clearTerminalCleanupTimers();
+              runningProcesses.delete(runId);
+              void logChain.finally(() => {
+                void Promise.resolve()
+                  .then(() => target.cleanup?.())
+                  .finally(() => {
+                    resolve({
+                      exitCode: lastExitCode,
+                      signal: lastExitSignal,
+                      timedOut,
+                      stdout,
+                      stderr,
+                      pid: child.pid ?? null,
+                      startedAt,
+                    });
+                  });
+              });
+            }, EXIT_CLOSE_FALLBACK_KILL_MS);
+          }, EXIT_CLOSE_FALLBACK_MS);
         });
 
         child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearExitFallbackTimers();
           runningProcesses.delete(runId);
           void logChain.finally(() => {
             void Promise.resolve()

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4357,7 +4357,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const reaped: string[] = [];
 
     for (const { run, adapterType, adapterConfig } of activeRuns) {
-      if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
+      // Validate the in-memory handle: if it's stale (entry exists but the
+      // child PID is dead), drop it so the reaper can finalize the run.
+      // This is belt-and-suspenders for the MISA-545 spawnTracked fix —
+      // without it, any path that fails to clear runningProcesses on exit
+      // (e.g. an unhandled exception in the close handler) leaves the
+      // agent slot locked.
+      const inMemHandle = runningProcesses.get(run.id);
+      if (inMemHandle) {
+        const memChildPid = inMemHandle.child.pid;
+        const memChildAlive = typeof memChildPid === "number" && memChildPid > 0
+          ? isProcessAlive(memChildPid)
+          : false;
+        if (memChildAlive) continue;
+        runningProcesses.delete(run.id);
+      }
+      if (activeRunExecutions.has(run.id)) continue;
 
       // Apply staleness threshold to avoid false positives
       if (staleThresholdMs > 0) {


### PR DESCRIPTION
## Problem

When the immediate child of `runChildProcess` (e.g. Claude CLI) spawns grandchildren (MCP servers, tool sub-shells) that inherit stdio, those grandchildren keep the parent's stdout/stderr pipes open even after the immediate child exits cleanly. Node only fires `child.on('close')` once **all** stdio streams of the spawned child are closed, so close never fires:

- The `runChildProcess` Promise never resolves
- The dispatcher's `await` hangs forever
- `runningProcesses[runId]` never gets cleared
- The agent slot is locked indefinitely

The orphan reaper at `server/src/services/heartbeat.ts` skips these runs because `runningProcesses.has(run.id)` is true. The silent-runs watchdog only triggers after 60 minutes of silence, so a single zombie blocks the agent slot for an hour.

## Real-world evidence

Discovered in a downstream environment after a wave of `process_lost` errors. Concrete repro: Claude CLI completes 116 turns, emits its terminal `{type:result, subtype:success}` line, exits cleanly. Parent receives the stdout chunk but never the close event. Run sits as `status=running` for 30+ minutes with the dead PID still recorded.

Multi-zombie cluster blocked dispatch on 7 agents simultaneously. Existing handle-loss orphan-reap-after-grace covered the *handle-loss* case but not this one — here the in-memory handle is still present, just stale.

## Fix (two commits, defense-in-depth)

### 1. `packages/adapter-utils/src/server-utils.ts` — exit→close fallback

Arm a 30s fallback timer on `child.on('exit')`. If `close` hasn't fired within the window:

1. SIGKILL the process group to evict any grandchildren still holding pipes
2. Wait 1s for SIGKILL to take effect
3. If `close` still hasn't fired, force-resolve the promise from the exit-event data and clean up `runningProcesses`

Configurable via new `exitCloseFallbackMs` opt (default 30s, set to 0 to disable, set lower in tests). The normal close-handler path is untouched — the fallback timer is cleared when close fires first.

### 2. `server/src/services/heartbeat.ts` — reaper PID liveness check

Belt-and-suspenders: in `reapOrphanedRuns`, before trusting `runningProcesses.has(run.id)`, validate the in-memory handle's child PID is actually alive (`isProcessAlive(child.pid)`). If entry exists but PID is dead, drop the map entry and let the run get reaped normally. Expected to never fire if (1) is working correctly, but covers any path where close-handler cleanup gets skipped (unhandled exception, shutdown race).

## Tests

Two new vitest cases in `server-utils.test.ts`:

- `force-resolves when child exits but a grandchild keeps stdio open` — direct repro: spawn a child whose grandchild inherits stdout and runs forever; assert the runChildProcess promise resolves under 5s, runningProcesses entry is cleared, grandchild is killed.
- `still resolves via the close handler when grandchildren behave normally` — regression coverage; normal exits hit the close path before the fallback timer.

Both pass locally (`force-resolves` resolves in ~317ms with a 200ms fallback window).

## Compatibility

- Default `exitCloseFallbackMs` is 30s — accommodates legitimate-grandchild scenarios (large MCP tool calls finishing) without prematurely killing healthy runs.
- Set to 0 to disable entirely (back to current behavior).
- The reaper PID check only acts when `runningProcesses` has an entry AND the PID is dead — false-positive rate near-zero.
- No DB schema changes. No public API additions beyond the new opt.
