### PR TITLE
fix: add goal owner editing in goals UI

### DIFF
--- a/ui/src/components/GoalProperties.test.tsx
+++ b/ui/src/components/GoalProperties.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import type { ComponentProps, ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GoalProperties } from "./GoalProperties";
+
+const companyState = vi.hoisted(() => ({
+  selectedCompanyId: "company-1",
+}));
+
+const mockAgentsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const mockGoalsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => companyState,
+}));
+
+vi.mock("../api/agents", () => ({
+  agentsApi: mockAgentsApi,
+}));
+
+vi.mock("../api/goals", () => ({
+  goalsApi: mockGoalsApi,
+}));
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to, ...props }: ComponentProps<"a"> & { to: string }) => <a href={to} {...props}>{children}</a>,
+}));
+
+vi.mock("@/components/ui/separator", () => ({
+  Separator: () => <div />,
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, type = "button", ...props }: ComponentProps<"button">) => (
+    <button type={type} onClick={onClick} {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("./StatusBadge", () => ({
+  StatusBadge: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+
+vi.mock("./AgentIconPicker", () => ({
+  AgentIcon: () => null,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function renderComponent(container: HTMLDivElement, goal: Record<string, unknown>) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <GoalProperties goal={goal as never} onUpdate={vi.fn()} />
+      </QueryClientProvider>,
+    );
+  });
+  return root;
+}
+
+describe("GoalProperties", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    mockAgentsApi.list.mockReset();
+    mockGoalsApi.list.mockReset();
+    mockAgentsApi.list.mockResolvedValue([
+      { id: "agent-1", name: "CEO", icon: "crown", status: "idle" },
+      { id: "agent-2", name: "CTO", icon: "wrench", status: "idle" },
+    ]);
+    mockGoalsApi.list.mockResolvedValue([]);
+  });
+
+  it("shows the resolved owner name when the goal already has an owner", async () => {
+    renderComponent(container, {
+      id: "goal-1",
+      title: "Goal",
+      status: "active",
+      level: "task",
+      ownerAgentId: "agent-1",
+      parentId: null,
+      createdAt: "2026-04-29T10:00:00.000Z",
+      updatedAt: "2026-04-29T10:00:00.000Z",
+    });
+
+    await flush();
+
+    expect(container.textContent).toContain("CEO");
+  });
+
+  it("shows the empty owner state when the goal has no owner", async () => {
+    renderComponent(container, {
+      id: "goal-1",
+      title: "Goal",
+      status: "active",
+      level: "task",
+      ownerAgentId: null,
+      parentId: null,
+      createdAt: "2026-04-29T10:00:00.000Z",
+      updatedAt: "2026-04-29T10:00:00.000Z",
+    });
+
+    await flush();
+
+    expect(container.textContent).toContain("No owner");
+  });
+});

--- a/ui/src/components/GoalProperties.test.tsx
+++ b/ui/src/components/GoalProperties.test.tsx
@@ -2,9 +2,10 @@
 
 import { act } from "react";
 import type { ComponentProps, ReactNode } from "react";
+import type { Root } from "react-dom/client";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GoalProperties } from "./GoalProperties";
 
 const companyState = vi.hoisted(() => ({
@@ -88,6 +89,7 @@ function renderComponent(container: HTMLDivElement, goal: Record<string, unknown
 
 describe("GoalProperties", () => {
   let container: HTMLDivElement;
+  let root: Root | null = null;
 
   beforeEach(() => {
     container = document.createElement("div");
@@ -101,8 +103,16 @@ describe("GoalProperties", () => {
     mockGoalsApi.list.mockResolvedValue([]);
   });
 
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    root = null;
+  });
+
   it("shows the resolved owner name when the goal already has an owner", async () => {
-    renderComponent(container, {
+    root = renderComponent(container, {
       id: "goal-1",
       title: "Goal",
       status: "active",
@@ -114,12 +124,13 @@ describe("GoalProperties", () => {
     });
 
     await flush();
+    await flush();
 
     expect(container.textContent).toContain("CEO");
   });
 
   it("shows the empty owner state when the goal has no owner", async () => {
-    renderComponent(container, {
+    root = renderComponent(container, {
       id: "goal-1",
       title: "Goal",
       status: "active",
@@ -130,6 +141,7 @@ describe("GoalProperties", () => {
       updatedAt: "2026-04-29T10:00:00.000Z",
     });
 
+    await flush();
     await flush();
 
     expect(container.textContent).toContain("No owner");

--- a/ui/src/components/GoalProperties.tsx
+++ b/ui/src/components/GoalProperties.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
-import type { Goal } from "@paperclipai/shared";
+import type { Agent, Goal } from "@paperclipai/shared";
 import { GOAL_STATUSES, GOAL_LEVELS } from "@paperclipai/shared";
 import { agentsApi } from "../api/agents";
 import { goalsApi } from "../api/goals";
@@ -12,6 +12,7 @@ import { formatDate, cn, agentUrl } from "../lib/utils";
 import { Separator } from "@/components/ui/separator";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { AgentIcon } from "./AgentIconPicker";
 
 interface GoalPropertiesProps {
   goal: Goal;
@@ -70,6 +71,61 @@ function PickerButton({
   );
 }
 
+function OwnerPicker({
+  currentOwnerAgentId,
+  agents,
+  onChange,
+  children,
+}: {
+  currentOwnerAgentId: string | null;
+  agents: Agent[];
+  onChange: (value: string | null) => void;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button className="cursor-pointer hover:opacity-80 transition-opacity text-left">
+          {children}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 p-1" align="end">
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn("w-full justify-start text-xs", !currentOwnerAgentId && "bg-accent")}
+          onClick={() => {
+            onChange(null);
+            setOpen(false);
+          }}
+        >
+          No owner
+        </Button>
+        {agents.map((agent) => (
+          <Button
+            key={agent.id}
+            variant="ghost"
+            size="sm"
+            className={cn("w-full justify-start gap-2 text-xs", agent.id === currentOwnerAgentId && "bg-accent")}
+            onClick={() => {
+              onChange(agent.id);
+              setOpen(false);
+            }}
+          >
+            <AgentIcon icon={agent.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="truncate">{agent.name}</span>
+            {agent.status !== "idle" && (
+              <span className="ml-auto text-[10px] text-muted-foreground capitalize">{label(agent.status)}</span>
+            )}
+          </Button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 export function GoalProperties({ goal, onUpdate }: GoalPropertiesProps) {
   const { selectedCompanyId } = useCompany();
 
@@ -88,6 +144,7 @@ export function GoalProperties({ goal, onUpdate }: GoalPropertiesProps) {
   const ownerAgent = goal.ownerAgentId
     ? agents?.find((a) => a.id === goal.ownerAgentId)
     : null;
+  const ownerOptions = (agents ?? []).filter((agent) => agent.status !== "terminated");
 
   const parentGoal = goal.parentId
     ? allGoals?.find((g) => g.id === goal.parentId)
@@ -125,7 +182,32 @@ export function GoalProperties({ goal, onUpdate }: GoalPropertiesProps) {
         </PropertyRow>
 
         <PropertyRow label="Owner">
-          {ownerAgent ? (
+          {onUpdate ? (
+            <>
+              <OwnerPicker
+                currentOwnerAgentId={goal.ownerAgentId ?? null}
+                agents={ownerOptions}
+                onChange={(ownerAgentId) => onUpdate({ ownerAgentId })}
+              >
+                {ownerAgent ? (
+                  <span className="inline-flex items-center gap-1.5 text-sm">
+                    <AgentIcon icon={ownerAgent.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    {ownerAgent.name}
+                  </span>
+                ) : (
+                  <span className="text-sm text-muted-foreground">No owner</span>
+                )}
+              </OwnerPicker>
+              {ownerAgent && (
+                <Link
+                  to={agentUrl(ownerAgent)}
+                  className="text-xs text-muted-foreground hover:underline"
+                >
+                  Open
+                </Link>
+              )}
+            </>
+          ) : ownerAgent ? (
             <Link
               to={agentUrl(ownerAgent)}
               className="text-sm hover:underline"
@@ -133,7 +215,7 @@ export function GoalProperties({ goal, onUpdate }: GoalPropertiesProps) {
               {ownerAgent.name}
             </Link>
           ) : (
-            <span className="text-sm text-muted-foreground">None</span>
+            <span className="text-sm text-muted-foreground">No owner</span>
           )}
         </PropertyRow>
 

--- a/ui/src/components/NewGoalDialog.test.tsx
+++ b/ui/src/components/NewGoalDialog.test.tsx
@@ -2,9 +2,10 @@
 
 import { act } from "react";
 import type { ComponentProps, ReactNode } from "react";
+import type { Root } from "react-dom/client";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NewGoalDialog } from "./NewGoalDialog";
 
 const dialogState = vi.hoisted(() => ({
@@ -139,6 +140,7 @@ function renderDialog(container: HTMLDivElement) {
 
 describe("NewGoalDialog", () => {
   let container: HTMLDivElement;
+  let root: Root | null = null;
 
   beforeEach(() => {
     container = document.createElement("div");
@@ -158,8 +160,16 @@ describe("NewGoalDialog", () => {
     ]);
   });
 
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    root = null;
+  });
+
   it("includes ownerAgentId in the create payload when an owner is selected", async () => {
-    renderDialog(container);
+    ({ root } = renderDialog(container));
     await flush();
 
     const titleInput = container.querySelector('input[placeholder="Goal title"]') as HTMLInputElement | null;

--- a/ui/src/components/NewGoalDialog.test.tsx
+++ b/ui/src/components/NewGoalDialog.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import type { ComponentProps, ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NewGoalDialog } from "./NewGoalDialog";
+
+const dialogState = vi.hoisted(() => ({
+  newGoalOpen: true,
+  newGoalDefaults: {} as Record<string, unknown>,
+  closeNewGoal: vi.fn(),
+}));
+
+const companyState = vi.hoisted(() => ({
+  selectedCompanyId: "company-1",
+  selectedCompany: {
+    id: "company-1",
+    name: "Paperclip",
+  },
+}));
+
+const mockGoalsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+  create: vi.fn(),
+}));
+
+const mockAgentsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const mockAssetsApi = vi.hoisted(() => ({
+  uploadImage: vi.fn(),
+}));
+
+vi.mock("../context/DialogContext", () => ({
+  useDialog: () => dialogState,
+}));
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => companyState,
+}));
+
+vi.mock("../api/goals", () => ({
+  goalsApi: mockGoalsApi,
+}));
+
+vi.mock("../api/agents", () => ({
+  agentsApi: mockAgentsApi,
+}));
+
+vi.mock("../api/assets", () => ({
+  assetsApi: mockAssetsApi,
+}));
+
+vi.mock("./MarkdownEditor", async () => {
+  const React = await import("react");
+  return {
+    MarkdownEditor: React.forwardRef<
+      { focus: () => void },
+      { value: string; onChange?: (value: string) => void; placeholder?: string }
+    >(function MarkdownEditorMock({ value, onChange, placeholder }, ref) {
+      React.useImperativeHandle(ref, () => ({
+        focus: () => undefined,
+      }));
+      return (
+        <textarea
+          aria-label={placeholder ?? "Description"}
+          value={value}
+          onChange={(event) => onChange?.(event.target.value)}
+        />
+      );
+    }),
+  };
+});
+
+vi.mock("./StatusBadge", () => ({
+  StatusBadge: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+
+vi.mock("./AgentIconPicker", () => ({
+  AgentIcon: () => null,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children, showCloseButton: _showCloseButton, ...props }: ComponentProps<"div"> & { showCloseButton?: boolean }) => <div {...props}>{children}</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, type = "button", ...props }: ComponentProps<"button">) => (
+    <button type={type} onClick={onClick} {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function click(element: Element | null | undefined) {
+  element && (element as HTMLButtonElement).click();
+}
+
+function renderDialog(container: HTMLDivElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <NewGoalDialog />
+      </QueryClientProvider>,
+    );
+  });
+  return { root, queryClient };
+}
+
+describe("NewGoalDialog", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    dialogState.newGoalOpen = true;
+    dialogState.newGoalDefaults = {};
+    dialogState.closeNewGoal.mockReset();
+    mockGoalsApi.list.mockReset();
+    mockGoalsApi.create.mockReset();
+    mockAgentsApi.list.mockReset();
+    mockAssetsApi.uploadImage.mockReset();
+    mockGoalsApi.list.mockResolvedValue([]);
+    mockGoalsApi.create.mockResolvedValue({ id: "goal-1" });
+    mockAgentsApi.list.mockResolvedValue([
+      { id: "agent-1", name: "CEO", icon: "crown", status: "idle" },
+      { id: "agent-2", name: "CTO", icon: "wrench", status: "idle" },
+    ]);
+  });
+
+  it("includes ownerAgentId in the create payload when an owner is selected", async () => {
+    renderDialog(container);
+    await flush();
+
+    const titleInput = container.querySelector('input[placeholder="Goal title"]') as HTMLInputElement | null;
+    expect(titleInput).toBeTruthy();
+
+    await act(async () => {
+      setInputValue(titleInput!, "SailAds MVP Boundary");
+    });
+
+    const ownerButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.trim() === "CEO");
+    expect(ownerButton).toBeTruthy();
+
+    await act(async () => {
+      click(ownerButton);
+    });
+
+    const createButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Create goal"));
+    expect(createButton).toBeTruthy();
+
+    await act(async () => {
+      click(createButton);
+    });
+    await flush();
+
+    expect(mockGoalsApi.create).toHaveBeenCalledWith("company-1", expect.objectContaining({
+      title: "SailAds MVP Boundary",
+      status: "planned",
+      level: "task",
+      ownerAgentId: "agent-1",
+    }));
+  });
+});

--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -4,6 +4,7 @@ import { GOAL_STATUSES, GOAL_LEVELS } from "@paperclipai/shared";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { goalsApi } from "../api/goals";
+import { agentsApi } from "../api/agents";
 import { assetsApi } from "../api/assets";
 import { queryKeys } from "../lib/queryKeys";
 import {
@@ -21,10 +22,12 @@ import {
   Minimize2,
   Target,
   Layers,
+  User,
 } from "lucide-react";
 import { cn } from "../lib/utils";
 import { MarkdownEditor, type MarkdownEditorRef } from "./MarkdownEditor";
 import { StatusBadge } from "./StatusBadge";
+import { AgentIcon } from "./AgentIconPicker";
 
 const levelLabels: Record<string, string> = {
   company: "Company",
@@ -41,11 +44,13 @@ export function NewGoalDialog() {
   const [description, setDescription] = useState("");
   const [status, setStatus] = useState("planned");
   const [level, setLevel] = useState("task");
+  const [ownerAgentId, setOwnerAgentId] = useState("");
   const [parentId, setParentId] = useState("");
   const [expanded, setExpanded] = useState(false);
 
   const [statusOpen, setStatusOpen] = useState(false);
   const [levelOpen, setLevelOpen] = useState(false);
+  const [ownerOpen, setOwnerOpen] = useState(false);
   const [parentOpen, setParentOpen] = useState(false);
   const descriptionEditorRef = useRef<MarkdownEditorRef>(null);
 
@@ -55,6 +60,12 @@ export function NewGoalDialog() {
   const { data: goals } = useQuery({
     queryKey: queryKeys.goals.list(selectedCompanyId!),
     queryFn: () => goalsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId && newGoalOpen,
+  });
+
+  const { data: agents } = useQuery({
+    queryKey: queryKeys.agents.list(selectedCompanyId!),
+    queryFn: () => agentsApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId && newGoalOpen,
   });
 
@@ -80,6 +91,7 @@ export function NewGoalDialog() {
     setDescription("");
     setStatus("planned");
     setLevel("task");
+    setOwnerAgentId("");
     setParentId("");
     setExpanded(false);
   }
@@ -91,6 +103,7 @@ export function NewGoalDialog() {
       description: description.trim() || undefined,
       status,
       level,
+      ...(ownerAgentId ? { ownerAgentId } : {}),
       ...(appliedParentId ? { parentId: appliedParentId } : {}),
     });
   }
@@ -103,6 +116,8 @@ export function NewGoalDialog() {
   }
 
   const currentParent = (goals ?? []).find((g) => g.id === appliedParentId);
+  const ownerOptions = (agents ?? []).filter((agent) => agent.status !== "terminated");
+  const currentOwner = ownerAgentId ? ownerOptions.find((agent) => agent.id === ownerAgentId) ?? null : null;
 
   return (
     <Dialog
@@ -227,6 +242,49 @@ export function NewGoalDialog() {
                   onClick={() => { setLevel(l); setLevelOpen(false); }}
                 >
                   {levelLabels[l] ?? l}
+                </button>
+              ))}
+            </PopoverContent>
+          </Popover>
+
+          {/* Owner */}
+          <Popover open={ownerOpen} onOpenChange={setOwnerOpen}>
+            <PopoverTrigger asChild>
+              <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs hover:bg-accent/50 transition-colors">
+                {currentOwner ? (
+                  <>
+                    <AgentIcon icon={currentOwner.icon} className="h-3 w-3 text-muted-foreground" />
+                    {currentOwner.name}
+                  </>
+                ) : (
+                  <>
+                    <User className="h-3 w-3 text-muted-foreground" />
+                    Owner
+                  </>
+                )}
+              </button>
+            </PopoverTrigger>
+            <PopoverContent className="w-48 p-1" align="start">
+              <button
+                className={cn(
+                  "flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50",
+                  !ownerAgentId && "bg-accent"
+                )}
+                onClick={() => { setOwnerAgentId(""); setOwnerOpen(false); }}
+              >
+                No owner
+              </button>
+              {ownerOptions.map((agent) => (
+                <button
+                  key={agent.id}
+                  className={cn(
+                    "flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 truncate",
+                    agent.id === ownerAgentId && "bg-accent"
+                  )}
+                  onClick={() => { setOwnerAgentId(agent.id); setOwnerOpen(false); }}
+                >
+                  <AgentIcon icon={agent.icon} className="h-3 w-3 shrink-0 text-muted-foreground" />
+                  <span className="truncate">{agent.name}</span>
                 </button>
               ))}
             </PopoverContent>


### PR DESCRIPTION
## Summary
- add an owner picker to editable goal properties so existing goals can be assigned or reassigned
- add owner selection to the new goal dialog and send ownerAgentId in the create payload
- cover the new goal owner flow with component tests

## Testing
- pnpm vitest run ui/src/components/GoalProperties.test.tsx ui/src/components/NewGoalDialog.test.tsx
- pnpm --filter @paperclipai/server prepare:ui-dist
