### PR TITLE
Expose plugin tools to adapter runs

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -392,6 +392,8 @@ By default, plugin tools are available to all agents. The operator may restrict 
 
 Plugin tools appear in the agent's tool list alongside core tools but are visually distinguished in the UI as plugin-contributed.
 
+During agent execution, Paperclip passes the available plugin tool descriptors to adapters through the adapter execution context. Adapters may expose those tools using their native tool mechanism; the OpenCode adapter writes temporary custom tool wrappers into an isolated `OPENCODE_CONFIG_DIR` for the run and routes calls back through Paperclip's authenticated `/api/plugins/tools/execute` endpoint.
+
 ### 11.4 Constraints
 
 - Plugin tools must not override or shadow core tools by name.

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -6,6 +6,7 @@ export type {
   AdapterRuntimeServiceReport,
   AdapterExecutionResult,
   AdapterInvocationMeta,
+  AdapterPluginToolDescriptor,
   AdapterExecutionContext,
   AdapterEnvironmentCheckLevel,
   AdapterEnvironmentCheck,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -119,6 +119,14 @@ export interface AdapterInvocationMeta {
   context?: Record<string, unknown>;
 }
 
+export interface AdapterPluginToolDescriptor {
+  name: string;
+  displayName: string;
+  description: string;
+  parametersSchema: Record<string, unknown>;
+  pluginId: string;
+}
+
 export interface AdapterExecutionContext {
   runId: string;
   agent: AdapterAgent;
@@ -133,6 +141,7 @@ export interface AdapterExecutionContext {
   executionTransport?: {
     remoteExecution?: Record<string, unknown> | null;
   };
+  pluginTools?: AdapterPluginToolDescriptor[];
   onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
   onMeta?: (meta: AdapterInvocationMeta) => Promise<void>;
   onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetPaperclipApiUrl,
@@ -43,6 +47,7 @@ import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
 import { removeMaintainerOnlySkillSymlinks } from "@paperclipai/adapter-utils/server-utils";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
+import { prepareOpenCodePluginTools } from "./plugin-tools.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -224,17 +229,33 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     env.PAPERCLIP_API_KEY = authToken;
   }
   const preparedRuntimeConfig = await prepareOpenCodeRuntimeConfig({ env, config });
+  let preparedPluginTools: Awaited<ReturnType<typeof prepareOpenCodePluginTools>> | null = null;
   const localRuntimeConfigHome =
     preparedRuntimeConfig.notes.length > 0 ? preparedRuntimeConfig.env.XDG_CONFIG_HOME : "";
   try {
+    preparedPluginTools = await prepareOpenCodePluginTools({
+      tools: ctx.pluginTools,
+      env: preparedRuntimeConfig.env,
+      runContext: {
+        agentId: agent.id,
+        runId,
+        companyId: agent.companyId,
+        projectId: asString(context.projectId, "").trim() || null,
+      },
+    });
+    const adapterEnv = preparedPluginTools.env;
+    const localPluginToolsConfigDir =
+      adapterEnv.OPENCODE_CONFIG_DIR && adapterEnv.OPENCODE_CONFIG_DIR !== preparedRuntimeConfig.env.OPENCODE_CONFIG_DIR
+        ? adapterEnv.OPENCODE_CONFIG_DIR
+        : "";
     const runtimeEnv = Object.fromEntries(
-      Object.entries(ensurePathInEnv({ ...process.env, ...preparedRuntimeConfig.env })).filter(
+      Object.entries(ensurePathInEnv({ ...process.env, ...adapterEnv })).filter(
         (entry): entry is [string, string] => typeof entry[1] === "string",
       ),
     );
     await ensureAdapterExecutionTargetCommandResolvable(command, executionTarget, cwd, runtimeEnv);
     const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(command, executionTarget, cwd, runtimeEnv);
-    const loggedEnv = buildInvocationEnvForLogs(preparedRuntimeConfig.env, {
+    const loggedEnv = buildInvocationEnvForLogs(adapterEnv, {
       runtimeEnv,
       includeRuntimeKeys: ["HOME"],
       resolvedCommand,
@@ -282,21 +303,30 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
               localDir: localRuntimeConfigHome,
             }]
             : []),
+          ...(localPluginToolsConfigDir
+            ? [{
+              key: "opencodeConfig",
+              localDir: localPluginToolsConfigDir,
+            }]
+            : []),
         ],
       });
       restoreRemoteWorkspace = () => preparedExecutionTargetRuntime.restoreWorkspace();
       const managedHome = adapterExecutionTargetUsesManagedHome(executionTarget);
       if (managedHome && preparedExecutionTargetRuntime.runtimeRootDir) {
-        preparedRuntimeConfig.env.HOME = preparedExecutionTargetRuntime.runtimeRootDir;
+        adapterEnv.HOME = preparedExecutionTargetRuntime.runtimeRootDir;
       }
       if (localRuntimeConfigHome && preparedExecutionTargetRuntime.assetDirs.xdgConfig) {
-        preparedRuntimeConfig.env.XDG_CONFIG_HOME = preparedExecutionTargetRuntime.assetDirs.xdgConfig;
+        adapterEnv.XDG_CONFIG_HOME = preparedExecutionTargetRuntime.assetDirs.xdgConfig;
+      }
+      if (localPluginToolsConfigDir && preparedExecutionTargetRuntime.assetDirs.opencodeConfig) {
+        adapterEnv.OPENCODE_CONFIG_DIR = preparedExecutionTargetRuntime.assetDirs.opencodeConfig;
       }
       const remoteHomeDir = managedHome && preparedExecutionTargetRuntime.runtimeRootDir
         ? preparedExecutionTargetRuntime.runtimeRootDir
         : await readAdapterExecutionTargetHomeDir(runId, executionTarget, {
             cwd,
-            env: preparedRuntimeConfig.env,
+            env: adapterEnv,
             timeoutSec,
             graceSec,
             onLog,
@@ -307,7 +337,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           runId,
           executionTarget,
           `mkdir -p ${JSON.stringify(path.posix.dirname(remoteSkillsDir))} && rm -rf ${JSON.stringify(remoteSkillsDir)} && cp -a ${JSON.stringify(preparedExecutionTargetRuntime.assetDirs.skills)} ${JSON.stringify(remoteSkillsDir)}`,
-          { cwd, env: preparedRuntimeConfig.env, timeoutSec, graceSec, onLog },
+          { cwd, env: adapterEnv, timeoutSec, graceSec, onLog },
         );
       }
     }
@@ -355,7 +385,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
 
     const commandNotes = (() => {
-      const notes = [...preparedRuntimeConfig.notes];
+      const notes = [...preparedRuntimeConfig.notes, ...preparedPluginTools.notes];
       if (!resolvedInstructionsFilePath) return notes;
       if (instructionsPrefix.length > 0) {
         notes.push(`Loaded agent instructions from ${resolvedInstructionsFilePath}`);
@@ -431,7 +461,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
       const proc = await runAdapterExecutionTargetProcess(runId, executionTarget, command, args, {
         cwd,
-        env: preparedRuntimeConfig.env,
+        env: adapterEnv,
         stdin: prompt,
         timeoutSec,
         graceSec,
@@ -543,6 +573,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ]);
     }
   } finally {
+    await preparedPluginTools?.cleanup();
     await preparedRuntimeConfig.cleanup();
   }
 }

--- a/packages/adapters/opencode-local/src/server/plugin-tools.test.ts
+++ b/packages/adapters/opencode-local/src/server/plugin-tools.test.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { prepareOpenCodePluginTools } from "./plugin-tools.js";
+
+const cleanupPaths = new Set<string>();
+
+afterEach(async () => {
+  await Promise.all(
+    [...cleanupPaths].map(async (filepath) => {
+      await fs.rm(filepath, { recursive: true, force: true });
+      cleanupPaths.delete(filepath);
+    }),
+  );
+});
+
+describe("prepareOpenCodePluginTools", () => {
+  it("creates ephemeral OpenCode custom tool wrappers for Paperclip plugin tools", async () => {
+    const prepared = await prepareOpenCodePluginTools({
+      tools: [
+        {
+          name: "paperclip.example:search-issues",
+          displayName: "Search Issues",
+          description: "Search plugin issues",
+          pluginId: "plugin-1",
+          parametersSchema: {
+            type: "object",
+            properties: {
+              query: { type: "string", description: "Search query" },
+              limit: { type: "integer" },
+            },
+            required: ["query"],
+          },
+        },
+      ],
+      env: {},
+      runContext: {
+        agentId: "agent-1",
+        runId: "run-1",
+        companyId: "company-1",
+        projectId: "project-1",
+      },
+    });
+    cleanupPaths.add(prepared.env.OPENCODE_CONFIG_DIR);
+
+    expect(prepared.notes).toEqual([
+      "Injected 1 Paperclip plugin tool wrapper(s) via OPENCODE_CONFIG_DIR.",
+    ]);
+
+    const toolFiles = await fs.readdir(`${prepared.env.OPENCODE_CONFIG_DIR}/tools`);
+    expect(toolFiles).toHaveLength(1);
+
+    const toolSource = await fs.readFile(
+      `${prepared.env.OPENCODE_CONFIG_DIR}/tools/${toolFiles[0]}`,
+      "utf8",
+    );
+    expect(toolSource).toContain('const TOOL_NAME = "paperclip.example:search-issues";');
+    expect(toolSource).toContain('"projectId": "project-1"');
+    expect(toolSource).toContain('Authorization: "Bearer " + apiKey');
+    expect(toolSource).toContain('"query": tool.schema.string().describe("Search query")');
+    expect(toolSource).toContain('"limit": tool.schema.number().int().optional()');
+
+    await prepared.cleanup();
+    cleanupPaths.delete(prepared.env.OPENCODE_CONFIG_DIR);
+    await expect(fs.access(prepared.env.OPENCODE_CONFIG_DIR)).rejects.toThrow();
+  });
+
+  it("skips injection when the run is not project-scoped", async () => {
+    const prepared = await prepareOpenCodePluginTools({
+      tools: [
+        {
+          name: "paperclip.example:search-issues",
+          displayName: "Search Issues",
+          description: "Search plugin issues",
+          pluginId: "plugin-1",
+          parametersSchema: { type: "object", properties: {} },
+        },
+      ],
+      env: {},
+      runContext: {
+        agentId: "agent-1",
+        runId: "run-1",
+        companyId: "company-1",
+        projectId: null,
+      },
+    });
+
+    expect(prepared.env).toEqual({});
+    expect(prepared.notes).toEqual([
+      "Skipped Paperclip plugin tool injection because the run has no projectId scope.",
+    ]);
+    await prepared.cleanup();
+  });
+});

--- a/packages/adapters/opencode-local/src/server/plugin-tools.ts
+++ b/packages/adapters/opencode-local/src/server/plugin-tools.ts
@@ -1,0 +1,255 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AdapterPluginToolDescriptor } from "@paperclipai/adapter-utils";
+
+type PreparedOpenCodePluginTools = {
+  env: Record<string, string>;
+  notes: string[];
+  cleanup: () => Promise<void>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function jsonString(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function sanitizeToolFileBase(name: string): string {
+  const sanitized = name.replace(/[^A-Za-z0-9_]+/g, "_").replace(/^_+|_+$/g, "").replace(/_+/g, "_");
+  return sanitized.length > 0 ? sanitized.slice(0, 80) : "paperclip_plugin_tool";
+}
+
+function jsStringLiteral(value: string): string {
+  return JSON.stringify(value);
+}
+
+function applySchemaDecorators(base: string, schema: Record<string, unknown>, required: boolean): string {
+  let source = base;
+  const description = typeof schema.description === "string" ? schema.description.trim() : "";
+  if (description) source += `.describe(${jsStringLiteral(description)})`;
+  if (schema.default !== undefined) source += `.default(${jsonString(schema.default)})`;
+  if (schema.nullable === true) source += ".nullable()";
+  if (!required) source += ".optional()";
+  return source;
+}
+
+function buildSchemaSource(rawSchema: unknown, required: boolean): string {
+  const schema = asRecord(rawSchema) ?? {};
+  const enumValues = Array.isArray(schema.enum) ? schema.enum : null;
+  if (enumValues && enumValues.length > 0 && enumValues.every((entry) => typeof entry === "string")) {
+    return applySchemaDecorators(
+      `tool.schema.enum(${jsonString(enumValues)})`,
+      schema,
+      required,
+    );
+  }
+
+  const typeValue = schema.type;
+  const typeList = Array.isArray(typeValue)
+    ? typeValue.filter((entry): entry is string => typeof entry === "string")
+    : typeof typeValue === "string"
+      ? [typeValue]
+      : [];
+  const allowsNull = typeList.includes("null");
+  const primaryType = typeList.find((entry) => entry !== "null") ?? (typeof typeValue === "string" ? typeValue : null);
+  const effectiveSchema = allowsNull ? { ...schema, nullable: true } : schema;
+
+  if (primaryType === "string") {
+    let source = "tool.schema.string()";
+    if (typeof schema.minLength === "number") source += `.min(${schema.minLength})`;
+    if (typeof schema.maxLength === "number") source += `.max(${schema.maxLength})`;
+    return applySchemaDecorators(source, effectiveSchema, required);
+  }
+
+  if (primaryType === "integer" || primaryType === "number") {
+    let source = "tool.schema.number()";
+    if (primaryType === "integer") source += ".int()";
+    if (typeof schema.minimum === "number") source += `.min(${schema.minimum})`;
+    if (typeof schema.maximum === "number") source += `.max(${schema.maximum})`;
+    return applySchemaDecorators(source, effectiveSchema, required);
+  }
+
+  if (primaryType === "boolean") {
+    return applySchemaDecorators("tool.schema.boolean()", effectiveSchema, required);
+  }
+
+  if (primaryType === "array") {
+    const itemSource = buildSchemaSource(schema.items, true);
+    let source = `tool.schema.array(${itemSource})`;
+    if (typeof schema.minItems === "number") source += `.min(${schema.minItems})`;
+    if (typeof schema.maxItems === "number") source += `.max(${schema.maxItems})`;
+    return applySchemaDecorators(source, effectiveSchema, required);
+  }
+
+  if (primaryType === "object") {
+    const properties = asRecord(schema.properties) ?? {};
+    const requiredSet = new Set(asStringArray(schema.required));
+    const entries = Object.entries(properties).map(
+      ([key, value]) => `${jsStringLiteral(key)}: ${buildSchemaSource(value, requiredSet.has(key))}`,
+    );
+    let source = `tool.schema.object({${entries.length > 0 ? `\n${entries.map((entry) => `  ${entry},`).join("\n")}\n` : ""}})`;
+    if (schema.additionalProperties !== false) source += ".passthrough()";
+    return applySchemaDecorators(source, effectiveSchema, required);
+  }
+
+  return applySchemaDecorators("tool.schema.any()", effectiveSchema, required);
+}
+
+function buildArgsSource(schema: Record<string, unknown>): string {
+  if (schema.type !== "object") return "{}";
+  const properties = asRecord(schema.properties) ?? {};
+  const requiredSet = new Set(asStringArray(schema.required));
+  const entries = Object.entries(properties).map(
+    ([key, value]) => `${jsStringLiteral(key)}: ${buildSchemaSource(value, requiredSet.has(key))}`,
+  );
+  return entries.length > 0 ? `{
+${entries.map((entry) => `  ${entry},`).join("\n")}
+}` : "{}";
+}
+
+function buildToolSource(params: {
+  tool: AdapterPluginToolDescriptor;
+  runContext: { agentId: string; runId: string; companyId: string; projectId: string };
+}): string {
+  const { tool, runContext } = params;
+  const description = `${tool.displayName || tool.name} (${tool.name})`;
+  return `import { tool } from "@opencode-ai/plugin";
+
+const TOOL_NAME = ${jsStringLiteral(tool.name)};
+const RUN_CONTEXT = ${JSON.stringify(runContext, null, 2)};
+
+async function executePaperclipPluginTool(args) {
+  const apiUrl = process.env.PAPERCLIP_API_URL?.trim();
+  const apiKey = process.env.PAPERCLIP_API_KEY?.trim();
+  if (!apiUrl) throw new Error("PAPERCLIP_API_URL is not set");
+  if (!apiKey) throw new Error("PAPERCLIP_API_KEY is not set");
+
+  const response = await fetch(new URL("/api/plugins/tools/execute", apiUrl), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + apiKey,
+    },
+    body: JSON.stringify({
+      tool: TOOL_NAME,
+      parameters: args,
+      runContext: RUN_CONTEXT,
+    }),
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const message = typeof payload?.error === "string" && payload.error.trim().length > 0
+      ? payload.error
+      : "Paperclip plugin tool request failed with status " + response.status;
+    throw new Error(message);
+  }
+
+  const result = payload?.result && typeof payload.result === "object" ? payload.result : payload;
+  if (typeof result?.error === "string" && result.error.trim().length > 0) {
+    throw new Error(result.error);
+  }
+  if (typeof result?.content === "string" && result.content.trim().length > 0) {
+    return result.content;
+  }
+  if (result?.data !== undefined) {
+    return JSON.stringify(result.data, null, 2);
+  }
+  return TOOL_NAME + " completed successfully.";
+}
+
+export default tool({
+  description: ${jsStringLiteral(`Paperclip plugin tool wrapper for ${description}`)},
+  args: ${buildArgsSource(tool.parametersSchema)},
+  async execute(args) {
+    return await executePaperclipPluginTool(args);
+  },
+});
+`;
+}
+
+export async function prepareOpenCodePluginTools(input: {
+  tools?: AdapterPluginToolDescriptor[];
+  env: Record<string, string>;
+  runContext: { agentId: string; runId: string; companyId: string; projectId: string | null };
+}): Promise<PreparedOpenCodePluginTools> {
+  const tools = Array.isArray(input.tools) ? input.tools : [];
+  if (tools.length === 0) {
+    return {
+      env: input.env,
+      notes: [],
+      cleanup: async () => {},
+    };
+  }
+  if (!input.runContext.projectId) {
+    return {
+      env: input.env,
+      notes: ["Skipped Paperclip plugin tool injection because the run has no projectId scope."],
+      cleanup: async () => {},
+    };
+  }
+
+  const tempConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-tools-"));
+  const toolsDir = path.join(tempConfigDir, "tools");
+  const existingConfigDir = input.env.OPENCODE_CONFIG_DIR?.trim() || process.env.OPENCODE_CONFIG_DIR?.trim() || "";
+
+  await fs.mkdir(toolsDir, { recursive: true });
+  if (existingConfigDir) {
+    try {
+      await fs.cp(existingConfigDir, tempConfigDir, {
+        recursive: true,
+        force: true,
+        errorOnExist: false,
+        dereference: false,
+      });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException | null)?.code !== "ENOENT") throw error;
+    }
+  }
+
+  const seenNames = new Set<string>();
+  for (const tool of tools) {
+    const baseName = sanitizeToolFileBase(`paperclip_${tool.name}`);
+    let fileBase = baseName;
+    let suffix = 2;
+    while (seenNames.has(fileBase)) {
+      fileBase = `${baseName}_${suffix++}`;
+    }
+    seenNames.add(fileBase);
+    await fs.writeFile(
+      path.join(toolsDir, `${fileBase}.js`),
+      buildToolSource({
+        tool,
+        runContext: {
+          agentId: input.runContext.agentId,
+          runId: input.runContext.runId,
+          companyId: input.runContext.companyId,
+          projectId: input.runContext.projectId,
+        },
+      }),
+      "utf8",
+    );
+  }
+
+  return {
+    env: {
+      ...input.env,
+      OPENCODE_CONFIG_DIR: tempConfigDir,
+    },
+    notes: [`Injected ${tools.length} Paperclip plugin tool wrapper(s) via OPENCODE_CONFIG_DIR.`],
+    cleanup: async () => {
+      await fs.rm(tempConfigDir, { recursive: true, force: true });
+    },
+  };
+}

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -101,6 +101,16 @@ function boardActor(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function agentActor(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "agent",
+    companyId: companyA,
+    agentId: agentA,
+    runId: runA,
+    ...overrides,
+  };
+}
+
 function readyPlugin() {
   mockRegistry.getById.mockResolvedValue({
     id: pluginId,
@@ -457,6 +467,79 @@ describe.sequential("plugin tool and bridge authz", () => {
         projectId: projectA,
       },
     );
+  });
+
+  it("allows authenticated agents to execute plugin tools for their own run", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ content: "ok" });
+    const { app } = await createApp(agentActor(), {}, {
+      db: createSelectQueueDb([
+        [{ companyId: companyA }],
+        [{ companyId: companyA, agentId: agentA }],
+        [{ companyId: companyA }],
+      ]),
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclip.example:search" })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: { q: "test" },
+        runContext: {
+          agentId: agentA,
+          runId: runA,
+          companyId: companyA,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(executeTool).toHaveBeenCalledWith(
+      "paperclip.example:search",
+      { q: "test" },
+      {
+        agentId: agentA,
+        runId: runA,
+        companyId: companyA,
+        projectId: projectA,
+      },
+    );
+  });
+
+  it("rejects agent tool execution when runContext.runId does not match the authenticated run", async () => {
+    const executeTool = vi.fn();
+    const { app } = await createApp(agentActor(), {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclip.example:search" })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: {},
+        runContext: {
+          agentId: agentA,
+          runId: "99999999-9999-4999-8999-999999999999",
+          companyId: companyA,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('"runContext.runId" must match the authenticated run');
+    expect(executeTool).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/server/src/adapters/index.ts
+++ b/server/src/adapters/index.ts
@@ -15,6 +15,7 @@ export type {
   AdapterExecutionContext,
   AdapterExecutionResult,
   AdapterInvocationMeta,
+  AdapterPluginToolDescriptor,
   AdapterEnvironmentCheckLevel,
   AdapterEnvironmentCheck,
   AdapterEnvironmentTestStatus,

--- a/server/src/adapters/types.ts
+++ b/server/src/adapters/types.ts
@@ -8,6 +8,7 @@ export type {
   UsageSummary,
   AdapterExecutionResult,
   AdapterInvocationMeta,
+  AdapterPluginToolDescriptor,
   AdapterExecutionContext,
   AdapterEnvironmentCheckLevel,
   AdapterEnvironmentCheck,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -48,6 +48,7 @@ import { createPluginWorkerManager, type PluginWorkerManager } from "./services/
 import { createPluginJobScheduler } from "./services/plugin-job-scheduler.js";
 import { pluginJobStore } from "./services/plugin-job-store.js";
 import { createPluginToolDispatcher } from "./services/plugin-tool-dispatcher.js";
+import { setCurrentPluginToolDispatcher } from "./services/plugin-tool-runtime.js";
 import { pluginLifecycleManager } from "./services/plugin-lifecycle.js";
 import { createPluginJobCoordinator } from "./services/plugin-job-coordinator.js";
 import { buildHostServices, flushPluginLogBuffer } from "./services/plugin-host-services.js";
@@ -229,6 +230,7 @@ export async function createApp(
     lifecycleManager: lifecycle,
     db,
   });
+  setCurrentPluginToolDispatcher(toolDispatcher);
   const jobCoordinator = createPluginJobCoordinator({
     db,
     lifecycle,

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -601,6 +601,34 @@ export function pluginRoutes(
     return null;
   }
 
+  function assertToolRunRequestAccess(req: Request, runContext: ToolRunContext): void {
+    assertAuthenticated(req);
+
+    if (req.actor.type === "board") {
+      assertCompanyAccess(req, runContext.companyId);
+      return;
+    }
+
+    if (req.actor.type !== "agent") {
+      throw forbidden("Board or agent access required");
+    }
+    if (!req.actor.runId?.trim()) {
+      throw unauthorized("Agent run id required");
+    }
+    if (!req.actor.agentId) {
+      throw forbidden("Agent authentication required");
+    }
+    if (req.actor.companyId !== runContext.companyId) {
+      throw forbidden("Agent key cannot access another company");
+    }
+    if (req.actor.agentId !== runContext.agentId) {
+      throw forbidden('"runContext.agentId" must match the authenticated agent');
+    }
+    if (req.actor.runId !== runContext.runId) {
+      throw forbidden('"runContext.runId" must match the authenticated run');
+    }
+  }
+
   /**
    * GET /api/plugins
    *
@@ -761,8 +789,6 @@ export function pluginRoutes(
    * - 502 if the plugin worker is unavailable or the RPC call fails
    */
   router.post("/plugins/tools/execute", async (req, res) => {
-    assertBoardOrgAccess(req);
-
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
       return;
@@ -794,7 +820,7 @@ export function pluginRoutes(
       return;
     }
 
-    assertCompanyAccess(req, runContext.companyId);
+    assertToolRunRequestAccess(req, runContext);
     const scopeError = await validateToolRunContextScope(runContext);
     if (scopeError) {
       res.status(403).json({ error: scopeError });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -127,6 +127,7 @@ import { environmentService } from "./environments.js";
 import { environmentRuntimeService } from "./environment-runtime.js";
 import { environmentRunOrchestrator } from "./environment-run-orchestrator.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
+import { getCurrentPluginToolDispatcher } from "./plugin-tool-runtime.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const MAX_PERSISTED_LOG_CHUNK_CHARS = 64 * 1024;
@@ -5509,6 +5510,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
+      const pluginTools = getCurrentPluginToolDispatcher()?.listToolsForAgent();
       const adapterResult = await adapter.execute({
         runId: run.id,
         agent,
@@ -5519,6 +5521,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         executionTransport: remoteExecution
           ? { remoteExecution: remoteExecution as unknown as Record<string, unknown> }
           : undefined,
+        pluginTools,
         onLog,
         onMeta: onAdapterMeta,
         onSpawn: async (meta) => {

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1826,7 +1826,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.test.ts
+++ b/server/src/services/plugin-tool-dispatcher.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPluginToolDispatcher } from "./plugin-tool-dispatcher.js";
+
+describe("createPluginToolDispatcher", () => {
+  it("routes tool execution through the plugin database id when manually registering tools", async () => {
+    const workerManager = {
+      isRunning: vi.fn((pluginId: string) => pluginId === "plugin-db-id"),
+      call: vi.fn().mockResolvedValue({ content: "ok" }),
+    };
+
+    const dispatcher = createPluginToolDispatcher({
+      workerManager: workerManager as never,
+    });
+
+    dispatcher.registerPluginTools(
+      "paperclip-plugin-hindsight",
+      {
+        apiVersion: 1,
+        id: "paperclip-plugin-hindsight",
+        displayName: "Hindsight",
+        version: "0.2.0",
+        description: "Hindsight memory plugin",
+        author: "Paperclip",
+        categories: ["automation"],
+        entrypoints: { worker: "dist/worker.js" },
+        capabilities: [],
+        tools: [
+          {
+            name: "hindsight_recall",
+            displayName: "Hindsight Recall",
+            description: "Recall memory",
+            parametersSchema: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+              },
+              required: ["query"],
+            },
+          },
+        ],
+      },
+      "plugin-db-id",
+    );
+
+    const result = await dispatcher.executeTool(
+      "paperclip-plugin-hindsight:hindsight_recall",
+      { query: "test" },
+      {
+        agentId: "agent-1",
+        runId: "run-1",
+        companyId: "company-1",
+        projectId: "project-1",
+      },
+    );
+
+    expect(workerManager.isRunning).toHaveBeenCalledWith("plugin-db-id");
+    expect(workerManager.call).toHaveBeenCalledWith(
+      "plugin-db-id",
+      "executeTool",
+      {
+        toolName: "hindsight_recall",
+        parameters: { query: "test" },
+        runContext: {
+          agentId: "agent-1",
+          runId: "run-1",
+          companyId: "company-1",
+          projectId: "project-1",
+        },
+      },
+    );
+    expect(result).toEqual({
+      pluginId: "paperclip-plugin-hindsight",
+      toolName: "hindsight_recall",
+      result: { content: "ok" },
+    });
+  });
+});

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -156,6 +156,7 @@ export interface PluginToolDispatcher {
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +430,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {

--- a/server/src/services/plugin-tool-runtime.ts
+++ b/server/src/services/plugin-tool-runtime.ts
@@ -1,0 +1,11 @@
+import type { PluginToolDispatcher } from "./plugin-tool-dispatcher.js";
+
+let currentPluginToolDispatcher: PluginToolDispatcher | null = null;
+
+export function setCurrentPluginToolDispatcher(dispatcher: PluginToolDispatcher): void {
+  currentPluginToolDispatcher = dispatcher;
+}
+
+export function getCurrentPluginToolDispatcher(): PluginToolDispatcher | null {
+  return currentPluginToolDispatcher;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The plugin system lets optional capabilities expose agent tools without bloating core.
> - Plugin tool declarations were registered and dispatchable, but adapters did not receive an execution-time tool list.
> - OpenCode runs need native custom tool files, scoped credentials, and run context to invoke those plugin tools safely.
> - The `/api/plugins/tools/execute` route also needs to accept authenticated agent calls for the active run, not only board calls.
> - This pull request passes plugin tool descriptors into adapter execution, wires OpenCode wrappers, and preserves company/run/project authorization.
> - The benefit is that plugin-provided tools can be used by OpenCode agents during Paperclip runs while still routing through the control plane.

## What Changed

- Added `AdapterPluginToolDescriptor` and optional `pluginTools` on `AdapterExecutionContext`.
- Passed registered plugin tools from the heartbeat execution path into adapters.
- Added OpenCode plugin-tool preparation that writes temporary custom tool wrappers into `OPENCODE_CONFIG_DIR` and cleans them after the run.
- Allowed authenticated agent calls to `/api/plugins/tools/execute` only when `runContext` matches the authenticated agent, run, and company.
- Preserved plugin worker dispatch via the plugin database id when registering tools.
- Added tests for OpenCode wrapper generation, plugin dispatcher routing, and agent-scoped plugin tool execution authz.
- Documented adapter-facing plugin tool exposure in `doc/plugins/PLUGIN_SPEC.md`.

## Verification

- `PATH="/tmp/paperclip-corepack-bin:$PATH" pnpm -r typecheck`
- `PATH="/tmp/paperclip-corepack-bin:$PATH" pnpm test:run`
- `PATH="/tmp/paperclip-corepack-bin:$PATH" pnpm build`
- Roadmap checked: this is a scoped plugin/adapter integration improvement and does not duplicate a planned core roadmap item.
- No UI changes; screenshots are not applicable.

## Risks

- Medium risk: OpenCode custom tool generation translates JSON Schema into the OpenCode plugin schema API, so unusual schema shapes may degrade to permissive `any()` wrappers.
- Medium risk: the server currently exposes the current plugin tool dispatcher through process-local runtime state for heartbeat use; this matches the existing single-process server shape but should be revisited if heartbeat execution moves out of process.
- Low migration risk: no database schema changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5, exact model ID `openai/gpt-5.5`, running in OpenCode with repository tool access and local command execution. Context window size was not reported by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge