### PR TITLE
Default agent runtime API URL to loopback

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   applyPaperclipWorkspaceEnv,
   appendWithByteCap,
+  buildPaperclipEnv,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   renderPaperclipWakePrompt,
   runningProcesses,
@@ -467,6 +468,104 @@ describe("applyPaperclipWorkspaceEnv", () => {
     );
 
     expect(env).toEqual({});
+  });
+});
+
+describe("buildPaperclipEnv", () => {
+  const ENV_KEYS = [
+    "PAPERCLIP_AGENT_API_URL",
+    "PAPERCLIP_RUNTIME_API_URL",
+    "PAPERCLIP_API_URL",
+    "PAPERCLIP_LISTEN_HOST",
+    "PAPERCLIP_LISTEN_PORT",
+    "HOST",
+    "PORT",
+  ] as const;
+  const saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = saved[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("defaults PAPERCLIP_API_URL to the runtime loopback when no override is set", () => {
+    process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+    process.env.PAPERCLIP_LISTEN_PORT = "3100";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_AGENT_ID).toBe("agent-1");
+    expect(env.PAPERCLIP_COMPANY_ID).toBe("company-1");
+    expect(env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3100");
+  });
+
+  it("does not fall back to PAPERCLIP_RUNTIME_API_URL or PAPERCLIP_API_URL", () => {
+    // Both legacy chain entries are commonly set to an unreachable public URL.
+    process.env.PAPERCLIP_RUNTIME_API_URL = "https://auth.public.example/";
+    process.env.PAPERCLIP_API_URL = "https://auth.public.example/";
+    process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+    process.env.PAPERCLIP_LISTEN_PORT = "3100";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3100");
+  });
+
+  it("honors PAPERCLIP_AGENT_API_URL when set", () => {
+    process.env.PAPERCLIP_AGENT_API_URL = "https://agent-api.internal.example";
+    process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+    process.env.PAPERCLIP_LISTEN_PORT = "3100";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("https://agent-api.internal.example");
+  });
+
+  it("ignores empty/whitespace PAPERCLIP_AGENT_API_URL and uses loopback", () => {
+    process.env.PAPERCLIP_AGENT_API_URL = "   ";
+    process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+    process.env.PAPERCLIP_LISTEN_PORT = "3100";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3100");
+  });
+
+  it("rewrites 0.0.0.0 to localhost for the loopback URL", () => {
+    process.env.PAPERCLIP_LISTEN_HOST = "0.0.0.0";
+    process.env.PAPERCLIP_LISTEN_PORT = "4242";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://localhost:4242");
+  });
+
+  it("falls back to HOST/PORT when PAPERCLIP_LISTEN_* are unset", () => {
+    process.env.HOST = "127.0.0.1";
+    process.env.PORT = "5500";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:5500");
+  });
+
+  it("defaults to localhost:3100 when no host/port env vars are set", () => {
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://localhost:3100");
   });
 });
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -827,9 +827,12 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
   );
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
+  // Agents run as child processes in the same container/host as the server.
+  // Prefer the loopback URL: PAPERCLIP_RUNTIME_API_URL/PAPERCLIP_API_URL may be a
+  // public/Tailscale/proxy hostname that is unreachable from inside the agent's
+  // network namespace. Operators can override with PAPERCLIP_AGENT_API_URL.
   const apiUrl =
-    process.env.PAPERCLIP_RUNTIME_API_URL ??
-    process.env.PAPERCLIP_API_URL ??
+    process.env.PAPERCLIP_AGENT_API_URL?.trim() ||
     `http://${runtimeHost}:${runtimePort}`;
   vars.PAPERCLIP_API_URL = apiUrl;
   return vars;

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { buildPaperclipEnv } from "../adapters/utils.js";
 
+const ORIGINAL_PAPERCLIP_AGENT_API_URL = process.env.PAPERCLIP_AGENT_API_URL;
 const ORIGINAL_PAPERCLIP_RUNTIME_API_URL = process.env.PAPERCLIP_RUNTIME_API_URL;
 const ORIGINAL_PAPERCLIP_API_URL = process.env.PAPERCLIP_API_URL;
 const ORIGINAL_PAPERCLIP_LISTEN_HOST = process.env.PAPERCLIP_LISTEN_HOST;
@@ -9,6 +10,9 @@ const ORIGINAL_HOST = process.env.HOST;
 const ORIGINAL_PORT = process.env.PORT;
 
 afterEach(() => {
+  if (ORIGINAL_PAPERCLIP_AGENT_API_URL === undefined) delete process.env.PAPERCLIP_AGENT_API_URL;
+  else process.env.PAPERCLIP_AGENT_API_URL = ORIGINAL_PAPERCLIP_AGENT_API_URL;
+
   if (ORIGINAL_PAPERCLIP_RUNTIME_API_URL === undefined) delete process.env.PAPERCLIP_RUNTIME_API_URL;
   else process.env.PAPERCLIP_RUNTIME_API_URL = ORIGINAL_PAPERCLIP_RUNTIME_API_URL;
 
@@ -29,9 +33,8 @@ afterEach(() => {
 });
 
 describe("buildPaperclipEnv", () => {
-  it("prefers an explicit PAPERCLIP_RUNTIME_API_URL", () => {
-    process.env.PAPERCLIP_RUNTIME_API_URL = "http://203.0.113.42:3102";
-    process.env.PAPERCLIP_API_URL = "http://localhost:4100";
+  it("prefers an explicit PAPERCLIP_AGENT_API_URL override", () => {
+    process.env.PAPERCLIP_AGENT_API_URL = "http://203.0.113.42:3102";
     process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
     process.env.PAPERCLIP_LISTEN_PORT = "3101";
 
@@ -40,15 +43,20 @@ describe("buildPaperclipEnv", () => {
     expect(env.PAPERCLIP_API_URL).toBe("http://203.0.113.42:3102");
   });
 
-  it("falls back to PAPERCLIP_API_URL when no runtime URL is configured", () => {
-    delete process.env.PAPERCLIP_RUNTIME_API_URL;
+  it("ignores the legacy PAPERCLIP_RUNTIME_API_URL / PAPERCLIP_API_URL fallbacks and uses loopback", () => {
+    // The previous implementation preferred PAPERCLIP_RUNTIME_API_URL, then
+    // PAPERCLIP_API_URL — both of which were typically set to the auth public
+    // base URL (often unreachable from the spawned-child's network namespace).
+    // The fix makes loopback the default; operators can opt back into a
+    // remote URL via PAPERCLIP_AGENT_API_URL.
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://203.0.113.42:3102";
     process.env.PAPERCLIP_API_URL = "http://localhost:4100";
     process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
     process.env.PAPERCLIP_LISTEN_PORT = "3101";
 
     const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
 
-    expect(env.PAPERCLIP_API_URL).toBe("http://localhost:4100");
+    expect(env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3101");
   });
 
   it("uses runtime listen host/port when explicit URL is not set", () => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - When Paperclip spawns a Claude Code child for an agent run, it injects `PAPERCLIP_API_URL` via `buildPaperclipEnv` so the child can call Paperclip's REST API
> - Today `buildPaperclipEnv` resolves `PAPERCLIP_API_URL` from a chain that prefers `PAPERCLIP_RUNTIME_API_URL` / `PAPERCLIP_API_URL`, which on many deployments points at a public, Tailscale, or proxy hostname served from a different network namespace than the Paperclip container hosting the child
> - On those deployments the spawned agent's API calls fail (we observed `HTTP=000` within milliseconds), the run "ends" without doing work, the watchdog re-queues it, and the loop bleeds cost on every continuation
> - This pull request defaults `PAPERCLIP_API_URL` to the runtime loopback (`http://${runtimeHost}:${runtimePort}`), with a new `PAPERCLIP_AGENT_API_URL` env override for operators who genuinely need a different host
> - The benefit is that out-of-the-box deployments with non-public or unreachable auth URLs no longer loop on unreachable APIs, and operators retain a single explicit knob if they really do need a remote URL

## What Changed

- `packages/adapter-utils/src/server-utils.ts:buildPaperclipEnv` now defaults the agent-injected `PAPERCLIP_API_URL` to `http://${runtimeHost}:${runtimePort}`
- New env override: `PAPERCLIP_AGENT_API_URL` — explicit operator override when loopback is wrong
- Removed the previous `PAPERCLIP_RUNTIME_API_URL ?? PAPERCLIP_API_URL ?? loopback` fallback chain; the first two were footguns because they almost always pointed to the auth public base URL the spawned child cannot reach
- Tests added in `packages/adapter-utils/src/server-utils.test.ts` covering: default loopback, ignored legacy chain, explicit `PAPERCLIP_AGENT_API_URL` override, whitespace-only override falling back to loopback, `0.0.0.0` rewrite, `HOST`/`PORT` fallback, and the no-env default

## Verification

- New tests in `packages/adapter-utils/src/server-utils.test.ts` (`describe("buildPaperclipEnv")`) — 7 cases covering the matrix above
- `npx vitest run --project @paperclipai/adapter-utils packages/adapter-utils/src/server-utils.test.ts` — 21 tests pass (1 file)
- `pnpm --filter @paperclipai/adapter-utils build` — typechecks cleanly
- Manual: deployed live on a self-hosted instance for ~36h — agent runs that previously bled cost on every continuation now complete normally; no more `HTTP=000` in agent logs

## Risks

- Behavioral shift for any deployment that was implicitly relying on the previous chain to forward an external URL to spawned agents — but any such deployment was likely seeing the same `HTTP=000` bug we hit. Operators can opt back in by setting `PAPERCLIP_AGENT_API_URL=<their-url>`.
- No DB or schema changes. No breaking API changes. New env var is additive.
- Low risk overall.

## Model Used

Claude Opus 4.7 (1M context window), 200k thinking budget, with tool use. Provider: Anthropic. Model ID: `claude-opus-4-7`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (no UI change)
- [x] I have updated relevant documentation to reflect my changes (no doc changes needed; new env var documented in commit + PR body)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
