### PR TITLE
feat: complete documented plugin lifecycle event plumbing

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -848,9 +848,20 @@ Each event must include:
 - event id
 - event type
 - occurred at
-- actor metadata when applicable
-- primary entity metadata
+- company id
+- entity id/type when applicable
+- actor id/type when applicable
 - typed payload
+
+Run lifecycle events (`agent.run.started`, `agent.run.finished`,
+`agent.run.failed`, `agent.run.cancelled`) use `run` as the primary
+entity and include the run id, agent id, status transition, invocation
+metadata, timestamps, error fields when applicable, and compact usage /
+result summaries when available. Timed-out runs are delivered as
+`agent.run.failed` with `status: "timed_out"` and `errorCode: "timeout"`;
+`agent.run.finished` is success-only, so terminal-state consumers should
+subscribe to `agent.run.finished`, `agent.run.failed`, and
+`agent.run.cancelled`.
 
 ### 16.1 Event Filtering
 

--- a/packages/plugins/sdk/README.md
+++ b/packages/plugins/sdk/README.md
@@ -132,6 +132,10 @@ Subscribe in `setup` with `ctx.events.on(name, handler)` or `ctx.events.on(name,
 
 **Filter (optional):** Pass a second argument to `on()`: `{ projectId?, companyId?, agentId? }` so the host only delivers matching events.
 
+Run lifecycle event payloads include `runId`, `agentId`, `status`, `previousStatus`, invocation metadata, timestamps, error fields for failures/cancellations, and compact `usage`/`result` summaries when available. Timed-out runs are delivered as `agent.run.failed` with `status: "timed_out"` and `errorCode: "timeout"`. `agent.run.finished` is success-only; subscribe to `agent.run.finished`, `agent.run.failed`, and `agent.run.cancelled` to observe all terminal outcomes.
+
+Cancelled runs may receive final adapter usage/result artifacts after the cancellation event if cancellation wins a race with adapter completion. Consumers that need those final artifacts should re-fetch the run after observing `agent.run.cancelled`.
+
 **Company context:** Events still carry `companyId` for company-scoped data, but plugin installation and activation are instance-wide in the current runtime.
 
 ## Scheduled (recurring) jobs

--- a/server/src/__tests__/heartbeat-run-lifecycle-events.test.ts
+++ b/server/src/__tests__/heartbeat-run-lifecycle-events.test.ts
@@ -1,0 +1,622 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  companySkills,
+  costEvents,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import type { PluginEvent } from "@paperclipai/plugin-sdk";
+import { eq } from "drizzle-orm";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { registerServerAdapter, unregisterServerAdapter, type ServerAdapterModule } from "../adapters/index.ts";
+import { setPluginEventBus } from "../services/activity-log.ts";
+import { createPluginEventBus } from "../services/plugin-event-bus.ts";
+
+const lifecycleTestAdapter: ServerAdapterModule = {
+  type: "lifecycle_test",
+  execute: async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    summary: "adapter complete",
+    provider: "test",
+    model: "test-model",
+  }),
+  testEnvironment: async () => ({
+    adapterType: "lifecycle_test",
+    status: "pass",
+    checks: [],
+    testedAt: new Date(0).toISOString(),
+  }),
+  supportsLocalAgentJwt: false,
+};
+
+const lifecycleTimeoutTestAdapter: ServerAdapterModule = {
+  type: "lifecycle_timeout_test",
+  execute: async () => ({
+    exitCode: null,
+    signal: null,
+    timedOut: true,
+    errorMessage: "Timed out",
+    summary: "adapter timed out",
+    provider: "test",
+    model: "test-model",
+  }),
+  testEnvironment: async () => ({
+    adapterType: "lifecycle_timeout_test",
+    status: "pass",
+    checks: [],
+    testedAt: new Date(0).toISOString(),
+  }),
+  supportsLocalAgentJwt: false,
+};
+
+let releaseRaceAdapter: (() => void) | null = null;
+
+function parseRecord(value: unknown) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+const lifecycleRaceTestAdapter: ServerAdapterModule = {
+  type: "lifecycle_race_test",
+  execute: async () => {
+    await new Promise<void>((resolve) => {
+      releaseRaceAdapter = resolve;
+    });
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: "completed after cancel",
+      usage: {
+        inputTokens: 7,
+        outputTokens: 11,
+      },
+      provider: "test",
+      model: "test-model",
+    };
+  },
+  testEnvironment: async () => ({
+    adapterType: "lifecycle_race_test",
+    status: "pass",
+    checks: [],
+    testedAt: new Date(0).toISOString(),
+  }),
+  supportsLocalAgentJwt: false,
+};
+
+const lifecycleFailureRaceTestAdapter: ServerAdapterModule = {
+  type: "lifecycle_failure_race_test",
+  execute: async ({ onLog }) => {
+    await new Promise<void>((resolve) => {
+      releaseRaceAdapter = resolve;
+    });
+    await onLog("stdout", "adapter reached failure race\n");
+    throw new Error("failed after cancel");
+  },
+  testEnvironment: async () => ({
+    adapterType: "lifecycle_failure_race_test",
+    status: "pass",
+    checks: [],
+    testedAt: new Date(0).toISOString(),
+  }),
+  supportsLocalAgentJwt: false,
+};
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat lifecycle event tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat run lifecycle events", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  const observedEvents: PluginEvent[] = [];
+
+  beforeAll(async () => {
+    registerServerAdapter(lifecycleTestAdapter);
+    registerServerAdapter(lifecycleTimeoutTestAdapter);
+    registerServerAdapter(lifecycleRaceTestAdapter);
+    registerServerAdapter(lifecycleFailureRaceTestAdapter);
+    const eventBus = createPluginEventBus();
+    const scopedBus = eventBus.forPlugin("heartbeat-run-lifecycle-events-test");
+    for (const eventType of [
+      "agent.run.started",
+      "agent.run.finished",
+      "agent.run.failed",
+      "agent.run.cancelled",
+    ] as const) {
+      scopedBus.subscribe(eventType, async (event) => {
+        observedEvents.push(event);
+      });
+    }
+    setPluginEventBus(eventBus);
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-run-events-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    releaseRaceAdapter?.();
+    releaseRaceAdapter = null;
+    observedEvents.length = 0;
+    await db.delete(costEvents);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(companySkills);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    unregisterServerAdapter("lifecycle_test");
+    unregisterServerAdapter("lifecycle_timeout_test");
+    unregisterServerAdapter("lifecycle_race_test");
+    unregisterServerAdapter("lifecycle_failure_race_test");
+    await tempDb?.cleanup();
+  });
+
+  async function waitForRunToSettle(runId: string, timeoutMs = 10_000) {
+    const heartbeat = heartbeatService(db);
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const run = await heartbeat.getRun(runId);
+      if (!run || (run.status !== "queued" && run.status !== "running")) return run;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return heartbeat.getRun(runId);
+  }
+
+  function runLifecycleEvents(runId: string, eventType?: string) {
+    return observedEvents.filter((event) => {
+      const payload = event.payload as Record<string, unknown> | null;
+      return payload?.runId === runId && (!eventType || event.eventType === eventType);
+    });
+  }
+
+  async function waitForLifecycleEvent(eventType: string, runId: string, timeoutMs = 10_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const event = runLifecycleEvents(runId, eventType)[0];
+      if (event) return event;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error(`Timed out waiting for ${eventType} plugin event for run ${runId}`);
+  }
+
+  async function waitForRunLogLifecycleEvent(runId: string, timeoutMs = 10_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const rows = await db
+        .select({ id: heartbeatRunEvents.id })
+        .from(heartbeatRunEvents)
+        .where(eq(heartbeatRunEvents.runId, runId))
+        .limit(1);
+      if (rows.length > 0) return;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error(`Timed out waiting for run-log lifecycle event for run ${runId}`);
+  }
+
+  async function waitForAgentStatus(agentId: string, status: string, timeoutMs = 10_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const [agent] = await db
+        .select({ status: agents.status })
+        .from(agents)
+        .where(eq(agents.id, agentId));
+      if (agent?.status === status) return;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error(`Timed out waiting for agent ${agentId} status ${status}`);
+  }
+
+  async function waitForRunResult(
+    runId: string,
+    predicate: (run: Awaited<ReturnType<ReturnType<typeof heartbeatService>["getRun"]>>) => boolean = (run) => Boolean(run?.resultJson),
+    timeoutMs = 10_000,
+  ) {
+    const heartbeat = heartbeatService(db);
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const run = await heartbeat.getRun(runId);
+      if (predicate(run)) return run;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return heartbeat.getRun(runId);
+  }
+
+  async function waitForRaceAdapterReady(timeoutMs = 10_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (releaseRaceAdapter) return releaseRaceAdapter;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error("Timed out waiting for race adapter to start");
+  }
+
+  async function waitForRuntimeState(agentId: string, expectedRunId: string, timeoutMs = 10_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const [runtime] = await db
+        .select()
+        .from(agentRuntimeState)
+        .where(eq(agentRuntimeState.agentId, agentId));
+      if (runtime?.lastRunId === expectedRunId) return runtime;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    const [runtime] = await db
+      .select()
+      .from(agentRuntimeState)
+      .where(eq(agentRuntimeState.agentId, agentId));
+    return runtime ?? null;
+  }
+
+  it("publishes started and finished run lifecycle events for plugin subscribers", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "lifecycle_test",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "manual",
+      status: "queued",
+      contextSnapshot: {},
+    });
+
+    await heartbeatService(db).resumeQueuedRuns();
+
+    const started = await waitForLifecycleEvent("agent.run.started", runId);
+    expect(started).toMatchObject({
+      eventType: "agent.run.started",
+      companyId,
+      actorType: "system",
+      actorId: "heartbeat",
+      entityType: "run",
+      entityId: runId,
+    });
+    expect(started.payload).toMatchObject({
+      runId,
+      agentId,
+      status: "running",
+      previousStatus: "queued",
+      invocationSource: "assignment",
+      triggerDetail: "manual",
+    });
+
+    const settled = await waitForRunToSettle(runId);
+    expect(settled?.status).toBe("succeeded");
+    const finished = await waitForLifecycleEvent("agent.run.finished", runId);
+    await waitForRunLogLifecycleEvent(runId);
+    await waitForAgentStatus(agentId, "idle");
+    expect(finished.payload).toMatchObject({
+      runId,
+      agentId,
+      status: "succeeded",
+      previousStatus: "running",
+      result: {
+        summary: "adapter complete",
+      },
+    });
+  });
+
+  it("publishes timed out runs as failed events with timeout details", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TimeoutAgent",
+      role: "engineer",
+      status: "running",
+      adapterType: "lifecycle_timeout_test",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "manual",
+      status: "queued",
+      contextSnapshot: {},
+    });
+
+    await heartbeatService(db).resumeQueuedRuns();
+    const settled = await waitForRunToSettle(runId);
+
+    expect(settled?.status).toBe("timed_out");
+    const failed = await waitForLifecycleEvent("agent.run.failed", runId);
+    await waitForRunLogLifecycleEvent(runId);
+    await waitForAgentStatus(agentId, "error");
+    expect(failed.payload).toMatchObject({
+      runId,
+      agentId,
+      status: "timed_out",
+      previousStatus: "running",
+      error: "Timed out",
+      errorCode: "timeout",
+    });
+  });
+
+  it("publishes cancelled run lifecycle events for plugin subscribers", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const wakeupRequestId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "lifecycle_test",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId,
+      source: "test",
+      triggerDetail: "manual",
+      status: "claimed",
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "manual",
+      status: "running",
+      startedAt: new Date("2026-04-28T00:00:00.000Z"),
+      wakeupRequestId,
+      contextSnapshot: {},
+      usageJson: {
+        input_tokens: 10,
+        outputTokens: 20,
+        total_cost_usd: 0.12,
+        rawPayload: "x".repeat(10_000),
+      },
+      resultJson: {
+        summary: "run summary",
+        nestedHuge: { ignored: true },
+      },
+    });
+
+    const heartbeat = heartbeatService(db);
+    await Promise.all([
+      heartbeat.cancelRun(runId),
+      heartbeat.cancelRun(runId),
+    ]);
+
+    const cancelled = await waitForLifecycleEvent("agent.run.cancelled", runId);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(runLifecycleEvents(runId, "agent.run.cancelled")).toHaveLength(1);
+    expect(cancelled).toMatchObject({
+      eventType: "agent.run.cancelled",
+      companyId,
+      actorType: "system",
+      actorId: "heartbeat",
+      entityType: "run",
+      entityId: runId,
+    });
+    expect(cancelled.payload).toMatchObject({
+      runId,
+      agentId,
+      status: "cancelled",
+      previousStatus: "running",
+      invocationSource: "assignment",
+      triggerDetail: "manual",
+      errorCode: "cancelled",
+      usage: {
+        inputTokens: 10,
+        outputTokens: 20,
+        costUsd: 0.12,
+      },
+      result: {
+        summary: "run summary",
+      },
+    });
+    const payload = cancelled.payload as Record<string, Record<string, unknown>>;
+    expect(payload.usage).not.toHaveProperty("rawPayload");
+    expect(payload.result).not.toHaveProperty("nestedHuge");
+
+    const [wakeup] = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId));
+    expect(wakeup?.status).toBe("cancelled");
+  });
+
+  it("preserves adapter artifacts when cancellation wins the finalization race", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "RaceAgent",
+      role: "engineer",
+      status: "running",
+      adapterType: "lifecycle_race_test",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "manual",
+      status: "queued",
+      contextSnapshot: {},
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.resumeQueuedRuns();
+    await waitForLifecycleEvent("agent.run.started", runId);
+    const release = await waitForRaceAdapterReady();
+
+    await heartbeat.cancelRun(runId);
+    release();
+    releaseRaceAdapter = null;
+
+    const run = await waitForRunResult(runId, (candidate) =>
+      parseRecord(candidate?.resultJson)?.summary === "completed after cancel"
+    );
+    expect(run?.status).toBe("cancelled");
+    expect(run?.resultJson).toMatchObject({ summary: "completed after cancel" });
+    expect(runLifecycleEvents(runId, "agent.run.cancelled")).toHaveLength(1);
+    expect(runLifecycleEvents(runId, "agent.run.finished")).toHaveLength(0);
+    expect(runLifecycleEvents(runId, "agent.run.failed")).toHaveLength(0);
+
+    const [runtime] = await db
+      .select()
+      .from(agentRuntimeState)
+      .where(eq(agentRuntimeState.agentId, agentId));
+    expect(runtime).toMatchObject({
+      lastRunId: runId,
+      lastRunStatus: "cancelled",
+      totalInputTokens: 7,
+      totalOutputTokens: 11,
+    });
+  }, 15_000);
+
+  it("updates runtime bookkeeping when cancellation wins an adapter failure race", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "FailureRaceAgent",
+      role: "engineer",
+      status: "running",
+      adapterType: "lifecycle_failure_race_test",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "manual",
+      status: "queued",
+      contextSnapshot: {},
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.resumeQueuedRuns();
+    await waitForLifecycleEvent("agent.run.started", runId);
+    const release = await waitForRaceAdapterReady();
+
+    await heartbeat.cancelRun(runId);
+    release();
+    releaseRaceAdapter = null;
+
+    const runtime = await waitForRuntimeState(agentId, runId);
+    expect(runtime).toMatchObject({
+      lastRunId: runId,
+      lastRunStatus: "cancelled",
+      lastError: "failed after cancel",
+    });
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("cancelled");
+    expect(run?.stdoutExcerpt).toContain("adapter reached failure race");
+    expect(runLifecycleEvents(runId, "agent.run.cancelled")).toHaveLength(1);
+    expect(runLifecycleEvents(runId, "agent.run.finished")).toHaveLength(0);
+    expect(runLifecycleEvents(runId, "agent.run.failed")).toHaveLength(0);
+
+    const [agent] = await db
+      .select()
+      .from(agents)
+      .where(eq(agents.id, agentId));
+    expect(agent?.status).toBe("idle");
+  }, 15_000);
+});

--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   summarizeHeartbeatRunResultJson,
+  summarizeHeartbeatRunUsageJson,
   buildHeartbeatRunIssueComment,
   mergeHeartbeatRunResultJson,
 } from "../services/heartbeat-run-summary.js";
@@ -41,6 +42,81 @@ describe("summarizeHeartbeatRunResultJson", () => {
     expect(summarizeHeartbeatRunResultJson(null)).toBeNull();
     expect(summarizeHeartbeatRunResultJson(["nope"] as unknown as Record<string, unknown>)).toBeNull();
     expect(summarizeHeartbeatRunResultJson({ nested: { only: "ignored" } })).toBeNull();
+  });
+});
+
+describe("summarizeHeartbeatRunUsageJson", () => {
+  it("keeps compact usage fields and drops unrelated payloads", () => {
+    const summary = summarizeHeartbeatRunUsageJson({
+      input_tokens: 10,
+      outputTokens: 20,
+      cache_read_input_tokens: 30,
+      billing_type: "metered",
+      total_cost_usd: 0.12,
+      provider: "anthropic",
+      model: "claude",
+      biller: "metered",
+      rawPayload: "x".repeat(10_000),
+    });
+
+    expect(summary).toEqual({
+      inputTokens: 10,
+      outputTokens: 20,
+      totalTokens: 30,
+      cachedInputTokens: 30,
+      billingType: "metered",
+      costUsd: 0.12,
+      provider: "anthropic",
+      model: "claude",
+      biller: "metered",
+    });
+  });
+
+  it("returns null for non-object and irrelevant payloads", () => {
+    expect(summarizeHeartbeatRunUsageJson(null)).toBeNull();
+    expect(summarizeHeartbeatRunUsageJson(["nope"] as unknown as Record<string, unknown>)).toBeNull();
+    expect(summarizeHeartbeatRunUsageJson({ raw: { only: "ignored" } })).toBeNull();
+  });
+
+  it("drops non-numeric token and cost fields", () => {
+    expect(summarizeHeartbeatRunUsageJson({
+      inputTokens: true,
+      input_tokens: 10,
+      outputTokens: "20",
+      output_tokens: 30,
+      costUsd: false,
+      total_cost_usd: 0.42,
+      provider: "anthropic",
+    })).toEqual({
+      inputTokens: 10,
+      outputTokens: 30,
+      totalTokens: 40,
+      costUsd: 0.42,
+      provider: "anthropic",
+    });
+  });
+
+  it("computes total tokens from input and output tokens only", () => {
+    expect(summarizeHeartbeatRunUsageJson({
+      inputTokens: 2,
+      outputTokens: 5,
+      cachedInputTokens: 99,
+    })).toEqual({
+      inputTokens: 2,
+      outputTokens: 5,
+      totalTokens: 7,
+      cachedInputTokens: 99,
+    });
+  });
+
+  it("drops blank usage string fields", () => {
+    expect(summarizeHeartbeatRunUsageJson({
+      provider: "  ",
+      model: "\n",
+      biller: "test-biller",
+    })).toEqual({
+      biller: "test-biller",
+    });
   });
 });
 

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -92,6 +92,66 @@ export function summarizeHeartbeatRunResultJson(
   return Object.keys(summary).length > 0 ? summary : null;
 }
 
+function normalizeUsageNumberField(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return undefined;
+}
+
+function normalizeUsageStringField(value: unknown) {
+  if (typeof value !== "string") return undefined;
+  const truncated = truncateSummaryText(value);
+  if (truncated === null) return undefined;
+  const trimmed = truncated.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readFirstUsageField(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  normalize: (value: unknown) => number | string | undefined,
+) {
+  for (const key of keys) {
+    if (key in record && record[key] !== null && record[key] !== undefined) {
+      const value = normalize(record[key]);
+      if (value !== undefined) return value;
+    }
+  }
+  return undefined;
+}
+
+export function summarizeHeartbeatRunUsageJson(
+  usageJson: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null {
+  if (!usageJson || typeof usageJson !== "object" || Array.isArray(usageJson)) {
+    return null;
+  }
+
+  const summary: Record<string, unknown> = {};
+  const fields = [
+    ["inputTokens", ["inputTokens", "input_tokens"], normalizeUsageNumberField],
+    ["outputTokens", ["outputTokens", "output_tokens"], normalizeUsageNumberField],
+    ["cachedInputTokens", ["cachedInputTokens", "cached_input_tokens", "cache_read_input_tokens"], normalizeUsageNumberField],
+    ["billingType", ["billingType", "billing_type"], normalizeUsageStringField],
+    ["costUsd", ["costUsd", "cost_usd", "total_cost_usd"], normalizeUsageNumberField],
+    ["provider", ["provider"], normalizeUsageStringField],
+    ["model", ["model"], normalizeUsageStringField],
+    ["biller", ["biller"], normalizeUsageStringField],
+  ] as const;
+
+  for (const [outputKey, aliases, normalize] of fields) {
+    const value = readFirstUsageField(usageJson, aliases, normalize);
+    if (value !== undefined) {
+      summary[outputKey] = value;
+    }
+  }
+
+  if (typeof summary.inputTokens === "number" && typeof summary.outputTokens === "number") {
+    summary.totalTokens = summary.inputTokens + summary.outputTokens;
+  }
+
+  return Object.keys(summary).length > 0 ? summary : null;
+}
+
 export function buildHeartbeatRunIssueComment(
   resultJson: Record<string, unknown> | null | undefined,
 ): string | null {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -63,6 +63,8 @@ import {
   HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS,
   HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES,
   mergeHeartbeatRunResultJson,
+  summarizeHeartbeatRunResultJson,
+  summarizeHeartbeatRunUsageJson,
 } from "./heartbeat-run-summary.js";
 import {
   buildHeartbeatRunStopMetadata,
@@ -2868,16 +2870,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function setRunStatus(
     runId: string,
     status: string,
-    patch?: Partial<typeof heartbeatRuns.$inferInsert>,
+    previousStatus: string,
+    patch: Partial<typeof heartbeatRuns.$inferInsert> = {},
   ) {
+    // Require the caller's observed status so stale concurrent finalizers cannot
+    // update wakeups, release issue locks, or emit lifecycle events after losing.
     const updated = await db
       .update(heartbeatRuns)
-      .set({ status, ...patch, updatedAt: new Date() })
-      .where(eq(heartbeatRuns.id, runId))
+      .set({ ...patch, status, updatedAt: new Date() })
+      .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.status, previousStatus)))
       .returning()
       .then((rows) => rows[0] ?? null);
 
-    if (updated) {
+    // Same-status writes are metadata refreshes; lifecycle/live status events
+    // only represent actual run status transitions.
+    if (updated && previousStatus !== updated.status) {
       publishLiveEvent({
         companyId: updated.companyId,
         type: "heartbeat.run.status",
@@ -2893,13 +2900,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           finishedAt: updated.finishedAt ? new Date(updated.finishedAt).toISOString() : null,
         },
       });
-      publishRunLifecyclePluginEvent(updated);
+      void publishRunLifecyclePluginEvent(updated, previousStatus);
     }
 
     return updated;
   }
 
-  function publishRunLifecyclePluginEvent(run: typeof heartbeatRuns.$inferSelect) {
+  async function preserveCancelledRunArtifacts(
+    runId: string,
+    patch: Partial<typeof heartbeatRuns.$inferInsert>,
+  ) {
+    // A cancelled run can still record adapter artifacts that arrive after
+    // cancellation wins the status race, so runtime accounting stays complete.
+    return db
+      .update(heartbeatRuns)
+      .set({ ...patch, updatedAt: new Date() })
+      .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.status, "cancelled")))
+      .returning()
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function publishRunLifecyclePluginEvent(
+    run: typeof heartbeatRuns.$inferSelect,
+    previousStatus: string | null,
+  ) {
+    if (previousStatus === run.status) return;
+
     const eventType =
       run.status === "running"
         ? "agent.run.started"
@@ -2911,30 +2937,63 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               ? "agent.run.cancelled"
               : null;
     if (!eventType) return;
-    publishPluginDomainEvent({
-      eventId: randomUUID(),
-      eventType,
-      occurredAt: new Date().toISOString(),
-      actorId: run.agentId,
-      actorType: "agent",
-      entityId: run.id,
-      entityType: "heartbeat_run",
-      companyId: run.companyId,
-      payload: {
-        runId: run.id,
-        agentId: run.agentId,
-        status: run.status,
-        invocationSource: run.invocationSource,
-        triggerDetail: run.triggerDetail,
-        error: run.error ?? null,
-        errorCode: run.errorCode ?? null,
-        issueId: typeof run.contextSnapshot === "object" && run.contextSnapshot !== null
-          ? (run.contextSnapshot as Record<string, unknown>).issueId ?? null
-          : null,
-        startedAt: run.startedAt ? new Date(run.startedAt).toISOString() : null,
-        finishedAt: run.finishedAt ? new Date(run.finishedAt).toISOString() : null,
-      },
-    });
+
+    try {
+      const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
+      const usage = redactCurrentUserValue(
+        summarizeHeartbeatRunUsageJson(run.usageJson),
+        currentUserRedactionOptions,
+      );
+      const result = redactCurrentUserValue(
+        summarizeHeartbeatRunResultJson(run.resultJson),
+        currentUserRedactionOptions,
+      );
+      const error = run.error
+        ? redactCurrentUserText(run.error, currentUserRedactionOptions)
+        : null;
+      const issueId = typeof run.contextSnapshot === "object" && run.contextSnapshot !== null
+        ? (run.contextSnapshot as Record<string, unknown>).issueId ?? null
+        : null;
+
+      publishPluginDomainEvent({
+        eventId: randomUUID(),
+        eventType,
+        occurredAt: new Date().toISOString(),
+        actorId: "heartbeat",
+        actorType: "system",
+        entityId: run.id,
+        entityType: "run",
+        companyId: run.companyId,
+        payload: {
+          runId: run.id,
+          agentId: run.agentId,
+          status: run.status,
+          previousStatus,
+          invocationSource: run.invocationSource,
+          triggerDetail: run.triggerDetail
+            ? redactCurrentUserText(run.triggerDetail, currentUserRedactionOptions)
+            : null,
+          wakeupRequestId: run.wakeupRequestId ?? null,
+          error,
+          errorCode: run.errorCode ?? null,
+          issueId: typeof issueId === "string"
+            ? redactCurrentUserText(issueId, currentUserRedactionOptions)
+            : issueId,
+          startedAt: run.startedAt ? new Date(run.startedAt).toISOString() : null,
+          finishedAt: run.finishedAt ? new Date(run.finishedAt).toISOString() : null,
+          exitCode: run.exitCode ?? null,
+          signal: run.signal ?? null,
+          ...(usage ? { usage } : {}),
+          ...(result ? { result } : {}),
+          logStore: run.logStore ?? null,
+          logRef: run.logRef ?? null,
+          logBytes: run.logBytes ?? null,
+          logSha256: run.logSha256 ?? null,
+        },
+      });
+    } catch (err) {
+      logger.warn({ err, runId: run.id, eventType }, "failed to publish agent run lifecycle plugin event");
+    }
   }
 
   async function setWakeupStatus(
@@ -3022,7 +3081,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         agentId: run.agentId,
       });
       if (productivityHold.held) {
-        await setRunStatus(run.id, run.status, {
+        await setRunStatus(run.id, run.status, run.status, {
           livenessReason:
             `${run.livenessReason ?? "Run ended without concrete progress"}; continuation held by productivity review ${productivityHold.reviewIdentifier ?? productivityHold.reviewIssueId}`,
         });
@@ -3067,7 +3126,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
 
     if (decision.kind === "exhausted") {
-      await setRunStatus(run.id, run.status, {
+      await setRunStatus(run.id, run.status, run.status, {
         livenessReason: `${run.livenessReason ?? "Run ended without concrete progress"}; continuation attempts exhausted`,
       });
       await addContinuationExhaustedCommentOnce({
@@ -4067,7 +4126,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         finishedAt: claimed.finishedAt ? new Date(claimed.finishedAt).toISOString() : null,
       },
     });
-    publishRunLifecyclePluginEvent(claimed);
+    await publishRunLifecyclePluginEvent(claimed, "queued");
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
 
@@ -4107,7 +4166,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const now = new Date();
     const reason =
       "Cancelled because issue dependencies are still blocked; Paperclip will wake the assignee when blockers resolve";
-    const cancelled = await setRunStatus(run.id, "cancelled", {
+    const cancelled = await setRunStatus(run.id, "cancelled", run.status, {
       finishedAt: now,
       error: reason,
       errorCode: "issue_dependencies_blocked",
@@ -4255,7 +4314,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     staleness: Extract<QueuedRunStaleness, { stale: true }>,
   ) {
     const now = new Date();
-    const cancelled = await setRunStatus(run.id, "cancelled", {
+    const cancelled = await setRunStatus(run.id, "cancelled", run.status, {
       finishedAt: now,
       error: staleness.reason,
       errorCode: staleness.errorCode,
@@ -4603,7 +4662,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (processPidAlive) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
-          const detachedRun = await setRunStatus(run.id, "running", {
+          const detachedRun = await setRunStatus(run.id, "running", run.status, {
             error: detachedMessage,
             errorCode: DETACHED_PROCESS_ERROR_CODE,
           });
@@ -4634,7 +4693,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
       const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
 
-      let finalizedRun = await setRunStatus(run.id, "failed", {
+      let finalizedRun = await setRunStatus(run.id, "failed", run.status, {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
         errorCode: "process_lost",
         finishedAt: now,
@@ -4648,12 +4707,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           },
         ),
       });
+      if (!finalizedRun) continue;
       await setWakeupStatus(run.wakeupRequestId, "failed", {
         finishedAt: now,
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
       });
-      if (!finalizedRun) finalizedRun = await getRun(run.id);
-      if (!finalizedRun) continue;
       finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
       await releaseEnvironmentLeasesForRun({
         runId: finalizedRun.id,
@@ -4906,17 +4964,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     try {
     const agent = await getAgent(run.agentId);
     if (!agent) {
-      await setRunStatus(runId, "failed", {
+      const failedRun = await setRunStatus(runId, "failed", run.status, {
         error: "Agent not found",
         errorCode: "agent_not_found",
         finishedAt: new Date(),
       });
-      await setWakeupStatus(run.wakeupRequestId, "failed", {
-        finishedAt: new Date(),
-        error: "Agent not found",
-      });
-      const failedRun = await getRun(runId);
-      if (failedRun) await releaseIssueExecutionAndPromote(failedRun);
+      if (failedRun) {
+        await setWakeupStatus(failedRun.wakeupRequestId, "failed", {
+          finishedAt: new Date(),
+          error: "Agent not found",
+        });
+        await releaseIssueExecutionAndPromote(failedRun);
+      }
       return;
     }
 
@@ -5938,7 +5997,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         adapterResult.summary ?? null,
       );
 
-      let persistedRun = await setRunStatus(run.id, status, {
+      const completionArtifacts = {
         finishedAt: new Date(),
         error: runErrorMessage,
         errorCode: runErrorCode,
@@ -5952,7 +6011,42 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         logBytes: logSummary?.bytes,
         logSha256: logSummary?.sha256,
         logCompressed: logSummary?.compressed ?? false,
-      });
+      };
+
+      const updateRuntimeBookkeeping = async (runForRuntime: typeof heartbeatRuns.$inferSelect) => {
+        await updateRuntimeState(agent, runForRuntime, adapterResult, {
+          legacySessionId: nextSessionState.legacySessionId,
+        }, normalizedUsage);
+        if (!taskKey) return;
+        if (adapterResult.clearSession || (!nextSessionState.params && !nextSessionState.displayId)) {
+          await clearTaskSessions(agent.companyId, agent.id, {
+            taskKey,
+            adapterType: agent.adapterType,
+          });
+          return;
+        }
+        await upsertTaskSession({
+          companyId: agent.companyId,
+          agentId: agent.id,
+          adapterType: agent.adapterType,
+          taskKey,
+          sessionParamsJson: nextSessionState.params,
+          sessionDisplayId: nextSessionState.displayId,
+          lastRunId: runForRuntime.id,
+          lastError: outcome === "succeeded" ? null : (adapterResult.errorMessage ?? "run_failed"),
+        });
+      };
+
+      let persistedRun = await setRunStatus(run.id, status, run.status, completionArtifacts);
+      if (!persistedRun) {
+        const artifactRun = await preserveCancelledRunArtifacts(run.id, completionArtifacts);
+        if (artifactRun) {
+          await updateRuntimeBookkeeping(artifactRun);
+          await finalizeAgentStatus(agent.id, artifactRun.status === "cancelled" ? "cancelled" : outcome);
+        }
+        return;
+      }
+
       if (persistedRun) {
         persistedRun = await classifyAndPersistRunLiveness(persistedRun, persistedResultJson) ?? persistedRun;
       }
@@ -6000,30 +6094,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         await handleRunLivenessContinuation(livenessRun);
       }
 
-      if (finalizedRun) {
-        await updateRuntimeState(agent, finalizedRun, adapterResult, {
-          legacySessionId: nextSessionState.legacySessionId,
-        }, normalizedUsage);
-        if (taskKey) {
-          if (adapterResult.clearSession || (!nextSessionState.params && !nextSessionState.displayId)) {
-            await clearTaskSessions(agent.companyId, agent.id, {
-              taskKey,
-              adapterType: agent.adapterType,
-            });
-          } else {
-            await upsertTaskSession({
-              companyId: agent.companyId,
-              agentId: agent.id,
-              adapterType: agent.adapterType,
-              taskKey,
-              sessionParamsJson: nextSessionState.params,
-              sessionDisplayId: nextSessionState.displayId,
-              lastRunId: finalizedRun.id,
-              lastError: outcome === "succeeded" ? null : (adapterResult.errorMessage ?? "run_failed"),
-            });
-          }
-        }
-      }
+      if (finalizedRun) await updateRuntimeBookkeeping(finalizedRun);
       await finalizeAgentStatus(agent.id, outcome);
     } catch (err) {
       const message = redactCurrentUserText(
@@ -6048,7 +6119,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         logger.warn({ err: flushErr, runId }, "failed to flush run output progress after error");
       });
 
-      const failedRun = await setRunStatus(run.id, "failed", {
+      const failureArtifacts = {
+        stdoutExcerpt,
+        stderrExcerpt,
+        logBytes: logSummary?.bytes,
+        logSha256: logSummary?.sha256,
+        logCompressed: logSummary?.compressed ?? false,
+      };
+      const failureResult = {
+        exitCode: null,
+        signal: null,
+        timedOut: false,
+        errorMessage: message,
+      };
+
+      const failedRun = await setRunStatus(run.id, "failed", run.status, {
         error: message,
         errorCode: "adapter_failed",
         finishedAt: new Date(),
@@ -6056,18 +6141,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           errorCode: "adapter_failed",
           errorMessage: message,
         }),
-        stdoutExcerpt,
-        stderrExcerpt,
-        logBytes: logSummary?.bytes,
-        logSha256: logSummary?.sha256,
-        logCompressed: logSummary?.compressed ?? false,
+        ...failureArtifacts,
       });
-      await setWakeupStatus(run.wakeupRequestId, "failed", {
-        finishedAt: new Date(),
-        error: message,
-      });
+      const preservedRun = failedRun ?? await preserveCancelledRunArtifacts(run.id, failureArtifacts);
+      const latestTerminalRun = preservedRun
+        ? null
+        : await getRun(run.id).catch(() => null);
+      const runtimeRun = preservedRun
+        ?? (latestTerminalRun && (latestTerminalRun.status === "failed" || latestTerminalRun.status === "timed_out" || latestTerminalRun.status === "cancelled")
+          ? latestTerminalRun
+          : null);
 
       if (failedRun) {
+        await setWakeupStatus(run.wakeupRequestId, "failed", {
+          finishedAt: new Date(),
+          error: message,
+        });
         await appendRunEvent(failedRun, seq++, {
           eventType: "error",
           stream: "system",
@@ -6078,13 +6167,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         await refreshContinuationSummaryForRun(livenessRun, agent);
         await finalizeIssueCommentPolicy(livenessRun, agent);
         await releaseIssueExecutionAndPromote(livenessRun);
+      } else if (latestTerminalRun && (
+        latestTerminalRun.status === "failed" ||
+        latestTerminalRun.status === "timed_out" ||
+        latestTerminalRun.status === "cancelled"
+      )) {
+        await setWakeupStatus(latestTerminalRun.wakeupRequestId, latestTerminalRun.status === "cancelled" ? "cancelled" : "failed", {
+          finishedAt: latestTerminalRun.finishedAt ?? new Date(),
+          error: latestTerminalRun.error ?? message,
+        }).catch(() => undefined);
+      }
 
-        await updateRuntimeState(agent, livenessRun, {
-          exitCode: null,
-          signal: null,
-          timedOut: false,
-          errorMessage: message,
-        }, {
+      if (runtimeRun) {
+        // If this catch lost the final status race, the winning terminal row
+        // owns wakeup/comment cleanup; this path only records runtime/session
+        // bookkeeping against the terminal run that actually persisted.
+        await updateRuntimeState(agent, runtimeRun, failureResult, {
           legacySessionId: runtimeForAdapter.sessionId,
         });
 
@@ -6096,13 +6194,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             taskKey,
             sessionParamsJson: previousSessionParams,
             sessionDisplayId: previousSessionDisplayId,
-            lastRunId: failedRun.id,
+            lastRunId: runtimeRun.id,
             lastError: message,
           });
         }
       }
 
-      await finalizeAgentStatus(agent.id, "failed");
+      await finalizeAgentStatus(agent.id, runtimeRun?.status === "cancelled" ? "cancelled" : "failed");
     }
     } catch (outerErr) {
           // Setup code before adapter.execute threw (e.g. ensureRuntimeState, resolveWorkspaceForRun).
@@ -6110,7 +6208,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           const message = outerErr instanceof Error ? outerErr.message : "Unknown setup failure";
           logger.error({ err: outerErr, runId }, "heartbeat execution setup failed");
           const setupFailureAgent = await getAgent(run.agentId).catch(() => null);
-          await setRunStatus(runId, "failed", {
+          const currentRun = await getRun(runId).catch(() => null);
+          const failedRun = currentRun && (currentRun.status === "queued" || currentRun.status === "running")
+            ? await setRunStatus(runId, "failed", currentRun.status, {
             error: message,
             errorCode: "adapter_failed",
             finishedAt: new Date(),
@@ -6120,13 +6220,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 errorMessage: message,
               }),
             } : {}),
-          }).catch(() => undefined);
-          await setWakeupStatus(run.wakeupRequestId, "failed", {
-            finishedAt: new Date(),
-            error: message,
-          }).catch(() => undefined);
-          const failedRun = await getRun(runId).catch(() => null);
+          }).catch(() => null)
+            : null;
           if (failedRun) {
+            await setWakeupStatus(failedRun.wakeupRequestId, "failed", {
+              finishedAt: new Date(),
+              error: message,
+            }).catch(() => undefined);
             // Emit a run-log event so the failure is visible in the run timeline,
             // consistent with what the inner catch block does for adapter failures.
             await appendRunEvent(failedRun, 1, {
@@ -6145,7 +6245,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
           // Ensure the agent is not left stuck in "running" if the inner catch handler's
           // DB calls threw (e.g. a transient DB error in finalizeAgentStatus).
-          await finalizeAgentStatus(run.agentId, "failed").catch(() => undefined);
+          const finalOutcome =
+            failedRun
+              ? "failed"
+              : currentRun?.status === "succeeded" || currentRun?.status === "failed" ||
+                  currentRun?.status === "timed_out" || currentRun?.status === "cancelled"
+                ? currentRun.status
+                : "failed";
+          const agentStatusRun = failedRun ?? currentRun ?? run;
+          if (agentStatusRun) {
+            await finalizeAgentStatus(agentStatusRun.agentId, finalOutcome).catch(() => undefined);
+          }
         } finally {
           const latestRun = await getRun(run.id).catch(() => null);
           await releaseEnvironmentLeasesForRun({
@@ -7401,7 +7511,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
     }
 
-    const cancelled = await setRunStatus(run.id, "cancelled", {
+    const cancelled = await setRunStatus(run.id, "cancelled", run.status, {
       finishedAt: new Date(),
       error: reason,
       errorCode: "cancelled",
@@ -7414,25 +7524,28 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       } : {}),
     });
 
-    await setWakeupStatus(run.wakeupRequestId, "cancelled", {
-      finishedAt: new Date(),
-      error: reason,
-    });
+    const finalRun = cancelled ?? await getRun(run.id);
 
     if (cancelled) {
+      await setWakeupStatus(cancelled.wakeupRequestId, "cancelled", {
+        finishedAt: new Date(),
+        error: reason,
+      });
       await appendRunEvent(cancelled, 1, {
         eventType: "lifecycle",
         stream: "system",
         level: "warn",
         message: "run cancelled",
       });
-      await releaseIssueExecutionAndPromote(cancelled);
     }
 
     runningProcesses.delete(run.id);
-    await finalizeAgentStatus(run.agentId, "cancelled");
+    if (finalRun?.status === "cancelled") {
+      await releaseIssueExecutionAndPromote(finalRun);
+    }
+    if (cancelled) await finalizeAgentStatus(run.agentId, "cancelled");
     await startNextQueuedRunForAgent(run.agentId);
-    return cancelled;
+    return finalRun ?? run;
   }
 
   async function cancelActiveForAgentInternal(agentId: string, reason = "Cancelled due to agent pause") {
@@ -7442,42 +7555,72 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .from(heartbeatRuns)
       .where(and(eq(heartbeatRuns.agentId, agentId), inArray(heartbeatRuns.status, [...CANCELLABLE_HEARTBEAT_RUN_STATUSES])));
 
+    let cancelledAny = false;
     for (const run of runs) {
-      await setRunStatus(run.id, "cancelled", {
-        finishedAt: new Date(),
-        error: reason,
-        errorCode: "cancelled",
-        ...(agent ? {
-          resultJson: mergeRunStopMetadataForAgent(agent, "cancelled", {
-            resultJson: parseObject(run.resultJson),
-            errorCode: "cancelled",
-            errorMessage: reason,
-          }),
-        } : {}),
-      });
-
-      await setWakeupStatus(run.wakeupRequestId, "cancelled", {
-        finishedAt: new Date(),
-        error: reason,
-      });
-
-      const running = runningProcesses.get(run.id);
-      if (running) {
-        await terminateHeartbeatRunProcess({
-          pid: running.child.pid ?? run.processPid,
-          processGroupId: running.processGroupId ?? run.processGroupId,
-          graceMs: Math.max(1, running.graceSec) * 1000,
+      let latestRun = run;
+      let cancelled: typeof heartbeatRuns.$inferSelect | null = null;
+      for (let attempt = 0; attempt < 2; attempt++) {
+        if (!CANCELLABLE_HEARTBEAT_RUN_STATUSES.includes(latestRun.status as (typeof CANCELLABLE_HEARTBEAT_RUN_STATUSES)[number])) break;
+        cancelled = await setRunStatus(latestRun.id, "cancelled", latestRun.status, {
+          finishedAt: new Date(),
+          error: reason,
+          errorCode: "cancelled",
+          ...(agent ? {
+            resultJson: mergeRunStopMetadataForAgent(agent, "cancelled", {
+              resultJson: parseObject(latestRun.resultJson),
+              errorCode: "cancelled",
+              errorMessage: reason,
+            }),
+          } : {}),
         });
-        runningProcesses.delete(run.id);
-      } else if (run.processPid || run.processGroupId) {
-        await terminateHeartbeatRunProcess({
-          pid: run.processPid,
-          processGroupId: run.processGroupId,
+        if (cancelled) break;
+        const refetchedRun = await getRun(run.id);
+        if (!refetchedRun) break;
+        latestRun = refetchedRun;
+      }
+
+      if (cancelled) {
+        cancelledAny = true;
+        await setWakeupStatus(cancelled.wakeupRequestId, "cancelled", {
+          finishedAt: new Date(),
+          error: reason,
         });
       }
-      await releaseIssueExecutionAndPromote(run);
+
+      const finalRun = cancelled ?? await getRun(run.id) ?? latestRun;
+      const processRun = finalRun;
+      const running = runningProcesses.get(run.id);
+      const shouldTerminateProcess =
+        Boolean(cancelled) ||
+        CANCELLABLE_HEARTBEAT_RUN_STATUSES.includes(finalRun.status as (typeof CANCELLABLE_HEARTBEAT_RUN_STATUSES)[number]);
+      if (running) {
+        if (shouldTerminateProcess) {
+          await terminateHeartbeatRunProcess({
+            pid: running.child.pid ?? processRun.processPid,
+            processGroupId: running.processGroupId ?? processRun.processGroupId,
+            graceMs: Math.max(1, running.graceSec) * 1000,
+          });
+          runningProcesses.delete(run.id);
+        } else if (running.child.exitCode !== null || running.child.signalCode !== null) {
+          runningProcesses.delete(run.id);
+        } else {
+          logger.warn(
+            { runId: run.id, status: finalRun.status },
+            "skipping process termination after cancel race lost to terminal run with live child handle",
+          );
+        }
+      } else if (shouldTerminateProcess && (processRun.processPid || processRun.processGroupId)) {
+        await terminateHeartbeatRunProcess({
+          pid: processRun.processPid,
+          processGroupId: processRun.processGroupId,
+        });
+      }
+      if (!CANCELLABLE_HEARTBEAT_RUN_STATUSES.includes(finalRun.status as (typeof CANCELLABLE_HEARTBEAT_RUN_STATUSES)[number])) {
+        await releaseIssueExecutionAndPromote(finalRun);
+      }
     }
 
+    if (cancelledAny) await finalizeAgentStatus(agentId, "cancelled");
     return runs.length;
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The plugin system is the documented extension path for thin-core integrations and product-specific edges.
> - `agent.run.*` lifecycle event names were documented, but run status transitions did not yet provide complete, transition-aware plugin event plumbing.
> - Consumers need stable run lifecycle payloads without polling internal heartbeat tables or depending on ad hoc side effects.
> - The race-prone part is run finalization: completion, failure, timeout, and cancellation can converge on the same run.
> - This pull request completes the documented plugin lifecycle event plumbing with CAS-guarded transitions, compact redacted payloads, and race coverage.
> - The benefit is a more usable plugin contract while keeping this scoped to the existing plugin system, not a new roadmap-level core feature.

## What Changed

- Publish `agent.run.started`, `agent.run.finished`, `agent.run.failed`, and `agent.run.cancelled` plugin events from heartbeat run transitions with `previousStatus`, run/agent IDs, trigger metadata, compact redacted usage/result summaries, error fields, and log references.
- Guard run status updates with the observed previous status so stale finalizers do not emit duplicate terminal lifecycle events.
- Preserve adapter usage/result/log artifacts when cancellation wins a completion/failure race, while keeping the cancellation event as the single terminal lifecycle event. Plugins that need final artifacts can re-fetch the run after `agent.run.cancelled`.
- Add compact usage summarization for lifecycle payloads, including provider field aliases and derived `totalTokens` from input plus output tokens.
- Add embedded-Postgres lifecycle event tests covering started/finished delivery, timeout failure mapping, cancellation payloads, and cancellation-vs-adapter race behavior.
- Update plugin spec and SDK README docs for the finalized lifecycle payload contract.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-run-lifecycle-events.test.ts server/src/__tests__/heartbeat-run-summary.test.ts`
- `pnpm --filter @paperclipai/plugin-sdk build`
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check`
- Live local plugin test: installed a plugin package through the app API, subscribed to `agent.run.*`, resumed a seeded heartbeat run, and verified the plugin observed started + finished events with compact usage/result payloads.
- Independent Fig/Claude review on fork PR `keegoid/paperclip#2`; latest round found no CAT-1/blocking defects and approved the head commit.
- Checked `ROADMAP.md`; this does not duplicate a roadmap-level core feature. It completes plumbing for the documented plugin lifecycle events under the existing plugin-system milestone.

## Risks

- Low to medium. This settles the documented lifecycle event envelope as `entityType: "run"` and `actorType: "system"`; any experimental consumer using an older event shape should update to the spec in this PR.
- Plugin event publication remains best-effort and logged on failure, so run execution is not blocked by plugin bus issues.
- Cancelled runs may receive adapter artifacts after the cancellation event when cancellation wins a race; this is documented so plugins can re-fetch the run if they need those final fields.

## Model Used

- OpenAI Codex, GPT-5 coding agent, tool-enabled local shell and GitHub workflow.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A; no UI changes)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
