### PR TITLE
fix(ssh-probe): retry + budget cap for SSH→API lease drops (BLO-1490, BLO-1489)

### DIFF
--- a/packages/adapter-utils/src/ssh-probe.test.ts
+++ b/packages/adapter-utils/src/ssh-probe.test.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it } from "vitest";
+import {
+  findReachablePaperclipApiUrlOverSsh,
+  type PaperclipApiProbeAttempt,
+  type SingleProbeAttempt,
+  type SingleProbeRunner,
+  type SshConnectionConfig,
+} from "./ssh.js";
+
+const SSH_CONFIG: SshConnectionConfig = {
+  host: "ssh.example.test",
+  port: 22,
+  username: "ssh-user",
+  remoteWorkspacePath: "/srv/paperclip",
+  privateKey: null,
+  knownHosts: null,
+  strictHostKeyChecking: false,
+};
+
+const NO_SLEEP = async () => undefined;
+
+function makeProbeRunner(
+  scripts: Record<string, Array<Partial<SingleProbeAttempt>>>,
+): { run: SingleProbeRunner; calls: Array<{ healthUrl: string }> } {
+  const cursors: Record<string, number> = {};
+  const calls: Array<{ healthUrl: string }> = [];
+  const run: SingleProbeRunner = async ({ healthUrl }) => {
+    calls.push({ healthUrl });
+    const series = scripts[healthUrl];
+    if (!series) {
+      throw new Error(`Test setup missing script for ${healthUrl}`);
+    }
+    const idx = cursors[healthUrl] ?? 0;
+    cursors[healthUrl] = idx + 1;
+    const stage = series[Math.min(idx, series.length - 1)] ?? {};
+    return {
+      exitCode: stage.exitCode ?? 0,
+      httpStatus: stage.httpStatus ?? null,
+      durationMs: stage.durationMs ?? 5,
+      stderrTail: stage.stderrTail ?? null,
+      sshError: stage.sshError ?? null,
+    };
+  };
+  return { run, calls };
+}
+
+describe("findReachablePaperclipApiUrlOverSsh", () => {
+  it("retries on 5xx and succeeds when the candidate recovers", async () => {
+    const { run, calls } = makeProbeRunner({
+      "https://api.example.test/api/health": [
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 200 },
+      ],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://api.example.test"],
+      attempts: 3,
+      backoffMs: [0, 0],
+      sleep: NO_SLEEP,
+      runProbe: run,
+    });
+
+    expect(result.url).toBe("https://api.example.test");
+    expect(result.attempts).toHaveLength(3);
+    expect(result.attempts.map((a) => a.classification)).toEqual(["transient", "transient", "ok"]);
+    expect(result.attempts[2]?.httpStatus).toBe(200);
+    expect(calls).toHaveLength(3);
+  });
+
+  it("retries an SSH handshake timeout (BLO-1487 incident shape) and recovers on the next attempt", async () => {
+    // The actual BLO-1487 root cause: SSH handshake + opkssh verify stalled
+    // past the 10s budget under load. runSshCommand rejects before curl ever
+    // runs — exitCode=null, httpStatus=null, sshError contains "timeout".
+    // Our classifier defaults this to "transient", so the retry should kick
+    // in and recover when the host clears. Pinning this shape here so a
+    // future refactor of the classifier can't silently regress the exact
+    // failure mode three lease drops on 2026-04-28 hit.
+    const { run, calls } = makeProbeRunner({
+      "https://api.example.test/api/health": [
+        {
+          exitCode: null,
+          httpStatus: null,
+          sshError: "ssh: connect to host api.example.test port 22: Connection timed out",
+        },
+        { exitCode: 0, httpStatus: 200 },
+      ],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://api.example.test"],
+      attempts: 3,
+      backoffMs: [0, 0],
+      sleep: NO_SLEEP,
+      runProbe: run,
+    });
+
+    expect(result.url).toBe("https://api.example.test");
+    expect(result.attempts).toHaveLength(2);
+    // Pinning the exact failure shape from BLO-1487: no HTTP code came back,
+    // sshError surfaces the handshake timeout. Any future classifier change
+    // that loses transient handling for httpStatus===null will fail here.
+    expect(result.attempts[0]?.classification).toBe("transient");
+    expect(result.attempts[0]?.httpStatus).toBeNull();
+    expect(result.attempts[0]?.error).toContain("timed out");
+    expect(result.attempts[1]?.classification).toBe("ok");
+    expect(calls).toHaveLength(2);
+  });
+
+  it("retries on curl network error (exit code != 0) until success", async () => {
+    const { run } = makeProbeRunner({
+      "https://api.example.test/api/health": [
+        { exitCode: 28, httpStatus: null, sshError: "curl: timed out" },
+        { exitCode: 0, httpStatus: 200 },
+      ],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://api.example.test"],
+      attempts: 3,
+      backoffMs: [0, 0],
+      sleep: NO_SLEEP,
+      runProbe: run,
+    });
+
+    expect(result.url).toBe("https://api.example.test");
+    expect(result.attempts[0]?.classification).toBe("transient");
+    expect(result.attempts[0]?.error).toContain("curl: timed out");
+  });
+
+  it("does not retry on permanent 4xx; moves to next candidate immediately", async () => {
+    const { run, calls } = makeProbeRunner({
+      "https://broken.example.test/api/health": [{ exitCode: 0, httpStatus: 404 }],
+      "https://good.example.test/api/health": [{ exitCode: 0, httpStatus: 200 }],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://broken.example.test", "https://good.example.test"],
+      attempts: 3,
+      backoffMs: [0, 0],
+      sleep: NO_SLEEP,
+      runProbe: run,
+    });
+
+    expect(result.url).toBe("https://good.example.test");
+    // Exactly one attempt against the broken candidate (no retry on 4xx),
+    // then one against the good candidate.
+    expect(calls.map((c) => c.healthUrl)).toEqual([
+      "https://broken.example.test/api/health",
+      "https://good.example.test/api/health",
+    ]);
+    const broken = result.attempts.filter((a) => a.candidate === "https://broken.example.test");
+    expect(broken).toHaveLength(1);
+    expect(broken[0]?.classification).toBe("permanent");
+  });
+
+  it("retries on transient 408/429 (rate-limit-ish)", async () => {
+    const { run } = makeProbeRunner({
+      "https://api.example.test/api/health": [
+        { exitCode: 0, httpStatus: 429 },
+        { exitCode: 0, httpStatus: 200 },
+      ],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://api.example.test"],
+      attempts: 2,
+      backoffMs: [0],
+      sleep: NO_SLEEP,
+      runProbe: run,
+    });
+
+    expect(result.url).toBe("https://api.example.test");
+    expect(result.attempts[0]?.classification).toBe("transient");
+    expect(result.attempts[0]?.httpStatus).toBe(429);
+  });
+
+  it("returns null with full attempt detail when every candidate stays 5xx", async () => {
+    const { run } = makeProbeRunner({
+      "https://a.example.test/api/health": [{ exitCode: 0, httpStatus: 503, durationMs: 51, stderrTail: "upstream timed out" }],
+      "https://b.example.test/api/health": [{ exitCode: 0, httpStatus: 502 }],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://a.example.test", "https://b.example.test"],
+      attempts: 2,
+      backoffMs: [0],
+      sleep: NO_SLEEP,
+      runProbe: run,
+    });
+
+    expect(result.url).toBeNull();
+    // 2 attempts per candidate × 2 candidates = 4 attempts.
+    expect(result.attempts).toHaveLength(4);
+    const byCandidate = (url: string) => result.attempts.filter((a) => a.candidate === url);
+    expect(byCandidate("https://a.example.test")).toHaveLength(2);
+    expect(byCandidate("https://b.example.test")).toHaveLength(2);
+    const first = result.attempts[0]!;
+    expect(first.candidate).toBe("https://a.example.test");
+    expect(first.httpStatus).toBe(503);
+    expect(first.durationMs).toBe(51);
+    expect(first.stderrTail).toBe("upstream timed out");
+    expect(first.error).toBe("HTTP 503");
+  });
+
+  it("short-circuits to a healthy preferredCandidate without probing the rest", async () => {
+    const { run, calls } = makeProbeRunner({
+      "https://cached.example.test/api/health": [{ exitCode: 0, httpStatus: 200 }],
+      "https://other.example.test/api/health": [{ exitCode: 0, httpStatus: 200 }],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://other.example.test"],
+      preferredCandidate: "https://cached.example.test",
+      attempts: 3,
+      backoffMs: [0, 0],
+      sleep: NO_SLEEP,
+      runProbe: run,
+    });
+
+    expect(result.url).toBe("https://cached.example.test");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.healthUrl).toBe("https://cached.example.test/api/health");
+  });
+
+  it("falls through from a stale preferredCandidate to the candidate list", async () => {
+    const { run, calls } = makeProbeRunner({
+      "https://cached.example.test/api/health": [
+        // The previously-cached URL is now down. Use up its full retry budget
+        // (transient 503), then fall through.
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 503 },
+      ],
+      "https://other.example.test/api/health": [{ exitCode: 0, httpStatus: 200 }],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://other.example.test"],
+      preferredCandidate: "https://cached.example.test",
+      attempts: 2,
+      backoffMs: [0],
+      sleep: NO_SLEEP,
+      runProbe: run,
+    });
+
+    expect(result.url).toBe("https://other.example.test");
+    expect(calls.map((c) => c.healthUrl)).toEqual([
+      "https://cached.example.test/api/health",
+      "https://cached.example.test/api/health",
+      "https://other.example.test/api/health",
+    ]);
+    const stale = result.attempts.filter((a) => a.candidate === "https://cached.example.test");
+    expect(stale).toHaveLength(2);
+    expect(stale.every((a) => a.classification === "transient")).toBe(true);
+  });
+
+  it("dedupes preferredCandidate that's already in the candidate list (no double-probe)", async () => {
+    const { run, calls } = makeProbeRunner({
+      "https://api.example.test/api/health": [{ exitCode: 0, httpStatus: 200 }],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://api.example.test"],
+      preferredCandidate: "https://api.example.test",
+      attempts: 2,
+      backoffMs: [0],
+      sleep: NO_SLEEP,
+      runProbe: run,
+    });
+
+    expect(result.url).toBe("https://api.example.test");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("respects PAPERCLIP_RUNTIME_API_PROBE_ATTEMPTS env var", async () => {
+    const previous = process.env.PAPERCLIP_RUNTIME_API_PROBE_ATTEMPTS;
+    process.env.PAPERCLIP_RUNTIME_API_PROBE_ATTEMPTS = "5";
+    try {
+      const { run } = makeProbeRunner({
+        "https://api.example.test/api/health": [
+          { exitCode: 0, httpStatus: 503 },
+          { exitCode: 0, httpStatus: 503 },
+          { exitCode: 0, httpStatus: 503 },
+          { exitCode: 0, httpStatus: 503 },
+          { exitCode: 0, httpStatus: 200 },
+        ],
+      });
+
+      const result = await findReachablePaperclipApiUrlOverSsh({
+        config: SSH_CONFIG,
+        candidates: ["https://api.example.test"],
+        backoffMs: [0, 0, 0, 0],
+        sleep: NO_SLEEP,
+        runProbe: run,
+      });
+
+      expect(result.url).toBe("https://api.example.test");
+      expect(result.attempts).toHaveLength(5);
+    } finally {
+      if (previous === undefined) delete process.env.PAPERCLIP_RUNTIME_API_PROBE_ATTEMPTS;
+      else process.env.PAPERCLIP_RUNTIME_API_PROBE_ATTEMPTS = previous;
+    }
+  });
+
+  it("caps the entire candidate sweep at totalBudgetMs (BLO-1490)", async () => {
+    // Two candidates, 5 attempts each, all transient. With a deterministic
+    // clock advanced 20 ms per probe + sleep, total budget = 60 ms means we
+    // get ~3 attempts before the budget cuts the sweep. Returns null with
+    // the partial attempts trail intact.
+    let nowMs = 0;
+    const advanceClockBy = (ms: number): void => {
+      nowMs += ms;
+    };
+    const { run } = makeProbeRunner({
+      "https://a.example.test/api/health": [
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 503 },
+      ],
+      "https://b.example.test/api/health": [
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 503 },
+      ],
+    });
+
+    const wrapped: typeof run = async (probeInput) => {
+      // Each probe takes 15 ms of wall clock.
+      advanceClockBy(15);
+      return run(probeInput);
+    };
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://a.example.test", "https://b.example.test"],
+      attempts: 5,
+      backoffMs: [5, 5, 5, 5],
+      sleep: async (ms) => {
+        advanceClockBy(ms);
+      },
+      now: () => nowMs,
+      totalBudgetMs: 60,
+      runProbe: wrapped,
+    });
+
+    expect(result.url).toBeNull();
+    // Probe 1 (15 ms elapsed), sleep 5 (20), probe 2 (35), sleep 5 (40),
+    // probe 3 (55), sleep 5 (60) → next budget check sees 60 >= 60 → break.
+    expect(result.attempts).toHaveLength(3);
+    expect(result.attempts.every((a) => a.candidate === "https://a.example.test")).toBe(true);
+  });
+
+  it("uses jittered default backoff when no backoff array is supplied", async () => {
+    // Don't actually sleep — just confirm that the function reaches into
+    // randomBackoffMs (the spec'd 250–750 ms jitter source) when callers
+    // don't pin a deterministic backoff array.
+    let randomCalls = 0;
+    const { run } = makeProbeRunner({
+      "https://api.example.test/api/health": [
+        { exitCode: 0, httpStatus: 503 },
+        { exitCode: 0, httpStatus: 200 },
+      ],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://api.example.test"],
+      attempts: 2,
+      sleep: NO_SLEEP,
+      runProbe: run,
+      randomBackoffMs: () => {
+        randomCalls++;
+        return 0;
+      },
+    });
+
+    expect(result.url).toBe("https://api.example.test");
+    // Sampled exactly once: between attempt 1 (503) and attempt 2 (200).
+    expect(randomCalls).toBe(1);
+  });
+
+  it("ignores a malformed PAPERCLIP_RUNTIME_API_PROBE_BACKOFF_MS_JSON instead of crashing", async () => {
+    const previous = process.env.PAPERCLIP_RUNTIME_API_PROBE_BACKOFF_MS_JSON;
+    process.env.PAPERCLIP_RUNTIME_API_PROBE_BACKOFF_MS_JSON = "{not json[";
+    try {
+      const { run } = makeProbeRunner({
+        "https://api.example.test/api/health": [{ exitCode: 0, httpStatus: 200 }],
+      });
+
+      // A malformed knob should NOT cause acquireRunLease to crash. Probing
+      // should still complete using the default backoff schedule.
+      const result = await findReachablePaperclipApiUrlOverSsh({
+        config: SSH_CONFIG,
+        candidates: ["https://api.example.test"],
+        sleep: NO_SLEEP,
+        runProbe: run,
+      });
+
+      expect(result.url).toBe("https://api.example.test");
+    } finally {
+      if (previous === undefined) delete process.env.PAPERCLIP_RUNTIME_API_PROBE_BACKOFF_MS_JSON;
+      else process.env.PAPERCLIP_RUNTIME_API_PROBE_BACKOFF_MS_JSON = previous;
+    }
+  });
+
+  it("filters invalid candidates without throwing", async () => {
+    const { run, calls } = makeProbeRunner({
+      "https://valid.example.test/api/health": [{ exitCode: 0, httpStatus: 200 }],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["", "not a url", "ftp://wrong.scheme/", "https://valid.example.test"],
+      attempts: 1,
+      backoffMs: [],
+      sleep: NO_SLEEP,
+      runProbe: run,
+    });
+
+    expect(result.url).toBe("https://valid.example.test");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("classifies attempt fields exactly as the orchestrator expects (acceptance line shape)", async () => {
+    // Acceptance criterion: the thrown error on full failure includes
+    // per-candidate { candidate, status, durationMs } lines.
+    const { run } = makeProbeRunner({
+      "https://api.example.test/api/health": [{ exitCode: 0, httpStatus: 503, durationMs: 47 }],
+    });
+
+    const result = await findReachablePaperclipApiUrlOverSsh({
+      config: SSH_CONFIG,
+      candidates: ["https://api.example.test"],
+      attempts: 1,
+      backoffMs: [],
+      sleep: NO_SLEEP,
+      runProbe: run,
+    });
+
+    expect(result.url).toBeNull();
+    const attempt: PaperclipApiProbeAttempt = result.attempts[0]!;
+    expect(attempt.candidate).toBe("https://api.example.test");
+    expect(attempt.httpStatus).toBe(503);
+    expect(attempt.durationMs).toBe(47);
+  });
+});

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -112,34 +112,392 @@ function normalizeHttpUrlCandidate(value: string): string | null {
   }
 }
 
+const DEFAULT_PAPERCLIP_API_PROBE_TIMEOUT_MS = 10_000;
+const DEFAULT_PAPERCLIP_API_PROBE_ATTEMPTS = 3;
+const MAX_PAPERCLIP_API_PROBE_ATTEMPTS = 10;
+const DEFAULT_PAPERCLIP_API_PROBE_TOTAL_BUDGET_MS = 30_000;
+// Per BLO-1490: 300 ms base, sampled uniform from [250, 750] ms per attempt.
+// Short-and-jittered absorbs the sub-second SSH-handshake stalls observed on
+// the worker host without pathologically inflating lease-acquire latency.
+const PROBE_BACKOFF_JITTER_MIN_MS = 250;
+const PROBE_BACKOFF_JITTER_MAX_MS = 750;
+const PROBE_STDERR_TAIL_BYTES = 512;
+
+function resolveProbeTimeoutMs(explicit?: number): number {
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
+    return explicit;
+  }
+  const raw = process.env.PAPERCLIP_RUNTIME_API_PROBE_TIMEOUT_MS;
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_PAPERCLIP_API_PROBE_TIMEOUT_MS;
+}
+
+function resolveProbeAttempts(explicit?: number): number {
+  // Cap at MAX_PAPERCLIP_API_PROBE_ATTEMPTS so a fat-fingered "9999" can't
+  // strand a heartbeat looping over a flapping upstream.
+  const clamp = (value: number): number =>
+    Math.min(MAX_PAPERCLIP_API_PROBE_ATTEMPTS, Math.max(1, Math.floor(value)));
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit >= 1) {
+    return clamp(explicit);
+  }
+  const raw = process.env.PAPERCLIP_RUNTIME_API_PROBE_ATTEMPTS;
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed >= 1) return clamp(parsed);
+  }
+  return DEFAULT_PAPERCLIP_API_PROBE_ATTEMPTS;
+}
+
+function resolveProbeTotalBudgetMs(explicit?: number): number {
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
+    return explicit;
+  }
+  const raw = process.env.PAPERCLIP_RUNTIME_API_PROBE_TOTAL_BUDGET_MS;
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_PAPERCLIP_API_PROBE_TOTAL_BUDGET_MS;
+}
+
+/**
+ * Backoff is either an explicit array of sleep durations (one per attempt
+ * boundary) or a function that samples per-attempt with optional jitter.
+ * Tests inject deterministic arrays; production defaults to jittered.
+ */
+type ProbeBackoffSource =
+  | readonly number[]
+  | ((attemptIndex: number, randomMs: () => number) => number);
+
+function defaultJitteredBackoff(_attemptIndex: number, randomMs: () => number): number {
+  return randomMs();
+}
+
+function defaultRandomBackoffMs(): number {
+  // Uniform inclusive [PROBE_BACKOFF_JITTER_MIN_MS, PROBE_BACKOFF_JITTER_MAX_MS].
+  const span = PROBE_BACKOFF_JITTER_MAX_MS - PROBE_BACKOFF_JITTER_MIN_MS;
+  return PROBE_BACKOFF_JITTER_MIN_MS + Math.floor(Math.random() * (span + 1));
+}
+
+function resolveProbeBackoff(explicit?: readonly number[]): ProbeBackoffSource {
+  const sanitize = (values: unknown): number[] | null => {
+    if (!Array.isArray(values)) return null;
+    const cleaned = values
+      .map((entry) => (typeof entry === "number" ? entry : Number(entry)))
+      .filter((entry): entry is number => Number.isFinite(entry) && entry >= 0)
+      // Cap each sleep at 30s so a fat-fingered config can never strand a heartbeat.
+      .map((entry) => Math.min(entry, 30_000));
+    return cleaned.length > 0 ? cleaned : null;
+  };
+  if (explicit) {
+    const cleaned = sanitize(explicit);
+    if (cleaned) return cleaned;
+  }
+  const raw = process.env.PAPERCLIP_RUNTIME_API_PROBE_BACKOFF_MS_JSON;
+  if (raw) {
+    try {
+      const cleaned = sanitize(JSON.parse(raw));
+      if (cleaned) return cleaned;
+    } catch {
+      // Fall through to the default. A malformed knob must never crash acquireRunLease.
+    }
+  }
+  return defaultJitteredBackoff;
+}
+
+function resolveBackoffMs(
+  source: ProbeBackoffSource,
+  attemptIndex: number,
+  randomMs: () => number,
+): number {
+  if (typeof source === "function") return source(attemptIndex, randomMs);
+  return source[Math.min(attemptIndex, source.length - 1)] ?? 0;
+}
+
+/**
+ * Per-attempt detail captured during a Paperclip API probe over SSH. Surfaced
+ * via {@link ProbeResult.attempts} so callers can attach the full failure
+ * trail to their thrown error / structured log instead of swallowing it.
+ */
+export interface PaperclipApiProbeAttempt {
+  candidate: string;
+  attempt: number; // 1-indexed within this candidate
+  ok: boolean;
+  exitCode: number | null;
+  httpStatus: number | null;
+  durationMs: number;
+  stderrTail: string | null;
+  classification: "ok" | "transient" | "permanent";
+  error: string | null;
+}
+
+export interface PaperclipApiProbeResult {
+  url: string | null;
+  attempts: PaperclipApiProbeAttempt[];
+}
+
+const TRANSIENT_HTTP_STATUSES = new Set<number>([408, 425, 429]);
+
+// Spec deviation note (BLO-1489 vs BLO-1490): BLO-1490 says "fast-fail on
+// non-2xx, the API is reachable but unhealthy". We deliberately keep BLO-1489's
+// 5xx-as-transient behavior because the BLO-1489 incident on 2026-04-28 was a
+// real ~50ms 503 from nginx during an upstream restart — exactly the blip the
+// retry budget is designed to absorb. Switching 5xx to permanent here would
+// re-introduce BLO-1489 in single-candidate prod setups. The total-budget cap
+// (PAPERCLIP_RUNTIME_API_PROBE_TOTAL_BUDGET_MS, default 30s) bounds the worst
+// case so a sustained 5xx storm still falls through to the next candidate.
+function classifyHttpStatus(status: number | null): "ok" | "transient" | "permanent" {
+  if (status === null) return "transient";
+  if (status >= 200 && status < 300) return "ok";
+  if (status >= 500 && status < 600) return "transient";
+  if (TRANSIENT_HTTP_STATUSES.has(status)) return "transient";
+  return "permanent";
+}
+
+const PROBE_STATUS_SENTINEL = "__PAPERCLIP_PROBE_HTTP_CODE__:";
+
+/**
+ * Test seam: the probe runner. Production code uses {@link runSingleProbe}
+ * which executes curl over SSH; tests can pass a fake to avoid spinning up
+ * a real sshd + http server per case.
+ */
+export type SingleProbeRunner = (input: {
+  config: SshConnectionConfig;
+  healthUrl: string;
+  curlSeconds: number;
+  timeoutMs: number;
+}) => Promise<SingleProbeAttempt>;
+
+export interface SingleProbeAttempt {
+  exitCode: number | null;
+  httpStatus: number | null;
+  durationMs: number;
+  stderrTail: string | null;
+  sshError: string | null;
+}
+
+async function runSingleProbe(input: {
+  config: SshConnectionConfig;
+  healthUrl: string;
+  curlSeconds: number;
+  timeoutMs: number;
+}): Promise<SingleProbeAttempt> {
+  // Capture %{http_code} explicitly. We deliberately drop curl's `-f` so a 5xx
+  // returns exit 0 with the actual status code in stdout — letting us
+  // distinguish transient (5xx) from permanent (4xx) without parsing stderr.
+  // Connection errors keep their non-zero curl exit and surface as null status.
+  const remote = `curl -sS -m ${input.curlSeconds} -o /dev/null -w '${PROBE_STATUS_SENTINEL}%{http_code}\\n' ${shellQuote(input.healthUrl)}`;
+  const startedAt = Date.now();
+  try {
+    const result = await runSshCommand(
+      input.config,
+      `sh -lc ${shellQuote(remote)}`,
+      { timeoutMs: input.timeoutMs },
+    );
+    const durationMs = Date.now() - startedAt;
+    const httpStatus = parseProbeHttpStatus(result.stdout);
+    return {
+      exitCode: 0,
+      httpStatus,
+      durationMs,
+      stderrTail: tailString(result.stderr, PROBE_STDERR_TAIL_BYTES),
+      sshError: null,
+    };
+  } catch (err) {
+    const durationMs = Date.now() - startedAt;
+    const e = err as NodeJS.ErrnoException & { code?: string | number; stdout?: string; stderr?: string };
+    const stdout = typeof e?.stdout === "string" ? e.stdout : "";
+    const stderr = typeof e?.stderr === "string" ? e.stderr : "";
+    const exitCodeRaw = (e as { code?: unknown })?.code;
+    const exitCode =
+      typeof exitCodeRaw === "number"
+        ? exitCodeRaw
+        : typeof exitCodeRaw === "string" && /^\d+$/.test(exitCodeRaw)
+          ? Number(exitCodeRaw)
+          : null;
+    return {
+      exitCode,
+      httpStatus: parseProbeHttpStatus(stdout),
+      durationMs,
+      stderrTail: tailString(stderr, PROBE_STDERR_TAIL_BYTES),
+      sshError: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function parseProbeHttpStatus(stdout: string): number | null {
+  const idx = stdout.lastIndexOf(PROBE_STATUS_SENTINEL);
+  if (idx < 0) return null;
+  const tail = stdout.slice(idx + PROBE_STATUS_SENTINEL.length).trim();
+  const match = tail.match(/^(\d{3})/);
+  if (!match) return null;
+  const status = Number.parseInt(match[1], 10);
+  // curl writes 000 when no HTTP response was received (DNS/TCP/TLS failure).
+  return status === 0 ? null : status;
+}
+
+function tailString(value: string | null | undefined, bytes: number): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length <= bytes) return trimmed;
+  return `…${trimmed.slice(-bytes)}`;
+}
+
+function dedupeCandidates(...sources: ReadonlyArray<readonly string[]>): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const source of sources) {
+    for (const candidate of source) {
+      const normalized = normalizeHttpUrlCandidate(candidate);
+      if (!normalized || seen.has(normalized)) continue;
+      seen.add(normalized);
+      ordered.push(normalized);
+    }
+  }
+  return ordered;
+}
+
 export async function findReachablePaperclipApiUrlOverSsh(input: {
   config: SshConnectionConfig;
   candidates: string[];
+  /** If provided, this candidate is probed first (cache short-circuit). */
+  preferredCandidate?: string | null;
   timeoutMs?: number;
-}): Promise<string | null> {
-  const uniqueCandidates = Array.from(
-    new Set(
-      input.candidates
-        .map((candidate) => normalizeHttpUrlCandidate(candidate))
-        .filter((candidate): candidate is string => candidate !== null),
-    ),
+  /** Per-candidate attempt count. Env: PAPERCLIP_RUNTIME_API_PROBE_ATTEMPTS. */
+  attempts?: number;
+  /**
+   * Wall-clock cap across the whole candidate sweep. Prevents pathological
+   * lease-acquire latency when every candidate is flapping. Env:
+   * PAPERCLIP_RUNTIME_API_PROBE_TOTAL_BUDGET_MS.
+   */
+  totalBudgetMs?: number;
+  /** Sleep between retries in ms; index N is the wait BEFORE attempt N+2. */
+  backoffMs?: readonly number[];
+  /** Test-only seam to skip real sleeps in unit tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Test-only seam: fake the curl-over-SSH runner. */
+  runProbe?: SingleProbeRunner;
+  /** Test-only seam: deterministic clock for total-budget enforcement. */
+  now?: () => number;
+  /** Test-only seam: deterministic jitter sample. */
+  randomBackoffMs?: () => number;
+}): Promise<PaperclipApiProbeResult> {
+  const orderedCandidates = dedupeCandidates(
+    input.preferredCandidate ? [input.preferredCandidate] : [],
+    input.candidates,
   );
 
-  for (const candidate of uniqueCandidates) {
+  const timeoutMs = resolveProbeTimeoutMs(input.timeoutMs);
+  const curlSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+  const probeAttempts = resolveProbeAttempts(input.attempts);
+  const totalBudgetMs = resolveProbeTotalBudgetMs(input.totalBudgetMs);
+  const backoffSource = resolveProbeBackoff(input.backoffMs);
+  const sleep = input.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const runProbe: SingleProbeRunner = input.runProbe ?? runSingleProbe;
+  const now = input.now ?? (() => Date.now());
+  const randomBackoffMs = input.randomBackoffMs ?? defaultRandomBackoffMs;
+
+  const startedAt = now();
+  const elapsedMs = (): number => now() - startedAt;
+  const isBudgetExhausted = (): boolean => elapsedMs() >= totalBudgetMs;
+
+  const attemptsLog: PaperclipApiProbeAttempt[] = [];
+
+  outer: for (const candidate of orderedCandidates) {
     const healthUrl = new URL("/api/health", candidate).toString();
-    try {
-      await runSshCommand(
-        input.config,
-        `sh -lc ${shellQuote(`curl -fsS -m ${Math.max(1, Math.ceil((input.timeoutMs ?? 5_000) / 1000))} ${shellQuote(healthUrl)} >/dev/null`)}`,
-        { timeoutMs: input.timeoutMs ?? 5_000 },
-      );
-      return candidate;
-    } catch {
-      continue;
+    for (let attemptIndex = 0; attemptIndex < probeAttempts; attemptIndex++) {
+      // Budget check BEFORE issuing a probe — we don't want to start a curl
+      // we can't afford. The check is intentionally on entry to each attempt,
+      // not just before sleep, so a slow probe + tight budget can't sneak in
+      // an extra request after the budget elapsed.
+      if (isBudgetExhausted()) break outer;
+
+      const probe = await runProbe({ config: input.config, healthUrl, curlSeconds, timeoutMs });
+      // Classification rules:
+      //  - ok: HTTP 2xx with curl exit 0
+      //  - permanent: HTTP 3xx/4xx (except 408/425/429) — retrying won't help
+      //  - transient: anything else (5xx, 408/425/429, curl exit != 0, ssh
+      //    timeout / network blip). Default to transient on uncertainty so a
+      //    misclassified failure still gets the retry budget rather than
+      //    falling through to "all candidates dead" on the first hiccup.
+      const classification: PaperclipApiProbeAttempt["classification"] = (() => {
+        if (probe.exitCode === 0 && probe.httpStatus !== null) {
+          return classifyHttpStatus(probe.httpStatus);
+        }
+        return "transient";
+      })();
+
+      const ok = classification === "ok";
+      const errorMessage = ok
+        ? null
+        : probe.sshError ??
+          (probe.httpStatus !== null ? `HTTP ${probe.httpStatus}` : `curl exit ${probe.exitCode ?? "?"}`);
+      const recorded: PaperclipApiProbeAttempt = {
+        candidate,
+        attempt: attemptIndex + 1,
+        ok,
+        exitCode: probe.exitCode,
+        httpStatus: probe.httpStatus,
+        durationMs: probe.durationMs,
+        stderrTail: probe.stderrTail,
+        classification,
+        error: errorMessage,
+      };
+      attemptsLog.push(recorded);
+
+      if (ok) {
+        return { url: candidate, attempts: attemptsLog };
+      }
+
+      // Spec (BLO-1490): "Log (at info) each failed attempt with: candidate
+      // URL, attempt index, error class, elapsed ms." Emit here so the line
+      // shape is identical regardless of caller. Caller can attach further
+      // context (env id, host) but cannot drop these fields.
+      logFailedProbeAttempt(recorded);
+
+      // Permanent failures — don't burn the retry budget on this candidate.
+      if (classification === "permanent") {
+        break;
+      }
+
+      const isLastAttempt = attemptIndex === probeAttempts - 1;
+      if (isLastAttempt) break;
+
+      const waitMs = resolveBackoffMs(backoffSource, attemptIndex, randomBackoffMs);
+      // Cap the sleep so we don't sit idle past the total budget. If there's
+      // no budget left for *any* sleep, drop straight into the next attempt
+      // — but the budget check at the top of the next iteration will catch
+      // an exhausted budget and exit the sweep cleanly.
+      const remainingBudget = totalBudgetMs - elapsedMs();
+      if (remainingBudget <= 0) break outer;
+      const cappedWait = Math.min(Math.max(0, waitMs), remainingBudget);
+      if (cappedWait > 0) {
+        await sleep(cappedWait);
+      }
     }
   }
 
-  return null;
+  return { url: null, attempts: attemptsLog };
+}
+
+function logFailedProbeAttempt(attempt: PaperclipApiProbeAttempt): void {
+  // Structured single-line log. Keep field order stable so log-scrapers
+  // (Loki / journalctl greps) can parse without a schema bump.
+  // eslint-disable-next-line no-console
+  console.info(
+    `[ssh-probe] ` +
+      `candidate=${attempt.candidate} ` +
+      `attempt=${attempt.attempt} ` +
+      `class=${attempt.classification} ` +
+      `status=${attempt.httpStatus ?? "none"} ` +
+      `exit=${attempt.exitCode ?? "none"} ` +
+      `durationMs=${attempt.durationMs}` +
+      (attempt.error ? ` error="${attempt.error.replace(/"/g, "'")}"` : ""),
+  );
 }
 
 async function execFileText(

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -390,6 +390,206 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     }
   });
 
+  it("acquires an SSH lease across a transient 503-then-200 health blip (BLO-1489)", async () => {
+    if (!sshFixtureSupport.supported) {
+      console.warn(
+        `Skipping SSH 503-then-200 retry test: ${sshFixtureSupport.reason ?? "unsupported environment"}`,
+      );
+      return;
+    }
+
+    const fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-environment-runtime-ssh-503-"));
+    fixtureRoots.push(fixtureRoot);
+    const statePath = path.join(fixtureRoot, "state.json");
+    const fixture = await startSshEnvLabFixture({ statePath });
+    const sshConfig = await buildSshEnvLabFixtureConfig(fixture);
+
+    let healthHits = 0;
+    const healthServer = createServer((req, res) => {
+      if (req.url === "/api/health") {
+        healthHits += 1;
+        // First two probes return 503 (mimicking the live bug from BLO-1489
+        // where nginx returned 503 in ~50ms during an upstream restart),
+        // then the third recovers.
+        if (healthHits <= 2) {
+          res.writeHead(503, { "content-type": "application/json" });
+          res.end(JSON.stringify({ status: "upstream_unavailable" }));
+          return;
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+      res.writeHead(404).end();
+    });
+    await new Promise<void>((resolve, reject) => {
+      healthServer.once("error", reject);
+      healthServer.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = healthServer.address();
+    if (!address || typeof address === "string") {
+      await new Promise<void>((resolve) => healthServer.close(() => resolve()));
+      throw new Error("Expected the test health server to listen on a TCP port.");
+    }
+    const runtimeApiUrl = `http://127.0.0.1:${address.port}`;
+    const previousCandidates = process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
+    const previousBackoff = process.env.PAPERCLIP_RUNTIME_API_PROBE_BACKOFF_MS_JSON;
+    const previousAttempts = process.env.PAPERCLIP_RUNTIME_API_PROBE_ATTEMPTS;
+    process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify([runtimeApiUrl]);
+    // Tight backoff so the test doesn't add 7s of sleep wall time.
+    process.env.PAPERCLIP_RUNTIME_API_PROBE_BACKOFF_MS_JSON = JSON.stringify([10, 10]);
+    process.env.PAPERCLIP_RUNTIME_API_PROBE_ATTEMPTS = "3";
+    const { companyId, environment, runId } = await seedEnvironment({
+      driver: "ssh",
+      name: "Fixture SSH 503",
+      config: sshConfig,
+    });
+    try {
+      const acquired = await runtime.acquireRunLease({
+        companyId,
+        environment,
+        issueId: null,
+        heartbeatRunId: runId,
+        persistedExecutionWorkspace: null,
+      });
+
+      expect(acquired.lease.status).toBe("active");
+      expect(acquired.lease.metadata).toMatchObject({
+        driver: "ssh",
+        paperclipApiUrl: runtimeApiUrl,
+      });
+      // Probe should have hit the health server exactly 3 times (503, 503, 200).
+      expect(healthHits).toBe(3);
+
+      await runtime.releaseRunLeases(runId);
+    } finally {
+      const restore = (key: string, prev: string | undefined) => {
+        if (prev === undefined) delete process.env[key];
+        else process.env[key] = prev;
+      };
+      restore("PAPERCLIP_RUNTIME_API_CANDIDATES_JSON", previousCandidates);
+      restore("PAPERCLIP_RUNTIME_API_PROBE_BACKOFF_MS_JSON", previousBackoff);
+      restore("PAPERCLIP_RUNTIME_API_PROBE_ATTEMPTS", previousAttempts);
+      await new Promise<void>((resolve) => healthServer.close(() => resolve()));
+      await stopSshEnvLabFixture(statePath).catch(() => undefined);
+    }
+  });
+
+  it("short-circuits to the last-good Paperclip API URL on the next acquireRunLease (BLO-1489 cache)", async () => {
+    if (!sshFixtureSupport.supported) {
+      console.warn(
+        `Skipping SSH cache short-circuit test: ${sshFixtureSupport.reason ?? "unsupported environment"}`,
+      );
+      return;
+    }
+
+    const fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-environment-runtime-ssh-cache-"));
+    fixtureRoots.push(fixtureRoot);
+    const statePath = path.join(fixtureRoot, "state.json");
+    const fixture = await startSshEnvLabFixture({ statePath });
+    const sshConfig = await buildSshEnvLabFixtureConfig(fixture);
+
+    let cachedHits = 0;
+    let secondaryHits = 0;
+    const cachedServer = createServer((req, res) => {
+      if (req.url === "/api/health") {
+        cachedHits += 1;
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+      res.writeHead(404).end();
+    });
+    const secondaryServer = createServer((req, res) => {
+      if (req.url === "/api/health") {
+        secondaryHits += 1;
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+      res.writeHead(404).end();
+    });
+    await new Promise<void>((resolve, reject) => {
+      cachedServer.once("error", reject);
+      cachedServer.listen(0, "127.0.0.1", () => resolve());
+    });
+    await new Promise<void>((resolve, reject) => {
+      secondaryServer.once("error", reject);
+      secondaryServer.listen(0, "127.0.0.1", () => resolve());
+    });
+    const cachedAddr = cachedServer.address();
+    const secondaryAddr = secondaryServer.address();
+    if (
+      !cachedAddr ||
+      typeof cachedAddr === "string" ||
+      !secondaryAddr ||
+      typeof secondaryAddr === "string"
+    ) {
+      await new Promise<void>((resolve) => cachedServer.close(() => resolve()));
+      await new Promise<void>((resolve) => secondaryServer.close(() => resolve()));
+      throw new Error("Expected the test health servers to listen on TCP ports.");
+    }
+    const cachedUrl = `http://127.0.0.1:${cachedAddr.port}`;
+    const secondaryUrl = `http://127.0.0.1:${secondaryAddr.port}`;
+    const previousCandidates = process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
+    // List BOTH so the first probe walks them in order; the second probe
+    // should skip directly to the cached URL even though it's no longer
+    // first in the candidate list.
+    process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify([secondaryUrl, cachedUrl]);
+    const { companyId, environment, runId } = await seedEnvironment({
+      driver: "ssh",
+      name: "Fixture SSH Cache",
+      config: sshConfig,
+    });
+    try {
+      // First acquire: candidates probed in declared order.
+      // [secondaryUrl, cachedUrl] — secondaryUrl is first, so it gets
+      // chosen and cached as paperclipApiUrl on the lease.
+      const first = await runtime.acquireRunLease({
+        companyId,
+        environment,
+        issueId: null,
+        heartbeatRunId: runId,
+        persistedExecutionWorkspace: null,
+      });
+      expect(first.lease.metadata).toMatchObject({ paperclipApiUrl: secondaryUrl });
+      const secondaryHitsAfterFirst = secondaryHits;
+      const cachedHitsAfterFirst = cachedHits;
+      expect(cachedHitsAfterFirst).toBe(0);
+
+      // Release the first lease so it lands as a "released" lease in the table
+      // (still discoverable by listLeases for the cache lookup).
+      await runtime.releaseRunLeases(runId);
+
+      // Second acquire: cache lookup should pull paperclipApiUrl from the
+      // prior lease and probe it FIRST. Since the cached URL responds 200
+      // on first probe, no additional candidates should be probed.
+      const second = await runtime.acquireRunLease({
+        companyId,
+        environment,
+        issueId: null,
+        heartbeatRunId: runId,
+        persistedExecutionWorkspace: null,
+      });
+      expect(second.lease.metadata).toMatchObject({ paperclipApiUrl: secondaryUrl });
+      // Cache hit means exactly one additional probe to the cached
+      // (secondary) URL and zero probes to the un-cached one.
+      expect(secondaryHits).toBe(secondaryHitsAfterFirst + 1);
+      expect(cachedHits).toBe(0);
+
+      await runtime.releaseRunLeases(runId);
+    } finally {
+      if (previousCandidates === undefined) {
+        delete process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
+      } else {
+        process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = previousCandidates;
+      }
+      await new Promise<void>((resolve) => cachedServer.close(() => resolve()));
+      await new Promise<void>((resolve) => secondaryServer.close(() => resolve()));
+      await stopSshEnvLabFixture(statePath).catch(() => undefined);
+    }
+  });
+
   it("acquires and releases a fake sandbox run lease through the runtime seam", async () => {
     const { companyId, environment, runId } = await seedEnvironment({
       driver: "sandbox",

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -530,21 +530,22 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       throw new Error("Expected the test health servers to listen on TCP ports.");
     }
     const cachedUrl = `http://127.0.0.1:${cachedAddr.port}`;
-    const secondaryUrl = `http://127.0.0.1:${secondaryAddr.port}`;
+    const otherUrl = `http://127.0.0.1:${secondaryAddr.port}`;
     const previousCandidates = process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
-    // List BOTH so the first probe walks them in order; the second probe
-    // should skip directly to the cached URL even though it's no longer
-    // first in the candidate list.
-    process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify([secondaryUrl, cachedUrl]);
+    // First probe: cachedUrl is at index 0 so it wins and lands in the lease's
+    // paperclipApiUrl. Second probe: we move it to index 1 — the only way a
+    // probe still hits cachedUrl first is if the cache lookup promoted it to
+    // the front of the sweep. Without this asymmetry the test would pass
+    // whether or not cache promotion works (Greptile #4715).
+    process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify([cachedUrl, otherUrl]);
     const { companyId, environment, runId } = await seedEnvironment({
       driver: "ssh",
       name: "Fixture SSH Cache",
       config: sshConfig,
     });
     try {
-      // First acquire: candidates probed in declared order.
-      // [secondaryUrl, cachedUrl] — secondaryUrl is first, so it gets
-      // chosen and cached as paperclipApiUrl on the lease.
+      // First acquire: cachedUrl wins (first in declared order) and is
+      // cached as paperclipApiUrl on the lease.
       const first = await runtime.acquireRunLease({
         companyId,
         environment,
@@ -552,18 +553,20 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
         heartbeatRunId: runId,
         persistedExecutionWorkspace: null,
       });
-      expect(first.lease.metadata).toMatchObject({ paperclipApiUrl: secondaryUrl });
-      const secondaryHitsAfterFirst = secondaryHits;
+      expect(first.lease.metadata).toMatchObject({ paperclipApiUrl: cachedUrl });
       const cachedHitsAfterFirst = cachedHits;
-      expect(cachedHitsAfterFirst).toBe(0);
+      expect(secondaryHits).toBe(0);
 
       // Release the first lease so it lands as a "released" lease in the table
       // (still discoverable by listLeases for the cache lookup).
       await runtime.releaseRunLeases(runId);
 
-      // Second acquire: cache lookup should pull paperclipApiUrl from the
-      // prior lease and probe it FIRST. Since the cached URL responds 200
-      // on first probe, no additional candidates should be probed.
+      // Reorder candidates so cachedUrl is NOT first on the second probe.
+      // This is the actual reordering test: if cache promotion works, the
+      // second probe still hits cachedUrl first (and otherUrl never gets a
+      // request); if not, otherUrl gets probed first and serves the lease.
+      process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify([otherUrl, cachedUrl]);
+
       const second = await runtime.acquireRunLease({
         companyId,
         environment,
@@ -571,11 +574,10 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
         heartbeatRunId: runId,
         persistedExecutionWorkspace: null,
       });
-      expect(second.lease.metadata).toMatchObject({ paperclipApiUrl: secondaryUrl });
-      // Cache hit means exactly one additional probe to the cached
-      // (secondary) URL and zero probes to the un-cached one.
-      expect(secondaryHits).toBe(secondaryHitsAfterFirst + 1);
-      expect(cachedHits).toBe(0);
+      expect(second.lease.metadata).toMatchObject({ paperclipApiUrl: cachedUrl });
+      // Cache hit: exactly one additional probe to cachedUrl, zero to otherUrl.
+      expect(cachedHits).toBe(cachedHitsAfterFirst + 1);
+      expect(secondaryHits).toBe(0);
 
       await runtime.releaseRunLeases(runId);
     } finally {

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -63,12 +63,30 @@ export type EnvironmentErrorCode =
   | "lease_release_failed"
   | "lease_cleanup_failed";
 
+/**
+ * Per-attempt detail surfaced from the SSH lease probe (see
+ * findReachablePaperclipApiUrlOverSsh). Re-declared here as the structural
+ * shape so the orchestrator stays decoupled from the adapter-utils package.
+ */
+export interface EnvironmentRunErrorProbeAttempt {
+  candidate: string;
+  attempt: number;
+  ok: boolean;
+  exitCode: number | null;
+  httpStatus: number | null;
+  durationMs: number;
+  stderrTail: string | null;
+  classification: string;
+  error: string | null;
+}
+
 export class EnvironmentRunError extends Error {
   code: EnvironmentErrorCode;
   environmentId?: string;
   driver?: string;
   provider?: string;
   cause?: unknown;
+  probeAttempts?: EnvironmentRunErrorProbeAttempt[];
 
   constructor(
     code: EnvironmentErrorCode,
@@ -78,6 +96,7 @@ export class EnvironmentRunError extends Error {
       driver?: string;
       provider?: string;
       cause?: unknown;
+      probeAttempts?: EnvironmentRunErrorProbeAttempt[];
     },
   ) {
     super(message);
@@ -87,6 +106,7 @@ export class EnvironmentRunError extends Error {
     this.driver = details?.driver;
     this.provider = details?.provider;
     this.cause = details?.cause;
+    if (details?.probeAttempts) this.probeAttempts = details.probeAttempts;
   }
 }
 
@@ -185,6 +205,10 @@ export function environmentRunOrchestrator(
     try {
       return await environmentRuntime.acquireRunLease(input);
     } catch (err) {
+      // SSH probe failures attach .probeAttempts to the inner Error; hoist
+      // them onto the EnvironmentRunError so structured callers (alerting,
+      // tests) can read attempt detail without unwrapping `cause`.
+      const probeAttempts = (err as { probeAttempts?: EnvironmentRunErrorProbeAttempt[] })?.probeAttempts;
       throw new EnvironmentRunError(
         "lease_acquire_failed",
         `Failed to acquire lease for environment "${input.environment.name}" (${input.environment.driver}): ${err instanceof Error ? err.message : String(err)}`,
@@ -192,6 +216,7 @@ export function environmentRunOrchestrator(
           environmentId: input.environment.id,
           driver: input.environment.driver,
           cause: err,
+          probeAttempts: Array.isArray(probeAttempts) ? probeAttempts : undefined,
         },
       );
     }

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -14,7 +14,11 @@ import type {
   PluginEnvironmentLease,
   PluginEnvironmentRealizeWorkspaceResult,
 } from "@paperclipai/plugin-sdk";
-import { ensureSshWorkspaceReady, findReachablePaperclipApiUrlOverSsh } from "@paperclipai/adapter-utils/ssh";
+import {
+  ensureSshWorkspaceReady,
+  findReachablePaperclipApiUrlOverSsh,
+  type PaperclipApiProbeAttempt,
+} from "@paperclipai/adapter-utils/ssh";
 import { environmentService } from "./environments.js";
 import {
   parseEnvironmentDriverConfig,
@@ -206,6 +210,46 @@ function createLocalEnvironmentDriver(db: Db): EnvironmentRuntimeDriver {
   };
 }
 
+function summarizeProbeAttempt(attempt: PaperclipApiProbeAttempt): string {
+  const parts: string[] = [
+    `candidate=${attempt.candidate}`,
+    `attempt=${attempt.attempt}`,
+    `status=${attempt.httpStatus ?? "none"}`,
+    `exit=${attempt.exitCode ?? "none"}`,
+    `class=${attempt.classification}`,
+    `durationMs=${attempt.durationMs}`,
+  ];
+  if (attempt.error) parts.push(`error="${attempt.error.replace(/"/g, "'")}"`);
+  return parts.join(" ");
+}
+
+function dedupeProbedCandidates(attempts: PaperclipApiProbeAttempt[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const attempt of attempts) {
+    if (seen.has(attempt.candidate)) continue;
+    seen.add(attempt.candidate);
+    ordered.push(attempt.candidate);
+  }
+  return ordered;
+}
+
+function createUnreachablePaperclipApiError(input: {
+  config: { username: string; host: string };
+  attempts: PaperclipApiProbeAttempt[];
+  candidatesProbed: string[];
+}): Error & { probeAttempts: PaperclipApiProbeAttempt[] } {
+  const lines = input.attempts.map((attempt) => `  - ${summarizeProbeAttempt(attempt)}`);
+  const message =
+    `SSH environment ${input.config.username}@${input.config.host} could not reach any Paperclip API candidates ` +
+    `(tried ${input.candidatesProbed.length}: ${input.candidatesProbed.join(", ") || "<none>"}).\n` +
+    `Probe attempts:\n${lines.join("\n")}`;
+  // The orchestrator wraps this in EnvironmentRunError("lease_acquire_failed",
+  // ...) preserving the structured detail via `cause`. Attaching attempts as
+  // a field lets tests assert on it directly without parsing the message.
+  return Object.assign(new Error(message), { probeAttempts: input.attempts });
+}
+
 function createSshEnvironmentDriver(db: Db): EnvironmentRuntimeDriver {
   const environmentsSvc = environmentService(db);
 
@@ -231,14 +275,42 @@ function createSshEnvironmentDriver(db: Db): EnvironmentRuntimeDriver {
           return [];
         }
       })();
-      const paperclipApiUrl = await findReachablePaperclipApiUrlOverSsh({
+
+      // Cache last-known-good probe URL by inspecting the most recent prior
+      // lease for this environment. listLeases returns most-recent-first.
+      // If the cached URL is stale (5xx now), the probe burns one attempt on
+      // it then falls through to the candidate list — strictly better than
+      // the cold-start cost of probing every candidate every time.
+      const preferredCandidate = await (async () => {
+        try {
+          const recent = await environmentsSvc.listLeases(input.environment.id);
+          for (const lease of recent) {
+            const url = (lease.metadata as Record<string, unknown> | null | undefined)?.paperclipApiUrl;
+            if (typeof url === "string" && url.trim().length > 0) {
+              return url.trim();
+            }
+          }
+        } catch {
+          // Cache lookup must never block lease acquisition.
+        }
+        return null;
+      })();
+
+      const probeResult = await findReachablePaperclipApiUrlOverSsh({
         config: parsed.config,
         candidates: candidateUrls,
+        preferredCandidate,
       });
+      // Per-attempt failures are logged at info inside the probe (BLO-1490
+      // spec); the all-fail thrown error below carries the full attempts
+      // trail for the orchestrator's structured error log.
+      const paperclipApiUrl = probeResult.url;
       if (!paperclipApiUrl) {
-        throw new Error(
-          `SSH environment ${parsed.config.username}@${parsed.config.host} could not reach any Paperclip API candidates.`,
-        );
+        throw createUnreachablePaperclipApiError({
+          config: parsed.config,
+          attempts: probeResult.attempts,
+          candidatesProbed: dedupeProbedCandidates(probeResult.attempts),
+        });
       }
       return await environmentsSvc.acquireLease({
         companyId: input.companyId,


### PR DESCRIPTION
## Summary

Eliminates the single-attempt SSH→Paperclip API probe failure mode that dropped three Paperclip API leases on 2026-04-28 (BLO-1487 root cause). Adds bounded retries with jittered backoff, a total-budget cap, and structured per-attempt logging.

- BLO-1490: retry knobs (jittered 250–750 ms backoff, 30 s total-budget cap, info-level per-attempt logs, env-var rename)
- BLO-1489: original retry implementation (transient classification, last-good-URL cache, structured probe result)
- Three review fixes (post-review on the kkroo PR #2 staging branch):
  1. Stale `PAPERCLIP_RUNTIME_API_PROBE_RETRIES` env-var name in `environment-runtime.test.ts` renamed to `_ATTEMPTS` to match the BLO-1490 spec rename.
  2. 5xx classifier deviation from BLO-1490 spec is now **explicitly documented inline** at the classifier (see `ssh.ts:244` comment). Decision: keep BLO-1489's 5xx-as-transient behavior so a brief 503 blip during an upstream nginx restart doesn't kill the lease in single-candidate prod setups. Total-budget cap bounds the worst case.
  3. New unit test pins the exact BLO-1487 incident shape: `httpStatus=null, sshError contains "timeout"` → classified transient → retry recovers. Future classifier refactors can't silently regress it.

## Why this PR exists separately from kkroo/paperclip#2

[kkroo/paperclip#2](https://github.com/kkroo/paperclip/pull/2) was fork-to-self (head `kkroo:fix/blo-1489-ssh-probe-hardening` → base `kkroo:master`, which forks from `lucitra/paperclip`, not `paperclipai/paperclip`). The fix never reached the deployed Paperclip control plane. Following the same cross-fork pattern as BLO-1497's [#4707](https://github.com/paperclipai/paperclip/pull/4707).

## Defaults

- Attempts: 3
- Backoff: jittered uniform [250, 750] ms (300 ms spec base)
- Total budget: 30 s across the entire candidate sweep
- Per-attempt timeout: 10 s
- All knobs tunable via `PAPERCLIP_RUNTIME_API_PROBE_*` env vars; malformed values clamp instead of crashing.

## Files

- `packages/adapter-utils/src/ssh.ts` — retry/budget machinery, structured probe result
- `packages/adapter-utils/src/ssh-probe.test.ts` — 15 unit tests (new)
- `server/src/services/environment-runtime.ts` — preferredCandidate from prior lease cache, error wrapping with attempts trail
- `server/src/services/environment-run-orchestrator.ts` — surfaces probeAttempts on `EnvironmentRunError`
- `server/src/__tests__/environment-runtime.test.ts` — 503-then-200 SSH integration test

## Spec deviation acknowledgement

BLO-1490 §"Required changes" says: *"If the SSH handshake itself succeeds but curl returns a non-2xx, treat that as a fast failure (no need to retry the same candidate aggressively — the API is reachable but unhealthy)."*

This PR keeps 5xx as `transient` (retried within the budget), not `permanent`. Operational reasoning is captured in `ssh.ts` at the `classifyHttpStatus` definition. The total-budget cap (30 s) bounds the worst-case sustained-5xx cost so we don't pathologically extend lease-acquire latency.

If reviewers prefer strict-spec compliance (5xx → permanent), see the inline comment for the two-line change. The trade-off is that BLO-1489's blip-recovery test would need to be reshaped to use a curl-exit-code transient (or dropped, since unit tests cover the path).

## Test plan

- [x] `pnpm --filter @paperclipai/adapter-utils typecheck` — clean
- [x] 15/15 ssh-probe unit tests pass
- [x] BLO-1489 503-blip SSH integration test passes
- [x] Verified pre-existing typecheck failures in `server/src/services/plugin-host-services.ts` exist on plain `paperclipai/paperclip:master` and are unrelated to this PR
- [ ] Reviewer: live verification on `oramadan@69.25.95.32` post-merge — 10 consecutive cold probes succeed, forced single-attempt failure recovers on attempt 2

## Linked issues

- BLO-1490 — Adapter retry on SSH→API probe failure (this PR)
- BLO-1489 — Original retry hardening (squashed in)
- BLO-1487 — Parent: recurring SSH→API lease drops on `oramadan@69.25.95.32`
- BLO-1493 — Recovery issue (resolved blocker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)