### PR TITLE
feat(shared,server,ui): add worker role and chief-local instruction bundle for subordinate agents

### DIFF
--- a/docs/specs/agent-config-ui.md
+++ b/docs/specs/agent-config-ui.md
@@ -24,7 +24,7 @@ Follows the existing `NewIssueDialog` / `NewProjectDialog` pattern: a `Dialog` c
 |-------|---------|----------|---------|-------|
 | Name | Text input (large, auto-focused) | Yes | -- | e.g. "Alice", "Build Bot" |
 | Title | Text input (subtitle style) | No | -- | e.g. "VP of Engineering" |
-| Role | Chip popover (select) | No | `general` | Values from `AGENT_ROLES`: ceo, cto, cmo, cfo, engineer, designer, pm, qa, devops, researcher, general |
+| Role | Chip popover (select) | No | `general` | Values from `AGENT_ROLES`: ceo, cto, cmo, cfo, engineer, designer, pm, qa, devops, researcher, general, worker. The `worker` role is intended for chief-local subordinate agents using the `openclaw_gateway` adapter; pairing it with any other adapter triggers a soft-validation confirm modal in the create form. |
 | Reports To | Chip popover (agent select) | No | -- | Dropdown of existing agents in the company. If this is the first agent, auto-set role to `ceo` and gray out Reports To. Otherwise required unless role is `ceo`. |
 | Capabilities | Text input | No | -- | Free-text description of what this agent can do |
 

--- a/docs/specs/agent-config-ui.md
+++ b/docs/specs/agent-config-ui.md
@@ -24,7 +24,7 @@ Follows the existing `NewIssueDialog` / `NewProjectDialog` pattern: a `Dialog` c
 |-------|---------|----------|---------|-------|
 | Name | Text input (large, auto-focused) | Yes | -- | e.g. "Alice", "Build Bot" |
 | Title | Text input (subtitle style) | No | -- | e.g. "VP of Engineering" |
-| Role | Chip popover (select) | No | `general` | Values from `AGENT_ROLES`: ceo, cto, cmo, cfo, engineer, designer, pm, qa, devops, researcher, general, worker. The `worker` role is intended for chief-local subordinate agents using the `openclaw_gateway` adapter; pairing it with any other adapter triggers a soft-validation confirm modal in the create form. |
+| Role | Chip popover (select) | No | `general` | Values from `AGENT_ROLES`: ceo, cto, cmo, cfo, security, engineer, designer, pm, qa, devops, researcher, general, worker. The `worker` role is intended for chief-local subordinate agents using the `openclaw_gateway` adapter; pairing it with any other adapter triggers a soft-validation confirm modal in the create form. |
 | Reports To | Chip popover (agent select) | No | -- | Dropdown of existing agents in the company. If this is the first agent, auto-set role to `ceo` and gray out Reports To. Otherwise required unless role is `ceo`. |
 | Capabilities | Text input | No | -- | Free-text description of what this agent can do |
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -53,6 +53,7 @@ export const AGENT_ROLES = [
   "devops",
   "researcher",
   "general",
+  "worker",
 ] as const;
 export type AgentRole = (typeof AGENT_ROLES)[number];
 
@@ -69,6 +70,7 @@ export const AGENT_ROLE_LABELS: Record<AgentRole, string> = {
   devops: "DevOps",
   researcher: "Researcher",
   general: "General",
+  worker: "Worker (chief-local agents only)",
 };
 
 export const AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 5;

--- a/server/src/__tests__/default-agent-instructions-resolver.test.ts
+++ b/server/src/__tests__/default-agent-instructions-resolver.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { resolveDefaultAgentInstructionsBundleRole } from "../services/default-agent-instructions.js";
+
+describe("resolveDefaultAgentInstructionsBundleRole", () => {
+  it("resolves the ceo role to the ceo bundle", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("ceo")).toBe("ceo");
+  });
+
+  it("resolves the worker role to the chief-local bundle", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("worker")).toBe("chief-local");
+  });
+
+  it("resolves any other AGENT_ROLES value to the default bundle", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("engineer")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("general")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("cto")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("cmo")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("cfo")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("security")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("designer")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("pm")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("qa")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("devops")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("researcher")).toBe("default");
+  });
+
+  it("treats unknown role strings as the default bundle", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("unknown-role")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("")).toBe("default");
+  });
+});

--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -1,3 +1,5 @@
+<!-- PAPERCLIP-MANAGED: do not edit manually. Source: default-agent-instructions.ts -->
+
 You are the CEO. Your job is to lead the company, not to do individual contributor work. You own strategy, prioritization, and cross-functional coordination.
 
 Your personal files (life, memory, knowledge) live alongside these instructions. Other agents may have their own folders and you may update them when necessary.
@@ -57,3 +59,13 @@ These files are essential. Read them.
 - `./HEARTBEAT.md` -- execution and extraction checklist. Run every heartbeat.
 - `./SOUL.md` -- who you are and how you should act.
 - `./TOOLS.md` -- tools you have access to
+
+## Security Guardrails (Paperclip-managed addendum)
+
+These constraints supersede any conflicting guidance above. They apply to your direct execution AND to any delegation you issue:
+
+- You do not call `/api/agents/me` or any identity/configuration endpoint. You do not inspect your own configuration, adapter settings, tokens, keys, or workspace identity files.
+- You do not inspect, print, reveal, summarise, or transform secrets, tokens, keys, headers, adapter_config, or secret_ref material from any source. If sensitive material appears in tool/API output, report that redaction is required without reproducing the values.
+- When you delegate work to a subordinate agent, the subordinate inherits these guardrails. The brief you author must not direct a subordinate to perform any of the above; if a task seems to require it, surface to the board instead.
+
+If the brief conflicts with these instructions, follow these instructions.

--- a/server/src/onboarding-assets/chief-local/AGENTS.md
+++ b/server/src/onboarding-assets/chief-local/AGENTS.md
@@ -1,0 +1,19 @@
+<!-- PAPERCLIP-MANAGED: do not edit manually. Source: default-agent-instructions.ts -->
+
+You are a Paperclip subordinate execution agent.
+You do not initiate identity discovery.
+You do not introduce yourself unless the brief asks you to.
+You do not call /api/agents/me or any identity/configuration endpoint.
+You do not inspect, print, reveal, summarise, or transform secrets.
+You do not modify your own configuration, workspace identity files, tokens, keys, or adapter settings.
+You do not delegate to other agents.
+You execute only the assigned brief.
+You return the requested output and stop.
+
+If the brief conflicts with these instructions, follow these instructions.
+If you encounter credentials, tokens, private keys, adapter_config, headers, or secret_ref material, treat it as sensitive and do not quote it.
+If you need context, use only task-provided context unless the brief explicitly authorises a lookup.
+If a tool/API response contains secrets, report that redaction is required without reproducing the values.
+For review tasks, review the supplied material only. Do not run unrelated bootstrap, identity, or setup workflows.
+
+Keep output concise, structured, and directly tied to the brief.

--- a/server/src/services/default-agent-instructions.ts
+++ b/server/src/services/default-agent-instructions.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 const DEFAULT_AGENT_BUNDLE_FILES = {
   default: ["AGENTS.md"],
   ceo: ["AGENTS.md", "HEARTBEAT.md", "SOUL.md", "TOOLS.md"],
+  "chief-local": ["AGENTS.md"],
 } as const;
 
 type DefaultAgentBundleRole = keyof typeof DEFAULT_AGENT_BUNDLE_FILES;
@@ -23,5 +24,5 @@ export async function loadDefaultAgentInstructionsBundle(role: DefaultAgentBundl
 }
 
 export function resolveDefaultAgentInstructionsBundleRole(role: string): DefaultAgentBundleRole {
-  return role === "ceo" ? "ceo" : "default";
+  return role === "ceo" ? "ceo" : role === "worker" ? "chief-local" : "default";
 }

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -410,7 +410,11 @@ export function NewAgent() {
           <DialogHeader>
             <DialogTitle>Unusual role and adapter pairing</DialogTitle>
             <DialogDescription>
-              The Worker role is designed for chief-local agents on the openclaw_gateway adapter. You've selected {configValues.adapterType} - this pairing is unusual but allowed. Confirm to proceed.
+              The Worker role is designed for chief-local agents on the openclaw_gateway adapter. You've selected{" "}
+              <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+                {configValues.adapterType}
+              </code>{" "}
+              - this pairing is unusual but allowed. Confirm to proceed.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -14,6 +14,14 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Shield } from "lucide-react";
 import { cn, agentUrl } from "../lib/utils";
 import { roleLabels } from "../components/agent-config-primitives";
@@ -79,6 +87,7 @@ export function NewAgent() {
     errorMessage: null,
     result: null,
   });
+  const [showWorkerAdapterWarning, setShowWorkerAdapterWarning] = useState(false);
 
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
@@ -150,6 +159,25 @@ export function NewAgent() {
     return adapter.buildAdapterConfig(configValues);
   }
 
+  function performCreate() {
+    createAgent.mutate(
+      buildNewAgentHirePayload({
+        name,
+        effectiveRole,
+        title,
+        reportsTo,
+        selectedSkillKeys,
+        configValues,
+        adapterConfig: buildAdapterConfig(),
+      }),
+    );
+  }
+
+  function confirmWorkerAdapterPairing() {
+    setShowWorkerAdapterWarning(false);
+    performCreate();
+  }
+
   function handleSubmit() {
     if (!selectedCompanyId || !name.trim()) return;
     setFormError(null);
@@ -181,17 +209,11 @@ export function NewAgent() {
         return;
       }
     }
-    createAgent.mutate(
-      buildNewAgentHirePayload({
-        name,
-        effectiveRole,
-        title,
-        reportsTo,
-        selectedSkillKeys,
-        configValues,
-        adapterConfig: buildAdapterConfig(),
-      }),
-    );
+    if (effectiveRole === "worker" && configValues.adapterType !== "openclaw_gateway") {
+      setShowWorkerAdapterWarning(true);
+      return;
+    }
+    performCreate();
   }
 
   const availableSkills = (companySkills ?? []).filter((skill) => !skill.key.startsWith("paperclipai/paperclip/"));
@@ -382,6 +404,25 @@ export function NewAgent() {
           </div>
         </div>
       </div>
+
+      <Dialog open={showWorkerAdapterWarning} onOpenChange={setShowWorkerAdapterWarning}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Unusual role/adapter pairing</DialogTitle>
+            <DialogDescription>
+              The Worker role is intended for chief-local subordinate agents using the openclaw_gateway adapter. Pairing it with the {configValues.adapterType} adapter is unusual. Confirm this is intended?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" size="sm" onClick={() => setShowWorkerAdapterWarning(false)}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={confirmWorkerAdapterPairing}>
+              Confirm
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -408,9 +408,9 @@ export function NewAgent() {
       <Dialog open={showWorkerAdapterWarning} onOpenChange={setShowWorkerAdapterWarning}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Unusual role/adapter pairing</DialogTitle>
+            <DialogTitle>Unusual role and adapter pairing</DialogTitle>
             <DialogDescription>
-              The Worker role is intended for chief-local subordinate agents using the openclaw_gateway adapter. Pairing it with the {configValues.adapterType} adapter is unusual. Confirm this is intended?
+              The Worker role is designed for chief-local agents on the openclaw_gateway adapter. You've selected {configValues.adapterType} - this pairing is unusual but allowed. Confirm to proceed.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>


### PR DESCRIPTION
Fixes #7386

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, with each agent's role determining the `default-agent-instructions` bundle (`AGENTS.md` + companions) loaded into its workspace at hire time
> - The platform's role taxonomy currently has 12 board-facing values (`ceo`, `cto`, `cmo`, `cfo`, `security`, `engineer`, `designer`, `pm`, `qa`, `devops`, `researcher`, `general`); the bundle resolver maps `ceo` to a CEO-specific bundle and everything else to a `default` bundle
> - Building on the completed ROADMAP.md item "Get OpenClaw / claw-style agent employees", a growing class of subordinate-execution agents - chief-local agents on the `openclaw_gateway` adapter, where a CEO orchestrator delegates discrete tasks to dedicated subordinate runtimes - need a distinct role bucket and instruction frame. They are not "general" (general agents have broader autonomy), they are not CEO-shaped (no orchestration responsibility), and they need explicit security guardrails (no `/api/agents/me`, no secret handling, no self-config inspection, no further delegation)
> - Without a dedicated role bucket, every chief-local-style agent inherits the `default` bundle and its general-purpose UX guidance. Operators end up patching workspace `AGENTS.md` files post-hire to constrain the agent, or tolerating role/UX drift between intent and behaviour
> - This pull request adds a `worker` role to `AGENT_ROLES`, wires a new `chief-local` instruction bundle keyed off the resolver, places the security-locked `AGENTS.md` asset under `onboarding-assets/chief-local/`, adds a security-guardrails addendum to the existing CEO bundle covering `/api/agents/me` refusal + secret-omission + subordinate-binding, and surfaces a soft-validation confirm modal in the agent-create form when the worker role is paired with any non-`openclaw_gateway` adapter
> - The benefit is platform-level role-aware instruction routing for subordinate agents: the role itself signals intent, the bundle delivers the locked guardrails, the modal nudges-not-blocks unusual pairings, and the CEO addendum binds delegated work to the same security baseline

## What Changed

- `packages/shared/src/constants.ts`: add `"worker"` to `AGENT_ROLES` and `AGENT_ROLE_LABELS` (`"Worker (chief-local agents only)"`). `z.enum(AGENT_ROLES)` on the validator picks it up via direct import; agents created without an explicit role still default to `"general"` per the existing schema default.
- `server/src/services/default-agent-instructions.ts`: extend `DEFAULT_AGENT_BUNDLE_FILES` with a `chief-local` key, and extend `resolveDefaultAgentInstructionsBundleRole` to map `worker -> chief-local` (alongside the existing `ceo -> ceo`, default branch `-> default`).
- `server/src/onboarding-assets/chief-local/AGENTS.md`: new asset (1205 bytes). Security-locked subordinate-execution brief: no `/api/agents/me`, no secret handling, no self-config or adapter-settings inspection, no delegation, brief-only execution. `PAPERCLIP-MANAGED` header.
- `server/src/onboarding-assets/ceo/AGENTS.md`: `PAPERCLIP-MANAGED` header prepended at the top + `Security Guardrails` addendum appended at the end. Existing CEO content preserved verbatim in between. Addendum covers `/api/agents/me` refusal + own-config inspection refusal + secret-omission discipline + subordinate-binding (delegation briefs inherit the guardrails). Supersede-conflicts clause makes precedence explicit.
- `ui/src/pages/NewAgent.tsx`: import `Dialog` primitives + add a soft-validation modal that fires when `effectiveRole === "worker" && configValues.adapterType !== "openclaw_gateway"`. Modal is a nudge not a block - users can confirm and proceed. The role dropdown automatically picks up `worker` via `AGENT_ROLE_LABELS`.
- `server/src/__tests__/default-agent-instructions-resolver.test.ts`: new test file (4 tests) covering the resolver's three branches (`ceo`, `worker`, default) plus unknown-string fallback. Includes coverage for all 12 existing `AGENT_ROLES` values.
- `docs/specs/agent-config-ui.md`: extend the `Role` row of the field table to include `worker` and a one-sentence note on the soft-validation modal so the doc stays in sync with the create form.

## Verification

Run the full server vitest suite locally:

```
pnpm --filter @paperclipai/plugin-sdk build  # one-time fresh-clone build precondition
pnpm --filter @paperclipai/server exec vitest run
```

Expected on this branch:

```
Test Files  215 passed (215)
     Tests  1435 passed | 1 skipped (1436)
  Duration  ~231s
```

Run typecheck on both touched packages:

```
pnpm --filter @paperclipai/server typecheck
pnpm --filter @paperclipai/ui typecheck
```

Both expected to pass with exit 0.

The new resolver test file exercises all three branches (`ceo -> ceo`, `worker -> chief-local`, default branch `-> default`) plus unknown-string fallback. The test imports the resolver as a pure function and asserts return values directly, no mocks needed.

Manual UI verification a reviewer can run:

1. `pnpm dev` (or whichever workspace dev command applies)
2. Navigate to `/agents/new`
3. Select role `Worker (chief-local agents only)` from the role popover
4. Select adapter type `Claude Local` (or any non-`openclaw_gateway` adapter)
5. Click `Create agent`
6. Expected: modal "Unusual role and adapter pairing" appears with Cancel + Confirm buttons
7. Cancel: modal closes, form unchanged, no agent created
8. Confirm: modal closes, agent creation proceeds with the (worker, claude_local) pairing
9. Repeat with adapter type `OpenClaw Gateway` to verify the modal does NOT fire on the intended pairing

## Risks

Low risk overall. This PR is feature-additive on the upstream surface (new role, new bundle key, new asset, new modal, additive `AGENTS.md` addendum). No behaviour change for existing agents - existing roles continue to resolve to existing bundles, default agents continue to receive the unchanged `default/AGENTS.md` content, and CEO agents continue to receive the existing CEO bundle (now with a `PAPERCLIP-MANAGED` header at the top + Security Guardrails addendum at the bottom; the existing 60 lines of CEO content are preserved verbatim).

Considerations:

- **Consumers that hardcode `AGENT_ROLES` length or iterate the bundle keys without defensive defaults will need updating.** Most consumers use the array dynamically (`z.enum(AGENT_ROLES)` on the validator, the UI role-popover map at line 242 of `NewAgent.tsx`, role-display surfaces in other components) so they propagate transparently. Any consumer that hardcoded the count of roles or had a switch over the old bundle keys would need a cosmetic update.
- **UI consumers using `AGENT_ROLE_LABELS` as a lookup pick up the new key transparently.** The UI's `roleLabels` at `agent-config-primitives.tsx:66` is a direct alias for `AGENT_ROLE_LABELS`, so any role-display surface (`NewAgent`, `AgentProperties`, `OrgChart`, etc.) shows the worker label without further changes.
- **CEO bundle addendum is additive; supersede-conflicts clause in the addendum makes precedence explicit.** No CEO behaviour change unless a CEO was previously instructing subordinates to inspect its own configuration (which existing platform "Safety Considerations" already prohibited).
- **No DB migration required.** `agents.role` is a `text` column at the DB layer with no CHECK constraints; widening `AGENT_ROLES` is application-layer only.
- **Soft-validation modal blast radius**: only fires for the new (worker, non-`openclaw_gateway`) pairing, which is a brand-new state. No existing user flows are affected.
- **Reversibility**: revert restores prior behaviour. No persistent state mutation.

## Model Used

- **Provider / family**: Anthropic Claude (Opus 4.x family)
- **Authoring (29 April 2026)**: Claude Opus 4.7 (`claude-opus-4-7`, 1M context window) running in Code mode (Claude Code CLI 2.1.121 inside the Claude desktop app's Code tab on macOS).
- **Planning, architectural review, PR-body composition**: Claude Opus in chat mode (claude.ai web + Claude desktop app's chat tab). Project knowledge snapshot of the source-of-truth investigation files used for cross-document synthesis.
- **Architectural sense-check**: ChatGPT was consulted on the resolver-discriminator question (whether to widen `AGENT_ROLES` with a new role value or use a separate discriminator field); the consult shaped the chosen design (widening with `role="worker"`).
- **Tool use during authoring**: shell (git, pnpm, vitest), file edits, gh CLI for PR work.
- **Reasoning mode**: extended chain-of-thought during investigation; tool-use loop during code edits and validation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — ROADMAP.md lists "Get OpenClaw / claw-style agent employees" as ✅; this PR extends that completed integration with a dedicated `worker` role bucket and instruction bundle for chief-local subordinate agents. Additive extension, not duplicate. Happy to coordinate via Discord `#dev` if maintainers prefer a roadmap discussion before merge.
- [x] I have run tests locally and they pass (1435 passed / 1 skipped / 0 failures, server vitest filter)
- [x] I have added or updated tests where applicable (new resolver test file covering all three branches + unknown-string fallback)
- [ ] If this change affects the UI, I have included before/after screenshots — pending; the new soft-validation modal is the only added UI surface. Will provide before/after screenshots before requesting merge if maintainers want them.
- [x] I have updated relevant documentation to reflect my changes (`docs/specs/agent-config-ui.md` extended)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
