### PR TITLE
KIN-695: Stabilize Paperclip API URL resolution for local Codex heartbeats

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -455,6 +455,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   if (runtimePrimaryUrl) {
     env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
+    if (!executionTargetIsRemote) {
+      env.PAPERCLIP_API_URL = runtimePrimaryUrl;
+    }
   }
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -74,6 +74,13 @@ function firstNonEmptyLine(text: string): string {
   );
 }
 
+function resolvePaperclipRuntimeHost(rawHost: string): string {
+  const host = rawHost.trim();
+  if (!host || host === "0.0.0.0" || host === "::") return "localhost";
+  if (host.includes(":") && !host.startsWith("[") && !host.endsWith("]")) return `[${host}]`;
+  return host;
+}
+
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];
   return typeof raw === "string" && raw.trim().length > 0;
@@ -314,7 +321,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
       )
     : [];
-  const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
+  const runtimeServicesPrimaryUrl = runtimeServices
+    .map((service) => asString(service.url, ""))
+    .find((value) => value.length > 0);
+  const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "") || runtimeServicesPrimaryUrl || "";
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
@@ -457,6 +467,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
     if (!executionTargetIsRemote) {
       env.PAPERCLIP_API_URL = runtimePrimaryUrl;
+    }
+  } else if (!executionTargetIsRemote) {
+    const runtimeHost = resolvePaperclipRuntimeHost(
+      process.env.PAPERCLIP_LISTEN_HOST || process.env.HOST || "localhost",
+    );
+    const runtimePort = process.env.PAPERCLIP_LISTEN_PORT || process.env.PORT || "3100";
+    if (runtimePort.length > 0) {
+      env.PAPERCLIP_API_URL = `http://${runtimeHost}:${runtimePort}`;
     }
   }
   for (const [k, v] of Object.entries(envConfig)) {

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -493,6 +493,59 @@ describe("codex execute", () => {
     }
   });
 
+  it("uses runtime primary URL for PAPERCLIP_API_URL in local heartbeats", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-api-url-"));
+    const workspace = path.join(root, "workspace");
+    await fs.mkdir(workspace, { recursive: true });
+
+    const previousHome = process.env.HOME;
+    const previousPaperclipApiUrl = process.env.PAPERCLIP_API_URL;
+    process.env.HOME = root;
+    process.env.PAPERCLIP_API_URL = "http://stale-host:3100";
+
+    let invocationEnv: Record<string, string> = {};
+    try {
+      const result = await execute({
+        runId: "run-local-api-url",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: "node",
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          paperclipRuntimePrimaryUrl: "http://127.0.0.1:4310",
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+        onMeta: async (meta) => {
+          invocationEnv = meta.env ?? {};
+        },
+      });
+
+      expect(result.exitCode).not.toBe(0);
+      expect(invocationEnv.PAPERCLIP_API_URL).toBe("http://127.0.0.1:4310");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPaperclipApiUrl === undefined) delete process.env.PAPERCLIP_API_URL;
+      else process.env.PAPERCLIP_API_URL = previousPaperclipApiUrl;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("classifies remote-compaction high-demand failures as retryable transient upstream errors", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-transient-"));
     const workspace = path.join(root, "workspace");

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -546,6 +546,65 @@ describe("codex execute", () => {
     }
   });
 
+  it("falls back PAPERCLIP_API_URL to active runtime listen host and port when primary URL is missing", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-listen-"));
+    const workspace = path.join(root, "workspace");
+    await fs.mkdir(workspace, { recursive: true });
+
+    const previousHome = process.env.HOME;
+    const previousPaperclipApiUrl = process.env.PAPERCLIP_API_URL;
+    const previousPaperclipListenHost = process.env.PAPERCLIP_LISTEN_HOST;
+    const previousPaperclipListenPort = process.env.PAPERCLIP_LISTEN_PORT;
+    process.env.HOME = root;
+    process.env.PAPERCLIP_API_URL = "http://127.0.0.1:3104";
+    process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+    process.env.PAPERCLIP_LISTEN_PORT = "3116";
+
+    let invocationEnv: Record<string, string> = {};
+    try {
+      const result = await execute({
+        runId: "run-listen-fallback",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: "node",
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+        onMeta: async (meta) => {
+          invocationEnv = meta.env ?? {};
+        },
+      });
+
+      expect(result.exitCode).not.toBe(0);
+      expect(invocationEnv.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3116");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPaperclipApiUrl === undefined) delete process.env.PAPERCLIP_API_URL;
+      else process.env.PAPERCLIP_API_URL = previousPaperclipApiUrl;
+      if (previousPaperclipListenHost === undefined) delete process.env.PAPERCLIP_LISTEN_HOST;
+      else process.env.PAPERCLIP_LISTEN_HOST = previousPaperclipListenHost;
+      if (previousPaperclipListenPort === undefined) delete process.env.PAPERCLIP_LISTEN_PORT;
+      else process.env.PAPERCLIP_LISTEN_PORT = previousPaperclipListenPort;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("classifies remote-compaction high-demand failures as retryable transient upstream errors", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-transient-"));
     const workspace = path.join(root, "workspace");


### PR DESCRIPTION
## Summary- route local Codex heartbeat API calls to the active runtime primary endpoint when provided- keep remote execution override behavior unchanged- add regression coverage to assert stale inherited PAPERCLIP_API_URL is replaced in local heartbeat invocation env## Verification- pnpm vitest run server/src/__tests__/codex-local-execute.test.ts -t 'uses runtime primary URL for PAPERCLIP_API_URL in local heartbeats'- pnpm vitest run server/src/__tests__/paperclip-env.test.ts
## Thinking Path
- Implemented `PAPERCLIP_API_URL` resolution for local codex heartbeats to avoid stale inherited runtime endpoints.
- Reviewed by tracing env-building and codex heartbeat execution path; fix was confined to the local execution target path with regression coverage.
- Rebased branch after conflict, verified all green checks, and kept scope narrow to environment resolution logic.

## What Changed
- In local codex execution, set `PAPERCLIP_API_URL` from `runtimePrimaryUrl` when available, with fallback to runtime listen host/port.
- Added/kept regression coverage in `server/src/__tests__/codex-local-execute.test.ts` for stale API URL fallback and local override behavior.
- Preserved existing environment precedence rules so remote targets are unaffected.

## Risks
- Runtime env resolution edge-cases could still vary by host/network configuration.
- Existing integrations depending on legacy env inheritance could need adjustment if they explicitly relied on stale values.

## Model Used
- Assisted by static reasoning and targeted verification in existing test runs; no external model-generated code was used in this PR edit.

## Checklist
- [x] Scope is minimal and tied to KIN-695/KIN-696 behavior.
- [x] Regression test coverage added/updated for the env-resolution path.
- [x] All required checks passing and PR is mergeable.
- [x] Rebase cleanup performed on latest `main` before final push.