### PR TITLE
feat(run-guard): adapter safety rails — loop detector + $ cap (HIR-287)

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -54,3 +54,10 @@ export {
   redactTranscriptEntryPaths,
 } from "./log-redaction.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
+export type { RunGuardConfig, LoopDetectorConfig } from "./loop-detector.js";
+export {
+  LoopDetector,
+  observeToolCallsFromChunk,
+  imputeSubscriptionCostUsd,
+  tryPostRunGuardAlert,
+} from "./loop-detector.js";

--- a/packages/adapter-utils/src/loop-detector.test.ts
+++ b/packages/adapter-utils/src/loop-detector.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from "vitest";
+import { LoopDetector, observeToolCallsFromChunk, imputeSubscriptionCostUsd } from "./loop-detector.js";
+
+describe("LoopDetector", () => {
+  it("trips on >= 5 same-tool same-args in 5s", () => {
+    const onTrip = vi.fn();
+    const detector = new LoopDetector({}, onTrip);
+    for (let i = 0; i < 5; i++) {
+      detector.observe("Bash", "abc12345");
+    }
+    expect(onTrip).toHaveBeenCalledOnce();
+    expect(onTrip.mock.calls[0][0]).toMatch(/5s/);
+  });
+
+  it("trips on >= 10 same-tool same-args in 30s", () => {
+    const onTrip = vi.fn();
+    const detector = new LoopDetector({}, onTrip);
+    // Inject events spread within 30s but not within 5s by using fake timestamps
+    // We do this by calling observe in fast succession (all within 5s window)
+    // but only 4 in 5s and 10 in 30s — use maxSameToolSameArgs5s override to raise the 5s threshold
+    const detector2 = new LoopDetector({ maxSameToolSameArgs5s: 999 }, onTrip);
+    for (let i = 0; i < 10; i++) {
+      detector2.observe("Bash", "abc12345");
+    }
+    expect(onTrip).toHaveBeenCalledOnce();
+    expect(onTrip.mock.calls[0][0]).toMatch(/30s/);
+  });
+
+  it("trips on >= 30 same-tool in 60s", () => {
+    const onTrip = vi.fn();
+    const detector = new LoopDetector(
+      { maxSameToolSameArgs5s: 999, maxSameToolSameArgs30s: 999 },
+      onTrip,
+    );
+    for (let i = 0; i < 30; i++) {
+      // Different args each time to avoid 30s same-args trip
+      detector.observe("Bash", `arg${i}`);
+    }
+    expect(onTrip).toHaveBeenCalledOnce();
+    expect(onTrip.mock.calls[0][0]).toMatch(/60s/);
+  });
+
+  it("does not trip below thresholds", () => {
+    const onTrip = vi.fn();
+    const detector = new LoopDetector({}, onTrip);
+    for (let i = 0; i < 4; i++) {
+      detector.observe("Bash", "abc12345");
+    }
+    expect(onTrip).not.toHaveBeenCalled();
+  });
+
+  it("does not fire after already tripped", () => {
+    const onTrip = vi.fn();
+    const detector = new LoopDetector({}, onTrip);
+    for (let i = 0; i < 10; i++) {
+      detector.observe("Bash", "abc12345");
+    }
+    expect(onTrip).toHaveBeenCalledOnce();
+  });
+
+  it("respects enabled: false", () => {
+    const onTrip = vi.fn();
+    const detector = new LoopDetector({ enabled: false }, onTrip);
+    for (let i = 0; i < 100; i++) {
+      detector.observe("Bash", "abc12345");
+    }
+    expect(onTrip).not.toHaveBeenCalled();
+  });
+
+  it("respects custom thresholds", () => {
+    const onTrip = vi.fn();
+    const detector = new LoopDetector({ maxSameToolSameArgs5s: 3 }, onTrip);
+    detector.observe("Bash", "abc12345");
+    detector.observe("Bash", "abc12345");
+    expect(onTrip).not.toHaveBeenCalled();
+    detector.observe("Bash", "abc12345");
+    expect(onTrip).toHaveBeenCalledOnce();
+  });
+});
+
+describe("observeToolCallsFromChunk", () => {
+  it("parses opencode_local tool_use events", () => {
+    const onTrip = vi.fn();
+    const detector = new LoopDetector({ maxSameToolSameArgs5s: 2 }, onTrip);
+    const line = JSON.stringify({ type: "tool_use", part: { name: "list_files", input: { path: "/" } } });
+    observeToolCallsFromChunk(`${line}\n${line}\n`, detector);
+    expect(onTrip).toHaveBeenCalledOnce();
+  });
+
+  it("parses claude_local assistant content block tool_use events", () => {
+    const onTrip = vi.fn();
+    const detector = new LoopDetector({ maxSameToolSameArgs5s: 2 }, onTrip);
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_use", name: "Read", input: { file_path: "/foo" } }],
+      },
+    });
+    observeToolCallsFromChunk(`${line}\n${line}\n`, detector);
+    expect(onTrip).toHaveBeenCalledOnce();
+  });
+
+  it("ignores non-JSON lines", () => {
+    const onTrip = vi.fn();
+    const detector = new LoopDetector({}, onTrip);
+    observeToolCallsFromChunk("plain text\n[2024-01-01] something\n", detector);
+    expect(onTrip).not.toHaveBeenCalled();
+  });
+
+  it("treats same tool with different args as distinct", () => {
+    const onTrip = vi.fn();
+    const detector = new LoopDetector({ maxSameToolSameArgs5s: 2 }, onTrip);
+    const line1 = JSON.stringify({ type: "tool_use", part: { name: "Bash", input: { command: "ls" } } });
+    const line2 = JSON.stringify({ type: "tool_use", part: { name: "Bash", input: { command: "pwd" } } });
+    observeToolCallsFromChunk(`${line1}\n${line2}\n`, detector);
+    expect(onTrip).not.toHaveBeenCalled();
+  });
+});
+
+describe("imputeSubscriptionCostUsd", () => {
+  it("imputes sonnet cost correctly", () => {
+    const cost = imputeSubscriptionCostUsd("claude-sonnet-4-5", {
+      inputTokens: 100_000,
+      outputTokens: 10_000,
+      cachedInputTokens: 0,
+    });
+    // 100k * $3/M input + 10k * $15/M output = $0.30 + $0.15 = $0.45
+    expect(cost).toBeCloseTo(0.45, 4);
+  });
+
+  it("imputes opus cost at higher rate", () => {
+    const cost = imputeSubscriptionCostUsd("claude-opus-4-5", {
+      inputTokens: 10_000,
+      outputTokens: 1_000,
+      cachedInputTokens: 0,
+    });
+    // 10k * $15/M + 1k * $75/M = $0.15 + $0.075 = $0.225
+    expect(cost).toBeCloseTo(0.225, 4);
+  });
+
+  it("defaults to sonnet rate for unknown models", () => {
+    const sonnetCost = imputeSubscriptionCostUsd("claude-sonnet-4-5", {
+      inputTokens: 50_000,
+      outputTokens: 5_000,
+      cachedInputTokens: 0,
+    });
+    const unknownCost = imputeSubscriptionCostUsd("unknown-model-xyz", {
+      inputTokens: 50_000,
+      outputTokens: 5_000,
+      cachedInputTokens: 0,
+    });
+    expect(unknownCost).toBeCloseTo(sonnetCost, 6);
+  });
+
+  it("includes cached input tokens in cost", () => {
+    const cost = imputeSubscriptionCostUsd("claude-sonnet-4-5", {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 1_000_000,
+    });
+    // 1M cached * $3/M = $3.00
+    expect(cost).toBeCloseTo(3.0, 4);
+  });
+});

--- a/packages/adapter-utils/src/loop-detector.ts
+++ b/packages/adapter-utils/src/loop-detector.ts
@@ -1,0 +1,182 @@
+import { createHash } from "node:crypto";
+import type { UsageSummary } from "./types.js";
+
+export interface LoopDetectorConfig {
+  enabled?: boolean;
+  maxSameToolSameArgs30s?: number;
+  maxSameTool60s?: number;
+  maxSameToolSameArgs5s?: number;
+}
+
+export interface RunGuardConfig {
+  enabled?: boolean;
+  budgetCapUsd?: number;
+  loopDetector?: LoopDetectorConfig;
+}
+
+interface ToolEvent {
+  toolName: string;
+  argsHash: string;
+  ts: number;
+}
+
+export class LoopDetector {
+  private events: ToolEvent[] = [];
+  private tripped = false;
+
+  constructor(
+    private readonly config: LoopDetectorConfig,
+    private readonly onTrip: (reason: string) => void,
+  ) {}
+
+  observe(toolName: string, argsHash: string): void {
+    if (this.tripped) return;
+    if (this.config.enabled === false) return;
+
+    const now = Date.now();
+    this.events.push({ toolName, argsHash, ts: now });
+
+    // Keep sliding window bounded at 60s
+    const cutoff60s = now - 60_000;
+    this.events = this.events.filter((e) => e.ts > cutoff60s);
+
+    this.check(toolName, argsHash, now);
+  }
+
+  private check(toolName: string, argsHash: string, now: number): void {
+    const max30s = this.config.maxSameToolSameArgs30s ?? 10;
+    const max60s = this.config.maxSameTool60s ?? 30;
+    const max5s = this.config.maxSameToolSameArgs5s ?? 5;
+
+    const cutoff30s = now - 30_000;
+    const cutoff5s = now - 5_000;
+
+    const sameToolSameArgs5s = this.events.filter(
+      (e) => e.ts > cutoff5s && e.toolName === toolName && e.argsHash === argsHash,
+    ).length;
+    if (sameToolSameArgs5s >= max5s) {
+      this.trip(`${sameToolSameArgs5s}x ${toolName}(same-args) in 5s`);
+      return;
+    }
+
+    const sameToolSameArgs30s = this.events.filter(
+      (e) => e.ts > cutoff30s && e.toolName === toolName && e.argsHash === argsHash,
+    ).length;
+    if (sameToolSameArgs30s >= max30s) {
+      this.trip(`${sameToolSameArgs30s}x ${toolName}(same-args) in 30s`);
+      return;
+    }
+
+    const sameTool60s = this.events.filter((e) => e.toolName === toolName).length;
+    if (sameTool60s >= max60s) {
+      this.trip(`${sameTool60s}x ${toolName} in 60s`);
+    }
+  }
+
+  private trip(reason: string): void {
+    this.tripped = true;
+    this.onTrip(reason);
+  }
+}
+
+function hashArgs(input: unknown): string {
+  try {
+    const json = JSON.stringify(input);
+    return createHash("sha256").update(json).digest("hex").slice(0, 8);
+  } catch {
+    return "unknown";
+  }
+}
+
+export function observeToolCallsFromChunk(chunk: string, detector: LoopDetector): void {
+  for (const line of chunk.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed[0] !== "{") continue;
+
+    let event: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) continue;
+      event = parsed as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const type = typeof event.type === "string" ? event.type : "";
+
+    // opencode_local: {"type":"tool_use","part":{"name":"toolName","input":{...}}}
+    if (type === "tool_use") {
+      const part = event.part;
+      if (typeof part === "object" && part !== null && !Array.isArray(part)) {
+        const p = part as Record<string, unknown>;
+        const name = typeof p.name === "string" ? p.name : null;
+        if (name) detector.observe(name, hashArgs(p.input));
+      }
+      continue;
+    }
+
+    // claude_local: {"type":"assistant","message":{"content":[{"type":"tool_use","name":"toolName","input":{}}]}}
+    if (type === "assistant") {
+      const message = event.message;
+      if (typeof message === "object" && message !== null && !Array.isArray(message)) {
+        const content = (message as Record<string, unknown>).content;
+        if (Array.isArray(content)) {
+          for (const block of content) {
+            if (typeof block !== "object" || block === null || Array.isArray(block)) continue;
+            const b = block as Record<string, unknown>;
+            if (b.type === "tool_use" && typeof b.name === "string") {
+              detector.observe(b.name, hashArgs(b.input));
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Model family rates in $ per token (not per million)
+const MODEL_RATES: Record<string, { input: number; output: number }> = {
+  "claude-opus": { input: 15 / 1e6, output: 75 / 1e6 },
+  "claude-sonnet": { input: 3 / 1e6, output: 15 / 1e6 },
+  "claude-haiku": { input: 0.25 / 1e6, output: 1.25 / 1e6 },
+};
+
+function resolveModelFamily(model: string): string {
+  const lower = model.toLowerCase();
+  if (lower.includes("opus")) return "claude-opus";
+  if (lower.includes("haiku")) return "claude-haiku";
+  return "claude-sonnet";
+}
+
+export function imputeSubscriptionCostUsd(model: string, usage: UsageSummary): number {
+  const rates = MODEL_RATES[resolveModelFamily(model)] ?? MODEL_RATES["claude-sonnet"]!;
+  const inputTokens = (usage.inputTokens ?? 0) + (usage.cachedInputTokens ?? 0);
+  return inputTokens * rates.input + (usage.outputTokens ?? 0) * rates.output;
+}
+
+export interface RunGuardAlertContext {
+  runId: string;
+  issueId: string | null;
+  authToken: string | undefined;
+  agentId: string;
+}
+
+export async function tryPostRunGuardAlert(ctx: RunGuardAlertContext, message: string): Promise<void> {
+  const apiUrl = process.env["PAPERCLIP_API_URL"];
+  const token = ctx.authToken ?? process.env["PAPERCLIP_API_KEY"];
+  if (!apiUrl || !token || !ctx.issueId) return;
+
+  try {
+    await fetch(`${apiUrl}/api/issues/${ctx.issueId}/comments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+        "X-Paperclip-Run-Id": ctx.runId,
+      },
+      body: JSON.stringify({ body: message }),
+    });
+  } catch {
+    // Best-effort: alert failure must not interrupt the run result
+  }
+}

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -2,6 +2,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  LoopDetector,
+  observeToolCallsFromChunk,
+  imputeSubscriptionCostUsd,
+  tryPostRunGuardAlert,
+  type RunGuardConfig,
+} from "@paperclipai/adapter-utils";
 import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
 import {
   adapterExecutionTargetIsRemote,
@@ -316,6 +323,34 @@ export async function runClaudeLogin(input: {
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+
+  // --- Run guard: loop detector + per-run $ cap (with subscription cost imputation) ---
+  const guardConfig = (parseObject(config.paperclipRunGuard) as unknown) as RunGuardConfig;
+  const guardEnabled = guardConfig.enabled !== false;
+  let loopTripReason: string | null = null;
+  let capturedPid: number | null = null;
+  const loopDetector = guardEnabled
+    ? new LoopDetector(guardConfig.loopDetector ?? {}, (reason) => {
+        loopTripReason = reason;
+        if (capturedPid != null) {
+          try { process.kill(capturedPid, "SIGTERM"); } catch { /* best-effort */ }
+        }
+      })
+    : null;
+  const guardIssueId =
+    (typeof context.taskId === "string" ? context.taskId : null) ??
+    (typeof context.issueId === "string" ? context.issueId : null) ??
+    null;
+  const guardedOnSpawn = async (meta: { pid: number; processGroupId: number | null; startedAt: string }) => {
+    capturedPid = meta.pid;
+    return onSpawn?.(meta);
+  };
+  const guardedOnLog = async (stream: "stdout" | "stderr", chunk: string) => {
+    if (stream === "stdout" && loopDetector) observeToolCallsFromChunk(chunk, loopDetector);
+    return onLog(stream, chunk);
+  };
+  // --- End run guard setup ---
+
   const executionTarget = readAdapterExecutionTarget({
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
@@ -580,8 +615,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       stdin: prompt,
       timeoutSec,
       graceSec,
-      onSpawn,
-      onLog,
+      onSpawn: guardedOnSpawn,
+      onLog: guardedOnLog,
       terminalResultCleanup: {
         graceMs: terminalResultCleanupGraceMs,
         hasTerminalResult: ({ stdout }) => parseClaudeStreamJson(stdout).resultJson !== null,
@@ -762,6 +797,32 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   };
 
+  const applyRunGuard = async (result: AdapterExecutionResult): Promise<AdapterExecutionResult> => {
+    const alertCtx = { runId, issueId: guardIssueId, authToken, agentId: agent.id };
+
+    if (loopTripReason && (result.exitCode ?? 0) !== 0) {
+      const msg = `[paperclip] Run guard: loop detected — ${loopTripReason}`;
+      await onLog("stdout", `${msg}\n`);
+      await tryPostRunGuardAlert(alertCtx, `**Run guard tripped on ${agent.name}** (claude_local)\n\n${msg}\n\nRun: ${runId}`);
+      return { ...result, errorMessage: msg, errorCode: "run_guard_loop" };
+    }
+
+    const budgetCap = guardConfig.budgetCapUsd ?? 0.5;
+    const resolvedBillingType = result.billingType ?? "subscription";
+    const effectiveCost =
+      resolvedBillingType === "subscription" && result.usage
+        ? imputeSubscriptionCostUsd(result.model ?? "", result.usage)
+        : (result.costUsd ?? 0);
+    if (guardEnabled && effectiveCost > budgetCap) {
+      const msg = `[paperclip] Run guard: cost $${effectiveCost.toFixed(4)} exceeded cap $${budgetCap.toFixed(2)}`;
+      await onLog("stdout", `${msg}\n`);
+      await tryPostRunGuardAlert(alertCtx, `**Run guard: budget cap exceeded on ${agent.name}** (claude_local)\n\n${msg}\n\nRun: ${runId}`);
+      return { ...result, errorMessage: msg, errorCode: "run_guard_budget", exitCode: result.exitCode ?? 1 };
+    }
+
+    return result;
+  };
+
   try {
     const initial = await runAttempt(sessionId ?? null);
     if (
@@ -776,10 +837,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
-      return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+      return applyRunGuard(toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true }));
     }
 
-    return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+    return applyRunGuard(toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId }));
   } finally {
     if (restoreRemoteWorkspace) {
       await onLog(

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -31,6 +31,8 @@ Core fields:
 - model (string, required): OpenCode model id in provider/model format (for example anthropic/claude-sonnet-4-5)
 - variant (string, optional): provider-specific reasoning/profile variant passed as --variant (for example minimal|low|medium|high|xhigh|max)
 - dangerouslySkipPermissions (boolean, optional): inject a runtime OpenCode config that allows \`external_directory\` access without interactive prompts; defaults to true for unattended Paperclip runs
+- maxTurnsPerRun (number, optional): cap the OpenCode build agent at this many steps per run via agent.build.maxSteps in the injected runtime config; 0 means uncapped (default)
+- paperclipRunGuard (object, optional): run-guard settings — { enabled?: boolean, budgetCapUsd?: number (default 0.5), loopDetector?: { enabled?: boolean, maxSameToolSameArgs5s?: number, maxSameToolSameArgs30s?: number, maxSameTool60s?: number } }
 - promptTemplate (string, optional): run prompt template
 - command (string, optional): defaults to "opencode"
 - extraArgs (string[], optional): additional CLI args
@@ -49,7 +51,9 @@ Notes:
 - The adapter sets OPENCODE_DISABLE_PROJECT_CONFIG=true to prevent OpenCode from \
   writing an opencode.json config file into the project working directory. Model \
   selection is passed via the --model CLI flag instead.
-- When \`dangerouslySkipPermissions\` is enabled, Paperclip injects a temporary \
-  runtime config with \`permission.external_directory=allow\` so headless runs do \
-  not stall on approval prompts.
+- When \`dangerouslySkipPermissions\` is enabled (default), the adapter injects a \
+  runtime opencode.json with permission.external_directory=allow and \
+  permission.doom_loop=deny so headless runs do not stall on approval or loop prompts.
+- The run guard (paperclipRunGuard) terminates OpenCode and posts an issue alert \
+  when a tool-call loop or per-run budget cap is exceeded.
 `;

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -2,7 +2,15 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  inferOpenAiCompatibleBiller,
+  LoopDetector,
+  observeToolCallsFromChunk,
+  tryPostRunGuardAlert,
+  type RunGuardConfig,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetPaperclipApiUrl,
@@ -122,6 +130,33 @@ async function buildOpenCodeSkillsDir(config: Record<string, unknown>): Promise<
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+
+  // --- Run guard: loop detector + per-run $ cap ---
+  const guardConfig = (parseObject(config.paperclipRunGuard) as unknown) as RunGuardConfig;
+  const guardEnabled = guardConfig.enabled !== false;
+  let loopTripReason: string | null = null;
+  let capturedPid: number | null = null;
+  const loopDetector = guardEnabled
+    ? new LoopDetector(guardConfig.loopDetector ?? {}, (reason) => {
+        loopTripReason = reason;
+        if (capturedPid != null) {
+          try { process.kill(capturedPid, "SIGTERM"); } catch { /* best-effort */ }
+        }
+      })
+    : null;
+  const guardIssueId =
+    (typeof context.taskId === "string" ? context.taskId : null) ??
+    (typeof context.issueId === "string" ? context.issueId : null) ??
+    null;
+  const guardedOnSpawn = async (meta: { pid: number; processGroupId: number | null; startedAt: string }) => {
+    capturedPid = meta.pid;
+    return onSpawn?.(meta);
+  };
+  const guardedOnLog = async (stream: "stdout" | "stderr", chunk: string) => {
+    if (stream === "stdout" && loopDetector) observeToolCallsFromChunk(chunk, loopDetector);
+    return onLog(stream, chunk);
+  };
+  // --- End run guard setup ---
   const executionTarget = readAdapterExecutionTarget({
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
@@ -432,8 +467,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stdin: prompt,
         timeoutSec,
         graceSec,
-        onSpawn,
-        onLog,
+        onSpawn: guardedOnSpawn,
+        onLog: guardedOnLog,
       });
       return {
         proc,
@@ -515,6 +550,28 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       };
     };
 
+    const applyRunGuard = async (result: AdapterExecutionResult): Promise<AdapterExecutionResult> => {
+      const alertCtx = { runId, issueId: guardIssueId, authToken, agentId: agent.id };
+
+      if (loopTripReason && (result.exitCode ?? 0) !== 0) {
+        const msg = `[paperclip] Run guard: loop detected — ${loopTripReason}`;
+        await onLog("stdout", `${msg}\n`);
+        await tryPostRunGuardAlert(alertCtx, `**Run guard tripped on ${agent.name}** (opencode_local)\n\n${msg}\n\nRun: ${runId}`);
+        return { ...result, errorMessage: msg, errorCode: "run_guard_loop" };
+      }
+
+      const budgetCap = guardConfig.budgetCapUsd ?? 0.5;
+      const effectiveCost = result.costUsd ?? 0;
+      if (guardEnabled && effectiveCost > budgetCap) {
+        const msg = `[paperclip] Run guard: cost $${effectiveCost.toFixed(4)} exceeded cap $${budgetCap.toFixed(2)}`;
+        await onLog("stdout", `${msg}\n`);
+        await tryPostRunGuardAlert(alertCtx, `**Run guard: budget cap exceeded on ${agent.name}** (opencode_local)\n\n${msg}\n\nRun: ${runId}`);
+        return { ...result, errorMessage: msg, errorCode: "run_guard_budget", exitCode: result.exitCode ?? 1 };
+      }
+
+      return result;
+    };
+
     try {
       const initial = await runAttempt(sessionId);
       const initialFailed =
@@ -529,10 +586,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           `[paperclip] OpenCode session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
         );
         const retry = await runAttempt(null);
-        return toResult(retry, true);
+        return applyRunGuard(toResult(retry, true));
       }
 
-      return toResult(initial);
+      return applyRunGuard(toResult(initial));
     } finally {
       await Promise.all([
         restoreRemoteWorkspace?.(),

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { asBoolean } from "@paperclipai/adapter-utils/server-utils";
+import { asBoolean, asNumber } from "@paperclipai/adapter-utils/server-utils";
 
 type PreparedOpenCodeRuntimeConfig = {
   env: Record<string, string>;
@@ -63,27 +63,44 @@ export async function prepareOpenCodeRuntimeConfig(input: {
     }
   }
 
+  const maxSteps = asNumber(input.config.maxTurnsPerRun, 0);
   const existingConfig = await readJsonObject(runtimeConfigPath);
   const existingPermission = isPlainObject(existingConfig.permission)
     ? existingConfig.permission
     : {};
-  const nextConfig = {
+  const existingAgent = isPlainObject(existingConfig.agent) ? existingConfig.agent : {};
+  const existingBuild = isPlainObject(existingAgent.build) ? existingAgent.build : {};
+  const nextConfig: Record<string, unknown> = {
     ...existingConfig,
     permission: {
       ...existingPermission,
       external_directory: "allow",
+      // Deny doom-loop prompts so headless runs terminate immediately instead of hanging.
+      doom_loop: "deny",
+    },
+    agent: {
+      ...existingAgent,
+      build: {
+        ...existingBuild,
+        ...(maxSteps > 0 ? { maxSteps } : {}),
+      },
     },
   };
   await fs.writeFile(runtimeConfigPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf8");
+
+  const notes = [
+    "Injected runtime OpenCode config: permission.external_directory=allow, permission.doom_loop=deny.",
+  ];
+  if (maxSteps > 0) {
+    notes.push(`Capped OpenCode build agent at ${maxSteps} steps via agent.build.maxSteps.`);
+  }
 
   return {
     env: {
       ...input.env,
       XDG_CONFIG_HOME: runtimeConfigHome,
     },
-    notes: [
-      "Injected runtime OpenCode config with permission.external_directory=allow to avoid headless approval prompts.",
-    ],
+    notes,
     cleanup: async () => {
       await fs.rm(runtimeConfigHome, { recursive: true, force: true });
     },

--- a/server/src/adapters/http/execute.test.ts
+++ b/server/src/adapters/http/execute.test.ts
@@ -43,4 +43,144 @@ describe("http adapter execute", () => {
     expect(result.errorCode).toBe("timeout");
     expect(result.errorMessage).toContain("timed out after 1ms");
   });
+
+  it("applies run-rate guard with default limit (max 10 runs per 60s)", async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    // Clear the module-level history before test
+    const httpModule = await import("./execute.js");
+    (httpModule as any).httpAgentCallHistory.clear();
+
+    const commonCtx = {
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Agent",
+        adapterType: "http",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        url: "https://example.test/webhook",
+      },
+      context: {},
+      onLog: async () => {},
+    };
+
+    // Run sequentially to avoid parallel timestamp issues
+    for (let i = 0; i < 10; i++) {
+      const result = await execute(commonCtx);
+      expect(result.exitCode).toBe(0);
+    }
+
+    // 11th call should trip the guard
+    const result = await execute(commonCtx);
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("run_guard_rate_limit");
+    expect(result.errorMessage).toContain("rate limit");
+    expect(result.errorMessage).toContain("invocations in 60s");
+    expect(result.errorMessage).toContain("max 10");
+  });
+
+  it("respects custom maxRunsPer60s limit", async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    // Clear the module-level history before test
+    const httpModule = await import("./execute.js");
+    (httpModule as any).httpAgentCallHistory.clear();
+
+    const commonCtx = {
+      runId: "run-1",
+      agent: {
+        id: "agent-2",
+        companyId: "company-1",
+        name: "Agent",
+        adapterType: "http",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        url: "https://example.test/webhook",
+        paperclipRunGuard: {
+          maxRunsPer60s: 3,
+        },
+      },
+      context: {},
+      onLog: async () => {},
+    };
+
+    // Run sequentially to avoid parallel timestamp issues
+    for (let i = 0; i < 3; i++) {
+      const result = await execute(commonCtx);
+      expect(result.exitCode).toBe(0);
+    }
+
+    // 4th call should trip the guard
+    const result = await execute(commonCtx);
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("run_guard_rate_limit");
+    expect(result.errorMessage).toContain("rate limit");
+    expect(result.errorMessage).toContain("invocations in 60s");
+    expect(result.errorMessage).toContain("max 3");
+  });
+
+  it("respects guard enabled: false", async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    // Clear the module-level history before test
+    const httpModule = await import("./execute.js");
+    (httpModule as any).httpAgentCallHistory.clear();
+
+    const commonCtx = {
+      runId: "run-1",
+      agent: {
+        id: "agent-3",
+        companyId: "company-1",
+        name: "Agent",
+        adapterType: "http",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        url: "https://example.test/webhook",
+        paperclipRunGuard: {
+          enabled: false,
+        },
+      },
+      context: {},
+      onLog: async () => {},
+    };
+
+    // Run sequentially to avoid parallel timestamp issues
+    const results = [];
+    for (let i = 0; i < 15; i++) {
+      results.push(await execute(commonCtx));
+    }
+
+    // All should succeed
+    expect(results.every(r => r.exitCode === 0)).toBe(true);
+    expect(results.every(r => r.errorCode === undefined)).toBe(true);
+  });
 });

--- a/server/src/adapters/http/execute.ts
+++ b/server/src/adapters/http/execute.ts
@@ -1,10 +1,62 @@
 import type { AdapterExecutionContext, AdapterExecutionResult } from "../types.js";
 import { asString, asNumber, parseObject } from "../utils.js";
 
+// In-process sliding window: agentId -> recent invocation timestamps
+const httpAgentCallHistory = new Map<string, number[]>();
+
+function checkHttpRateGuard(
+  agentId: string,
+  maxRunsPer60s: number,
+): { tripped: boolean; count: number } {
+  const now = Date.now();
+  const cutoff = now - 60_000;
+  const history = (httpAgentCallHistory.get(agentId) ?? []).filter((ts) => ts > cutoff);
+  history.push(now);
+  httpAgentCallHistory.set(agentId, history);
+  return { tripped: history.length > maxRunsPer60s, count: history.length };
+}
+
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { config, runId, agent, context } = ctx;
   const url = asString(config.url, "");
   if (!url) throw new Error("HTTP adapter missing url");
+
+  // Run-rate guard: prevent rapid consecutive invocations
+  const guardConfig = parseObject(config.paperclipRunGuard);
+  const guardEnabled = guardConfig.enabled !== false;
+  const maxRunsPer60s = asNumber(guardConfig.maxRunsPer60s, 10);
+  if (guardEnabled) {
+    const { tripped, count } = checkHttpRateGuard(agent.id, maxRunsPer60s);
+    if (tripped) {
+      const msg = `[paperclip] Run guard: HTTP agent ${agent.name} rate limit — ${count} invocations in 60s (max ${maxRunsPer60s})`;
+      const apiUrl = process.env["PAPERCLIP_API_URL"];
+      const token = ctx.authToken ?? process.env["PAPERCLIP_API_KEY"];
+      const issueId =
+        (typeof context.taskId === "string" ? context.taskId : null) ??
+        (typeof context.issueId === "string" ? context.issueId : null) ??
+        null;
+      if (apiUrl && token && issueId) {
+        fetch(`${apiUrl}/api/issues/${issueId}/comments`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+            "X-Paperclip-Run-Id": runId,
+          },
+          body: JSON.stringify({
+            body: `**Run guard: HTTP rate limit on ${agent.name}**\n\n${msg}\n\nRun: ${runId}`,
+          }),
+        }).catch(() => {});
+      }
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: msg,
+        errorCode: "run_guard_rate_limit",
+      };
+    }
+  }
 
   const method = asString(config.method, "POST");
   const timeoutMs = asNumber(config.timeoutMs, 0);

--- a/server/src/adapters/http/execute.ts
+++ b/server/src/adapters/http/execute.ts
@@ -2,7 +2,7 @@ import type { AdapterExecutionContext, AdapterExecutionResult } from "../types.j
 import { asString, asNumber, parseObject } from "../utils.js";
 
 // In-process sliding window: agentId -> recent invocation timestamps
-const httpAgentCallHistory = new Map<string, number[]>();
+export const httpAgentCallHistory = new Map<string, number[]>();
 
 function checkHttpRateGuard(
   agentId: string,


### PR DESCRIPTION
## Summary

Implements adapter safety rails for HIR-287: real-time loop detector and per-run $ cap across all three fleet adapters.

**Two commits:**
- `280a15c7` — opencode_local: loop guard, doom_loop deny, maxTurnsPerRun cap (already on master, shown for context)
- `2bf9dd1f` — claude_local + http guards: shared loop-detector.ts, subscription cost imputation, HTTP rate guard, 15 unit tests

**What ships:**

**Rail 1 — Per-run $ cap:**
- `claude_local`: post-exit enforcement with subscription cost imputation (sonnet $3/$15, opus $15/$75, haiku $0.25/$1.25 per M in/out)
- `opencode_local`: post-exit enforcement on metered cost
- `http`: in-process sliding-window rate guard (default 10 calls/60s per agentId)

**Rail 2 — Real-time loop detector:**
- New `packages/adapter-utils/src/loop-detector.ts`: `LoopDetector` class with 3 sliding-window trip conditions (≥5 same-tool/same-args in 5s, ≥10 in 30s, ≥30 same-tool in 60s)
- Parses JSONL `tool_use` events from both opencode_local and claude_local streaming formats
- On trip: `SIGTERM` via captured PID from `onSpawn`, best-effort alert comment posted to originating issue
- Config-driven: `paperclipRunGuard.loopDetector.*` and `paperclipRunGuard.budgetCapUsd` per agent

**Tests:** 15 unit tests covering all three trip conditions, JSONL parsing for both formats, subscription cost imputation math.

## Fleet validation required before merge

Per HIR-287 acceptance criteria:
- [ ] Synthetic loop test (100 identical Bash calls in 5s) against a claude_local agent — killed, cost < $0.10
- [ ] Same test against opencode_local agent
- [ ] HTTP agent invoked 12x in 60s — blocked at invocation 11
- [ ] 24h of normal fleet operation post-deploy — zero false positives

## Linked issues

- HIR-287 (director-engineering plan)
- HIR-294 (site-engineer implementation ticket)