### PR TITLE
fix(server): terminate detached orphan heartbeat children on later reap

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -837,6 +837,41 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("claimed");
   });
 
+  it("reaps and terminates a detached local child on a later orphan pass", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+    const pid = child.pid!;
+
+    const { runId, wakeupRequestId } = await seedRunFixture({
+      processPid: pid,
+      includeIssue: false,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.reapOrphanedRuns();
+    expect(first.reaped).toBe(0);
+    const runAfterFirst = await heartbeat.getRun(runId);
+    expect(runAfterFirst?.errorCode).toBe("process_detached");
+
+    const second = await heartbeat.reapOrphanedRuns();
+    expect(second.reaped).toBe(1);
+    expect(second.runIds).toEqual([runId]);
+
+    expect(await waitForPidExit(pid, 2_000)).toBe(true);
+
+    const failed = await heartbeat.getRun(runId);
+    expect(failed?.status).toBe("failed");
+    expect(failed?.errorCode).toBe("process_lost");
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("failed");
+  });
+
   it("queues exactly one retry when the recorded local pid is dead", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       processPid: 999_999_999,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4393,6 +4393,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
+      let descendantOnlyCleanup = false;
       if (processPidAlive) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
@@ -4420,10 +4421,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           pid: run.processPid,
           processGroupId: run.processGroupId,
         });
-      }
-
-      let descendantOnlyCleanup = false;
-      else if (processGroupAlive) {
+      } else if (processGroupAlive) {
         descendantOnlyCleanup = true;
         await terminateHeartbeatRunProcess({
           pid: run.processPid,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4423,7 +4423,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       let descendantOnlyCleanup = false;
-      if (processGroupAlive) {
+      else if (processGroupAlive) {
         descendantOnlyCleanup = true;
         await terminateHeartbeatRunProcess({
           pid: run.processPid,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4411,8 +4411,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               },
             });
           }
+          continue;
         }
-        continue;
+        // Already marked detached on a prior reap pass (e.g. periodic with staleness), but the
+        // adapter child is still alive — do not spin forever at 100% CPU. Terminate and fall
+        // through to the normal process-loss path (same as descendant-only PGID cleanup).
+        await terminateHeartbeatRunProcess({
+          pid: run.processPid,
+          processGroupId: run.processGroupId,
+        });
       }
 
       let descendantOnlyCleanup = false;


### PR DESCRIPTION
## Summary

Ships the [CAS-239](https://paperclip.ing) detached-orphan reap fix: when a run is already `process_detached` and the adapter child PID is still alive on a later reap pass, call `terminateHeartbeatRunProcess` and finalize via the existing `process_lost` path.

## Test plan

```bash
pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts
```

34 tests passed locally (includes new coverage: detached child terminated on a later reap pass).

---

Internal tracking: [CAS-374](https://paperclip.ing/CAS/issues/CAS-374)

Co-authored trail: implementation from Product Engineer run; PR opened from fork due to org direct-push 403.

Made with [Cursor](https://cursor.com)