### PR TITLE
feat: implement MEA-79 recovery writer, asset cutover, and status

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -36,6 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.888.0",
     "@clack/prompts": "^0.10.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
@@ -52,7 +53,8 @@
     "dotenv": "^17.0.1",
     "commander": "^13.1.0",
     "embedded-postgres": "^18.1.0-beta.16",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "postgres": "^3.4.5"
   },
   "devDependencies": {
     "@types/node": "^22.12.0",

--- a/cli/src/__tests__/recovery-command-registration.test.ts
+++ b/cli/src/__tests__/recovery-command-registration.test.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { registerRecoveryCommands } from "../commands/recovery.js";
+
+describe("registerRecoveryCommands", () => {
+  it("registers publish, cutover, and drill commands", () => {
+    const program = new Command();
+
+    expect(() => registerRecoveryCommands(program)).not.toThrow();
+
+    expect(program.commands.find((command) => command.name() === "recovery:publish")).toBeDefined();
+    expect(program.commands.find((command) => command.name() === "recovery:cutover-assets")).toBeDefined();
+
+    const drill = program.commands.find((command) => command.name() === "recovery:drill");
+    expect(drill).toBeDefined();
+    expect(drill?.options.some((option) => option.long === "--restore-url" && option.required)).toBe(true);
+  });
+});

--- a/cli/src/__tests__/recovery-lib.test.ts
+++ b/cli/src/__tests__/recovery-lib.test.ts
@@ -1,0 +1,129 @@
+import { createCipheriv, createHash, randomBytes } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  canSkipRemoteAssetUpload,
+  detectConcurrentLocalAssetIds,
+  deriveRecoveryManifestAssetProof,
+  getRecoveryDrillAssetProofFailures,
+  publishRecoveryArtifacts,
+  verifyRecoveredLocalEncryptedSecretValue,
+} from "../commands/recovery-lib.js";
+
+function createLocalEncryptedMaterial(masterKey: Buffer, value: string) {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", masterKey, iv);
+  const ciphertext = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    scheme: "local_encrypted_v1" as const,
+    iv: iv.toString("base64"),
+    tag: tag.toString("base64"),
+    ciphertext: ciphertext.toString("base64"),
+  };
+}
+
+describe("publishRecoveryArtifacts", () => {
+  it("uploads backup artifacts before config and writes the manifest last", async () => {
+    const writes: string[] = [];
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const manifest = await publishRecoveryArtifacts({
+      writer: {
+        async putObject({ objectKey, body }) {
+          writes.push(objectKey);
+          return {
+            objectKey,
+            sizeBytes: body.length,
+            sha256: createHash("sha256").update(body).digest("hex"),
+            uploadedAt: now.toISOString(),
+          };
+        },
+      },
+      now,
+      previousManifest: null,
+      backupFilePath: "/tmp/paperclip-20260428.sql.gz",
+      backupBuffer: Buffer.from("backup-bytes"),
+      backupSha256: "backup-sha",
+      backupCreatedAt: "2026-04-28T11:55:00.000Z",
+      storageProvider: "s3",
+      assetCutoverComplete: true,
+      assetSampleKeys: ["assets/sample-1"],
+      keySnapshotBuffer: Buffer.from("{\"encrypted\":true}"),
+      keySnapshotFingerprint: "fingerprint-123",
+      configSnapshotBuffer: Buffer.from("{\"storage\":{\"provider\":\"s3\"}}"),
+      warnings: [],
+    });
+
+    expect(manifest.backupArtifacts.map((artifact) => artifact.tier)).toEqual([
+      "hourly",
+      "daily",
+      "weekly",
+      "monthly",
+    ]);
+    expect(writes.slice(0, 4)).toEqual([
+      "db/hourly/paperclip-20260428.sql.gz",
+      "db/daily/paperclip-20260428.sql.gz",
+      "db/weekly/paperclip-20260428.sql.gz",
+      "db/monthly/paperclip-20260428.sql.gz",
+    ]);
+    expect(writes[4]).toBe("keys/fingerprint-123/20260428-120000.json");
+    expect(writes[5]).toMatch(/^manifests\/config\/20260428-120000-/);
+    expect(writes[6]).toBe(manifest.manifestObjectKey);
+  });
+});
+
+describe("asset cutover safeguards", () => {
+  it("does not skip an existing remote object when the bytes differ but the size matches", () => {
+    const original = Buffer.from("correct-bytes");
+    const stale = Buffer.from("stale-bytes!!");
+
+    expect(original.length).toBe(stale.length);
+    expect(canSkipRemoteAssetUpload({
+      remoteBody: stale,
+      expectedSha256: createHash("sha256").update(original).digest("hex"),
+      expectedByteSize: original.length,
+    })).toBe(false);
+  });
+
+  it("detects local asset rows that appeared after the migration snapshot", () => {
+    expect(
+      detectConcurrentLocalAssetIds(
+        ["asset-1", "asset-2"],
+        [{ id: "asset-1" }, { id: "asset-2" }, { id: "asset-3" }],
+      ),
+    ).toEqual(["asset-3"]);
+  });
+
+  it("does not mark asset cutover complete without authoritative asset samples", () => {
+    expect(deriveRecoveryManifestAssetProof({
+      storageProvider: "s3",
+      remainingLocalAssetCount: 0,
+      sampleObjectKeys: [],
+    })).toEqual({
+      assetCutoverComplete: false,
+      assetSampleKeys: [],
+    });
+  });
+});
+
+describe("drill asset proof guards", () => {
+  it("fails drills that do not have manifest asset samples to verify", () => {
+    expect(getRecoveryDrillAssetProofFailures({
+      assetCutoverComplete: true,
+      assetSampleKeys: [],
+    })).toContain("Recovery manifest does not include any asset sample keys to verify.");
+  });
+});
+
+describe("verifyRecoveredLocalEncryptedSecretValue", () => {
+  it("proves recovered key material can decrypt stored local_encrypted secret versions", () => {
+    const masterKey = randomBytes(32);
+    const value = "OPENAI_API_KEY=pc-secret";
+    const material = createLocalEncryptedMaterial(masterKey, value);
+
+    expect(verifyRecoveredLocalEncryptedSecretValue({
+      masterKeyFileContents: Buffer.from(masterKey.toString("base64"), "utf8"),
+      material,
+      valueSha256: createHash("sha256").update(value).digest("hex"),
+    })).toBe(value);
+  });
+});

--- a/cli/src/commands/recovery-lib.ts
+++ b/cli/src/commands/recovery-lib.ts
@@ -1,0 +1,1316 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { S3Client, GetObjectCommand, HeadObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { desc, eq, inArray } from "drizzle-orm";
+import postgres from "postgres";
+import {
+  assets,
+  createDb,
+  runDatabaseRestore,
+  type Db,
+} from "@paperclipai/db";
+import {
+  DEFAULT_RECOVERY_STATUS_FILE,
+  evaluateRecoveryStatus,
+  type RecoveryAssetCutoverStatus,
+  type RecoveryBackupArtifact,
+  type RecoveryBackupTier,
+  type RecoveryDrillRecord,
+  type RecoveryManifestRecord,
+  type RecoveryStatusFile,
+  type RecoveryStatusSnapshot,
+  type RecoveryVaultSummary,
+  type StorageProvider,
+  type PaperclipConfig,
+} from "@paperclipai/shared";
+import {
+  expandHomePrefix,
+  resolveDefaultBackupDir,
+  resolveDefaultRecoveryStatusPath,
+  resolvePaperclipInstanceId,
+} from "../config/home.js";
+import { readConfig, writeConfig } from "../config/store.js";
+
+const RECOVERY_STATUS_FILE_VERSION = 1;
+const DEFAULT_BACKUP_FILENAME_PREFIX = "paperclip";
+const RECOVERY_KEY_ENCRYPTION_ALGORITHM = "aes-256-gcm";
+const RECOVERY_ASSET_SAMPLE_LIMIT = 5;
+const RECOVERY_ASSET_PROVIDER_UPDATE_BATCH_SIZE = 500;
+
+type RecoveryS3Config = RecoveryVaultSummary & {
+  forcePathStyle: boolean;
+};
+
+type S3HeadResult = {
+  exists: boolean;
+  contentLength: number | null;
+};
+
+type RecoveryLocalAssetRow = typeof assets.$inferSelect;
+
+type LocalEncryptedSecretMaterial = {
+  scheme: "local_encrypted_v1";
+  iv: string;
+  tag: string;
+  ciphertext: string;
+};
+
+type RecoveryAssetProofSnapshot = {
+  remainingLocalAssetCount: number;
+  sampleObjectKeys: string[];
+};
+
+export interface RecoveryStatusContext {
+  config: PaperclipConfig;
+  vault: RecoveryVaultSummary | null;
+}
+
+export interface PublishRecoveryResult {
+  status: RecoveryStatusSnapshot;
+  manifest: RecoveryManifestRecord;
+  statusPath: string;
+}
+
+export interface AssetCutoverResult {
+  status: RecoveryStatusSnapshot;
+  statusPath: string;
+  migratedAssets: number;
+  migratedBytes: number;
+  skippedAssets: number;
+  switchedProvider: boolean;
+}
+
+export interface RecoveryDrillResult {
+  status: RecoveryStatusSnapshot;
+  drill: RecoveryDrillRecord;
+  statusPath: string;
+}
+
+type RecoveryVaultWriter = {
+  putObject(input: {
+    objectKey: string;
+    body: Buffer;
+    contentType: string;
+  }): Promise<{
+    objectKey: string;
+    sizeBytes: number;
+    sha256: string;
+    uploadedAt: string;
+  }>;
+};
+
+type PublishRecoveryArtifactsInput = {
+  writer: RecoveryVaultWriter;
+  now: Date;
+  previousManifest: RecoveryManifestRecord | null;
+  backupFilePath: string;
+  backupBuffer: Buffer;
+  backupSha256: string;
+  backupCreatedAt: string | null;
+  storageProvider: StorageProvider;
+  assetCutoverComplete: boolean;
+  assetSampleKeys: string[];
+  keySnapshotBuffer: Buffer | null;
+  keySnapshotFingerprint: string | null;
+  configSnapshotBuffer: Buffer;
+  warnings: string[];
+};
+
+function resolveConnectionString(configPath?: string): string {
+  const envUrl = process.env.DATABASE_URL?.trim();
+  if (envUrl) return envUrl;
+
+  const config = readConfig(configPath);
+  if (config?.database.mode === "postgres" && config.database.connectionString?.trim()) {
+    return config.database.connectionString.trim();
+  }
+
+  const port = config?.database.embeddedPostgresPort ?? 54329;
+  return `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`;
+}
+
+function normalizePrefix(prefix: string | null | undefined): string {
+  return (prefix ?? "").trim().replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function buildObjectKey(prefix: string, objectKey: string): string {
+  return prefix ? `${prefix}/${objectKey}` : objectKey;
+}
+
+function isoWeekKey(date: Date): string {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((d.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, "0")}`;
+}
+
+function monthKey(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function deriveBackupTiers(now: Date, previousManifestCreatedAt: string | null): RecoveryBackupTier[] {
+  const tiers: RecoveryBackupTier[] = ["hourly"];
+  const previous = previousManifestCreatedAt ? new Date(previousManifestCreatedAt) : null;
+  if (!previous || Number.isNaN(previous.getTime()) || previous.toISOString().slice(0, 10) !== now.toISOString().slice(0, 10)) {
+    tiers.push("daily");
+  }
+  if (!previous || Number.isNaN(previous.getTime()) || isoWeekKey(previous) !== isoWeekKey(now)) {
+    tiers.push("weekly");
+  }
+  if (!previous || Number.isNaN(previous.getTime()) || monthKey(previous) !== monthKey(now)) {
+    tiers.push("monthly");
+  }
+  return tiers;
+}
+
+function sha256(input: Buffer | string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  if (size < 1) {
+    throw new Error(`Invalid chunk size: ${size}`);
+  }
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function timestampId(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}-${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}`;
+}
+
+function deriveEncryptionKey(secret: string): Buffer {
+  return createHash("sha256").update(secret).digest();
+}
+
+export function canSkipRemoteAssetUpload(input: {
+  remoteBody: Buffer;
+  expectedSha256: string;
+  expectedByteSize: number;
+}): boolean {
+  return input.remoteBody.length === input.expectedByteSize && sha256(input.remoteBody) === input.expectedSha256;
+}
+
+export function deriveRecoveryManifestAssetProof(input: {
+  storageProvider: StorageProvider;
+  remainingLocalAssetCount: number;
+  sampleObjectKeys: string[];
+}): {
+  assetCutoverComplete: boolean;
+  assetSampleKeys: string[];
+} {
+  return {
+    assetCutoverComplete:
+      input.storageProvider === "s3" &&
+      input.remainingLocalAssetCount === 0 &&
+      input.sampleObjectKeys.length > 0,
+    assetSampleKeys: input.sampleObjectKeys,
+  };
+}
+
+export function detectConcurrentLocalAssetIds(
+  migratedAssetIds: Iterable<string>,
+  currentLocalAssets: Array<{ id: string }>,
+): string[] {
+  const migrated = new Set(migratedAssetIds);
+  return currentLocalAssets
+    .map((asset) => asset.id)
+    .filter((assetId) => !migrated.has(assetId));
+}
+
+export function decodeLocalEncryptedMasterKeyFile(raw: Buffer | string): Buffer {
+  const text = Buffer.isBuffer(raw) ? raw.toString("utf8") : raw;
+  const trimmed = text.trim();
+  if (!trimmed) {
+    throw new Error("Recovered secrets master key file is empty.");
+  }
+
+  if (/^[A-Fa-f0-9]{64}$/.test(trimmed)) {
+    return Buffer.from(trimmed, "hex");
+  }
+
+  try {
+    const decoded = Buffer.from(trimmed, "base64");
+    if (decoded.length === 32) {
+      return decoded;
+    }
+  } catch {
+    // ignored
+  }
+
+  if (Buffer.byteLength(trimmed, "utf8") === 32) {
+    return Buffer.from(trimmed, "utf8");
+  }
+
+  throw new Error("Recovered secrets master key file is not a valid 32-byte key.");
+}
+
+function asLocalEncryptedSecretMaterial(material: Record<string, unknown>): LocalEncryptedSecretMaterial {
+  if (
+    material.scheme === "local_encrypted_v1" &&
+    typeof material.iv === "string" &&
+    typeof material.tag === "string" &&
+    typeof material.ciphertext === "string"
+  ) {
+    return material as LocalEncryptedSecretMaterial;
+  }
+  throw new Error("Secret material is not valid local_encrypted_v1 data.");
+}
+
+export function decryptLocalEncryptedSecretMaterial(
+  masterKeyFileContents: Buffer | string,
+  material: Record<string, unknown>,
+): string {
+  const masterKey = decodeLocalEncryptedMasterKeyFile(masterKeyFileContents);
+  const parsed = asLocalEncryptedSecretMaterial(material);
+  const decipher = createDecipheriv(
+    RECOVERY_KEY_ENCRYPTION_ALGORITHM,
+    masterKey,
+    Buffer.from(parsed.iv, "base64"),
+  );
+  decipher.setAuthTag(Buffer.from(parsed.tag, "base64"));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(parsed.ciphertext, "base64")),
+    decipher.final(),
+  ]);
+  return plaintext.toString("utf8");
+}
+
+export function verifyRecoveredLocalEncryptedSecretValue(input: {
+  masterKeyFileContents: Buffer | string;
+  material: Record<string, unknown>;
+  valueSha256: string;
+}): string {
+  const plaintext = decryptLocalEncryptedSecretMaterial(input.masterKeyFileContents, input.material);
+  if (sha256(plaintext) !== input.valueSha256) {
+    throw new Error("Recovered secrets master key decrypted secret material, but the plaintext hash did not match.");
+  }
+  return plaintext;
+}
+
+export function getRecoveryDrillAssetProofFailures(
+  manifest: Pick<RecoveryManifestRecord, "assetCutoverComplete" | "assetSampleKeys">,
+): string[] {
+  const failures: string[] = [];
+  if (!manifest.assetCutoverComplete) {
+    failures.push("Recovery manifest was published before asset cutover completed.");
+  }
+  if (manifest.assetSampleKeys.length === 0) {
+    failures.push("Recovery manifest does not include any asset sample keys to verify.");
+  }
+  return failures;
+}
+
+export function encryptRecoveryKeySnapshot(secret: string, plaintext: Buffer): Buffer {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv(RECOVERY_KEY_ENCRYPTION_ALGORITHM, deriveEncryptionKey(secret), iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.from(
+    JSON.stringify({
+      version: 1,
+      alg: RECOVERY_KEY_ENCRYPTION_ALGORITHM,
+      iv: iv.toString("base64"),
+      tag: tag.toString("base64"),
+      ciphertext: ciphertext.toString("base64"),
+    }),
+    "utf8",
+  );
+}
+
+export function decryptRecoveryKeySnapshot(secret: string, payload: Buffer): Buffer {
+  const parsed = JSON.parse(payload.toString("utf8")) as {
+    iv?: string;
+    tag?: string;
+    ciphertext?: string;
+  };
+  if (!parsed.iv || !parsed.tag || !parsed.ciphertext) {
+    throw new Error("Invalid encrypted recovery key snapshot payload.");
+  }
+  const decipher = createDecipheriv(
+    RECOVERY_KEY_ENCRYPTION_ALGORITHM,
+    deriveEncryptionKey(secret),
+    Buffer.from(parsed.iv, "base64"),
+  );
+  decipher.setAuthTag(Buffer.from(parsed.tag, "base64"));
+  return Buffer.concat([
+    decipher.update(Buffer.from(parsed.ciphertext, "base64")),
+    decipher.final(),
+  ]);
+}
+
+function createS3ConfigFromEnv(env: NodeJS.ProcessEnv): RecoveryS3Config | null {
+  const bucket = env.PAPERCLIP_RECOVERY_VAULT_BUCKET?.trim();
+  const region = env.PAPERCLIP_RECOVERY_VAULT_REGION?.trim();
+  if (!bucket && !region) return null;
+  if (!bucket || !region) {
+    throw new Error("Recovery vault requires both PAPERCLIP_RECOVERY_VAULT_BUCKET and PAPERCLIP_RECOVERY_VAULT_REGION.");
+  }
+  return {
+    bucket,
+    region,
+    endpoint: env.PAPERCLIP_RECOVERY_VAULT_ENDPOINT?.trim() || null,
+    prefix: normalizePrefix(env.PAPERCLIP_RECOVERY_VAULT_PREFIX),
+    forcePathStyle: env.PAPERCLIP_RECOVERY_VAULT_FORCE_PATH_STYLE === "true",
+  };
+}
+
+function createRecoveryAssetCheckConfig(
+  config: PaperclipConfig,
+  env: NodeJS.ProcessEnv,
+): RecoveryS3Config | null {
+  const bucket = env.PAPERCLIP_RECOVERY_ASSET_BUCKET?.trim();
+  const region = env.PAPERCLIP_RECOVERY_ASSET_REGION?.trim();
+  if (bucket || region) {
+    if (!bucket || !region) {
+      throw new Error("Recovery asset verification requires both PAPERCLIP_RECOVERY_ASSET_BUCKET and PAPERCLIP_RECOVERY_ASSET_REGION.");
+    }
+    return {
+      bucket,
+      region,
+      endpoint: env.PAPERCLIP_RECOVERY_ASSET_ENDPOINT?.trim() || null,
+      prefix: normalizePrefix(env.PAPERCLIP_RECOVERY_ASSET_PREFIX),
+      forcePathStyle: env.PAPERCLIP_RECOVERY_ASSET_FORCE_PATH_STYLE === "true",
+    };
+  }
+
+  if (config.storage.provider !== "s3") {
+    return null;
+  }
+
+  return {
+    bucket: config.storage.s3.bucket,
+    region: config.storage.s3.region,
+    endpoint: config.storage.s3.endpoint ?? null,
+    prefix: normalizePrefix(config.storage.s3.prefix),
+    forcePathStyle: config.storage.s3.forcePathStyle ?? false,
+  };
+}
+
+function createS3Client(config: RecoveryS3Config): S3Client {
+  return new S3Client({
+    region: config.region,
+    endpoint: config.endpoint ?? undefined,
+    forcePathStyle: config.forcePathStyle,
+  });
+}
+
+async function bodyToBuffer(body: unknown): Promise<Buffer> {
+  if (!body) return Buffer.alloc(0);
+  if (Buffer.isBuffer(body)) return body;
+  if (body instanceof Uint8Array) return Buffer.from(body);
+  if (body instanceof Readable) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of body) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  }
+
+  const candidate = body as {
+    transformToByteArray?: () => Promise<Uint8Array>;
+    transformToWebStream?: () => ReadableStream<Uint8Array>;
+    arrayBuffer?: () => Promise<ArrayBuffer>;
+  };
+
+  if (typeof candidate.transformToByteArray === "function") {
+    return Buffer.from(await candidate.transformToByteArray());
+  }
+
+  if (typeof candidate.arrayBuffer === "function") {
+    return Buffer.from(await candidate.arrayBuffer());
+  }
+
+  if (typeof candidate.transformToWebStream === "function") {
+    const reader = candidate.transformToWebStream().getReader();
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+    return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+  }
+
+  throw new Error("Unsupported S3 body type.");
+}
+
+async function putS3Object(
+  client: S3Client,
+  config: RecoveryS3Config,
+  objectKey: string,
+  body: Buffer,
+  contentType: string,
+): Promise<{ objectKey: string; sizeBytes: number; sha256: string; uploadedAt: string }> {
+  const key = buildObjectKey(config.prefix, objectKey);
+  await client.send(
+    new PutObjectCommand({
+      Bucket: config.bucket,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+      ContentLength: body.length,
+    }),
+  );
+
+  return {
+    objectKey,
+    sizeBytes: body.length,
+    sha256: sha256(body),
+    uploadedAt: new Date().toISOString(),
+  };
+}
+
+async function getS3ObjectBuffer(client: S3Client, config: RecoveryS3Config, objectKey: string): Promise<Buffer> {
+  const key = buildObjectKey(config.prefix, objectKey);
+  const response = await client.send(
+    new GetObjectCommand({
+      Bucket: config.bucket,
+      Key: key,
+    }),
+  );
+  return bodyToBuffer(response.Body);
+}
+
+async function headS3Object(client: S3Client, config: RecoveryS3Config, objectKey: string): Promise<S3HeadResult> {
+  try {
+    const response = await client.send(
+      new HeadObjectCommand({
+        Bucket: config.bucket,
+        Key: buildObjectKey(config.prefix, objectKey),
+      }),
+    );
+
+    return {
+      exists: true,
+      contentLength: response.ContentLength ?? null,
+    };
+  } catch (error) {
+    const name = (error as { name?: string }).name;
+    if (name === "NotFound" || name === "NoSuchKey") {
+      return { exists: false, contentLength: null };
+    }
+    throw error;
+  }
+}
+
+function readConfigOrThrow(configPath?: string): PaperclipConfig {
+  const config = readConfig(configPath);
+  if (!config) {
+    throw new Error("Paperclip config not found.");
+  }
+  return config;
+}
+
+async function listLocalDiskAssets(connectionString: string): Promise<RecoveryLocalAssetRow[]> {
+  return withDb(connectionString, async (db) =>
+    db
+      .select()
+      .from(assets)
+      .where(eq(assets.provider, "local_disk")),
+  );
+}
+
+async function countCurrentLocalDiskAssets(connectionString: string): Promise<number> {
+  const current = await listLocalDiskAssets(connectionString);
+  return current.length;
+}
+
+async function getRecoveryAssetProofSnapshot(
+  connectionString: string,
+  sampleLimit = RECOVERY_ASSET_SAMPLE_LIMIT,
+): Promise<RecoveryAssetProofSnapshot> {
+  return withDb(connectionString, async (db) => {
+    const [localAssets, sampleAssets] = await Promise.all([
+      db
+        .select({ id: assets.id })
+        .from(assets)
+        .where(eq(assets.provider, "local_disk")),
+      db
+        .select({ objectKey: assets.objectKey })
+        .from(assets)
+        .orderBy(desc(assets.createdAt))
+        .limit(sampleLimit),
+    ]);
+
+    return {
+      remainingLocalAssetCount: localAssets.length,
+      sampleObjectKeys: sampleAssets.map((asset) => asset.objectKey),
+    };
+  });
+}
+
+export function loadRecoveryVaultSummaryFromEnv(env: NodeJS.ProcessEnv = process.env): RecoveryVaultSummary | null {
+  const config = createS3ConfigFromEnv(env);
+  if (!config) return null;
+  return {
+    bucket: config.bucket,
+    region: config.region,
+    endpoint: config.endpoint,
+    prefix: config.prefix,
+  };
+}
+
+export function resolveRecoveryStatusFilePath(instanceId?: string): string {
+  return resolveDefaultRecoveryStatusPath(instanceId ?? resolvePaperclipInstanceId());
+}
+
+function mergeRecoveryStatus(raw: unknown): RecoveryStatusFile {
+  const base = structuredClone(DEFAULT_RECOVERY_STATUS_FILE);
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return base;
+  }
+
+  const record = raw as Record<string, unknown>;
+  return {
+    version: RECOVERY_STATUS_FILE_VERSION,
+    updatedAt: typeof record.updatedAt === "string" ? record.updatedAt : base.updatedAt,
+    backupIntervalMinutes:
+      typeof record.backupIntervalMinutes === "number" && Number.isFinite(record.backupIntervalMinutes)
+        ? Math.max(1, Math.trunc(record.backupIntervalMinutes))
+        : base.backupIntervalMinutes,
+    storageProvider:
+      record.storageProvider === "s3" || record.storageProvider === "local_disk"
+        ? record.storageProvider
+        : base.storageProvider,
+    vault:
+      record.vault && typeof record.vault === "object"
+        ? {
+            bucket: String((record.vault as Record<string, unknown>).bucket ?? ""),
+            region: String((record.vault as Record<string, unknown>).region ?? ""),
+            endpoint:
+              (record.vault as Record<string, unknown>).endpoint == null
+                ? null
+                : String((record.vault as Record<string, unknown>).endpoint),
+            prefix: String((record.vault as Record<string, unknown>).prefix ?? ""),
+          }
+        : null,
+    latestUploadedManifest:
+      record.latestUploadedManifest && typeof record.latestUploadedManifest === "object"
+        ? (record.latestUploadedManifest as RecoveryManifestRecord)
+        : null,
+    latestDrillAttempt:
+      record.latestDrillAttempt && typeof record.latestDrillAttempt === "object"
+        ? (record.latestDrillAttempt as RecoveryDrillRecord)
+        : null,
+    latestVerifiedRestore:
+      record.latestVerifiedRestore && typeof record.latestVerifiedRestore === "object"
+        ? (record.latestVerifiedRestore as RecoveryDrillRecord)
+        : null,
+    assetCutover:
+      record.assetCutover && typeof record.assetCutover === "object"
+        ? {
+            lastRunAt:
+              (record.assetCutover as Record<string, unknown>).lastRunAt == null
+                ? null
+                : String((record.assetCutover as Record<string, unknown>).lastRunAt),
+            switchedAt:
+              (record.assetCutover as Record<string, unknown>).switchedAt == null
+                ? null
+                : String((record.assetCutover as Record<string, unknown>).switchedAt),
+            migratedAssetCount: Number((record.assetCutover as Record<string, unknown>).migratedAssetCount ?? 0) || 0,
+            migratedByteCount: Number((record.assetCutover as Record<string, unknown>).migratedByteCount ?? 0) || 0,
+            remainingLocalAssetCount:
+              Number((record.assetCutover as Record<string, unknown>).remainingLocalAssetCount ?? 0) || 0,
+            sampleObjectKeys: Array.isArray((record.assetCutover as Record<string, unknown>).sampleObjectKeys)
+              ? ((record.assetCutover as Record<string, unknown>).sampleObjectKeys as string[]).map(String)
+              : [],
+            lastError:
+              (record.assetCutover as Record<string, unknown>).lastError == null
+                ? null
+                : String((record.assetCutover as Record<string, unknown>).lastError),
+          }
+        : base.assetCutover,
+    warnings: Array.isArray(record.warnings) ? record.warnings.map(String) : [],
+  };
+}
+
+export async function readRecoveryStatusFile(statusPath = resolveRecoveryStatusFilePath()): Promise<RecoveryStatusFile> {
+  try {
+    const raw = await fsp.readFile(statusPath, "utf8");
+    return mergeRecoveryStatus(JSON.parse(raw));
+  } catch {
+    return structuredClone(DEFAULT_RECOVERY_STATUS_FILE);
+  }
+}
+
+export async function writeRecoveryStatusFile(
+  status: RecoveryStatusFile,
+  statusPath = resolveRecoveryStatusFilePath(),
+): Promise<void> {
+  await fsp.mkdir(path.dirname(statusPath), { recursive: true });
+  await fsp.writeFile(statusPath, JSON.stringify(status, null, 2) + "\n", { mode: 0o600 });
+}
+
+export async function getRecoveryStatusSnapshot(
+  context: RecoveryStatusContext,
+  opts?: { statusPath?: string; now?: Date },
+): Promise<RecoveryStatusSnapshot> {
+  const base = await readRecoveryStatusFile(opts?.statusPath);
+  return evaluateRecoveryStatus({
+    ...base,
+    backupIntervalMinutes: context.config.database.backup.intervalMinutes,
+    storageProvider: context.config.storage.provider,
+    vault: context.vault,
+  }, opts?.now);
+}
+
+function resolveBackupDir(config: PaperclipConfig): string {
+  return path.resolve(expandHomePrefix(config.database.backup.dir || resolveDefaultBackupDir(resolvePaperclipInstanceId())));
+}
+
+export async function findLatestBackupFile(
+  config: PaperclipConfig,
+  filenamePrefix = DEFAULT_BACKUP_FILENAME_PREFIX,
+): Promise<{ filePath: string; createdAt: string | null }> {
+  const backupDir = resolveBackupDir(config);
+  const names = await fsp.readdir(backupDir).catch(() => []);
+  const candidates = await Promise.all(
+    names
+      .filter((name) => name.startsWith(`${filenamePrefix}-`) && (name.endsWith(".sql") || name.endsWith(".sql.gz")))
+      .map(async (name) => {
+        const filePath = path.resolve(backupDir, name);
+        const stat = await fsp.stat(filePath);
+        return {
+          filePath,
+          mtimeMs: stat.mtimeMs,
+          createdAt: stat.mtime.toISOString(),
+        };
+      }),
+  );
+
+  const latest = candidates.sort((left, right) => right.mtimeMs - left.mtimeMs)[0];
+  if (!latest) {
+    throw new Error(`No completed backup files were found in ${backupDir}. Run \`paperclipai db:backup\` first.`);
+  }
+
+  return {
+    filePath: latest.filePath,
+    createdAt: latest.createdAt,
+  };
+}
+
+function buildSanitizedConfigSnapshot(config: PaperclipConfig): Buffer {
+  return Buffer.from(
+    JSON.stringify(
+      {
+        version: 1,
+        generatedAt: new Date().toISOString(),
+        database: {
+          mode: config.database.mode,
+          embeddedPostgresDataDir: config.database.embeddedPostgresDataDir,
+          embeddedPostgresPort: config.database.embeddedPostgresPort,
+          backup: config.database.backup,
+        },
+        server: {
+          deploymentMode: config.server.deploymentMode,
+          exposure: config.server.exposure,
+          host: config.server.host,
+          port: config.server.port,
+        },
+        storage: {
+          provider: config.storage.provider,
+          localDisk: config.storage.localDisk,
+          s3: {
+            bucket: config.storage.s3.bucket,
+            region: config.storage.s3.region,
+            endpoint: config.storage.s3.endpoint ?? null,
+            prefix: config.storage.s3.prefix,
+            forcePathStyle: config.storage.s3.forcePathStyle ?? false,
+          },
+        },
+        secrets: {
+          provider: config.secrets.provider,
+          strictMode: config.secrets.strictMode,
+          localEncrypted: {
+            keyFilePath: config.secrets.localEncrypted.keyFilePath,
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+function resolveMasterKeyPath(config: PaperclipConfig): string {
+  const override = process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE?.trim();
+  const configured = override || config.secrets.localEncrypted.keyFilePath;
+  return path.resolve(expandHomePrefix(configured));
+}
+
+function buildRecoveryWriter(config: RecoveryS3Config): RecoveryVaultWriter {
+  const client = createS3Client(config);
+  return {
+    async putObject(input) {
+      return putS3Object(client, config, input.objectKey, input.body, input.contentType);
+    },
+  };
+}
+
+export async function publishRecoveryArtifacts(input: PublishRecoveryArtifactsInput): Promise<RecoveryManifestRecord> {
+  const manifestId = randomUUID();
+  const createdAt = input.now.toISOString();
+  const ts = timestampId(input.now);
+  const backupFileName = path.basename(input.backupFilePath);
+  const tiers = deriveBackupTiers(input.now, input.previousManifest?.createdAt ?? null);
+  const backupArtifacts: RecoveryBackupArtifact[] = [];
+
+  for (const tier of tiers) {
+    const upload = await input.writer.putObject({
+      objectKey: `db/${tier}/${backupFileName}`,
+      body: input.backupBuffer,
+      contentType: "application/gzip",
+    });
+    backupArtifacts.push({
+      tier,
+      objectKey: upload.objectKey,
+      sizeBytes: upload.sizeBytes,
+      sha256: input.backupSha256,
+      uploadedAt: upload.uploadedAt,
+    });
+  }
+
+  const keySnapshot = input.keySnapshotBuffer && input.keySnapshotFingerprint
+    ? await input.writer.putObject({
+        objectKey: `keys/${input.keySnapshotFingerprint}/${ts}.json`,
+        body: input.keySnapshotBuffer,
+        contentType: "application/json",
+      }).then((upload) => ({
+        objectKey: upload.objectKey,
+        sizeBytes: upload.sizeBytes,
+        sha256: upload.sha256,
+        uploadedAt: upload.uploadedAt,
+        fingerprint: input.keySnapshotFingerprint as string,
+        encrypted: true,
+      }))
+    : null;
+
+  const configSnapshot = await input.writer.putObject({
+    objectKey: `manifests/config/${ts}-${manifestId}.json`,
+    body: input.configSnapshotBuffer,
+    contentType: "application/json",
+  });
+
+  const manifestObjectKey = `manifests/${ts}-${manifestId}.json`;
+  const manifest: RecoveryManifestRecord = {
+    manifestId,
+    createdAt,
+    manifestObjectKey,
+    sourceBackupFile: input.backupFilePath,
+    sourceBackupCreatedAt: input.backupCreatedAt,
+    storageProvider: input.storageProvider,
+    assetCutoverComplete: input.assetCutoverComplete,
+    assetSampleKeys: input.assetSampleKeys,
+    backupArtifacts,
+    keySnapshot,
+    configSnapshot,
+    warnings: input.warnings,
+  };
+
+  await input.writer.putObject({
+    objectKey: manifestObjectKey,
+    body: Buffer.from(JSON.stringify(manifest, null, 2) + "\n", "utf8"),
+    contentType: "application/json",
+  });
+
+  return manifest;
+}
+
+function assertVaultBoundary(config: PaperclipConfig, vault: RecoveryVaultSummary | null): void {
+  if (!vault) {
+    throw new Error("Recovery vault is not configured. Set PAPERCLIP_RECOVERY_VAULT_BUCKET and PAPERCLIP_RECOVERY_VAULT_REGION.");
+  }
+
+  if (
+    config.storage.s3.bucket.trim() &&
+    config.storage.s3.bucket.trim() === vault.bucket &&
+    normalizePrefix(config.storage.s3.prefix) === normalizePrefix(vault.prefix)
+  ) {
+    throw new Error("Recovery vault bucket/prefix must not match the live storage bucket/prefix.");
+  }
+}
+
+export async function publishRecoveryManifest(opts: {
+  configPath?: string;
+  statusPath?: string;
+  backupFile?: string;
+  now?: Date;
+}): Promise<PublishRecoveryResult> {
+  const config = readConfigOrThrow(opts.configPath);
+  const vaultConfig = createS3ConfigFromEnv(process.env);
+  const vaultSummary = loadRecoveryVaultSummaryFromEnv(process.env);
+  assertVaultBoundary(config, vaultSummary);
+
+  const statusPath = opts.statusPath ?? resolveRecoveryStatusFilePath();
+  const currentStatus = await readRecoveryStatusFile(statusPath);
+  const connectionString = resolveConnectionString(opts.configPath);
+  const now = opts.now ?? new Date();
+  const backupFile = opts.backupFile
+    ? path.resolve(opts.backupFile)
+    : (await findLatestBackupFile(config)).filePath;
+  const backupStat = await fsp.stat(backupFile);
+  const backupBuffer = await fsp.readFile(backupFile);
+  const keyPath = resolveMasterKeyPath(config);
+  const keyPlaintext = await fsp.readFile(keyPath, "utf8");
+  const encryptionSecret = process.env.PAPERCLIP_RECOVERY_KEY_ENCRYPTION_SECRET?.trim();
+  if (!encryptionSecret) {
+    throw new Error("PAPERCLIP_RECOVERY_KEY_ENCRYPTION_SECRET is required to publish encrypted key snapshots.");
+  }
+  const keySnapshotBuffer = encryptRecoveryKeySnapshot(encryptionSecret, Buffer.from(keyPlaintext, "utf8"));
+  const keySnapshotFingerprint = sha256(Buffer.from(keyPlaintext, "utf8"));
+  const configSnapshotBuffer = buildSanitizedConfigSnapshot(config);
+  const assetProof = await getRecoveryAssetProofSnapshot(connectionString);
+  const manifestAssetProof = deriveRecoveryManifestAssetProof({
+    storageProvider: config.storage.provider,
+    remainingLocalAssetCount: assetProof.remainingLocalAssetCount,
+    sampleObjectKeys: assetProof.sampleObjectKeys,
+  });
+  const statusBefore = evaluateRecoveryStatus({
+    ...currentStatus,
+    backupIntervalMinutes: config.database.backup.intervalMinutes,
+    storageProvider: config.storage.provider,
+    vault: vaultSummary,
+    assetCutover: {
+      ...currentStatus.assetCutover,
+      remainingLocalAssetCount: assetProof.remainingLocalAssetCount,
+      sampleObjectKeys: assetProof.sampleObjectKeys,
+    },
+  }, now);
+  const writer = buildRecoveryWriter(vaultConfig!);
+  const manifest = await publishRecoveryArtifacts({
+    writer,
+    now,
+    previousManifest: currentStatus.latestUploadedManifest,
+    backupFilePath: backupFile,
+    backupBuffer,
+    backupSha256: sha256(backupBuffer),
+    backupCreatedAt: backupStat.mtime.toISOString(),
+    storageProvider: config.storage.provider,
+    assetCutoverComplete: manifestAssetProof.assetCutoverComplete,
+    assetSampleKeys: manifestAssetProof.assetSampleKeys,
+    keySnapshotBuffer,
+    keySnapshotFingerprint,
+    configSnapshotBuffer,
+    warnings: statusBefore.warnings,
+  });
+
+  const nextStatus: RecoveryStatusFile = {
+    ...currentStatus,
+    version: RECOVERY_STATUS_FILE_VERSION,
+    updatedAt: now.toISOString(),
+    backupIntervalMinutes: config.database.backup.intervalMinutes,
+    storageProvider: config.storage.provider,
+    vault: vaultSummary,
+    latestUploadedManifest: manifest,
+    warnings: statusBefore.warnings,
+  };
+  await writeRecoveryStatusFile(nextStatus, statusPath);
+
+  return {
+    status: evaluateRecoveryStatus(nextStatus, now),
+    manifest,
+    statusPath,
+  };
+}
+
+function resolveLocalAssetPath(baseDir: string, objectKey: string): string {
+  const normalized = objectKey.replace(/\\/g, "/").trim();
+  if (!normalized || normalized.startsWith("/") || normalized.includes("..")) {
+    throw new Error(`Invalid asset object key: ${objectKey}`);
+  }
+  return path.resolve(baseDir, normalized);
+}
+
+function withDb<T>(connectionString: string, action: (db: Db) => Promise<T>): Promise<T> {
+  const db = createDb(connectionString);
+  return action(db);
+}
+
+export async function migrateAssetsToS3(opts: {
+  configPath?: string;
+  statusPath?: string;
+  switchProvider?: boolean;
+}): Promise<AssetCutoverResult> {
+  const config = readConfigOrThrow(opts.configPath);
+  const statusPath = opts.statusPath ?? resolveRecoveryStatusFilePath();
+  const currentStatus = await readRecoveryStatusFile(statusPath);
+  const connectionString = resolveConnectionString(opts.configPath);
+  const localBaseDir = path.resolve(expandHomePrefix(config.storage.localDisk.baseDir));
+  const targetConfig: RecoveryS3Config = {
+    bucket: config.storage.s3.bucket,
+    region: config.storage.s3.region,
+    endpoint: config.storage.s3.endpoint ?? null,
+    prefix: normalizePrefix(config.storage.s3.prefix),
+    forcePathStyle: config.storage.s3.forcePathStyle ?? false,
+  };
+
+  if (!targetConfig.bucket.trim() || !targetConfig.region.trim()) {
+    throw new Error("Storage S3 bucket and region must be configured before asset cutover.");
+  }
+
+  const client = createS3Client(targetConfig);
+  let migratedAssets = 0;
+  let migratedBytes = 0;
+  let skippedAssets = 0;
+  let remainingLocalAssetCount = 0;
+  let sampleObjectKeys: string[] = [];
+  let switchApplied = false;
+  const localAssets = await listLocalDiskAssets(connectionString);
+  const migratedAssetIds = new Set<string>();
+  const runStartedAt = new Date();
+
+  try {
+    for (const asset of localAssets) {
+      const existing = await headS3Object(client, targetConfig, asset.objectKey);
+      if (existing.exists && existing.contentLength === asset.byteSize) {
+        const remoteBody = await getS3ObjectBuffer(client, targetConfig, asset.objectKey);
+        if (canSkipRemoteAssetUpload({
+          remoteBody,
+          expectedSha256: asset.sha256,
+          expectedByteSize: asset.byteSize,
+        })) {
+          skippedAssets += 1;
+          migratedAssets += 1;
+          migratedBytes += asset.byteSize;
+          migratedAssetIds.add(asset.id);
+          if (sampleObjectKeys.length < RECOVERY_ASSET_SAMPLE_LIMIT) {
+            sampleObjectKeys.push(asset.objectKey);
+          }
+          continue;
+        }
+      }
+
+      const sourcePath = resolveLocalAssetPath(localBaseDir, asset.objectKey);
+      const body = await fsp.readFile(sourcePath);
+      if (sha256(body) !== asset.sha256) {
+        throw new Error(`Asset checksum mismatch for ${asset.objectKey}; aborting cutover.`);
+      }
+      await putS3Object(client, targetConfig, asset.objectKey, body, asset.contentType);
+      migratedAssets += 1;
+      migratedBytes += asset.byteSize;
+      migratedAssetIds.add(asset.id);
+      if (sampleObjectKeys.length < RECOVERY_ASSET_SAMPLE_LIMIT) {
+        sampleObjectKeys.push(asset.objectKey);
+      }
+    }
+
+    const currentLocalAssets = await listLocalDiskAssets(connectionString);
+    const concurrentLocalAssetIds = detectConcurrentLocalAssetIds(migratedAssetIds, currentLocalAssets);
+    remainingLocalAssetCount = concurrentLocalAssetIds.length;
+
+    if (opts.switchProvider) {
+      if (concurrentLocalAssetIds.length > 0) {
+        throw new Error(
+          `Asset cutover detected ${concurrentLocalAssetIds.length} concurrent local asset upload(s) during migration. Rerun with asset writes quiesced before switching storage.provider to s3.`,
+        );
+      }
+
+      const migratedIds = [...migratedAssetIds];
+      if (migratedIds.length > 0) {
+        await withDb(connectionString, async (db) => {
+          for (const batch of chunkArray(migratedIds, RECOVERY_ASSET_PROVIDER_UPDATE_BATCH_SIZE)) {
+            await db
+              .update(assets)
+              .set({ provider: "s3" })
+              .where(inArray(assets.id, batch));
+          }
+        });
+      }
+      writeConfig({
+        ...config,
+        storage: {
+          ...config.storage,
+          provider: "s3",
+        },
+      }, opts.configPath);
+      switchApplied = true;
+    }
+
+    const nextAssetCutover: RecoveryAssetCutoverStatus = {
+      lastRunAt: runStartedAt.toISOString(),
+      switchedAt: switchApplied ? new Date().toISOString() : currentStatus.assetCutover.switchedAt,
+      migratedAssetCount: migratedAssets,
+      migratedByteCount: migratedBytes,
+      remainingLocalAssetCount,
+      sampleObjectKeys,
+      lastError: null,
+    };
+
+    const nextConfig = readConfigOrThrow(opts.configPath);
+    const nextStatus: RecoveryStatusFile = {
+      ...currentStatus,
+      version: RECOVERY_STATUS_FILE_VERSION,
+      updatedAt: new Date().toISOString(),
+      backupIntervalMinutes: nextConfig.database.backup.intervalMinutes,
+      storageProvider: nextConfig.storage.provider,
+      vault: loadRecoveryVaultSummaryFromEnv(process.env),
+      assetCutover: nextAssetCutover,
+    };
+    await writeRecoveryStatusFile(nextStatus, statusPath);
+
+    return {
+      status: evaluateRecoveryStatus(nextStatus),
+      statusPath,
+      migratedAssets,
+      migratedBytes,
+      skippedAssets,
+      switchedProvider: switchApplied,
+    };
+  } catch (error) {
+    remainingLocalAssetCount = await countCurrentLocalDiskAssets(connectionString);
+    const failedConfig = readConfigOrThrow(opts.configPath);
+    const failedStatus: RecoveryStatusFile = {
+      ...currentStatus,
+      version: RECOVERY_STATUS_FILE_VERSION,
+      updatedAt: new Date().toISOString(),
+      backupIntervalMinutes: failedConfig.database.backup.intervalMinutes,
+      storageProvider: failedConfig.storage.provider,
+      vault: loadRecoveryVaultSummaryFromEnv(process.env),
+      assetCutover: {
+        lastRunAt: runStartedAt.toISOString(),
+        switchedAt: currentStatus.assetCutover.switchedAt,
+        migratedAssetCount: migratedAssets,
+        migratedByteCount: migratedBytes,
+        remainingLocalAssetCount,
+        sampleObjectKeys,
+        lastError: error instanceof Error ? error.message : String(error),
+      },
+    };
+    await writeRecoveryStatusFile(failedStatus, statusPath);
+    throw error;
+  }
+}
+
+function createTempFilePath(prefix: string, extension: string): string {
+  return path.resolve(process.cwd(), ".tmp", `${prefix}-${randomUUID()}${extension}`);
+}
+
+async function ensureParentDir(filePath: string): Promise<void> {
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function readManifestFromVault(
+  client: S3Client,
+  config: RecoveryS3Config,
+  objectKey: string,
+): Promise<RecoveryManifestRecord> {
+  const body = await getS3ObjectBuffer(client, config, objectKey);
+  return JSON.parse(body.toString("utf8")) as RecoveryManifestRecord;
+}
+
+export async function runRecoveryDrill(opts: {
+  configPath?: string;
+  statusPath?: string;
+  manifestObjectKey?: string;
+  restoreConnectionString: string;
+  restoreKeyFilePath?: string;
+}): Promise<RecoveryDrillResult> {
+  const config = readConfigOrThrow(opts.configPath);
+  const statusPath = opts.statusPath ?? resolveRecoveryStatusFilePath();
+  const currentStatus = await readRecoveryStatusFile(statusPath);
+  const vaultConfig = createS3ConfigFromEnv(process.env);
+  const vaultSummary = loadRecoveryVaultSummaryFromEnv(process.env);
+  assertVaultBoundary(config, vaultSummary);
+
+  const manifestKey = opts.manifestObjectKey ?? currentStatus.latestUploadedManifest?.manifestObjectKey;
+  if (!manifestKey) {
+    throw new Error("No recovery manifest is available to drill. Publish a manifest first or pass --manifest-key.");
+  }
+
+  const drillId = randomUUID();
+  const startedAt = new Date();
+  const failures: string[] = [];
+  const verifiedChecks: string[] = [];
+  let recoveredMasterKeyFileContents: Buffer | null = null;
+  const client = createS3Client(vaultConfig!);
+  const manifest = await readManifestFromVault(client, vaultConfig!, manifestKey);
+
+  const backupArtifact = manifest.backupArtifacts.find((artifact) => artifact.tier === "hourly") ?? manifest.backupArtifacts[0];
+  if (!backupArtifact) {
+    throw new Error(`Recovery manifest ${manifest.manifestId} does not reference a DB backup artifact.`);
+  }
+
+  const tempBackupFile = createTempFilePath("paperclip-recovery-drill", ".sql.gz");
+  const tempKeyFile = opts.restoreKeyFilePath
+    ? path.resolve(opts.restoreKeyFilePath)
+    : createTempFilePath("paperclip-recovery-key", ".key");
+
+  try {
+    await ensureParentDir(tempBackupFile);
+    await ensureParentDir(tempKeyFile);
+    await fsp.writeFile(
+      tempBackupFile,
+      await getS3ObjectBuffer(client, vaultConfig!, backupArtifact.objectKey),
+    );
+    await runDatabaseRestore({
+      connectionString: opts.restoreConnectionString,
+      backupFile: tempBackupFile,
+    });
+    verifiedChecks.push("database_restore");
+
+    if (manifest.keySnapshot) {
+      const encryptionSecret = process.env.PAPERCLIP_RECOVERY_KEY_ENCRYPTION_SECRET?.trim();
+      if (!encryptionSecret) {
+        failures.push("PAPERCLIP_RECOVERY_KEY_ENCRYPTION_SECRET is required to decrypt the recovery key snapshot.");
+      } else {
+        const keyPayload = await getS3ObjectBuffer(client, vaultConfig!, manifest.keySnapshot.objectKey);
+        const keyBuffer = decryptRecoveryKeySnapshot(encryptionSecret, keyPayload);
+        recoveredMasterKeyFileContents = keyBuffer;
+        await fsp.writeFile(tempKeyFile, keyBuffer, { mode: 0o600 });
+        verifiedChecks.push("secrets_key_snapshot");
+      }
+    } else {
+      failures.push("Manifest does not contain a key snapshot.");
+    }
+
+    failures.push(...getRecoveryDrillAssetProofFailures(manifest));
+
+    const sql = postgres(opts.restoreConnectionString, { max: 1, onnotice: () => {} });
+    try {
+      const restoredCompanies = await sql<{ count: number }[]>`
+        SELECT COUNT(*)::int AS count FROM public.companies
+      `;
+      if ((restoredCompanies[0]?.count ?? 0) <= 0) {
+        failures.push("Restored database does not contain any companies.");
+      } else {
+        verifiedChecks.push("companies_present");
+      }
+
+      const restoredIssues = await sql<{ count: number }[]>`
+        SELECT COUNT(*)::int AS count FROM public.issues
+      `;
+      if ((restoredIssues[0]?.count ?? 0) >= 0) {
+        verifiedChecks.push("issues_query");
+      }
+
+      const restoredSecrets = await sql<{ count: number }[]>`
+        SELECT COUNT(*)::int AS count FROM public.company_secrets
+      `;
+      if ((restoredSecrets[0]?.count ?? 0) >= 0) {
+        verifiedChecks.push("secrets_query");
+      }
+
+      if (!recoveredMasterKeyFileContents) {
+        failures.push("Recovered secrets master key is unavailable for restored secret verification.");
+      } else {
+        const restoredSecretSamples = await sql<Array<{
+          companyId: string;
+          secretId: string;
+          name: string;
+          version: number;
+          material: Record<string, unknown>;
+          valueSha256: string;
+        }>>`
+          SELECT
+            cs.company_id AS "companyId",
+            cs.id AS "secretId",
+            cs.name AS "name",
+            csv.version AS "version",
+            csv.material AS "material",
+            csv.value_sha256 AS "valueSha256"
+          FROM public.company_secrets cs
+          INNER JOIN public.company_secret_versions csv
+            ON csv.secret_id = cs.id
+          WHERE cs.provider = 'local_encrypted'
+          ORDER BY csv.created_at DESC
+          LIMIT 1
+        `;
+
+        const restoredSecretSample = restoredSecretSamples[0];
+        if (!restoredSecretSample) {
+          failures.push("Restored database does not contain any local_encrypted secret versions to validate.");
+        } else {
+          try {
+            verifyRecoveredLocalEncryptedSecretValue({
+              masterKeyFileContents: recoveredMasterKeyFileContents,
+              material: restoredSecretSample.material,
+              valueSha256: restoredSecretSample.valueSha256,
+            });
+            verifiedChecks.push("secrets_material_restore");
+          } catch (error) {
+            failures.push(
+              `Recovered secrets master key could not decrypt restored secret material: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+        }
+      }
+    } finally {
+      await sql.end();
+    }
+
+    const assetCheckConfig = createRecoveryAssetCheckConfig(config, process.env);
+    const assetSampleKeys = manifest.assetSampleKeys.slice(0, RECOVERY_ASSET_SAMPLE_LIMIT);
+    if (assetCheckConfig && assetSampleKeys.length > 0) {
+      const assetClient = createS3Client(assetCheckConfig);
+      for (const objectKey of assetSampleKeys) {
+        const head = await headS3Object(assetClient, assetCheckConfig, objectKey);
+        if (!head.exists) {
+          failures.push(`Recovery asset sample is missing: ${objectKey}`);
+        }
+      }
+      if (!failures.some((failure) => failure.startsWith("Recovery asset sample is missing"))) {
+        verifiedChecks.push("asset_samples_present");
+      }
+    } else if (manifest.assetSampleKeys.length > 0) {
+      failures.push("Asset sample verification is unavailable because no S3 asset verification target is configured.");
+    }
+
+    const finishedAt = new Date();
+    const drill: RecoveryDrillRecord = {
+      drillId,
+      manifestId: manifest.manifestId,
+      status: failures.length === 0 ? "passed" : "failed",
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      durationMs: finishedAt.getTime() - startedAt.getTime(),
+      verifiedChecks,
+      failures,
+      evidenceObjectKey: null,
+    };
+
+    const evidenceObjectKey = `drills/${timestampId(finishedAt)}-${drillId}.json`;
+    const evidenceUpload = await putS3Object(
+      client,
+      vaultConfig!,
+      evidenceObjectKey,
+      Buffer.from(JSON.stringify({ manifest, drill }, null, 2) + "\n", "utf8"),
+      "application/json",
+    );
+    drill.evidenceObjectKey = evidenceUpload.objectKey;
+
+    const nextStatus: RecoveryStatusFile = {
+      ...currentStatus,
+      version: RECOVERY_STATUS_FILE_VERSION,
+      updatedAt: finishedAt.toISOString(),
+      backupIntervalMinutes: config.database.backup.intervalMinutes,
+      storageProvider: config.storage.provider,
+      vault: vaultSummary,
+      latestDrillAttempt: drill,
+      latestVerifiedRestore: drill.status === "passed" ? drill : currentStatus.latestVerifiedRestore,
+    };
+    await writeRecoveryStatusFile(nextStatus, statusPath);
+
+    return {
+      status: evaluateRecoveryStatus(nextStatus, finishedAt),
+      drill,
+      statusPath,
+    };
+  } finally {
+    if (!opts.restoreKeyFilePath && fs.existsSync(tempKeyFile)) {
+      await fsp.rm(tempKeyFile, { force: true });
+    }
+    if (fs.existsSync(tempBackupFile)) {
+      await fsp.rm(tempBackupFile, { force: true });
+    }
+  }
+}

--- a/cli/src/commands/recovery.ts
+++ b/cli/src/commands/recovery.ts
@@ -1,0 +1,159 @@
+import type { Command } from "commander";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import {
+  migrateAssetsToS3,
+  publishRecoveryManifest,
+  runRecoveryDrill,
+} from "./recovery-lib.js";
+import { printPaperclipCliBanner } from "../utils/banner.js";
+
+const DATA_DIR_OPTION_HELP =
+  "Paperclip data directory root (isolates state from ~/.paperclip)";
+
+type RecoveryPublishOptions = {
+  config?: string;
+  dataDir?: string;
+  backupFile?: string;
+  statusPath?: string;
+  json?: boolean;
+};
+
+type RecoveryCutoverOptions = {
+  config?: string;
+  dataDir?: string;
+  statusPath?: string;
+  switchProvider?: boolean;
+  json?: boolean;
+};
+
+type RecoveryDrillOptions = {
+  config?: string;
+  dataDir?: string;
+  statusPath?: string;
+  manifestKey?: string;
+  restoreUrl: string;
+  restoreKeyFile?: string;
+  json?: boolean;
+};
+
+async function recoveryPublishCommand(opts: RecoveryPublishOptions): Promise<void> {
+  printPaperclipCliBanner();
+  p.intro(pc.bgCyan(pc.black(" paperclip recovery:publish ")));
+  const spinner = p.spinner();
+  spinner.start("Publishing recovery manifest...");
+  try {
+    const result = await publishRecoveryManifest({
+      configPath: opts.config,
+      statusPath: opts.statusPath,
+      backupFile: opts.backupFile,
+    });
+    spinner.stop(`Published ${result.manifest.manifestId}`);
+    p.log.message(pc.dim(`Manifest: ${result.manifest.manifestObjectKey}`));
+    p.log.message(pc.dim(`Status file: ${result.statusPath}`));
+    p.log.message(pc.dim(`Recovery state: ${result.status.state}`));
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    }
+    p.outro(pc.green("Recovery manifest published."));
+  } catch (error) {
+    spinner.stop(pc.red("Recovery publish failed."));
+    throw error;
+  }
+}
+
+async function recoveryCutoverCommand(opts: RecoveryCutoverOptions): Promise<void> {
+  printPaperclipCliBanner();
+  p.intro(pc.bgCyan(pc.black(" paperclip recovery:cutover-assets ")));
+  const spinner = p.spinner();
+  spinner.start("Migrating local assets into S3...");
+  try {
+    const result = await migrateAssetsToS3({
+      configPath: opts.config,
+      statusPath: opts.statusPath,
+      switchProvider: opts.switchProvider === true,
+    });
+    spinner.stop(`Migrated ${result.migratedAssets} asset(s)`);
+    p.log.message(pc.dim(`Migrated bytes: ${result.migratedBytes}`));
+    p.log.message(pc.dim(`Skipped assets: ${result.skippedAssets}`));
+    p.log.message(pc.dim(`Switched provider: ${result.switchedProvider ? "yes" : "no"}`));
+    p.log.message(pc.dim(`Status file: ${result.statusPath}`));
+    p.log.message(pc.dim(`Recovery state: ${result.status.state}`));
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    }
+    p.outro(pc.green("Asset cutover finished."));
+  } catch (error) {
+    spinner.stop(pc.red("Asset cutover failed."));
+    throw error;
+  }
+}
+
+async function recoveryDrillCommand(opts: RecoveryDrillOptions): Promise<void> {
+  printPaperclipCliBanner();
+  p.intro(pc.bgCyan(pc.black(" paperclip recovery:drill ")));
+  const spinner = p.spinner();
+  spinner.start("Running restore drill...");
+  try {
+    const result = await runRecoveryDrill({
+      configPath: opts.config,
+      statusPath: opts.statusPath,
+      manifestObjectKey: opts.manifestKey,
+      restoreConnectionString: opts.restoreUrl,
+      restoreKeyFilePath: opts.restoreKeyFile,
+    });
+    spinner.stop(`Drill ${result.drill.status}`);
+    p.log.message(pc.dim(`Drill id: ${result.drill.drillId}`));
+    p.log.message(pc.dim(`Manifest id: ${result.drill.manifestId}`));
+    p.log.message(pc.dim(`Evidence: ${result.drill.evidenceObjectKey ?? "none"}`));
+    p.log.message(pc.dim(`Status file: ${result.statusPath}`));
+    p.log.message(pc.dim(`Recovery state: ${result.status.state}`));
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    }
+    p.outro(pc.green("Restore drill finished."));
+  } catch (error) {
+    spinner.stop(pc.red("Restore drill failed."));
+    throw error;
+  }
+}
+
+export function registerRecoveryCommands(program: Command): void {
+  program
+    .command("recovery:publish")
+    .description("Publish the latest local DB backup, config snapshot, and key snapshot to the recovery vault")
+    .option("-c, --config <path>", "Path to config file")
+    .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
+    .option("--backup-file <path>", "Use a specific local backup file instead of auto-detecting the newest one")
+    .option("--status-path <path>", "Override the local recovery status file path")
+    .option("--json", "Print the publish result as JSON")
+    .action(async (opts) => {
+      await recoveryPublishCommand(opts);
+    });
+
+  program
+    .command("recovery:cutover-assets")
+    .description("Copy local asset objects into S3 and optionally switch the live storage provider")
+    .option("-c, --config <path>", "Path to config file")
+    .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
+    .option("--status-path <path>", "Override the local recovery status file path")
+    .option("--switch-provider", "Switch storage.provider to s3 after the copy completes", false)
+    .option("--json", "Print the cutover result as JSON")
+    .action(async (opts) => {
+      await recoveryCutoverCommand(opts);
+    });
+
+  program
+    .command("recovery:drill")
+    .description("Restore a published recovery manifest into a clean target and record drill status")
+    .requiredOption("--restore-url <url>", "Connection string for the clean restore target database")
+    .option("-c, --config <path>", "Path to config file")
+    .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
+    .option("--status-path <path>", "Override the local recovery status file path")
+    .option("--manifest-key <key>", "Recovery manifest object key to drill; defaults to the latest published manifest")
+    .option("--restore-key-file <path>", "Optional destination for the decrypted master key during the drill")
+    .option("--json", "Print the drill result as JSON")
+    .action(async (opts) => {
+      await recoveryDrillCommand(opts as RecoveryDrillOptions);
+    });
+}

--- a/cli/src/config/home.ts
+++ b/cli/src/config/home.ts
@@ -57,6 +57,14 @@ export function resolveDefaultBackupDir(instanceId?: string): string {
   return path.resolve(resolvePaperclipInstanceRoot(instanceId), "data", "backups");
 }
 
+export function resolveDefaultRecoveryDir(instanceId?: string): string {
+  return path.resolve(resolvePaperclipInstanceRoot(instanceId), "data", "recovery");
+}
+
+export function resolveDefaultRecoveryStatusPath(instanceId?: string): string {
+  return path.resolve(resolveDefaultRecoveryDir(instanceId), "status.json");
+}
+
 export function expandHomePrefix(value: string): string {
   if (value === "~") return os.homedir();
   if (value.startsWith("~/")) return path.resolve(os.homedir(), value.slice(2));
@@ -73,6 +81,8 @@ export function describeLocalInstancePaths(instanceId?: string) {
     configPath: resolveDefaultConfigPath(resolvedInstanceId),
     embeddedPostgresDataDir: resolveDefaultEmbeddedPostgresDir(resolvedInstanceId),
     backupDir: resolveDefaultBackupDir(resolvedInstanceId),
+    recoveryDir: resolveDefaultRecoveryDir(resolvedInstanceId),
+    recoveryStatusPath: resolveDefaultRecoveryStatusPath(resolvedInstanceId),
     logDir: resolveDefaultLogsDir(resolvedInstanceId),
     secretsKeyFilePath: resolveDefaultSecretsKeyFilePath(resolvedInstanceId),
     storageDir: resolveDefaultStorageDir(resolvedInstanceId),

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ import { initTelemetryFromConfigFile, flushTelemetry } from "./telemetry.js";
 import { registerWorktreeCommands } from "./commands/worktree.js";
 import { registerPluginCommands } from "./commands/client/plugin.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
+import { registerRecoveryCommands } from "./commands/recovery.js";
 import { cliVersion } from "./version.js";
 
 const program = new Command();
@@ -150,6 +151,7 @@ registerFeedbackCommands(program);
 registerWorktreeCommands(program);
 registerEnvLabCommands(program);
 registerPluginCommands(program);
+registerRecoveryCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -271,6 +271,19 @@ export type {
   IssueGraphLivenessAutoRecoveryPreview,
   IssueGraphLivenessAutoRecoveryPreviewItem,
   BackupRetentionPolicy,
+  RecoveryState,
+  RecoveryManifestFreshness,
+  RecoveryBackupTier,
+  RecoveryDrillStatus,
+  RecoveryVaultSummary,
+  RecoveryArtifactRef,
+  RecoveryBackupArtifact,
+  RecoveryKeySnapshotArtifact,
+  RecoveryManifestRecord,
+  RecoveryDrillRecord,
+  RecoveryAssetCutoverStatus,
+  RecoveryStatusFile,
+  RecoveryStatusSnapshot,
   Agent,
   AgentAccessState,
   AgentChainOfCommandEntry,
@@ -560,6 +573,14 @@ export {
   MIN_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
   MAX_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
 } from "./types/instance.js";
+export {
+  RECOVERY_STATES,
+  RECOVERY_MANIFEST_FRESHNESS,
+  RECOVERY_BACKUP_TIERS,
+  RECOVERY_DRILL_STATUSES,
+  DEFAULT_RECOVERY_STATUS_FILE,
+  evaluateRecoveryStatus,
+} from "./types/recovery.js";
 
 export {
   getClosedIsolatedExecutionWorkspaceMessage,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -41,6 +41,29 @@ export {
   MAX_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
 } from "./instance.js";
 export type {
+  RecoveryState,
+  RecoveryManifestFreshness,
+  RecoveryBackupTier,
+  RecoveryDrillStatus,
+  RecoveryVaultSummary,
+  RecoveryArtifactRef,
+  RecoveryBackupArtifact,
+  RecoveryKeySnapshotArtifact,
+  RecoveryManifestRecord,
+  RecoveryDrillRecord,
+  RecoveryAssetCutoverStatus,
+  RecoveryStatusFile,
+  RecoveryStatusSnapshot,
+} from "./recovery.js";
+export {
+  RECOVERY_STATES,
+  RECOVERY_MANIFEST_FRESHNESS,
+  RECOVERY_BACKUP_TIERS,
+  RECOVERY_DRILL_STATUSES,
+  DEFAULT_RECOVERY_STATUS_FILE,
+  evaluateRecoveryStatus,
+} from "./recovery.js";
+export type {
   CompanySkillSourceType,
   CompanySkillTrustLevel,
   CompanySkillCompatibility,

--- a/packages/shared/src/types/recovery.test.ts
+++ b/packages/shared/src/types/recovery.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_RECOVERY_STATUS_FILE,
+  evaluateRecoveryStatus,
+  type RecoveryDrillRecord,
+  type RecoveryManifestRecord,
+} from "./recovery.js";
+
+function createManifest(createdAt: string): RecoveryManifestRecord {
+  return {
+    manifestId: "manifest-1",
+    createdAt,
+    manifestObjectKey: "manifests/20260428-120000-manifest-1.json",
+    sourceBackupFile: "/tmp/paperclip-20260428.sql.gz",
+    sourceBackupCreatedAt: createdAt,
+    storageProvider: "s3",
+    assetCutoverComplete: true,
+    assetSampleKeys: ["assets/sample-1"],
+    backupArtifacts: [
+      {
+        tier: "hourly",
+        objectKey: "db/hourly/paperclip-20260428.sql.gz",
+        sizeBytes: 128,
+        sha256: "backup-sha",
+        uploadedAt: createdAt,
+      },
+    ],
+    keySnapshot: {
+      objectKey: "keys/fingerprint/20260428-120000.json",
+      sizeBytes: 64,
+      sha256: "key-sha",
+      uploadedAt: createdAt,
+      fingerprint: "fingerprint",
+      encrypted: true,
+    },
+    configSnapshot: {
+      objectKey: "manifests/config/20260428-120000-manifest-1.json",
+      sizeBytes: 96,
+      sha256: "config-sha",
+      uploadedAt: createdAt,
+    },
+    warnings: [],
+  };
+}
+
+function createDrill(input: {
+  drillId: string;
+  status: "passed" | "failed";
+  startedAt: string;
+  finishedAt: string;
+  failures?: string[];
+}): RecoveryDrillRecord {
+  return {
+    drillId: input.drillId,
+    manifestId: "manifest-1",
+    status: input.status,
+    startedAt: input.startedAt,
+    finishedAt: input.finishedAt,
+    durationMs: 60_000,
+    verifiedChecks: input.status === "passed" ? ["database_restore", "asset_samples_present"] : ["database_restore"],
+    failures: input.failures ?? [],
+    evidenceObjectKey: "drills/20260428-120000-drill.json",
+  };
+}
+
+describe("evaluateRecoveryStatus", () => {
+  it("reports restore verified when manifest, cutover, and verified drill are healthy", () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const manifest = createManifest("2026-04-28T11:30:00.000Z");
+    const verifiedDrill = createDrill({
+      drillId: "drill-verified",
+      status: "passed",
+      startedAt: "2026-04-28T11:40:00.000Z",
+      finishedAt: "2026-04-28T11:41:00.000Z",
+    });
+
+    const status = evaluateRecoveryStatus(
+      {
+        ...DEFAULT_RECOVERY_STATUS_FILE,
+        backupIntervalMinutes: 60,
+        storageProvider: "s3",
+        vault: {
+          bucket: "recovery-vault",
+          region: "us-east-1",
+          endpoint: null,
+          prefix: "paperclip",
+        },
+        latestUploadedManifest: manifest,
+        latestDrillAttempt: verifiedDrill,
+        latestVerifiedRestore: verifiedDrill,
+        assetCutover: {
+          lastRunAt: "2026-04-28T11:20:00.000Z",
+          switchedAt: "2026-04-28T11:25:00.000Z",
+          migratedAssetCount: 12,
+          migratedByteCount: 4096,
+          remainingLocalAssetCount: 0,
+          sampleObjectKeys: ["assets/sample-1"],
+          lastError: null,
+        },
+      },
+      now,
+    );
+
+    expect(status.state).toBe("RestoreVerified");
+    expect(status.manifestFreshness).toBe("fresh");
+    expect(status.degradedReasons).toEqual([]);
+  });
+
+  it("preserves the last verified restore when the newest drill fails", () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const manifest = createManifest("2026-04-28T11:30:00.000Z");
+    const verifiedDrill = createDrill({
+      drillId: "drill-verified",
+      status: "passed",
+      startedAt: "2026-04-28T10:00:00.000Z",
+      finishedAt: "2026-04-28T10:01:00.000Z",
+    });
+    const failedDrill = createDrill({
+      drillId: "drill-failed",
+      status: "failed",
+      startedAt: "2026-04-28T11:50:00.000Z",
+      finishedAt: "2026-04-28T11:51:00.000Z",
+      failures: ["Restored database does not contain any companies."],
+    });
+
+    const status = evaluateRecoveryStatus(
+      {
+        ...DEFAULT_RECOVERY_STATUS_FILE,
+        backupIntervalMinutes: 60,
+        storageProvider: "s3",
+        vault: {
+          bucket: "recovery-vault",
+          region: "us-east-1",
+          endpoint: null,
+          prefix: "paperclip",
+        },
+        latestUploadedManifest: manifest,
+        latestDrillAttempt: failedDrill,
+        latestVerifiedRestore: verifiedDrill,
+        assetCutover: {
+          lastRunAt: "2026-04-28T11:20:00.000Z",
+          switchedAt: "2026-04-28T11:25:00.000Z",
+          migratedAssetCount: 12,
+          migratedByteCount: 4096,
+          remainingLocalAssetCount: 0,
+          sampleObjectKeys: ["assets/sample-1"],
+          lastError: null,
+        },
+      },
+      now,
+    );
+
+    expect(status.state).toBe("RestoreDrillFailed");
+    expect(status.latestVerifiedRestore?.drillId).toBe("drill-verified");
+    expect(status.degradedReasons).toContain("Latest restore drill failed.");
+  });
+});

--- a/packages/shared/src/types/recovery.ts
+++ b/packages/shared/src/types/recovery.ts
@@ -1,0 +1,231 @@
+import type { StorageProvider } from "../constants.js";
+
+export const RECOVERY_STATES = [
+  "LocalOnly",
+  "VaultProvisioned",
+  "AssetStorageCutoverReady",
+  "RecoveryWriterHealthy",
+  "ManifestPublished",
+  "RestoreVerified",
+  "ManifestStale",
+  "AssetReplicationLagging",
+  "KeySnapshotMissing",
+  "RestoreDrillFailed",
+  "RecoveryDegraded",
+] as const;
+
+export type RecoveryState = (typeof RECOVERY_STATES)[number];
+
+export const RECOVERY_MANIFEST_FRESHNESS = ["missing", "fresh", "stale"] as const;
+export type RecoveryManifestFreshness = (typeof RECOVERY_MANIFEST_FRESHNESS)[number];
+
+export const RECOVERY_BACKUP_TIERS = ["hourly", "daily", "weekly", "monthly"] as const;
+export type RecoveryBackupTier = (typeof RECOVERY_BACKUP_TIERS)[number];
+
+export const RECOVERY_DRILL_STATUSES = ["passed", "failed"] as const;
+export type RecoveryDrillStatus = (typeof RECOVERY_DRILL_STATUSES)[number];
+
+export interface RecoveryVaultSummary {
+  bucket: string;
+  region: string;
+  endpoint: string | null;
+  prefix: string;
+}
+
+export interface RecoveryArtifactRef {
+  objectKey: string;
+  sizeBytes: number;
+  sha256: string;
+  uploadedAt: string;
+}
+
+export interface RecoveryBackupArtifact extends RecoveryArtifactRef {
+  tier: RecoveryBackupTier;
+}
+
+export interface RecoveryKeySnapshotArtifact extends RecoveryArtifactRef {
+  fingerprint: string;
+  encrypted: boolean;
+}
+
+export interface RecoveryManifestRecord {
+  manifestId: string;
+  createdAt: string;
+  manifestObjectKey: string;
+  sourceBackupFile: string;
+  sourceBackupCreatedAt: string | null;
+  storageProvider: StorageProvider;
+  assetCutoverComplete: boolean;
+  assetSampleKeys: string[];
+  backupArtifacts: RecoveryBackupArtifact[];
+  keySnapshot: RecoveryKeySnapshotArtifact | null;
+  configSnapshot: RecoveryArtifactRef | null;
+  warnings: string[];
+}
+
+export interface RecoveryDrillRecord {
+  drillId: string;
+  manifestId: string;
+  status: RecoveryDrillStatus;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  verifiedChecks: string[];
+  failures: string[];
+  evidenceObjectKey: string | null;
+}
+
+export interface RecoveryAssetCutoverStatus {
+  lastRunAt: string | null;
+  switchedAt: string | null;
+  migratedAssetCount: number;
+  migratedByteCount: number;
+  remainingLocalAssetCount: number;
+  sampleObjectKeys: string[];
+  lastError: string | null;
+}
+
+export interface RecoveryStatusFile {
+  version: 1;
+  updatedAt: string;
+  backupIntervalMinutes: number;
+  storageProvider: StorageProvider;
+  vault: RecoveryVaultSummary | null;
+  latestUploadedManifest: RecoveryManifestRecord | null;
+  latestDrillAttempt: RecoveryDrillRecord | null;
+  latestVerifiedRestore: RecoveryDrillRecord | null;
+  assetCutover: RecoveryAssetCutoverStatus;
+  warnings: string[];
+}
+
+export interface RecoveryStatusSnapshot extends RecoveryStatusFile {
+  state: RecoveryState;
+  manifestFreshness: RecoveryManifestFreshness;
+  degradedReasons: string[];
+}
+
+export const DEFAULT_RECOVERY_STATUS_FILE: RecoveryStatusFile = {
+  version: 1,
+  updatedAt: new Date(0).toISOString(),
+  backupIntervalMinutes: 60,
+  storageProvider: "local_disk",
+  vault: null,
+  latestUploadedManifest: null,
+  latestDrillAttempt: null,
+  latestVerifiedRestore: null,
+  assetCutover: {
+    lastRunAt: null,
+    switchedAt: null,
+    migratedAssetCount: 0,
+    migratedByteCount: 0,
+    remainingLocalAssetCount: 0,
+    sampleObjectKeys: [],
+    lastError: null,
+  },
+  warnings: [],
+};
+
+function toDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function uniq(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
+}
+
+export function evaluateRecoveryStatus(
+  input: RecoveryStatusFile,
+  now: Date = new Date(),
+): RecoveryStatusSnapshot {
+  const degradedReasons: string[] = [];
+  const manifest = input.latestUploadedManifest;
+  const latestDrill = input.latestDrillAttempt;
+  const manifestCreatedAt = toDate(manifest?.createdAt);
+  const staleThresholdMs = Math.max(1, input.backupIntervalMinutes) * 60 * 1000 + 15 * 60 * 1000;
+  const manifestFreshness: RecoveryManifestFreshness =
+    !manifestCreatedAt
+      ? "missing"
+      : now.getTime() - manifestCreatedAt.getTime() > staleThresholdMs
+        ? "stale"
+        : "fresh";
+
+  const cutoverReady = input.assetCutover.remainingLocalAssetCount === 0 &&
+    (input.storageProvider === "s3" || input.assetCutover.migratedAssetCount > 0);
+  const cutoverComplete = input.storageProvider === "s3" && cutoverReady;
+
+  if (!input.vault) {
+    degradedReasons.push("Recovery vault is not configured.");
+  }
+
+  if (input.storageProvider !== "s3") {
+    degradedReasons.push("Live asset storage is still local_disk; asset cutover to S3 is incomplete.");
+  }
+
+  if (input.assetCutover.remainingLocalAssetCount > 0) {
+    degradedReasons.push(
+      `${input.assetCutover.remainingLocalAssetCount} asset object(s) still need migration before cutover is complete.`,
+    );
+  }
+
+  if (input.assetCutover.lastError) {
+    degradedReasons.push(`Asset cutover error: ${input.assetCutover.lastError}`);
+  }
+
+  if (manifestFreshness === "missing") {
+    degradedReasons.push("No recovery manifest has been published yet.");
+  }
+
+  if (manifestFreshness === "stale") {
+    degradedReasons.push("Latest recovery manifest is older than the configured backup interval.");
+  }
+
+  if (manifest && !manifest.keySnapshot) {
+    degradedReasons.push("Latest recovery manifest is missing a secrets master-key snapshot.");
+  }
+
+  if (manifest && !manifest.configSnapshot) {
+    degradedReasons.push("Latest recovery manifest is missing a sanitized config snapshot.");
+  }
+
+  if (manifest && !manifest.assetCutoverComplete) {
+    degradedReasons.push("Latest recovery manifest was published before asset storage cutover completed.");
+  }
+
+  if (latestDrill?.status === "failed") {
+    degradedReasons.push("Latest restore drill failed.");
+  }
+
+  let state: RecoveryState;
+  if (!input.vault) {
+    state = "LocalOnly";
+  } else if (latestDrill?.status === "failed") {
+    state = "RestoreDrillFailed";
+  } else if (manifest && !manifest.keySnapshot) {
+    state = "KeySnapshotMissing";
+  } else if (manifestFreshness === "stale") {
+    state = "ManifestStale";
+  } else if (input.latestVerifiedRestore?.status === "passed" && cutoverComplete && manifestFreshness === "fresh") {
+    state = "RestoreVerified";
+  } else if (manifestFreshness === "fresh" && cutoverComplete) {
+    state = "ManifestPublished";
+  } else if (cutoverReady) {
+    state = manifestFreshness === "fresh" ? "RecoveryWriterHealthy" : "AssetStorageCutoverReady";
+  } else if (manifestFreshness === "fresh") {
+    state = "RecoveryDegraded";
+  } else {
+    state = "VaultProvisioned";
+  }
+
+  return {
+    ...input,
+    state,
+    manifestFreshness,
+    degradedReasons: uniq(degradedReasons),
+    warnings: uniq([
+      ...input.warnings,
+      ...(manifest?.warnings ?? []),
+    ]),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
 
   cli:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.888.0
+        version: 3.994.0
       '@clack/prompts':
         specifier: ^0.10.0
         version: 0.10.1
@@ -85,6 +88,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      postgres:
+        specifier: ^3.4.5
+        version: 3.4.8
     devDependencies:
       '@types/node':
         specifier: ^22.12.0

--- a/server/src/__tests__/instance-settings-routes.test.ts
+++ b/server/src/__tests__/instance-settings-routes.test.ts
@@ -13,11 +13,15 @@ const mockHeartbeatService = vi.hoisted(() => ({
   buildIssueGraphLivenessAutoRecoveryPreview: vi.fn(),
   reconcileIssueGraphLiveness: vi.fn(),
 }));
+const mockInstanceRecoveryStatusService = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
 const mockLogActivity = vi.hoisted(() => vi.fn());
 
 function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     heartbeatService: () => mockHeartbeatService,
+    instanceRecoveryStatusService: () => mockInstanceRecoveryStatusService,
     instanceSettingsService: () => mockInstanceSettingsService,
     logActivity: mockLogActivity,
   }));
@@ -55,6 +59,7 @@ describe("instance settings routes", () => {
     mockInstanceSettingsService.listCompanyIds.mockReset();
     mockHeartbeatService.buildIssueGraphLivenessAutoRecoveryPreview.mockReset();
     mockHeartbeatService.reconcileIssueGraphLiveness.mockReset();
+    mockInstanceRecoveryStatusService.get.mockReset();
     mockLogActivity.mockReset();
     mockInstanceSettingsService.getGeneral.mockResolvedValue({
       censorUsernameInLogs: false,
@@ -107,6 +112,30 @@ describe("instance settings routes", () => {
       skippedAutoRecoveryDisabled: 0,
       skippedOutsideLookback: 0,
       escalationIssueIds: ["issue-2"],
+    });
+    mockInstanceRecoveryStatusService.get.mockReturnValue({
+      version: 1,
+      updatedAt: "2026-04-29T03:00:00.000Z",
+      backupIntervalMinutes: 60,
+      storageProvider: "local_disk",
+      vault: null,
+      latestUploadedManifest: null,
+      latestDrillAttempt: null,
+      latestVerifiedRestore: null,
+      assetCutover: {
+        lastRunAt: null,
+        switchedAt: null,
+        migratedAssetCount: 0,
+        migratedByteCount: 0,
+        remainingLocalAssetCount: 0,
+        sampleObjectKeys: [],
+        lastError: null,
+      },
+      warnings: [],
+      state: "LocalOnly",
+      manifestFreshness: "missing",
+      degradedReasons: ["Recovery vault is not configured."],
+      statusFilePath: "/tmp/recovery/status.json",
     });
   });
 
@@ -179,6 +208,23 @@ describe("instance settings routes", () => {
       enableIssueGraphLivenessAutoRecovery: true,
       issueGraphLivenessAutoRecoveryLookbackHours: 12,
     });
+  });
+
+  it("returns recovery status to board users", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "local-board",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+    });
+
+    const res = await request(app).get("/api/instance/recovery-status").expect(200);
+    expect(res.body).toMatchObject({
+      state: "LocalOnly",
+      statusFilePath: "/tmp/recovery/status.json",
+      storageProvider: "local_disk",
+    });
+    expect(mockInstanceRecoveryStatusService.get).toHaveBeenCalledTimes(1);
   });
 
   it("previews issue graph liveness recovery candidates before enabling", async () => {

--- a/server/src/__tests__/storage-service.test.ts
+++ b/server/src/__tests__/storage-service.test.ts
@@ -1,0 +1,53 @@
+import { Readable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { createStorageService } from "../storage/service.js";
+
+function createFakeProvider(id: "local_disk" | "s3", body: string) {
+  return {
+    id,
+    putObject: vi.fn().mockResolvedValue(undefined),
+    getObject: vi.fn().mockResolvedValue({
+      stream: Readable.from(Buffer.from(body, "utf8")),
+      contentType: "text/plain",
+      contentLength: body.length,
+    }),
+    headObject: vi.fn().mockResolvedValue({
+      exists: true,
+      contentType: "text/plain",
+      contentLength: body.length,
+    }),
+    deleteObject: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+async function readStream(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+describe("createStorageService", () => {
+  it("routes reads through the row-level provider override instead of the active provider", async () => {
+    const activeS3 = createFakeProvider("s3", "from-s3");
+    const localDisk = createFakeProvider("local_disk", "from-local-disk");
+    const service = createStorageService({
+      activeProvider: activeS3,
+      providers: {
+        s3: activeS3,
+        local_disk: localDisk,
+      },
+    });
+
+    const object = await service.getObject(
+      "company-1",
+      "company-1/assets/2026/04/29/demo.txt",
+      "local_disk",
+    );
+
+    expect(await readStream(object.stream)).toBe("from-local-disk");
+    expect(localDisk.getObject).toHaveBeenCalledTimes(1);
+    expect(activeS3.getObject).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -54,6 +54,14 @@ export function resolveDefaultBackupDir(): string {
   return path.resolve(resolvePaperclipInstanceRoot(), "data", "backups");
 }
 
+export function resolveDefaultRecoveryDir(): string {
+  return path.resolve(resolvePaperclipInstanceRoot(), "data", "recovery");
+}
+
+export function resolveDefaultRecoveryStatusPath(): string {
+  return path.resolve(resolveDefaultRecoveryDir(), "status.json");
+}
+
 export function resolveDefaultAgentWorkspaceDir(agentId: string): string {
   const trimmed = agentId.trim();
   if (!PATH_SEGMENT_RE.test(trimmed)) {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -2789,7 +2789,11 @@ export function accessRoutes(
       if (logoAsset?.companyId) {
         try {
           const storage = getStorageService();
-          const logoObject = await storage.headObject(logoAsset.companyId, logoAsset.objectKey);
+          const logoObject = await storage.headObject(
+            logoAsset.companyId,
+            logoAsset.objectKey,
+            logoAsset.provider as "local_disk" | "s3",
+          );
           if (logoObject.exists) {
             logoUrl = `/api/invites/${inviteToken}/logo`;
           }
@@ -2816,6 +2820,7 @@ export function accessRoutes(
 
   async function getInviteLogoAsset(companyId: string | null): Promise<{
     companyId: string | null;
+    provider: string | null;
     objectKey: string;
     contentType: string | null;
     byteSize: number | null;
@@ -2825,6 +2830,7 @@ export function accessRoutes(
     const logoAsset = await db
       .select({
         companyId: companies.id,
+        provider: assets.provider,
         objectKey: assets.objectKey,
         contentType: assets.contentType,
         byteSize: assets.byteSize,
@@ -2839,6 +2845,7 @@ export function accessRoutes(
     if (!logoAsset?.objectKey) return null;
     return {
       companyId: logoAsset.companyId,
+      provider: logoAsset.provider,
       objectKey: logoAsset.objectKey,
       contentType: logoAsset.contentType,
       byteSize: logoAsset.byteSize,
@@ -3046,11 +3053,19 @@ export function accessRoutes(
     const companyId = logoAsset.companyId;
 
     const storage = getStorageService();
-    const logoHead = await storage.headObject(companyId, logoAsset.objectKey);
+    const logoHead = await storage.headObject(
+      companyId,
+      logoAsset.objectKey,
+      logoAsset.provider as "local_disk" | "s3",
+    );
     if (!logoHead.exists) {
       throw notFound("Invite logo not found");
     }
-    const object = await storage.getObject(companyId, logoAsset.objectKey);
+    const object = await storage.getObject(
+      companyId,
+      logoAsset.objectKey,
+      logoAsset.provider as "local_disk" | "s3",
+    );
     const responseContentType =
       logoAsset.contentType ||
       logoHead.contentType ||

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -318,7 +318,11 @@ export function assetRoutes(db: Db, storage: StorageService) {
     }
     assertCompanyAccess(req, asset.companyId);
 
-    const object = await storage.getObject(asset.companyId, asset.objectKey);
+    const object = await storage.getObject(
+      asset.companyId,
+      asset.objectKey,
+      asset.provider as "local_disk" | "s3",
+    );
     const responseContentType = asset.contentType || object.contentType || "application/octet-stream";
     res.setHeader("Content-Type", responseContentType);
     res.setHeader("Content-Length", String(asset.byteSize || object.contentLength || 0));

--- a/server/src/routes/instance-settings.ts
+++ b/server/src/routes/instance-settings.ts
@@ -7,7 +7,7 @@ import {
 } from "@paperclipai/shared";
 import { forbidden } from "../errors.js";
 import { validate } from "../middleware/validate.js";
-import { heartbeatService, instanceSettingsService, logActivity } from "../services/index.js";
+import { heartbeatService, instanceRecoveryStatusService, instanceSettingsService, logActivity } from "../services/index.js";
 import { assertBoardOrgAccess, getActorInfo } from "./authz.js";
 
 function assertCanManageInstanceSettings(req: Request) {
@@ -23,6 +23,7 @@ function assertCanManageInstanceSettings(req: Request) {
 export function instanceSettingsRoutes(db: Db) {
   const router = Router();
   const svc = instanceSettingsService(db);
+  const recoveryStatus = instanceRecoveryStatusService();
   const heartbeat = heartbeatService(db);
 
   router.get("/instance/settings/general", async (req, res) => {
@@ -67,6 +68,11 @@ export function instanceSettingsRoutes(db: Db) {
     // or instance admin. Only PATCH requires instance-admin.
     assertBoardOrgAccess(req);
     res.json(await svc.getExperimental());
+  });
+
+  router.get("/instance/recovery-status", async (req, res) => {
+    assertBoardOrgAccess(req);
+    res.json(recoveryStatus.get());
   });
 
   router.patch(

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2707,7 +2707,11 @@ export function issueRoutes(
 
     for (const attachment of attachments) {
       try {
-        await storage.deleteObject(attachment.companyId, attachment.objectKey);
+        await storage.deleteObject(
+          attachment.companyId,
+          attachment.objectKey,
+          attachment.provider as "local_disk" | "s3",
+        );
       } catch (err) {
         logger.warn({ err, issueId: id, attachmentId: attachment.id }, "failed to delete attachment object during issue delete");
       }
@@ -3818,7 +3822,11 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, attachment.companyId);
 
-    const object = await storage.getObject(attachment.companyId, attachment.objectKey);
+    const object = await storage.getObject(
+      attachment.companyId,
+      attachment.objectKey,
+      attachment.provider as "local_disk" | "s3",
+    );
     const responseContentType = normalizeContentType(attachment.contentType || object.contentType);
     res.setHeader("Content-Type", responseContentType);
     res.setHeader("Content-Length", String(attachment.byteSize || object.contentLength || 0));
@@ -3853,7 +3861,11 @@ export function issueRoutes(
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
 
     try {
-      await storage.deleteObject(attachment.companyId, attachment.objectKey);
+      await storage.deleteObject(
+        attachment.companyId,
+        attachment.objectKey,
+        attachment.provider as "local_disk" | "s3",
+      );
     } catch (err) {
       logger.warn({ err, attachmentId }, "storage delete failed while removing attachment");
     }

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -3180,7 +3180,11 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           warnings.push(`Skipped company logo ${company.logoAssetId} because the asset record was not found.`);
         } else {
           try {
-            const object = await storage.getObject(company.id, logoAsset.objectKey);
+            const object = await storage.getObject(
+              company.id,
+              logoAsset.objectKey,
+              logoAsset.provider as "local_disk" | "s3",
+            );
             const body = await streamToBuffer(object.stream);
             companyLogoPath = `images/${COMPANY_LOGO_FILE_NAME}${resolveCompanyLogoExtension(logoAsset.contentType, logoAsset.originalFilename)}`;
             files[companyLogoPath] = bufferToPortableBinaryFile(body, logoAsset.contentType);

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -44,6 +44,7 @@ export { inboxDismissalService } from "./inbox-dismissals.js";
 export { accessService } from "./access.js";
 export { boardAuthService } from "./board-auth.js";
 export { instanceSettingsService } from "./instance-settings.js";
+export { instanceRecoveryStatusService } from "./instance-recovery-status.js";
 export { companyPortabilityService } from "./company-portability.js";
 export { environmentService } from "./environments.js";
 export { executionWorkspaceService } from "./execution-workspaces.js";

--- a/server/src/services/instance-recovery-status.ts
+++ b/server/src/services/instance-recovery-status.ts
@@ -1,0 +1,128 @@
+import { existsSync, readFileSync } from "node:fs";
+import {
+  DEFAULT_RECOVERY_STATUS_FILE,
+  evaluateRecoveryStatus,
+  type RecoveryStatusFile,
+  type RecoveryStatusSnapshot,
+  type RecoveryVaultSummary,
+} from "@paperclipai/shared";
+import { loadConfig } from "../config.js";
+import { resolveDefaultRecoveryStatusPath } from "../home-paths.js";
+
+function normalizePrefix(prefix: string | null | undefined): string {
+  return (prefix ?? "").trim().replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function loadRecoveryVaultSummaryFromEnv(env: NodeJS.ProcessEnv = process.env): RecoveryVaultSummary | null {
+  const bucket = env.PAPERCLIP_RECOVERY_VAULT_BUCKET?.trim();
+  const region = env.PAPERCLIP_RECOVERY_VAULT_REGION?.trim();
+  if (!bucket && !region) return null;
+  if (!bucket || !region) return null;
+  return {
+    bucket,
+    region,
+    endpoint: env.PAPERCLIP_RECOVERY_VAULT_ENDPOINT?.trim() || null,
+    prefix: normalizePrefix(env.PAPERCLIP_RECOVERY_VAULT_PREFIX),
+  };
+}
+
+function mergeRecoveryStatus(raw: unknown): RecoveryStatusFile {
+  const base = structuredClone(DEFAULT_RECOVERY_STATUS_FILE);
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return base;
+  }
+
+  const record = raw as Record<string, unknown>;
+  return {
+    version: 1,
+    updatedAt: typeof record.updatedAt === "string" ? record.updatedAt : base.updatedAt,
+    backupIntervalMinutes:
+      typeof record.backupIntervalMinutes === "number" && Number.isFinite(record.backupIntervalMinutes)
+        ? Math.max(1, Math.trunc(record.backupIntervalMinutes))
+        : base.backupIntervalMinutes,
+    storageProvider:
+      record.storageProvider === "local_disk" || record.storageProvider === "s3"
+        ? record.storageProvider
+        : base.storageProvider,
+    vault:
+      record.vault && typeof record.vault === "object"
+        ? {
+            bucket: String((record.vault as Record<string, unknown>).bucket ?? ""),
+            region: String((record.vault as Record<string, unknown>).region ?? ""),
+            endpoint:
+              (record.vault as Record<string, unknown>).endpoint == null
+                ? null
+                : String((record.vault as Record<string, unknown>).endpoint),
+            prefix: String((record.vault as Record<string, unknown>).prefix ?? ""),
+          }
+        : null,
+    latestUploadedManifest:
+      record.latestUploadedManifest && typeof record.latestUploadedManifest === "object"
+        ? record.latestUploadedManifest as RecoveryStatusFile["latestUploadedManifest"]
+        : null,
+    latestDrillAttempt:
+      record.latestDrillAttempt && typeof record.latestDrillAttempt === "object"
+        ? record.latestDrillAttempt as RecoveryStatusFile["latestDrillAttempt"]
+        : null,
+    latestVerifiedRestore:
+      record.latestVerifiedRestore && typeof record.latestVerifiedRestore === "object"
+        ? record.latestVerifiedRestore as RecoveryStatusFile["latestVerifiedRestore"]
+        : null,
+    assetCutover: {
+      ...base.assetCutover,
+      ...(typeof record.assetCutover === "object" && record.assetCutover !== null
+        ? record.assetCutover as Record<string, unknown>
+        : {}),
+    },
+    warnings: Array.isArray(record.warnings) ? record.warnings.map(String) : [],
+  };
+}
+
+export function instanceRecoveryStatusService() {
+  return {
+    get(): RecoveryStatusSnapshot & { statusFilePath: string } {
+      const config = loadConfig();
+      const vault = loadRecoveryVaultSummaryFromEnv();
+      const statusFilePath =
+        process.env.PAPERCLIP_RECOVERY_STATUS_PATH?.trim() || resolveDefaultRecoveryStatusPath();
+
+      const base = (() => {
+        if (!existsSync(statusFilePath)) {
+          return {
+            ...structuredClone(DEFAULT_RECOVERY_STATUS_FILE),
+            backupIntervalMinutes: config.databaseBackupIntervalMinutes,
+            storageProvider: config.storageProvider,
+            vault,
+          };
+        }
+
+        try {
+          const raw = JSON.parse(readFileSync(statusFilePath, "utf8"));
+          return mergeRecoveryStatus(raw);
+        } catch (error) {
+          return {
+            ...structuredClone(DEFAULT_RECOVERY_STATUS_FILE),
+            backupIntervalMinutes: config.databaseBackupIntervalMinutes,
+            storageProvider: config.storageProvider,
+            vault,
+            warnings: [
+              `Recovery status file is unreadable: ${error instanceof Error ? error.message : String(error)}`,
+            ],
+          };
+        }
+      })();
+
+      return {
+        ...evaluateRecoveryStatus(
+          {
+            ...base,
+            backupIntervalMinutes: config.databaseBackupIntervalMinutes,
+            storageProvider: config.storageProvider,
+            vault,
+          },
+        ),
+        statusFilePath,
+      };
+    },
+  };
+}

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -1,5 +1,5 @@
 import { loadConfig, type Config } from "../config.js";
-import { createStorageProviderFromConfig } from "./provider-registry.js";
+import { createStorageProviderFromConfig, createStorageProvidersFromConfig } from "./provider-registry.js";
 import { createStorageService } from "./service.js";
 import type { StorageService } from "./types.js";
 
@@ -19,7 +19,10 @@ function signatureForConfig(config: Config): string {
 }
 
 export function createStorageServiceFromConfig(config: Config): StorageService {
-  return createStorageService(createStorageProviderFromConfig(config));
+  return createStorageService({
+    activeProvider: createStorageProviderFromConfig(config),
+    providers: createStorageProvidersFromConfig(config),
+  });
 }
 
 export function getStorageService(): StorageService {

--- a/server/src/storage/provider-registry.ts
+++ b/server/src/storage/provider-registry.ts
@@ -1,18 +1,22 @@
 import type { Config } from "../config.js";
+import type { StorageProvider as StorageProviderId } from "@paperclipai/shared";
 import type { StorageProvider } from "./types.js";
 import { createLocalDiskStorageProvider } from "./local-disk-provider.js";
 import { createS3StorageProvider } from "./s3-provider.js";
 
-export function createStorageProviderFromConfig(config: Config): StorageProvider {
-  if (config.storageProvider === "local_disk") {
-    return createLocalDiskStorageProvider(config.storageLocalDiskBaseDir);
-  }
+export function createStorageProvidersFromConfig(config: Config): Record<StorageProviderId, StorageProvider> {
+  return {
+    local_disk: createLocalDiskStorageProvider(config.storageLocalDiskBaseDir),
+    s3: createS3StorageProvider({
+      bucket: config.storageS3Bucket,
+      region: config.storageS3Region,
+      endpoint: config.storageS3Endpoint,
+      prefix: config.storageS3Prefix,
+      forcePathStyle: config.storageS3ForcePathStyle,
+    }),
+  };
+}
 
-  return createS3StorageProvider({
-    bucket: config.storageS3Bucket,
-    region: config.storageS3Region,
-    endpoint: config.storageS3Endpoint,
-    prefix: config.storageS3Prefix,
-    forcePathStyle: config.storageS3ForcePathStyle,
-  });
+export function createStorageProviderFromConfig(config: Config): StorageProvider {
+  return createStorageProvidersFromConfig(config)[config.storageProvider];
 }

--- a/server/src/storage/service.ts
+++ b/server/src/storage/service.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
+import type { StorageProvider as StorageProviderId } from "@paperclipai/shared";
 import type { StorageService, StorageProvider, PutFileInput, PutFileResult } from "./types.js";
 import { badRequest, forbidden, unprocessable } from "../errors.js";
 
@@ -87,16 +88,43 @@ function assertPutFileInput(input: PutFileInput): void {
   }
 }
 
-export function createStorageService(provider: StorageProvider): StorageService {
+type StorageServiceFactoryInput =
+  | StorageProvider
+  | {
+      activeProvider: StorageProvider;
+      providers: Partial<Record<StorageProviderId, StorageProvider>>;
+    };
+
+function isStorageProvider(input: StorageServiceFactoryInput): input is StorageProvider {
+  return typeof (input as StorageProvider).putObject === "function";
+}
+
+function resolveProvider(
+  providers: Partial<Record<StorageProviderId, StorageProvider>>,
+  providerId: StorageProviderId,
+): StorageProvider {
+  const provider = providers[providerId];
+  if (!provider) {
+    throw unprocessable(`Storage provider '${providerId}' is not configured.`);
+  }
+  return provider;
+}
+
+export function createStorageService(input: StorageServiceFactoryInput): StorageService {
+  const activeProvider = isStorageProvider(input) ? input : input.activeProvider;
+  const providers = isStorageProvider(input)
+    ? { [input.id]: input }
+    : input.providers;
+
   return {
-    provider: provider.id,
+    provider: activeProvider.id,
 
     async putFile(input: PutFileInput): Promise<PutFileResult> {
       assertPutFileInput(input);
       const objectKey = buildObjectKey(input.companyId, input.namespace, input.originalFilename);
       const byteSize = input.body.length;
       const contentType = input.contentType.trim().toLowerCase();
-      await provider.putObject({
+      await activeProvider.putObject({
         objectKey,
         body: input.body,
         contentType,
@@ -104,7 +132,7 @@ export function createStorageService(provider: StorageProvider): StorageService 
       });
 
       return {
-        provider: provider.id,
+        provider: activeProvider.id,
         objectKey,
         contentType,
         byteSize,
@@ -113,19 +141,19 @@ export function createStorageService(provider: StorageProvider): StorageService 
       };
     },
 
-    async getObject(companyId: string, objectKey: string) {
+    async getObject(companyId: string, objectKey: string, providerOverride?: StorageProviderId) {
       ensureCompanyPrefix(companyId, objectKey);
-      return provider.getObject({ objectKey });
+      return resolveProvider(providers, providerOverride ?? activeProvider.id).getObject({ objectKey });
     },
 
-    async headObject(companyId: string, objectKey: string) {
+    async headObject(companyId: string, objectKey: string, providerOverride?: StorageProviderId) {
       ensureCompanyPrefix(companyId, objectKey);
-      return provider.headObject({ objectKey });
+      return resolveProvider(providers, providerOverride ?? activeProvider.id).headObject({ objectKey });
     },
 
-    async deleteObject(companyId: string, objectKey: string) {
+    async deleteObject(companyId: string, objectKey: string, providerOverride?: StorageProviderId) {
       ensureCompanyPrefix(companyId, objectKey);
-      await provider.deleteObject({ objectKey });
+      await resolveProvider(providers, providerOverride ?? activeProvider.id).deleteObject({ objectKey });
     },
   };
 }

--- a/server/src/storage/types.ts
+++ b/server/src/storage/types.ts
@@ -56,7 +56,7 @@ export interface PutFileResult {
 export interface StorageService {
   provider: StorageProviderId;
   putFile(input: PutFileInput): Promise<PutFileResult>;
-  getObject(companyId: string, objectKey: string): Promise<GetObjectResult>;
-  headObject(companyId: string, objectKey: string): Promise<HeadObjectResult>;
-  deleteObject(companyId: string, objectKey: string): Promise<void>;
+  getObject(companyId: string, objectKey: string, providerOverride?: StorageProviderId): Promise<GetObjectResult>;
+  headObject(companyId: string, objectKey: string, providerOverride?: StorageProviderId): Promise<HeadObjectResult>;
+  deleteObject(companyId: string, objectKey: string, providerOverride?: StorageProviderId): Promise<void>;
 }

--- a/ui/src/api/instanceSettings.ts
+++ b/ui/src/api/instanceSettings.ts
@@ -1,6 +1,7 @@
 import type {
   InstanceExperimentalSettings,
   InstanceGeneralSettings,
+  RecoveryStatusSnapshot,
   IssueGraphLivenessAutoRecoveryPreview,
   PatchInstanceGeneralSettings,
   PatchInstanceExperimentalSettings,
@@ -14,6 +15,8 @@ export const instanceSettingsApi = {
     api.patch<InstanceGeneralSettings>("/instance/settings/general", patch),
   getExperimental: () =>
     api.get<InstanceExperimentalSettings>("/instance/settings/experimental"),
+  getRecoveryStatus: () =>
+    api.get<RecoveryStatusSnapshot & { statusFilePath: string }>("/instance/recovery-status"),
   updateExperimental: (patch: PatchInstanceExperimentalSettings) =>
     api.patch<InstanceExperimentalSettings>("/instance/settings/experimental", patch),
   previewIssueGraphLivenessAutoRecovery: (input: { lookbackHours?: number }) =>

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -120,6 +120,7 @@ export const queryKeys = {
     generalSettings: ["instance", "general-settings"] as const,
     schedulerHeartbeats: ["instance", "scheduler-heartbeats"] as const,
     experimentalSettings: ["instance", "experimental-settings"] as const,
+    recoveryStatus: ["instance", "recovery-status"] as const,
   },
   health: ["health"] as const,
   secrets: {

--- a/ui/src/pages/InstanceGeneralSettings.tsx
+++ b/ui/src/pages/InstanceGeneralSettings.tsx
@@ -51,6 +51,10 @@ export function InstanceGeneralSettings() {
     queryFn: () => healthApi.get(),
     retry: false,
   });
+  const recoveryStatusQuery = useQuery({
+    queryKey: queryKeys.instance.recoveryStatus,
+    queryFn: () => instanceSettingsApi.getRecoveryStatus(),
+  });
 
   const updateGeneralMutation = useMutation({
     mutationFn: instanceSettingsApi.updateGeneral,
@@ -270,6 +274,66 @@ export function InstanceGeneralSettings() {
               })}
             </div>
           </div>
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-border bg-card p-5">
+        <div className="space-y-5">
+          <div className="space-y-1.5">
+            <h2 className="text-sm font-semibold">Recovery status</h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Tracks the authoritative off-box recovery path: latest manifest freshness, asset
+              cutover completion, and the most recent verified restore drill.
+            </p>
+          </div>
+
+          {recoveryStatusQuery.isLoading ? (
+            <div className="text-sm text-muted-foreground">Loading recovery status...</div>
+          ) : recoveryStatusQuery.error ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              {recoveryStatusQuery.error instanceof Error
+                ? recoveryStatusQuery.error.message
+                : "Failed to load recovery status."}
+            </div>
+          ) : recoveryStatusQuery.data ? (
+            <>
+              <div className="grid gap-3 md:grid-cols-4">
+                <StatusBox label="State" value={recoveryStatusQuery.data.state} />
+                <StatusBox label="Manifest freshness" value={recoveryStatusQuery.data.manifestFreshness} />
+                <StatusBox label="Live asset storage" value={recoveryStatusQuery.data.storageProvider} />
+                <StatusBox
+                  label="Last verified restore"
+                  value={recoveryStatusQuery.data.latestVerifiedRestore?.finishedAt ?? "None"}
+                />
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-2">
+                <StatusBox
+                  label="Latest manifest"
+                  value={recoveryStatusQuery.data.latestUploadedManifest?.createdAt ?? "None"}
+                />
+                <StatusBox
+                  label="Status file"
+                  value={recoveryStatusQuery.data.statusFilePath}
+                />
+              </div>
+
+              {recoveryStatusQuery.data.degradedReasons.length > 0 ? (
+                <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-100">
+                  <div className="font-medium text-amber-50">Degraded reasons</div>
+                  <div className="mt-2 space-y-1">
+                    {recoveryStatusQuery.data.degradedReasons.map((reason) => (
+                      <div key={reason}>{reason}</div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100">
+                  Recovery is healthy: the latest manifest is fresh and a restore drill has passed.
+                </div>
+              )}
+            </>
+          ) : null}
         </div>
       </section>
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, so operational recovery has to be first-class rather than ad-hoc.
> - This change sits in the instance ops stack: CLI recovery workflows, shared recovery contract types, storage-service behavior, server instance settings APIs, and instance admin UI.
> - The gap was that recovery state was not represented as an authoritative contract, recovery writer/cutover/drill flows were incomplete for operators, and storage reads assumed a single active provider.
> - That made off-box recovery confidence and asset-provider cutover verification weaker than required for production operations.
> - This pull request implements MEA-79 by adding recovery publish/cutover/drill command plumbing, recovery status modeling/evaluation, provider-aware storage reads, and board-visible recovery status.
> - The benefit is a ship-ready recovery path with explicit status, stronger cutover safety, and safer mixed-provider asset access.

## What Changed

- Added CLI recovery command registration and implementations for `recovery:publish`, `recovery:cutover-assets`, and `recovery:drill`, including tests.
- Added shared recovery types/state evaluation (`RecoveryStatusFile`, `RecoveryStatusSnapshot`, `evaluateRecoveryStatus`, tier/drill enums) and exports.
- Added server recovery status service and new board endpoint `GET /api/instance/recovery-status`.
- Extended storage service/provider registry to support provider overrides per asset row, then updated asset/logo/attachment reads and deletes to use row-level provider values.
- Added server tests for provider-override storage routing and instance recovery-status route coverage.
- Added Instance General Settings UI recovery-status panel plus API/query-key wiring.

## Verification

- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run --project @paperclipai/shared packages/shared/src/types/recovery.test.ts`
- `pnpm exec vitest run --project paperclipai cli/src/__tests__/recovery-lib.test.ts cli/src/__tests__/recovery-command-registration.test.ts`
- `pnpm exec vitest run --project @paperclipai/server server/src/__tests__/storage-service.test.ts --pool=forks --poolOptions.forks.isolate=true`
- `pnpm exec vitest run --project @paperclipai/server server/src/__tests__/instance-settings-routes.test.ts --pool=forks --poolOptions.forks.isolate=true`
- `pnpm test` was attempted but terminated by the environment with exit code `137` after passing multiple non-server project suites; focused affected-suite runs above all passed.

## Risks

- Medium: recovery writer/cutover/drill paths are sensitive to real S3 and restore-target configuration; misconfiguration can produce degraded status/warnings.
- Medium: provider override relies on persisted asset provider values being valid (`local_disk`/`s3`), so malformed legacy rows could surface unprocessable errors.
- Low: UI addition is read-only and scoped to instance settings, but relies on the status file parser tolerating partial/invalid JSON.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex (GPT-5 class model in Codex CLI agent runtime) with tool-enabled code execution (`git`, `pnpm`, `vitest`, `gh`) and medium reasoning profile.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
