### PR TITLE
heartbeat: trim per-wake preamble and de-duplicate description

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -287,9 +287,9 @@ describe("renderPaperclipWakePrompt", () => {
     });
 
     expect(prompt).toContain("## Paperclip Wake Payload");
-    expect(prompt).toContain("Execution contract: take concrete action in this heartbeat");
-    expect(prompt).toContain("use child issues instead of polling");
-    expect(prompt).toContain("mark blocked work with the unblock owner/action");
+    expect(prompt).toContain("Highest-priority for this heartbeat");
+    expect(prompt).toContain("skills/paperclip/SKILL.md");
+    expect(prompt).toContain("acknowledge the latest comment first");
   });
 
   it("renders dependency-blocked interaction guidance", () => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -597,13 +597,7 @@ export function renderPaperclipWakePrompt(
   const lines = resumedSession
       ? [
         "## Paperclip Resume Delta",
-        "",
-        "You are resuming an existing Paperclip session.",
-        "This heartbeat is scoped to the issue below. Do not switch to another issue until you have handled this wake.",
-        "Focus on the new wake delta below and continue the current task without restating the full heartbeat boilerplate.",
-        "Fetch the API thread only when `fallbackFetchNeeded` is true or you need broader history than this batch.",
-        "",
-        "Execution contract: take concrete action in this heartbeat when the issue is actionable; do not stop at a plan unless planning was requested. Leave durable progress with a clear next action, use child issues instead of polling for long or parallel work, and mark blocked work with the unblock owner/action.",
+        "Resuming session. Scoped to the issue below; focus on new comments. See `skills/paperclip/SKILL.md` (The Heartbeat Procedure, Critical Rules) for the execution contract.",
         "",
         `- reason: ${normalized.reason ?? "unknown"}`,
         `- issue: ${normalized.issue?.identifier ?? normalized.issue?.id ?? "unknown"}${normalized.issue?.title ? ` ${normalized.issue.title}` : ""}`,
@@ -613,14 +607,7 @@ export function renderPaperclipWakePrompt(
       ]
     : [
         "## Paperclip Wake Payload",
-        "",
-        "Treat this wake payload as the highest-priority change for the current heartbeat.",
-        "This heartbeat is scoped to the issue below. Do not switch to another issue until you have handled this wake.",
-        "Before generic repo exploration or boilerplate heartbeat updates, acknowledge the latest comment and explain how it changes your next action.",
-        "Use this inline wake data first before refetching the issue thread.",
-        "Only fetch the API thread when `fallbackFetchNeeded` is true or you need broader history than this batch.",
-        "",
-        "Execution contract: take concrete action in this heartbeat when the issue is actionable; do not stop at a plan unless planning was requested. Leave durable progress with a clear next action, use child issues instead of polling for long or parallel work, and mark blocked work with the unblock owner/action.",
+        "Highest-priority for this heartbeat. Scoped to the issue below; acknowledge the latest comment first. See `skills/paperclip/SKILL.md` (The Heartbeat Procedure, Critical Rules) for the execution contract.",
         "",
         `- reason: ${normalized.reason ?? "unknown"}`,
         `- issue: ${normalized.issue?.identifier ?? normalized.issue?.id ?? "unknown"}${normalized.issue?.title ? ` ${normalized.issue.title}` : ""}`,

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -364,11 +364,9 @@ describe("codex execute", () => {
         commentIds: ["comment-1", "comment-2"],
       });
       expect(capture.prompt).toContain("## Paperclip Wake Payload");
-      expect(capture.prompt).toContain("Treat this wake payload as the highest-priority change for the current heartbeat.");
-      expect(capture.prompt).toContain("Do not switch to another issue until you have handled this wake.");
-      expect(capture.prompt).toContain(
-        "acknowledge the latest comment and explain how it changes your next action.",
-      );
+      expect(capture.prompt).toContain("Highest-priority for this heartbeat");
+      expect(capture.prompt).toContain("acknowledge the latest comment first");
+      expect(capture.prompt).toContain("skills/paperclip/SKILL.md");
       expect(capture.prompt).toContain("First comment");
       expect(capture.prompt).toContain("Second comment");
     } finally {
@@ -803,7 +801,7 @@ describe("codex execute", () => {
         commentIds: [],
       });
       expect(capture.prompt).toContain("## Paperclip Wake Payload");
-      expect(capture.prompt).toContain("Do not switch to another issue until you have handled this wake.");
+      expect(capture.prompt).toContain("Scoped to the issue below");
       expect(capture.prompt).toContain("- issue: PAP-1201 Fix gallery opening for inline images");
       expect(capture.prompt).toContain("- pending comments: 0/0");
       expect(capture.prompt).toContain("- issue status: in_progress");
@@ -910,7 +908,7 @@ describe("codex execute", () => {
       const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
       expect(capture.argv).toEqual(expect.arrayContaining(["resume", "codex-session-1", "-"]));
       expect(capture.prompt).toContain("## Paperclip Resume Delta");
-      expect(capture.prompt).toContain("Do not switch to another issue until you have handled this wake.");
+      expect(capture.prompt).toContain("Resuming session");
       expect(capture.prompt).toContain("Second comment");
       expect(capture.prompt).not.toContain("Follow the paperclip heartbeat.");
       expect(capture.prompt).not.toContain("You are managed instructions.");

--- a/server/src/__tests__/gemini-local-execute.test.ts
+++ b/server/src/__tests__/gemini-local-execute.test.ts
@@ -253,7 +253,7 @@ describe("gemini execute", () => {
       expect(capture.argv).toContain("--resume");
       expect(capture.argv).toContain("gemini-session-1");
       expect(promptArg).toContain("## Paperclip Resume Delta");
-      expect(promptArg).toContain("Do not switch to another issue until you have handled this wake.");
+      expect(promptArg).toContain("Resuming session");
       expect(promptArg).toContain("Second comment");
       expect(promptArg).not.toContain("Follow the paperclip heartbeat.");
     } finally {

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1066,7 +1066,7 @@ describe("heartbeat comment wake batching", () => {
         },
       });
       expect(String(firstPayload.message ?? "")).toContain("## Paperclip Wake Payload");
-      expect(String(firstPayload.message ?? "")).toContain("Do not switch to another issue until you have handled this wake.");
+      expect(String(firstPayload.message ?? "")).toContain("Scoped to the issue below");
       expect(String(firstPayload.message ?? "")).toContain("- checkout: already claimed by the harness for this run");
       expect(String(firstPayload.message ?? "")).toContain(
         "The harness already checked out this issue for the current run.",

--- a/server/src/__tests__/issue-continuation-summary.test.ts
+++ b/server/src/__tests__/issue-continuation-summary.test.ts
@@ -49,9 +49,10 @@ describe("issue continuation summaries", () => {
     expect(body).toContain("- Summary is issue-local");
     expect(body).toContain("## Recent Concrete Actions");
     expect(body).toContain("Run `run-1` finished with status `succeeded`");
+    expect(body).toContain("## Files / Routes Touched");
     expect(body).toContain("`server/src/services/heartbeat.ts`");
-    expect(body).toContain("## Commands Run");
-    expect(body).toContain("## Blockers / Decisions");
+    expect(body).not.toContain("## Commands Run");
+    expect(body).not.toContain("## Blockers / Decisions");
     expect(body).toContain("## Next Action");
     expect(body.length).toBeLessThanOrEqual(ISSUE_CONTINUATION_SUMMARY_MAX_BODY_CHARS);
   });

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -494,12 +494,8 @@ describe("openclaw gateway adapter execute", () => {
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_RUN_ID=run-123");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_TASK_ID=task-123");
       expect(String(payload?.message ?? "")).toContain("## Paperclip Wake Payload");
-      expect(String(payload?.message ?? "")).toContain(
-        "Treat this wake payload as the highest-priority change for the current heartbeat.",
-      );
-      expect(String(payload?.message ?? "")).toContain(
-        "Do not switch to another issue until you have handled this wake.",
-      );
+      expect(String(payload?.message ?? "")).toContain("Highest-priority for this heartbeat");
+      expect(String(payload?.message ?? "")).toContain("acknowledge the latest comment first");
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
       expect(payload?.paperclip).toMatchObject({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1734,10 +1734,10 @@ async function buildPaperclipWakePayload(input: {
           key: continuationSummary.key,
           title: continuationSummary.title,
           body:
-            continuationSummary.body.length > 4_000
-              ? continuationSummary.body.slice(0, 4_000)
+            continuationSummary.body.length > 2_000
+              ? continuationSummary.body.slice(0, 2_000)
               : continuationSummary.body,
-          bodyTruncated: continuationSummary.body.length > 4_000,
+          bodyTruncated: continuationSummary.body.length > 2_000,
           updatedAt: continuationSummary.updatedAt.toISOString(),
         }
       : null,
@@ -1785,6 +1785,7 @@ export function buildPaperclipTaskMarkdown(input: {
     id: string;
     body: string;
   } | null;
+  continuationSummaryBody?: string | null;
 }) {
   const quoteTaskScalar = (value: string) => JSON.stringify(value);
   const fenceTaskText = (value: string) => {
@@ -1809,7 +1810,12 @@ export function buildPaperclipTaskMarkdown(input: {
       `- Title: ${quoteTaskScalar(issue.title)}`,
     );
     const description = issue.description?.trim();
-    if (description) {
+    const continuationBody = input.continuationSummaryBody?.trim() ?? "";
+    const descriptionAlreadyInSummary =
+      !!description &&
+      continuationBody.length > 0 &&
+      continuationBody.includes(description);
+    if (description && !descriptionAlreadyInSummary) {
       lines.push("", "Issue description:", fenceTaskText(description));
     }
   }
@@ -4864,6 +4870,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         : null,
       wakeComment: wakeCommentContext,
+      continuationSummaryBody: continuationSummary?.body ?? null,
     });
     if (issueRef) {
       context.paperclipIssue = {

--- a/server/src/services/issue-continuation-summary.ts
+++ b/server/src/services/issue-continuation-summary.ts
@@ -111,6 +111,11 @@ function bulletList(items: string[], empty: string) {
   return items.map((item) => `- ${item}`).join("\n");
 }
 
+function optionalSection(heading: string, items: string[]): string[] | null {
+  if (items.length === 0) return null;
+  return ["", `## ${heading}`, "", items.map((item) => `- ${item}`).join("\n")];
+}
+
 function extractPreviousNextAction(previousBody: string | null | undefined) {
   const section = extractMarkdownSection(previousBody, "Next Action");
   if (!section) return null;
@@ -142,7 +147,11 @@ export function buildContinuationSummaryMarkdown(input: {
   const mode = inferMode(issue, run);
   const nextAction = inferNextAction(issue, run, extractPreviousNextAction(input.previousSummaryBody));
 
-  const body = [
+  const filesTouched = paths.map((path) => `\`${path}\``);
+  const blockerItems = run.error
+    ? [`Latest run ended with \`${run.status}\`; inspect the error before continuing.`]
+    : [];
+  const sections: string[] = [
     "# Continuation Summary",
     "",
     `- Issue: ${issue.identifier ?? issue.id} — ${issue.title}`,
@@ -163,34 +172,15 @@ export function buildContinuationSummaryMarkdown(input: {
     "## Recent Concrete Actions",
     "",
     bulletList(recentActions, "No recent actions captured."),
-    "",
-    "## Files / Routes Touched",
-    "",
-    bulletList(paths.map((path) => `\`${path}\``), "No file or route paths were detected in the captured run summary."),
-    "",
-    "## Commands Run",
-    "",
-    bulletList(
-      [
-        `Heartbeat run \`${run.id}\` invoked adapter \`${agent.adapterType ?? "unknown"}\`.`,
-        "Detailed shell/tool commands remain in the run log and transcript.",
-      ],
-      "No command metadata captured.",
-    ),
-    "",
-    "## Blockers / Decisions",
-    "",
-    bulletList(
-      run.error
-        ? [`Latest run ended with \`${run.status}\`; inspect the error before continuing.`]
-        : ["No new blocker was recorded by the latest run."],
-      "No blockers or decisions captured.",
-    ),
-    "",
-    "## Next Action",
-    "",
-    `- ${nextAction}`,
-  ].join("\n");
+  ];
+  for (const part of [
+    optionalSection("Files / Routes Touched", filesTouched),
+    optionalSection("Blockers / Decisions", blockerItems),
+  ]) {
+    if (part) sections.push(...part);
+  }
+  sections.push("", "## Next Action", "", `- ${nextAction}`);
+  const body = sections.join("\n");
 
   return truncateText(body, ISSUE_CONTINUATION_SUMMARY_MAX_BODY_CHARS);
 }


### PR DESCRIPTION
## Summary

Trims per-wake preamble for `claude_local` agents to reduce cache prefill cost on every heartbeat. Implements trims 1–4 from THE-273 spec (trim 5 — splitting `SKILL.md` — deferred as flagged riskier in the spec).

**Files changed (8 files, +46/−67):**
- `packages/adapter-utils/src/server-utils.ts` — compress wake-preamble boilerplate (trim 1)
- `server/src/services/heartbeat.ts` — drop duplicate description when continuation summary already contains it (trim 2)
- `server/src/services/issue-continuation-summary.ts` — cap continuation summary at 2k chars + strip empty auto-sections (trims 3 + 4)
- 5 test files updated to match new output

## Test plan

- [x] `pnpm --filter @paperclipai/adapter-utils typecheck` — clean
- [x] `pnpm --filter @paperclipai/server typecheck` — clean
- [x] `vitest run packages/adapter-utils/src/server-utils.test.ts` — 14/14 pass
- [x] `vitest run server/src/__tests__/issue-continuation-summary.test.ts` — 2/2 pass
- [x] `vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts` — 9/9 pass
- [x] `vitest run server/src/__tests__/codex-local-execute.test.ts` — 12/12 pass
- [x] `vitest run server/src/__tests__/openclaw-gateway-adapter.test.ts` — 7/7 pass
- [ ] Post-deploy: re-sample 50+ runs across all `claude_local` agents and verify median `cache_read_input_tokens` per wake drops vs prior 7-day window

## Expected impact

Modest: ~250–900 tokens saved per wake (~0.07–0.24% of the 381k median baseline from THE-269). The 30% target in the parent (THE-269) needs the session-compaction work explicitly out of scope here.

## Rollback

All trims are pure-text changes in three files plus their tests; revert via `git revert` of this PR.

## Context

- Parent: paperclipai/paperclip's tracker → THE-269 (audit + baseline)
- Spec: THE-273
