### PR TITLE
fix: redact sensitive fields from HTTP logs and suppress auth route bodies (PAP-4759)

### DIFF
--- a/server/src/__tests__/logger-body-sanitize.test.ts
+++ b/server/src/__tests__/logger-body-sanitize.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Capture the customProps function injected into pinoHttp so we can call it directly.
+let capturedCustomProps: ((req: any, res: any) => Record<string, unknown>) | undefined;
+
+vi.mock("pino", () => ({
+  default: Object.assign(
+    vi.fn(() => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() })),
+    { transport: vi.fn(() => ({})) },
+  ),
+}));
+
+vi.mock("pino-http", () => ({
+  pinoHttp: vi.fn((opts: any) => {
+    capturedCustomProps = opts.customProps;
+    return vi.fn();
+  }),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, mkdirSync: vi.fn() };
+});
+
+vi.mock("../config-file.js", () => ({ readConfigFile: vi.fn(() => null) }));
+vi.mock("../home-paths.js", () => ({
+  resolveHomeAwarePath: vi.fn((p: string) => p),
+  resolveDefaultLogsDir: vi.fn(() => "/tmp/paperclip-test-logs"),
+}));
+vi.mock("../middleware/http-log-policy.js", () => ({
+  shouldSilenceHttpSuccessLog: vi.fn(() => false),
+}));
+
+describe("HTTP logger body sanitization", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    capturedCustomProps = undefined;
+    await import("../middleware/logger.js");
+  });
+
+  it("redacts known sensitive fields from reqBody on 4xx responses", () => {
+    const props = capturedCustomProps!(
+      {
+        url: "/api/companies/1/settings",
+        body: { name: "Acme", apiKey: "sk-secret", password: "hunter2", email: "a@b.com" },
+        params: {},
+        query: {},
+      },
+      { statusCode: 400 },
+    );
+
+    expect((props.reqBody as any).apiKey).toBe("[REDACTED]");
+    expect((props.reqBody as any).password).toBe("[REDACTED]");
+    expect((props.reqBody as any).name).toBe("Acme");
+    expect((props.reqBody as any).email).toBe("a@b.com");
+  });
+
+  it("does not log reqBody at all for /api/auth/* routes", () => {
+    const props = capturedCustomProps!(
+      {
+        url: "/api/auth/sign-in/email",
+        body: { email: "a@b.com", password: "hunter2" },
+        params: {},
+        query: {},
+      },
+      { statusCode: 401 },
+    );
+
+    expect(props.reqBody).toBeUndefined();
+  });
+
+  it("returns empty object for 2xx responses (no body logged)", () => {
+    const props = capturedCustomProps!(
+      { url: "/api/issues", body: { password: "hunter2" }, params: {}, query: {} },
+      { statusCode: 200 },
+    );
+
+    expect(props).toEqual({});
+  });
+
+  it("redacts sensitive fields in __errorContext.reqBody", () => {
+    const props = capturedCustomProps!(
+      { url: "/api/companies/1/agents", body: {}, params: {}, query: {} },
+      {
+        statusCode: 422,
+        __errorContext: {
+          error: { message: "validation failed" },
+          reqBody: { name: "Bot", secret: "top-secret" },
+          reqParams: {},
+          reqQuery: {},
+        },
+      },
+    );
+
+    expect((props.reqBody as any).secret).toBe("[REDACTED]");
+    expect((props.reqBody as any).name).toBe("Bot");
+  });
+});

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -27,9 +27,28 @@ const sharedOpts = {
   singleLine: true,
 };
 
+const SENSITIVE_BODY_KEYS = new Set([
+  "password", "newPassword", "currentPassword", "confirmPassword",
+  "token", "accessToken", "refreshToken", "resetToken", "verificationToken",
+  "apiKey", "api_key", "secret", "otp", "code",
+]);
+
+function sanitizeBody(body: unknown): unknown {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return body;
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+    sanitized[key] = SENSITIVE_BODY_KEYS.has(key) ? "[REDACTED]" : value;
+  }
+  return sanitized;
+}
+
 export const logger = pino({
   level: "debug",
-  redact: ["req.headers.authorization"],
+  redact: [
+    "req.headers.authorization",
+    "req.headers.cookie",
+    "req.headers['x-api-key']",
+  ],
 }, pino.transport({
   targets: [
     {
@@ -65,11 +84,15 @@ export const httpLogger = pinoHttp({
   },
   customProps(req, res) {
     if (res.statusCode >= 400) {
+      // Never log request bodies for auth routes — they contain passwords and tokens.
+      const isAuthRoute = typeof req.url === "string" && req.url.startsWith("/api/auth");
+      if (isAuthRoute) return {};
+
       const ctx = (res as any).__errorContext;
       if (ctx) {
         return {
           errorContext: ctx.error,
-          reqBody: ctx.reqBody,
+          reqBody: sanitizeBody(ctx.reqBody),
           reqParams: ctx.reqParams,
           reqQuery: ctx.reqQuery,
         };
@@ -77,7 +100,7 @@ export const httpLogger = pinoHttp({
       const props: Record<string, unknown> = {};
       const { body, params, query } = req as any;
       if (body && typeof body === "object" && Object.keys(body).length > 0) {
-        props.reqBody = body;
+        props.reqBody = sanitizeBody(body);
       }
       if (params && typeof params === "object" && Object.keys(params).length > 0) {
         props.reqParams = params;


### PR DESCRIPTION
## Summary

Closes #4759

Passwords, tokens, API keys, and other credential fields were being logged in plaintext whenever a request returned a 4xx status. An attacker with log access could harvest credentials from failed sign-in or API calls.

### Changes

- Added SENSITIVE_BODY_KEYS set covering password, 
ewPassword, currentPassword, confirmPassword, 	oken, ccessToken, efreshToken, esetToken, erificationToken, piKey, pi_key, secret, otp, code
- Added sanitizeBody() helper that replaces any key present in the set with [REDACTED] before logging, leaving non-sensitive fields intact
- Applied sanitization to both the direct eq.body path and the __errorContext.reqBody path in customProps
- Added auth-route suppression: /api/auth/* requests never log eqBody at all (passwords are expected in those payloads)
- Extended pino edact list to also cover eq.headers.cookie and eq.headers['x-api-key']

### Tests

New file server/src/__tests__/logger-body-sanitize.test.ts with 4 Vitest cases:

1. Redacts known sensitive fields (piKey, password) while keeping safe fields (
ame, email) on 4xx responses
2. Returns no eqBody at all for /api/auth/* routes
3. Returns empty object for 2xx responses (no body ever logged on success)
4. Redacts sensitive fields present in __errorContext.reqBody

## Test plan

- [x] pnpm --filter @paperclipai/server test - all 4 new tests pass, no regressions
- [x] Verify piKey and password fields show as [REDACTED] in test assertions
- [x] Verify non-sensitive fields (
ame, email) are not redacted
- [x] Verify /api/auth/* routes produce no eqBody in log props

?? Generated with [Claude Code](https://claude.com/claude-code)