### PR TITLE
chore(repo): ignore macOS AppleDouble metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ drizzle/meta/
 .vite/
 coverage/
 .DS_Store
+._*
+.AppleDouble
+.LSOverride
 data/
 .paperclip/
 .pnpm-store/


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Contributors clone this repository and work in it on macOS
> - macOS writes AppleDouble sidecar files named `._<filename>` next to real files
> - The repository ignores `.DS_Store`, but it does not ignore these sidecars
> - `git status` then lists the sidecars together with real untracked files
> - The noise hides real changes during development and review
> - This pull request adds the standard macOS sidecar patterns to `.gitignore`
> - The benefit is a clean `git status` for every macOS contributor

## Linked Issues or Issue Description

No existing issue covers this. The problem is described below, in the format of
`.github/ISSUE_TEMPLATE/enhancement.yml`.

**What existing behavior does this improve?**

The root `.gitignore` file, and the `git status` output that developers see.

**Subsystem affected**

Cross-cutting (multiple of the above) — repository tooling, not application code.

**Current behavior**

The root `.gitignore` ignores `.DS_Store`. It does not ignore the AppleDouble
sidecar files that macOS writes. macOS creates a file named `._<filename>` next
to a regular file when the volume cannot store extended attributes. This happens
on exFAT and NTFS volumes, on FUSE mounts, and on network shares. Git shows
every one of these files as untracked. The author reports approximately 58,000
such files in one local checkout. Real untracked files, such as new scaffold
directories, are lost in that list.

**Proposed behavior**

`.gitignore` ignores `._*`, `.AppleDouble`, and `.LSOverride`. `git status` then
shows only real files. These three patterns are the macOS set from GitHub's
gitignore collection: https://github.com/github/gitignore/blob/main/Global/macOS.gitignore

**Reason and benefit**

Developers lose time when they read `git status` output that contains thousands
of operating system files. They can also commit a sidecar file by accident. The
repository already suppresses these same files in its own code: `ssh.ts` sets
`COPYFILE_DISABLE=1` to stop `bsdtar` from writing them, and the Daytona
file-sync path excludes them from tarballs. This change applies the same rule
to git.

**Breaking changes**

None. No tracked file matches the new patterns. Git continues to track any file
that is already tracked, because `.gitignore` applies to untracked files only.

## What Changed

- Added `._*`, `.AppleDouble`, and `.LSOverride` to the root `.gitignore`, below
  the existing `.DS_Store` entry.

## Verification

- `git status` no longer lists `._*` files after the change.
- `git ls-files | grep -E '^\._|\.AppleDouble|\.LSOverride'` returns no output.
  No tracked file becomes ignored.
- `.DS_Store` behavior does not change.

## Risks

Low risk. This is a configuration change with no runtime effect. A file that
starts with `._` becomes ignored, so a contributor who needs such a file must
add it with `git add -f`. Git refuses to add an ignored path without that flag,
so the effect is visible and not silent. No such file exists in the repository.

Note for contributors who already have these files in a working tree: the ignore
rule does not delete them. Remove them with:
`find . -name '._*' -not -path './node_modules/*' -not -path './.git/*' -delete`

## Model Used

- Provider: Anthropic Claude, through Claude Code.
- The original description recorded only "Generated with Claude Code". It did not
  record an exact model ID.
- This description was rewritten to the repository template by Claude Opus 5
  (1M context, extended thinking, tool use), on behalf of the maintainers. The
  code in this pull request is unchanged.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (no duplicates found)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change (`chore/gitignore-appledouble`) and contains no internal ticket id
- [ ] I have run tests locally and they pass — not applicable, no code is executed by this change
- [x] I have added or updated tests where applicable (not applicable — `.gitignore` only)
- [x] I have updated relevant documentation to reflect my changes (none required)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s — pending re-review of this updated description
- [x] I will address all Greptile and reviewer comments before requesting merge
