### PR TITLE
feat(heartbeat): preserve last-error payload on agents.metadata when finalizing to error

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4116,12 +4116,47 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           ? "idle"
           : "error";
 
+    // When transitioning to "error", preserve the last failed run's error
+    // payload on agents.metadata so operators can diagnose why the agent
+    // stopped accepting work without trawling logs.
+    let nextMetadata: Record<string, unknown> | undefined;
+    if (nextStatus === "error") {
+      const lastFailed = await db
+        .select({
+          runId: heartbeatRuns.id,
+          status: heartbeatRuns.status,
+          error: heartbeatRuns.error,
+          errorCode: heartbeatRuns.errorCode,
+          finishedAt: heartbeatRuns.finishedAt,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId))
+        .orderBy(desc(heartbeatRuns.finishedAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      const prevMetadata =
+        (existing.metadata && typeof existing.metadata === "object"
+          ? (existing.metadata as Record<string, unknown>)
+          : {}) ?? {};
+      nextMetadata = {
+        ...prevMetadata,
+        lastError: {
+          outcome,
+          message: lastFailed?.error ?? null,
+          code: lastFailed?.errorCode ?? null,
+          runId: lastFailed?.runId ?? null,
+          at: new Date().toISOString(),
+        },
+      };
+    }
+
     const updated = await db
       .update(agents)
       .set({
         status: nextStatus,
         lastHeartbeatAt: new Date(),
         updatedAt: new Date(),
+        ...(nextMetadata ? { metadata: nextMetadata } : {}),
       })
       .where(eq(agents.id, agentId))
       .returning()


### PR DESCRIPTION
## Summary

When `finalizeAgentStatus` flips an agent to `status="error"`, capture the most recent failed run's `error`/`errorCode`/`runId` and persist them onto `agents.metadata.lastError`. No schema change — `metadata jsonb` already exists.

## The problem

`finalizeAgentStatus` (in `server/src/services/heartbeat.ts`) is called from at least five sites — orphaned-run reaper, run finalizer, watchdog, exception handler, and the cancel path — whenever a heartbeat run ends. If the outcome is anything other than `succeeded` or `cancelled`, the agent is moved to `status="error"` and stops accepting new work.

The error payload **already exists** on `heartbeatRuns.error` and `heartbeatRuns.errorCode`. But nothing carries it onto the `agents` row. The result is that an operator looking at `GET /api/agents/:id` (or the dashboard) sees:

\`\`\`json
{ \"name\": \"CFO\", \"status\": \"error\", \"errorMessage\": null, \"lastError\": null, \"statusReason\": null }
\`\`\`

…with no way to find out _why_ the agent stopped without trawling the full server log or hand-joining `heartbeatRuns` by `agentId` ordered by `finishedAt desc`.

In a recent operational incident this took **8 agents across two companies** offline silently — the agents kept emitting heartbeats every hour but refused to claim work, and the only signal was the `\"error\"` status. Recovery required manually `PATCH /api/agents/:id { status: \"active\" }` on each one without ever knowing the original cause.

## What this PR changes

In `finalizeAgentStatus`, when the computed `nextStatus === \"error\"`:

1. Look up the most recent `heartbeatRuns` row for this `agentId`, ordered by `finishedAt desc`.
2. Merge a `lastError` object into the existing `agents.metadata`:
   \`\`\`ts
   metadata.lastError = {
     outcome,                          // \"failed\" | \"timed_out\"
     message: lastFailed?.error,       // human-readable error from the run
     code: lastFailed?.errorCode,      // structured code if present
     runId: lastFailed?.runId,         // link back to the failing run
     at: new Date().toISOString(),     // when the agent transitioned
   };
   \`\`\`
3. Existing fields on `metadata` are preserved (shallow merge with the previous object).

Behaviour for `running` / `idle` transitions is unchanged. The `metadata` write is skipped entirely unless we're entering the `error` state, so the success path is unaffected.

## Why metadata.jsonb instead of new columns

Keeping the change inside the existing `agents.metadata jsonb` column means **no migration**, no breaking change for downstream consumers, and a small diff that's easy to revert if the design moves toward dedicated columns later. Happy to refactor to first-class columns (`last_error_message`, `last_error_code`, `last_errored_at`, etc.) if that's the preferred direction — let me know and I'll resubmit.

## Test plan

- [x] `pnpm --filter @paperclipai/server typecheck` — patch is type-clean (the pre-existing `plugin-host-services.ts` and `plugin-worker-manager.ts` errors on master are not introduced by this PR)
- [x] Manual: triggered an agent into `error` state and confirmed `agents.metadata.lastError` is populated on the next finalize, with `runId` linking to the failing `heartbeatRuns` row
- [x] Manual: confirmed the success path still leaves `metadata` unchanged
- [ ] Unit test for `finalizeAgentStatus` covering both transitions — happy to add one if you'd like; pointed me at any preferred test location

## Follow-ups (not in this PR)

These are intentionally out of scope so this stays minimal and reviewable, but they're the natural next steps if this lands:

1. **UI surfacing** — render `metadata.lastError` as a status badge on the agent card with a deep link to the run.
2. **Auto-recovery** — exponential backoff that tries `error → idle` after N minutes, since most failures observed in practice are transient (rate limits, network blips).
3. **Daily health digest** — per-company `status` rollup at a configurable hour.

Happy to file separate issues for any of these if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)