### PR TITLE
TEC-1070: strip JWT signing secrets from spawned agent env

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -40,6 +40,42 @@ async function waitForTextMatch(read: () => string, pattern: RegExp, timeoutMs =
 }
 
 describe("runChildProcess", () => {
+  it("never exposes PAPERCLIP_AGENT_JWT_SECRET or BETTER_AUTH_SECRET to the spawned child", async () => {
+    const previousJwt = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    const previousBetterAuth = process.env.BETTER_AUTH_SECRET;
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = "inherited-jwt-should-not-leak";
+    process.env.BETTER_AUTH_SECRET = "inherited-better-auth-should-not-leak";
+    try {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        [
+          "-e",
+          "process.stdout.write(JSON.stringify({jwt: process.env.PAPERCLIP_AGENT_JWT_SECRET ?? null, betterAuth: process.env.BETTER_AUTH_SECRET ?? null}));",
+        ],
+        {
+          cwd: process.cwd(),
+          // Also inject via opts.env to prove agent config.env cannot smuggle it in.
+          env: {
+            PAPERCLIP_AGENT_JWT_SECRET: "config-jwt-should-not-leak",
+            BETTER_AUTH_SECRET: "config-better-auth-should-not-leak",
+          },
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({ jwt: null, betterAuth: null });
+    } finally {
+      if (previousJwt === undefined) delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+      else process.env.PAPERCLIP_AGENT_JWT_SECRET = previousJwt;
+      if (previousBetterAuth === undefined) delete process.env.BETTER_AUTH_SECRET;
+      else process.env.BETTER_AUTH_SECRET = previousBetterAuth;
+    }
+  });
+
   it("does not arm a timeout when timeoutSec is 0", async () => {
     const result = await runChildProcess(
       randomUUID(),

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1479,6 +1479,16 @@ export async function runChildProcess(
       ...opts.env,
     };
 
+    // Never expose JWT signing secrets to spawned agent processes. The server
+    // uses PAPERCLIP_AGENT_JWT_SECRET / BETTER_AUTH_SECRET to mint and verify
+    // agent JWTs; the agent itself only needs PAPERCLIP_API_KEY (a per-run JWT)
+    // to authenticate API calls. sanitizeInheritedPaperclipEnv already strips
+    // PAPERCLIP_AGENT_JWT_SECRET from process.env above; this block also strips
+    // it from opts.env (covering agent config.env) and from BETTER_AUTH_SECRET
+    // which the inherited-env sanitizer does not touch (TEC-1067, TEC-1070).
+    delete rawMerged.PAPERCLIP_AGENT_JWT_SECRET;
+    delete rawMerged.BETTER_AUTH_SECRET;
+
     // Strip Claude Code nesting-guard env vars so spawned `claude` processes
     // don't refuse to start with "cannot be launched inside another session".
     // These vars leak in when the Paperclip server itself is started from


### PR DESCRIPTION
## Summary
- remove `PAPERCLIP_AGENT_JWT_SECRET` and `BETTER_AUTH_SECRET` from the merged child-process env in `runChildProcess`
- keep `PAPERCLIP_API_KEY` flow unchanged while preventing server signing secrets from entering agent runtime
- add regression test proving both secrets are null inside spawned children, including config-injected env

## Verification
- `pnpm vitest run packages/adapter-utils/src/server-utils.test.ts`
  - Passed: `1 passed`, `15 passed`

## Scope
- limited to env-secret stripping and targeted tests for TEC-1070
