### PR TITLE
fix(openclaw-gateway): re-remove paperclip property from agent params

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1136,7 +1136,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {


### PR DESCRIPTION
Re-removes the `paperclip` property from `agentParams` in the OpenClaw gateway adapter.

## Why

Commit `6c9e639a` (shipped in `v2026.325.0`) originally fixed `openclaw_gateway_request_failed` by removing `agentParams.paperclip` — OpenClaw's gateway uses strict param validation and rejects unknown properties.

Commit `91e040a6` ("Batch inline comment wake payloads", 2026-03-28) inadvertently re-introduced the same line, shipping the regression in `v2026.428.0` (current `npm latest`). Every OpenClaw request now fails, silently dropping inbound Telegram / WhatsApp / Google Workspace traffic.

## What

Removes the offending assignment from `packages/adapters/openclaw-gateway/src/server/execute.ts` (line 1139 in master at the parent commit).

## Verification

- Local Paperclip instance has been running with the equivalent patch applied directly to the installed `dist/server/execute.js` since QA sign-off on EUR-328 — gateway requests stopped failing.
- After merge, CI canary auto-publish should ship a new `@paperclipai/adapter-openclaw-gateway` version. We will then `npx clear-npx-cache` + reinstall and confirm the unpatched dist file passes.

## Tracking

- Tracking issue (Eurojob West company): EUR-336
- Original fix commit: `6c9e639a`
- Regression commit: `91e040a6`
- Re-fix commit (this PR): `e6a86d68`

Co-Authored-By: Paperclip <noreply@paperclip.ing>
