### PR TITLE
Add continuation loop guard & token budgets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/cod
   && apt-get update \
   && apt-get install -y --no-install-recommends openssh-client jq \
   && rm -rf /var/lib/apt/lists/* \
+  && curl https://cursor.com/install -fsS | bash \
+  && ln -sf /root/.local/bin/agent /usr/local/bin/agent \
   && mkdir -p /paperclip \
   && chown node:node /paperclip
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -364,7 +364,7 @@ export type FinanceUnit = (typeof FINANCE_UNITS)[number];
 export const BUDGET_SCOPE_TYPES = ["company", "agent", "project"] as const;
 export type BudgetScopeType = (typeof BUDGET_SCOPE_TYPES)[number];
 
-export const BUDGET_METRICS = ["billed_cents"] as const;
+export const BUDGET_METRICS = ["billed_cents", "inference_tokens"] as const;
 export type BudgetMetric = (typeof BUDGET_METRICS)[number];
 
 export const BUDGET_WINDOW_KINDS = ["calendar_month_utc", "lifetime"] as const;

--- a/server/src/__tests__/budgets-service.test.ts
+++ b/server/src/__tests__/budgets-service.test.ts
@@ -151,6 +151,64 @@ describe("budgetService", () => {
     });
   });
 
+  it("creates a hard-stop when monthly inference tokens exceed a token budget", async () => {
+    const policy = {
+      id: "policy-tokens-1",
+      companyId: "company-1",
+      scopeType: "agent",
+      scopeId: "agent-1",
+      metric: "inference_tokens",
+      windowKind: "calendar_month_utc",
+      amount: 1000,
+      warnPercent: 80,
+      hardStopEnabled: true,
+      notifyEnabled: false,
+      isActive: true,
+    };
+
+    const dbStub = createDbStub([
+      [policy],
+      [{ total: 5000 }],
+      [],
+      [{
+        companyId: "company-1",
+        name: "Budget Agent",
+        status: "running",
+        pauseReason: null,
+      }],
+    ]);
+    dbStub.queueInsert([{
+      id: "approval-tokens-1",
+      companyId: "company-1",
+      status: "pending",
+    }]);
+    dbStub.queueInsert([{
+      id: "incident-tokens-1",
+      companyId: "company-1",
+      policyId: "policy-tokens-1",
+      approvalId: "approval-tokens-1",
+    }]);
+    dbStub.queueUpdate([]);
+    const cancelWorkForScope = vi.fn().mockResolvedValue(undefined);
+
+    const service = budgetService(dbStub.db as any, { cancelWorkForScope });
+    await service.evaluateCostEvent({
+      companyId: "company-1",
+      agentId: "agent-1",
+      projectId: null,
+    } as any);
+
+    expect(dbStub.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policyId: "policy-tokens-1",
+        thresholdType: "hard",
+        amountLimit: 1000,
+        amountObserved: 5000,
+      }),
+    );
+    expect(cancelWorkForScope).toHaveBeenCalled();
+  });
+
   it("blocks new work when an agent hard-stop remains exceeded even if the agent is not paused yet", async () => {
     const agentPolicy = {
       id: "policy-agent-1",

--- a/server/src/__tests__/continuation-loop-guard.test.ts
+++ b/server/src/__tests__/continuation-loop-guard.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  areContinuationLoopGuardCommentsSimilar,
+  CONTINUATION_LOOP_GUARD_SIMILARITY_THRESHOLD,
+  cosineSimilarity,
+  normalizeContinuationLoopGuardComment,
+} from "../services/continuation-loop-guard.js";
+
+describe("continuation-loop-guard similarity", () => {
+  it("treats identical normalized bodies as similar", () => {
+    const a = "## Heartbeat\n\nRun abc-123 succeeded.";
+    const b = "## Heartbeat\n\nRun xyz-789 succeeded.";
+    expect(normalizeContinuationLoopGuardComment(a)).toBe(normalizeContinuationLoopGuardComment(b));
+    expect(areContinuationLoopGuardCommentsSimilar(a, b)).toBe(true);
+  });
+
+  it("scores high cosine similarity on paraphrases", () => {
+    const a = "waiting on external reviewer feedback before merging";
+    const b = "still waiting on external reviewer feedback prior to merging";
+    expect(
+      cosineSimilarity(normalizeContinuationLoopGuardComment(a), normalizeContinuationLoopGuardComment(b)),
+    ).toBeGreaterThanOrEqual(CONTINUATION_LOOP_GUARD_SIMILARITY_THRESHOLD);
+    expect(areContinuationLoopGuardCommentsSimilar(a, b)).toBe(true);
+  });
+
+  it("does not classify substantially different updates as similar", () => {
+    const a = "blocked: need prod credentials";
+    const b = "implemented feature and opened pull request";
+    expect(areContinuationLoopGuardCommentsSimilar(a, b)).toBe(false);
+  });
+});

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1390,7 +1390,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   });
 
   it("re-enqueues assigned todo work when the last issue run died and no wake remains", async () => {
-    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+    const { agentId, companyId, issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",
       runStatus: "failed",
     });
@@ -2055,37 +2055,95 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeups).toHaveLength(1);
   });
 
-  it("re-enqueues continuation when the latest automatic continuation succeeded without closing the issue", async () => {
-    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+  it("skips stale continuation recovery when the latest successful continuation only produced similar self-comments", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "succeeded",
       retryReason: "issue_continuation_needed",
     });
+    await db.insert(issueComments).values([
+      {
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        createdByRunId: runId,
+        body: "I am still waiting for input before I can continue.",
+      },
+      {
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        createdByRunId: runId,
+        body: "I am still waiting for input before I can continue.",
+      },
+    ]);
     const heartbeat = heartbeatService(db);
 
     const result = await heartbeat.reconcileStrandedAssignedIssues();
-    expect(result.continuationRequeued).toBe(1);
+    expect(result.continuationRequeued).toBe(0);
     expect(result.escalated).toBe(0);
-    expect(result.issueIds).toEqual([issueId]);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
     expect(issue?.status).toBe("in_progress");
-
-    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
-    expect(comments).toHaveLength(0);
 
     const runs = await db
       .select()
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.agentId, agentId));
-    expect(runs).toHaveLength(2);
+    expect(runs).toHaveLength(1);
 
-    const retryRun = runs.find((row) => row.id !== runId);
-    expect(retryRun?.id).toBeTruthy();
-    expect((retryRun?.contextSnapshot as Record<string, unknown>)?.retryReason).toBe("issue_continuation_needed");
-    if (retryRun) {
-      await waitForRunToSettle(heartbeat, retryRun.id);
-    }
+    const skippedWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId))
+      .then((rows) => rows.find((row) => row.reason === "continuation_loop_guard.similar_recent_comment") ?? null);
+    expect(skippedWake).toBeTruthy();
+    expect(skippedWake?.status).toBe("skipped");
+  });
+
+  it("auto-blocks after repeated similar self-comments without external deltas", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+    });
+    await db.insert(issueComments).values([
+      {
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        createdByRunId: runId,
+        body: "I am still waiting for input before I can continue.",
+      },
+      {
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        createdByRunId: runId,
+        body: "I am still waiting for input before I can continue.",
+      },
+    ]);
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.reconcileStrandedAssignedIssues();
+    await heartbeat.reconcileStrandedAssignedIssues();
+    const third = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(third.escalated).toBe(1);
+    expect(third.issueIds).toEqual([issueId]);
+
+    const blocked = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(blocked?.status).toBe("blocked");
+
+    const autoBlockedWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId))
+      .then((rows) =>
+        rows.find((row) => row.reason === "continuation_loop_guard.auto_blocked") ?? null,
+      );
+    expect(autoBlockedWake).toBeTruthy();
   });
 
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -51,6 +51,7 @@ const mockFeedbackService = vi.hoisted(() => ({
 const mockHeartbeatService = vi.hoisted(() => ({
   wakeup: vi.fn(async () => undefined),
   reportRunActivity: vi.fn(async () => undefined),
+  getContinuationLoopGuardHeartbeatContext: vi.fn(async () => null),
 }));
 
 const mockInstanceSettingsService = vi.hoisted(() => ({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1050,6 +1050,16 @@ export function issueRoutes(
         currentExecutionWorkspacePromise,
       ]);
 
+    let continuationLoopGuardSnapshot = null;
+    if (issue.assigneeAgentId) {
+      try {
+        continuationLoopGuardSnapshot =
+          await heartbeat.getContinuationLoopGuardHeartbeatContext(issue.id, issue.companyId);
+      } catch (err) {
+        logger.warn({ err, issueId: issue.id }, "failed to compute continuation loop guard snapshot");
+      }
+    }
+
     res.json({
       issue: {
         id: issue.id,
@@ -1105,16 +1115,22 @@ export function issueRoutes(
         contentPath: withContentPath(a).contentPath,
         createdAt: a.createdAt,
       })),
-      continuationSummary: continuationSummary
-        ? {
-            key: continuationSummary.key,
-            title: continuationSummary.title,
-            body: continuationSummary.body,
-            latestRevisionId: continuationSummary.latestRevisionId,
-            latestRevisionNumber: continuationSummary.latestRevisionNumber,
-            updatedAt: continuationSummary.updatedAt,
-          }
-        : null,
+      continuationSummary:
+        !continuationSummary && !continuationLoopGuardSnapshot
+          ? null
+          : {
+              ...(continuationSummary
+                ? {
+                    key: continuationSummary.key,
+                    title: continuationSummary.title,
+                    body: continuationSummary.body,
+                    latestRevisionId: continuationSummary.latestRevisionId,
+                    latestRevisionNumber: continuationSummary.latestRevisionNumber,
+                    updatedAt: continuationSummary.updatedAt,
+                  }
+                : {}),
+              ...(continuationLoopGuardSnapshot ? { loopGuard: continuationLoopGuardSnapshot } : {}),
+            },
       currentExecutionWorkspace,
     });
   });

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -143,8 +143,6 @@ async function computeObservedAmount(
   db: Db,
   policy: Pick<PolicyRow, "companyId" | "scopeType" | "scopeId" | "windowKind" | "metric">,
 ) {
-  if (policy.metric !== "billed_cents") return 0;
-
   const conditions = [eq(costEvents.companyId, policy.companyId)];
   if (policy.scopeType === "agent") conditions.push(eq(costEvents.agentId, policy.scopeId));
   if (policy.scopeType === "project") conditions.push(eq(costEvents.projectId, policy.scopeId));
@@ -154,14 +152,28 @@ async function computeObservedAmount(
     conditions.push(lt(costEvents.occurredAt, end));
   }
 
-  const [row] = await db
-    .select({
-      total: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::double precision`,
-    })
-    .from(costEvents)
-    .where(and(...conditions));
+  if (policy.metric === "billed_cents") {
+    const [row] = await db
+      .select({
+        total: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::double precision`,
+      })
+      .from(costEvents)
+      .where(and(...conditions));
+    return Number(row?.total ?? 0);
+  }
 
-  return Number(row?.total ?? 0);
+  if (policy.metric === "inference_tokens") {
+    const [row] = await db
+      .select({
+        total:
+          sql<number>`coalesce(sum(${costEvents.inputTokens} + ${costEvents.cachedInputTokens} + ${costEvents.outputTokens}), 0)::double precision`,
+      })
+      .from(costEvents)
+      .where(and(...conditions));
+    return Number(row?.total ?? 0);
+  }
+
+  return 0;
 }
 
 function buildApprovalPayload(input: {
@@ -566,7 +578,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
           .returning()
           .then((rows) => rows[0]);
 
-      if (input.scopeType === "company" && windowKind === "calendar_month_utc") {
+      if (metric === "billed_cents" && input.scopeType === "company" && windowKind === "calendar_month_utc") {
         await db
           .update(companies)
           .set({
@@ -576,7 +588,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
           .where(eq(companies.id, input.scopeId));
       }
 
-      if (input.scopeType === "agent" && windowKind === "calendar_month_utc") {
+      if (metric === "billed_cents" && input.scopeType === "agent" && windowKind === "calendar_month_utc") {
         await db
           .update(agents)
           .set({
@@ -664,7 +676,9 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
       });
 
       for (const policy of relevantPolicies) {
-        if (policy.metric !== "billed_cents" || policy.amount <= 0) continue;
+        if ((policy.metric !== "billed_cents" && policy.metric !== "inference_tokens") || policy.amount <= 0) {
+          continue;
+        }
         const observedAmount = await computeObservedAmount(db, policy);
         const softThreshold = Math.ceil((policy.amount * policy.warnPercent) / 100);
 
@@ -752,7 +766,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         };
       }
 
-      const companyPolicy = await db
+      const companyPolicies = await db
         .select()
         .from(budgetPolicies)
         .where(
@@ -761,18 +775,21 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
             eq(budgetPolicies.scopeType, "company"),
             eq(budgetPolicies.scopeId, companyId),
             eq(budgetPolicies.isActive, true),
-            eq(budgetPolicies.metric, "billed_cents"),
+            inArray(budgetPolicies.metric, ["billed_cents", "inference_tokens"]),
           ),
-        )
-        .then((rows) => rows[0] ?? null);
-      if (companyPolicy && companyPolicy.hardStopEnabled && companyPolicy.amount > 0) {
+        );
+      for (const companyPolicy of companyPolicies) {
+        if (!companyPolicy.hardStopEnabled || companyPolicy.amount <= 0) continue;
         const observed = await computeObservedAmount(db, companyPolicy);
         if (observed >= companyPolicy.amount) {
           return {
             scopeType: "company" as const,
             scopeId: companyId,
             scopeName: company.name,
-            reason: "Company cannot start new work because its budget hard-stop is exceeded.",
+            reason:
+              companyPolicy.metric === "inference_tokens"
+                ? "Company cannot start new work because its monthly inference token limit is exceeded."
+                : "Company cannot start new work because its budget hard-stop is exceeded.",
           };
         }
       }
@@ -786,7 +803,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         };
       }
 
-      const agentPolicy = await db
+      const agentPolicies = await db
         .select()
         .from(budgetPolicies)
         .where(
@@ -795,18 +812,21 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
             eq(budgetPolicies.scopeType, "agent"),
             eq(budgetPolicies.scopeId, agentId),
             eq(budgetPolicies.isActive, true),
-            eq(budgetPolicies.metric, "billed_cents"),
+            inArray(budgetPolicies.metric, ["billed_cents", "inference_tokens"]),
           ),
-        )
-        .then((rows) => rows[0] ?? null);
-      if (agentPolicy && agentPolicy.hardStopEnabled && agentPolicy.amount > 0) {
+        );
+      for (const agentPolicy of agentPolicies) {
+        if (!agentPolicy.hardStopEnabled || agentPolicy.amount <= 0) continue;
         const observed = await computeObservedAmount(db, agentPolicy);
         if (observed >= agentPolicy.amount) {
           return {
             scopeType: "agent" as const,
             scopeId: agentId,
             scopeName: agent.name,
-            reason: "Agent cannot start because its budget hard-stop is still exceeded.",
+            reason:
+              agentPolicy.metric === "inference_tokens"
+                ? "Agent cannot start because its monthly inference token limit is still exceeded."
+                : "Agent cannot start because its budget hard-stop is still exceeded.",
           };
         }
       }
@@ -827,7 +847,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         .then((rows) => rows[0] ?? null);
 
       if (!project || project.companyId !== companyId) return null;
-      const projectPolicy = await db
+      const projectPolicies = await db
         .select()
         .from(budgetPolicies)
         .where(
@@ -836,18 +856,21 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
             eq(budgetPolicies.scopeType, "project"),
             eq(budgetPolicies.scopeId, project.id),
             eq(budgetPolicies.isActive, true),
-            eq(budgetPolicies.metric, "billed_cents"),
+            inArray(budgetPolicies.metric, ["billed_cents", "inference_tokens"]),
           ),
-        )
-        .then((rows) => rows[0] ?? null);
-      if (projectPolicy && projectPolicy.hardStopEnabled && projectPolicy.amount > 0) {
+        );
+      for (const projectPolicy of projectPolicies) {
+        if (!projectPolicy.hardStopEnabled || projectPolicy.amount <= 0) continue;
         const observed = await computeObservedAmount(db, projectPolicy);
         if (observed >= projectPolicy.amount) {
           return {
             scopeType: "project" as const,
             scopeId: project.id,
             scopeName: project.name,
-            reason: "Project cannot start work because its budget hard-stop is still exceeded.",
+            reason:
+              projectPolicy.metric === "inference_tokens"
+                ? "Project cannot start work because its inference token limit is still exceeded."
+                : "Project cannot start work because its budget hard-stop is still exceeded.",
           };
         }
       }
@@ -894,14 +917,14 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
           })
           .where(eq(budgetPolicies.id, policy.id));
 
-        if (policy.scopeType === "company" && policy.windowKind === "calendar_month_utc") {
+        if (policy.metric === "billed_cents" && policy.scopeType === "company" && policy.windowKind === "calendar_month_utc") {
           await db
             .update(companies)
             .set({ budgetMonthlyCents: nextAmount, updatedAt: now })
             .where(eq(companies.id, policy.scopeId));
         }
 
-        if (policy.scopeType === "agent" && policy.windowKind === "calendar_month_utc") {
+        if (policy.metric === "billed_cents" && policy.scopeType === "agent" && policy.windowKind === "calendar_month_utc") {
           await db
             .update(agents)
             .set({ budgetMonthlyCents: nextAmount, updatedAt: now })

--- a/server/src/services/continuation-loop-guard.ts
+++ b/server/src/services/continuation-loop-guard.ts
@@ -1,0 +1,44 @@
+/**
+ * Helpers for continuation recovery loop guard (dedupe self-sustaining continuation wakes).
+ */
+/** Bag-of-words cosine; ~0.75+ matches terse paraphrases with shared vocabulary. */
+export const CONTINUATION_LOOP_GUARD_SIMILARITY_THRESHOLD = 0.75;
+
+export function normalizeContinuationLoopGuardComment(body: string) {
+  return body
+    .toLowerCase()
+    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi, "<uuid>")
+    .replace(/\b\d{4}-\d{2}-\d{2}(?:[t\s]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?(?:z|[+-]\d{2}:?\d{2})?)?\b/gi, "<timestamp>")
+    .replace(/\b(?:run|comment|heartbeat|wake)[-_ ]?(?:id)?[:#]?\s*[a-z0-9_-]{6,}\b/gi, "<volatile-id>")
+    .replace(/https?:\/\/\S+/gi, "<url>")
+    .replace(/[^\p{L}\p{N}<>\s_-]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function cosineSimilarity(left: string, right: string) {
+  const leftTokens = left.split(/\s+/).filter(Boolean);
+  const rightTokens = right.split(/\s+/).filter(Boolean);
+  if (leftTokens.length === 0 || rightTokens.length === 0) return 0;
+
+  const leftCounts = new Map<string, number>();
+  const rightCounts = new Map<string, number>();
+  for (const token of leftTokens) leftCounts.set(token, (leftCounts.get(token) ?? 0) + 1);
+  for (const token of rightTokens) rightCounts.set(token, (rightCounts.get(token) ?? 0) + 1);
+
+  let dot = 0;
+  for (const [token, count] of leftCounts) {
+    dot += count * (rightCounts.get(token) ?? 0);
+  }
+  const leftMagnitude = Math.sqrt([...leftCounts.values()].reduce((sum, count) => sum + count * count, 0));
+  const rightMagnitude = Math.sqrt([...rightCounts.values()].reduce((sum, count) => sum + count * count, 0));
+  if (leftMagnitude === 0 || rightMagnitude === 0) return 0;
+  return dot / (leftMagnitude * rightMagnitude);
+}
+
+export function areContinuationLoopGuardCommentsSimilar(leftBody: string, rightBody: string) {
+  const left = normalizeContinuationLoopGuardComment(leftBody);
+  const right = normalizeContinuationLoopGuardComment(rightBody);
+  if (!left || !right) return false;
+  return left === right || cosineSimilarity(left, right) >= CONTINUATION_LOOP_GUARD_SIMILARITY_THRESHOLD;
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7,6 +7,7 @@ import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lte, notInArr
 import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
+  buildAgentMentionHref,
   ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
   isEnvironmentDriverSupportedForAdapter,
   type BillingType,
@@ -126,6 +127,7 @@ import { environmentService } from "./environments.js";
 import { environmentRuntimeService } from "./environment-runtime.js";
 import { environmentRunOrchestrator } from "./environment-run-orchestrator.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
+import { areContinuationLoopGuardCommentsSimilar } from "./continuation-loop-guard.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const MAX_PERSISTED_LOG_CHUNK_CHARS = 64 * 1024;
@@ -1012,6 +1014,10 @@ function didAutomaticRecoveryFail(
     )
   );
 }
+
+const CONTINUATION_LOOP_GUARD_SKIP_REASON = "continuation_loop_guard.similar_recent_comment";
+const CONTINUATION_LOOP_GUARD_AUTO_BLOCK_REASON = "continuation_loop_guard.auto_blocked";
+const CONTINUATION_LOOP_GUARD_BLOCK_THRESHOLD = 3;
 
 function normalizeLedgerBillingType(value: unknown): BillingType {
   const raw = readNonEmptyString(value);
@@ -4473,8 +4479,757 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
   }
 
+  async function getLatestIssueRun(companyId: string, issueId: string) {
+    return db
+      .select({
+        id: heartbeatRuns.id,
+        status: heartbeatRuns.status,
+        error: heartbeatRuns.error,
+        errorCode: heartbeatRuns.errorCode,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function hasActiveExecutionPath(companyId: string, issueId: string) {
+    const [run, deferredWake] = await Promise.all([
+      db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, companyId),
+            inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: agentWakeupRequests.id })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.status, "deferred_issue_execution"),
+            sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    return Boolean(run || deferredWake);
+  }
+
+  async function getLatestSuccessfulIssueRun(companyId: string, issueId: string, agentId: string) {
+    return db
+      .select({
+        id: heartbeatRuns.id,
+        createdAt: heartbeatRuns.createdAt,
+        finishedAt: heartbeatRuns.finishedAt,
+        updatedAt: heartbeatRuns.updatedAt,
+      })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.status, "succeeded"),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.finishedAt), desc(heartbeatRuns.updatedAt), desc(heartbeatRuns.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function hasExternalContinuationDelta(input: {
+    companyId: string;
+    issueId: string;
+    agentId: string;
+    since: Date;
+  }) {
+    const [comment, issueActivity, documentRevision, relation, approvalApproved] = await Promise.all([
+      db
+        .select({ id: issueComments.id })
+        .from(issueComments)
+        .where(
+          and(
+            eq(issueComments.companyId, input.companyId),
+            eq(issueComments.issueId, input.issueId),
+            gt(issueComments.createdAt, input.since),
+            or(
+              sql`${issueComments.authorUserId} is not null`,
+              and(
+                sql`${issueComments.authorAgentId} is not null`,
+                sql`${issueComments.authorAgentId} <> ${input.agentId}`,
+              ),
+            ),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: activityLog.id })
+        .from(activityLog)
+        .where(
+          and(
+            eq(activityLog.companyId, input.companyId),
+            eq(activityLog.entityType, "issue"),
+            eq(activityLog.entityId, input.issueId),
+            gt(activityLog.createdAt, input.since),
+            inArray(activityLog.action, [
+              "issue.updated",
+              "issue.blockers_updated",
+              "issue.reviewers_updated",
+              "issue.approvers_updated",
+              "issue.approval_linked",
+              "issue.approval_unlinked",
+            ]),
+            or(
+              eq(activityLog.actorType, "user"),
+              and(
+                eq(activityLog.actorType, "agent"),
+                sql`${activityLog.agentId} <> ${input.agentId}`,
+              ),
+            ),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: documentRevisions.id })
+        .from(documentRevisions)
+        .innerJoin(issueDocuments, eq(documentRevisions.documentId, issueDocuments.documentId))
+        .where(
+          and(
+            eq(documentRevisions.companyId, input.companyId),
+            eq(issueDocuments.companyId, input.companyId),
+            eq(issueDocuments.issueId, input.issueId),
+            gt(documentRevisions.createdAt, input.since),
+            sql`${issueDocuments.key} != ${ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY}`,
+            or(
+              sql`${documentRevisions.createdByUserId} is not null`,
+              and(
+                sql`${documentRevisions.createdByAgentId} is not null`,
+                sql`${documentRevisions.createdByAgentId} <> ${input.agentId}`,
+              ),
+            ),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: issueRelations.id })
+        .from(issueRelations)
+        .where(
+          and(
+            eq(issueRelations.companyId, input.companyId),
+            or(eq(issueRelations.issueId, input.issueId), eq(issueRelations.relatedIssueId, input.issueId)),
+            gt(issueRelations.updatedAt, input.since),
+            or(
+              sql`${issueRelations.createdByUserId} is not null`,
+              and(
+                sql`${issueRelations.createdByAgentId} is not null`,
+                sql`${issueRelations.createdByAgentId} <> ${input.agentId}`,
+              ),
+            ),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: activityLog.id })
+        .from(activityLog)
+        .where(
+          and(
+            eq(activityLog.companyId, input.companyId),
+            eq(activityLog.action, "approval.approved"),
+            gt(activityLog.createdAt, input.since),
+            sql`exists (
+              select 1
+              from jsonb_array_elements_text(coalesce(${activityLog.details}->'linkedIssueIds', '[]'::jsonb)) as approval_issue_ids(value)
+              where approval_issue_ids.value = ${input.issueId}
+            )`,
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    return Boolean(comment || issueActivity || documentRevision || relation || approvalApproved);
+  }
+
+  async function getRecentAgentIssueComments(companyId: string, issueId: string, agentId: string) {
+    return db
+      .select({
+        id: issueComments.id,
+        body: issueComments.body,
+        createdAt: issueComments.createdAt,
+      })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, companyId),
+          eq(issueComments.issueId, issueId),
+          eq(issueComments.authorAgentId, agentId),
+        ),
+      )
+      .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+      .limit(2);
+  }
+
+  async function countPriorContinuationLoopGuardAttempts(input: {
+    companyId: string;
+    issueId: string;
+    agentId: string;
+    since: Date;
+  }) {
+    const [row] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, input.companyId),
+          eq(agentWakeupRequests.agentId, input.agentId),
+          eq(agentWakeupRequests.status, "skipped"),
+          gt(agentWakeupRequests.createdAt, input.since),
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${input.issueId}`,
+          sql`${agentWakeupRequests.reason} like 'continuation_loop_guard.%'`,
+        ),
+      );
+    return Number(row?.count ?? 0);
+  }
+
+  async function evaluateContinuationLoopGuard(input: {
+    issue: typeof issues.$inferSelect;
+    agent: typeof agents.$inferSelect;
+  }) {
+    const latestSuccessfulRun = await getLatestSuccessfulIssueRun(
+      input.issue.companyId,
+      input.issue.id,
+      input.agent.id,
+    );
+    if (!latestSuccessfulRun) {
+      return {
+        shouldSkip: false,
+        shouldBlock: false,
+        externalDeltaSignal: true,
+        similarRecentComment: false,
+        staleWakeAttempts: 0,
+        latestSuccessfulRunId: null,
+      };
+    }
+
+    const since =
+      latestSuccessfulRun.finishedAt ??
+      latestSuccessfulRun.updatedAt ??
+      latestSuccessfulRun.createdAt;
+    const externalDeltaSignal = await hasExternalContinuationDelta({
+      companyId: input.issue.companyId,
+      issueId: input.issue.id,
+      agentId: input.agent.id,
+      since,
+    });
+    if (externalDeltaSignal) {
+      return {
+        shouldSkip: false,
+        shouldBlock: false,
+        externalDeltaSignal,
+        similarRecentComment: false,
+        staleWakeAttempts: 0,
+        latestSuccessfulRunId: latestSuccessfulRun.id,
+      };
+    }
+
+    const recentComments = await getRecentAgentIssueComments(input.issue.companyId, input.issue.id, input.agent.id);
+    const similarRecentComment =
+      recentComments.length >= 2 &&
+      areContinuationLoopGuardCommentsSimilar(recentComments[0]!.body, recentComments[1]!.body);
+    if (!similarRecentComment) {
+      return {
+        shouldSkip: false,
+        shouldBlock: false,
+        externalDeltaSignal,
+        similarRecentComment,
+        staleWakeAttempts: 0,
+        latestSuccessfulRunId: latestSuccessfulRun.id,
+      };
+    }
+
+    const staleWakeAttempts = await countPriorContinuationLoopGuardAttempts({
+      companyId: input.issue.companyId,
+      issueId: input.issue.id,
+      agentId: input.agent.id,
+      since,
+    }).then((priorAttempts) => priorAttempts + 1);
+
+    return {
+      shouldSkip: true,
+      shouldBlock: staleWakeAttempts >= CONTINUATION_LOOP_GUARD_BLOCK_THRESHOLD,
+      externalDeltaSignal,
+      similarRecentComment,
+      staleWakeAttempts,
+      latestSuccessfulRunId: latestSuccessfulRun.id,
+    };
+  }
+
+  async function insertContinuationLoopGuardSkippedWake(input: {
+    issue: typeof issues.$inferSelect;
+    agentId: string;
+    staleWakeAttempts: number;
+    latestSuccessfulRunId: string | null;
+    reason?: string;
+  }) {
+    await db.insert(agentWakeupRequests).values({
+      companyId: input.issue.companyId,
+      agentId: input.agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: input.reason ?? CONTINUATION_LOOP_GUARD_SKIP_REASON,
+      payload: {
+        issueId: input.issue.id,
+        staleWakeAttempts: input.staleWakeAttempts,
+        latestSuccessfulRunId: input.latestSuccessfulRunId,
+        loopGuard: {
+          externalDeltaSignal: false,
+          similarRecentComment: true,
+          staleWakeAttempts: input.staleWakeAttempts,
+          autoBlocked: input.reason === CONTINUATION_LOOP_GUARD_AUTO_BLOCK_REASON,
+        },
+      },
+      status: "skipped",
+      requestedByActorType: "system",
+      requestedByActorId: "heartbeat.continuation_loop_guard",
+      finishedAt: new Date(),
+    });
+  }
+
+  async function buildContinuationLoopGuardAutoBlockedComment(input: {
+    agent: typeof agents.$inferSelect;
+    staleWakeAttempts: number;
+  }) {
+    const manager = input.agent.reportsTo
+      ? await db
+        .select({ id: agents.id, name: agents.name, icon: agents.icon })
+        .from(agents)
+        .where(and(eq(agents.companyId, input.agent.companyId), eq(agents.id, input.agent.reportsTo)))
+        .then((rows) => rows[0] ?? null)
+      : null;
+    const managerMention = manager
+      ? `\n\nManager: [@${manager.name}](${buildAgentMentionHref(manager.id, manager.icon)})`
+      : "";
+
+    return [
+      `Loop guard: ${input.staleWakeAttempts} continuation heartbeats without an external signal, auto-blocked.`,
+      "",
+      "Reason: `stale_no_external_signal`.",
+      "",
+      "To unblock: add a new external comment, change upstream status/blockers, or resolve a blocker.",
+      managerMention,
+    ].filter(Boolean).join("\n");
+  }
+
+  async function enqueueStrandedIssueRecovery(input: {
+    issueId: string;
+    agentId: string;
+    reason: "issue_assignment_recovery" | "issue_continuation_needed";
+    retryReason: "assignment_recovery" | "issue_continuation_needed";
+    source: string;
+    retryOfRunId?: string | null;
+  }) {
+    const queued = await enqueueWakeup(input.agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: input.reason,
+      payload: {
+        issueId: input.issueId,
+        ...(input.retryOfRunId ? { retryOfRunId: input.retryOfRunId } : {}),
+      },
+      requestedByActorType: "system",
+      requestedByActorId: null,
+      contextSnapshot: {
+        issueId: input.issueId,
+        taskId: input.issueId,
+        wakeReason: input.reason,
+        retryReason: input.retryReason,
+        source: input.source,
+        ...(input.retryOfRunId ? { retryOfRunId: input.retryOfRunId } : {}),
+      },
+    });
+
+    if (queued && input.retryOfRunId) {
+      return db
+        .update(heartbeatRuns)
+        .set({
+          retryOfRunId: input.retryOfRunId,
+          updatedAt: new Date(),
+        })
+        .where(eq(heartbeatRuns.id, queued.id))
+        .returning()
+        .then((rows) => rows[0] ?? queued);
+    }
+
+    return queued;
+  }
+
+  function formatIssueLinksForComment(relations: Array<{ identifier?: string | null }>) {
+    const identifiers = [
+      ...new Set(
+        relations
+          .map((relation) => relation.identifier)
+          .filter((identifier): identifier is string => Boolean(identifier)),
+      ),
+    ];
+    if (identifiers.length === 0) return "another open issue";
+    return identifiers
+      .slice(0, 5)
+      .map((identifier) => {
+        const prefix = identifier.split("-")[0] || "PAP";
+        return `[${identifier}](/${prefix}/issues/${identifier})`;
+      })
+      .join(", ");
+  }
+
+  async function reconcileUnassignedBlockingIssues() {
+    const candidates = await db
+      .select({
+        id: issues.id,
+        companyId: issues.companyId,
+        identifier: issues.identifier,
+        status: issues.status,
+        createdByAgentId: issues.createdByAgentId,
+      })
+      .from(issueRelations)
+      .innerJoin(issues, eq(issueRelations.issueId, issues.id))
+      .where(
+        and(
+          eq(issueRelations.type, "blocks"),
+          inArray(issues.status, ["todo", "blocked"]),
+          isNull(issues.assigneeAgentId),
+          isNull(issues.assigneeUserId),
+          sql`${issues.createdByAgentId} is not null`,
+          sql`exists (
+            select 1
+            from issues blocked_issue
+            where blocked_issue.id = ${issueRelations.relatedIssueId}
+              and blocked_issue.company_id = ${issues.companyId}
+              and blocked_issue.status not in ('done', 'cancelled')
+          )`,
+        ),
+      );
+
+    let assigned = 0;
+    let skipped = 0;
+    const issueIds: string[] = [];
+    const seen = new Set<string>();
+
+    for (const candidate of candidates) {
+      if (seen.has(candidate.id)) continue;
+      seen.add(candidate.id);
+
+      const creatorAgentId = candidate.createdByAgentId;
+      if (!creatorAgentId) {
+        skipped += 1;
+        continue;
+      }
+      const creatorAgent = await getAgent(creatorAgentId);
+      if (
+        !creatorAgent ||
+        creatorAgent.companyId !== candidate.companyId ||
+        creatorAgent.status === "paused" ||
+        creatorAgent.status === "terminated" ||
+        creatorAgent.status === "pending_approval"
+      ) {
+        skipped += 1;
+        continue;
+      }
+
+      const relations = await issuesSvc.getRelationSummaries(candidate.id);
+      const blockingLinks = formatIssueLinksForComment(relations.blocks);
+      const updated = await issuesSvc.update(candidate.id, {
+        assigneeAgentId: creatorAgent.id,
+        assigneeUserId: null,
+      });
+      if (!updated) {
+        skipped += 1;
+        continue;
+      }
+
+      await issuesSvc.addComment(
+        candidate.id,
+        [
+          "## Assigned Orphan Blocker",
+          "",
+          `Paperclip found this issue is blocking ${blockingLinks} but had no assignee, so no heartbeat could pick it up.`,
+          "",
+          "- Assigned it back to the agent that created the blocker.",
+          "- Next action: resolve this blocker or reassign it to the right owner.",
+        ].join("\n"),
+        {},
+      );
+
+      await logActivity(db, {
+        companyId: candidate.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: candidate.id,
+        details: {
+          identifier: candidate.identifier,
+          assigneeAgentId: creatorAgent.id,
+          source: "heartbeat.reconcile_unassigned_blocking_issue",
+        },
+      });
+
+      const queued = await enqueueWakeup(creatorAgent.id, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: {
+          issueId: candidate.id,
+          mutation: "unassigned_blocker_recovery",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        contextSnapshot: {
+          issueId: candidate.id,
+          taskId: candidate.id,
+          wakeReason: "issue_assigned",
+          source: "issue.unassigned_blocker_recovery",
+        },
+      });
+
+      if (queued) {
+        assigned += 1;
+        issueIds.push(candidate.id);
+      } else {
+        skipped += 1;
+      }
+    }
+
+    return { assigned, skipped, issueIds };
+  }
+
+  async function escalateStrandedAssignedIssue(input: {
+    issue: typeof issues.$inferSelect;
+    previousStatus: "todo" | "in_progress";
+    latestRun: Pick<
+      typeof heartbeatRuns.$inferSelect,
+      "id" | "status" | "error" | "errorCode" | "contextSnapshot"
+    > | null;
+    comment: string;
+  }) {
+    const updated = await issuesSvc.update(input.issue.id, {
+      status: "blocked",
+    });
+    if (!updated) return null;
+
+    await issuesSvc.addComment(input.issue.id, input.comment, {});
+
+    await logActivity(db, {
+      companyId: input.issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: null,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: input.issue.id,
+      details: {
+        identifier: input.issue.identifier,
+        status: "blocked",
+        previousStatus: input.previousStatus,
+        source: "heartbeat.reconcile_stranded_assigned_issue",
+        latestRunId: input.latestRun?.id ?? null,
+        latestRunStatus: input.latestRun?.status ?? null,
+        latestRunErrorCode: input.latestRun?.errorCode ?? null,
+      },
+    });
+
+    return updated;
+  }
+
   async function reconcileStrandedAssignedIssues() {
-    return recovery.reconcileStrandedAssignedIssues();
+    const candidates = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          isNull(issues.assigneeUserId),
+          inArray(issues.status, ["todo", "in_progress"]),
+          sql`${issues.assigneeAgentId} is not null`,
+        ),
+      );
+
+    const result = {
+      dispatchRequeued: 0,
+      continuationRequeued: 0,
+      orphanBlockersAssigned: 0,
+      escalated: 0,
+      skipped: 0,
+      issueIds: [] as string[],
+    };
+
+    for (const issue of candidates) {
+      const agentId = issue.assigneeAgentId;
+      if (!agentId) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const agent = await getAgent(agentId);
+      if (!agent || agent.companyId !== issue.companyId) {
+        result.skipped += 1;
+        continue;
+      }
+      if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await hasActiveExecutionPath(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
+      if (issue.status === "todo") {
+        if (!latestRun || latestRun.status === "succeeded") {
+          result.skipped += 1;
+          continue;
+        }
+
+        if (didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
+          const failureSummary = summarizeRunFailureForIssueComment(latestRun);
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "todo",
+            latestRun,
+            comment:
+              "Paperclip automatically retried dispatch for this assigned `todo` issue after a lost wake/run, " +
+              `but it still has no live execution path.${failureSummary ?? ""} ` +
+              "Moving it to `blocked` so it is visible for intervention.",
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+          continue;
+        }
+
+        const queued = await enqueueStrandedIssueRecovery({
+          issueId: issue.id,
+          agentId,
+          reason: "issue_assignment_recovery",
+          retryReason: "assignment_recovery",
+          source: "issue.assignment_recovery",
+          retryOfRunId: latestRun.id,
+        });
+        if (queued) {
+          result.dispatchRequeued += 1;
+          result.issueIds.push(issue.id);
+        } else {
+          result.skipped += 1;
+        }
+        continue;
+      }
+
+      if (!latestRun && !issue.checkoutRunId && !issue.executionRunId) {
+        result.skipped += 1;
+        continue;
+      }
+      if (didAutomaticRecoveryFail(latestRun, "issue_continuation_needed")) {
+        const failureSummary = summarizeRunFailureForIssueComment(latestRun);
+        const updated = await escalateStrandedAssignedIssue({
+          issue,
+          previousStatus: "in_progress",
+          latestRun,
+          comment:
+            "Paperclip automatically retried continuation for this assigned `in_progress` issue after its live " +
+            `execution disappeared, but it still has no live execution path.${failureSummary ?? ""} ` +
+            "Moving it to `blocked` so it is visible for intervention.",
+        });
+        if (updated) {
+          result.escalated += 1;
+          result.issueIds.push(issue.id);
+        } else {
+          result.skipped += 1;
+        }
+        continue;
+      }
+
+      const loopGuard = await evaluateContinuationLoopGuard({ issue, agent });
+      if (loopGuard.shouldSkip) {
+        await insertContinuationLoopGuardSkippedWake({
+          issue,
+          agentId,
+          staleWakeAttempts: loopGuard.staleWakeAttempts,
+          latestSuccessfulRunId: loopGuard.latestSuccessfulRunId,
+          reason: loopGuard.shouldBlock
+            ? CONTINUATION_LOOP_GUARD_AUTO_BLOCK_REASON
+            : CONTINUATION_LOOP_GUARD_SKIP_REASON,
+        });
+
+        if (loopGuard.shouldBlock) {
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "in_progress",
+            latestRun,
+            comment: await buildContinuationLoopGuardAutoBlockedComment({
+              agent,
+              staleWakeAttempts: loopGuard.staleWakeAttempts,
+            }),
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+        } else {
+          result.skipped += 1;
+        }
+        continue;
+      }
+
+      const queued = await enqueueStrandedIssueRecovery({
+        issueId: issue.id,
+        agentId,
+        reason: "issue_continuation_needed",
+        retryReason: "issue_continuation_needed",
+        source: "issue.continuation_recovery",
+        retryOfRunId: latestRun?.id ?? issue.checkoutRunId ?? null,
+      });
+      if (queued) {
+        result.continuationRequeued += 1;
+        result.issueIds.push(issue.id);
+      } else {
+        result.skipped += 1;
+      }
+    }
+
+    const orphanBlockerRecovery = await reconcileUnassignedBlockingIssues();
+    result.orphanBlockersAssigned = orphanBlockerRecovery.assigned;
+    result.skipped += orphanBlockerRecovery.skipped;
+    result.issueIds.push(...orphanBlockerRecovery.issueIds);
+
+    return result;
   }
 
   function issueIdFromRunContext(contextSnapshot: unknown) {
@@ -7235,6 +7990,28 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     await cancelPendingWakeupsForBudgetScope(scope);
   }
 
+  async function getContinuationLoopGuardHeartbeatContext(issueId: string, companyId: string) {
+    const issueRow = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.id, issueId), eq(issues.companyId, companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (!issueRow?.assigneeAgentId) return null;
+
+    const assignee = await getAgent(issueRow.assigneeAgentId);
+    if (!assignee) return null;
+
+    const evaluation = await evaluateContinuationLoopGuard({ issue: issueRow, agent: assignee });
+    return {
+      externalDeltaSignal: evaluation.externalDeltaSignal,
+      similarRecentComment: evaluation.similarRecentComment,
+      staleWakeAttempts: evaluation.staleWakeAttempts,
+      skipStaleContinuationRecovery: evaluation.shouldSkip,
+      autoBlockThresholdReached: evaluation.shouldBlock,
+      latestSuccessfulRunId: evaluation.latestSuccessfulRunId,
+    };
+  }
+
   return {
     list: async (companyId: string, agentId?: string, limit?: number) => {
       const safeForLegacyEncoding = await hasUnsafeTextProjectionDatabase();
@@ -7485,6 +8262,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (!agent) return { outcome: "missing_agent" as const };
       return scheduleBoundedRetryForRun(run, agent, opts);
     },
+
+    getContinuationLoopGuardHeartbeatContext,
 
     reconcileStrandedAssignedIssues,
 

--- a/ui/src/components/BudgetPolicyCard.tsx
+++ b/ui/src/components/BudgetPolicyCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { BudgetPolicySummary } from "@paperclipai/shared";
 import { AlertTriangle, PauseCircle, ShieldAlert, Wallet } from "lucide-react";
-import { cn, formatCents } from "../lib/utils";
+import { cn, formatCents, formatTokens } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -10,12 +10,24 @@ function centsInputValue(value: number) {
   return (value / 100).toFixed(2);
 }
 
+function tokensInputValue(value: number) {
+  return value <= 0 ? "" : String(Math.floor(value));
+}
+
 function parseDollarInput(value: string) {
   const normalized = value.trim();
   if (normalized.length === 0) return 0;
   const parsed = Number(normalized);
   if (!Number.isFinite(parsed) || parsed < 0) return null;
   return Math.round(parsed * 100);
+}
+
+function parseTokensInput(value: string) {
+  const normalized = value.trim();
+  if (normalized.length === 0) return 0;
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Math.floor(parsed);
 }
 
 function windowLabel(windowKind: BudgetPolicySummary["windowKind"]) {
@@ -36,28 +48,36 @@ export function BudgetPolicyCard({
   variant = "card",
 }: {
   summary: BudgetPolicySummary;
-  onSave?: (amountCents: number) => void;
+  onSave?: (amount: number) => void;
   isSaving?: boolean;
   compact?: boolean;
   variant?: "card" | "plain";
 }) {
-  const [draftBudget, setDraftBudget] = useState(centsInputValue(summary.amount));
+  const isTokenMetric = summary.metric === "inference_tokens";
+  const [draftBudget, setDraftBudget] = useState(
+    isTokenMetric ? tokensInputValue(summary.amount) : centsInputValue(summary.amount),
+  );
 
   useEffect(() => {
-    setDraftBudget(centsInputValue(summary.amount));
-  }, [summary.amount]);
+    setDraftBudget(isTokenMetric ? tokensInputValue(summary.amount) : centsInputValue(summary.amount));
+  }, [summary.amount, isTokenMetric]);
 
-  const parsedDraft = parseDollarInput(draftBudget);
+  const parsedDraft = isTokenMetric ? parseTokensInput(draftBudget) : parseDollarInput(draftBudget);
   const canSave = typeof parsedDraft === "number" && parsedDraft !== summary.amount && Boolean(onSave);
   const progress = summary.amount > 0 ? Math.min(100, summary.utilizationPercent) : 0;
   const StatusIcon = summary.status === "hard_stop" ? ShieldAlert : summary.status === "warning" ? AlertTriangle : Wallet;
   const isPlain = variant === "plain";
 
+  const fmtObserved = isTokenMetric ? formatTokens : formatCents;
+  const fmtLimit = isTokenMetric ? formatTokens : formatCents;
+
+  const metricSubtitle = isTokenMetric ? "Inference tokens (input + cached + output)" : "Billed spend (USD)";
+
   const observedBudgetGrid = isPlain ? (
     <div className="grid gap-6 sm:grid-cols-2">
       <div>
         <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Observed</div>
-        <div className="mt-2 text-xl font-semibold tabular-nums">{formatCents(summary.observedAmount)}</div>
+        <div className="mt-2 text-xl font-semibold tabular-nums">{fmtObserved(summary.observedAmount)}</div>
         <div className="mt-1 text-xs text-muted-foreground">
           {summary.amount > 0 ? `${summary.utilizationPercent}% of limit` : "No cap configured"}
         </div>
@@ -65,7 +85,7 @@ export function BudgetPolicyCard({
       <div>
         <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Budget</div>
         <div className="mt-2 text-xl font-semibold tabular-nums">
-          {summary.amount > 0 ? formatCents(summary.amount) : "Disabled"}
+          {summary.amount > 0 ? fmtLimit(summary.amount) : "Disabled"}
         </div>
         <div className="mt-1 text-xs text-muted-foreground">
           Soft alert at {summary.warnPercent}%{summary.paused && summary.pauseReason ? ` · ${summary.pauseReason} pause` : ""}
@@ -76,7 +96,7 @@ export function BudgetPolicyCard({
     <div className="grid gap-3 sm:grid-cols-2">
       <div className="rounded-xl border border-border/70 bg-black/[0.18] px-4 py-3">
         <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Observed</div>
-        <div className="mt-2 text-xl font-semibold tabular-nums">{formatCents(summary.observedAmount)}</div>
+        <div className="mt-2 text-xl font-semibold tabular-nums">{fmtObserved(summary.observedAmount)}</div>
         <div className="mt-1 text-xs text-muted-foreground">
           {summary.amount > 0 ? `${summary.utilizationPercent}% of limit` : "No cap configured"}
         </div>
@@ -84,7 +104,7 @@ export function BudgetPolicyCard({
       <div className="rounded-xl border border-border/70 bg-black/[0.18] px-4 py-3">
         <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Budget</div>
         <div className="mt-2 text-xl font-semibold tabular-nums">
-          {summary.amount > 0 ? formatCents(summary.amount) : "Disabled"}
+          {summary.amount > 0 ? fmtLimit(summary.amount) : "Disabled"}
         </div>
         <div className="mt-1 text-xs text-muted-foreground">
           Soft alert at {summary.warnPercent}%{summary.paused && summary.pauseReason ? ` · ${summary.pauseReason} pause` : ""}
@@ -97,7 +117,7 @@ export function BudgetPolicyCard({
     <div className="space-y-2">
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span>Remaining</span>
-        <span>{summary.amount > 0 ? formatCents(summary.remainingAmount) : "Unlimited"}</span>
+        <span>{summary.amount > 0 ? fmtLimit(summary.remainingAmount) : "Unlimited"}</span>
       </div>
       <div className={cn("h-2 overflow-hidden rounded-full", isPlain ? "bg-border/70" : "bg-muted/70")}>
         <div
@@ -130,14 +150,14 @@ export function BudgetPolicyCard({
     <div className={cn("flex flex-col gap-3 sm:flex-row sm:items-end", isPlain ? "" : "rounded-xl border border-border/70 bg-background/50 p-3")}>
       <div className="min-w-0 flex-1">
         <label className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-          Budget (USD)
+          {isTokenMetric ? "Monthly token cap" : "Budget (USD)"}
         </label>
         <Input
           value={draftBudget}
           onChange={(event) => setDraftBudget(event.target.value)}
           className="mt-2"
-          inputMode="decimal"
-          placeholder="0.00"
+          inputMode={isTokenMetric ? "numeric" : "decimal"}
+          placeholder={isTokenMetric ? "e.g. 500000" : "0.00"}
         />
       </div>
       <Button
@@ -151,6 +171,10 @@ export function BudgetPolicyCard({
     </div>
   ) : null;
 
+  const validationHint = isTokenMetric
+    ? "Enter a valid non-negative whole number of tokens."
+    : "Enter a valid non-negative dollar amount.";
+
   if (isPlain) {
     return (
       <div className="space-y-6">
@@ -161,6 +185,7 @@ export function BudgetPolicyCard({
             </div>
             <div className="mt-2 text-xl font-semibold">{summary.scopeName}</div>
             <div className="mt-2 text-sm text-muted-foreground">{windowLabel(summary.windowKind)}</div>
+            <div className="mt-1 text-xs text-muted-foreground">{metricSubtitle}</div>
           </div>
           <div
             className={cn(
@@ -182,7 +207,7 @@ export function BudgetPolicyCard({
         {pausedPane}
         {saveSection}
         {parsedDraft === null ? (
-          <p className="text-xs text-destructive">Enter a valid non-negative dollar amount.</p>
+          <p className="text-xs text-destructive">{validationHint}</p>
         ) : null}
       </div>
     );
@@ -198,6 +223,7 @@ export function BudgetPolicyCard({
             </div>
             <CardTitle className="mt-1 text-base">{summary.scopeName}</CardTitle>
             <CardDescription className="mt-1">{windowLabel(summary.windowKind)}</CardDescription>
+            <CardDescription className="mt-0.5 text-xs">{metricSubtitle}</CardDescription>
           </div>
           <div className={cn("inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] uppercase tracking-[0.18em]", statusTone(summary.status))}>
             <StatusIcon className="h-3.5 w-3.5" />
@@ -211,7 +237,7 @@ export function BudgetPolicyCard({
         {pausedPane}
         {saveSection}
         {parsedDraft === null ? (
-          <p className="text-xs text-destructive">Enter a valid non-negative dollar amount.</p>
+          <p className="text-xs text-destructive">{validationHint}</p>
         ) : null}
       </CardContent>
     </Card>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -9,6 +9,7 @@ import {
 } from "../api/agents";
 import { companySkillsApi } from "../api/companySkills";
 import { budgetsApi } from "../api/budgets";
+import { costsApi } from "../api/costs";
 import { heartbeatsApi } from "../api/heartbeats";
 import { instanceSettingsApi } from "../api/instanceSettings";
 import { ApiError } from "../api/client";
@@ -694,41 +695,96 @@ export function AgentDetail() {
     staleTime: 5_000,
   });
 
+  const utcMonthBounds = useMemo(() => {
+    const now = new Date();
+    const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+    const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+    return { from: start.toISOString(), to: end.toISOString() };
+  }, []);
+
+  const { data: agentMonthCostRows } = useQuery({
+    queryKey: queryKeys.costs(resolvedCompanyId ?? "__none__", utcMonthBounds.from, utcMonthBounds.to),
+    queryFn: () => costsApi.byAgent(resolvedCompanyId!, utcMonthBounds.from, utcMonthBounds.to),
+    enabled: !!resolvedCompanyId && !!agent?.id && activeView === "budget",
+    staleTime: 10_000,
+  });
+
   const assignedIssues = (allIssues ?? [])
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
   const reportsToAgent = (allAgents ?? []).find((a) => a.id === agent?.reportsTo);
   const directReports = (allAgents ?? []).filter((a) => a.reportsTo === agent?.id && a.status !== "terminated");
-  const agentBudgetSummary = useMemo(() => {
-    const matched = budgetOverview?.policies.find(
-      (policy) => policy.scopeType === "agent" && policy.scopeId === (agent?.id ?? routeAgentRef),
+  const agentBudgetSummaries = useMemo((): BudgetPolicySummary[] => {
+    if (!agent?.id || !resolvedCompanyId) return [];
+    const fromOverview = (budgetOverview?.policies ?? []).filter(
+      (policy) => policy.scopeType === "agent" && policy.scopeId === agent.id,
     );
-    if (matched) return matched;
-    const budgetMonthlyCents = agent?.budgetMonthlyCents ?? 0;
-    const spentMonthlyCents = agent?.spentMonthlyCents ?? 0;
-    return {
-      policyId: "",
-      companyId: resolvedCompanyId ?? "",
-      scopeType: "agent",
-      scopeId: agent?.id ?? routeAgentRef,
-      scopeName: agent?.name ?? "Agent",
-      metric: "billed_cents",
-      windowKind: "calendar_month_utc",
-      amount: budgetMonthlyCents,
-      observedAmount: spentMonthlyCents,
-      remainingAmount: Math.max(0, budgetMonthlyCents - spentMonthlyCents),
-      utilizationPercent:
-        budgetMonthlyCents > 0 ? Number(((spentMonthlyCents / budgetMonthlyCents) * 100).toFixed(2)) : 0,
-      warnPercent: 80,
-      hardStopEnabled: true,
-      notifyEnabled: true,
-      isActive: budgetMonthlyCents > 0,
-      status: budgetMonthlyCents > 0 && spentMonthlyCents >= budgetMonthlyCents ? "hard_stop" : "ok",
-      paused: agent?.status === "paused",
-      pauseReason: agent?.pauseReason ?? null,
-      windowStart: new Date(),
-      windowEnd: new Date(),
-    } satisfies BudgetPolicySummary;
-  }, [agent, budgetOverview?.policies, resolvedCompanyId, routeAgentRef]);
+    const hasBilledFromServer = fromOverview.some((p) => p.metric === "billed_cents");
+    const hasTokenFromServer = fromOverview.some((p) => p.metric === "inference_tokens");
+    const costRow = agentMonthCostRows?.find((r) => r.agentId === agent.id);
+    const monthlyTokens = costRow
+      ? costRow.inputTokens + costRow.cachedInputTokens + costRow.outputTokens
+      : 0;
+
+    const result: BudgetPolicySummary[] = [...fromOverview].sort((a, b) => {
+      if (a.metric === b.metric) return 0;
+      return a.metric === "billed_cents" ? -1 : 1;
+    });
+
+    if (!hasBilledFromServer) {
+      const budgetMonthlyCents = agent.budgetMonthlyCents ?? 0;
+      const spentMonthlyCents = agent.spentMonthlyCents ?? 0;
+      result.unshift({
+        policyId: "",
+        companyId: resolvedCompanyId,
+        scopeType: "agent",
+        scopeId: agent.id,
+        scopeName: agent.name ?? "Agent",
+        metric: "billed_cents",
+        windowKind: "calendar_month_utc",
+        amount: budgetMonthlyCents,
+        observedAmount: spentMonthlyCents,
+        remainingAmount: Math.max(0, budgetMonthlyCents - spentMonthlyCents),
+        utilizationPercent:
+          budgetMonthlyCents > 0 ? Number(((spentMonthlyCents / budgetMonthlyCents) * 100).toFixed(2)) : 0,
+        warnPercent: 80,
+        hardStopEnabled: true,
+        notifyEnabled: true,
+        isActive: budgetMonthlyCents > 0,
+        status: budgetMonthlyCents > 0 && spentMonthlyCents >= budgetMonthlyCents ? "hard_stop" : "ok",
+        paused: agent.status === "paused",
+        pauseReason: agent.pauseReason ?? null,
+        windowStart: new Date(),
+        windowEnd: new Date(),
+      });
+    }
+
+    if (!hasTokenFromServer) {
+      result.push({
+        policyId: "",
+        companyId: resolvedCompanyId,
+        scopeType: "agent",
+        scopeId: agent.id,
+        scopeName: agent.name ?? "Agent",
+        metric: "inference_tokens",
+        windowKind: "calendar_month_utc",
+        amount: 0,
+        observedAmount: monthlyTokens,
+        remainingAmount: 0,
+        utilizationPercent: 0,
+        warnPercent: 80,
+        hardStopEnabled: true,
+        notifyEnabled: true,
+        isActive: false,
+        status: "ok",
+        paused: agent.status === "paused",
+        pauseReason: agent.pauseReason ?? null,
+        windowStart: new Date(),
+        windowEnd: new Date(),
+      });
+    }
+
+    return result;
+  }, [agent, agentMonthCostRows, budgetOverview?.policies, resolvedCompanyId]);
   const mobileLiveRun = useMemo(
     () => (heartbeats ?? []).find((r) => r.status === "running" || r.status === "queued") ?? null,
     [heartbeats],
@@ -802,6 +858,7 @@ export function AgentDetail() {
       budgetsApi.upsertPolicy(resolvedCompanyId!, {
         scopeType: "agent",
         scopeId: agent?.id ?? routeAgentRef,
+        metric: "billed_cents",
         amount,
         windowKind: "calendar_month_utc",
       }),
@@ -812,6 +869,23 @@ export function AgentDetail() {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentLookupRef) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(resolvedCompanyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(resolvedCompanyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.costs(resolvedCompanyId) });
+    },
+  });
+
+  const tokenBudgetMutation = useMutation({
+    mutationFn: (amount: number) =>
+      budgetsApi.upsertPolicy(resolvedCompanyId!, {
+        scopeType: "agent",
+        scopeId: agent!.id,
+        metric: "inference_tokens",
+        amount,
+        windowKind: "calendar_month_utc",
+      }),
+    onSuccess: () => {
+      if (!resolvedCompanyId) return;
+      queryClient.invalidateQueries({ queryKey: queryKeys.budgets.overview(resolvedCompanyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.costs(resolvedCompanyId) });
     },
   });
 
@@ -1145,13 +1219,24 @@ export function AgentDetail() {
       )}
 
       {activeView === "budget" && resolvedCompanyId ? (
-        <div className="max-w-3xl">
-          <BudgetPolicyCard
-            summary={agentBudgetSummary}
-            isSaving={budgetMutation.isPending}
-            onSave={(amount) => budgetMutation.mutate(amount)}
-            variant="plain"
-          />
+        <div className="max-w-3xl space-y-10">
+          {agentBudgetSummaries.map((summary) => (
+            <BudgetPolicyCard
+              key={`${summary.metric}-${summary.policyId || "default"}`}
+              summary={summary}
+              isSaving={
+                summary.metric === "inference_tokens"
+                  ? tokenBudgetMutation.isPending
+                  : budgetMutation.isPending
+              }
+              onSave={(amount) =>
+                summary.metric === "inference_tokens"
+                  ? tokenBudgetMutation.mutate(amount)
+                  : budgetMutation.mutate(amount)
+              }
+              variant="plain"
+            />
+          ))}
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
Introduce a continuation-loop-guard to detect and dedupe self-sustaining continuation wakes (normalization, cosine similarity, evaluation, skipping and auto-blocking after repeated similar self-comments). Integrate the guard into heartbeat reconciliation (skip stale continuation requeues, auto-block issues after threshold), expose getContinuationLoopGuardHeartbeatContext, and include the snapshot in issue route responses.

Add inference_tokens as a new budget metric across the stack: constants, budgets service (token aggregation, checks for company/agent/project hard-stops, and messaging), UI (BudgetPolicyCard input/formatting for token metrics), and tests (budget and continuation-loop-guard tests). Also add a new test for the continuation loop guard and update heartbeat tests to reflect guard behavior. Finally, update the Dockerfile to install the cursor agent.

Closes [#4482](https://github.com/paperclipai/paperclip/issues/4482).

## Thinking Path

> - Paperclip is a control plane for orchestrating AI agents across companies, issues, runs, budgets, and recovery workflows.
> - Continuation recovery re-enqueues wakes when assigned issues lose an execution path; without dedupeing, repetitive continuation-needed chatter can churn runs and overwhelm operators.
> - Budgets expose spend and invocation limits; callers need visibility and hard-stop behavior for inference token consumption alongside existing metrics.
> - Issue detail routes should surface heartbeat context operators need without extra round trips; container builds should bundle tooling (Cursor CLI) consistently in images.
> - This pull request implements a continuation-loop guard (similarity checks, skip or auto-block escalation), wires inference_tokens through budgets end-to-end, extends issue APIs with heartbeat snapshot metadata, adjusts tests and Dockerfile accordingly, and addresses the scenario tracked in #4482.
> - The benefit is fewer pointless continuation wakes when agents post near-duplicate self-updates, clearer budget enforcement on tokens, richer issue payloads for operators, and reproducible installs in Docker.

## What Changed

- Added continuation-loop-guard: normalize continuation comments, cosine similarity with configurable threshold (`CONTINUATION_LOOP_GUARD_SIMILARITY_THRESHOLD`), classification of similar self-comments, skip and auto-block escalation after repeated stalls.
- Integrated the guard into heartbeat reconciliation for stranded continuation paths; tests updated for guard behavior.
- Exposed `getContinuationLoopGuardHeartbeatContext` and included continuation-loop snapshot data in relevant issue route responses (`server/src/routes/issues.ts`).
- Introduced **inference_tokens** as a budget metric in shared constants, budgets service aggregation and hard-stop checks with messaging, and UI on BudgetPolicyCard.
- Added or updated Vitest coverage for budgets, continuation-loop guard, and heartbeat recovery.
- Dockerfile: install the Cursor agent for agent/CI image consistency.

## Verification

Run from the repo root (adjust scope if you prefer targeted suites):

    pnpm exec vitest run
    pnpm -r typecheck && pnpm build

Optional manual check: with `pnpm dev`, call the issue endpoint for an issue that exercises continuation-loop context and confirm snapshot fields in the JSON response.

## Risks

- Continuation guard: cosine and normalization tuning can misclassify borderline updates; threshold is centralized for tuning.
- Budget metrics: token-based enforcement may pause agents sooner under tight quotas.
- Docker/Cursor: image size and reproducible CLI installs in CI/production.

For core feature work, check [ROADMAP.md](ROADMAP.md) and [CONTRIBUTING.md](CONTRIBUTING.md); discuss in `#dev` if overlapping planned core work.

## Model Used

**Cursor**, coding model **Composer 2**. Assisted structuring and wording of this description; implementation and validation remain reviewer-owned.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge