### PR TITLE
[codex] Fail-fast on codex-local startup hang (NOD-240)

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -72,6 +72,13 @@ export interface AdapterExecutionTargetProcessOptions {
   onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
   onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
   terminalResultCleanup?: TerminalResultCleanupOptions;
+  /**
+   * If > 0, terminate the process when no stdout chunk is observed within
+   * this many seconds after spawn. The result will carry `timedOut: true`
+   * and `startupHang: true`. Currently only applied for local (non-remote)
+   * execution; remote sandbox/ssh paths fall back to their own `timeoutMs`.
+   */
+  startupStdoutTimeoutSec?: number;
 }
 
 export interface AdapterExecutionTargetShellOptions {
@@ -216,6 +223,7 @@ export async function runAdapterExecutionTargetProcess(
     onSpawn: options.onSpawn,
     terminalResultCleanup: options.terminalResultCleanup,
     remoteExecution: adapterExecutionTargetToRemoteSpec(target),
+    startupStdoutTimeoutSec: options.startupStdoutTimeoutSec,
   });
 }
 

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -249,6 +249,84 @@ describe("runChildProcess", () => {
       }
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "terminates the child and reports startupHang when no stdout arrives in time",
+    async () => {
+      let observedStdout = "";
+      let observedStderr = "";
+
+      const startedAt = Date.now();
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        [
+          "-e",
+          [
+            // Emit only stderr — this should NOT clear the startup watchdog.
+            "process.stderr.write('boot error: simulated mcp auth required\\n');",
+            // Hang forever, simulating the codex-local startup-hang case.
+            "setInterval(() => {}, 1000);",
+          ].join(" "),
+        ],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          startupStdoutTimeoutSec: 1,
+          onLog: async (stream, chunk) => {
+            if (stream === "stdout") observedStdout += chunk;
+            else observedStderr += chunk;
+          },
+        },
+      );
+      const elapsedMs = Date.now() - startedAt;
+
+      expect(result.timedOut).toBe(true);
+      expect(result.startupHang).toBe(true);
+      expect(elapsedMs).toBeLessThan(8_000);
+      expect(observedStderr).toContain("[paperclip] startup-hang watchdog");
+      expect(observedStderr).toContain("Last stderr:");
+      expect(observedStderr).toContain("simulated mcp auth required");
+      // Stdout should be empty since the child never wrote to it.
+      expect(observedStdout).toBe("");
+    },
+    15_000,
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "does not fire the startup watchdog when the child emits stdout in time",
+    async () => {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        [
+          "-e",
+          [
+            "process.stdout.write('{\"type\":\"thread.started\"}\\n');",
+            "setTimeout(() => process.stdout.write('{\"type\":\"turn.completed\"}\\n'), 100);",
+            "setTimeout(() => process.exit(0), 200);",
+          ].join(" "),
+        ],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          startupStdoutTimeoutSec: 1,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.timedOut).toBe(false);
+      expect(result.startupHang).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("thread.started");
+      expect(result.stdout).toContain("turn.completed");
+    },
+    10_000,
+  );
 });
 
 describe("renderPaperclipWakePrompt", () => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -15,6 +15,12 @@ export interface RunProcessResult {
   stderr: string;
   pid: number | null;
   startedAt: string | null;
+  /**
+   * True when the process was terminated by the startup-stdout watchdog
+   * (`startupStdoutTimeoutSec`) because no stdout chunk arrived within
+   * the configured window after spawn. Always paired with `timedOut=true`.
+   */
+  startupHang?: boolean;
 }
 
 export interface TerminalResultCleanupOptions {
@@ -1470,6 +1476,16 @@ export async function runChildProcess(
     terminalResultCleanup?: TerminalResultCleanupOptions;
     stdin?: string;
     remoteExecution?: RemoteExecutionSpec | null;
+    /**
+     * If > 0, fire SIGTERM (then SIGKILL after `graceSec`) when no stdout
+     * chunk has been observed within this many seconds after spawn. The
+     * resolved {@link RunProcessResult} carries `timedOut: true` and
+     * `startupHang: true` so callers can distinguish a startup hang from
+     * the absolute `timeoutSec` watchdog. Stderr does not clear the timer:
+     * many adapters emit benign stderr noise during init even when their
+     * main loop is wedged.
+     */
+    startupStdoutTimeoutSec?: number;
   },
 ): Promise<RunProcessResult> {
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
@@ -1520,6 +1536,7 @@ export async function runChildProcess(
         runningProcesses.set(runId, { child, graceSec: opts.graceSec, processGroupId });
 
         let timedOut = false;
+        let startupHang = false;
         let stdout = "";
         let stderr = "";
         let logChain: Promise<void> = Promise.resolve();
@@ -1529,6 +1546,26 @@ export async function runChildProcess(
         let terminalCleanupKillTimer: NodeJS.Timeout | null = null;
         let terminalResultStdoutScanOffset = 0;
         let terminalResultStderrScanOffset = 0;
+        let startupStdoutTimer: NodeJS.Timeout | null = null;
+        let startupStdoutKillTimer: NodeJS.Timeout | null = null;
+        let firstStdoutSeen = false;
+
+        const clearStartupStdoutWatchdog = () => {
+          if (startupStdoutTimer) {
+            clearTimeout(startupStdoutTimer);
+            startupStdoutTimer = null;
+          }
+          if (startupStdoutKillTimer) {
+            clearTimeout(startupStdoutKillTimer);
+            startupStdoutKillTimer = null;
+          }
+        };
+
+        const tailForLog = (text: string, max: number): string => {
+          const trimmed = text.replace(/[\s ]+$/g, "");
+          if (trimmed.length <= max) return trimmed;
+          return `…${trimmed.slice(-max)}`;
+        };
 
         const clearTerminalCleanupTimers = () => {
           if (terminalCleanupTimer) clearTimeout(terminalCleanupTimer);
@@ -1577,6 +1614,7 @@ export async function runChildProcess(
             ? setTimeout(() => {
                 timedOut = true;
                 clearTerminalCleanupTimers();
+                clearStartupStdoutWatchdog();
                 signalRunningProcess({ child, processGroupId }, "SIGTERM");
                 setTimeout(() => {
                   signalRunningProcess({ child, processGroupId }, "SIGKILL");
@@ -1584,11 +1622,48 @@ export async function runChildProcess(
               }, opts.timeoutSec * 1000)
             : null;
 
+        if (
+          typeof opts.startupStdoutTimeoutSec === "number" &&
+          opts.startupStdoutTimeoutSec > 0
+        ) {
+          const startupSec = opts.startupStdoutTimeoutSec;
+          startupStdoutTimer = setTimeout(() => {
+            startupStdoutTimer = null;
+            if (firstStdoutSeen || timedOut || child.killed) return;
+            timedOut = true;
+            startupHang = true;
+            clearTerminalCleanupTimers();
+            const stderrTail = tailForLog(stderr, 1_000);
+            const message =
+              `[paperclip] startup-hang watchdog: no stdout for ${startupSec}s ` +
+              `after spawn (pid=${child.pid ?? "?"}). Sending SIGTERM. ` +
+              (stderrTail.length > 0
+                ? `Last stderr: ${stderrTail.replace(/\n+/g, " | ")}`
+                : "No stderr captured.") +
+              "\n";
+            logChain = logChain
+              .then(() => opts.onLog("stderr", message))
+              .catch((err) =>
+                onLogError(err, runId, "failed to log startup-hang watchdog message"),
+              );
+            signalRunningProcess({ child, processGroupId }, "SIGTERM");
+            startupStdoutKillTimer = setTimeout(() => {
+              startupStdoutKillTimer = null;
+              if (child.killed) return;
+              signalRunningProcess({ child, processGroupId }, "SIGKILL");
+            }, Math.max(1, opts.graceSec) * 1000);
+          }, startupSec * 1000);
+        }
+
         child.stdout?.on("data", (chunk: unknown) => {
           const readable = child.stdout;
           if (!readable) return;
           readable.pause();
           const text = String(chunk);
+          if (!firstStdoutSeen) {
+            firstStdoutSeen = true;
+            clearStartupStdoutWatchdog();
+          }
           stdout = appendWithCap(stdout, text);
           maybeArmTerminalResultCleanup();
           logChain = logChain
@@ -1628,6 +1703,7 @@ export async function runChildProcess(
         child.on("error", (err: Error) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearStartupStdoutWatchdog();
           runningProcesses.delete(runId);
           void target.cleanup?.();
           const errno = (err as NodeJS.ErrnoException).code;
@@ -1646,6 +1722,7 @@ export async function runChildProcess(
         child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearStartupStdoutWatchdog();
           runningProcesses.delete(runId);
           void logChain.finally(() => {
             void Promise.resolve()
@@ -1659,6 +1736,7 @@ export async function runChildProcess(
                 stderr,
                 pid: child.pid ?? null,
                 startedAt,
+                ...(startupHang ? { startupHang: true } : {}),
               });
               });
           });

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -64,7 +64,7 @@ export interface AdapterRuntimeServiceReport {
   healthStatus?: "unknown" | "healthy" | "unhealthy";
 }
 
-export type AdapterExecutionErrorFamily = "transient_upstream";
+export type AdapterExecutionErrorFamily = "transient_upstream" | "startup_hang";
 
 export interface AdapterExecutionResult {
   exitCode: number | null;

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -47,6 +47,14 @@ const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const CODEX_ROLLOUT_NOISE_RE =
   /^\d{4}-\d{2}-\d{2}T[^\s]+\s+ERROR\s+codex_core::rollout::list:\s+state db missing rollout path for thread\s+[a-z0-9-]+$/i;
 
+// Codex `exec --json` should emit at least a `thread.started` JSONL event
+// soon after spawn. If it produces zero stdout for this long the process is
+// wedged in startup (known causes: malformed local skill, MCP transport
+// AuthRequired close, shell snapshot validation failure) and the run will
+// otherwise sit `running` indefinitely. 120s gives slow boxes / cold MCP
+// connectors plenty of headroom while keeping silent failures bounded.
+const DEFAULT_CODEX_STARTUP_STDOUT_TIMEOUT_SEC = 120;
+
 function stripCodexRolloutNoise(text: string): string {
   const parts = text.split(/\r?\n/);
   const kept: string[] = [];
@@ -473,6 +481,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const timeoutSec = asNumber(config.timeoutSec, 0);
   const graceSec = asNumber(config.graceSec, 20);
+  const rawStartupStdoutTimeoutSec = asNumber(
+    config.startupStdoutTimeoutSec,
+    DEFAULT_CODEX_STARTUP_STDOUT_TIMEOUT_SEC,
+  );
+  // Allow operators to disable the watchdog with 0 / negative; clamp anything
+  // else to at least 5s so a misconfigured value can't punt the watchdog past
+  // the absolute timeout.
+  const startupStdoutTimeoutSec =
+    rawStartupStdoutTimeoutSec > 0 ? Math.max(5, rawStartupStdoutTimeoutSec) : 0;
 
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
@@ -644,13 +661,33 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       });
     }
 
+    const wrappedOnSpawn = onSpawn
+      ? async (meta: { pid: number; processGroupId: number | null; startedAt: string }) => {
+          await onSpawn(meta);
+          if (startupStdoutTimeoutSec > 0) {
+            await onLog(
+              "stdout",
+              `[paperclip] codex spawned (pid=${meta.pid}); awaiting first JSONL event within ${startupStdoutTimeoutSec}s.\n`,
+            );
+          }
+        }
+      : startupStdoutTimeoutSec > 0
+        ? async (meta: { pid: number; processGroupId: number | null; startedAt: string }) => {
+            await onLog(
+              "stdout",
+              `[paperclip] codex spawned (pid=${meta.pid}); awaiting first JSONL event within ${startupStdoutTimeoutSec}s.\n`,
+            );
+          }
+        : undefined;
+
     const proc = await runAdapterExecutionTargetProcess(runId, executionTarget, command, args, {
       cwd,
       env,
       stdin: prompt,
       timeoutSec,
       graceSec,
-      onSpawn,
+      onSpawn: wrappedOnSpawn,
+      startupStdoutTimeoutSec,
       onLog: async (stream, chunk) => {
         if (stream !== "stderr") {
           await onLog(stream, chunk);
@@ -673,10 +710,38 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const toResult = (
-    attempt: { proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string }; rawStderr: string; parsed: ReturnType<typeof parseCodexJsonl> },
+    attempt: { proc: { exitCode: number | null; signal: string | null; timedOut: boolean; startupHang?: boolean; stdout: string; stderr: string }; rawStderr: string; parsed: ReturnType<typeof parseCodexJsonl> },
     clearSessionOnMissingSession = false,
     isRetry = false,
   ): AdapterExecutionResult => {
+    if (attempt.proc.startupHang) {
+      const stderrTail = firstNonEmptyLine(attempt.proc.stderr);
+      const errorMessage =
+        `Codex produced no JSONL output for ${startupStdoutTimeoutSec}s after spawn; ` +
+        `terminated by startup watchdog. ` +
+        (stderrTail.length > 0
+          ? `First stderr line: ${stderrTail}`
+          : "No stderr captured.");
+      return {
+        exitCode: attempt.proc.exitCode,
+        signal: attempt.proc.signal,
+        timedOut: true,
+        errorMessage,
+        errorCode: "codex_startup_hang",
+        errorFamily: "startup_hang",
+        errorMeta: {
+          startupStdoutTimeoutSec,
+          stderrTail: stderrTail || null,
+        },
+        resultJson: {
+          stdout: attempt.proc.stdout,
+          stderr: attempt.proc.stderr,
+          errorFamily: "startup_hang",
+          startupStdoutTimeoutSec,
+        },
+        clearSession: clearSessionOnMissingSession,
+      };
+    }
     if (attempt.proc.timedOut) {
       return {
         exitCode: attempt.proc.exitCode,

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -38,6 +38,17 @@ process.exit(1);
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeStartupHangCodexCommand(commandPath: string, stderrLine: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+process.stderr.write(${JSON.stringify(stderrLine + "\n")});
+// Simulate codex stuck after partial init — never emits a JSONL event,
+// never exits. Paperclip's startup-stdout watchdog must terminate this.
+setInterval(() => {}, 1000);
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 type CapturePayload = {
   argv: string[];
   prompt: string;
@@ -489,6 +500,89 @@ describe("codex execute", () => {
       await fs.rm(root, { recursive: true, force: true });
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "terminates a codex child stuck before any JSONL output and surfaces codex_startup_hang",
+    async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-startup-hang-"));
+      const workspace = path.join(root, "workspace");
+      const commandPath = path.join(root, "codex");
+      await fs.mkdir(workspace, { recursive: true });
+      const stderrLine =
+        "ERROR codex_core::mcp::worker: figma server closed: AuthRequired";
+      await writeStartupHangCodexCommand(commandPath, stderrLine);
+
+      const previousHome = process.env.HOME;
+      process.env.HOME = root;
+      const logs: { stream: "stdout" | "stderr"; chunk: string }[] = [];
+
+      try {
+        const startedAt = Date.now();
+        const result = await execute({
+          runId: "run-startup-hang",
+          agent: {
+            id: "agent-1",
+            companyId: "company-1",
+            name: "Codex Coder",
+            adapterType: "codex_local",
+            adapterConfig: {},
+          },
+          runtime: {
+            sessionId: null,
+            sessionParams: null,
+            sessionDisplayId: null,
+            taskKey: null,
+          },
+          config: {
+            command: commandPath,
+            cwd: workspace,
+            promptTemplate: "Follow the paperclip heartbeat.",
+            // Watchdog clamps to 5s minimum; pick a small value so the test
+            // finishes quickly without flaking on a slow box.
+            startupStdoutTimeoutSec: 5,
+            graceSec: 1,
+          },
+          context: {},
+          authToken: "run-jwt-token",
+          onLog: async (stream, chunk) => {
+            logs.push({ stream, chunk });
+          },
+        });
+        const elapsedMs = Date.now() - startedAt;
+
+        expect(result.timedOut).toBe(true);
+        expect(result.errorCode).toBe("codex_startup_hang");
+        expect(result.errorFamily).toBe("startup_hang");
+        expect(result.errorMessage).toContain("no JSONL output for 5s");
+        expect(result.errorMessage).toContain("AuthRequired");
+        expect(result.errorMeta?.startupStdoutTimeoutSec).toBe(5);
+        expect(result.errorMeta?.stderrTail).toContain("AuthRequired");
+        expect(result.resultJson?.errorFamily).toBe("startup_hang");
+        // Should fail fast (well under the 1h heartbeat watchdog threshold).
+        expect(elapsedMs).toBeLessThan(20_000);
+
+        // Stage-tracking instrumentation must surface in the run log so the
+        // operator can see the run got past spawn and where it stopped.
+        const allOut = logs
+          .filter((entry) => entry.stream === "stdout")
+          .map((entry) => entry.chunk)
+          .join("");
+        const allErr = logs
+          .filter((entry) => entry.stream === "stderr")
+          .map((entry) => entry.chunk)
+          .join("");
+        expect(allOut).toContain("[paperclip] codex spawned (pid=");
+        expect(allOut).toContain("awaiting first JSONL event within 5s");
+        expect(allErr).toContain("[paperclip] startup-hang watchdog");
+        expect(allErr).toContain("AuthRequired");
+      } finally {
+        if (previousHome === undefined) delete process.env.HOME;
+        else process.env.HOME = previousHome;
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+    30_000,
+  );
 
   it("uses safer invocation settings and a fresh-session handoff for codex transient fallback retries", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-fallback-"));


### PR DESCRIPTION
## Summary

Closes the codex-local startup-hang state machine gap behind NOD-240. Runs that emit a single stderr line during init (skill parse error / MCP `AuthRequired` / shell snapshot validation failure) and never produce a JSONL event no longer sit in `running` indefinitely.

- New `startupStdoutTimeoutSec` watchdog in `runChildProcess` (`packages/adapter-utils/src/server-utils.ts`). When > 0, SIGTERM (then SIGKILL after `graceSec`) the child if no stdout chunk arrives within the window after spawn. Stderr does not clear it. Result carries `startupHang: true` paired with `timedOut: true`. Watchdog fire writes a `[paperclip] startup-hang watchdog: …` line through `onLog` with the captured stderr tail.
- Plumbed through `AdapterExecutionTargetProcessOptions` / `runAdapterExecutionTargetProcess`. Local execution path only — remote sandbox/ssh keep their own `timeoutMs` (called out in JSDoc).
- `AdapterExecutionErrorFamily` extended with `"startup_hang"`. Heartbeat retry policy auto-retries only `transient_upstream`, so startup hangs become terminal `failed` (correct — they are not transient).
- `codex-local` (`packages/adapters/codex-local/src/server/execute.ts`) defaults `startupStdoutTimeoutSec` to 120s, configurable via adapter config; `<= 0` disables, `> 0` clamps to `>= 5`. Adds `wrappedOnSpawn` that emits `[paperclip] codex spawned (pid=…); awaiting first JSONL event within Ns.` so the run log shows the stage transition. `toResult` handles `attempt.proc.startupHang` before the generic `timedOut` and returns `errorCode: "codex_startup_hang"`, `errorFamily: "startup_hang"`, `errorMeta.stderrTail`, plus a `resultJson.errorFamily` so existing heartbeat serializers (`readHeartbeatRunErrorFamily`, `mergeAdapterRecoveryMetadata`) persist it without changes.

## Test plan

- [x] `pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts` — 16/16 pass, including the new `terminates the child and reports startupHang when no stdout arrives in time` (deterministic reproducer: stderr-only / hang-forever child) and `does not fire the startup watchdog when the child emits stdout in time` (anti-flake).
- [x] `pnpm exec vitest run server/src/__tests__/codex-local-execute.test.ts` — 13/13 pass, including the new `terminates a codex child stuck before any JSONL output and surfaces codex_startup_hang` (asserts `errorCode`/`errorFamily`/`errorMeta.stderrTail`/run-log instrumentation).
- [x] `pnpm exec vitest run server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts` — 8/8 still pass (heartbeat-side silence watchdog and recovery-decision flow are untouched).
- [x] `pnpm exec vitest run packages/adapter-utils packages/adapters/codex-local` — 54/54 pass.
- [x] `tsc --noEmit` clean for `@paperclipai/adapter-utils`, `@paperclipai/adapter-codex-local`, `@paperclipai/server`.

## Out of scope (deliberate)

- Sandbox/ssh remote-execution paths. Adding a startup watchdog there should be a follow-up.
- Other local adapters (`claude-local` / `cursor-local` / `gemini-local` / `opencode-local`) can opt in by setting `startupStdoutTimeoutSec` in their adapter `execute`. Scoped to NOD-240 deliverables to keep review surface bounded.

Refs: NOD-240, NOD-239