### PR TITLE
Reject stale terminal-status PATCHes from agents (PF-2)

### DIFF
--- a/server/src/__tests__/issue-terminal-status-noop-routes.test.ts
+++ b/server/src/__tests__/issue-terminal-status-noop-routes.test.ts
@@ -1,0 +1,391 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ISSUE_ID = "11111111-1111-4111-8111-111111111111";
+const AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const COMPANY_ID = "company-1";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  assertCheckoutOwner: vi.fn(),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  getDependencyReadiness: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+  list: vi.fn(),
+  listDependencyReadiness: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  list: vi.fn(),
+  resolveByReference: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockTxInsertValues = vi.hoisted(() => vi.fn(async () => undefined));
+const mockTxInsert = vi.hoisted(() => vi.fn(() => ({ values: mockTxInsertValues })));
+const mockTx = vi.hoisted(() => ({ insert: mockTxInsert }));
+const mockDb = vi.hoisted(() => ({
+  transaction: vi.fn(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx)),
+}));
+const mockFeedbackService = vi.hoisted(() => ({
+  listIssueVotesForUser: vi.fn(async () => []),
+  saveIssueVote: vi.fn(async () => ({
+    vote: null,
+    consentEnabledNow: false,
+    sharingEnabled: false,
+  })),
+}));
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  get: vi.fn(async () => ({
+    id: "instance-settings-1",
+    general: {
+      censorUsernameInLogs: false,
+      feedbackDataSharingPreference: "prompt",
+    },
+  })),
+  listCompanyIds: vi.fn(async () => [COMPANY_ID]),
+}));
+const mockRoutineService = vi.hoisted(() => ({
+  syncRunStatusForIssue: vi.fn(async () => undefined),
+}));
+const mockIssueThreadInteractionService = vi.hoisted(() => ({
+  expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+  expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+}));
+const mockIssueTreeControlService = vi.hoisted(() => ({
+  getActivePauseHoldGate: vi.fn(async () => null),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentTaskCompleted: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+}));
+
+vi.mock("../services/access.js", () => ({
+  accessService: () => mockAccessService,
+}));
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+}));
+
+vi.mock("../services/agents.js", () => ({
+  agentService: () => mockAgentService,
+}));
+
+vi.mock("../services/feedback.js", () => ({
+  feedbackService: () => mockFeedbackService,
+}));
+
+vi.mock("../services/heartbeat.js", () => ({
+  heartbeatService: () => mockHeartbeatService,
+}));
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: () => mockInstanceSettingsService,
+}));
+
+vi.mock("../services/issues.js", () => ({
+  issueService: () => mockIssueService,
+}));
+
+vi.mock("../services/routines.js", () => ({
+  routineService: () => mockRoutineService,
+}));
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: COMPANY_ID, attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
+  // additional services agentRoutes touches at construction time
+  approvalService: () => ({}),
+  budgetService: () => ({}),
+  environmentService: () => ({ getById: vi.fn() }),
+  secretService: () => ({
+    normalizeAdapterConfigForPersistence: vi.fn(),
+    resolveAdapterConfigForRuntime: vi.fn(),
+  }),
+  workspaceOperationService: () => ({}),
+  companySkillService: () => ({
+    listRuntimeSkillEntries: vi.fn(),
+    resolveRequestedSkillKeys: vi.fn(),
+  }),
+  agentInstructionsService: () => ({ materializeManagedBundle: vi.fn() }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => mockFeedbackService,
+  goalService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  instanceSettingsService: () => mockInstanceSettingsService,
+  issueApprovalService: () => ({}),
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueService: () => mockIssueService,
+  issueThreadInteractionService: () => mockIssueThreadInteractionService,
+  issueTreeControlService: () => mockIssueTreeControlService,
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  routineService: () => mockRoutineService,
+  workProductService: () => ({}),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  return app;
+}
+
+async function installActor(app: express.Express, actor?: Record<string, unknown>) {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/issues.js"),
+    import("../middleware/index.js"),
+  ]);
+  app.use((req, _res, next) => {
+    (req as any).actor =
+      actor ?? {
+        type: "board",
+        userId: "local-board",
+        companyIds: [COMPANY_ID],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      };
+    next();
+  });
+  app.use("/api", issueRoutes(mockDb as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue(status: "todo" | "in_progress" | "blocked" | "done" | "cancelled") {
+  return {
+    id: ISSUE_ID,
+    companyId: COMPANY_ID,
+    status,
+    assigneeAgentId: AGENT_ID,
+    assigneeUserId: null,
+    createdByUserId: "local-board",
+    identifier: "PAP-PF2",
+    title: "Terminal status guard",
+    executionState: null,
+    executionPolicy: null,
+  };
+}
+
+function agentActor(agentId = AGENT_ID, runId: string | null = "run-pf2") {
+  return {
+    type: "agent",
+    agentId,
+    companyId: COMPANY_ID,
+    source: "agent_key",
+    runId,
+  };
+}
+
+describe.sequential("PF-2 issue terminal-status no-op guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.getById.mockReset();
+    mockIssueService.update.mockReset();
+    mockIssueService.addComment.mockReset();
+    mockIssueService.getDependencyReadiness.mockReset();
+    mockIssueService.assertCheckoutOwner.mockReset();
+    mockAgentService.list.mockReset();
+    mockAgentService.getById.mockReset();
+    mockAgentService.resolveByReference.mockReset();
+    mockLogActivity.mockReset();
+
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: ISSUE_ID,
+      blockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-pf2",
+      issueId: ISSUE_ID,
+      companyId: COMPANY_ID,
+      body: "",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: AGENT_ID,
+      authorUserId: null,
+    });
+    mockAgentService.list.mockResolvedValue([]);
+    mockAgentService.getById.mockResolvedValue(null);
+    mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: null });
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("returns existing issue without invoking update when an agent re-PATCHes status=done on a done issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done", comment: "All done!" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: ISSUE_ID, status: "done" });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.terminal_status_noop",
+        entityId: ISSUE_ID,
+        details: expect.objectContaining({
+          currentStatus: "done",
+          attemptedStatus: "done",
+          hadComment: true,
+        }),
+      }),
+    );
+  });
+
+  it("returns existing issue without invoking update when an agent re-PATCHes status=cancelled on a cancelled issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("cancelled"));
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "cancelled" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.terminal_status_noop",
+        details: expect.objectContaining({
+          currentStatus: "cancelled",
+          attemptedStatus: "cancelled",
+          hadComment: false,
+        }),
+      }),
+    );
+  });
+
+  it("does not no-op when the actor is a user (humans can re-mark terminal issues)", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.terminal_status_noop" }),
+    );
+  });
+
+  it("does not no-op when the agent's request includes an explicit reopen flag", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done", reopen: true });
+
+    // The terminal-status no-op guard should NOT fire because reopen is explicit.
+    // (Subsequent business logic may still reject the request for other reasons,
+    // but the no-op log entry must not be written.)
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.terminal_status_noop" }),
+    );
+  });
+
+  it("does not no-op when the agent's PATCH targets a non-terminal status (legitimate reopen attempt)", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "todo" });
+
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.terminal_status_noop" }),
+    );
+  });
+
+  it("does not no-op when the issue is not yet terminal", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("in_progress"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("in_progress"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done" });
+
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.terminal_status_noop" }),
+    );
+  });
+});
+
+// Note on PF-1 (terminal-status exclusion from actionable selection):
+// The /agents/me/inbox-lite endpoint already filters status to
+// "todo,in_progress,blocked" at server/src/routes/agents.ts (the call site
+// for issueService.list). That literal filter is verified via:
+//   1. Manual code inspection (see PR description)
+//   2. The route-level test in wip/ui-cli-pending-changes:
+//      server/src/__tests__/agent-inbox-lite.test.ts
+// This file therefore focuses on PF-2 (PATCH no-op) which is where the new
+// code change lives. Defense-in-depth: even if a stale wakeup payload causes
+// an agent to act on a terminal issue, the PATCH guard above prevents the
+// observed bug (re-marking + duplicate completion comment).

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1954,6 +1954,38 @@ export function issueRoutes(
     } = req.body;
     const shouldCancelActiveRunForCancelledStatus =
       existing.status !== "cancelled" && updateFields.status === "cancelled";
+
+    // PF-2: Reject stale completion attempts. If an agent re-PATCHes an
+    // already-terminal issue with another terminal status (and isn't explicitly
+    // reopening or resuming), short-circuit with a no-op response instead of
+    // re-marking the issue and posting a duplicate completion comment.
+    if (
+      req.actor.type === "agent" &&
+      isClosed &&
+      typeof updateFields.status === "string" &&
+      isClosedIssueStatus(updateFields.status) &&
+      resumeRequested !== true &&
+      reopenRequested !== true
+    ) {
+      await logActivity(db, {
+        companyId: existing.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "issue.terminal_status_noop",
+        entityType: "issue",
+        entityId: existing.id,
+        details: {
+          currentStatus: existing.status,
+          attemptedStatus: updateFields.status,
+          hadComment: Boolean(commentBody),
+        },
+      });
+      res.json(existing);
+      return;
+    }
+
     if (resumeRequested === true && !commentBody) {
       res.status(400).json({ error: "Follow-up intent requires a comment" });
       return;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The agent runtime path includes a heartbeat → wakeup → work-selection → mutation loop where agents pick actionable issues and act on them
> - In CEO run `292a5fd1`, an agent treated `CMP-1` as actionable even though it was already `done`, then re-PATCHed it with `{"status":"done"}` and posted a duplicate completion comment
> - The 2026-04-16 hangeul-school operational issue report (PF-1, PF-2) split this into two fixes: (a) exclude terminal issues from actionable selection, (b) guard the heartbeat/PATCH path so terminal-state mutations are no-ops
> - PF-1 is already satisfied at the listing endpoint — `/agents/me/inbox-lite` filters `status` to `"todo,in_progress,blocked"` (`server/src/routes/agents.ts:1410`), and `wip/ui-cli-pending-changes` already includes a route-level test that locks that contract
> - This pull request adds the **PF-2** server-side guard on `PATCH /issues/:id`: when an agent re-PATCHes an already-terminal issue with another terminal status (no explicit reopen/resume), short-circuit with a no-op response instead of running the full update path
> - The benefit is defense-in-depth — even if a stale wakeup payload causes an agent to act on a now-terminal issue, the bug-causing mutation (re-mark + duplicate comment) is rejected at the API boundary and recorded as `issue.terminal_status_noop` for audit

## What Changed

- Added a guard in `PATCH /issues/:id` (`server/src/routes/issues.ts`) that returns the existing issue unchanged when **all four** conditions hold: actor is an agent, existing issue status is terminal (`done`/`cancelled`), request `status` is also terminal, and the request does not include explicit `reopen: true` or `resume: true`.
- The guard logs `action: "issue.terminal_status_noop"` via `logActivity` so the no-op is visible in audit/run history.
- Added 6 new tests in `server/src/__tests__/issue-terminal-status-noop-routes.test.ts` covering: agent re-PATCH `status=done` on done issue (no-op), agent re-PATCH `status=cancelled` on cancelled issue (no-op), user actor on done issue (passes through), agent with explicit `reopen: true` (passes through), agent with `status=todo` target (passes through), agent on `in_progress` source (passes through).

## Verification

```bash
cd server
pnpm vitest run src/__tests__/issue-terminal-status-noop-routes.test.ts
# 6/6 pass

pnpm vitest run \
  src/__tests__/issue-comment-reopen-routes.test.ts \
  src/__tests__/issue-closed-workspace-routes.test.ts \
  src/__tests__/issue-execution-policy-routes.test.ts \
  src/__tests__/issue-agent-mutation-ownership-routes.test.ts
# 47/47 adjacent regression tests pass

pnpm vitest run src/__tests__/heartbeat-stale-queue-invalidation.test.ts
# 5/5 pass
```

Acceptance test from PF-2 spec:
1. Assign an issue to an agent
2. Mark it `done`
3. Have the agent attempt to PATCH `{"status":"done","comment":"..."}`
4. Confirm: 200 response, no DB update, no duplicate comment, activity log shows `issue.terminal_status_noop`

The guard is verified in test case `returns existing issue without invoking update when an agent re-PATCHes status=done on a done issue`.

## Risks

- **Low.** The guard is narrowly scoped: it only fires when the actor is an agent **and** the existing issue is already terminal **and** the request targets another terminal status **and** there is no explicit `reopen`/`resume` flag. Every existing legitimate path is preserved (human actors, status-to-non-terminal PATCHes, explicit reopen/resume from agents, non-terminal source issues).
- The no-op response returns the existing issue body unchanged, which is the canonical "no work happened" shape for this route. Calling code that retries or asserts on response shape will see the same fields it already expects.
- Pre-existing typecheck errors in `plugin-host-services.ts` and `plugin-worker-manager.ts` are unrelated to this change and are present on `origin/master`.

## Model Used

Claude Opus 4.7 (1M context), model ID `claude-opus-4-7[1m]`. Used in interactive Claude Code session with extended reasoning, tool use (Read/Edit/Write/Bash), and explicit verification gates between exploration → fix → tests → push.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (6 new + 47 adjacent + 5 heartbeat = 58 tests, no regressions)
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — N/A, server-only change
- [x] I have updated relevant documentation to reflect my changes — no doc changes needed; the activity-log action name is self-describing
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

## Background context (kept from original draft)

PF-1 (terminal-status exclusion from actionable selection) is **already satisfied** at the inbox-lite endpoint. The route-level test in `wip/ui-cli-pending-changes:server/src/__tests__/agent-inbox-lite.test.ts` locks that contract; that branch is in flight separately. This PR adds the PATCH guard as defense-in-depth so even if a stale wakeup payload causes an agent to act on a now-terminal issue, the bug-causing mutation is rejected at the API boundary.

PF-3 (workspace selection), PF-4 (session freshness), and PF-5 (broader regression coverage) are intentionally out of scope and can land in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
