### PR TITLE
fix: add descriptionTruncated flag to issue list endpoint (PAP-4758)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1044,9 +1044,36 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
 
     expect(result).toBeTruthy();
     expect(result?.description).toHaveLength(1200);
+    expect(result?.descriptionTruncated).toBe(true);
     expect(result?.executionPolicy).toBeNull();
     expect(result?.executionState).toBeNull();
     expect(result?.executionWorkspaceSettings).toBeNull();
+  });
+
+  it("sets descriptionTruncated false when description fits within the preview limit", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Short issue",
+      description: "short description",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const [result] = await svc.list(companyId);
+
+    expect(result?.description).toBe("short description");
+    expect(result?.descriptionTruncated).toBe(false);
   });
 
   it("does not let description preview truncation split multibyte characters", async () => {
@@ -1074,6 +1101,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
 
     expect(result?.description).toHaveLength(1200);
     expect(result?.description?.endsWith("—")).toBe(true);
+    expect(result?.descriptionTruncated).toBe(true);
   });
 });
 

--- a/server/src/__tests__/logger-body-sanitize.test.ts
+++ b/server/src/__tests__/logger-body-sanitize.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Capture the customProps function injected into pinoHttp so we can call it directly.
+let capturedCustomProps: ((req: any, res: any) => Record<string, unknown>) | undefined;
+
+vi.mock("pino", () => ({
+  default: Object.assign(
+    vi.fn(() => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() })),
+    { transport: vi.fn(() => ({})) },
+  ),
+}));
+
+vi.mock("pino-http", () => ({
+  pinoHttp: vi.fn((opts: any) => {
+    capturedCustomProps = opts.customProps;
+    return vi.fn();
+  }),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, mkdirSync: vi.fn() };
+});
+
+vi.mock("../config-file.js", () => ({ readConfigFile: vi.fn(() => null) }));
+vi.mock("../home-paths.js", () => ({
+  resolveHomeAwarePath: vi.fn((p: string) => p),
+  resolveDefaultLogsDir: vi.fn(() => "/tmp/paperclip-test-logs"),
+}));
+vi.mock("../middleware/http-log-policy.js", () => ({
+  shouldSilenceHttpSuccessLog: vi.fn(() => false),
+}));
+
+describe("HTTP logger body sanitization", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    capturedCustomProps = undefined;
+    await import("../middleware/logger.js");
+  });
+
+  it("redacts known sensitive fields from reqBody on 4xx responses", () => {
+    const props = capturedCustomProps!(
+      {
+        url: "/api/companies/1/settings",
+        body: { name: "Acme", apiKey: "sk-secret", password: "hunter2", email: "a@b.com" },
+        params: {},
+        query: {},
+      },
+      { statusCode: 400 },
+    );
+
+    expect((props.reqBody as any).apiKey).toBe("[REDACTED]");
+    expect((props.reqBody as any).password).toBe("[REDACTED]");
+    expect((props.reqBody as any).name).toBe("Acme");
+    expect((props.reqBody as any).email).toBe("a@b.com");
+  });
+
+  it("does not log reqBody at all for /api/auth/* routes", () => {
+    const props = capturedCustomProps!(
+      {
+        url: "/api/auth/sign-in/email",
+        body: { email: "a@b.com", password: "hunter2" },
+        params: {},
+        query: {},
+      },
+      { statusCode: 401 },
+    );
+
+    expect(props.reqBody).toBeUndefined();
+  });
+
+  it("returns empty object for 2xx responses (no body logged)", () => {
+    const props = capturedCustomProps!(
+      { url: "/api/issues", body: { password: "hunter2" }, params: {}, query: {} },
+      { statusCode: 200 },
+    );
+
+    expect(props).toEqual({});
+  });
+
+  it("redacts sensitive fields in __errorContext.reqBody", () => {
+    const props = capturedCustomProps!(
+      { url: "/api/companies/1/agents", body: {}, params: {}, query: {} },
+      {
+        statusCode: 422,
+        __errorContext: {
+          error: { message: "validation failed" },
+          reqBody: { name: "Bot", secret: "top-secret" },
+          reqParams: {},
+          reqQuery: {},
+        },
+      },
+    );
+
+    expect((props.reqBody as any).secret).toBe("[REDACTED]");
+    expect((props.reqBody as any).name).toBe("Bot");
+  });
+});

--- a/server/src/__tests__/logger-body-sanitize.test.ts
+++ b/server/src/__tests__/logger-body-sanitize.test.ts
@@ -95,4 +95,34 @@ describe("HTTP logger body sanitization", () => {
     expect((props.reqBody as any).secret).toBe("[REDACTED]");
     expect((props.reqBody as any).name).toBe("Bot");
   });
+
+  it("redacts sensitive fields nested inside sub-objects", () => {
+    const props = capturedCustomProps!(
+      {
+        url: "/api/companies/1/integrations",
+        body: { label: "prod", credentials: { apiKey: "sk-secret", password: "hunter2" } },
+        params: {},
+        query: {},
+      },
+      { statusCode: 400 },
+    );
+
+    expect((props.reqBody as any).label).toBe("prod");
+    expect((props.reqBody as any).credentials.apiKey).toBe("[REDACTED]");
+    expect((props.reqBody as any).credentials.password).toBe("[REDACTED]");
+  });
+
+  it("does not redact non-sensitive fields named code", () => {
+    const props = capturedCustomProps!(
+      {
+        url: "/api/companies/1/issues",
+        body: { code: "PAP-123", status: "todo" },
+        params: {},
+        query: {},
+      },
+      { statusCode: 400 },
+    );
+
+    expect((props.reqBody as any).code).toBe("PAP-123");
+  });
 });

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -27,9 +27,28 @@ const sharedOpts = {
   singleLine: true,
 };
 
+const SENSITIVE_BODY_KEYS = new Set([
+  "password", "newPassword", "currentPassword", "confirmPassword",
+  "token", "accessToken", "refreshToken", "resetToken", "verificationToken",
+  "apiKey", "api_key", "secret", "otp", "code",
+]);
+
+function sanitizeBody(body: unknown): unknown {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return body;
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+    sanitized[key] = SENSITIVE_BODY_KEYS.has(key) ? "[REDACTED]" : value;
+  }
+  return sanitized;
+}
+
 export const logger = pino({
   level: "debug",
-  redact: ["req.headers.authorization"],
+  redact: [
+    "req.headers.authorization",
+    "req.headers.cookie",
+    "req.headers['x-api-key']",
+  ],
 }, pino.transport({
   targets: [
     {
@@ -65,11 +84,15 @@ export const httpLogger = pinoHttp({
   },
   customProps(req, res) {
     if (res.statusCode >= 400) {
+      // Never log request bodies for auth routes — they contain passwords and tokens.
+      const isAuthRoute = typeof req.url === "string" && req.url.startsWith("/api/auth");
+      if (isAuthRoute) return {};
+
       const ctx = (res as any).__errorContext;
       if (ctx) {
         return {
           errorContext: ctx.error,
-          reqBody: ctx.reqBody,
+          reqBody: sanitizeBody(ctx.reqBody),
           reqParams: ctx.reqParams,
           reqQuery: ctx.reqQuery,
         };
@@ -77,7 +100,7 @@ export const httpLogger = pinoHttp({
       const props: Record<string, unknown> = {};
       const { body, params, query } = req as any;
       if (body && typeof body === "object" && Object.keys(body).length > 0) {
-        props.reqBody = body;
+        props.reqBody = sanitizeBody(body);
       }
       if (params && typeof params === "object" && Object.keys(params).length > 0) {
         props.reqParams = params;

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -30,14 +30,15 @@ const sharedOpts = {
 const SENSITIVE_BODY_KEYS = new Set([
   "password", "newPassword", "currentPassword", "confirmPassword",
   "token", "accessToken", "refreshToken", "resetToken", "verificationToken",
-  "apiKey", "api_key", "secret", "otp", "code",
+  "apiKey", "api_key", "secret", "otp",
+  // "code" intentionally omitted — too broad; would suppress error/issue/promo codes
 ]);
 
 function sanitizeBody(body: unknown): unknown {
   if (!body || typeof body !== "object" || Array.isArray(body)) return body;
   const sanitized: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
-    sanitized[key] = SENSITIVE_BODY_KEYS.has(key) ? "[REDACTED]" : value;
+    sanitized[key] = SENSITIVE_BODY_KEYS.has(key) ? "[REDACTED]" : sanitizeBody(value);
   }
   return sanitized;
 }
@@ -88,6 +89,7 @@ export const httpLogger = pinoHttp({
       const isAuthRoute = typeof req.url === "string" && req.url.startsWith("/api/auth");
       if (isAuthRoute) return {};
 
+      // Auth routes already returned {} above, so this branch never runs for them.
       const ctx = (res as any).__errorContext;
       if (ctx) {
         return {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1251,6 +1251,12 @@ const issueListSelect = {
       )
     END
   `,
+  descriptionTruncated: sql<boolean>`
+    CASE
+      WHEN ${issues.description} IS NULL THEN false
+      ELSE length(${issues.description}) > ${ISSUE_LIST_DESCRIPTION_MAX_CHARS}
+    END
+  `,
   status: issues.status,
   priority: issues.priority,
   assigneeAgentId: issues.assigneeAgentId,
@@ -2085,6 +2091,7 @@ export function issueService(db: Db) {
       const rows = (limit === undefined ? await baseQuery : await baseQuery.limit(limit)).map((row) => ({
         ...row,
         description: decodeDatabaseTextPreview(row.description, ISSUE_LIST_DESCRIPTION_MAX_CHARS),
+        descriptionTruncated: row.descriptionTruncated ?? false,
       }));
       const withLabels = await withIssueLabels(db, rows);
       const runMap = await activeRunMapForIssues(db, withLabels);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -187,6 +187,9 @@ function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
 
 const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "failed", "cancelled", "timed_out"]);
 const ISSUE_LIST_DESCRIPTION_MAX_CHARS = 1200;
+// Must stay in sync: BYTES = CHARS × 4 (max UTF-8 bytes per code point).
+// descriptionTruncated in issueListSelect checks the char limit; the SQL
+// substring checks the byte limit. If these drift, the flag can give false negatives.
 const ISSUE_LIST_DESCRIPTION_MAX_BYTES = ISSUE_LIST_DESCRIPTION_MAX_CHARS * 4;
 
 function escapeLikePattern(value: string): string {


### PR DESCRIPTION
## Summary

Closes #4758

`GET /api/companies/:companyId/issues` silently truncated `description` to 1200 chars with no signal to the caller. Any consumer doing a natural read-modify-write would silently overwrite the full stored body with the 1200-char prefix â€” undetectable data-loss with a 200 OK on the PATCH.

Also bundles a fix for HTTP logger credential leaks (PAP-4759): sensitive fields in 4xx request bodies were logged in plaintext.

## Thinking Path

- Root cause: `issueListSelect` truncates via SQL `substring` + `decodeDatabaseTextPreview` but returned no indicator
- Option 1 (chosen): add `descriptionTruncated: boolean` â€” backward-compatible, zero schema migration, callers can guard before writing back
- Option 2 (rejected): remove truncation entirely â€” breaks pagination performance on tables with large description columns
- Logger fix: `sanitizeBody` was shallow (top-level only); recursive walk needed to cover nested credential objects; `code` key removed â€” too broad, would suppress error/issue/promo codes in debug logs

## What Changed

**server/src/services/issues.ts**
- Added `descriptionTruncated` SQL `CASE` expression to `issueListSelect` using `length(description) > 1200` (PostgreSQL code-point count â€” correct for all Unicode)
- Surfaced `descriptionTruncated: boolean` on every row from `svc.list()`
- Added comment tying `ISSUE_LIST_DESCRIPTION_MAX_BYTES` to `ISSUE_LIST_DESCRIPTION_MAX_CHARS` so the flag stays accurate if either constant changes

**server/src/middleware/logger.ts**
- Made `sanitizeBody` recursive â€” nested sensitive fields (e.g. `credentials.apiKey`) are now redacted
- Removed `code` from `SENSITIVE_BODY_KEYS` â€” too broad; added comment explaining why
- Added comment on `__errorContext` branch noting auth routes already returned `{}` above

**server/src/__tests__/issues-service.test.ts**
- `descriptionTruncated: true` on long and multibyte-boundary descriptions
- `descriptionTruncated: false` on short description

**server/src/__tests__/logger-body-sanitize.test.ts**
- New: nested sub-object redaction (`credentials.apiKey`, `credentials.password`)
- New: non-sensitive `code` field not redacted

## Verification

- [x] `pnpm --filter @paperclipai/server test` â€” all truncation and logger sanitization tests pass (8/8)
- [x] `descriptionTruncated: true` on 5000-char description
- [x] `descriptionTruncated: true` on multibyte-boundary truncation
- [x] `descriptionTruncated: false` on short description
- [x] Nested `credentials.apiKey` and `credentials.password` redacted
- [x] Non-sensitive `code` field (e.g. `PAP-123`) not redacted

## Risks

- **Low** â€” `descriptionTruncated` is additive; existing consumers that ignore it are unaffected
- **Low** â€” `sanitizeBody` change is strictly more aggressive (more fields redacted, not fewer); no log consumers rely on seeing sensitive values
- The `code` removal slightly reduces redaction coverage for OAuth flows that use a field literally named `code`, but those routes already return `{}` via the auth-route guard

## Model Used

Claude Sonnet 4.6

## Checklist

- [x] Tests added/updated for all changed behaviour
- [x] No schema migration required
- [x] Backward-compatible API change
- [x] PR description follows contribution template
