### PR TITLE
Add MCP governance gatekeeper policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,22 @@ Prefer additive updates. Keep `doc/SPEC.md` and `doc/SPEC-implementation.md` ali
 5. Keep plan docs dated and centralized.
 New plan documents belong in `doc/plans/` and should use `YYYY-MM-DD-slug.md` filenames.
 
-## 6. Database Change Workflow
+6. Add MCP governance checkpoints before trust.
+MCP Registry/allowlist/quarantine/audit log must be defined before any external MCP execution surface is used as a trusted tool.
+
+## 6. Paperclip MCP Governance (Do Not Trust First)
+
+Before any MCP server is treated as trusted or allowed for production operations:
+
+1. Register the candidate in the Paperclip MCP Registry (`pending` state).
+2. Run automated and manual security checks; if suspicious, move it to `quarantine`.
+3. Only an approved Security or Board-admin actor can move it to `allowlist`.
+4. Every state transition must be written to the audit log with runId, actor, reason, and evidence link.
+5. Any heartbeat or issue depending on a non-allowlisted MCP server must be blocked before checkout, and downstream execution must not proceed until the MCP server is allowlisted.
+
+Gatekeeper enforcement applies in heartbeat preflight and the `paperclip` skill operating rules.
+
+## 7. Database Change Workflow
 
 When changing data model:
 
@@ -103,7 +118,7 @@ Notes:
 - `packages/db/drizzle.config.ts` reads compiled schema from `dist/schema/*.js`
 - `pnpm db:generate` compiles `packages/db` first
 
-## 7. Verification Before Hand-off
+## 8. Verification Before Hand-off
 
 Run this full check before claiming done:
 
@@ -115,7 +130,7 @@ pnpm build
 
 If anything cannot be run, explicitly report what was not run and why.
 
-## 8. API and Auth Expectations
+## 9. API and Auth Expectations
 
 - Base path: `/api`
 - Board access is treated as full-control operator context
@@ -129,13 +144,13 @@ When adding endpoints:
 - write activity log entries for mutations
 - return consistent HTTP errors (`400/401/403/404/409/422/500`)
 
-## 9. UI Expectations
+## 10. UI Expectations
 
 - Keep routes and nav aligned with available API surface
 - Use company selection context for company-scoped pages
 - Surface failures clearly; do not silently ignore API errors
 
-## 10. Definition of Done
+## 11. Definition of Done
 
 A change is done when all are true:
 

--- a/doc/plans/2026-04-28-paperclip-mcp-registry-allowlist-quarantine-audit-policy.md
+++ b/doc/plans/2026-04-28-paperclip-mcp-registry-allowlist-quarantine-audit-policy.md
@@ -1,0 +1,47 @@
+# Paperclip MCP Registry / Allowlist / Quarantine / Audit Log 우선 정책
+
+작성일: 2026-04-28
+상태: 제안(실행 전 설계)
+
+## 배경
+현재 요청은 `trusted tool` 목록에 MCP 서버를 바로 추가하는 방식의 위험을 줄이고,
+Paperclip가 먼저 MCP 등록-검증-승인-감사 흐름을 통과하도록 강제하는 운영 통제면을 추가하는 것이다.
+
+## 정책 결론
+- **Do not trust-first**: MCP 서버를 바로 trusted tool로 등록/실행하지 않는다.
+- **4단계 게이트**: `pending -> quarantine -> allowlist -> revoked`(혹은 disabled) 상태 전이.
+- **아웃풋 제약**: allowlist가 아닌 MCP는 자동 실행/다운스트림 해제 불가.
+- **감사 의무**: 등록/격리/승인/폐기에 대한 audit log 기록 + runId 보존.
+
+## 제안 데이터 모델 (최소 단위)
+- `mcp_servers`(또는 기존 plugin/adapter 메타에 통합 가능한 registry 테이블)
+  - 필수 컬럼: `id`, `companyId`, `endpoint`, `transport`, `metadata`, `ownerAgentId`, `status`, `riskLevel`, `scope`, `approvedBy`, `approvedAt`, `approvedUntil`, `evidence`, `createdBy`, `createdAt`, `updatedAt`
+  - 상태: `pending`, `quarantine`, `allowlist`, `revoked`, `disabled`
+- `mcp_server_audit_log`
+  - 필수: `id`, `companyId`, `actor`, `serverId`, `from_status`, `to_status`, `reason`, `runId`, `evidence`, `createdAt`
+
+## 운영 규칙(Heartbeat/Gatekeeper 반영)
+- 다운스트림 이슈에 MCP 의존성이 있으면 다음을 확인:
+  1) MCP 서버 등록 여부
+  2) 상태가 `allowlist`
+  3) 만료/승인 scope 유효성
+- 위 조건 미충족 시 해당 이슈는 기본 `blocked` 처리 후 작업 중단
+- 승인 사유가 빈약한 경우: blocker 코멘트에 명확한 `누가/무엇을/언제` 기입 필요
+
+## 구현 단계
+1. **스키마 정의**: `mcp_servers`, `mcp_server_audit_log` 추가.
+2. **Registry API**:
+   - 생성(등록): 승인 전 상태 `pending`
+   - 점검/격리/승인/폐기 전이 API
+   - `allowlist` 상태 조회 API(플러그인/runner 조회 시 사용)
+3. **엔드포인트 통합**: tool 실행 전 MCP 상태 확인 훅 삽입
+   - 비허용 상태면 실행 거부 + 명시적 error code
+4. **SKILL/AGENTS 반영**: 현재 요청사항대로 heartbeat에서 선행 체크 우선화
+5. **감사 로그 대시보드/쿼리**: runId 기준 추적
+6. **테스트/마이그레이션**: 마이그레이션 + 상태 전이 단위 테스트 + Heartbeat 차단 케이스 통합 테스트
+
+## 수용 기준
+- MCP 서버를 등록만 했고 allowlist 안 된 상태에서는 자동 실행/dispatch되지 않아야 함
+- `pending`/`quarantine` 상태 이슈가 있을 때 downsteam 실행이 block 되며, blocked 코멘트가 남아야 함
+- 상태 전이 1건당 audit log 1건 이상 생성
+- 변경 후 운영자에게 `runId`, `serverId`, `from/to`, `actor`, `evidence`가 조회 가능해야 함

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -24,6 +24,53 @@ Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli
 
 Follow these steps every time you wake up:
 
+### 운영감사 Gatekeeper 모드 (downstream 방지/운영통제)
+
+이 모드는 각 heartbeat 시작 시 최우선으로 실행된다. 목적: CMP 포함 모든 할당 작업이 조기 실행되지 않게 보장하고, 산출물/blocked 근거를 통해 다음 실행 가능 상태를 판단한다.
+
+**Heartbeat 시작 즉시 점검 항목 (순차):**
+1. **이슈 상태 스냅샷:** 대상 이슈의 `status`를 조회/기록한다.
+2. **산출물 존재 확인:** `GET /api/issues/{issueId}/documents` 실행
+   - 핵심 산출물(최소 1개) 존재 여부를 확인하고, 없다면 `blocked` 사유 생성 대상.
+   - 권장 핵심 키: `plan`, `design`, `requirements`, `spec`, `result`.
+3. **blocked 이유 점검:** 최신 코멘트에서 블로커, 담당자, 요구 액션(누가/무엇/언제)을 추출한다.
+4. **다운스트림 후보 탐색:**
+   - `GET /api/companies/{companyId}/issues?parentId={issueId}`로 하위 이슈(후속) 존재 여부 확인
+   - `GET /api/issues/{issueId}/heartbeat-context` 또는 ancestors로 상위 의존 상태 확인
+
+**게이트키핑 규칙 (반드시 준수):**
+- 상위 이슈(ancestor)가 완료되지 않았거나, 산출물 부재/근거 불명확한 경우: 본 이슈를 `blocked` 처리 후 작업 진입 금지
+- 현재 이슈가 `blocked`면 해제 가능한 조치가 보일 때만 언블록 시도.
+- **최우선 금지 규칙:** 선행 의존이 해결되지 않은 상태에서 downstream(하위/후속) 이슈는 절대 실행하지 않는다.
+- blocked 코멘트는 "무엇이 막는지, 누가 풀어야 하는지, 다음 언블록 후보(관련 상위 이슈/필요 산출물)는 무엇인지"를 명시한다.
+
+### MCP 운영통제: Paperclip MCP Registry 선결 조건
+
+`trusted tool`에 MCP 서버를 바로 등록하지 않는다. MCP 서버를 활성화(allowlist)하기 전 다음을 반드시 거쳐야 한다.
+
+1. **Registry 등록 (상태= `pending`):**
+   - 신규 MCP 서버는 먼저 Paperclip MCP Registry에 후보로 등록한다.
+   - `server_id`, `endpoint`, `transport`, `owner`, `risk_owner`, `capability_scope`를 남긴다.
+   - `allowlist` 미등록 상태는 실행 컨텍스트에서 사용 불가.
+
+2. **Quarantine 점검:**
+   - 보안 점검 자동 룰(허용되지 않은 transport, 로컬 파일/시크릿 노출 패턴, 과도한 권한 요구, 비인가 네트워크 도메인)은 `quarantine` 상태로 분리.
+   - quarantine 항목은 담당자 확인 전까지 실행 금지.
+   - quarantine 사유는 `BLOCKED` 유형 코멘트에 명확히 남긴다.
+
+3. **Allowlist 승인:**
+   - `security` 또는 `board-admin` 승인자만 `allowlist`로 승격 가능.
+   - 승인 시 `reviewer`, `approved_at`, `runId`, 승인 근거(`reason`, ticket/PR 링크), 적용 만료일을 기록.
+
+4. **Audit log 기록:**
+   - Registry 상태 전이(등록/격리/승인/폐기)마다 Paperclip 감사 로그에 남긴다.
+   - 로그 필드는 최소 `action`, `actor`, `server_id`, `before`, `after`, `run_id`, `evidence`를 포함.
+   - 감사 로그를 보고 전/후속 실행 가능 판단 시 사용한다.
+
+5. **Downstream 실행 방지:**
+   - allowlist 미승인/quarantine 상태 MCP에 의존한 issue는 `blocked` 처리 후 진행 금지.
+   - 승인되지 않은 MCP를 호출한 로그(도구 실행 오류 포함)가 있으면 즉시 상위 이슈 및 감사 채널에 escalation comment.
+
 **Step 1 — Identity.** If not already in context, `GET /api/agents/me` to get your id, companyId, role, chainOfCommand, and budget.
 
 **Step 2 — Approval follow-up (when triggered).** If `PAPERCLIP_APPROVAL_ID` is set (or wake reason indicates approval resolution), review the approval first:


### PR DESCRIPTION
Adds MCP registry allowlist + quarantine + audit policy.

- AGENTS.md updated
- skills/paperclip/SKILL.md updated
- doc/plans/2026-04-28-paperclip-mcp-registry-allowlist-quarantine-audit-policy.md added