### PR TITLE
fix(server): redact passwords and secrets in HTTP error logs

### DIFF
--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -27,9 +27,77 @@ const sharedOpts = {
   singleLine: true,
 };
 
+// Field-level redaction. Applied by pino at serialization time so any structured
+// log entry that surfaces these keys (req body, custom props, error contexts)
+// gets scrubbed regardless of which middleware attached them.
+//
+// `*` is a single-segment wildcard in pino redact paths, so for nested objects
+// we have to enumerate the parent keys we actually emit (`reqBody`,
+// `errorContext`, `req.body`).
+const SENSITIVE_KEYS = [
+  "password",
+  "newPassword",
+  "currentPassword",
+  "passwordConfirmation",
+  "token",
+  "accessToken",
+  "refreshToken",
+  "idToken",
+  "apiKey",
+  "secret",
+  "clientSecret",
+  "privateKey",
+];
+
+const REDACT_PATHS = [
+  "req.headers.authorization",
+  "req.headers.cookie",
+  'req.headers["x-api-key"]',
+  'req.headers["proxy-authorization"]',
+  ...SENSITIVE_KEYS.flatMap((key) => [
+    `req.body.${key}`,
+    `reqBody.${key}`,
+    `errorContext.${key}`,
+    `*.${key}`,
+  ]),
+];
+
+const REDACTED = "[REDACTED]";
+
+// Defensive sanitizer applied before we hand a body to pino. Pino's redact paths
+// already cover the structured log path, but we shallow-clone here too so we
+// never mutate the live `req.body` and so deeply-nested or untyped shapes still
+// get scrubbed.
+function sanitizeForLog<T>(value: T, depth = 0): T {
+  if (depth > 4 || value == null) return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeForLog(item, depth + 1)) as unknown as T;
+  }
+  if (typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    if (SENSITIVE_KEYS.includes(key)) {
+      out[key] = REDACTED;
+      continue;
+    }
+    out[key] = sanitizeForLog(val, depth + 1);
+  }
+  return out as unknown as T;
+}
+
+// Auth endpoints accept credentials in the body. Even with field-level redaction
+// we don't want to log the body shape at all - log only the route + status.
+function isAuthPath(url: string | undefined): boolean {
+  if (!url) return false;
+  return url.startsWith("/api/auth/") || url.startsWith("/auth/");
+}
+
 export const logger = pino({
   level: "debug",
-  redact: ["req.headers.authorization"],
+  redact: {
+    paths: REDACT_PATHS,
+    censor: REDACTED,
+  },
 }, pino.transport({
   targets: [
     {
@@ -65,19 +133,25 @@ export const httpLogger = pinoHttp({
   },
   customProps(req, res) {
     if (res.statusCode >= 400) {
+      const onAuthPath = isAuthPath((req as any).url);
       const ctx = (res as any).__errorContext;
       if (ctx) {
         return {
-          errorContext: ctx.error,
-          reqBody: ctx.reqBody,
+          errorContext: sanitizeForLog(ctx.error),
+          reqBody: onAuthPath ? undefined : sanitizeForLog(ctx.reqBody),
           reqParams: ctx.reqParams,
           reqQuery: ctx.reqQuery,
         };
       }
       const props: Record<string, unknown> = {};
       const { body, params, query } = req as any;
-      if (body && typeof body === "object" && Object.keys(body).length > 0) {
-        props.reqBody = body;
+      if (
+        !onAuthPath &&
+        body &&
+        typeof body === "object" &&
+        Object.keys(body).length > 0
+      ) {
+        props.reqBody = sanitizeForLog(body);
       }
       if (params && typeof params === "object" && Object.keys(params).length > 0) {
         props.reqParams = params;


### PR DESCRIPTION
## Summary

Fixes #4759.

The HTTP logger writes the entire request body to logs on every 4xx/5xx response. Pino's redact list only covers `req.headers.authorization`, so **plaintext passwords (and any other secret-bearing body fields) get written to stdout and `server.log` on every failed login** - i.e. on a routine event, not just an attack scenario.

Reproduced on `v2026.428.0`:

```
WARN: POST /api/auth/sign-in/email 401 {"reqBody":{"email":"user@example.com","password":"<plaintext>"},"reqParams":{"authPath":["sign-in","email"]},"routePath":"/api/auth/{*authPath}"}
```

## Fix

Three layers, in order from cheapest to most defensive:

1. **Pino field-level redaction.** Enumerate sensitive keys (`password`, `newPassword`, `currentPassword`, `passwordConfirmation`, `token`, `accessToken`, `refreshToken`, `idToken`, `apiKey`, `secret`, `clientSecret`, `privateKey`) and add them to `redact.paths`, scoped to `req.body.*`, `reqBody.*`, and `errorContext.*`. Catches anything that lands in a structured log entry, regardless of which middleware attached it.

2. **Defensive sanitizer in `customProps`.** Shallow-clones the body to depth 4 and replaces sensitive keys with `[REDACTED]` before pino sees it. Belt-and-suspenders: if a future code path adds a new property name that pino's enumerated paths don't catch, the sanitizer still scrubs it.

3. **Skip body logging on `/api/auth/*` entirely.** The auth surface should never echo user input back into logs - route + status is enough to debug failed signins. Both the `__errorContext` path and the fallback path respect this.

Headers `cookie`, `x-api-key`, and `proxy-authorization` are also added to the redact list while we're here.

## Why both pino redact AND the sanitizer?

- Pino redact runs at serialization time on the full log object - covers the structured shape we know we emit.
- The sanitizer runs eagerly on the body we pass in - covers nested/dynamic shapes pino's path patterns can't easily reach (pino's `*` wildcard is single-segment, so deep nesting needs explicit paths).

Removing either one would leak under specific shapes; keeping both makes the fix shape-agnostic.

## Test plan

Manual repro before/after:

```bash
# Before
curl -X POST -H 'content-type: application/json' \
  -d '{"email":"a@b.com","password":"hunter2"}' \
  http://localhost:3100/api/auth/sign-in/email
# server.log: ... "reqBody":{"email":"a@b.com","password":"hunter2"} ...

# After
curl -X POST -H 'content-type: application/json' \
  -d '{"email":"a@b.com","password":"hunter2"}' \
  http://localhost:3100/api/auth/sign-in/email
# server.log: POST /api/auth/sign-in/email 401  (no body, no password)
```

Also verified non-auth 4xx still logs `reqBody` with sensitive keys redacted:

```bash
curl -X POST -H 'content-type: application/json' \
  -d '{"name":"foo","apiKey":"sk-secret"}' \
  http://localhost:3100/api/some/endpoint
# server.log: ... "reqBody":{"name":"foo","apiKey":"[REDACTED]"} ...
```

## Notes for reviewers

- I left existing `reqBody` logging on **non-auth** error paths intact because debugging validation errors against malformed payloads is genuinely useful - the redaction list should make that safe. Happy to flip it to opt-in (env var) if maintainers prefer.
- The sensitive-key list is conservative. If the codebase has other internal field names worth scrubbing (e.g. `connectionString`, `dsn`, plugin-specific creds), I'm glad to extend it.
- Marked **draft** because there's a follow-up question worth confirming: should we also rotate any logs that may already have leaked credentials? That's an operational note for self-hosters more than a code change.

## Severity (per #4759)

High - passive plaintext credential leak triggered by routine user input, persisted to disk, and visible to anyone with log access (kubectl, log shippers, observability stacks).