### PR TITLE
fix(ui): render local filesystem paths as inline code, not broken app routes

### DIFF
--- a/ui/src/components/MarkdownBody.test.tsx
+++ b/ui/src/components/MarkdownBody.test.tsx
@@ -378,4 +378,38 @@ describe("MarkdownBody", () => {
     expect(html).toContain("paperclip-markdown-issue-ref");
     expect(html).not.toContain("paperclip-mention-chip--issue");
   });
+
+  describe("local filesystem paths", () => {
+    it("renders /home/... links as inline code, not anchor tags", () => {
+      const html = renderMarkdown(
+        "[draft file](/home/paperclip/projects/sdl-framework/draft.md)",
+      );
+
+      expect(html).toContain("<code");
+      expect(html).toContain("paperclip-local-path");
+      expect(html).toContain("draft file");
+      expect(html).not.toContain('<a href="/home/');
+    });
+
+    it("renders /etc/... links as inline code", () => {
+      const html = renderMarkdown("[config](/etc/nginx/nginx.conf)");
+
+      expect(html).toContain("<code");
+      expect(html).not.toContain('<a href="/etc/');
+    });
+
+    it("renders /var/... links as inline code", () => {
+      const html = renderMarkdown("[log](/var/log/app.log)");
+
+      expect(html).toContain("<code");
+      expect(html).not.toContain('<a href="/var/');
+    });
+
+    it("does not affect normal internal app routes", () => {
+      const html = renderMarkdown("[settings](/company/settings)");
+
+      expect(html).toContain('<a href="/company/settings"');
+      expect(html).not.toContain("paperclip-local-path");
+    });
+  });
 });

--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -133,6 +133,17 @@ function isExternalHttpUrl(href: string | null | undefined): boolean {
   }
 }
 
+/**
+ * Returns true for absolute Unix filesystem paths like /home/…, /etc/…, /var/…, etc.
+ * These cannot be opened by a browser as app routes and must not be rendered as
+ * clickable links — doing so causes the SPA router to misinterpret the path segment
+ * (e.g. "/home" → company prefix "HOME") and display a "Company not found" error.
+ */
+function isLocalFilesystemPath(href: string | null | undefined): boolean {
+  if (!href) return false;
+  return /^\/(?:home|etc|usr|var|tmp|root|opt|srv|mnt|proc|sys|dev|run)\//.test(href);
+}
+
 function renderLinkBody(
   children: ReactNode,
   leadingIcon: ReactNode,
@@ -329,6 +340,18 @@ export function MarkdownBody({
           </a>
         );
       }
+      if (isLocalFilesystemPath(href)) {
+        return (
+          <code
+            className="paperclip-local-path"
+            title="Local filesystem path (not openable in browser)"
+            style={mergeWrapStyle(linkStyle as React.CSSProperties | undefined)}
+          >
+            {linkChildren}
+          </code>
+        );
+      }
+
       const isGitHubLink = isGitHubUrl(href);
       const isExternal = isExternalHttpUrl(href);
       const leadingIcon = isGitHubLink ? (


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agent work and surfaces issue threads in a React SPA.
> - Issue comments are rendered as Markdown via `MarkdownBody.tsx`, which overrides the default `<a>` component in react-markdown.
> - Agents and humans sometimes write absolute filesystem paths (e.g. `/home/paperclip/projects/…`) as markdown links in comments to reference local files.
> - The SPA router receives those paths as navigation targets; it interprets the first path segment as a company prefix — `/home/…` → prefix `HOME` — and shows a "Company not found" / `No company matches prefix "HOME"` error.
> - This is a rendering bug: local filesystem paths cannot be opened by a browser and should never become clickable SPA routes.
> - This pull request adds `isLocalFilesystemPath()` and uses it in the `a` component handler to render matching paths as `<code>` instead of `<a>`.
> - The benefit is that paths remain visible and readable, without broken navigation or confusing error pages.

## What Changed

- **`ui/src/components/MarkdownBody.tsx`** — added `isLocalFilesystemPath(href)` helper that matches paths starting with `/home/`, `/etc/`, `/usr/`, `/var/`, `/tmp/`, `/root/`, `/opt/`, `/srv/`, `/mnt/`, `/proc/`, `/sys/`, `/dev/`, `/run/`. In the `a` component renderer, a matching href now returns `<code class="paperclip-local-path" title="Local filesystem path (not openable in browser)">…</code>` instead of an anchor.
- **`ui/src/components/MarkdownBody.test.tsx`** — added 4 test cases covering `/home/…`, `/etc/…`, `/var/…` links rendering as `<code>`, and confirming that normal internal app routes (e.g. `/company/settings`) are unaffected.

## Verification

```bash
pnpm vitest run ui/src/components/MarkdownBody.test.tsx
# All 33 tests pass (29 pre-existing + 4 new)
```

Manual: write a comment containing `[file](/home/paperclip/projects/foo/bar.md)` in any issue thread. Before this fix the link opens a "Company not found" error page; after the fix the path text is displayed as inline code with a tooltip.

## Risks

Low risk. The change only affects the markdown `<a>` renderer and only for hrefs matching the `isLocalFilesystemPath` regex. Existing internal app links, external HTTP/HTTPS links, mention chips, and issue reference links are all tested and unaffected. The regex is anchored and specific to well-known Unix root directories.

## Model Used

- Provider: Anthropic  
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)  
- Tool use enabled; extended context window  
- Ran via Paperclip CTO agent heartbeat

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge