### PR TITLE
Authenticate skill-importer GitHub requests when GITHUB_TOKEN is set

### DIFF
--- a/server/src/__tests__/github-fetch.test.ts
+++ b/server/src/__tests__/github-fetch.test.ts
@@ -19,10 +19,12 @@ function getAuthHeader(init: RequestInit | undefined): string | null {
 describe("ghFetch GitHub authentication", () => {
   const originalGithubToken = process.env.GITHUB_TOKEN;
   const originalGhToken = process.env.GH_TOKEN;
+  const originalGithubHosts = process.env.PAPERCLIP_GITHUB_HOSTS;
 
   beforeEach(() => {
     delete process.env.GITHUB_TOKEN;
     delete process.env.GH_TOKEN;
+    delete process.env.PAPERCLIP_GITHUB_HOSTS;
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeOkResponse()));
   });
 
@@ -31,6 +33,8 @@ describe("ghFetch GitHub authentication", () => {
     else process.env.GITHUB_TOKEN = originalGithubToken;
     if (originalGhToken === undefined) delete process.env.GH_TOKEN;
     else process.env.GH_TOKEN = originalGhToken;
+    if (originalGithubHosts === undefined) delete process.env.PAPERCLIP_GITHUB_HOSTS;
+    else process.env.PAPERCLIP_GITHUB_HOSTS = originalGithubHosts;
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -61,9 +65,9 @@ describe("ghFetch GitHub authentication", () => {
     expect(getAuthHeader(init)).toBe("Bearer ghp_raw_token");
   });
 
-  it("attaches Authorization header for GitHub Enterprise API URLs", async () => {
-    // gitHubApiBase() routes GHE traffic to <host>/api/v3 — recognized by path.
+  it("attaches Authorization header for an operator-configured GitHub Enterprise host", async () => {
     process.env.GITHUB_TOKEN = "ghp_ghe_token";
+    process.env.PAPERCLIP_GITHUB_HOSTS = "github.example.com";
 
     await ghFetch("https://github.example.com/api/v3/repos/acme/widgets");
 
@@ -71,22 +75,43 @@ describe("ghFetch GitHub authentication", () => {
     expect(getAuthHeader(init)).toBe("Bearer ghp_ghe_token");
   });
 
-  it("attaches Authorization header for GitHub Enterprise raw URLs", async () => {
-    // resolveRawGitHubUrl() routes GHE raw traffic to <host>/raw/... — recognized by path.
-    process.env.GITHUB_TOKEN = "ghp_ghe_raw_token";
+  it("supports multiple GHE hosts via PAPERCLIP_GITHUB_HOSTS comma-separated list", async () => {
+    process.env.GITHUB_TOKEN = "ghp_multi";
+    process.env.PAPERCLIP_GITHUB_HOSTS = "ghe-east.example.com, ghe-west.example.com";
 
-    await ghFetch("https://github.example.com/raw/acme/widgets/main/README.md");
+    await ghFetch("https://ghe-west.example.com/api/v3/user");
 
     const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
-    expect(getAuthHeader(init)).toBe("Bearer ghp_ghe_raw_token");
+    expect(getAuthHeader(init)).toBe("Bearer ghp_multi");
+  });
+
+  it("does not attach Authorization header to a path-only GHE-shaped URL on an unconfigured host", async () => {
+    // Defense in depth: an attacker-controlled URL whose path looks like
+    // `/api/v3/...` must NOT receive the token unless the host is explicitly
+    // allowlisted via PAPERCLIP_GITHUB_HOSTS.
+    process.env.GITHUB_TOKEN = "ghp_test_token_value";
+
+    await ghFetch("https://attacker.example.com/api/v3/collect");
+
+    const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
+    expect(getAuthHeader(init)).toBeNull();
   });
 
   it("does not attach Authorization header for unrecognized hosts even when token is set", async () => {
-    // Defense in depth: ghFetch is GitHub-specific by contract, but if a
-    // caller mistakenly passes a non-GitHub URL we must not leak the token.
     process.env.GITHUB_TOKEN = "ghp_test_token_value";
 
     await ghFetch("https://example.com/some/resource");
+
+    const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
+    expect(getAuthHeader(init)).toBeNull();
+  });
+
+  it("does not attach Authorization header to a configured GHE host that does not match the URL", async () => {
+    // Configured a different GHE host — example.org should NOT get the token.
+    process.env.GITHUB_TOKEN = "ghp_test_token_value";
+    process.env.PAPERCLIP_GITHUB_HOSTS = "github.example.com";
+
+    await ghFetch("https://example.org/api/v3/whatever");
 
     const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
     expect(getAuthHeader(init)).toBeNull();

--- a/server/src/__tests__/github-fetch.test.ts
+++ b/server/src/__tests__/github-fetch.test.ts
@@ -61,16 +61,35 @@ describe("ghFetch GitHub authentication", () => {
     expect(getAuthHeader(init)).toBe("Bearer ghp_raw_token");
   });
 
-  it("attaches Authorization header for GitHub Enterprise hosts", async () => {
-    // gitHubApiBase()/resolveRawGitHubUrl() route GHE traffic to <host>/api/v3
-    // and <host>/raw paths. ghFetch is the GitHub-specific helper, so the
-    // token must reach those hosts too — not just *.github.com.
+  it("attaches Authorization header for GitHub Enterprise API URLs", async () => {
+    // gitHubApiBase() routes GHE traffic to <host>/api/v3 — recognized by path.
     process.env.GITHUB_TOKEN = "ghp_ghe_token";
 
     await ghFetch("https://github.example.com/api/v3/repos/acme/widgets");
 
     const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
     expect(getAuthHeader(init)).toBe("Bearer ghp_ghe_token");
+  });
+
+  it("attaches Authorization header for GitHub Enterprise raw URLs", async () => {
+    // resolveRawGitHubUrl() routes GHE raw traffic to <host>/raw/... — recognized by path.
+    process.env.GITHUB_TOKEN = "ghp_ghe_raw_token";
+
+    await ghFetch("https://github.example.com/raw/acme/widgets/main/README.md");
+
+    const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
+    expect(getAuthHeader(init)).toBe("Bearer ghp_ghe_raw_token");
+  });
+
+  it("does not attach Authorization header for unrecognized hosts even when token is set", async () => {
+    // Defense in depth: ghFetch is GitHub-specific by contract, but if a
+    // caller mistakenly passes a non-GitHub URL we must not leak the token.
+    process.env.GITHUB_TOKEN = "ghp_test_token_value";
+
+    await ghFetch("https://example.com/some/resource");
+
+    const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
+    expect(getAuthHeader(init)).toBeNull();
   });
 
   it("does not overwrite a caller-supplied Authorization header", async () => {

--- a/server/src/__tests__/github-fetch.test.ts
+++ b/server/src/__tests__/github-fetch.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ghFetch } from "../services/github-fetch.js";
+
+function makeOkResponse(): Response {
+  return new Response("ok", { status: 200 });
+}
+
+function getInitForCall(call: unknown): RequestInit | undefined {
+  const args = call as [unknown, RequestInit | undefined];
+  return args[1];
+}
+
+function getAuthHeader(init: RequestInit | undefined): string | null {
+  if (!init?.headers) return null;
+  const headers = new Headers(init.headers);
+  return headers.get("Authorization");
+}
+
+describe("ghFetch GitHub authentication", () => {
+  const originalGithubToken = process.env.GITHUB_TOKEN;
+  const originalGhToken = process.env.GH_TOKEN;
+
+  beforeEach(() => {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeOkResponse()));
+  });
+
+  afterEach(() => {
+    if (originalGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = originalGithubToken;
+    if (originalGhToken === undefined) delete process.env.GH_TOKEN;
+    else process.env.GH_TOKEN = originalGhToken;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not attach an Authorization header when no token is set", async () => {
+    await ghFetch("https://api.github.com/repos/octocat/hello-world");
+
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(call?.[0]).toBe("https://api.github.com/repos/octocat/hello-world");
+    expect(getAuthHeader(getInitForCall(call))).toBeNull();
+  });
+
+  it("attaches Authorization: Bearer header for api.github.com when GITHUB_TOKEN is set", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test_token_value";
+
+    await ghFetch("https://api.github.com/repos/octocat/hello-world");
+
+    const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
+    expect(getAuthHeader(init)).toBe("Bearer ghp_test_token_value");
+  });
+
+  it("attaches Authorization header for raw.githubusercontent.com requests", async () => {
+    process.env.GITHUB_TOKEN = "ghp_raw_token";
+
+    await ghFetch("https://raw.githubusercontent.com/octocat/hello/main/README.md");
+
+    const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
+    expect(getAuthHeader(init)).toBe("Bearer ghp_raw_token");
+  });
+
+  it("does not attach Authorization header for non-GitHub hosts even when token is set", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test_token_value";
+
+    await ghFetch("https://example.com/some/resource");
+
+    const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
+    expect(getAuthHeader(init)).toBeNull();
+  });
+
+  it("does not overwrite a caller-supplied Authorization header", async () => {
+    process.env.GITHUB_TOKEN = "ghp_env_token";
+
+    await ghFetch("https://api.github.com/user", {
+      headers: { Authorization: "Bearer caller-supplied-token" },
+    });
+
+    const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
+    expect(getAuthHeader(init)).toBe("Bearer caller-supplied-token");
+  });
+
+  it("falls back to GH_TOKEN when GITHUB_TOKEN is unset", async () => {
+    process.env.GH_TOKEN = "ghp_gh_fallback";
+
+    await ghFetch("https://api.github.com/repos/octocat/hello-world");
+
+    const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
+    expect(getAuthHeader(init)).toBe("Bearer ghp_gh_fallback");
+  });
+
+  it("prefers GITHUB_TOKEN over GH_TOKEN when both are set", async () => {
+    process.env.GITHUB_TOKEN = "ghp_primary";
+    process.env.GH_TOKEN = "ghp_fallback";
+
+    await ghFetch("https://api.github.com/repos/octocat/hello-world");
+
+    const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
+    expect(getAuthHeader(init)).toBe("Bearer ghp_primary");
+  });
+});

--- a/server/src/__tests__/github-fetch.test.ts
+++ b/server/src/__tests__/github-fetch.test.ts
@@ -61,13 +61,16 @@ describe("ghFetch GitHub authentication", () => {
     expect(getAuthHeader(init)).toBe("Bearer ghp_raw_token");
   });
 
-  it("does not attach Authorization header for non-GitHub hosts even when token is set", async () => {
-    process.env.GITHUB_TOKEN = "ghp_test_token_value";
+  it("attaches Authorization header for GitHub Enterprise hosts", async () => {
+    // gitHubApiBase()/resolveRawGitHubUrl() route GHE traffic to <host>/api/v3
+    // and <host>/raw paths. ghFetch is the GitHub-specific helper, so the
+    // token must reach those hosts too — not just *.github.com.
+    process.env.GITHUB_TOKEN = "ghp_ghe_token";
 
-    await ghFetch("https://example.com/some/resource");
+    await ghFetch("https://github.example.com/api/v3/repos/acme/widgets");
 
     const init = getInitForCall(vi.mocked(fetch).mock.calls[0]);
-    expect(getAuthHeader(init)).toBeNull();
+    expect(getAuthHeader(init)).toBe("Bearer ghp_ghe_token");
   });
 
   it("does not overwrite a caller-supplied Authorization header", async () => {

--- a/server/src/services/github-fetch.ts
+++ b/server/src/services/github-fetch.ts
@@ -16,24 +16,28 @@ export function resolveRawGitHubUrl(hostname: string, owner: string, repo: strin
     : `https://${hostname}/raw/${owner}/${repo}/${ref}/${p}`;
 }
 
+/**
+ * Attaches `Authorization: Bearer ${GITHUB_TOKEN}` (with `GH_TOKEN` as fallback)
+ * to outgoing requests when a token is set in the environment.
+ *
+ * `ghFetch` is the GitHub-specific fetch helper for this module: every URL
+ * passed in originates from `gitHubApiBase()` or `resolveRawGitHubUrl()`,
+ * which produce either `api.github.com` / `raw.githubusercontent.com` (for
+ * github.com) or `https://<host>/api/v3` / `https://<host>/raw/...` (for
+ * GitHub Enterprise). We therefore attach the token unconditionally rather
+ * than gating on a github.com allowlist that would silently skip GHE.
+ * Caller-supplied `Authorization` headers always win.
+ */
 function authHeadersForGitHub(url: string, init?: RequestInit): RequestInit | undefined {
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token) return init;
-  let host: string;
   try {
-    host = new URL(url).hostname.toLowerCase();
+    new URL(url);
   } catch {
     return init;
   }
-  const isGitHubHost =
-    host === "api.github.com" ||
-    host === "github.com" ||
-    host === "www.github.com" ||
-    host === "raw.githubusercontent.com" ||
-    host === "codeload.github.com";
-  if (!isGitHubHost) return init;
   const headers = new Headers(init?.headers);
-  if (!headers.has("Authorization") && !headers.has("authorization")) {
+  if (!headers.has("Authorization")) {
     headers.set("Authorization", `Bearer ${token}`);
   }
   return { ...(init ?? {}), headers };

--- a/server/src/services/github-fetch.ts
+++ b/server/src/services/github-fetch.ts
@@ -17,12 +17,12 @@ export function resolveRawGitHubUrl(hostname: string, owner: string, repo: strin
 }
 
 /**
- * Recognizes URLs that look like they target GitHub or a GitHub Enterprise
- * instance. github.com properties are matched by hostname; GHE installs are
- * detected by the URL shape produced by {@link gitHubApiBase} (paths under
- * `/api/v3`) and {@link resolveRawGitHubUrl} (paths under `/raw`). Anything
- * else is treated as a non-GitHub URL — even if a caller mistakenly passes
- * one to {@link ghFetch}, no credentials will be attached to it.
+ * Recognizes URLs that target GitHub or an explicitly-configured GitHub
+ * Enterprise instance. Matching is hostname-only — github.com properties are
+ * built in; GHE hosts must be opted in via the `PAPERCLIP_GITHUB_HOSTS` env
+ * var (comma-separated). Path-based detection is intentionally avoided so a
+ * URL like `https://attacker.example.com/api/v3/collect` cannot trick
+ * {@link authHeadersForGitHub} into attaching a token.
  */
 function looksLikeGitHubUrl(url: URL): boolean {
   const host = url.hostname.toLowerCase();
@@ -30,10 +30,14 @@ function looksLikeGitHubUrl(url: URL): boolean {
   if (host === "api.github.com") return true;
   if (host === "raw.githubusercontent.com" || host === "codeload.github.com") return true;
   if (host.endsWith(".github.com")) return true;
-  // GitHub Enterprise: gitHubApiBase / resolveRawGitHubUrl emit /api/v3 and /raw paths.
-  const path = url.pathname;
-  if (path === "/api/v3" || path.startsWith("/api/v3/")) return true;
-  if (path === "/raw" || path.startsWith("/raw/")) return true;
+  const enterpriseHosts = process.env.PAPERCLIP_GITHUB_HOSTS;
+  if (enterpriseHosts) {
+    const allowlist = enterpriseHosts
+      .split(",")
+      .map((h) => h.trim().toLowerCase())
+      .filter(Boolean);
+    if (allowlist.includes(host)) return true;
+  }
   return false;
 }
 

--- a/server/src/services/github-fetch.ts
+++ b/server/src/services/github-fetch.ts
@@ -17,25 +17,42 @@ export function resolveRawGitHubUrl(hostname: string, owner: string, repo: strin
 }
 
 /**
+ * Recognizes URLs that look like they target GitHub or a GitHub Enterprise
+ * instance. github.com properties are matched by hostname; GHE installs are
+ * detected by the URL shape produced by {@link gitHubApiBase} (paths under
+ * `/api/v3`) and {@link resolveRawGitHubUrl} (paths under `/raw`). Anything
+ * else is treated as a non-GitHub URL — even if a caller mistakenly passes
+ * one to {@link ghFetch}, no credentials will be attached to it.
+ */
+function looksLikeGitHubUrl(url: URL): boolean {
+  const host = url.hostname.toLowerCase();
+  if (host === "github.com" || host === "www.github.com") return true;
+  if (host === "api.github.com") return true;
+  if (host === "raw.githubusercontent.com" || host === "codeload.github.com") return true;
+  if (host.endsWith(".github.com")) return true;
+  // GitHub Enterprise: gitHubApiBase / resolveRawGitHubUrl emit /api/v3 and /raw paths.
+  const path = url.pathname;
+  if (path === "/api/v3" || path.startsWith("/api/v3/")) return true;
+  if (path === "/raw" || path.startsWith("/raw/")) return true;
+  return false;
+}
+
+/**
  * Attaches `Authorization: Bearer ${GITHUB_TOKEN}` (with `GH_TOKEN` as fallback)
- * to outgoing requests when a token is set in the environment.
- *
- * `ghFetch` is the GitHub-specific fetch helper for this module: every URL
- * passed in originates from `gitHubApiBase()` or `resolveRawGitHubUrl()`,
- * which produce either `api.github.com` / `raw.githubusercontent.com` (for
- * github.com) or `https://<host>/api/v3` / `https://<host>/raw/...` (for
- * GitHub Enterprise). We therefore attach the token unconditionally rather
- * than gating on a github.com allowlist that would silently skip GHE.
- * Caller-supplied `Authorization` headers always win.
+ * to outgoing requests when a token is set in the environment AND the URL is
+ * recognized by {@link looksLikeGitHubUrl}. Caller-supplied `Authorization`
+ * headers always win.
  */
 function authHeadersForGitHub(url: string, init?: RequestInit): RequestInit | undefined {
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token) return init;
+  let parsed: URL;
   try {
-    new URL(url);
+    parsed = new URL(url);
   } catch {
     return init;
   }
+  if (!looksLikeGitHubUrl(parsed)) return init;
   const headers = new Headers(init?.headers);
   if (!headers.has("Authorization")) {
     headers.set("Authorization", `Bearer ${token}`);

--- a/server/src/services/github-fetch.ts
+++ b/server/src/services/github-fetch.ts
@@ -16,9 +16,32 @@ export function resolveRawGitHubUrl(hostname: string, owner: string, repo: strin
     : `https://${hostname}/raw/${owner}/${repo}/${ref}/${p}`;
 }
 
+function authHeadersForGitHub(url: string, init?: RequestInit): RequestInit | undefined {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!token) return init;
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return init;
+  }
+  const isGitHubHost =
+    host === "api.github.com" ||
+    host === "github.com" ||
+    host === "www.github.com" ||
+    host === "raw.githubusercontent.com" ||
+    host === "codeload.github.com";
+  if (!isGitHubHost) return init;
+  const headers = new Headers(init?.headers);
+  if (!headers.has("Authorization") && !headers.has("authorization")) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  return { ...(init ?? {}), headers };
+}
+
 export async function ghFetch(url: string, init?: RequestInit): Promise<Response> {
   try {
-    return await fetch(url, init);
+    return await fetch(url, authHeadersForGitHub(url, init));
   } catch {
     throw unprocessable(`Could not connect to ${new URL(url).hostname} — ensure the URL points to a GitHub or GitHub Enterprise instance`);
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Skills are reusable Markdown bundles imported into a company's catalog from external sources (skills.sh, GitHub, …)
> - When the skill-importer resolves a skills.sh URL it issues unauthenticated calls to api.github.com to look up the repo's default branch and commit SHA via the existing ghFetch helper
> - The anonymous GitHub API rate limit is 60 requests per IP per hour; bulk imports of more than ~5 skills consistently exhaust this budget and fail mid-run with HTTP 403
> - This pull request adds an opt-in auth header — when GITHUB_TOKEN or GH_TOKEN is set in the server's environment, ghFetch attaches a Bearer header for github.com properties (built in) and any GitHub Enterprise hosts the operator allowlists via the new `PAPERCLIP_GITHUB_HOSTS` env var
> - The benefit is that operators can lift the rate limit from 60/h to 5000/h with a no-scope classic PAT, unblocking bulk and re-runnable skill imports without changing default behavior

## What Changed
- `server/src/services/github-fetch.ts` — new `looksLikeGitHubUrl` helper that recognizes GitHub URLs by **hostname only**: github.com properties built in (`github.com`, `www.github.com`, `api.github.com`, `raw.githubusercontent.com`, `codeload.github.com`, any `*.github.com` subdomain); GHE hosts opt in via the new `PAPERCLIP_GITHUB_HOSTS` env var (comma-separated allowlist). New `authHeadersForGitHub` helper attaches `Authorization: Bearer $GITHUB_TOKEN` (with `GH_TOKEN` fallback) for recognized URLs only when a token is present in the environment
- `ghFetch` now routes its `init` through that helper
- Caller-supplied `Authorization` header is preserved (helper only adds when none exists)
- Behavior is unchanged when no token is set — strictly additive

## Verification
- New test: `server/src/__tests__/github-fetch.test.ts` — 11 cases:
  - **Positive**: api.github.com (token attached), raw.githubusercontent.com (token attached), single configured GHE host, multi-host GHE via comma-separated list, GH_TOKEN fallback, GITHUB_TOKEN preferred over GH_TOKEN
  - **Negative (defense-in-depth)**: no token → no header; unrecognized host (`example.com`) → no header; path-only GHE-shaped URL on unconfigured host (`attacker.example.com/api/v3/collect`) → no header; configured-but-unmatched host (`example.org` while config is `github.example.com`) → no header; caller-supplied Authorization → preserved
- `pnpm --filter @paperclipai/server test -- github-fetch` — 11/11 passing
- `pnpm --filter @paperclipai/server build` — typechecks
- Manual: deployed on our self-hosted instance with a no-scope classic PAT — bulk import of 10 skills.sh URLs that previously failed mid-batch with HTTP 403 now succeeds end-to-end

## Risks
- None for users who don't set the env var — behavior is byte-identical
- Token leakage to non-GitHub hosts: prevented by hostname-only allowlist; path-based detection deliberately avoided after security review
- Existing redaction in `server/src/redaction.ts` already strips classic-PAT shapes from outbound logs
- Operator misconfigures `PAPERCLIP_GITHUB_HOSTS`: only attaches token to the misconfigured host. Recommended deploy: scope-less classic PAT (rate-limit-only, can't write).
- Low risk overall.

## Model Used
Claude Opus 4.7 (1M context window), 200k thinking budget, with tool use. Provider: Anthropic. Model ID: claude-opus-4-7.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (no UI change)
- [x] I have updated relevant documentation to reflect my changes (no doc changes needed; new env var documented in commit message + PR body)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge