### PR TITLE
Fix openclaw gateway paperclip payload routing

### DIFF
--- a/packages/adapters/openclaw-gateway/CHANGELOG.md
+++ b/packages/adapters/openclaw-gateway/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paperclipai/adapter-openclaw-gateway
 
+## 0.3.2
+
+### Patch Changes
+
+- Avoid sending a root-level `paperclip` field to OpenClaw gateway agents; standardized Paperclip context is now embedded into the outbound message body for compatibility with strict gateway schemas.
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -43,10 +43,8 @@ Session routing fields:
 - sessionKey (string, optional): fixed session key when strategy=fixed (default paperclip)
 
 Standard outbound payload additions:
-- paperclip (object): standardized Paperclip context added to every gateway agent request
-- paperclip.workspace (object, optional): resolved execution workspace for this run
-- paperclip.workspaces (array, optional): additional workspace hints Paperclip exposed to the run
-- paperclip.workspaceRuntime (object, optional): reserved workspace runtime metadata when explicitly supplied outside normal heartbeat execution
+- message always includes a "Paperclip Context" JSON block with standardized Paperclip run metadata
+- that context may include workspace, workspaces, and workspaceRuntime details when Paperclip exposes them for the run
 
 Standard result metadata supported:
 - meta.runtimeServices (array, optional): normalized adapter-managed runtime service reports

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -452,6 +452,16 @@ function appendWakeText(baseText: string, wakeText: string): string {
   return trimmedBase.length > 0 ? `${trimmedBase}\n\n${wakeText}` : wakeText;
 }
 
+function appendPaperclipContext(baseText: string, paperclipPayload: Record<string, unknown>): string {
+  const contextText = [
+    "## Paperclip Context",
+    "```json",
+    JSON.stringify(paperclipPayload, null, 2),
+    "```",
+  ].join("\n");
+  return appendWakeText(baseText, contextText);
+}
+
 function joinWakePayloadSections(structuredWakePrompt: string, structuredWakeJson: string): string {
   const sections = [
     structuredWakePrompt.trim(),
@@ -1126,8 +1136,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
-  const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
   const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
+  const wakeMessage = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
+  const message = appendPaperclipContext(wakeMessage, paperclipPayload);
 
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
@@ -1136,7 +1147,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -28,6 +28,13 @@ async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
   await db?.$client?.end?.({ timeout: 0 });
 }
 
+function extractPaperclipContext(message: unknown): Record<string, unknown> {
+  const text = typeof message === "string" ? message : "";
+  const match = text.match(/## Paperclip Context\n```json\n([\s\S]+?)\n```/);
+  expect(match?.[1]).toBeTruthy();
+  return JSON.parse(match![1]) as Record<string, unknown>;
+}
+
 async function createControlledGatewayServer() {
   const server = createServer();
   const wss = new WebSocketServer({ server });
@@ -447,7 +454,7 @@ describe("heartbeat comment wake batching", () => {
       }, 90_000);
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
+      expect(extractPaperclipContext(secondPayload.message)).toMatchObject({
         wake: {
           commentIds: [comment2.id, comment3.id],
           latestCommentId: comment3.id,
@@ -570,7 +577,7 @@ describe("heartbeat comment wake batching", () => {
 
       await waitFor(() => gateway.getAgentPayloads().length === 2);
       const promotedPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(promotedPayload.paperclip).toMatchObject({
+      expect(extractPaperclipContext(promotedPayload.message)).toMatchObject({
         wake: {
           commentIds: [queuedComment.id],
           latestCommentId: queuedComment.id,
@@ -765,7 +772,7 @@ describe("heartbeat comment wake batching", () => {
       });
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
+      expect(extractPaperclipContext(secondPayload.message)).toMatchObject({
         wake: {
           reason: "issue_commented",
           commentIds: [comment2.id],
@@ -965,7 +972,7 @@ describe("heartbeat comment wake batching", () => {
       expect(issueAfterPromotion?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
+      expect(extractPaperclipContext(secondPayload.message)).toMatchObject({
         wake: {
           reason: "issue_comment_mentioned",
           commentIds: [comment.id],
@@ -1051,7 +1058,7 @@ describe("heartbeat comment wake batching", () => {
       expect(firstRun).not.toBeNull();
       await waitFor(() => gateway.getAgentPayloads().length === 1);
       const firstPayload = gateway.getAgentPayloads()[0] ?? {};
-      expect(firstPayload.paperclip).toMatchObject({
+      expect(extractPaperclipContext(firstPayload.message)).toMatchObject({
         wake: {
           reason: "issue_assigned",
           issue: {

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -501,13 +501,11 @@ describe("openclaw gateway adapter execute", () => {
         "Do not switch to another issue until you have handled this wake.",
       );
       expect(String(payload?.message ?? "")).toContain("First comment");
+      expect(String(payload?.message ?? "")).toContain("## Paperclip Context");
+      expect(String(payload?.message ?? "")).toContain("\"runId\": \"run-123\"");
+      expect(String(payload?.message ?? "")).toContain("\"latestCommentId\": \"comment-2\"");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
-      expect(payload?.paperclip).toMatchObject({
-        wake: {
-          latestCommentId: "comment-2",
-          commentIds: ["comment-1", "comment-2"],
-        },
-      });
+      expect(payload).not.toHaveProperty("paperclip");
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
     } finally {


### PR DESCRIPTION
## Summary
- stop sending a root-level `paperclip` field in openclaw gateway agent params
- append standardized Paperclip context to the outbound message body instead
- update adapter docs/changelog and cover the new payload shape in the gateway adapter test

## Testing
- pnpm run preflight:workspace-links
- pnpm vitest run server/src/__tests__/openclaw-gateway-adapter.test.ts

## Notes
- `packages/adapters/openclaw-gateway/src/server/execute.test.ts` is not included in the current Vitest workspace config, so the direct path run reports "No test files found"