### PR TITLE
fix(test): inline drizzle-orm in vite-node to fix ESM require cycle on Windows (ANGA-163)

### DIFF
--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -3,5 +3,15 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
+    server: {
+      deps: {
+        // drizzle-orm ships as type:"module" (ESM) and has internal circular
+        // references that cause "Cannot require() ES Module ... in a cycle"
+        // errors on Windows when vite-node loads it natively. Inlining it tells
+        // vite-node to transform drizzle-orm (and all its sub-paths) through
+        // Vite's pipeline, which resolves the cycles and makes it loadable.
+        inline: [/drizzle-orm/],
+      },
+    },
   },
 });

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -20,5 +20,15 @@ export default defineConfig({
       hooks: "list",
     },
     setupFiles: ["./src/__tests__/setup-supertest.ts"],
+    server: {
+      deps: {
+        // drizzle-orm ships as type:"module" (ESM) and has internal circular
+        // references that cause "Cannot require() ES Module ... in a cycle"
+        // errors on Windows when vite-node loads it natively. Inlining it tells
+        // vite-node to transform drizzle-orm (and all its sub-paths) through
+        // Vite's pipeline, which resolves the cycles and makes it loadable.
+        inline: [/drizzle-orm/],
+      },
+    },
   },
 });


### PR DESCRIPTION
## Thinking path

`drizzle-orm` is declared `type: "module"` (pure ESM) and ships both `.js` (ESM) and `.cjs` (CJS) exports. Its ESM bundle has internal circular references between submodules.

On Windows (and in any environment where vite-node loads node_modules natively), the forks pool child process calls `require()` to load server code. When that code imports drizzle-orm, vite-node passes the request to Node's native module system. Node sees `type: "module"` → loads as ESM → hits the circular ESM reference during initialization → throws `Cannot require() ES Module ... drizzle-orm ... in a cycle`.

The fix is `test.server.deps.inline: [/drizzle-orm/]`. This tells vite-node to transform drizzle-orm (and all its sub-path imports like `drizzle-orm/pg-core`, `drizzle-orm/postgres-js`) through Vite's Rollup/esbuild pipeline instead of handing it off to Node. The bundler resolves circular references and outputs a single loadable CJS chunk.

## What changed

- **`server/vitest.config.ts`** — add `test.server.deps.inline: [/drizzle-orm/]`
- **`packages/db/vitest.config.ts`** — same fix; db tests also import drizzle-orm directly

## Verification

- `tsc --noEmit` on both configs: no type errors
- `server.deps.inline` is the Vitest 3.x-canonical option for this pattern (replaces deprecated `deps.inline` per `ViteNodeServerOptions.DepsHandlingOptions`)
- Branch is based directly on `paperclipai/paperclip:master` (commit `c0ce35d1f`) — diff shows exactly 2 files, 20 insertions

## Issue link

Closes [ANGA-163](/ANGA/issues/ANGA-163)