### PR TITLE
fix(recovery): dead-pid detection + all-time dedup in scanSilentActiveRuns

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -94,7 +94,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     await tempDb?.cleanup();
   });
 
-  async function seedRunningRun(opts: { now: Date; ageMs: number; withOutput?: boolean; logChunk?: string }) {
+  async function seedRunningRun(opts: { now: Date; ageMs: number; withOutput?: boolean; logChunk?: string; processPid?: number }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
     const coderId = randomUUID();
@@ -162,6 +162,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       contextSnapshot: { issueId },
       stdoutExcerpt: "OPENAI_API_KEY=sk-test-secret-value should not leak",
       logBytes: 0,
+      processPid: opts.processPid ?? null,
     });
     if (opts.logChunk) {
       const store = getRunLogStore();
@@ -545,5 +546,158 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       createdByRunId: randomUUID(),
     });
     expect(decision.createdByRunId).toBe(managerRunId);
+  });
+
+  describe("dead-pid detection", () => {
+    it("reaps a run whose processPid is dead (ESRCH) without creating an eval issue", async () => {
+      const now = new Date("2026-04-22T20:00:00.000Z");
+      const fakePid = 99999;
+      const { companyId, runId } = await seedRunningRun({
+        now,
+        ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+        processPid: fakePid,
+      });
+
+      const killSpy = vi.spyOn(process, "kill").mockImplementation((pid) => {
+        if (pid === fakePid) {
+          const err = Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+          throw err;
+        }
+        return true;
+      });
+
+      try {
+        const heartbeat = heartbeatService(db);
+        const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+        expect(result.reaped).toBe(1);
+        expect(result.created).toBe(0);
+
+        const evaluations = await db
+          .select()
+          .from(issues)
+          .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+        expect(evaluations).toHaveLength(0);
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+
+    it("does NOT reap a run when process.kill throws EPERM (process exists, different OS user)", async () => {
+      const now = new Date("2026-04-22T20:00:00.000Z");
+      const fakePid = 99998;
+      const { companyId } = await seedRunningRun({
+        now,
+        ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+        processPid: fakePid,
+      });
+
+      const killSpy = vi.spyOn(process, "kill").mockImplementation((pid) => {
+        if (pid === fakePid) {
+          const err = Object.assign(new Error("EPERM"), { code: "EPERM" });
+          throw err;
+        }
+        return true;
+      });
+
+      try {
+        const heartbeat = heartbeatService(db);
+        const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+        // EPERM means the process is alive — should create eval, not reap
+        expect(result.reaped).toBe(0);
+        expect(result.created).toBe(1);
+
+        const evaluations = await db
+          .select()
+          .from(issues)
+          .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+        expect(evaluations).toHaveLength(1);
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("all-time dedup with closed eval", () => {
+    it("returns existing when closed eval is found for an alive-pid run, does not create new eval or re-block source", async () => {
+      const now = new Date("2026-04-22T20:00:00.000Z");
+      const { companyId, runId, issueId } = await seedRunningRun({
+        now,
+        ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      });
+      const heartbeat = heartbeatService(db);
+
+      // First scan creates the eval issue
+      const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+      expect(first.created).toBe(1);
+      const evalIssueId = first.evaluationIssueIds[0];
+      expect(evalIssueId).toBeTruthy();
+
+      // Close the eval issue
+      await db.update(issues).set({ status: "done" }).where(eq(issues.id, evalIssueId!));
+
+      // Second scan: closed eval exists, pid alive → return existing, no new ticket, no re-block
+      const second = await heartbeat.scanSilentActiveRuns({ now, companyId });
+      expect(second.created).toBe(0);
+      expect(second.existing).toBe(1);
+
+      // Source issue must NOT be blocked by the done eval issue
+      const sourceIssue = await db.select({ status: issues.status }).from(issues).where(eq(issues.id, issueId)).then((r) => r[0]);
+      expect(sourceIssue?.status).not.toBe("blocked");
+
+      const allEvals = await db
+        .select()
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+      expect(allEvals).toHaveLength(1);
+    });
+
+    it("reaps a dead-pid run even when a closed eval issue exists", async () => {
+      const now = new Date("2026-04-22T20:00:00.000Z");
+      const fakePid = 99997;
+      const { companyId, runId } = await seedRunningRun({
+        now,
+        ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+        processPid: fakePid,
+      });
+      const heartbeat = heartbeatService(db);
+
+      // Manually seed a closed eval issue for this run
+      const companyRows = await db.select({ issuePrefix: companies.issuePrefix }).from(companies).where(eq(companies.id, companyId));
+      const issuePrefix = companyRows[0]?.issuePrefix ?? "TST";
+      await db.insert(issues).values({
+        id: randomUUID(),
+        companyId,
+        title: "Review silent active run (closed)",
+        status: "done",
+        priority: "medium",
+        issueNumber: 99,
+        identifier: `${issuePrefix}-99`,
+        updatedAt: now,
+        createdAt: now,
+        originKind: "stale_active_run_evaluation",
+        originId: runId,
+        originFingerprint: `stale_active_run:${companyId}:${runId}`,
+      });
+
+      const killSpy = vi.spyOn(process, "kill").mockImplementation((pid) => {
+        if (pid === fakePid) {
+          const err = Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+          throw err;
+        }
+        return true;
+      });
+
+      try {
+        const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+        // Dead pid takes priority — run is reaped, no new eval
+        expect(result.reaped).toBe(1);
+        expect(result.created).toBe(0);
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2004,7 +2004,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     cancelWorkForScope: cancelBudgetScopeWork,
   };
   const budgets = budgetService(db, budgetHooks);
-  const recovery = recoveryService(db, { enqueueWakeup });
+  const recovery = recoveryService(db, { enqueueWakeup, cancelRun: cancelRunInternal });
   const productivityReviews = productivityReviewService(db, { enqueueWakeup });
   let unsafeTextProjectionPromise: Promise<boolean> | null = null;
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -291,7 +291,7 @@ function isProcessAlive(pid: number): boolean {
   try { process.kill(pid, 0); return true; } catch { return false; }
 }
 
-export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; cancelRun: (runId: string, reason: string) => Promise<unknown> }) {
+export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; cancelRun?: (runId: string, reason: string) => Promise<unknown> }) {
   const issuesSvc = issueService(db);
   const treeControlSvc = issueTreeControlService(db);
   const budgets = budgetService(db);
@@ -1084,9 +1084,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; c
         continue;
       }
       if (!runningProcesses.has(run.id) && run.processPid && !isProcessAlive(run.processPid)) {
-        logger.info({ runId: run.id, pid: run.processPid }, "Dead pid detected by stale-run scanner — reaping run");
-        await deps.cancelRun(run.id, "Dead pid detected by stale-run scanner");
-        result.reaped += 1;
+        if (deps.cancelRun) {
+          logger.info({ runId: run.id, pid: run.processPid }, "Dead pid detected by stale-run scanner — reaping run");
+          await deps.cancelRun(run.id, "Dead pid detected by stale-run scanner");
+          result.reaped += 1;
+        } else {
+          logger.warn({ runId: run.id, pid: run.processPid }, "Dead pid detected but cancelRun not available — skipping reap");
+        }
         continue;
       }
       const outcome = await createOrUpdateStaleRunEvaluation({ run, now });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -287,7 +287,11 @@ function buildLivenessOriginalIssueComment(finding: IssueLivenessFinding, escala
   ].join("\n");
 }
 
-export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup }) {
+function isProcessAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; cancelRun: (runId: string, reason: string) => Promise<unknown> }) {
   const issuesSvc = issueService(db);
   const treeControlSvc = issueTreeControlService(db);
   const budgets = budgetService(db);
@@ -614,7 +618,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
           eq(issues.originId, runId),
           isNull(issues.hiddenAt),
-          notInArray(issues.status, ["done", "cancelled"]),
         ),
       )
       .limit(1);
@@ -1070,6 +1073,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       existing: 0,
       escalated: 0,
       snoozed: 0,
+      reaped: 0,
       skipped: 0,
       evaluationIssueIds: [] as string[],
     };
@@ -1077,6 +1081,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     for (const run of candidates) {
       if (await latestActiveOutputQuietUntilDecision(run.companyId, run.id, now)) {
         result.snoozed += 1;
+        continue;
+      }
+      if (!runningProcesses.has(run.id) && run.processPid && !isProcessAlive(run.processPid)) {
+        logger.info({ runId: run.id, pid: run.processPid }, "Dead pid detected by stale-run scanner — reaping run");
+        await deps.cancelRun(run.id, "Dead pid detected by stale-run scanner");
+        result.reaped += 1;
         continue;
       }
       const outcome = await createOrUpdateStaleRunEvaluation({ run, now });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -288,7 +288,13 @@ function buildLivenessOriginalIssueComment(finding: IssueLivenessFinding, escala
 }
 
 function isProcessAlive(pid: number): boolean {
-  try { process.kill(pid, 0); return true; } catch { return false; }
+  try { process.kill(pid, 0); return true; }
+  catch (err) {
+    // EPERM: the process exists but we can't signal it (different OS user). Treat as alive.
+    if ((err as NodeJS.ErrnoException).code === "EPERM") return true;
+    // ESRCH or anything else: process not found.
+    return false;
+  }
 }
 
 export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; cancelRun?: (runId: string, reason: string) => Promise<unknown> }) {
@@ -940,7 +946,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; c
     const level = (evidence.silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS ? "critical" : "suspicious";
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
     if (existing) {
-      if (level === "critical" && existing.priority !== "high") {
+      const existingIsTerminal = ["done", "cancelled"].includes(existing.status);
+      if (level === "critical" && !existingIsTerminal && existing.priority !== "high") {
         await issuesSvc.update(existing.id, {
           priority: "high",
         });
@@ -958,7 +965,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; c
         });
         return { kind: "escalated" as const, evaluationIssueId: existing.id };
       }
-      if (level === "critical") {
+      // Re-escalate via source issue priority when the prior eval is closed — do NOT add it
+      // as a blocker since that would leave the source permanently blocked by a done issue.
+      if (level === "critical" && existingIsTerminal && sourceIssue && !["done", "cancelled"].includes(sourceIssue.status)) {
+        const escalatedPriority = sourceIssue.priority === "critical" ? "critical" : "high";
+        if (sourceIssue.priority !== escalatedPriority) {
+          await issuesSvc.update(sourceIssue.id, { priority: escalatedPriority });
+        }
+        return { kind: "existing" as const, evaluationIssueId: existing.id };
+      }
+      if (level === "critical" && !existingIsTerminal) {
         await ensureSourceIssueBlockedByStaleEvaluation({
           sourceIssue,
           evaluationIssue: existing,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -947,41 +947,60 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; c
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
     if (existing) {
       const existingIsTerminal = ["done", "cancelled"].includes(existing.status);
-      if (level === "critical" && !existingIsTerminal && existing.priority !== "high") {
-        await issuesSvc.update(existing.id, {
-          priority: "high",
-        });
-        await issuesSvc.addComment(existing.id, [
-          "Critical output silence threshold crossed.",
-          "",
-          `- Run: \`${input.run.id}\``,
-          `- Silent for: ${formatDuration(evidence.silenceAgeMs)}`,
-          `- Last output at: ${input.run.lastOutputAt?.toISOString() ?? "none recorded"}`,
-        ].join("\n"), { runId: input.run.id });
-        await ensureSourceIssueBlockedByStaleEvaluation({
-          sourceIssue,
-          evaluationIssue: existing,
-          run: input.run,
-        });
-        return { kind: "escalated" as const, evaluationIssueId: existing.id };
-      }
-      // Re-escalate via source issue priority when the prior eval is closed — do NOT add it
-      // as a blocker since that would leave the source permanently blocked by a done issue.
-      if (level === "critical" && existingIsTerminal && sourceIssue && !["done", "cancelled"].includes(sourceIssue.status)) {
-        const escalatedPriority = sourceIssue.priority === "critical" ? "critical" : "high";
-        if (sourceIssue.priority !== escalatedPriority) {
-          await issuesSvc.update(sourceIssue.id, { priority: escalatedPriority });
+      if (existingIsTerminal) {
+        // Re-arm check: a "continue"/"snooze" decision on this eval means the quiet window
+        // has since expired and a fresh evaluation should be created. Without a prior continue
+        // decision the eval was simply closed — return existing to prevent looping.
+        const [priorContinue] = await db
+          .select({ id: heartbeatRunWatchdogDecisions.id })
+          .from(heartbeatRunWatchdogDecisions)
+          .where(and(
+            eq(heartbeatRunWatchdogDecisions.companyId, input.run.companyId),
+            eq(heartbeatRunWatchdogDecisions.runId, input.run.id),
+            eq(heartbeatRunWatchdogDecisions.evaluationIssueId, existing.id),
+            inArray(heartbeatRunWatchdogDecisions.decision, ["continue", "snooze"]),
+          ))
+          .limit(1);
+        if (!priorContinue) {
+          // Dedup: closed without re-arm — re-escalate source priority if critical but don't re-block.
+          if (level === "critical" && sourceIssue && !["done", "cancelled"].includes(sourceIssue.status)) {
+            const escalatedPriority = sourceIssue.priority === "critical" ? "critical" : "high";
+            if (sourceIssue.priority !== escalatedPriority) {
+              await issuesSvc.update(sourceIssue.id, { priority: escalatedPriority });
+            }
+          }
+          return { kind: "existing" as const, evaluationIssueId: existing.id };
+        }
+        // priorContinue exists: re-arm after snooze expiry — fall through to create a new eval.
+      } else {
+        // Non-terminal: escalate priority or ensure source is blocked, then dedup.
+        if (level === "critical" && existing.priority !== "high") {
+          await issuesSvc.update(existing.id, {
+            priority: "high",
+          });
+          await issuesSvc.addComment(existing.id, [
+            "Critical output silence threshold crossed.",
+            "",
+            `- Run: \`${input.run.id}\``,
+            `- Silent for: ${formatDuration(evidence.silenceAgeMs)}`,
+            `- Last output at: ${input.run.lastOutputAt?.toISOString() ?? "none recorded"}`,
+          ].join("\n"), { runId: input.run.id });
+          await ensureSourceIssueBlockedByStaleEvaluation({
+            sourceIssue,
+            evaluationIssue: existing,
+            run: input.run,
+          });
+          return { kind: "escalated" as const, evaluationIssueId: existing.id };
+        }
+        if (level === "critical") {
+          await ensureSourceIssueBlockedByStaleEvaluation({
+            sourceIssue,
+            evaluationIssue: existing,
+            run: input.run,
+          });
         }
         return { kind: "existing" as const, evaluationIssueId: existing.id };
       }
-      if (level === "critical" && !existingIsTerminal) {
-        await ensureSourceIssueBlockedByStaleEvaluation({
-          sourceIssue,
-          evaluationIssue: existing,
-          run: input.run,
-        });
-      }
-      return { kind: "existing" as const, evaluationIssueId: existing.id };
     }
 
     const ownerAgentId = await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });


### PR DESCRIPTION
## Summary

Fixes the duplicate-ticket loop for dead-pid runs (COM-324). Two changes to `server/src/services/recovery/service.ts`:

- **Dead-pid detection** (`scanSilentActiveRuns`): before `createOrUpdateStaleRunEvaluation`, checks `!runningProcesses.has(run.id) && run.processPid && !isProcessAlive(run.processPid)`. When both are true, calls `deps.cancelRun` (wired to `cancelRunInternal` in `heartbeat.ts`) and `continue` — no eval issue is created. Adds a `reaped` counter to the scan result.
- **All-time dedup** (`findOpenStaleRunEvaluation`): removes the `notInArray(issues.status, ["done","cancelled"])` filter so the query returns ANY existing eval issue for the run. Combined with Change 1 (dead runs are reaped before `createOrUpdateStaleRunEvaluation`), this breaks the close→re-create→close loop for live runs too.

## Changed files

- `server/src/services/recovery/service.ts` — `isProcessAlive` helper, updated `deps` type, dead-pid guard in scan loop, removed terminal-status filter from `findOpenStaleRunEvaluation`
- `server/src/services/heartbeat.ts` — wires `cancelRunInternal` into `recoveryService` deps as `cancelRun`

## Test plan

- [ ] Verify that a run with a dead pid (e.g. `kill -9 <pid>` then wait for next scan) results in the run being cancelled rather than a new eval issue being created
- [ ] Verify that a run with a live pid that already has a closed eval issue returns `kind: "existing"` — no new issue created
- [ ] Verify that a run with a live pid that has no prior eval issue creates a new eval issue as before
- [ ] Verify `reaped` counter increments in scan result for dead-pid runs

Refs: COM-324, COM-303, COM-306

🤖 Generated with [Claude Code](https://claude.com/claude-code)