### PR TITLE
feat(SUP-1261): run project workspace setupCommand during realization

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -25,6 +25,7 @@ function buildResolvedWorkspace(overrides: Partial<ResolvedWorkspaceForRun> = {}
     source: "project_primary",
     projectId: "project-1",
     workspaceId: "workspace-1",
+    setupCommand: null,
     repoUrl: null,
     repoRef: null,
     workspaceHints: [],

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -720,6 +720,52 @@ describe("realizeExecutionWorkspace", () => {
     await expect(fs.readFile(path.join(reused.cwd, ".paperclip-provision-created"), "utf8")).resolves.toBe("false\n");
   });
 
+  it("runs project workspace setup command when no provision command is configured", async () => {
+    const repoRoot = await createTempRepo();
+    await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, "scripts", "setup.sh"),
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "printf 'setup-ran\\n' > .paperclip-setup-marker",
+      ].join("\n"),
+      "utf8",
+    );
+    await runGit(repoRoot, ["add", "scripts/setup.sh"]);
+    await runGit(repoRoot, ["commit", "-m", "Add workspace setup script"]);
+
+    const workspace = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      projectSetupCommand: "bash ./scripts/setup.sh",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-1261",
+        title: "Run setup command",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    await expect(fs.readFile(path.join(workspace.cwd, ".paperclip-setup-marker"), "utf8")).resolves.toBe("setup-ran\n");
+  });
+
   it("uses the latest repo-managed provision script when reusing an existing worktree", async () => {
     const repoRoot = await createTempRepo();
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -766,6 +766,151 @@ describe("realizeExecutionWorkspace", () => {
     await expect(fs.readFile(path.join(workspace.cwd, ".paperclip-setup-marker"), "utf8")).resolves.toBe("setup-ran\n");
   });
 
+
+  it("re-runs project workspace setup command when reusing an existing worktree", async () => {
+    const repoRoot = await createTempRepo();
+    await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, "scripts", "setup.sh"),
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "printf 'v1\\n' > .paperclip-setup-version",
+      ].join("\n"),
+      "utf8",
+    );
+    await runGit(repoRoot, ["add", "scripts/setup.sh"]);
+    await runGit(repoRoot, ["commit", "-m", "Add initial setup script"]);
+
+    const initial = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      projectSetupCommand: "bash ./scripts/setup.sh",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-1261",
+        title: "Reuse setup command",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    await expect(fs.readFile(path.join(initial.cwd, ".paperclip-setup-version"), "utf8")).resolves.toBe("v1\n");
+
+    await fs.writeFile(
+      path.join(repoRoot, "scripts", "setup.sh"),
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "printf 'v2\\n' > .paperclip-setup-version",
+      ].join("\n"),
+      "utf8",
+    );
+    await runGit(repoRoot, ["add", "scripts/setup.sh"]);
+    await runGit(repoRoot, ["commit", "-m", "Update setup script"]);
+
+    const reused = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      projectSetupCommand: "bash ./scripts/setup.sh",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-1261",
+        title: "Reuse setup command",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(reused.cwd).toBe(initial.cwd);
+    await expect(fs.readFile(path.join(reused.cwd, ".paperclip-setup-version"), "utf8")).resolves.toBe("v2\n");
+  }, 30_000);
+
+  it("prefers strategy provisionCommand over project setupCommand when both are configured", async () => {
+    const repoRoot = await createTempRepo();
+    await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, "scripts", "provision.sh"),
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "printf 'provision-ran\\n' > .paperclip-which-ran",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(repoRoot, "scripts", "setup.sh"),
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "printf 'setup-ran\\n' > .paperclip-which-ran",
+      ].join("\n"),
+      "utf8",
+    );
+    await runGit(repoRoot, ["add", "scripts/provision.sh", "scripts/setup.sh"]);
+    await runGit(repoRoot, ["commit", "-m", "Add competing provision and setup scripts"]);
+
+    const workspace = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+          provisionCommand: "bash ./scripts/provision.sh",
+        },
+      },
+      projectSetupCommand: "bash ./scripts/setup.sh",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-1261",
+        title: "Provision wins over setup",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    await expect(fs.readFile(path.join(workspace.cwd, ".paperclip-which-ran"), "utf8")).resolves.toBe("provision-ran\n");
+  });
   it("uses the latest repo-managed provision script when reusing an existing worktree", async () => {
     const repoRoot = await createTempRepo();
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -888,6 +888,7 @@ export type ResolvedWorkspaceForRun = {
   source: "project_primary" | "task_session" | "agent_home";
   projectId: string | null;
   workspaceId: string | null;
+  setupCommand: string | null;
   repoUrl: string | null;
   repoRef: string | null;
   workspaceHints: Array<{
@@ -2461,6 +2462,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             source: "project_primary" as const,
             projectId: resolvedProjectId,
             workspaceId: workspace.id,
+            setupCommand: readNonEmptyString(workspace.setupCommand),
             repoUrl: workspace.repoUrl,
             repoRef: workspace.repoRef,
             workspaceHints,
@@ -2500,6 +2502,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         source: "project_primary" as const,
         projectId: resolvedProjectId,
         workspaceId: projectWorkspaceRows[0]?.id ?? null,
+        setupCommand: readNonEmptyString(projectWorkspaceRows[0]?.setupCommand),
         repoUrl: projectWorkspaceRows[0]?.repoUrl ?? null,
         repoRef: projectWorkspaceRows[0]?.repoRef ?? null,
         workspaceHints,
@@ -2518,6 +2521,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         source: "project_primary" as const,
         projectId: resolvedProjectId,
         workspaceId: null,
+        setupCommand: null,
         repoUrl: null,
         repoRef: null,
         workspaceHints,
@@ -2537,6 +2541,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           source: "task_session" as const,
           projectId: resolvedProjectId,
           workspaceId: readNonEmptyString(previousSessionParams?.workspaceId),
+          setupCommand: null,
           repoUrl: readNonEmptyString(previousSessionParams?.repoUrl),
           repoRef: readNonEmptyString(previousSessionParams?.repoRef),
           workspaceHints,
@@ -2566,6 +2571,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       source: "agent_home" as const,
       projectId: resolvedProjectId,
       workspaceId: null,
+      setupCommand: null,
       repoUrl: null,
       repoRef: null,
       workspaceHints,
@@ -4969,6 +4975,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const executionWorkspace = reusedExecutionWorkspace ?? await realizeExecutionWorkspace({
           base: executionWorkspaceBase,
           config: runtimeConfig,
+          projectSetupCommand: resolvedWorkspace.setupCommand,
           issue: issueRef,
           agent: {
             id: agent.id,

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -930,7 +930,7 @@ async function provisionExecutionWorktree(input: {
       commandSource: commandLabel,
       resolvedCommand: resolvedProvisionCommand === command ? null : resolvedProvisionCommand,
     },
-    successMessage: `Provisioned workspace at ${input.worktreePath}\n`,
+    successMessage: `${commandLabel === "setup" ? "Set up" : "Provisioned"} workspace at ${input.worktreePath}\n`,
   });
 }
 

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -890,6 +890,7 @@ async function recordWorkspaceCommandOperation(
 
 async function provisionExecutionWorktree(input: {
   strategy: Record<string, unknown>;
+  projectSetupCommand?: string | null;
   base: ExecutionWorkspaceInput;
   repoRoot: string;
   worktreePath: string;
@@ -900,12 +901,15 @@ async function provisionExecutionWorktree(input: {
   recorder?: WorkspaceOperationRecorder | null;
 }) {
   const provisionCommand = asString(input.strategy.provisionCommand, "").trim();
-  if (!provisionCommand) return;
-  const resolvedProvisionCommand = resolveRepoManagedWorkspaceCommand(provisionCommand, input.repoRoot);
+  const setupCommand = asString(input.projectSetupCommand, "").trim();
+  const command = provisionCommand || setupCommand;
+  if (!command) return;
+  const resolvedProvisionCommand = resolveRepoManagedWorkspaceCommand(command, input.repoRoot);
+  const commandLabel = provisionCommand ? "provision" : "setup";
 
   await recordWorkspaceCommandOperation(input.recorder, {
     phase: "workspace_provision",
-    command: provisionCommand,
+    command,
     resolvedCommand: resolvedProvisionCommand,
     cwd: input.worktreePath,
     env: buildWorkspaceCommandEnv({
@@ -917,13 +921,14 @@ async function provisionExecutionWorktree(input: {
       agent: input.agent,
       created: input.created,
     }),
-    label: `Execution workspace provision command "${provisionCommand}"`,
+    label: `Execution workspace ${commandLabel} command "${command}"`,
     metadata: {
       repoRoot: input.repoRoot,
       worktreePath: input.worktreePath,
       branchName: input.branchName,
       created: input.created,
-      resolvedCommand: resolvedProvisionCommand === provisionCommand ? null : resolvedProvisionCommand,
+      commandSource: commandLabel,
+      resolvedCommand: resolvedProvisionCommand === command ? null : resolvedProvisionCommand,
     },
     successMessage: `Provisioned workspace at ${input.worktreePath}\n`,
   });
@@ -981,6 +986,7 @@ async function resolveGitRepoRootForWorkspaceCleanup(
 export async function realizeExecutionWorkspace(input: {
   base: ExecutionWorkspaceInput;
   config: Record<string, unknown>;
+  projectSetupCommand?: string | null;
   issue: ExecutionWorkspaceIssueRef | null;
   agent: ExecutionWorkspaceAgentRef;
   recorder?: WorkspaceOperationRecorder | null;
@@ -1044,6 +1050,7 @@ export async function realizeExecutionWorkspace(input: {
     }
     await provisionExecutionWorktree({
       strategy: rawStrategy,
+      projectSetupCommand: input.projectSetupCommand ?? null,
       base: input.base,
       repoRoot,
       worktreePath: reusablePath,
@@ -1140,6 +1147,7 @@ export async function realizeExecutionWorkspace(input: {
   }
   await provisionExecutionWorktree({
     strategy: rawStrategy,
+    projectSetupCommand: input.projectSetupCommand ?? null,
     base: input.base,
     repoRoot,
     worktreePath,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The workspace-realization subsystem provisions per-agent checkouts so each agent runs in an isolated tree (mode: shared_workspace, project_primary strategy)
> - `project_workspaces.setup_command` is plumbed at the schema/API/Drizzle layer, but no code in the runtime actually executes it during realization (`paperclipai@2026.428.0`)
> - As a result, fresh per-agent workspaces for projects like `modular-alpha` (which has `setupCommand: "npm ci --legacy-peer-deps"` configured) land without `node_modules`, and every agent verification command fails with `Cannot find package 'vitest'` etc. until a human runs `npm ci` manually
> - This pull request wires `setupCommand` execution into `realizeExecutionWorkspace` so the runtime spawns the configured command in the realized cwd before returning the lease to the agent
> - The benefit is that fresh workspaces self-bootstrap, eliminating the manual-intervention floor on every per-agent checkout

## What Changed

- Threaded the project workspace's `setupCommand` from heartbeat workspace resolution into `realizeExecutionWorkspace`.
- Realization now executes `setupCommand` in the realized cwd when `provisionCommand` is absent (consistent precedence with the existing schema).
- Non-zero exit from `setupCommand` surfaces as a workspace-realization failure (no half-realized lease returned to the agent).
- Added regression test `runs project workspace setup command when no provision command is configured` in `server/src/__tests__/workspace-runtime.test.ts`.
- Updated heartbeat workspace session fixture typing to carry the new field through.

## Verification

- `pnpm vitest run server/src/__tests__/workspace-runtime.test.ts -t "runs project workspace setup command when no provision command is configured"` -> pass
- `pnpm vitest run server/src/__tests__/heartbeat-workspace-session.test.ts` -> pass

End-to-end smoke against a real Paperclip instance is pending until this lands and an agent provisions a fresh workspace; the operator has been bootstrapping `node_modules` manually as a one-shot today (1016 packages, 12s) — once this PR is in, that manual step becomes unnecessary.

## Risks

- Low. The new code path is gated on `setupCommand` being non-null AND `provisionCommand` being null, matching the existing precedence. Workspaces without `setupCommand` configured (the current default for every project) are unaffected.
- One behavioral shift: a misconfigured `setupCommand` (e.g. typo, missing binary) now fails workspace realization instead of silently no-op'ing. This is desired — the previous silent-skip was the bug — but it does mean operators need to validate their `setupCommand` value when they set it.
- `cleanupCommand` and `provisionCommand`/`teardownCommand` are out of scope for this PR; their wiring should be a follow-up if symmetry is desired.

## Model Used

- Codex CLI (`gpt-5.3-codex`, medium reasoning effort) operating as the "Lead Engineer" agent in a Paperclip multi-agent dev shop. The implementation was done in an isolated git worktree per the `superpowers:using-git-worktrees` discipline, with TDD red-then-green covering the new `setupCommand` execution path.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, runtime-only change
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge

---

Filed downstream as [SUP-1261](https://paperclip.dvit.io/SUP/issues/SUP-1261); parent epic [SUP-1259](https://paperclip.dvit.io/SUP/issues/SUP-1259) (auto-bootstrap node_modules in per-agent paperclip workspaces). Cross-fork delivery via `TEA-Core/paperclip` per OSS contribution flow.
