### PR TITLE
fix(issues): mark truncated descriptions in list results

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -247,6 +247,7 @@ export interface Issue {
   ancestors?: IssueAncestor[];
   title: string;
   description: string | null;
+  descriptionTruncated?: boolean;
   status: IssueStatus;
   priority: IssuePriority;
   assigneeAgentId: string | null;

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -90,6 +90,33 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await tempDb?.cleanup();
   });
 
+  it("marks truncated descriptions on company issue list results", async () => {
+    const companyId = randomUUID();
+    const longDescription = "x".repeat(1600);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: randomUUID(),
+      companyId,
+      title: "Long issue",
+      description: longDescription,
+      status: "backlog",
+      priority: "medium",
+    });
+
+    const [issue] = await svc.list(companyId, {});
+
+    expect(issue).toBeDefined();
+    expect(issue?.description).toHaveLength(1200);
+    expect(issue?.descriptionTruncated).toBe(true);
+  });
+
   it("returns issues an agent participated in across the supported signals", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1390,6 +1390,12 @@ const issueListSelect = {
       )
     END
   `,
+  descriptionTruncated: sql<boolean>`
+    CASE
+      WHEN ${issues.description} IS NULL THEN false
+      ELSE octet_length(convert_to(${issues.description}, current_setting('server_encoding'))) > ${ISSUE_LIST_DESCRIPTION_MAX_BYTES}
+    END
+  `,
   status: issues.status,
   priority: issues.priority,
   assigneeAgentId: issues.assigneeAgentId,

--- a/ui/src/api/issues.test.ts
+++ b/ui/src/api/issues.test.ts
@@ -47,4 +47,13 @@ describe("issuesApi.list", () => {
       "/companies/company-1/issues?limit=500&offset=1500",
     );
   });
+
+  it("returns issue list payloads without client-side shape rewriting", async () => {
+    const payload = [{ id: "issue-1", title: "Test", description: "x", descriptionTruncated: true }];
+    mockApi.get.mockResolvedValue(payload);
+
+    const result = await issuesApi.list("company-1");
+
+    expect(result).toEqual(payload);
+  });
 });


### PR DESCRIPTION
## Thinking Path
The reported bug is a list/read-model problem rather than a full issue-write contract redesign. The narrowest safe fix is to keep the existing truncated `description` preview for list endpoints, but make truncation explicit so API consumers can avoid blindly round-tripping it back into PATCH requests. That preserves compatibility while removing the silent data-loss footgun.

## What Changed
- Added `descriptionTruncated` to company issue list results when the server-side preview clipped the original description.
- Preserved existing list payload shape otherwise; no write-path behavior was changed.
- Added a server-side regression test for truncated list descriptions.
- Added a UI API test proving the client preserves the new flag in issue list payloads.

## Verification
- `pnpm exec vitest run ui/src/api/issues.test.ts`
- `pnpm exec vitest run server/src/__tests__/issues-service.test.ts -t "marks truncated descriptions"` *(blocked in this fresh worktree by unresolved root package dependency resolution for `drizzle-orm`; the failure is environment/worktree linkage, not a code assertion failure)*

## Risks
- Adds a new optional field to the shared `Issue` type; consumers that assume an exhaustive shape may need to tolerate the extra property.
- Does not fully solve accidental PATCH round-trips by itself; it only makes truncation explicit so clients can avoid them.

## Model Used
- OpenAI GPT-5 Codex via Codex CLI

## Checklist
- [x] Change is scoped to the reported issue
- [x] Added regression coverage for the bug fix
- [x] Did not include unrelated refactors
- [x] Verification run where environment allowed
- [x] PR description follows repository template sections
