### PR TITLE
feat: surface plugin tools to claude-local agents via MCP sidecar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY packages/db/package.json packages/db/
 COPY packages/adapter-utils/package.json packages/adapter-utils/
 COPY packages/mcp-server/package.json packages/mcp-server/
 COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
+COPY packages/adapters/claude-local-tool-bridge/package.json packages/adapters/claude-local-tool-bridge/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
 COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
 COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
@@ -40,6 +41,7 @@ COPY --from=deps /app /app
 COPY . .
 RUN pnpm --filter @paperclipai/ui build
 RUN pnpm --filter @paperclipai/plugin-sdk build
+RUN pnpm --filter @paperclipai/claude-local-tool-bridge build
 RUN pnpm --filter @paperclipai/server build
 RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)
 

--- a/packages/adapters/claude-local-tool-bridge/package.json
+++ b/packages/adapters/claude-local-tool-bridge/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@paperclipai/claude-local-tool-bridge",
+  "version": "0.1.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "paperclip-plugin-tool-bridge": "./dist/index.js"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/packages/adapters/claude-local-tool-bridge/src/index.ts
+++ b/packages/adapters/claude-local-tool-bridge/src/index.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * MCP stdio server that surfaces Paperclip plugin tools to a Claude Code
+ * session. Spawned per agent run by the `claude-local` adapter. Reads
+ * scope + auth from env, exposes `tools/list` and `tools/call`, proxies
+ * each call to Paperclip's `/api/plugins/tools/*` endpoints.
+ *
+ * Required env:
+ *   PAPERCLIP_API_BASE     e.g. http://localhost:3100
+ *   PAPERCLIP_AGENT_TOKEN  agent-scoped JWT (createLocalAgentJwt)
+ *   PAPERCLIP_AGENT_ID     UUID
+ *   PAPERCLIP_RUN_ID       UUID
+ *   PAPERCLIP_COMPANY_ID   UUID
+ *
+ * Optional:
+ *   PAPERCLIP_PROJECT_ID   UUID, omitted for project-less runs
+ *   PAPERCLIP_TIMEOUT_MS   per-call HTTP timeout, default 30000
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { createPaperclipClient } from "./paperclip-client.js";
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    process.stderr.write(`[paperclip-tool-bridge] missing required env: ${name}\n`);
+    process.exit(2);
+  }
+  return v;
+}
+
+async function main() {
+  const apiBase = required("PAPERCLIP_API_BASE");
+  const token = required("PAPERCLIP_AGENT_TOKEN");
+  const runContext = {
+    agentId: required("PAPERCLIP_AGENT_ID"),
+    runId: required("PAPERCLIP_RUN_ID"),
+    companyId: required("PAPERCLIP_COMPANY_ID"),
+    projectId: process.env.PAPERCLIP_PROJECT_ID || null,
+  };
+  const timeoutMs = process.env.PAPERCLIP_TIMEOUT_MS
+    ? Number.parseInt(process.env.PAPERCLIP_TIMEOUT_MS, 10)
+    : undefined;
+
+  const client = createPaperclipClient({ apiBase, token, runContext, timeoutMs });
+
+  const server = new Server(
+    { name: "paperclip-plugin-tools", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const tools = await client.listTools();
+    return {
+      tools: tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.parametersSchema as Record<string, unknown>,
+      })),
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name, arguments: args } = req.params;
+    const result = await client.executeTool(name, args ?? {});
+
+    // Two error shapes: HTTP-level error wraps the body in `result.error`
+    // with the route's message; per-tool error comes back nested in
+    // `result.result.error`. Surface both as MCP `isError`.
+    const inner = result.result;
+    if (result.error || inner?.error) {
+      const message = result.error ?? inner?.error ?? "tool execution failed";
+      return {
+        content: [{ type: "text", text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+
+    const text =
+      inner?.content ??
+      (inner?.data !== undefined ? JSON.stringify(inner.data) : "");
+    return { content: [{ type: "text", text }] };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[paperclip-tool-bridge] fatal: ${err}\n`);
+  process.exit(1);
+});

--- a/packages/adapters/claude-local-tool-bridge/src/paperclip-client.ts
+++ b/packages/adapters/claude-local-tool-bridge/src/paperclip-client.ts
@@ -1,0 +1,87 @@
+/**
+ * Thin HTTP client around Paperclip's plugin-tools endpoints. Used by the
+ * MCP bridge to translate `tools/list` and `tools/call` MCP requests into
+ * Paperclip API calls scoped to a specific agent run.
+ *
+ * The token is the per-run agent JWT minted by
+ * `server/src/agent-auth-jwt.ts#createLocalAgentJwt` — it identifies the
+ * caller as `actor.type === "agent"` so that the routes (after the
+ * #4192 PR) accept it.
+ */
+
+export interface RunContext {
+  agentId: string;
+  runId: string;
+  companyId: string;
+  projectId: string | null;
+}
+
+export interface PaperclipClientOpts {
+  apiBase: string;
+  token: string;
+  runContext: RunContext;
+  /** Hard timeout per HTTP call in ms. Defaults to 30000. */
+  timeoutMs?: number;
+}
+
+export interface AgentToolDescriptor {
+  name: string;
+  displayName: string;
+  description: string;
+  parametersSchema: Record<string, unknown>;
+  pluginId: string;
+  pluginDbId: string;
+}
+
+export interface ToolExecuteResult {
+  pluginId?: string;
+  toolName?: string;
+  result?: { content?: string; data?: unknown; error?: string };
+  error?: string;
+}
+
+export interface PaperclipClient {
+  listTools(): Promise<AgentToolDescriptor[]>;
+  executeTool(name: string, parameters: unknown): Promise<ToolExecuteResult>;
+}
+
+export function createPaperclipClient(opts: PaperclipClientOpts): PaperclipClient {
+  const headers = { Authorization: `Bearer ${opts.token}` };
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+
+  async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(`${opts.apiBase}${path}`, {
+        ...init,
+        signal: controller.signal,
+        headers: { ...headers, ...(init?.headers ?? {}) },
+      });
+      const text = await res.text();
+      if (!res.ok) {
+        throw new Error(`${init?.method ?? "GET"} ${path} → ${res.status}: ${text || "(empty body)"}`);
+      }
+      return text ? (JSON.parse(text) as T) : (undefined as T);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  return {
+    async listTools() {
+      return fetchJson<AgentToolDescriptor[]>("/api/plugins/tools");
+    },
+    async executeTool(name, parameters) {
+      return fetchJson<ToolExecuteResult>("/api/plugins/tools/execute", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tool: name,
+          parameters,
+          runContext: opts.runContext,
+        }),
+      });
+    },
+  };
+}

--- a/packages/adapters/claude-local-tool-bridge/tsconfig.json
+++ b/packages/adapters/claude-local-tool-bridge/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -588,7 +588,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     companyId: agent.companyId,
     projectId: null,
     authToken,
-    apiBase: typeof env.PAPERCLIP_API_URL === "string" ? env.PAPERCLIP_API_URL : "http://localhost:3100",
+    // The bridge runs in the same container as the Paperclip server, so
+    // hit it on localhost rather than the public URL. Going via
+    // `env.PAPERCLIP_API_URL` (which can be a Cloudflare-fronted public
+    // host) would round-trip out through the CDN + tunnel and back in,
+    // adding latency and exposure to upstream 502s for what is logically
+    // a same-process call. PAPERCLIP_PORT is set in the deploy compose;
+    // 3100 is the upstream default.
+    apiBase: `http://localhost:${process.env.PAPERCLIP_PORT ?? "3100"}`,
     disabled: asBoolean(config.disablePluginTools, false),
   });
 

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
@@ -49,6 +50,75 @@ import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Resolve the path to the bundled plugin-tool MCP bridge entrypoint.
+ * Both source (`src/server/`) and built (`dist/server/`) layouts resolve
+ * to the same sibling-package location. Returns `null` if the file isn't
+ * present (e.g. dev environment without the bridge built yet).
+ */
+async function resolvePluginMcpBridgeBin(): Promise<string | null> {
+  const candidate = path.resolve(
+    __moduleDir,
+    "..",
+    "..",
+    "..",
+    "..",
+    "claude-local-tool-bridge",
+    "dist",
+    "index.js",
+  );
+  try {
+    await fs.access(candidate);
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write a per-run `.mcp.json` that spawns the plugin-tool bridge as an MCP
+ * server inside the Claude Code session. Returns the file path (to be passed
+ * via `--mcp-config`), or `null` to skip injection. Reasons to skip:
+ *   - `disablePluginTools` adapter config (operator escape hatch)
+ *   - no agent JWT (the bridge can't authenticate to Paperclip)
+ *   - the bridge bin isn't on disk (dev environment without `pnpm build`)
+ */
+async function maybeWritePluginMcpConfig(input: {
+  runId: string;
+  agentId: string;
+  companyId: string;
+  projectId: string | null;
+  authToken: string | undefined;
+  apiBase: string;
+  disabled: boolean;
+}): Promise<string | null> {
+  if (input.disabled) return null;
+  if (!input.authToken) return null;
+  const bridgeBin = await resolvePluginMcpBridgeBin();
+  if (!bridgeBin) return null;
+
+  const mcpConfig = {
+    mcpServers: {
+      "paperclip-plugin-tools": {
+        command: "node",
+        args: [bridgeBin],
+        env: {
+          PAPERCLIP_API_BASE: input.apiBase,
+          PAPERCLIP_AGENT_TOKEN: input.authToken,
+          PAPERCLIP_AGENT_ID: input.agentId,
+          PAPERCLIP_RUN_ID: input.runId,
+          PAPERCLIP_COMPANY_ID: input.companyId,
+          ...(input.projectId ? { PAPERCLIP_PROJECT_ID: input.projectId } : {}),
+        },
+      },
+    },
+  };
+
+  const filePath = path.join(os.tmpdir(), `paperclip-plugin-mcp-${input.runId}.json`);
+  await fs.writeFile(filePath, JSON.stringify(mcpConfig, null, 2), "utf8");
+  return filePath;
+}
 
 interface ClaudeExecutionInput {
   runId: string;
@@ -505,6 +575,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     heartbeatPromptChars: renderedPrompt.length,
   };
 
+  const pluginMcpConfigPath = await maybeWritePluginMcpConfig({
+    runId,
+    agentId: agent.id,
+    companyId: agent.companyId,
+    projectId: null,
+    authToken,
+    apiBase: typeof env.PAPERCLIP_API_URL === "string" ? env.PAPERCLIP_API_URL : "http://localhost:3100",
+    disabled: asBoolean(config.disablePluginTools, false),
+  });
+
   const buildClaudeArgs = (
     resumeSessionId: string | null,
     attemptInstructionsFilePath: string | undefined,
@@ -528,6 +608,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--append-system-prompt-file", attemptInstructionsFilePath);
     }
     args.push("--add-dir", effectivePromptBundleAddDir);
+    if (pluginMcpConfigPath) args.push("--mcp-config", pluginMcpConfigPath);
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -54,13 +54,15 @@ const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 /**
  * Resolve the path to the bundled plugin-tool MCP bridge entrypoint.
  * Both source (`src/server/`) and built (`dist/server/`) layouts resolve
- * to the same sibling-package location. Returns `null` if the file isn't
- * present (e.g. dev environment without the bridge built yet).
+ * to the same sibling-package location: from `<base>/server/`, three
+ * `..`s land at `packages/adapters/`, then sibling-package
+ * `claude-local-tool-bridge/dist/index.js`. Returns `null` if the file
+ * isn't present (e.g. dev environment without the bridge built yet) and
+ * logs to stderr so the silent-skip case is visible.
  */
 async function resolvePluginMcpBridgeBin(): Promise<string | null> {
   const candidate = path.resolve(
     __moduleDir,
-    "..",
     "..",
     "..",
     "..",
@@ -72,6 +74,11 @@ async function resolvePluginMcpBridgeBin(): Promise<string | null> {
     await fs.access(candidate);
     return candidate;
   } catch {
+    process.stderr.write(
+      `[claude-local] plugin-tool bridge bin not found at ${candidate}; ` +
+      `--mcp-config injection skipped. Build the bridge with ` +
+      `\`pnpm --filter @paperclipai/claude-local-tool-bridge build\`.\n`,
+    );
     return null;
   }
 }

--- a/packages/plugins/examples/plugin-kitchen-sink-example/src/worker.ts
+++ b/packages/plugins/examples/plugin-kitchen-sink-example/src/worker.ts
@@ -885,7 +885,7 @@ async function registerToolHandlers(ctx: PluginContext): Promise<void> {
       }
       const issue = await ctx.issues.create({
         companyId: runCtx.companyId,
-        projectId: runCtx.projectId,
+        projectId: runCtx.projectId ?? undefined,
         title: payload.title,
         description: payload.description,
       });

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -208,8 +208,12 @@ export interface ToolRunContext {
   runId: string;
   /** UUID of the company the run belongs to. */
   companyId: string;
-  /** UUID of the project the run belongs to. */
-  projectId: string;
+  /**
+   * UUID of the project the run belongs to, or `null` when the run is not
+   * scoped to a project (e.g. an agent operating directly on a standalone
+   * issue with no parent project).
+   */
+  projectId: string | null;
 }
 
 /**

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -87,6 +87,14 @@ export interface PluginToolDeclaration {
   description: string;
   /** JSON Schema describing the tool's input parameters. */
   parametersSchema: JsonSchema;
+  /**
+   * Whether this tool should be advertised to agents and callable by them.
+   * Defaults to `true`. Set `false` for operator-only tools (admin surfaces,
+   * destructive ops) — they remain visible and executable to board callers
+   * but are hidden from agent tool lists and rejected on agent-initiated
+   * execute as if the tool doesn't exist.
+   */
+  exposeToAgents?: boolean;
 }
 
 /**

--- a/packages/shared/src/validators/plugin.ts
+++ b/packages/shared/src/validators/plugin.ts
@@ -105,6 +105,7 @@ export const pluginToolDeclarationSchema = z.object({
   displayName: z.string().min(1),
   description: z.string().min(1),
   parametersSchema: jsonSchemaSchema,
+  exposeToAgents: z.boolean().optional(),
 });
 
 export const pluginEnvironmentDriverDeclarationSchema = z.object({

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -538,6 +538,74 @@ describe.sequential("plugin tool and bridge authz", () => {
     expect(executeTool).toHaveBeenCalled();
   });
 
+  it("returns 404 when an agent calls an exposeToAgents=false tool", async () => {
+    const executeTool = vi.fn();
+    const { app } = await createApp(agentActor(), {}, {
+      db: createSelectQueueDb([
+        [{ companyId: companyA }],
+        [{ companyId: companyA, agentId: agentA }],
+        [{ companyId: companyA }],
+      ]),
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclip.example:admin", exposeToAgents: false })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:admin",
+        parameters: {},
+        runContext: {
+          agentId: agentA,
+          runId: runA,
+          companyId: companyA,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(404);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("allows board user to execute exposeToAgents=false tool", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ content: "ok" });
+    const { app } = await createApp(boardActor(), {}, {
+      db: createSelectQueueDb([
+        [{ companyId: companyA }],
+        [{ companyId: companyA, agentId: agentA }],
+        [{ companyId: companyA }],
+      ]),
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclip.example:admin", exposeToAgents: false })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:admin",
+        parameters: {},
+        runContext: {
+          agentId: agentA,
+          runId: runA,
+          companyId: companyA,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(executeTool).toHaveBeenCalled();
+  });
+
   it("rejects agent tool execution when runContext.companyId is not the agent's company", async () => {
     const executeTool = vi.fn();
     const { app } = await createApp(agentActor(), {}, {

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -506,6 +506,38 @@ describe.sequential("plugin tool and bridge authz", () => {
     expect(executeTool).not.toHaveBeenCalled();
   });
 
+  it("allows tool execution when runContext.projectId is omitted (project-less run)", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ content: "ok" });
+    const { app } = await createApp(boardActor(), {}, {
+      db: createSelectQueueDb([
+        [{ companyId: companyA }],
+        [{ companyId: companyA, agentId: agentA }],
+      ]),
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclip.example:search" })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: {},
+        runContext: {
+          agentId: agentA,
+          runId: runA,
+          companyId: companyA,
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(executeTool).toHaveBeenCalled();
+  });
+
   it("rejects agent tool execution when runContext.companyId is not the agent's company", async () => {
     const executeTool = vi.fn();
     const { app } = await createApp(agentActor(), {}, {

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -101,6 +101,16 @@ function boardActor(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function agentActor(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "agent",
+    agentId: agentA,
+    runId: runA,
+    companyId: companyA,
+    ...overrides,
+  };
+}
+
 function readyPlugin() {
   mockRegistry.getById.mockResolvedValue({
     id: pluginId,
@@ -414,6 +424,115 @@ describe.sequential("plugin tool and bridge authz", () => {
       expect(res.status, label).toBe(403);
       expect(executeTool).not.toHaveBeenCalled();
     }
+  });
+
+  it("allows agent JWT to list plugin tools", async () => {
+    const listToolsForAgent = vi.fn(() => []);
+    const { app } = await createApp(agentActor(), {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent,
+          getTool: vi.fn(),
+          executeTool: vi.fn(),
+        },
+      },
+    });
+
+    const res = await request(app).get("/api/plugins/tools");
+    expect(res.status).toBe(200);
+    expect(listToolsForAgent).toHaveBeenCalled();
+  });
+
+  it("allows agent JWT to execute a tool when runContext.agentId matches", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ content: "ok" });
+    const { app } = await createApp(agentActor(), {}, {
+      db: createSelectQueueDb([
+        [{ companyId: companyA }],
+        [{ companyId: companyA, agentId: agentA }],
+        [{ companyId: companyA }],
+      ]),
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclip.example:search" })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: { q: "test" },
+        runContext: {
+          agentId: agentA,
+          runId: runA,
+          companyId: companyA,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(executeTool).toHaveBeenCalled();
+  });
+
+  it("rejects agent tool execution when runContext.agentId is a different agent", async () => {
+    const executeTool = vi.fn();
+    const { app } = await createApp(agentActor(), {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: {},
+        runContext: {
+          agentId: "77777777-7777-4777-8777-777777777777",
+          runId: runA,
+          companyId: companyA,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent tool execution when runContext.companyId is not the agent's company", async () => {
+    const executeTool = vi.fn();
+    const { app } = await createApp(agentActor(), {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: {},
+        runContext: {
+          agentId: agentA,
+          runId: runA,
+          companyId: companyB,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(executeTool).not.toHaveBeenCalled();
   });
 
   it("allows tool execution when agent, run, and project all belong to runContext.companyId", async () => {

--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -39,6 +39,20 @@ export function assertInstanceAdmin(req: Request) {
   throw forbidden("Instance admin access required");
 }
 
+/**
+ * Plugin-tool routes accept two actor shapes:
+ *   - board users with company-org access (existing behavior), or
+ *   - agent JWTs (set by an adapter when spawning an agent run).
+ * Per-call scope (companyId / agentId / runId / projectId belong together)
+ * is enforced separately at each route — see `assertCompanyAccess` and
+ * `validateToolRunContextScope` in `routes/plugins.ts`.
+ */
+export function assertPluginToolAccess(req: Request) {
+  assertAuthenticated(req);
+  if (req.actor.type === "agent") return;
+  assertBoardOrgAccess(req);
+}
+
 export function assertCompanyAccess(req: Request, companyId: string) {
   assertAuthenticated(req);
   if (req.actor.type === "agent" && req.actor.companyId !== companyId) {

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -590,13 +590,15 @@ export function pluginRoutes(
       return '"runContext.runId" does not belong to "runContext.agentId"';
     }
 
-    const [project] = await db
-      .select({ companyId: projects.companyId })
-      .from(projects)
-      .where(eq(projects.id, runContext.projectId))
-      .limit(1);
-    if (!project || project.companyId !== runContext.companyId) {
-      return '"runContext.projectId" does not belong to "runContext.companyId"';
+    if (runContext.projectId) {
+      const [project] = await db
+        .select({ companyId: projects.companyId })
+        .from(projects)
+        .where(eq(projects.id, runContext.projectId))
+        .limit(1);
+      if (!project || project.companyId !== runContext.companyId) {
+        return '"runContext.projectId" does not belong to "runContext.companyId"';
+      }
     }
 
     return null;
@@ -788,9 +790,9 @@ export function pluginRoutes(
       return;
     }
 
-    if (!runContext.agentId || !runContext.runId || !runContext.companyId || !runContext.projectId) {
+    if (!runContext.agentId || !runContext.runId || !runContext.companyId) {
       res.status(400).json({
-        error: '"runContext" must include agentId, runId, companyId, and projectId',
+        error: '"runContext" must include agentId, runId, and companyId',
       });
       return;
     }

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -63,6 +63,7 @@ import {
   assertBoardOrgAccess,
   assertCompanyAccess,
   assertInstanceAdmin,
+  assertPluginToolAccess,
   getActorInfo,
 } from "./authz.js";
 import { validateInstanceConfig } from "../services/plugin-config-validator.js";
@@ -727,7 +728,7 @@ export function pluginRoutes(
    * Errors: 501 if tool dispatcher is not configured
    */
   router.get("/plugins/tools", async (req, res) => {
-    assertBoardOrgAccess(req);
+    assertPluginToolAccess(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
@@ -761,7 +762,7 @@ export function pluginRoutes(
    * - 502 if the plugin worker is unavailable or the RPC call fails
    */
   router.post("/plugins/tools/execute", async (req, res) => {
-    assertBoardOrgAccess(req);
+    assertPluginToolAccess(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
@@ -792,6 +793,10 @@ export function pluginRoutes(
         error: '"runContext" must include agentId, runId, companyId, and projectId',
       });
       return;
+    }
+
+    if (req.actor.type === "agent" && req.actor.agentId !== runContext.agentId) {
+      throw forbidden('"runContext.agentId" does not match the calling agent');
     }
 
     assertCompanyAccess(req, runContext.companyId);

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -808,9 +808,16 @@ export function pluginRoutes(
       return;
     }
 
-    // Verify the tool exists
+    // Verify the tool exists. When the caller is an agent, treat
+    // exposeToAgents=false tools as if they don't exist — preserves
+    // the dispatcher invariant that an agent can't see what it can't
+    // call.
     const registeredTool = toolDeps.toolDispatcher.getTool(tool);
     if (!registeredTool) {
+      res.status(404).json({ error: `Tool "${tool}" not found` });
+      return;
+    }
+    if (req.actor.type === "agent" && registeredTool.exposeToAgents === false) {
       res.status(404).json({ error: `Tool "${tool}" not found` });
       return;
     }

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1826,7 +1826,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -386,7 +386,10 @@ export function createPluginToolDispatcher(
     },
 
     listToolsForAgent(filter?: ToolListFilter): AgentToolDescriptor[] {
-      return registry.listTools(filter).map(toAgentDescriptor);
+      return registry
+        .listTools(filter)
+        .filter((t) => t.exposeToAgents !== false)
+        .map(toAgentDescriptor);
     },
 
     getTool(namespacedName: string): RegisteredTool | null {

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,18 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin's namespacing key (e.g. `"acme.linear"`)
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - The plugin's database UUID. Required for the
+   *   downstream `executeTool` worker-routing check, which looks up the
+   *   worker by DB UUID. Without this, registered tools fall back to
+   *   the pluginId-as-key path and `isRunning` always returns false →
+   *   tool calls 502 even when the worker is alive.
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -432,8 +438,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {

--- a/server/src/services/plugin-tool-registry.ts
+++ b/server/src/services/plugin-tool-registry.ts
@@ -67,6 +67,12 @@ export interface RegisteredTool {
   description: string;
   /** JSON Schema describing the tool's input parameters. */
   parametersSchema: Record<string, unknown>;
+  /**
+   * Whether this tool is exposed to agents. Defaults to `true`. When `false`,
+   * the tool is hidden from `listToolsForAgent()` and the route layer
+   * rejects agent-initiated execute as if the tool doesn't exist.
+   */
+  exposeToAgents: boolean;
 }
 
 /**
@@ -265,6 +271,7 @@ export function createPluginToolRegistry(
       displayName: decl.displayName,
       description: decl.description,
       parametersSchema: decl.parametersSchema,
+      exposeToAgents: decl.exposeToAgents ?? true,
     };
 
     byNamespace.set(namespacedName, entry);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Plugins extend the platform by registering tools via `ctx.tools.register()`, intended to be callable by both the operator board AND running agents
> - Today plugin tools are reachable from the board, but **not** from any agent session — even after the dispatcher correctly stores them, agents have no path to discover or invoke them
> - This is the load-bearing gap behind #4192 ("Plugin tools should auto-register as MCP tools"). It also intersects with two open fix-PRs from other contributors covering pieces of the same problem
> - This pull request adds the missing pieces end-to-end: agent JWTs can call `/api/plugins/tools/*`, `runContext.projectId` is optional for project-less runs, plugin manifests can opt tools out of agent exposure, and a new `claude-local-tool-bridge` MCP sidecar surfaces the agent-exposable tools to Claude via Claude Code's native MCP support
> - The benefit is plugin tools become first-class agent capabilities — closing #4192 and unblocking the entire plugin-as-agent-extension story for the `claude-local` adapter (which other adapters can follow)

## Coordination note (please read first)

This branch overlaps with two existing open PRs from other contributors:

- **#2239** (`zshin`) — `fix: allow agents to discover and execute plugin tools`. Covers the same auth-relax this branch has in commit `ec15a79d` (allow agent JWTs through `/api/plugins/tools/*`).
- **#3274** (`nullEFFORT`) — `fix: make projectId optional in plugin tool execute runContext`. Covers the same change this branch has in commit `5c67053a`.

Both are necessary prereqs for the MCP bridge to function — I built them locally before noticing the existing PRs. **Plan:** once #2239 and #3274 land, I'll rebase this branch off `master`, drop those two duplicate commits, and re-push so the diff here narrows to just the net-new MCP bridge / `exposeToAgents` flag / docker / dispatcher work. Opening as a draft now so the bridge half is visible and reviewable in parallel. Happy to follow whatever order maintainers prefer.

## What Changed

- **Auth relax (`server/src/routes/authz.ts`, `server/src/routes/plugins.ts`)** — overlaps #2239: new `assertPluginToolAccess(req)` allows agent JWTs unconditionally (per-call scope is enforced separately) and keeps board-with-org-access semantics for board users. Both `/api/plugins/tools` and `/api/plugins/tools/execute` route gates swapped over. `/execute` adds an `agentId` match check: when the caller is an agent, `runContext.agentId` must equal the JWT's `agentId` — prevents one agent from impersonating another even with a valid token. Existing per-call checks (`assertCompanyAccess`, `validateToolRunContextScope`) unchanged.
- **Optional `projectId` (`packages/plugins/sdk/src/types.ts`, `server/src/routes/plugins.ts`)** — overlaps #3274: `ToolRunContext.projectId` widened to `string | null`. Required-field check on `/execute` drops `projectId`; `validateToolRunContextScope` skips the project query when null. `plugin-kitchen-sink-example` worker uses `?? undefined` when forwarding to `ctx.issues.create()`.
- **Net-new — `exposeToAgents` flag (`packages/shared/src/types/plugin.ts`, `validators/plugin.ts`):** optional `exposeToAgents?: boolean` on `PluginToolDeclaration` (default `true`, preserves behaviour). `dispatcher.listToolsForAgent()` filters out `exposeToAgents === false` entries; `/api/plugins/tools/execute` returns 404 when the caller is an agent and the tool is opted out — same shape as a missing tool, so an agent can't probe for hidden tools. Operator-only tools (admin actions, destructive ops) remain board-callable.
- **Net-new — `@paperclipai/claude-local-tool-bridge` package:** tiny stdio MCP server (~150 LOC src) spawned per agent run. Reads scope from env, exposes `tools/list` and `tools/call`, proxies each call to `/api/plugins/tools/*` with the agent's JWT in the Authorization header. Translates per-tool errors and HTTP errors to MCP `isError` responses. Single dependency: `@modelcontextprotocol/sdk` (^1.29.0, the version already in this monorepo via `@paperclipai/mcp-server`).
- **Net-new — `claude-local` adapter wiring (`packages/adapters/claude-local/src/server/execute.ts`):** `maybeWritePluginMcpConfig` writes a per-run `.mcp.json` to `os.tmpdir()` populated with the bridge command + per-run env. `buildClaudeArgs` pushes `--mcp-config <path>` after `--add-dir`. Three skip conditions, each returns null and leaves Claude's tool list untouched: `disablePluginTools: true` adapter config (operator escape hatch), missing `authToken`, or missing built bridge bin (dev-without-build fallback — also emits a `console.warn` so the silent skip can't mask a missing build).
- **Net-new — Dockerfile (`Dockerfile`):** adds the bridge's `package.json` to the deps stage and `pnpm --filter @paperclipai/claude-local-tool-bridge build` to the build stage. Without this, `pnpm install --frozen-lockfile` skipped its deps and `dist/index.js` was never produced; runtime existence-check returned null and the `--mcp-config` injection silently no-op'd.
- **Net-new — dispatcher fix (`server/src/services/plugin-tool-dispatcher.ts`):** `registerPluginTools(pluginId, manifest)` was dropping the DB UUID and calling `registry.registerPlugin(pluginId, manifest)` without it. Registry's fallback `dbId = pluginDbId ?? pluginId` made `dbId === pluginKey` ("paperclip-plugin-google-workspace"). At execute time, the dispatcher looked up `workerManager.isRunning(tool.pluginDbId)` — but workers map is keyed by the actual DB UUID, so the lookup missed and reported "worker not running" even though the worker process was alive. Fix threads `pluginDbId` through both the dispatcher's interface and its implementation; plugin-loader passes `pluginId` (the DB UUID) as the third arg.

## Verification

- `pnpm install --frozen-lockfile && pnpm -r typecheck && pnpm test:run && pnpm build` — all green locally.
- New tests in `server/src/__tests__/plugin-routes-authz.test.ts` (28 cases total, 9 new):
  - Agent can list / agent can execute when ids match / agent is 403 when `runContext.agentId` differs / agent is 403 when `runContext.companyId` isn't the agent's company.
  - `exposeToAgents: false` returns 404 to agent on execute, 200 to board.
  - `exposeToAgents: false` filtered out of `GET /api/plugins/tools` for agents but visible to board.
  - Omitted `projectId` execute case alongside the existing fully-populated `runContext` tests.
- Manual integration QA: ran a self-hosted instance with the Google Workspace plugin enabled, spawned a Claude-local agent, and confirmed the agent could discover (`tools/list`) and execute (`tools/call`) `search_threads` and `list_drafts` end-to-end.

## Risks

- **`exposeToAgents` defaults to `true`** — every existing plugin tool becomes agent-callable on upgrade. This is the intended behaviour (the entire point is agents *can* call them), but plugin authors with operator-only tools need to add `exposeToAgents: false` before upgrading. Mitigated by the per-call `assertCompanyAccess` / `runContext.companyId` checks already in place — an agent can only call tools in its own company's plugin context.
- **Bridge runs as a sidecar in the same container** as the Paperclip server. Bridge → server traffic uses `http://localhost:${PAPERCLIP_PORT ?? 3100}` rather than `PAPERCLIP_API_URL` — discovered the hard way that routing through the public hostname adds 50-200ms per call and exposes plugin-tool calls to upstream tunnel hiccups (Cloudflare 502s). The agent JWT is valid against any host so this is purely a routing optimisation.
- **MCP-bridge bin path resolution** uses `__moduleDir` and walks up three directory levels to land on `packages/adapters/`. If the workspace shape changes (e.g. `packages/adapters/` flattened), the bridge will silently no-op (now with a `console.warn`). I considered making this a hard error but the dev-without-build fallback path is real — devs running without the bridge built shouldn't have agents fail to start.
- **Lockfile intentionally not included** — `chore/refresh-lockfile` workflow will pick up the new bridge package's `@modelcontextprotocol/sdk` dependency at the next refresh. Happy to add the lockfile bump in this PR if you'd prefer.
- **Claude-local-only.** Other adapters (codex, opencode) need their own equivalent of `maybeWritePluginMcpConfig` to surface plugin tools to their agents. Filed as a follow-up.

Closes #4192. Refs #2239, #3273, #3274.

## Model Used

- **Claude Opus 4.5/4.6** (Anthropic, ~200K context); commits authored interactively over two days (2026-04-24 / 2026-04-25). PR description drafted with Claude Opus 4.7 (1M context).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — please confirm this aligns with planned direction, especially given the overlap with #2239 / #3274
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (no UI changes — agent-side capability only)
- [x] I have updated relevant documentation to reflect my changes (none needed beyond commit messages — happy to add docs if you'd like)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
