### PR TITLE
KIN-675: restore Notion query/update runtime contract parity

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { prepareManagedCodexHome, resolveManagedCodexHomeDir } from "./codex-home.js";
+
+async function makeTempDir(prefix: string): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+describe("prepareManagedCodexHome", () => {
+  const createdDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      createdDirs.splice(0).map(async (dir) => {
+        await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+      }),
+    );
+  });
+
+  it("adds missing MCP server sections from shared config.toml into existing managed config", async () => {
+    const paperclipHome = await makeTempDir("paperclip-home-");
+    const sourceHome = await makeTempDir("codex-home-source-");
+    createdDirs.push(paperclipHome, sourceHome);
+
+    await fs.writeFile(
+      path.join(sourceHome, "config.toml"),
+      [
+        'model = "gpt-5.4"',
+        "",
+        '[mcp_servers.kinetica_rag]',
+        'url = "http://127.0.0.1:8765/sse"',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const env: NodeJS.ProcessEnv = {
+      PAPERCLIP_HOME: paperclipHome,
+      PAPERCLIP_INSTANCE_ID: "default",
+      CODEX_HOME: sourceHome,
+    };
+    const targetHome = resolveManagedCodexHomeDir(env, "company-1");
+    await fs.mkdir(targetHome, { recursive: true });
+    await fs.writeFile(
+      path.join(targetHome, "config.toml"),
+      ['model = "gpt-5.4"', "", "[projects.'c:/repo']", 'trust_level = "trusted"'].join("\n"),
+      "utf8",
+    );
+
+    const logs: string[] = [];
+    await prepareManagedCodexHome(
+      env,
+      async (_stream, chunk) => {
+        logs.push(chunk);
+      },
+      "company-1",
+    );
+
+    const mergedToml = await fs.readFile(path.join(targetHome, "config.toml"), "utf8");
+    expect(mergedToml).toContain("[projects.'c:/repo']");
+    expect(mergedToml).toContain("[mcp_servers.kinetica_rag]");
+    expect(logs.join("")).toContain("Synced missing Codex MCP server blocks");
+  });
+
+  it("normalizes Notion update-page requirements and adds query-data-sources alias in cached app tools", async () => {
+    const paperclipHome = await makeTempDir("paperclip-home-");
+    const sourceHome = await makeTempDir("codex-home-source-");
+    createdDirs.push(paperclipHome, sourceHome);
+
+    await fs.writeFile(path.join(sourceHome, "config.toml"), 'model = "gpt-5.4"\n', "utf8");
+
+    const env: NodeJS.ProcessEnv = {
+      PAPERCLIP_HOME: paperclipHome,
+      PAPERCLIP_INSTANCE_ID: "default",
+      CODEX_HOME: sourceHome,
+    };
+    const targetHome = resolveManagedCodexHomeDir(env, "company-1");
+    const cacheDir = path.join(targetHome, "cache", "codex_apps_tools");
+    await fs.mkdir(cacheDir, { recursive: true });
+
+    const cacheFile = path.join(cacheDir, "tools.json");
+    const cacheFixture = {
+      schema_version: 2,
+      tools: [
+        {
+          server_name: "codex_apps",
+          tool_name: "_notion_update_page",
+          tool_namespace: "mcp__codex_apps__notion",
+          tool: {
+            inputSchema: {
+              type: "object",
+              properties: {
+                page_id: { type: "string" },
+                command: {
+                  type: "string",
+                  enum: [
+                    "update_properties",
+                    "update_content",
+                    "replace_content",
+                    "apply_template",
+                    "update_verification",
+                  ],
+                },
+                properties: { type: "object" },
+                content_updates: { type: "array" },
+                new_str: { type: "string" },
+                template_id: { type: "string" },
+                verification_status: { type: "string" },
+              },
+              required: ["page_id", "command", "properties", "content_updates"],
+            },
+          },
+        },
+        {
+          server_name: "codex_apps",
+          tool_name: "_notion_query_data_sources",
+          tool_namespace: "mcp__codex_apps__notion",
+          tool: {
+            inputSchema: {
+              type: "object",
+              properties: {
+                data: { type: "object" },
+              },
+              required: ["data"],
+            },
+          },
+        },
+      ],
+    };
+    await fs.writeFile(cacheFile, `${JSON.stringify(cacheFixture, null, 2)}\n`, "utf8");
+
+    const logs: string[] = [];
+    await prepareManagedCodexHome(
+      env,
+      async (_stream, chunk) => {
+        logs.push(chunk);
+      },
+      "company-1",
+    );
+
+    const updated = JSON.parse(await fs.readFile(cacheFile, "utf8")) as {
+      tools: Array<{ tool_name: string; tool_namespace: string; tool: { inputSchema: Record<string, unknown> } }>;
+    };
+
+    const updatePage = updated.tools.find((entry) => entry.tool_name === "_notion_update_page");
+    expect(updatePage).toBeDefined();
+
+    const updateSchema = updatePage?.tool.inputSchema ?? {};
+    expect(updateSchema.required).toEqual(["page_id", "command"]);
+    const allOf = Array.isArray(updateSchema.allOf) ? updateSchema.allOf : [];
+    expect(allOf).toHaveLength(5);
+    expect(JSON.stringify(allOf)).toContain("\"update_properties\"");
+    expect(JSON.stringify(allOf)).toContain("\"content_updates\"");
+    expect(JSON.stringify(allOf)).toContain("\"verification_status\"");
+
+    const queryAlias = updated.tools.find((entry) => entry.tool_name === "notion-query-data-sources");
+    expect(queryAlias).toBeDefined();
+    expect(queryAlias?.tool_namespace).toBe("mcp__codex_apps__notion");
+    expect(logs.join("")).toContain("Normalized");
+  });
+});

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -7,6 +7,13 @@ const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
 const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
 const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
 const DEFAULT_PAPERCLIP_INSTANCE_ID = "default";
+const TOML_SECTION_RE = /^\[[^\]]+\]\s*$/gm;
+const MCP_SERVER_SECTION_RE = /^\[mcp_servers\.(?:"([^"]+)"|([^\]]+))\]\s*$/gm;
+const CODEX_APPS_TOOLS_CACHE_DIR = path.join("cache", "codex_apps_tools");
+const NOTION_NAMESPACE = "mcp__codex_apps__notion";
+const NOTION_UPDATE_PAGE_TOOL_NAME = "_notion_update_page";
+const NOTION_QUERY_DATA_SOURCES_TOOL_NAME = "_notion_query_data_sources";
+const NOTION_QUERY_DATA_SOURCES_ALIAS = "notion-query-data-sources";
 
 function nonEmpty(value: string | undefined): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
@@ -71,6 +78,209 @@ async function ensureCopiedFile(target: string, source: string): Promise<void> {
   await fs.copyFile(source, target);
 }
 
+function parseMcpServerBlocks(toml: string): Map<string, string> {
+  const sectionStarts: number[] = [];
+  TOML_SECTION_RE.lastIndex = 0;
+  for (let header = TOML_SECTION_RE.exec(toml); header; header = TOML_SECTION_RE.exec(toml)) {
+    sectionStarts.push(header.index);
+  }
+
+  const output = new Map<string, string>();
+  MCP_SERVER_SECTION_RE.lastIndex = 0;
+  for (let match = MCP_SERVER_SECTION_RE.exec(toml); match; match = MCP_SERVER_SECTION_RE.exec(toml)) {
+    const serverName = (match[1] ?? match[2] ?? "").trim();
+    if (!serverName) continue;
+    const start = match.index;
+    const nextSectionStart = sectionStarts.find((candidate) => candidate > start) ?? toml.length;
+    const block = toml.slice(start, nextSectionStart).trimEnd();
+    if (!block) continue;
+    output.set(serverName, block);
+  }
+
+  return output;
+}
+
+function mergeMissingMcpServerBlocks(
+  targetToml: string,
+  sourceToml: string,
+): { mergedToml: string; addedNames: string[] } {
+  const sourceBlocks = parseMcpServerBlocks(sourceToml);
+  if (sourceBlocks.size === 0) {
+    return { mergedToml: targetToml, addedNames: [] };
+  }
+
+  const targetBlocks = parseMcpServerBlocks(targetToml);
+  const blocksToAdd: string[] = [];
+  const addedNames: string[] = [];
+  for (const [name, block] of sourceBlocks.entries()) {
+    if (targetBlocks.has(name)) continue;
+    blocksToAdd.push(block);
+    addedNames.push(name);
+  }
+
+  if (blocksToAdd.length === 0) {
+    return { mergedToml: targetToml, addedNames: [] };
+  }
+
+  const base = targetToml.trimEnd();
+  const mergedToml = `${base}\n\n${blocksToAdd.join("\n\n")}\n`;
+  return { mergedToml, addedNames };
+}
+
+async function ensureConfigTomlWithMcpServers(
+  target: string,
+  source: string,
+  onLog: AdapterExecutionContext["onLog"],
+): Promise<void> {
+  const existing = await fs.lstat(target).catch(() => null);
+  if (!existing) {
+    await ensureParentDir(target);
+    await fs.copyFile(source, target);
+    return;
+  }
+  if (!existing.isFile()) return;
+
+  const [sourceToml, targetToml] = await Promise.all([
+    fs.readFile(source, "utf8").catch(() => null),
+    fs.readFile(target, "utf8").catch(() => null),
+  ]);
+  if (sourceToml == null || targetToml == null) return;
+
+  const { mergedToml, addedNames } = mergeMissingMcpServerBlocks(targetToml, sourceToml);
+  if (addedNames.length === 0) return;
+
+  await fs.writeFile(target, mergedToml, "utf8");
+  await onLog(
+    "stdout",
+    `[paperclip] Synced missing Codex MCP server blocks (${addedNames.join(", ")}) into "${target}".\n`,
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function normalizeNotionUpdatePageSchema(inputSchema: Record<string, unknown>): boolean {
+  const required = Array.isArray(inputSchema.required) ? inputSchema.required : [];
+  const nextRequired = required.filter((value) =>
+    typeof value === "string" && value !== "properties" && value !== "content_updates"
+  );
+  const changedRequired =
+    nextRequired.length !== required.length || nextRequired.some((value, index) => value !== required[index]);
+
+  const existingAllOf = Array.isArray(inputSchema.allOf) ? inputSchema.allOf : [];
+  const nextAllOf = [
+    {
+      if: { properties: { command: { const: "update_properties" } }, required: ["command"] },
+      then: { required: ["properties"] },
+    },
+    {
+      if: { properties: { command: { const: "update_content" } }, required: ["command"] },
+      then: { required: ["content_updates"] },
+    },
+    {
+      if: { properties: { command: { const: "replace_content" } }, required: ["command"] },
+      then: { required: ["new_str"] },
+    },
+    {
+      if: { properties: { command: { const: "apply_template" } }, required: ["command"] },
+      then: { required: ["template_id"] },
+    },
+    {
+      if: { properties: { command: { const: "update_verification" } }, required: ["command"] },
+      then: { required: ["verification_status"] },
+    },
+  ];
+
+  const changedAllOf = JSON.stringify(existingAllOf) !== JSON.stringify(nextAllOf);
+  if (!changedRequired && !changedAllOf) return false;
+
+  inputSchema.required = nextRequired;
+  inputSchema.allOf = nextAllOf;
+  return true;
+}
+
+function normalizeCodexAppsToolCacheJson(raw: string): { nextRaw: string | null; changed: boolean } {
+  const parsed = JSON.parse(raw) as { tools?: unknown };
+  if (!Array.isArray(parsed.tools)) return { nextRaw: null, changed: false };
+
+  let changed = false;
+  let hasQueryDataSourcesAlias = false;
+  let canonicalQueryDataSourcesEntry: Record<string, unknown> | null = null;
+
+  for (const toolEntryValue of parsed.tools) {
+    const toolEntry = asRecord(toolEntryValue);
+    if (!toolEntry) continue;
+
+    const namespace = toolEntry.tool_namespace;
+    const toolName = toolEntry.tool_name;
+    if (namespace !== NOTION_NAMESPACE || typeof toolName !== "string") continue;
+
+    if (toolName === NOTION_QUERY_DATA_SOURCES_ALIAS) {
+      hasQueryDataSourcesAlias = true;
+      continue;
+    }
+
+    if (toolName === NOTION_QUERY_DATA_SOURCES_TOOL_NAME) {
+      canonicalQueryDataSourcesEntry = toolEntry;
+      continue;
+    }
+
+    if (toolName !== NOTION_UPDATE_PAGE_TOOL_NAME) continue;
+    const toolNode = asRecord(toolEntry.tool);
+    const inputSchema = asRecord(toolNode?.inputSchema);
+    if (!toolNode || !inputSchema) continue;
+    if (normalizeNotionUpdatePageSchema(inputSchema)) {
+      changed = true;
+    }
+  }
+
+  if (!hasQueryDataSourcesAlias && canonicalQueryDataSourcesEntry) {
+    parsed.tools.push({
+      ...canonicalQueryDataSourcesEntry,
+      tool_name: NOTION_QUERY_DATA_SOURCES_ALIAS,
+    });
+    changed = true;
+  }
+
+  if (!changed) return { nextRaw: null, changed: false };
+  return { nextRaw: `${JSON.stringify(parsed, null, 2)}\n`, changed: true };
+}
+
+async function normalizeCodexAppsToolCache(
+  targetHome: string,
+  onLog: AdapterExecutionContext["onLog"],
+): Promise<void> {
+  const cacheDir = path.join(targetHome, CODEX_APPS_TOOLS_CACHE_DIR);
+  const entries = await fs.readdir(cacheDir, { withFileTypes: true }).catch(() => []);
+  let changedCount = 0;
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const filePath = path.join(cacheDir, entry.name);
+    const raw = await fs.readFile(filePath, "utf8").catch(() => null);
+    if (raw == null) continue;
+
+    try {
+      const { nextRaw, changed } = normalizeCodexAppsToolCacheJson(raw);
+      if (!changed || nextRaw == null) continue;
+      await fs.writeFile(filePath, nextRaw, "utf8");
+      changedCount += 1;
+    } catch {
+      // Ignore malformed cache entries and keep startup resilient.
+    }
+  }
+
+  if (changedCount > 0) {
+    await onLog(
+      "stdout",
+      `[paperclip] Normalized ${changedCount} Codex app-tool cache file(s) for Notion query/update compatibility.\n`,
+    );
+  }
+}
+
 export async function prepareManagedCodexHome(
   env: NodeJS.ProcessEnv,
   onLog: AdapterExecutionContext["onLog"],
@@ -92,8 +302,15 @@ export async function prepareManagedCodexHome(
   for (const name of COPIED_SHARED_FILES) {
     const source = path.join(sourceHome, name);
     if (!(await pathExists(source))) continue;
-    await ensureCopiedFile(path.join(targetHome, name), source);
+    const target = path.join(targetHome, name);
+    if (name === "config.toml") {
+      await ensureConfigTomlWithMcpServers(target, source, onLog);
+      continue;
+    }
+    await ensureCopiedFile(target, source);
   }
+
+  await normalizeCodexAppsToolCache(targetHome, onLog);
 
   await onLog(
     "stdout",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that runs agent heartbeats and supplies managed adapter runtime context, including each adapter's Codex home and MCP tool surface.
> - COO Notion validation failures (KIN-663/KIN-672/KIN-675) narrowed to Codex runtime contract drift, not Foundry.Node application logic.
> - The codex-local adapter seeds per-company managed `codex-home`, which is the runtime boundary where MCP server config and cached codex app-tool schemas are materialized.
> - Two defects were observed in that boundary: missing reconciliation of new shared MCP server blocks and stale/over-strict cached Notion tool schemas.
> - `notion-update-page` cache schema required `content_updates` globally, breaking `update_properties` calls despite command-specific behavior.
> - `notion-query-data-sources` compatibility required explicit callable parity in the cache layer for COO's routine contract.
> - This pull request hardens `prepareManagedCodexHome` to reconcile MCP blocks and normalize Notion app-tool cache contracts at startup.
> - The benefit is a runtime-level compatibility fix with focused automated tests that directly cover the failing query/update contract paths.

## What Changed

- Added managed `config.toml` MCP reconciliation in codex-local home preparation: missing `[mcp_servers.*]` blocks from shared `~/.codex/config.toml` are now merged into existing managed config files.
- Added Codex app-tool cache normalization in `codex-home.ts` for Notion tools under `mcp__codex_apps__notion`.
- Normalized `_notion_update_page` schema to command-specific requirements:
  - `update_properties` => requires `properties`
  - `update_content` => requires `content_updates`
  - `replace_content` => requires `new_str`
  - `apply_template` => requires `template_id`
  - `update_verification` => requires `verification_status`
- Removed incorrect global `properties`/`content_updates` requirements from top-level required list and encoded command requirements via JSON Schema `allOf` conditionals.
- Added `notion-query-data-sources` compatibility alias entry in the cached tool list when canonical `_notion_query_data_sources` exists.
- Added focused tests in `packages/adapters/codex-local/src/server/codex-home.test.ts` for both MCP block merge and Notion cache contract normalization.
- Closes KIN-675.

## Verification

- `pnpm vitest packages/adapters/codex-local/src/server/codex-home.test.ts`
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`

## Risks

- Medium-low: runtime cache normalization mutates managed cache JSON on startup; malformed or unexpected future cache shapes are ignored by design to avoid boot failures.
- Medium-low: query alias assumes consumers may call `notion-query-data-sources`; canonical `_notion_query_data_sources` remains intact to preserve existing behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected � check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 (Codex agent runtime), high-reasoning tool-use mode via local shell + repo editing workflow.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

