### PR TITLE
fix(server): redact adapter_config secrets in agent detail responses

### DIFF
--- a/server/src/__tests__/agent-detail-secret-redaction.test.ts
+++ b/server/src/__tests__/agent-detail-secret-redaction.test.ts
@@ -1,0 +1,359 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const agentId = "11111111-1111-4111-8111-111111111111";
+const companyId = "22222222-2222-4222-8222-222222222222";
+
+const SECRET_DEVICE_KEY =
+  "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIMzFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEF\n-----END PRIVATE KEY-----\n";
+const SECRET_DEVICE_TOKEN = "fake-device-token-43-char-fixture-FAKEFAKEFAKE";
+const SECRET_GATEWAY_TOKEN = "fake-gateway-token-64-char-fixture-FAKEFAKEFAKEFAKEFAKEFAKEFAK";
+const SECRET_SESSION_KEY = "fake-session-key-fixture";
+const SECRET_ENV_API_KEY = "sk-fake-env-api-key-fixture-not-real";
+
+const baseAgent = {
+  id: agentId,
+  companyId,
+  name: "Builder",
+  urlKey: "builder",
+  role: "engineer",
+  title: "Builder",
+  icon: null,
+  status: "idle",
+  reportsTo: null,
+  capabilities: null,
+  adapterType: "openclaw_gateway",
+  adapterConfig: {
+    url: "ws://example.invalid:18789/",
+    deviceFamily: "linux",
+    scopes: ["operator.read", "operator.write"],
+    paperclipApiUrl: "http://api.example.invalid:3100",
+    waitTimeoutMs: 120000,
+    headers: { "x-openclaw-token": SECRET_GATEWAY_TOKEN },
+    devicePrivateKeyPem: SECRET_DEVICE_KEY,
+    deviceToken: SECRET_DEVICE_TOKEN,
+    sessionKey: SECRET_SESSION_KEY,
+    env: { SAMPLE_API_KEY: SECRET_ENV_API_KEY },
+  },
+  runtimeConfig: {},
+  budgetMonthlyCents: 0,
+  spentMonthlyCents: 0,
+  pauseReason: null,
+  pausedAt: null,
+  permissions: { canCreateAgents: false },
+  lastHeartbeatAt: null,
+  metadata: null,
+  createdAt: new Date("2026-04-29T00:00:00.000Z"),
+  updatedAt: new Date("2026-04-29T00:00:00.000Z"),
+};
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  list: vi.fn(),
+  create: vi.fn(),
+  activatePendingApproval: vi.fn(),
+  update: vi.fn(),
+  updatePermissions: vi.fn(),
+  getChainOfCommand: vi.fn(),
+  resolveByReference: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+  getMembership: vi.fn(),
+  ensureMembership: vi.fn(),
+  listPrincipalGrants: vi.fn(),
+  setPrincipalPermission: vi.fn(),
+}));
+
+const mockApprovalService = vi.hoisted(() => ({ create: vi.fn(), getById: vi.fn() }));
+const mockBudgetService = vi.hoisted(() => ({ upsertPolicy: vi.fn() }));
+const mockHeartbeatService = vi.hoisted(() => ({
+  listTaskSessions: vi.fn(),
+  resetRuntimeSession: vi.fn(),
+  getRun: vi.fn(),
+  cancelRun: vi.fn(),
+}));
+const mockIssueApprovalService = vi.hoisted(() => ({ linkManyForApproval: vi.fn() }));
+const mockIssueService = vi.hoisted(() => ({ list: vi.fn() }));
+const mockSecretService = vi.hoisted(() => ({
+  normalizeAdapterConfigForPersistence: vi.fn(),
+  resolveAdapterConfigForRuntime: vi.fn(),
+}));
+const mockAgentInstructionsService = vi.hoisted(() => ({ materializeManagedBundle: vi.fn() }));
+const mockCompanySkillService = vi.hoisted(() => ({
+  listRuntimeSkillEntries: vi.fn(),
+  resolveRequestedSkillKeys: vi.fn(),
+}));
+const mockWorkspaceOperationService = vi.hoisted(() => ({}));
+const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockTrackAgentCreated = vi.hoisted(() => vi.fn());
+const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
+const mockSyncInstructionsBundleConfigFromFilePath = vi.hoisted(() => vi.fn());
+const mockEnsureOpenCodeModelConfiguredAndAvailable = vi.hoisted(() => vi.fn());
+const mockEnvironmentService = vi.hoisted(() => ({ getById: vi.fn() }));
+const mockInstanceSettingsService = vi.hoisted(() => ({ getGeneral: vi.fn() }));
+
+function registerModuleMocks() {
+  vi.doMock("@paperclipai/adapter-opencode-local/server", async () => {
+    const actual = await vi.importActual<typeof import("@paperclipai/adapter-opencode-local/server")>(
+      "@paperclipai/adapter-opencode-local/server",
+    );
+    return { ...actual, ensureOpenCodeModelConfiguredAndAvailable: mockEnsureOpenCodeModelConfiguredAndAvailable };
+  });
+  vi.doMock("@paperclipai/shared/telemetry", () => ({
+    trackAgentCreated: mockTrackAgentCreated,
+    trackErrorHandlerCrash: vi.fn(),
+  }));
+  vi.doMock("../telemetry.js", () => ({ getTelemetryClient: mockGetTelemetryClient }));
+  vi.doMock("../services/agents.js", () => ({ agentService: () => mockAgentService }));
+  vi.doMock("../services/access.js", () => ({ accessService: () => mockAccessService }));
+  vi.doMock("../services/approvals.js", () => ({ approvalService: () => mockApprovalService }));
+  vi.doMock("../services/company-skills.js", () => ({ companySkillService: () => mockCompanySkillService }));
+  vi.doMock("../services/budgets.js", () => ({ budgetService: () => mockBudgetService }));
+  vi.doMock("../services/heartbeat.js", () => ({ heartbeatService: () => mockHeartbeatService }));
+  vi.doMock("../services/issue-approvals.js", () => ({ issueApprovalService: () => mockIssueApprovalService }));
+  vi.doMock("../services/issues.js", () => ({ issueService: () => mockIssueService }));
+  vi.doMock("../services/secrets.js", () => ({ secretService: () => mockSecretService }));
+  vi.doMock("../services/environments.js", () => ({ environmentService: () => mockEnvironmentService }));
+  vi.doMock("../services/agent-instructions.js", () => ({
+    agentInstructionsService: () => mockAgentInstructionsService,
+    syncInstructionsBundleConfigFromFilePath: mockSyncInstructionsBundleConfigFromFilePath,
+  }));
+  vi.doMock("../services/workspace-operations.js", () => ({
+    workspaceOperationService: () => mockWorkspaceOperationService,
+  }));
+  vi.doMock("../services/activity-log.js", () => ({ logActivity: mockLogActivity }));
+  vi.doMock("../services/instance-settings.js", () => ({
+    instanceSettingsService: () => mockInstanceSettingsService,
+  }));
+  vi.doMock("../services/index.js", () => ({
+    agentService: () => mockAgentService,
+    agentInstructionsService: () => mockAgentInstructionsService,
+    accessService: () => mockAccessService,
+    approvalService: () => mockApprovalService,
+    companySkillService: () => mockCompanySkillService,
+    budgetService: () => mockBudgetService,
+    heartbeatService: () => mockHeartbeatService,
+    ISSUE_LIST_DEFAULT_LIMIT: 500,
+    issueApprovalService: () => mockIssueApprovalService,
+    issueService: () => mockIssueService,
+    logActivity: mockLogActivity,
+    secretService: () => mockSecretService,
+    syncInstructionsBundleConfigFromFilePath: mockSyncInstructionsBundleConfigFromFilePath,
+    workspaceOperationService: () => mockWorkspaceOperationService,
+    environmentService: () => mockEnvironmentService,
+  }));
+}
+
+function createDbStub() {
+  return {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          then: vi.fn((resolve) =>
+            Promise.resolve(
+              resolve([{ id: companyId, name: "Paperclip", requireBoardApprovalForNewAgents: false }]),
+            ),
+          ),
+        }),
+      }),
+    }),
+  };
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ errorHandler }, { agentRoutes }] = await Promise.all([
+    import("../middleware/index.js") as Promise<typeof import("../middleware/index.js")>,
+    import("../routes/agents.js") as Promise<typeof import("../routes/agents.js")>,
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      ...actor,
+      companyIds: Array.isArray(actor.companyIds) ? [...actor.companyIds] : actor.companyIds,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes(createDbStub() as any));
+  app.use(errorHandler);
+  return app;
+}
+
+async function requestApp(
+  app: express.Express,
+  buildRequest: (baseUrl: string) => request.Test,
+) {
+  const { createServer } = await vi.importActual<typeof import("node:http")>("node:http");
+  const server = createServer(app);
+  try {
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected HTTP server to listen on a TCP port");
+    }
+    return await buildRequest(`http://127.0.0.1:${address.port}`);
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    }
+  }
+}
+
+describe.sequential("agent detail secret redaction", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@paperclipai/shared/telemetry");
+    vi.doUnmock("../telemetry.js");
+    vi.doUnmock("../services/access.js");
+    vi.doUnmock("../services/activity-log.js");
+    vi.doUnmock("../services/agent-instructions.js");
+    vi.doUnmock("../services/agents.js");
+    vi.doUnmock("../services/approvals.js");
+    vi.doUnmock("../services/budgets.js");
+    vi.doUnmock("../services/company-skills.js");
+    vi.doUnmock("../services/heartbeat.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../services/instance-settings.js");
+    vi.doUnmock("../services/issue-approvals.js");
+    vi.doUnmock("../services/issues.js");
+    vi.doUnmock("../services/secrets.js");
+    vi.doUnmock("../services/environments.js");
+    vi.doUnmock("../services/workspace-operations.js");
+    vi.doUnmock("../adapters/index.js");
+    vi.doUnmock("../routes/agents.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.doUnmock("@paperclipai/adapter-opencode-local/server");
+    registerModuleMocks();
+    vi.resetAllMocks();
+    mockSyncInstructionsBundleConfigFromFilePath.mockImplementation((_agent, config) => config);
+    mockGetTelemetryClient.mockReturnValue({ track: vi.fn() });
+    mockAgentService.getById.mockResolvedValue(baseAgent);
+    mockAgentService.list.mockResolvedValue([baseAgent]);
+    mockAgentService.getChainOfCommand.mockResolvedValue([]);
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAccessService.getMembership.mockResolvedValue({
+      id: "membership-1",
+      companyId,
+      principalType: "agent",
+      principalId: agentId,
+      role: "member",
+      status: "active",
+    });
+    mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+    mockInstanceSettingsService.getGeneral.mockResolvedValue({ censorUsernameInLogs: false });
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  function assertNoSecretLeaks(body: unknown) {
+    const text = JSON.stringify(body);
+    expect(text).not.toContain(SECRET_DEVICE_KEY);
+    expect(text).not.toContain(SECRET_DEVICE_TOKEN);
+    expect(text).not.toContain(SECRET_GATEWAY_TOKEN);
+    expect(text).not.toContain(SECRET_SESSION_KEY);
+    expect(text).not.toContain(SECRET_ENV_API_KEY);
+  }
+
+  it("GET /api/agents/me omits adapterConfig secrets, preserves non-secret fields, includes builder shape", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get("/api/agents/me"));
+
+    expect(res.status).toBe(200);
+
+    expect(res.body.adapterConfig).toBeDefined();
+    expect(res.body.adapterConfig.devicePrivateKeyPem).toBeUndefined();
+    expect(res.body.adapterConfig.deviceToken).toBeUndefined();
+    expect(res.body.adapterConfig.headers).toBeUndefined();
+    expect(res.body.adapterConfig.sessionKey).toBeUndefined();
+
+    expect(res.body.adapterConfig.url).toBe("ws://example.invalid:18789/");
+    expect(res.body.adapterConfig.deviceFamily).toBe("linux");
+    expect(res.body.adapterConfig.scopes).toEqual(["operator.read", "operator.write"]);
+    expect(res.body.adapterConfig.paperclipApiUrl).toBe("http://api.example.invalid:3100");
+    expect(res.body.adapterConfig.waitTimeoutMs).toBe(120000);
+
+    expect(res.body.adapterConfig.env).toBeDefined();
+    expect(res.body.adapterConfig.env.SAMPLE_API_KEY).toBe("***REDACTED***");
+
+    expect(res.body.id).toBe(agentId);
+    expect(res.body.role).toBe("engineer");
+    expect(res.body.chainOfCommand).toBeDefined();
+    expect(res.body.access).toBeDefined();
+
+    assertNoSecretLeaks(res.body);
+  });
+
+  it("GET /api/agents/:id self path omits adapterConfig secrets", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
+
+    expect(res.status).toBe(200);
+    expect(res.body.adapterConfig.devicePrivateKeyPem).toBeUndefined();
+    expect(res.body.adapterConfig.deviceToken).toBeUndefined();
+    expect(res.body.adapterConfig.headers).toBeUndefined();
+    expect(res.body.adapterConfig.sessionKey).toBeUndefined();
+    expect(res.body.adapterConfig.url).toBe("ws://example.invalid:18789/");
+    expect(res.body.chainOfCommand).toBeDefined();
+
+    assertNoSecretLeaks(res.body);
+  });
+
+  it("GET /api/companies/:companyId/agents admin path omits adapterConfig secrets in each list entry", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "instance-admin",
+      source: "local_implicit",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/companies/${companyId}/agents`),
+    );
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(1);
+
+    const [first] = res.body;
+    expect(first.adapterConfig).toBeDefined();
+    expect(first.adapterConfig.devicePrivateKeyPem).toBeUndefined();
+    expect(first.adapterConfig.deviceToken).toBeUndefined();
+    expect(first.adapterConfig.headers).toBeUndefined();
+    expect(first.adapterConfig.sessionKey).toBeUndefined();
+    expect(first.adapterConfig.url).toBe("ws://example.invalid:18789/");
+    expect(first.adapterConfig.env).toBeDefined();
+    expect(first.adapterConfig.env.SAMPLE_API_KEY).toBe("***REDACTED***");
+
+    expect(first.chainOfCommand).toBeUndefined();
+    expect(first.access).toBeUndefined();
+
+    assertNoSecretLeaks(res.body);
+  });
+});

--- a/server/src/__tests__/agent-detail-secret-redaction.test.ts
+++ b/server/src/__tests__/agent-detail-secret-redaction.test.ts
@@ -356,4 +356,37 @@ describe.sequential("agent detail secret redaction", () => {
 
     assertNoSecretLeaks(res.body);
   });
+
+  it("PATCH /api/agents/:id/permissions response omits adapterConfig secrets", async () => {
+    mockAgentService.updatePermissions.mockResolvedValue(baseAgent);
+
+    const app = await createApp({
+      type: "board",
+      userId: "instance-admin",
+      source: "local_implicit",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .patch(`/api/agents/${agentId}/permissions`)
+        .send({ canCreateAgents: false, canAssignTasks: false }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.adapterConfig).toBeDefined();
+    expect(res.body.adapterConfig.devicePrivateKeyPem).toBeUndefined();
+    expect(res.body.adapterConfig.deviceToken).toBeUndefined();
+    expect(res.body.adapterConfig.headers).toBeUndefined();
+    expect(res.body.adapterConfig.sessionKey).toBeUndefined();
+    expect(res.body.adapterConfig.url).toBe("ws://example.invalid:18789/");
+    expect(res.body.adapterConfig.env).toBeDefined();
+    expect(res.body.adapterConfig.env.SAMPLE_API_KEY).toBe("***REDACTED***");
+
+    expect(res.body.chainOfCommand).toBeDefined();
+    expect(res.body.access).toBeDefined();
+
+    assertNoSecretLeaks(res.body);
+  });
 });

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -78,3 +78,25 @@ export function redactSensitiveText(input: string): string {
     .replace(GITHUB_TOKEN_TEXT_RE, REDACTED_EVENT_VALUE)
     .replace(JWT_TEXT_RE, REDACTED_EVENT_VALUE);
 }
+
+// Top-level adapterConfig keys whose mere presence in API responses constitutes
+// a leak: their values are bearer credentials or signing material that the
+// redactEventPayload key-name regex above does not catch (e.g. "deviceToken"
+// has no separator between "device" and "token", and "headers" is a generic
+// container whose composition varies by adapter type).
+export const OMITTED_ADAPTER_CONFIG_KEYS: readonly string[] = [
+  "devicePrivateKeyPem",
+  "deviceToken",
+  "headers",
+  "sessionKey",
+];
+
+export function omitAdapterConfigSecrets(adapterConfig: unknown): unknown {
+  if (!isPlainObject(adapterConfig)) return adapterConfig ?? {};
+  const stripped: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(adapterConfig)) {
+    if (OMITTED_ADAPTER_CONFIG_KEYS.includes(key)) continue;
+    stripped[key] = value;
+  }
+  return redactEventPayload(stripped) ?? stripped;
+}

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -80,10 +80,19 @@ export function redactSensitiveText(input: string): string {
 }
 
 // Top-level adapterConfig keys whose mere presence in API responses constitutes
-// a leak: their values are bearer credentials or signing material that the
-// redactEventPayload key-name regex above does not catch (e.g. "deviceToken"
-// has no separator between "device" and "token", and "headers" is a generic
-// container whose composition varies by adapter type).
+// a leak: their values are bearer credentials or signing material.
+//
+// devicePrivateKeyPem IS caught by SECRET_PAYLOAD_KEY_RE above (the
+// private[-_]?key alternative) and is listed here for defence-in-depth and to
+// keep all OpenClaw adapter secret fields under a single uniform omit-list
+// shape.
+//
+// deviceToken (no separator between "device" and "token"), headers (generic
+// container whose composition varies by adapter type), and sessionKey (not
+// matched by any current regex alternative) are genuine SECRET_PAYLOAD_KEY_RE
+// coverage gaps. Closing those gaps in the regex itself is banked as future
+// work in the broader API-redaction sweep; this primitive is the targeted
+// fix scoped to this leak class.
 export const OMITTED_ADAPTER_CONFIG_KEYS: readonly string[] = [
   "devicePrivateKeyPem",
   "deviceToken",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -248,16 +248,8 @@ export function agentRoutes(
   async function buildSafeAgentDetail(
     agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>,
   ) {
-    const [chainOfCommand, accessState] = await Promise.all([
-      svc.getChainOfCommand(agent.id),
-      buildAgentAccessState(agent),
-    ]);
-
-    return {
-      ...withSafeAdapterConfig(agent),
-      chainOfCommand,
-      access: accessState,
-    };
+    const detail = await buildAgentDetail(agent);
+    return withSafeAdapterConfig(detail);
   }
 
   async function applyDefaultAgentTaskAssignGrant(

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -63,7 +63,7 @@ import {
   refreshAdapterModels,
   requireServerAdapter,
 } from "../adapters/index.js";
-import { redactEventPayload } from "../redaction.js";
+import { omitAdapterConfigSecrets, redactEventPayload } from "../redaction.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
@@ -233,6 +233,28 @@ export function agentRoutes(
 
     return {
       ...(options?.restricted ? redactForRestrictedAgentView(agent) : agent),
+      chainOfCommand,
+      access: accessState,
+    };
+  }
+
+  function withSafeAdapterConfig<T extends { adapterConfig: unknown }>(agent: T): T {
+    return {
+      ...agent,
+      adapterConfig: omitAdapterConfigSecrets(agent.adapterConfig),
+    };
+  }
+
+  async function buildSafeAgentDetail(
+    agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>,
+  ) {
+    const [chainOfCommand, accessState] = await Promise.all([
+      svc.getChainOfCommand(agent.id),
+      buildAgentAccessState(agent),
+    ]);
+
+    return {
+      ...withSafeAdapterConfig(agent),
       chainOfCommand,
       access: accessState,
     };
@@ -1145,7 +1167,7 @@ export function agentRoutes(
     const result = await svc.list(companyId);
     const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
     if (canReadConfigs) {
-      res.json(result);
+      res.json(result.map(withSafeAdapterConfig));
       return;
     }
     res.json(result.map((agent) => redactForRestrictedAgentView(agent)));
@@ -1263,7 +1285,7 @@ export function agentRoutes(
       res.status(404).json({ error: "Agent not found" });
       return;
     }
-    res.json(await buildAgentDetail(agent));
+    res.json(await buildSafeAgentDetail(agent));
   });
 
   router.get("/agents/me/inbox-lite", async (req, res) => {
@@ -1337,7 +1359,7 @@ export function agentRoutes(
       res.json(await buildAgentDetail(agent, { restricted: true }));
       return;
     }
-    res.json(await buildAgentDetail(agent));
+    res.json(await buildSafeAgentDetail(agent));
   });
 
   router.get("/agents/:id/configuration", async (req, res) => {
@@ -1830,7 +1852,7 @@ export function agentRoutes(
       },
     });
 
-    res.json(await buildAgentDetail(agent));
+    res.json(await buildSafeAgentDetail(agent));
   });
 
   router.patch("/agents/:id/instructions-path", validate(updateAgentInstructionsPathSchema), async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -238,7 +238,7 @@ export function agentRoutes(
     };
   }
 
-  function withSafeAdapterConfig<T extends { adapterConfig: unknown }>(agent: T): T {
+  function withSafeAdapterConfig<T extends { adapterConfig?: unknown }>(agent: T): T {
     return {
       ...agent,
       adapterConfig: omitAdapterConfigSecrets(agent.adapterConfig),


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, with each agent storing its connection material (API keys, device tokens, gateway-header tokens, private keys) in a JSON `adapter_config` column on the `agents` table
> - Several authenticated HTTP endpoints serialise full agent rows for self-view, admin-view, and admin-list callers
> - While running an identity-discovery code path, an agent on a downstream deployment posted its own configuration verbatim into a public comment, exposing the secret-bearing fields in `adapterConfig` in plaintext
> - Investigation traced the leak to four endpoints (`GET /api/agents/me`, `GET /api/agents/:id` self/admin, `PATCH /api/agents/:id` permissions response, `GET /api/companies/:companyId/agents` admin) all calling unredacted detail builders, while sibling restricted-view endpoints already redacted via `redactForRestrictedAgentView` / `redactAgentConfiguration`
> - Existing redaction primitives have two coverage gaps for this fix: `redactEventPayload`'s key-name regex matches conventional secret naming but misses `deviceToken` (no separator) and arbitrary `headers` map keys like `x-openclaw-token`; and `redactForRestrictedAgentView` nukes `adapterConfig` entirely, which works for restricted viewers but breaks the `/me` heartbeat path agents call for runtime metadata
> - This pull request adds a shared `buildSafeAgentDetail()` builder backed by an `omitAdapterConfigSecrets()` primitive — explicit field-omit on secret-bearing top-level keys, then `redactEventPayload` pass for nested env-style secrets — wired into all four leaking endpoints
> - The benefit is defence-in-depth on a real leak class: the four endpoints now redact `adapterConfig` secrets across all auth tiers (self, admin, list) while preserving non-secret fields needed by the UI and by running agents on the heartbeat path

## What Changed

- New `omitAdapterConfigSecrets()` primitive in `server/src/redaction.ts` (explicit field-omit for OpenClaw secret keys: `devicePrivateKeyPem`, `deviceToken`, `headers`, `sessionKey`; followed by `redactEventPayload` pass for nested env-style secrets)
- New `withSafeAdapterConfig()` + `buildSafeAgentDetail()` helpers in `server/src/routes/agents.ts` (the latter delegates to the existing `buildAgentDetail()` then applies `withSafeAdapterConfig()` to the result)
- Four call sites updated to use the safe builder: `GET /api/agents/me`, `GET /api/agents/:id` self/admin path, `PATCH /api/agents/:id` permissions update response, `GET /api/companies/:companyId/agents` admin path
- New regression test file `server/src/__tests__/agent-detail-secret-redaction.test.ts` (4 tests, one per endpoint, asserting secret omission + non-secret preservation + nested-secret redaction + serialised-body fixture-secret absence)
- Inline comment on `OMITTED_ADAPTER_CONFIG_KEYS` narrowed to call out only the genuine `redactEventPayload` regex coverage gaps (`deviceToken`, `headers["x-openclaw-token"]`) — `devicePrivateKeyPem` IS caught by the existing `private[-_]?key` regex and the comment no longer overstates the gap

## Architectural pattern

The four endpoints listed above all return agent records produced by `agentService.list()` or `agentService.getById()`. Existing redaction infrastructure (`redactForRestrictedAgentView`, `redactAgentConfiguration`, `redactEventPayload`) is wired into a subset of routes — but only on the *non-admin / non-self* paths. Authorised callers (admins, agent self-view) currently bypass redaction and receive the full record.

Two coverage gaps in the existing redaction primitives compound the leak:

1. `redactEventPayload`'s key-name regex catches conventional secret naming (`api_key`, `access_token`, `private_key`, etc.) but does not match `deviceToken` (no separator between `device` and `token`) or arbitrary `headers` map keys like `x-openclaw-token`. (This regex gap is acknowledged as banked future work — see comment on `OMITTED_ADAPTER_CONFIG_KEYS` in the diff.)
2. The existing `redactForRestrictedAgentView` nukes `adapterConfig` entirely (sets it to `{}`), which works for non-self viewers but would break the `/api/agents/me` hot path that running agents call during heartbeat for runtime metadata (URL, scopes, deviceFamily).

## Fix shape

`buildSafeAgentDetail()` (`server/src/routes/agents.ts`) wraps the agent record with `withSafeAdapterConfig()`, which calls a new `omitAdapterConfigSecrets()` primitive in `server/src/redaction.ts`. The primitive:

- Omits an explicit list of secret-bearing top-level keys: `devicePrivateKeyPem`, `deviceToken`, `headers`, `sessionKey`. Field-omit shape rather than value-redaction; preserves response payload size and avoids `***REDACTED***` placeholder pollution.
- Passes the remainder through `redactEventPayload` to catch conventional nested secrets (e.g. `adapterConfig.env.SAMPLE_API_KEY`) via the existing regex pattern.

Field omission rather than value replacement keeps non-secret fields (`url`, `deviceFamily`, `scopes`, `paperclipApiUrl`, `waitTimeoutMs`) available to UI consumers and to running agents on the `/me` heartbeat path.

`buildSafeAgentDetail()` delegates to the existing `buildAgentDetail()` rather than rebuilding the async setup / data fetches independently — single source of truth on the underlying detail-construction logic.

## Endpoints fixed

| Path | Method | Builder used |
|------|--------|--------------|
| `/api/agents/me` | GET | `buildSafeAgentDetail` |
| `/api/agents/:id` (self / admin) | GET | `buildSafeAgentDetail` |
| `/api/companies/:companyId/agents` (admin path) | GET | `result.map(withSafeAdapterConfig)` |
| `/api/agents/:id` permissions update response | PATCH | `buildSafeAgentDetail` |

The non-admin / restricted call sites (`/api/agents/:id` non-admin via `redactForRestrictedAgentView`, `/api/companies/:companyId/agents` non-admin, `/api/companies/:companyId/agent-configurations` via `redactAgentConfiguration`) are unchanged — they already redact, just with a different shape that suits their use cases.

## Verification

Run the full server vitest suite locally:

```
pnpm --filter @paperclipai/plugin-sdk build  # one-time fresh-clone build precondition
pnpm --filter @paperclipai/server exec vitest run
```

Expected on this branch:

```
Test Files  214 passed (214)
     Tests  1419 passed | 1 skipped (1420)
  Duration  ~240s
```

The new file `server/src/__tests__/agent-detail-secret-redaction.test.ts` contains 4 regression tests asserting (per endpoint):

- Secret-bearing `adapterConfig` keys are absent from response bodies (not present as `***REDACTED***` placeholders, fully omitted)
- Non-secret `adapterConfig` keys remain visible (`url`, `deviceFamily`, `scopes`, `paperclipApiUrl`, `waitTimeoutMs`)
- Nested `env`-style secrets are redacted via `redactEventPayload` (positive control for the combined approach)
- The built response shape is preserved (`chainOfCommand`, `access` fields present where expected; absent on the list endpoint)
- Defense-in-depth: the serialised JSON body string contains none of the test fixture's secret values anywhere

The 4 tests cover, one each: the agent self-auth path (`/api/agents/me`), the agent-self GET-by-id path (`/api/agents/:id`), the board-with-config-read list path (`/api/companies/:companyId/agents`), and the permissions update response path (`PATCH /api/agents/:id`). The pre-existing redaction test for the non-admin restricted path (`agent-permissions-routes.test.ts:379`) continues to pass — confirming no regression to the unchanged paths.

Manual verification a reviewer can run:

```bash
# Pull this branch, run the server, then hit any of the four fixed endpoints
# with appropriate auth and verify the response JSON contains no devicePrivateKeyPem,
# no deviceToken, no headers, no sessionKey on adapterConfig, while url + deviceFamily
# + scopes are still present.
curl -H "Authorization: Bearer <TOKEN>" https://your-paperclip-host/api/agents/me | jq '.adapterConfig | keys'
```

## Risks

Low risk overall. The change removes fields from API response bodies — it does not change semantics or auth/authz behaviour, and there is no DB migration. Considerations:

- **API consumer breakage**: any UI flow or agent client that depended on receiving secret material via these four endpoints will now find those keys absent. The `/api/agents/me` heartbeat path is the most exposed: agents that previously parsed their own `devicePrivateKeyPem` or `deviceToken` from `/me` would need to source those from the running process or from a different endpoint. Recommended editing-time access path: `/api/agents/:id/configuration` (which uses `redactAgentConfiguration`) for UI agent-config edit flows.
- **Restricted call-site behaviour unchanged**: existing `redactForRestrictedAgentView` / `redactAgentConfiguration` call sites are not modified — non-admin restricted readers still see the same redacted shape they did before.
- **Reversibility**: revert restores prior behaviour. No persistent state mutation.
- **Test coverage parity**: 4 endpoints fixed, 4 regression tests added. Each endpoint has a direct test asserting the redaction shape.

## Cross-references

- **Closes #1818** — same architectural pattern. Note: a previous comment on that issue indicated a fix had been applied; the admin path at `routes/agents.ts:1148` still ships full agent records as of master HEAD `3494e84a`, and this PR completes the redaction across all four leaking endpoints.
- **Related to #4491** — that issue covers the CLI counterpart (`agent get` / `agent list` / `agent inspect` redaction). This PR covers the HTTP API path; the CLI is separate scope.
- Same security-hygiene family as **#3072** (auth sign-in plaintext password logging) — both share the pattern of authenticated endpoints returning full records before applying secret redaction.

## Model Used

- **Provider / family**: Anthropic Claude (Opus 4.x family)
- **5t-M original PR authoring (28-29 April 2026)**: Claude Opus 4.x family running in Code mode (Claude Code CLI inside the Claude desktop app's Code tab on macOS, version 2.1.119 or 2.1.120 - exact patch not recorded in the audit trail at that session).
- **5t-N revision (29 April 2026, this push)**: Claude Opus 4.7 (`claude-opus-4-7`, 1M context), Claude Code CLI 2.1.121.
- **Planning, architectural review, PR-body composition**: Claude Opus in chat mode (claude.ai web + Claude desktop app's chat tab). Project knowledge snapshot of the source-of-truth investigation files (`paperclip-knowledge.md`, `paperclip-runbooks.md`, `paperclip-session-history.md`) used for cross-document synthesis.
- **Architectural sense-check**: ChatGPT was consulted on an architectural question that shaped a planned follow-up PR but is not directly load-bearing on the scope of this PR.
- **Tool use during authoring + revisions**: shell (SSH, docker exec, psql), file edits (Edit/Write), vitest test runner, gh CLI for PR submission and post-submission edits, git CLI.
- **Reasoning mode**: extended chain-of-thought during investigation; tool-use loop during code edits and validation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — N/A: security fix, not feature scope
- [x] I have run tests locally and they pass (1419 passed / 1 skipped / 0 failures, server filter)
- [x] I have added or updated tests where applicable (4 regression tests added, one per fixed endpoint)
- [x] If this change affects the UI, I have included before/after screenshots — N/A: backend-only API redaction change, no UI changes
- [x] I have updated relevant documentation to reflect my changes — N/A: internal redaction primitive, no public API docs to update; inline code comments updated
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge — this revision addresses all four P2 findings from the initial Greptile review
