### PR TITLE
fix: decode non-ASCII upload filenames and RFC 6266 Content-Disposition headers (PAP-4706)

### DIFF
--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -289,14 +289,37 @@ describe("issue attachment routes", () => {
     ]).toContain(res.headers["content-disposition"]);
   });
 
-  it("decodes non-ASCII upload filenames from latin1 to UTF-8", () => {
-    // Browsers send raw UTF-8 bytes in the multipart Content-Disposition filename
-    // parameter. Multer/Busboy defaults defParamCharset to latin1, so it misreads
-    // those bytes and produces a garbled originalname. The route re-decodes using
-    // Buffer.from(name, "latin1").toString("utf8") to recover the correct text.
-    const originalUTF8 = "한국어.zip";
-    const latin1Mangled = Buffer.from(originalUTF8, "utf8").toString("latin1");
-    const recovered = Buffer.from(latin1Mangled, "latin1").toString("utf8");
-    expect(recovered).toBe(originalUTF8);
+  it("stores non-ASCII upload filenames correctly after latin1 decode", { timeout: 15000 }, async () => {
+    const storage = createStorageService();
+    mockIssueService.getById.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      identifier: "PAP-1",
+    });
+    mockIssueService.createAttachment.mockResolvedValue(makeAttachment("application/zip", "한국어.zip"));
+
+    const app = await createApp(storage);
+
+    // Construct a raw multipart body where the filename is encoded as UTF-8 bytes,
+    // exactly as a browser would transmit it. Multer/Busboy will misread those bytes
+    // as latin1 (its default); the route then re-decodes to recover the correct text.
+    const boundary = "----TestBoundaryNonASCII";
+    const partHeader = `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="한국어.zip"\r\nContent-Type: application/zip\r\n\r\n`;
+    const partFooter = `\r\n--${boundary}--\r\n`;
+    const rawBody = Buffer.concat([
+      Buffer.from(partHeader, "utf8"),
+      Buffer.from("zip-content"),
+      Buffer.from(partFooter, "utf8"),
+    ]);
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/issues/11111111-1111-4111-8111-111111111111/attachments")
+        .set("Content-Type", `multipart/form-data; boundary=${boundary}`)
+        .send(rawBody),
+    );
+
+    expect([200, 201]).toContain(res.status);
+    expect(storage.__calls.putFile?.originalFilename).toBe("한국어.zip");
   });
 });

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -145,6 +145,33 @@ async function createApp(storage: StorageService) {
   return app;
 }
 
+async function requestApp(
+  app: express.Express,
+  buildRequest: (baseUrl: string) => request.Test,
+) {
+  const { createServer } = await vi.importActual<typeof import("node:http")>("node:http");
+  const server = createServer(app);
+  try {
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected HTTP server to listen on a TCP port");
+    }
+    return await buildRequest(`http://127.0.0.1:${address.port}`);
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    }
+  }
+}
+
 function makeAttachment(contentType: string, originalFilename: string) {
   const now = new Date("2026-01-01T00:00:00.000Z");
   return {
@@ -182,7 +209,9 @@ describe("issue attachment routes", () => {
     mockLogActivity.mockResolvedValue(undefined);
   });
 
-  it("accepts zip uploads for issue attachments", async () => {
+  // Extended timeout: vi.importActual("../routes/issues.js") is slow on cold transform
+  // because issues.ts is large; subsequent tests are faster once the cache warms up.
+  it("accepts zip uploads for issue attachments", { timeout: 15000 }, async () => {
     const storage = createStorageService();
     mockIssueService.getById.mockResolvedValue({
       id: "11111111-1111-4111-8111-111111111111",
@@ -192,9 +221,11 @@ describe("issue attachment routes", () => {
     mockIssueService.createAttachment.mockResolvedValue(makeAttachment("application/zip", "bundle.zip"));
 
     const app = await createApp(storage);
-    const res = await request(app)
-      .post("/api/companies/company-1/issues/11111111-1111-4111-8111-111111111111/attachments")
-      .attach("file", Buffer.from("zip"), { filename: "bundle.zip", contentType: "application/zip" });
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/issues/11111111-1111-4111-8111-111111111111/attachments")
+        .attach("file", Buffer.from("zip"), { filename: "bundle.zip", contentType: "application/zip" }),
+    );
 
     expect([200, 201]).toContain(res.status);
     const putFileCall = storage.__calls.putFile;
@@ -225,7 +256,7 @@ describe("issue attachment routes", () => {
     expect(res.status).toBe(200);
     expect([
       undefined,
-      'attachment; filename="report.html"',
+      "attachment; filename=\"report.html\"; filename*=UTF-8''report.html",
     ]).toContain(res.headers["content-disposition"]);
     expect(res.headers["x-content-type-options"]).toBe("nosniff");
   });
@@ -240,7 +271,32 @@ describe("issue attachment routes", () => {
     expect(res.status).toBe(200);
     expect([
       undefined,
-      'inline; filename="preview.png"',
+      "inline; filename=\"preview.png\"; filename*=UTF-8''preview.png",
     ]).toContain(res.headers["content-disposition"]);
+  });
+
+  it("serves non-ASCII filename attachments with RFC 6266 Content-Disposition", async () => {
+    const storage = createStorageService();
+    mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("application/zip", "한국어.zip"));
+
+    const app = await createApp(storage);
+    const res = await request(app).get("/api/attachments/attachment-1/content");
+
+    expect(res.status).toBe(200);
+    expect([
+      undefined,
+      "attachment; filename=\"___.zip\"; filename*=UTF-8''%ED%95%9C%EA%B5%AD%EC%96%B4.zip",
+    ]).toContain(res.headers["content-disposition"]);
+  });
+
+  it("decodes non-ASCII upload filenames from latin1 to UTF-8", () => {
+    // Browsers send raw UTF-8 bytes in the multipart Content-Disposition filename
+    // parameter. Multer/Busboy defaults defParamCharset to latin1, so it misreads
+    // those bytes and produces a garbled originalname. The route re-decodes using
+    // Buffer.from(name, "latin1").toString("utf8") to recover the correct text.
+    const originalUTF8 = "한국어.zip";
+    const latin1Mangled = Buffer.from(originalUTF8, "utf8").toString("latin1");
+    const recovered = Buffer.from(latin1Mangled, "latin1").toString("utf8");
+    expect(recovered).toBe(originalUTF8);
   });
 });

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -3062,7 +3062,9 @@ export function accessRoutes(
       res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'");
     }
     const filename = logoAsset.originalFilename ?? "company-logo";
-    res.setHeader("Content-Disposition", `inline; filename=\"${filename.replaceAll("\"", "")}\"`);
+    const asciiFallback = filename.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+    const encodedFilename = encodeURIComponent(filename);
+    res.setHeader("Content-Disposition", `inline; filename="${asciiFallback}"; filename*=UTF-8''${encodedFilename}`);
 
     object.stream.on("error", (err) => {
       next(err);

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -158,6 +158,9 @@ export function assetRoutes(db: Db, storage: StorageService) {
     }
 
     const actor = getActorInfo(req);
+    // Browsers send the filename as raw UTF-8 bytes; Busboy reads them as latin1 by
+    // default, producing a garbled string. Re-decoding recovers the correct text.
+    // Non-browser clients that send a non-UTF-8 encoding may see replacement chars.
     const originalFilename = file.originalname
       ? Buffer.from(file.originalname, "latin1").toString("utf8")
       : null;
@@ -259,6 +262,9 @@ export function assetRoutes(db: Db, storage: StorageService) {
     }
 
     const actor = getActorInfo(req);
+    // Browsers send the filename as raw UTF-8 bytes; Busboy reads them as latin1 by
+    // default, producing a garbled string. Re-decoding recovers the correct text.
+    // Non-browser clients that send a non-UTF-8 encoding may see replacement chars.
     const logoOriginalFilename = file.originalname
       ? Buffer.from(file.originalname, "latin1").toString("utf8")
       : null;

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -158,10 +158,13 @@ export function assetRoutes(db: Db, storage: StorageService) {
     }
 
     const actor = getActorInfo(req);
+    const originalFilename = file.originalname
+      ? Buffer.from(file.originalname, "latin1").toString("utf8")
+      : null;
     const stored = await storage.putFile({
       companyId,
       namespace: `assets/${namespaceSuffix}`,
-      originalFilename: file.originalname || null,
+      originalFilename,
       contentType,
       body: fileBody,
     });
@@ -256,10 +259,13 @@ export function assetRoutes(db: Db, storage: StorageService) {
     }
 
     const actor = getActorInfo(req);
+    const logoOriginalFilename = file.originalname
+      ? Buffer.from(file.originalname, "latin1").toString("utf8")
+      : null;
     const stored = await storage.putFile({
       companyId,
       namespace: "assets/companies",
-      originalFilename: file.originalname || null,
+      originalFilename: logoOriginalFilename,
       contentType,
       body: fileBody,
     });
@@ -328,7 +334,9 @@ export function assetRoutes(db: Db, storage: StorageService) {
       res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'");
     }
     const filename = asset.originalFilename ?? "asset";
-    res.setHeader("Content-Disposition", `inline; filename=\"${filename.replaceAll("\"", "")}\"`);
+    const asciiFallback = filename.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+    const encodedFilename = encodeURIComponent(filename);
+    res.setHeader("Content-Disposition", `inline; filename="${asciiFallback}"; filename*=UTF-8''${encodedFilename}`);
 
     object.stream.on("error", (err) => {
       next(err);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3724,6 +3724,9 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
+    // Browsers send the filename as raw UTF-8 bytes; Busboy reads them as latin1 by
+    // default, producing a garbled string. Re-decoding recovers the correct text.
+    // Non-browser clients that send a non-UTF-8 encoding may see replacement chars.
     const originalFilename = file.originalname
       ? Buffer.from(file.originalname, "latin1").toString("utf8")
       : null;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3724,10 +3724,13 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
+    const originalFilename = file.originalname
+      ? Buffer.from(file.originalname, "latin1").toString("utf8")
+      : null;
     const stored = await storage.putFile({
       companyId,
       namespace: `issues/${issueId}`,
-      originalFilename: file.originalname || null,
+      originalFilename,
       contentType,
       body: file.buffer,
     });
@@ -3785,7 +3788,9 @@ export function issueRoutes(
     }
     const filename = attachment.originalFilename ?? "attachment";
     const disposition = isInlineAttachmentContentType(responseContentType) ? "inline" : "attachment";
-    res.setHeader("Content-Disposition", `${disposition}; filename=\"${filename.replaceAll("\"", "")}\"`);
+    const asciiFallback = filename.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+    const encodedFilename = encodeURIComponent(filename);
+    res.setHeader("Content-Disposition", `${disposition}; filename="${asciiFallback}"; filename*=UTF-8''${encodedFilename}`);
 
     object.stream.on("error", (err) => {
       next(err);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents and users can attach files to issues and upload assets/logos through the file management system
> - The server uses Multer (via Busboy) to parse multipart file uploads
> - Busboy defaults `defParamCharset` to `latin1`, but modern browsers send the `filename` parameter as raw UTF-8 bytes
> - This encoding mismatch causes filenames with non-ASCII characters (Korean, Japanese, Arabic, Cyrillic, emojis, accented Latin) to be stored as mojibake in the database
> - On download, the server was using the legacy `filename="..."` Content-Disposition format which browsers cannot use to reconstruct the original non-ASCII name
> - This PR fixes both sides: decoding the filename on upload and emitting RFC 6266 compliant headers on download
> - The benefit is that users in East Asia, Russia, Latin Europe, and anywhere non-ASCII filenames are common can reliably upload and download files with correct names

## What Changed

- **`server/src/routes/issues.ts`** - decode `file.originalname` from latin1 to UTF-8 after multer parses it; update Content-Disposition response header to RFC 6266 dual format
- **`server/src/routes/assets.ts`** - same decode fix for image and company logo uploads; same RFC 6266 download header fix
- **`server/src/routes/access.ts`** - RFC 6266 download header fix for invite logo route
- **`server/src/__tests__/issue-attachment-routes.test.ts`** - update existing Content-Disposition assertions to match new format; add RFC 6266 non-ASCII download test; add latin1 to UTF-8 round-trip unit test; fix a pre-existing test timeout by binding the upload test server explicitly to 127.0.0.1 and extending its timeout to 15s

## Verification

Upload fix - the decode is a deterministic round-trip:

    const latin1Mangled = Buffer.from("hangeul.zip", "utf8").toString("latin1");
    const recovered = Buffer.from(latin1Mangled, "latin1").toString("utf8");
    // recovered === "hangeul.zip"

Download fix - for a non-ASCII filename the response header becomes:

    Content-Disposition: attachment; filename="___.zip"; filename*=UTF-8''%ED%95%9C%EA%B5%AD%EC%96%B4.zip

Test command:

    cd server && node_modules/.bin/vitest run src/__tests__/issue-attachment-routes.test.ts
    # 5/5 tests pass

## Risks

- ASCII filenames are unaffected (latin1 and UTF-8 are identical in the ASCII range).
- Pre-existing corrupted data in the database is not retroactively repaired.
- RFC 6266 dual format is supported by all major browsers since 2012; ASCII fallback remains for legacy clients.
- Overall risk: Low - confined to filename encoding at upload time and a header value at download time; no schema changes, no breaking API changes.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (claude-sonnet-4-6)
- Context window: 200K tokens
- Capabilities used: tool use (file read/edit, shell execution, web fetch), multi-step reasoning, test execution and iteration

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge