### PR TITLE
ELEAAA-457-C: add Prometheus metrics endpoint

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: 0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -230,7 +230,7 @@ importers:
         version: link:../shared
       drizzle-orm:
         specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -522,7 +522,7 @@ importers:
         version: 3.0.1(ajv@8.18.0)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -537,7 +537,7 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -565,6 +565,9 @@ importers:
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -2185,6 +2188,10 @@ packages:
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@paperclipai/adapter-utils@2026.325.0':
     resolution: {integrity: sha512-YDVSAgjkeJ0PvxXDJVN9MZDX7oYRzidLtGHmGgRGd6gSk/bF2ygAKvND4FI1YxDc/cRLQjqAFCpCYaC/9wqIEA==}
@@ -3952,6 +3959,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -5593,6 +5603,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -6007,6 +6021,9 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
@@ -8343,6 +8360,8 @@ snapshots:
 
   '@open-draft/deferred-promise@2.2.0': {}
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@paperclipai/adapter-utils@2026.325.0': {}
 
   '@paralleldrive/cuid2@2.3.1':
@@ -10204,7 +10223,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
+  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -10220,7 +10239,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -10238,6 +10257,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bintrees@1.0.2: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -10748,9 +10769,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4):
+  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
+      '@opentelemetry/api': 1.9.1
       '@types/react': 19.2.14
       kysely: 0.28.11
       pg: 8.18.0
@@ -12193,6 +12215,11 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -12773,6 +12800,10 @@ snapshots:
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   thread-stream@3.1.0:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -40,6 +40,7 @@
     "postpack": "rm -rf ui-dist",
     "clean": "rm -rf dist",
     "start": "node dist/index.js",
+    "test": "vitest run",
     "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit"
   },
   "dependencies": {
@@ -72,6 +73,7 @@
     "pino": "^9.6.0",
     "pino-http": "^10.4.0",
     "pino-pretty": "^13.1.3",
+    "prom-client": "^15.1.3",
     "sharp": "^0.34.5",
     "ws": "^8.19.0",
     "zod": "^3.24.2"

--- a/server/src/__tests__/metrics-endpoint.test.ts
+++ b/server/src/__tests__/metrics-endpoint.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import request from "supertest";
+import type { Db } from "@paperclipai/db";
+import { createApp } from "../app.js";
+import type { StorageService } from "../storage/types.js";
+
+const { loadAllMock, schedulerStartMock, coordinatorStartMock, dispatcherInitializeMock } = vi.hoisted(() => ({
+  loadAllMock: vi.fn().mockResolvedValue({ total: 0, succeeded: 0, failed: 0, results: [] }),
+  schedulerStartMock: vi.fn(),
+  coordinatorStartMock: vi.fn(),
+  dispatcherInitializeMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../services/plugin-loader.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/plugin-loader.js")>("../services/plugin-loader.js");
+  return {
+    ...actual,
+    pluginLoader: vi.fn(() => ({
+      loadAll: loadAllMock,
+    })),
+  };
+});
+
+vi.mock("../services/plugin-job-scheduler.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/plugin-job-scheduler.js")>(
+    "../services/plugin-job-scheduler.js",
+  );
+  return {
+    ...actual,
+    createPluginJobScheduler: vi.fn(() => ({
+      start: schedulerStartMock,
+      stop: vi.fn(),
+    })),
+  };
+});
+
+vi.mock("../services/plugin-job-coordinator.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/plugin-job-coordinator.js")>(
+    "../services/plugin-job-coordinator.js",
+  );
+  return {
+    ...actual,
+    createPluginJobCoordinator: vi.fn(() => ({
+      start: coordinatorStartMock,
+      stop: vi.fn(),
+    })),
+  };
+});
+
+vi.mock("../services/plugin-tool-dispatcher.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/plugin-tool-dispatcher.js")>(
+    "../services/plugin-tool-dispatcher.js",
+  );
+  return {
+    ...actual,
+    createPluginToolDispatcher: vi.fn(() => ({
+      initialize: dispatcherInitializeMock,
+      listToolsForAgent: vi.fn(() => []),
+      getTool: vi.fn(() => null),
+      executeTool: vi.fn(),
+    })),
+  };
+});
+
+function createStorageService(): StorageService {
+  return {
+    provider: "local_disk",
+    putFile: vi.fn(),
+    getObject: vi.fn(),
+    headObject: vi.fn(),
+    deleteObject: vi.fn(),
+  };
+}
+
+describe("GET /metrics", () => {
+  it("returns Prometheus text with placeholder cap counters registered", async () => {
+    const app = await createApp({} as Db, {
+      uiMode: "none",
+      serverPort: 0,
+      storageService: createStorageService(),
+      deploymentMode: "local_trusted",
+      deploymentExposure: "public",
+      allowedHostnames: [],
+      bindHost: "127.0.0.1",
+      authReady: true,
+      companyDeletionEnabled: false,
+    });
+
+    const res = await request(app).get("/metrics");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/^text\/plain;\s*version=0\.0\.4/);
+    expect(res.text).toContain(
+      "# HELP paperclip_placeholder_cap_hits_total Times the placeholder-comment cap blocked an agent comment post.",
+    );
+    expect(res.text).toContain("# TYPE paperclip_placeholder_cap_hits_total counter");
+    expect(res.text).toContain(
+      "# HELP paperclip_placeholder_cap_overrides_total Times a board override bypassed the placeholder-comment cap.",
+    );
+    expect(res.text).toContain("# TYPE paperclip_placeholder_cap_overrides_total counter");
+  });
+});

--- a/server/src/__tests__/metrics-endpoint.test.ts
+++ b/server/src/__tests__/metrics-endpoint.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import request from "supertest";
 import type { Db } from "@paperclipai/db";
 import { createApp } from "../app.js";
+import { placeholderCapHits, placeholderCapOverrides } from "../observability/prom.js";
 import type { StorageService } from "../storage/types.js";
 
 const { loadAllMock, schedulerStartMock, coordinatorStartMock, dispatcherInitializeMock } = vi.hoisted(() => ({
@@ -98,5 +99,7 @@ describe("GET /metrics", () => {
       "# HELP paperclip_placeholder_cap_overrides_total Times a board override bypassed the placeholder-comment cap.",
     );
     expect(res.text).toContain("# TYPE paperclip_placeholder_cap_overrides_total counter");
+    expect((placeholderCapHits as unknown as { labelNames: string[] }).labelNames).toEqual(["agent_id"]);
+    expect((placeholderCapOverrides as unknown as { labelNames: string[] }).labelNames).toEqual(["agent_id"]);
   });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -41,6 +41,7 @@ import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
+import { register as metricsRegister } from "./observability/prom.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
 import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
@@ -160,6 +161,15 @@ export async function createApp(
       bindHost: opts.bindHost,
     }),
   );
+  // Intentionally unauthenticated so Prometheus can scrape it; the private hostname guard still applies.
+  app.get("/metrics", async (_req, res, next) => {
+    try {
+      res.set("Content-Type", metricsRegister.contentType);
+      res.end(await metricsRegister.metrics());
+    } catch (err) {
+      next(err);
+    }
+  });
   app.use(
     actorMiddleware(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/observability/prom.ts
+++ b/server/src/observability/prom.ts
@@ -1,0 +1,19 @@
+import { collectDefaultMetrics, Counter, Registry } from "prom-client";
+
+export const register = new Registry();
+
+collectDefaultMetrics({ register });
+
+export const placeholderCapHits = new Counter<"agent_id">({
+  name: "paperclip_placeholder_cap_hits_total",
+  help: "Times the placeholder-comment cap blocked an agent comment post.",
+  labelNames: ["agent_id"] as const,
+  registers: [register],
+});
+
+export const placeholderCapOverrides = new Counter<"agent_id">({
+  name: "paperclip_placeholder_cap_overrides_total",
+  help: "Times a board override bypassed the placeholder-comment cap.",
+  labelNames: ["agent_id"] as const,
+  registers: [register],
+});


### PR DESCRIPTION
## Diff summary

- Adds `prom-client@^15.1.3` to `@paperclipai/server` and refreshes `pnpm-lock.yaml`.
- Adds `server/src/observability/prom.ts` with a singleton registry, Node default metrics, and the two ELEAAA-457 counters:
  - `paperclip_placeholder_cap_hits_total{agent_id}`
  - `paperclip_placeholder_cap_overrides_total{agent_id}`
- Mounts unauthenticated `GET /metrics` after the private-hostname guard and before actor auth.
- Adds an app-level regression test proving `/metrics` returns Prometheus text, exposes HELP/TYPE lines, and keeps counter labels to exactly `agent_id`.
- Scope vs spec: this implements only ELEAAA-457-C metric scaffolding. Route-guard increments stay in ELEAAA-457-B; alerting remains deferred. Cross-checked against `technical-specs/infrastructure/observability`, `specs/07-premium-gating-logic`, and `concepts/observability-spanmetrics-vs-application-metrics`.

## Rollback

```bash
git revert e4dfd2cb a6a8f354
```

## Test output

- Red test before implementation: `pnpm --filter @paperclipai/server exec vitest run src/__tests__/metrics-endpoint.test.ts` failed as expected with `expected 404 to be 200`.
- `pnpm --filter @paperclipai/server test metrics-endpoint` PASS: 1 file, 1 test.
- `pnpm --filter @paperclipai/server typecheck` PASS.
- `pnpm --filter @paperclipai/server test` was attempted. The metrics test passed in the full run, but the full suite ended with 5 failures outside this diff:
  - `worktree-config.test.ts`: 2 port expectation failures (`54331` vs `54335`), also fails isolated.
  - `paperclip-env.test.ts`: 2 failures under inherited heartbeat `PAPERCLIP_API_URL=http://elevopt.com:3100`; passes isolated with `PAPERCLIP_API_URL`/`PAPERCLIP_RUNTIME_API_URL` unset.
  - `heartbeat-dependency-scheduling.test.ts`: 1 FK failure in the full run; passes isolated.

## CTO review request

@CTO ready for review. Please run `/plan-eng-review` plus `/review` against this PR. The only behavioral surface is the server `/metrics` endpoint and exported counter module for ELEAAA-457-B.

## Tech-debt log reference

No intentional tech debt introduced; no `concepts/tech-debt-log` entry needed.
