### PR TITLE
fix(routines): coalesce_if_active matches any open execution issue (GRA-62)

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -223,14 +223,14 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(allRoutines.map((entry) => entry.id)).toEqual(expect.arrayContaining([routine.id, otherRoutine.id]));
   });
 
-  it("creates a fresh execution issue when the previous routine issue is open but idle", async () => {
+  it("coalesces when the previous routine issue is open but its heartbeat run completed (GRA-62)", async () => {
     const { companyId, issueSvc, routine, svc } = await seedFixture();
     const previousRunId = randomUUID();
     const previousIssue = await issueSvc.create(companyId, {
       projectId: routine.projectId,
       title: routine.title,
       description: routine.description,
-      status: "todo",
+      status: "blocked",
       priority: routine.priority,
       assigneeAgentId: routine.assigneeAgentId,
       originKind: "routine_execution",
@@ -251,23 +251,93 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     });
 
     const detailBefore = await svc.getDetail(routine.id);
-    expect(detailBefore?.activeIssue).toBeNull();
+    expect(detailBefore?.activeIssue?.id).toBe(previousIssue.id);
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("coalesced");
+    expect(run.linkedIssueId).toBe(previousIssue.id);
+    expect(run.coalescedIntoRunId).toBe(previousRunId);
+
+    const routineIssues = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+
+    expect(routineIssues).toHaveLength(1);
+    expect(routineIssues[0]?.id).toBe(previousIssue.id);
+  });
+
+  it("does not coalesce when the previous routine issue is done", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "done",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+      completedAt: new Date("2026-03-20T12:00:00.000Z"),
+    });
 
     const run = await svc.runRoutine(routine.id, { source: "manual" });
     expect(run.status).toBe("issue_created");
     expect(run.linkedIssueId).not.toBe(previousIssue.id);
 
     const routineIssues = await db
-      .select({
-        id: issues.id,
-        originRunId: issues.originRunId,
-      })
+      .select({ id: issues.id })
       .from(issues)
       .where(eq(issues.originId, routine.id));
 
     expect(routineIssues).toHaveLength(2);
     expect(routineIssues.map((issue) => issue.id)).toContain(previousIssue.id);
     expect(routineIssues.map((issue) => issue.id)).toContain(run.linkedIssueId);
+  });
+
+  it("does not coalesce when the previous routine issue is cancelled", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "cancelled",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+      completedAt: new Date("2026-03-20T12:00:00.000Z"),
+    });
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("issue_created");
+    expect(run.linkedIssueId).not.toBe(previousIssue.id);
   });
 
   it("creates draft routines without a project or default assignee", async () => {
@@ -719,7 +789,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(wakeupResolved).toBe(true);
   });
 
-  it("coalesces only when the existing routine issue has a live execution run", async () => {
+  it("coalesces against an in-progress routine issue with a live execution run", async () => {
     const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
     const previousRunId = randomUUID();
     const liveHeartbeatRunId = randomUUID();

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -178,14 +178,58 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     return { companyId, agentId, issueSvc, projectId, routine, svc, wakeups };
   }
 
-  it("creates a fresh execution issue when the previous routine issue is open but idle", async () => {
+  it("coalesces when the previous routine issue is open but its heartbeat run completed (GRA-62)", async () => {
     const { companyId, issueSvc, routine, svc } = await seedFixture();
     const previousRunId = randomUUID();
     const previousIssue = await issueSvc.create(companyId, {
       projectId: routine.projectId,
       title: routine.title,
       description: routine.description,
-      status: "todo",
+      status: "blocked",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+      completedAt: new Date("2026-03-20T12:00:00.000Z"),
+    });
+
+    const detailBefore = await svc.getDetail(routine.id);
+    expect(detailBefore?.activeIssue?.id).toBe(previousIssue.id);
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("coalesced");
+    expect(run.linkedIssueId).toBe(previousIssue.id);
+    expect(run.coalescedIntoRunId).toBe(previousRunId);
+
+    const routineIssues = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+
+    expect(routineIssues).toHaveLength(1);
+    expect(routineIssues[0]?.id).toBe(previousIssue.id);
+  });
+
+  it("does not coalesce when the previous routine issue is done", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "done",
       priority: routine.priority,
       assigneeAgentId: routine.assigneeAgentId,
       originKind: "routine_execution",
@@ -213,16 +257,45 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(run.linkedIssueId).not.toBe(previousIssue.id);
 
     const routineIssues = await db
-      .select({
-        id: issues.id,
-        originRunId: issues.originRunId,
-      })
+      .select({ id: issues.id })
       .from(issues)
       .where(eq(issues.originId, routine.id));
 
     expect(routineIssues).toHaveLength(2);
     expect(routineIssues.map((issue) => issue.id)).toContain(previousIssue.id);
     expect(routineIssues.map((issue) => issue.id)).toContain(run.linkedIssueId);
+  });
+
+  it("does not coalesce when the previous routine issue is cancelled", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "cancelled",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+      completedAt: new Date("2026-03-20T12:00:00.000Z"),
+    });
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("issue_created");
+    expect(run.linkedIssueId).not.toBe(previousIssue.id);
   });
 
   it("creates draft routines without a project or default assignee", async () => {
@@ -319,7 +392,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(wakeupResolved).toBe(true);
   });
 
-  it("coalesces only when the existing routine issue has a live execution run", async () => {
+  it("coalesces against an in-progress routine issue with a live execution run", async () => {
     const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
     const previousRunId = randomUUID();
     const liveHeartbeatRunId = randomUUID();

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -8,7 +8,6 @@ import {
   companySecrets,
   executionWorkspaces,
   goals,
-  heartbeatRuns,
   issueInboxArchives,
   issueReadStates,
   issues,
@@ -62,7 +61,6 @@ import { logActivity } from "./activity-log.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
 
 const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
-const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"];
 const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
 const MAX_CATCH_UP_RUNS = 25;
 const MAX_ROUTINE_REVISIONS = 100;
@@ -748,7 +746,10 @@ export function routineService(
 
   async function listLiveIssueByRoutineIds(companyId: string, routineIds: string[]) {
     if (routineIds.length === 0) return new Map<string, RoutineListItem["activeIssue"]>();
-    const executionBoundRows = await db
+    // "Active" = open (not done/cancelled) routine execution issue. We do NOT
+    // require a live heartbeat run: a `blocked` issue waiting for human input is
+    // still the canonical execution for the routine. See GRA-62.
+    const rows = await db
       .selectDistinctOn([issues.originId], {
         originId: issues.originId,
         id: issues.id,
@@ -759,13 +760,6 @@ export function routineService(
         updatedAt: issues.updatedAt,
       })
       .from(issues)
-      .innerJoin(
-        heartbeatRuns,
-        and(
-          eq(heartbeatRuns.id, issues.executionRunId),
-          inArray(heartbeatRuns.status, LIVE_HEARTBEAT_RUN_STATUSES),
-        ),
-      )
       .where(
         and(
           eq(issues.companyId, companyId),
@@ -777,52 +771,8 @@ export function routineService(
       )
       .orderBy(issues.originId, desc(issues.updatedAt), desc(issues.createdAt));
 
-    const rowsByOriginId = new Map<string, (typeof executionBoundRows)[number]>();
-    for (const row of executionBoundRows) {
-      if (!row.originId) continue;
-      rowsByOriginId.set(row.originId, row);
-    }
-
-    const missingRoutineIds = routineIds.filter((routineId) => !rowsByOriginId.has(routineId));
-    if (missingRoutineIds.length > 0) {
-      const legacyRows = await db
-        .selectDistinctOn([issues.originId], {
-          originId: issues.originId,
-          id: issues.id,
-          identifier: issues.identifier,
-          title: issues.title,
-          status: issues.status,
-          priority: issues.priority,
-          updatedAt: issues.updatedAt,
-        })
-        .from(issues)
-        .innerJoin(
-          heartbeatRuns,
-          and(
-            eq(heartbeatRuns.companyId, issues.companyId),
-            inArray(heartbeatRuns.status, LIVE_HEARTBEAT_RUN_STATUSES),
-            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = cast(${issues.id} as text)`,
-          ),
-        )
-        .where(
-          and(
-            eq(issues.companyId, companyId),
-            eq(issues.originKind, "routine_execution"),
-            inArray(issues.originId, missingRoutineIds),
-            inArray(issues.status, OPEN_ISSUE_STATUSES),
-            isNull(issues.hiddenAt),
-          ),
-        )
-        .orderBy(issues.originId, desc(issues.updatedAt), desc(issues.createdAt));
-
-      for (const row of legacyRows) {
-        if (!row.originId) continue;
-        rowsByOriginId.set(row.originId, row);
-      }
-    }
-
     const map = new Map<string, RoutineListItem["activeIssue"]>();
-    for (const row of rowsByOriginId.values()) {
+    for (const row of rows) {
       if (!row.originId) continue;
       map.set(row.originId, {
         id: row.id,
@@ -945,42 +895,15 @@ export function routineService(
     const fingerprintCondition = routineExecutionFingerprintCondition(dispatchFingerprint);
     const originKind = origin?.kind ?? "routine_execution";
     const originId = origin?.id ?? routine.id;
-    const executionBoundIssue = await executor
-      .select()
-      .from(issues)
-      .innerJoin(
-        heartbeatRuns,
-        and(
-          eq(heartbeatRuns.id, issues.executionRunId),
-          inArray(heartbeatRuns.status, LIVE_HEARTBEAT_RUN_STATUSES),
-        ),
-      )
-      .where(
-        and(
-          eq(issues.companyId, routine.companyId),
-          eq(issues.originKind, originKind),
-          eq(issues.originId, originId),
-          inArray(issues.status, OPEN_ISSUE_STATUSES),
-          isNull(issues.hiddenAt),
-          ...(fingerprintCondition ? [fingerprintCondition] : []),
-        ),
-      )
-      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
-      .limit(1)
-      .then((rows) => rows[0]?.issues ?? null);
-    if (executionBoundIssue) return executionBoundIssue;
-
+    // "Active" here = open (not done/cancelled) routine execution issue. We
+    // intentionally do NOT require a live heartbeat run: a `blocked` issue
+    // waiting for human input is still the canonical execution for the routine,
+    // and `coalesce_if_active` should coalesce against it. Tying coalescing to
+    // heartbeat-run liveness produced duplicate execution issues every time the
+    // prior agent finished its run while the issue stayed open. See GRA-62.
     return executor
       .select()
       .from(issues)
-      .innerJoin(
-        heartbeatRuns,
-        and(
-          eq(heartbeatRuns.companyId, issues.companyId),
-          inArray(heartbeatRuns.status, LIVE_HEARTBEAT_RUN_STATUSES),
-          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = cast(${issues.id} as text)`,
-        ),
-      )
       .where(
         and(
           eq(issues.companyId, routine.companyId),
@@ -993,7 +916,7 @@ export function routineService(
       )
       .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
       .limit(1)
-      .then((rows) => rows[0]?.issues ?? null);
+      .then((rows) => rows[0] ?? null);
   }
 
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -6,7 +6,6 @@ import {
   companySecrets,
   executionWorkspaces,
   goals,
-  heartbeatRuns,
   issueInboxArchives,
   issueReadStates,
   issues,
@@ -50,7 +49,6 @@ import { logActivity } from "./activity-log.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
 
 const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
-const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"];
 const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
 const MAX_CATCH_UP_RUNS = 25;
 const WEEKDAY_INDEX: Record<string, number> = {
@@ -532,7 +530,7 @@ export function routineService(
 
   async function listLiveIssueByRoutineIds(companyId: string, routineIds: string[]) {
     if (routineIds.length === 0) return new Map<string, RoutineListItem["activeIssue"]>();
-    const executionBoundRows = await db
+    const rows = await db
       .selectDistinctOn([issues.originId], {
         originId: issues.originId,
         id: issues.id,
@@ -543,13 +541,6 @@ export function routineService(
         updatedAt: issues.updatedAt,
       })
       .from(issues)
-      .innerJoin(
-        heartbeatRuns,
-        and(
-          eq(heartbeatRuns.id, issues.executionRunId),
-          inArray(heartbeatRuns.status, LIVE_HEARTBEAT_RUN_STATUSES),
-        ),
-      )
       .where(
         and(
           eq(issues.companyId, companyId),
@@ -561,52 +552,8 @@ export function routineService(
       )
       .orderBy(issues.originId, desc(issues.updatedAt), desc(issues.createdAt));
 
-    const rowsByOriginId = new Map<string, (typeof executionBoundRows)[number]>();
-    for (const row of executionBoundRows) {
-      if (!row.originId) continue;
-      rowsByOriginId.set(row.originId, row);
-    }
-
-    const missingRoutineIds = routineIds.filter((routineId) => !rowsByOriginId.has(routineId));
-    if (missingRoutineIds.length > 0) {
-      const legacyRows = await db
-        .selectDistinctOn([issues.originId], {
-          originId: issues.originId,
-          id: issues.id,
-          identifier: issues.identifier,
-          title: issues.title,
-          status: issues.status,
-          priority: issues.priority,
-          updatedAt: issues.updatedAt,
-        })
-        .from(issues)
-        .innerJoin(
-          heartbeatRuns,
-          and(
-            eq(heartbeatRuns.companyId, issues.companyId),
-            inArray(heartbeatRuns.status, LIVE_HEARTBEAT_RUN_STATUSES),
-            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = cast(${issues.id} as text)`,
-          ),
-        )
-        .where(
-          and(
-            eq(issues.companyId, companyId),
-            eq(issues.originKind, "routine_execution"),
-            inArray(issues.originId, missingRoutineIds),
-            inArray(issues.status, OPEN_ISSUE_STATUSES),
-            isNull(issues.hiddenAt),
-          ),
-        )
-        .orderBy(issues.originId, desc(issues.updatedAt), desc(issues.createdAt));
-
-      for (const row of legacyRows) {
-        if (!row.originId) continue;
-        rowsByOriginId.set(row.originId, row);
-      }
-    }
-
     const map = new Map<string, RoutineListItem["activeIssue"]>();
-    for (const row of rowsByOriginId.values()) {
+    for (const row of rows) {
       if (!row.originId) continue;
       map.set(row.originId, {
         id: row.id,
@@ -660,48 +607,21 @@ export function routineService(
     );
   }
 
+  // "Active" here = open (not done/cancelled) routine execution issue. We
+  // intentionally do NOT require a live heartbeat run: a `blocked` issue
+  // waiting for human input is still the canonical execution for the routine,
+  // and `coalesce_if_active` should coalesce against it. Tying coalescing to
+  // heartbeat-run liveness produced duplicate execution issues every time the
+  // prior agent finished its run while the issue stayed open. See GRA-62.
   async function findLiveExecutionIssue(
     routine: typeof routines.$inferSelect,
     executor: Db = db,
     dispatchFingerprint?: string | null,
   ) {
     const fingerprintCondition = routineExecutionFingerprintCondition(dispatchFingerprint);
-    const executionBoundIssue = await executor
-      .select()
-      .from(issues)
-      .innerJoin(
-        heartbeatRuns,
-        and(
-          eq(heartbeatRuns.id, issues.executionRunId),
-          inArray(heartbeatRuns.status, LIVE_HEARTBEAT_RUN_STATUSES),
-        ),
-      )
-      .where(
-        and(
-          eq(issues.companyId, routine.companyId),
-          eq(issues.originKind, "routine_execution"),
-          eq(issues.originId, routine.id),
-          inArray(issues.status, OPEN_ISSUE_STATUSES),
-          isNull(issues.hiddenAt),
-          ...(fingerprintCondition ? [fingerprintCondition] : []),
-        ),
-      )
-      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
-      .limit(1)
-      .then((rows) => rows[0]?.issues ?? null);
-    if (executionBoundIssue) return executionBoundIssue;
-
     return executor
       .select()
       .from(issues)
-      .innerJoin(
-        heartbeatRuns,
-        and(
-          eq(heartbeatRuns.companyId, issues.companyId),
-          inArray(heartbeatRuns.status, LIVE_HEARTBEAT_RUN_STATUSES),
-          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = cast(${issues.id} as text)`,
-        ),
-      )
       .where(
         and(
           eq(issues.companyId, routine.companyId),
@@ -714,7 +634,7 @@ export function routineService(
       )
       .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
       .limit(1)
-      .then((rows) => rows[0]?.issues ?? null);
+      .then((rows) => rows[0] ?? null);
   }
 
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Routines are the recurring-task subsystem: each fire dispatches an execution issue assigned to the routine's agent, governed by a `concurrencyPolicy`.
> - `coalesce_if_active` is meant to suppress a new fire while a prior execution of the same routine is still active, so a routine doesn't spawn duplicates.
> - The dispatcher decided "active" via `findLiveExecutionIssue`, which AND-ed two conditions: the issue is open **and** it is joined to a *live heartbeat run* (`queued | running | scheduled_retry`).
> - The problem: an execution issue that goes `blocked` (a normal state — waiting on a human) keeps its open status, but its heartbeat run completes and drops out of the live set. So `findLiveExecutionIssue` returns `null`, the coalesce branch is skipped, and the next fire creates a **duplicate** execution issue.
> - This pull request removes the heartbeat-run requirement so "active" means *any open routine-execution issue* — matching the policy name and the intuitive contract.
> - The benefit is that routines which legitimately block for human input no longer generate duplicate execution issues, thread-noise, and wasted budget on every subsequent fire.

## Linked Issues or Issue Description

Fixes #7926

The bug is also described inline below (following the [`bug_report.yml`](.github/ISSUE_TEMPLATE/bug_report.yml) template fields) so reviewers have full context without leaving the PR.

**What happened?**
The routine concurrency policy `coalesce_if_active` does not coalesce against `blocked` open routine-execution issues. Once a routine's prior execution issue is `blocked` (a normal state — waiting on a human) and the heartbeat run that owned it has `completed`, the next fire of the same routine creates a **duplicate** execution issue instead of coalescing against the still-open one.

**Expected behavior**
When a routine with `concurrencyPolicy: coalesce_if_active` fires while a prior execution issue of the same routine is still open (including `blocked`, `in_review`, `todo`, `backlog`), the new fire should coalesce against the existing issue rather than create a new one. Only terminal issues (`done`/`cancelled`) should permit a fresh execution.

**Steps to reproduce** (observed in production)
- `2026-04-28 13:35:51Z` — manual fire of routine `00cca5fc` ⇒ execution issue GRA-51.
- `13:38:20Z` — GRA-51 transitioned to `blocked` (waiting on a human); its owning heartbeat run later `completed`.
- `13:39:10Z` — a second manual fire produced a **duplicate** GRA-52, even though `concurrencyPolicy` is `coalesce_if_active` and GRA-51 was still open.

**Paperclip version or commit**
Reproduced on `master` at commit `f3db7b88` (the base this PR is built on); the offending join was still present in `findLiveExecutionIssue` and `listLiveIssueByRoutineIds`.

**Deployment mode**
Self-hosted / local adapter (`claude_local`). Not deployment-specific — the bug is in core routine dispatch logic and applies to all deployment modes.

**Root cause**
`findLiveExecutionIssue` / `listLiveIssueByRoutineIds` (`server/src/services/routines.ts`) inner-joined the execution issue to a heartbeat run whose status is in `LIVE_HEARTBEAT_RUN_STATUSES` (`queued | running | scheduled_retry`). A `blocked`-but-open issue with a `completed` run falls out of that set, so coalescing is skipped and a duplicate is dispatched.

## What Changed

- `server/src/services/routines.ts` — dropped the heartbeat-run join from `findLiveExecutionIssue` and `listLiveIssueByRoutineIds`; "active" now means any open routine-execution issue (`status` in `OPEN_ISSUE_STATUSES`, `hidden_at IS NULL`, fingerprint matches). `done`/`cancelled` remain excluded by status; legacy `default`-fingerprint coalescing is preserved by `routineExecutionFingerprintCondition`.
- Both helpers collapse from a dual exec-bound + context-snapshot query into a single `select()` from `issues`; the now-dead `heartbeatRuns` import and `LIVE_HEARTBEAT_RUN_STATUSES` constant were removed.
- `server/src/__tests__/routines-service.test.ts` — replaced the test that asserted the buggy "fresh issue when prior is open-but-idle" behavior with three focused tests and kept the live-run regression.

## Verification

- `pnpm -C server typecheck` — clean (`tsc --noEmit`, 0 errors).
- `pnpm -C server exec vitest run src/__tests__/routines-service.test.ts src/__tests__/routines-routes.test.ts src/__tests__/routines-e2e.test.ts src/__tests__/routine-run-telemetry.test.ts` — all routines suites pass.
- New tests added (per the bug report):
  - [x] Coalesces when the prior routine issue is `blocked` and its heartbeat run completed (headline GRA-62 case).
  - [x] Does **not** coalesce when the prior routine issue is `done`.
  - [x] Does **not** coalesce when the prior routine issue is `cancelled`.
  - [x] Existing live-run + variable-fingerprint divergence regressions unchanged and passing.
- Server-only change; no UI surface. The one failing `General tests` lane is an unrelated, pre-existing frontend flake (`@paperclipai/ui` `IssueProperties.test.tsx > edits existing custom assignee model options`) in a package this PR does not touch (diff is `server/` only).

## Risks

- Low risk. Behavioral shift is intentional and narrow: routines using `coalesce_if_active` will now coalesce against open `blocked`/`in_review`/`todo`/`backlog` execution issues, not only those with a live heartbeat run. Terminal (`done`/`cancelled`) issues are still excluded, so no resurrection of completed work. No schema/migration changes. Regression coverage for the live-run path is retained.

## Model Used

Claude Opus 4.8 (model ID `claude-opus-4-8`, 1M context window), with extended thinking and tool use (Paperclip agent harness). Original fix authored with Claude Code; rebased onto current master and description completed in the same model family.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found beyond this PR)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only change
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending re-run; the only red lane is an unrelated pre-existing frontend flake
- [ ] Greptile is 5/5 with no open P2s — Greptile rated 4/5 "safe to merge"; sole P2 was the missing PR-template sections, addressed by this description update
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
