### PR TITLE
fix(recovery): dispatch in_progress sub-issues with no execution history as fresh assignment (PAP-4766)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1391,6 +1391,93 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(runs).toHaveLength(0);
   });
 
+  it("dispatches in_progress sub-issue with no execution history as an initial assignment wake (PAP-4766)", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const parentIssueId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "SubIssueAgent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: parentIssueId,
+        companyId,
+        title: "Parent issue",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      },
+      {
+        id: issueId,
+        companyId,
+        parentId: parentIssueId,
+        title: "Sub-issue with no execution history",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+        checkoutRunId: null,
+        executionRunId: null,
+        startedAt: new Date(),
+      },
+    ]);
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Sub-issue should be dispatched fresh, not silently skipped or routed through continuation
+    expect(result.assignmentDispatched).toBeGreaterThanOrEqual(1);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toContain(issueId);
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.agentId, agentId), eq(agentWakeupRequests.reason, "issue_assigned")));
+    const subIssueWake = wakeups.find((w) => {
+      const payload = w.payload as Record<string, unknown> | null;
+      return payload?.issueId === issueId;
+    });
+    expect(subIssueWake).toBeDefined();
+    expect(subIssueWake?.source).toBe("assignment");
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    const subIssueRun = runs.find((r) => {
+      const ctx = r.contextSnapshot as Record<string, unknown> | null;
+      return ctx?.issueId === issueId;
+    });
+    expect(subIssueRun).toBeDefined();
+    expect((subIssueRun?.contextSnapshot as Record<string, unknown>)?.retryReason).toBeUndefined();
+
+    if (subIssueRun?.id) {
+      await waitForRunToSettle(heartbeat, subIssueRun.id);
+    }
+  });
+
   it("re-enqueues assigned todo work when the last issue run died and no wake remains", async () => {
     const { agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1702,7 +1702,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (!latestRun && !issue.checkoutRunId && !issue.executionRunId) {
-        result.skipped += 1;
+        // in_progress with no execution history means the issue was set to in_progress
+        // programmatically (e.g. by an agent creating a sub-issue) without ever going
+        // through a dispatch run. Treat it like an unstarted todo: dispatch it fresh
+        // rather than silently skipping it, so it doesn't get permanently stranded.
+        if (await hasQueuedIssueWake(issue.companyId, issue.id)) {
+          result.skipped += 1;
+          continue;
+        }
+
+        if (await isInvocationBudgetBlocked(issue, agentId)) {
+          result.skipped += 1;
+          continue;
+        }
+
+        const queued = await enqueueInitialAssignedTodoDispatch(issue, agentId);
+        if (queued) {
+          result.assignmentDispatched += 1;
+          result.issueIds.push(issue.id);
+        } else {
+          result.skipped += 1;
+        }
         continue;
       }
       if (isSuccessfulInProgressContinuationRun(latestRun)) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1702,10 +1702,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (!latestRun && !issue.checkoutRunId && !issue.executionRunId) {
-        // in_progress with no execution history means the issue was set to in_progress
-        // programmatically (e.g. by an agent creating a sub-issue) without ever going
-        // through a dispatch run. Treat it like an unstarted todo: dispatch it fresh
-        // rather than silently skipping it, so it doesn't get permanently stranded.
+        // Only dispatch if this is a sub-issue (parentId set): it was created programmatically
+        // as in_progress by an agent without ever going through a dispatch run. Standalone
+        // in_progress issues with no run linkage are seeded data and should remain skipped.
+        if (!issue.parentId) {
+          result.skipped += 1;
+          continue;
+        }
         if (await hasQueuedIssueWake(issue.companyId, issue.id)) {
           result.skipped += 1;
           continue;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents can create sub-issues and assign them to other agents as part of multi-step task decomposition
> - When an agent creates a sub-issue, it sets the issue status directly to `in_progress` with an `assigneeAgentId` â€” but without ever going through a dispatch run, so `checkoutRunId`, `executionRunId`, and any heartbeat run history are all null
> - The `reconcileStrandedAssignedIssues` recovery loop in the heartbeat service is responsible for detecting stranded assigned issues and re-dispatching them
> - But the loop had a guard that silently skipped any `in_progress` issue with no execution history â€” treating it as seeded/legacy data rather than a legitimately unstarted sub-issue
> - This meant agent-created sub-issues were permanently stranded: they showed as `in_progress` but were never executed and never recovered
> - This PR fixes the guard to detect sub-issues (those with a `parentId`) that are `in_progress` with no execution history and dispatch them fresh via the existing `enqueueInitialAssignedTodoDispatch` path â€” the same path used for unstarted `todo` issues
> - The benefit is that agent-created sub-issues are now automatically recovered by the heartbeat, eliminating a class of permanently stuck work items with no manual intervention required

## What Changed

- `server/src/services/recovery/service.ts` â€” in `reconcileStrandedAssignedIssues`, changed the `!latestRun && !checkoutRunId && !executionRunId` guard: standalone issues (no `parentId`) still skip as before; sub-issues (`parentId` set) now go through `hasQueuedIssueWake` / `isInvocationBudgetBlocked` guards and are dispatched fresh via `enqueueInitialAssignedTodoDispatch`
- `server/src/__tests__/heartbeat-process-recovery.test.ts` â€” added integration test: _"dispatches in_progress sub-issue with no execution history as an initial assignment wake (PAP-4766)"_ â€” creates a parent + sub-issue both assigned to an agent, sub-issue has `parentId`, `status: "in_progress"`, no run linkage; asserts `assignmentDispatched >= 1` and a wake with `reason: "issue_assigned"` / `source: "assignment"` is created

## Verification

- Run `pnpm test --filter @paperclipai/server -- src/__tests__/heartbeat-process-recovery.test.ts`
- All 34 tests in the file should pass, including:
  - New: _"dispatches in_progress sub-issue with no execution history as an initial assignment wake (PAP-4766)"_
  - Existing: _"does not continue seeded in-progress work that has no run linkage"_ â€” still skips standalone issues

## Risks

- Low risk. The change only affects `in_progress` issues that have `parentId` set AND have no execution history whatsoever (`checkoutRunId`, `executionRunId`, and no heartbeat runs all null). All existing idempotency guards (`hasQueuedIssueWake`, `isInvocationBudgetBlocked`) remain in place to prevent double-dispatch. Standalone `in_progress` issues with no run linkage are unaffected.

## Model Used

- **Provider:** Anthropic  
- **Model:** Claude Sonnet 4.6 (`claude-sonnet-4-6`)  
- **Context window:** 200K tokens  
- **Mode:** Tool use (agentic â€” read, edit, grep, bash)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A â€” backend only)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
