### PR TITLE
fix(codex-local): pass --skip-git-repo-check on every codex exec invocation

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-args.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.test.ts
@@ -16,6 +16,7 @@ describe("buildCodexExecArgs", () => {
       "--search",
       "exec",
       "--json",
+      "--skip-git-repo-check",
       "--model",
       "gpt-5.4",
       "-c",
@@ -38,6 +39,7 @@ describe("buildCodexExecArgs", () => {
     expect(result.args).toEqual([
       "exec",
       "--json",
+      "--skip-git-repo-check",
       "--model",
       "gpt-5.5",
       "-c",
@@ -62,6 +64,7 @@ describe("buildCodexExecArgs", () => {
     expect(result.args).toEqual([
       "exec",
       "--json",
+      "--skip-git-repo-check",
       "--model",
       "gpt-5.3-codex",
       "-",

--- a/packages/adapters/codex-local/src/server/codex-args.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.ts
@@ -47,7 +47,7 @@ export function buildCodexExecArgs(
   );
   const extraArgs = readExtraArgs(record);
 
-  const args = ["exec", "--json"];
+  const args = ["exec", "--json", "--skip-git-repo-check"];
   if (search) args.unshift("--search");
   if (bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
   if (model) args.push("--model", model);


### PR DESCRIPTION
## Summary

- Always include `--skip-git-repo-check` in the args produced by `buildCodexExecArgs`, so the codex_local adapter can spawn `codex exec --json -` from any working directory without hanging on Codex CLI 0.125+'s trusted-directory gate.
- Update unit tests to reflect the new args order.

Closes #4774

## Why always-on

Codex CLI 0.125+ refuses to run `codex exec` outside a Git repository unless `--skip-git-repo-check` is passed; the process waits for additional stdin instead of producing JSONL output. The flag is harmless inside Git repos and required outside them. The adapter does not rely on Codex's trusted-directory check for any of its own controls — sandbox and approval policies are already gated through Paperclip's own settings (`dangerouslyBypassApprovalsAndSandbox` → `--dangerously-bypass-approvals-and-sandbox`).

The user-facing `Extra args (comma-separated)` field on the agent configuration page is not a reliable workaround in current code: the backend's `readExtraArgs` calls `asStringArray`, which returns `[]` for any non-array input, so the comma-separated string from the form often does not reach `buildCodexExecArgs` as `[\"--skip-git-repo-check\"]`. That behavior is a separate bug worth tracking, but adding the flag here unconditionally fixes the immediate hang for everyone regardless of UI input.

## Test plan

- [x] `pnpm --filter @paperclipai/adapters-codex-local test` (existing tests updated to include the new flag in the expected args order)
- [ ] Manual: open agent configuration page for a Codex agent in a non-Git cwd, click **Test environment**, and verify the hello probe returns instead of timing out
- [ ] Manual: confirm Codex live runs inside a Git repository still succeed (flag is a no-op there)

## Model Used

Claude Opus 4.7 (1M context)