### PR TITLE
Report agent_home truthfully when project workspaces are unavailable (PF-3)

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-source-pf3.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-source-pf3.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProjectWorkspaceUnavailableFallback,
+  prioritizeProjectWorkspaceCandidatesForRun,
+  type ResolvedWorkspaceForRun,
+} from "../services/heartbeat.ts";
+
+// PF-3 contract: when project workspaces exist for an issue's project but
+// none of their configured cwds are usable, the resolver must report the
+// fallback truthfully — source "agent_home", with project-scoped metadata
+// (workspaceId / repoUrl / repoRef) nulled because those candidates were
+// NOT used. Pre-fix this branch returned source: "project_primary" with
+// stale workspaceId/repoUrl/repoRef, which made fallback invisible to
+// session-resume logic, audit logs, and adapter behavior.
+
+describe("PF-3 buildProjectWorkspaceUnavailableFallback", () => {
+  const baseHints: ResolvedWorkspaceForRun["workspaceHints"] = [
+    {
+      workspaceId: "workspace-1",
+      cwd: "/missing/dir",
+      repoUrl: "git@example.com:org/repo.git",
+      repoRef: "main",
+    },
+  ];
+
+  it("reports source as 'agent_home', not 'project_primary'", () => {
+    const result = buildProjectWorkspaceUnavailableFallback({
+      fallbackCwd: "/agent/home/abc",
+      resolvedProjectId: "project-1",
+      workspaceHints: baseHints,
+      warnings: ["Project workspace path \"/missing/dir\" is not available yet."],
+    });
+    expect(result.source).toBe("agent_home");
+    expect(result.source).not.toBe("project_primary");
+  });
+
+  it("nulls out workspaceId / repoUrl / repoRef so downstream consumers do not see stale project-scoped metadata", () => {
+    const result = buildProjectWorkspaceUnavailableFallback({
+      fallbackCwd: "/agent/home/abc",
+      resolvedProjectId: "project-1",
+      workspaceHints: baseHints,
+      warnings: [],
+    });
+    expect(result.workspaceId).toBeNull();
+    expect(result.repoUrl).toBeNull();
+    expect(result.repoRef).toBeNull();
+  });
+
+  it("preserves resolvedProjectId so consumers can still tell which project was attempted", () => {
+    const result = buildProjectWorkspaceUnavailableFallback({
+      fallbackCwd: "/agent/home/abc",
+      resolvedProjectId: "project-1",
+      workspaceHints: baseHints,
+      warnings: [],
+    });
+    expect(result.projectId).toBe("project-1");
+  });
+
+  it("uses the supplied fallbackCwd as the run cwd", () => {
+    const result = buildProjectWorkspaceUnavailableFallback({
+      fallbackCwd: "/agent/home/specific/abc",
+      resolvedProjectId: null,
+      workspaceHints: [],
+      warnings: [],
+    });
+    expect(result.cwd).toBe("/agent/home/specific/abc");
+  });
+
+  it("surfaces the candidate workspaces via workspaceHints for diagnostics", () => {
+    const hints: ResolvedWorkspaceForRun["workspaceHints"] = [
+      {
+        workspaceId: "ws-a",
+        cwd: "/missing/a",
+        repoUrl: "git@x.y:a.git",
+        repoRef: "main",
+      },
+      {
+        workspaceId: "ws-b",
+        cwd: "/missing/b",
+        repoUrl: null,
+        repoRef: null,
+      },
+    ];
+    const result = buildProjectWorkspaceUnavailableFallback({
+      fallbackCwd: "/agent/home/abc",
+      resolvedProjectId: "project-1",
+      workspaceHints: hints,
+      warnings: [],
+    });
+    expect(result.workspaceHints).toEqual(hints);
+  });
+
+  it("surfaces the fallback-reason warnings unchanged", () => {
+    const warnings = [
+      "Selected project workspace \"abc\" is not available on this project.",
+      "Project workspace path \"/missing/dir\" is not available yet. Using fallback workspace \"/agent/home/abc\" for this run.",
+    ];
+    const result = buildProjectWorkspaceUnavailableFallback({
+      fallbackCwd: "/agent/home/abc",
+      resolvedProjectId: "project-1",
+      workspaceHints: [],
+      warnings,
+    });
+    expect(result.warnings).toEqual(warnings);
+  });
+});
+
+// Sanity: keep the existing prioritizeProjectWorkspaceCandidatesForRun
+// behavior visible alongside the new helper so the contract pair stays in
+// view for future changes to the resolution path.
+describe("PF-3 sanity: prioritizeProjectWorkspaceCandidatesForRun", () => {
+  it("returns rows unchanged when no preferred id is supplied", () => {
+    const rows = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    expect(prioritizeProjectWorkspaceCandidatesForRun(rows, null)).toBe(rows);
+    expect(prioritizeProjectWorkspaceCandidatesForRun(rows, undefined)).toBe(rows);
+  });
+
+  it("hoists the preferred id to the front when present", () => {
+    const rows = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const result = prioritizeProjectWorkspaceCandidatesForRun(rows, "b");
+    expect(result.map((r) => r.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("returns rows unchanged when the preferred id is not in the list", () => {
+    const rows = [{ id: "a" }, { id: "b" }];
+    expect(prioritizeProjectWorkspaceCandidatesForRun(rows, "missing")).toBe(rows);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -913,6 +913,35 @@ export function prioritizeProjectWorkspaceCandidatesForRun<T extends ProjectWork
   return [rows[preferredIndex]!, ...rows.slice(0, preferredIndex), ...rows.slice(preferredIndex + 1)];
 }
 
+/**
+ * PF-3: Build the ResolvedWorkspaceForRun shape for the case where project
+ * workspaces existed for the issue's project but none of their configured
+ * cwds were available on disk. The run uses the agent home fallback dir, so
+ * the source field reports "agent_home" — not "project_primary" — and any
+ * project-scoped metadata that does not apply to the fallback is nulled.
+ *
+ * Extracted as a pure helper so the fallback contract can be unit-tested
+ * directly. workspaceHints (the candidates considered) and warnings (why
+ * fallback was chosen) are still surfaced so operators can audit the path.
+ */
+export function buildProjectWorkspaceUnavailableFallback(input: {
+  fallbackCwd: string;
+  resolvedProjectId: string | null;
+  workspaceHints: ResolvedWorkspaceForRun["workspaceHints"];
+  warnings: string[];
+}): ResolvedWorkspaceForRun {
+  return {
+    cwd: input.fallbackCwd,
+    source: "agent_home",
+    projectId: input.resolvedProjectId,
+    workspaceId: null,
+    repoUrl: null,
+    repoRef: null,
+    workspaceHints: input.workspaceHints,
+    warnings: input.warnings,
+  };
+}
+
 function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
@@ -2520,16 +2549,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           `Project workspace has no local cwd configured. Using fallback workspace "${fallbackCwd}" for this run.`,
         );
       }
-      return {
-        cwd: fallbackCwd,
-        source: "project_primary" as const,
-        projectId: resolvedProjectId,
-        workspaceId: projectWorkspaceRows[0]?.id ?? null,
-        repoUrl: projectWorkspaceRows[0]?.repoUrl ?? null,
-        repoRef: projectWorkspaceRows[0]?.repoRef ?? null,
+      return buildProjectWorkspaceUnavailableFallback({
+        fallbackCwd,
+        resolvedProjectId,
         workspaceHints,
         warnings,
-      };
+      });
     }
 
     if (workspaceProjectId) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each heartbeat run resolves a workspace cwd by walking a decision tree: preferred project workspace → other project workspaces → prior session workspace → agent home fallback
> - In CEO run `292a5fd1`, the fallback workspace was used because no project workspace was attached to the issue, but the run telemetry suggested fallback usage was hard to surface; PF-3 in the 2026-04-16 hangeul-school operational issue set asks for "fallback workspace usage visible but rare"
> - On audit, the resolver's middle branch (project workspaces existed but none of their cwds were available on disk) was returning `source: "project_primary"` while actually using the agent home dir, and was also keeping stale `workspaceId` / `repoUrl` / `repoRef` from the first considered candidate
> - This made fallback invisible to three real consumers: `resolveRuntimeSessionParamsForWorkspace` (line 1204 — gates session-resume behavior on `source !== "project_primary"`), the persisted `execution_workspaces` audit row, and adapter logic such as `packages/adapters/gemini-local/src/server/execute.ts:200` (which checks `source === "agent_home"` to choose a configured cwd)
> - This pull request reports that branch truthfully — `source: "agent_home"` with the orphan project metadata nulled — so all three consumers see the fallback case and behave correctly
> - The benefit is that fallback workspace usage is now surfaceable in audit logs and run telemetry, satisfying the "visible" half of PF-3's done-when, without changing the resolution decision tree itself

## What Changed

- In `resolveWorkspaceForRun` (`server/src/services/heartbeat.ts`), the branch entered when project workspaces exist for the issue's project but none of their cwds are available on disk now returns `source: "agent_home"` (was `"project_primary"`) and nulls out `workspaceId`, `repoUrl`, and `repoRef` to match the fact that no project workspace was actually used. `projectId` is preserved so consumers can still see which project was attempted; `workspaceHints` still surfaces the candidates that were considered; `warnings` still explains why the fallback was chosen.
- Extracted the fallback construction into a new exported pure helper `buildProjectWorkspaceUnavailableFallback` so the contract can be unit-tested directly (the surrounding `resolveWorkspaceForRun` is internal and bound to `db`/`fs`).

## Verification

```bash
cd server
pnpm vitest run src/__tests__/heartbeat-workspace-source-pf3.test.ts
# 9/9 pass

pnpm vitest run \
  src/__tests__/heartbeat-stale-queue-invalidation.test.ts \
  src/__tests__/heartbeat-process-recovery.test.ts
# 39/39 adjacent heartbeat tests pass, no regression
```

The 9 new tests assert that the helper:
1. Reports `source: "agent_home"` (and explicitly NOT `"project_primary"`)
2. Nulls `workspaceId`, `repoUrl`, `repoRef`
3. Preserves `projectId` so the attempted project stays traceable
4. Uses the supplied `fallbackCwd`
5. Surfaces `workspaceHints` unchanged
6. Surfaces fallback-reason `warnings` unchanged
7. Plus three sanity tests for `prioritizeProjectWorkspaceCandidatesForRun` (existing exported helper) so the candidate-ordering and fallback-construction contracts stay co-located in a single PF-3 test file.

## Risks

- **Low.** Pure data-shape change in one specific branch. Three consumers were audited:
  - `resolveRuntimeSessionParamsForWorkspace` (line 1204): previously short-circuited session-resume only for `task_session` / `agent_home`. Post-fix, the fallback case correctly joins the short-circuit path, which is the intended behavior — we should not try to graft prior session params onto a workspace that is no longer available.
  - `executionWorkspaceBase.source` (line 4999): just propagates the value to persistence. Audit rows now carry the truthful source.
  - `packages/adapters/gemini-local/src/server/execute.ts:200`: checks `source === "agent_home"` to pick a configured cwd. Post-fix, the fallback case correctly opts into this behavior.
- No schema or API change. No migration. No breaking change for clients.

## Model Used

Claude Opus 4.7 (1M context), model ID `claude-opus-4-7[1m]`. Used in interactive Claude Code session with extended reasoning, tool use (Read/Edit/Write/Bash), and verification gates between exploration → fix → tests → push.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (9 new + 39 adjacent = 48 tests, no regressions)
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — N/A, server-only change
- [x] I have updated relevant documentation to reflect my changes — none needed; the new helper carries its own JSDoc and the source field meaning is self-describing
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
