### PR TITLE
ELEAAA-457-A placeholder detection helper

### DIFF
--- a/packages/shared/src/__tests__/placeholder.test.ts
+++ b/packages/shared/src/__tests__/placeholder.test.ts
@@ -44,6 +44,8 @@ describe("placeholder comments", () => {
     "No operation performed because the API was unavailable.",
     "Continuing with implementation after reading the plan.",
     "Polling Paperclip would be wrong here, so I am exiting.",
+    "Self-wake: implemented rate-limiting for ELEAAA-462 and verified all edge cases.",
+    "Self-wake — actually pausing because the Redis pool is exhausted; investigating now",
     "....",
   ])("rejects non-placeholder body %j", (body) => {
     expect(isPlaceholderCommentBody(body)).toBe(false);

--- a/packages/shared/src/__tests__/placeholder.test.ts
+++ b/packages/shared/src/__tests__/placeholder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_PLACEHOLDER_PATTERNS, isPlaceholderCommentBody } from "./placeholder.js";
+import { DEFAULT_PLACEHOLDER_PATTERNS, isPlaceholderCommentBody } from "../placeholder.js";
 
 describe("placeholder comments", () => {
   it("ships the approved 9-pattern default set", () => {
@@ -33,7 +33,11 @@ describe("placeholder comments", () => {
 
   it.each([
     "",
+    "   ",
+    null,
+    undefined,
     "Done: implemented the placeholder detector.",
+    "Parked. Investigating M2 dashboard outage.",
     "Blocked by ELEAAA-457: waiting for CTO review.",
     "Working on the failing test now.",
     "Parking lot update: route guard still needs a child issue.",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -218,6 +218,8 @@ export {
   validateConfiguredBindMode,
 } from "./network-bind.js";
 
+export { DEFAULT_PLACEHOLDER_PATTERNS, isPlaceholderCommentBody } from "./placeholder.js";
+
 export type {
   Company,
   Environment,

--- a/packages/shared/src/placeholder.test.ts
+++ b/packages/shared/src/placeholder.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_PLACEHOLDER_PATTERNS, isPlaceholderCommentBody } from "./placeholder.js";
+
+describe("placeholder comments", () => {
+  it("ships the approved 9-pattern default set", () => {
+    expect(DEFAULT_PLACEHOLDER_PATTERNS).toHaveLength(9);
+  });
+
+  it.each([
+    "Parked",
+    "parked.",
+    "  Parking  ",
+    "Silent",
+    "Silent.",
+    "Silent exit",
+    "silent exit.",
+    "Self-wake waiting for review",
+    "selfwake loop",
+    "Done for this heartbeat",
+    "Noop.",
+    "Blocked",
+    ".",
+    "..",
+    "...",
+    "Heartbeat over",
+    "Continuing.",
+    "Working",
+    "Idle",
+    "Polling.",
+  ])("matches default placeholder body %j", (body) => {
+    expect(isPlaceholderCommentBody(body)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "Done: implemented the placeholder detector.",
+    "Blocked by ELEAAA-457: waiting for CTO review.",
+    "Working on the failing test now.",
+    "Parking lot update: route guard still needs a child issue.",
+    "No operation performed because the API was unavailable.",
+    "Continuing with implementation after reading the plan.",
+    "Polling Paperclip would be wrong here, so I am exiting.",
+    "....",
+  ])("rejects non-placeholder body %j", (body) => {
+    expect(isPlaceholderCommentBody(body)).toBe(false);
+  });
+
+  it("accepts an explicit regex set override", () => {
+    expect(isPlaceholderCommentBody("ship it", [/^ship it$/i])).toBe(true);
+    expect(isPlaceholderCommentBody("ship it")).toBe(false);
+  });
+});

--- a/packages/shared/src/placeholder.ts
+++ b/packages/shared/src/placeholder.ts
@@ -2,7 +2,7 @@ export const DEFAULT_PLACEHOLDER_PATTERNS: ReadonlyArray<RegExp> = Object.freeze
   /^\s*Parked\.?\s*$/i,
   /^\s*Parking\.?\s*$/i,
   /^\s*Silent(?:\.|\s+exit\.?)?\s*$/i,
-  /^\s*Self-?wake.*$/i,
+  /^\s*Self-?wake(?:\s+(?:loop|exit|waiting(?:\s+for\s+\w+)?))?\.?\s*$/i,
   /^\s*Done for this heartbeat\.?\s*$/i,
   /^\s*Noop\.?\s*$/i,
   /^\s*Blocked\.?\s*$/i,

--- a/packages/shared/src/placeholder.ts
+++ b/packages/shared/src/placeholder.ts
@@ -1,0 +1,25 @@
+export const DEFAULT_PLACEHOLDER_PATTERNS: ReadonlyArray<RegExp> = Object.freeze([
+  /^\s*Parked\.?\s*$/i,
+  /^\s*Parking\.?\s*$/i,
+  /^\s*Silent(?:\.|\s+exit\.?)?\s*$/i,
+  /^\s*Self-?wake.*$/i,
+  /^\s*Done for this heartbeat\.?\s*$/i,
+  /^\s*Noop\.?\s*$/i,
+  /^\s*Blocked\.?\s*$/i,
+  /^\s*\.{1,3}\s*$/,
+  /^\s*(?:Heartbeat over|Continuing|Working|Idle|Polling)\.?\s*$/i,
+]);
+
+export function isPlaceholderCommentBody(
+  body: string | null | undefined,
+  regexSet: ReadonlyArray<RegExp> = DEFAULT_PLACEHOLDER_PATTERNS,
+): boolean {
+  const normalizedBody = body?.trim();
+  if (!normalizedBody) return false;
+
+  for (const pattern of regexSet) {
+    pattern.lastIndex = 0;
+    if (pattern.test(normalizedBody)) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Issue comments are part of the control-plane audit trail for what agents did and why.
> - Placeholder comments like `Parked.` or `.` can create wake loops and bury useful state.
> - The ELEAAA-457 placeholder-comment cap needs a small shared classifier before route/window enforcement can use it.
> - This pull request adds that pure classifier, exports it from `@paperclipai/shared`, and locks the default pattern set with unit tests.
> - The benefit is that the server can later suppress low-information placeholder spam without suppressing substantive progress notes.

## What Changed

- Added `packages/shared/src/placeholder.ts` with `DEFAULT_PLACEHOLDER_PATTERNS` and `isPlaceholderCommentBody(body, patterns?)`.
- Re-exported the helper from `packages/shared/src/index.ts`.
- Added Vitest coverage at `packages/shared/src/__tests__/placeholder.test.ts` for positive matches, anchored non-matches, nullish/blank bodies, 1-3 dot behavior, custom pattern override, and substantive `Self-wake` comments.
- Follow-up review patch bounded the `Self-?wake` pattern to known sentinel forms instead of matching any body starting with `Self-wake`.

Scope vs spec: this ships only ELEAAA-457-A, the pure detection helper. Parent ELEAAA-457 still needs window logic, route guard, Prom/audit wiring, and docs/SOUL addendum in the B/C/D child issues.

## Verification

- Initial red: `pnpm --filter @paperclipai/shared exec vitest run src/placeholder.test.ts` failed before implementation with `Cannot find module './placeholder.js'`.
- Review red: `pnpm --filter @paperclipai/shared exec vitest run src/__tests__/placeholder.test.ts` failed on the two substantive `Self-wake` negative cases before the bounded regex fix.
- Final focused: `pnpm --filter @paperclipai/shared exec vitest run src/__tests__/placeholder.test.ts` -> 1 file passed, 37 tests passed.
- Typecheck: `pnpm --filter @paperclipai/shared typecheck` -> pass.
- Shared suite: `pnpm --filter @paperclipai/shared exec vitest run` -> 10 files passed, 84 tests passed.

## Risks

- Low runtime risk: this is a pure shared helper and is not wired into the comment route yet.
- Main behavior risk is false positives. The regexes are full-body matches, and tests now cover substantive comments such as `Parked. Investigating...`, `Working on...`, and `Self-wake: implemented...`.
- No runtime dependency added.

## Model Used

- OpenAI Codex via the Paperclip Backend Engineer adapter, `gpt-5.3-codex`, tool use enabled, reasoning mode: medium. Runtime did not expose an exact context-window value.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A, no UI)
- [x] I have updated relevant documentation to reflect my changes (N/A, pure helper; route docs are out of scope for ELEAAA-457-D)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

## Rollback

- Before merge: close this PR and delete branch `feature/eleaaa-457-A-placeholder-detection-helper` from `alexanderkiehl/paperclip`.
- After merge: `git revert <merge_commit_sha>`.
- If reverting locally before merge: `git revert 1bcf4c07 a037217c eec576bd 025001e6`.

## CTO Review Request

CTO review requested for ELEAAA-460 / ELEAAA-457-A. Please run `/plan-eng-review` + `/review`; ELEAAA-462 route guard depends on this helper.

## Tech-Debt Log

None. No runtime dependency added; out-of-scope work remains tracked in the B/C/D child issues.
