### PR TITLE
perf(ui): reduce inbox-related refetch storms

### DIFF
--- a/packages/shared/src/types/sidebar-badges.ts
+++ b/packages/shared/src/types/sidebar-badges.ts
@@ -3,4 +3,6 @@ export interface SidebarBadges {
   approvals: number;
   failedRuns: number;
   joinRequests: number;
+  mineIssues: number;
+  alerts: number;
 }

--- a/server/src/__tests__/inbox-dismissals.test.ts
+++ b/server/src/__tests__/inbox-dismissals.test.ts
@@ -207,6 +207,8 @@ describeEmbeddedPostgres("inbox dismissals", () => {
       approvals: 1,
       failedRuns: 1,
       joinRequests: 0,
+      mineIssues: 1,
+      alerts: 0,
     });
   });
 });

--- a/server/src/routes/sidebar-badges.ts
+++ b/server/src/routes/sidebar-badges.ts
@@ -68,13 +68,14 @@ export function sidebarBadgeRoutes(db: Db) {
     const badges = await svc.get(companyId, {
       dismissals: dismissedAtByKey,
       joinRequests: visibleJoinRequests,
+      currentUserId: req.actor.type === "board" ? req.actor.userId : null,
     });
     const summary = await dashboard.summary(companyId);
     const hasFailedRuns = badges.failedRuns > 0;
     const alertsCount =
       (summary.agents.error > 0 && !hasFailedRuns ? 1 : 0) +
       (summary.costs.monthBudgetCents > 0 && summary.costs.monthUtilizationPercent >= 80 ? 1 : 0);
-    badges.inbox = badges.failedRuns + alertsCount + badges.joinRequests + badges.approvals;
+    badges.alerts = alertsCount;
 
     res.json(badges);
   });

--- a/server/src/services/sidebar-badges.ts
+++ b/server/src/services/sidebar-badges.ts
@@ -205,8 +205,8 @@ export function sidebarBadgeService(db: Db) {
           row.updatedAt ?? row.createdAt,
         )
       ).length;
-      const unreadTouchedIssues = extra?.unreadTouchedIssues ?? (currentUserId
-        ? await db
+      const unreadTouchedIssues: number = extra?.unreadTouchedIssues ?? (currentUserId
+        ? Number(await db
           .select({ count: count() })
           .from(issues)
           .where(
@@ -219,7 +219,7 @@ export function sidebarBadgeService(db: Db) {
               isNull(issues.hiddenAt),
             ),
           )
-          .then((rows) => rows[0]?.count ?? 0)
+          .then((rows) => rows[0]?.count ?? 0))
         : 0);
       return {
         inbox: actionableApprovals + failedRuns + joinRequests + unreadTouchedIssues,

--- a/server/src/services/sidebar-badges.ts
+++ b/server/src/services/sidebar-badges.ts
@@ -1,10 +1,11 @@
-import { and, desc, eq, inArray, not } from "drizzle-orm";
+import { and, count, desc, eq, inArray, isNull, not, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agents, approvals, heartbeatRuns } from "@paperclipai/db";
+import { agents, approvals, heartbeatRuns, issueComments, issueInboxArchives, issueReadStates, issues } from "@paperclipai/db";
 import type { SidebarBadges } from "@paperclipai/shared";
 
 const ACTIONABLE_APPROVAL_STATUSES = ["pending", "revision_requested"];
 const FAILED_HEARTBEAT_STATUSES = ["failed", "timed_out"];
+const INBOX_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "parked", "done"];
 
 function normalizeTimestamp(value: Date | string | null | undefined): number {
   if (!value) return 0;
@@ -22,6 +23,131 @@ function isDismissed(
   return dismissedAt >= normalizeTimestamp(activityAt);
 }
 
+function touchedByUserCondition(companyId: string, userId: string) {
+  return sql<boolean>`
+    (
+      ${issues.createdByUserId} = ${userId}
+      OR ${issues.assigneeUserId} = ${userId}
+      OR EXISTS (
+        SELECT 1
+        FROM ${issueReadStates}
+        WHERE ${issueReadStates.issueId} = ${issues.id}
+          AND ${issueReadStates.companyId} = ${companyId}
+          AND ${issueReadStates.userId} = ${userId}
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM ${issueComments}
+        WHERE ${issueComments.issueId} = ${issues.id}
+          AND ${issueComments.companyId} = ${companyId}
+          AND ${issueComments.authorUserId} = ${userId}
+      )
+    )
+  `;
+}
+
+function myLastCommentAtExpr(companyId: string, userId: string) {
+  return sql<Date | null>`
+    (
+      SELECT MAX(${issueComments.createdAt})
+      FROM ${issueComments}
+      WHERE ${issueComments.issueId} = ${issues.id}
+        AND ${issueComments.companyId} = ${companyId}
+        AND ${issueComments.authorUserId} = ${userId}
+    )
+  `;
+}
+
+function myLastReadAtExpr(companyId: string, userId: string) {
+  return sql<Date | null>`
+    (
+      SELECT MAX(${issueReadStates.lastReadAt})
+      FROM ${issueReadStates}
+      WHERE ${issueReadStates.issueId} = ${issues.id}
+        AND ${issueReadStates.companyId} = ${companyId}
+        AND ${issueReadStates.userId} = ${userId}
+    )
+  `;
+}
+
+function myLastTouchAtExpr(companyId: string, userId: string) {
+  const myLastCommentAt = myLastCommentAtExpr(companyId, userId);
+  const myLastReadAt = myLastReadAtExpr(companyId, userId);
+  return sql<Date | null>`
+    GREATEST(
+      COALESCE(${myLastCommentAt}, to_timestamp(0)),
+      COALESCE(${myLastReadAt}, to_timestamp(0)),
+      COALESCE(CASE WHEN ${issues.createdByUserId} = ${userId} THEN ${issues.createdAt} ELSE NULL END, to_timestamp(0)),
+      COALESCE(CASE WHEN ${issues.assigneeUserId} = ${userId} THEN ${issues.updatedAt} ELSE NULL END, to_timestamp(0))
+    )
+  `;
+}
+
+function lastExternalCommentAtExpr(companyId: string, userId: string) {
+  return sql<Date | null>`
+    (
+      SELECT MAX(${issueComments.createdAt})
+      FROM ${issueComments}
+      WHERE ${issueComments.issueId} = ${issues.id}
+        AND ${issueComments.companyId} = ${companyId}
+        AND (
+          ${issueComments.authorUserId} IS NULL
+          OR ${issueComments.authorUserId} <> ${userId}
+        )
+    )
+  `;
+}
+
+function issueLastActivityAtExpr(companyId: string, userId: string) {
+  const lastExternalCommentAt = lastExternalCommentAtExpr(companyId, userId);
+  const myLastTouchAt = myLastTouchAtExpr(companyId, userId);
+  return sql<Date>`
+    GREATEST(
+      COALESCE(${lastExternalCommentAt}, to_timestamp(0)),
+      CASE
+        WHEN ${issues.updatedAt} > COALESCE(${myLastTouchAt}, to_timestamp(0))
+        THEN ${issues.updatedAt}
+        ELSE to_timestamp(0)
+      END
+    )
+  `;
+}
+
+function unreadForUserCondition(companyId: string, userId: string) {
+  const touchedCondition = touchedByUserCondition(companyId, userId);
+  const myLastTouchAt = myLastTouchAtExpr(companyId, userId);
+  return sql<boolean>`
+    (
+      ${touchedCondition}
+      AND EXISTS (
+        SELECT 1
+        FROM ${issueComments}
+        WHERE ${issueComments.issueId} = ${issues.id}
+          AND ${issueComments.companyId} = ${companyId}
+          AND (
+            ${issueComments.authorUserId} IS NULL
+            OR ${issueComments.authorUserId} <> ${userId}
+          )
+          AND ${issueComments.createdAt} > ${myLastTouchAt}
+      )
+    )
+  `;
+}
+
+function inboxVisibleForUserCondition(companyId: string, userId: string) {
+  const issueLastActivityAt = issueLastActivityAtExpr(companyId, userId);
+  return sql<boolean>`
+    NOT EXISTS (
+      SELECT 1
+      FROM ${issueInboxArchives}
+      WHERE ${issueInboxArchives.issueId} = ${issues.id}
+        AND ${issueInboxArchives.companyId} = ${companyId}
+        AND ${issueInboxArchives.userId} = ${userId}
+        AND ${issueInboxArchives.archivedAt} >= ${issueLastActivityAt}
+    )
+  `;
+}
+
 export function sidebarBadgeService(db: Db) {
   return {
     get: async (
@@ -29,9 +155,11 @@ export function sidebarBadgeService(db: Db) {
       extra?: {
         dismissals?: ReadonlyMap<string, number>;
         joinRequests?: Array<{ id: string; updatedAt: Date | string | null; createdAt: Date | string }>;
+        currentUserId?: string | null;
         unreadTouchedIssues?: number;
       },
     ): Promise<SidebarBadges> => {
+      const currentUserId = extra?.currentUserId?.trim() || undefined;
       const actionableApprovals = await db
         .select({ id: approvals.id, updatedAt: approvals.updatedAt })
         .from(approvals)
@@ -39,6 +167,9 @@ export function sidebarBadgeService(db: Db) {
           and(
             eq(approvals.companyId, companyId),
             inArray(approvals.status, ACTIONABLE_APPROVAL_STATUSES),
+            currentUserId
+              ? sql<boolean>`(${approvals.requestedByUserId} = ${currentUserId} OR ${approvals.decidedByUserId} = ${currentUserId})`
+              : undefined,
           ),
         )
         .then((rows) =>
@@ -74,12 +205,29 @@ export function sidebarBadgeService(db: Db) {
           row.updatedAt ?? row.createdAt,
         )
       ).length;
-      const unreadTouchedIssues = extra?.unreadTouchedIssues ?? 0;
+      const unreadTouchedIssues = extra?.unreadTouchedIssues ?? (currentUserId
+        ? await db
+          .select({ count: count() })
+          .from(issues)
+          .where(
+            and(
+              eq(issues.companyId, companyId),
+              inArray(issues.status, INBOX_ISSUE_STATUSES),
+              touchedByUserCondition(companyId, currentUserId),
+              inboxVisibleForUserCondition(companyId, currentUserId),
+              unreadForUserCondition(companyId, currentUserId),
+              isNull(issues.hiddenAt),
+            ),
+          )
+          .then((rows) => rows[0]?.count ?? 0)
+        : 0);
       return {
         inbox: actionableApprovals + failedRuns + joinRequests + unreadTouchedIssues,
         approvals: actionableApprovals,
         failedRuns,
         joinRequests,
+        mineIssues: unreadTouchedIssues,
+        alerts: 0,
       };
     },
   };

--- a/server/src/services/sidebar-badges.ts
+++ b/server/src/services/sidebar-badges.ts
@@ -167,9 +167,6 @@ export function sidebarBadgeService(db: Db) {
           and(
             eq(approvals.companyId, companyId),
             inArray(approvals.status, ACTIONABLE_APPROVAL_STATUSES),
-            currentUserId
-              ? sql<boolean>`(${approvals.requestedByUserId} = ${currentUserId} OR ${approvals.decidedByUserId} = ${currentUserId})`
-              : undefined,
           ),
         )
         .then((rows) =>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,60 +1,66 @@
+import { lazy, Suspense } from "react";
 import { Navigate, Outlet, Route, Routes, useLocation, useParams } from "@/lib/router";
 import { Button } from "@/components/ui/button";
 import { Layout } from "./components/Layout";
 import { OnboardingWizard } from "./components/OnboardingWizard";
 import { CloudAccessGate } from "./components/CloudAccessGate";
-import { Dashboard } from "./pages/Dashboard";
-import { DashboardLive } from "./pages/DashboardLive";
-import { Companies } from "./pages/Companies";
-import { Agents } from "./pages/Agents";
-import { AgentDetail } from "./pages/AgentDetail";
-import { Projects } from "./pages/Projects";
-import { ProjectDetail } from "./pages/ProjectDetail";
-import { ProjectWorkspaceDetail } from "./pages/ProjectWorkspaceDetail";
-import { Workspaces } from "./pages/Workspaces";
-import { Issues } from "./pages/Issues";
-import { IssueDetail } from "./pages/IssueDetail";
-import { IssueChatLongThreadPerf } from "./pages/IssueChatLongThreadPerf";
-import { Routines } from "./pages/Routines";
-import { RoutineDetail } from "./pages/RoutineDetail";
-import { UserProfile } from "./pages/UserProfile";
-import { ExecutionWorkspaceDetail } from "./pages/ExecutionWorkspaceDetail";
-import { Goals } from "./pages/Goals";
-import { GoalDetail } from "./pages/GoalDetail";
-import { Approvals } from "./pages/Approvals";
-import { ApprovalDetail } from "./pages/ApprovalDetail";
-import { Costs } from "./pages/Costs";
-import { Activity } from "./pages/Activity";
-import { Inbox } from "./pages/Inbox";
-import { CompanySettings } from "./pages/CompanySettings";
-import { CompanyEnvironments } from "./pages/CompanyEnvironments";
-import { CompanyAccess } from "./pages/CompanyAccess";
-import { CompanyInvites } from "./pages/CompanyInvites";
-import { CompanySkills } from "./pages/CompanySkills";
-import { CompanyExport } from "./pages/CompanyExport";
-import { CompanyImport } from "./pages/CompanyImport";
-import { DesignGuide } from "./pages/DesignGuide";
-import { InstanceGeneralSettings } from "./pages/InstanceGeneralSettings";
-import { InstanceAccess } from "./pages/InstanceAccess";
-import { InstanceSettings } from "./pages/InstanceSettings";
-import { InstanceExperimentalSettings } from "./pages/InstanceExperimentalSettings";
-import { ProfileSettings } from "./pages/ProfileSettings";
-import { PluginManager } from "./pages/PluginManager";
-import { PluginSettings } from "./pages/PluginSettings";
-import { AdapterManager } from "./pages/AdapterManager";
-import { PluginPage } from "./pages/PluginPage";
-import { OrgChart } from "./pages/OrgChart";
-import { NewAgent } from "./pages/NewAgent";
-import { AuthPage } from "./pages/Auth";
-import { BoardClaimPage } from "./pages/BoardClaim";
-import { CliAuthPage } from "./pages/CliAuth";
-import { InviteLandingPage } from "./pages/InviteLanding";
-import { JoinRequestQueue } from "./pages/JoinRequestQueue";
-import { NotFoundPage } from "./pages/NotFound";
 import { useCompany } from "./context/CompanyContext";
 import { useDialogActions } from "./context/DialogContext";
 import { loadLastInboxTab } from "./lib/inbox";
 import { shouldRedirectCompanylessRouteToOnboarding } from "./lib/onboarding-route";
+
+const Dashboard = lazy(() => import("./pages/Dashboard").then((m) => ({ default: m.Dashboard })));
+const DashboardLive = lazy(() => import("./pages/DashboardLive").then((m) => ({ default: m.DashboardLive })));
+const Companies = lazy(() => import("./pages/Companies").then((m) => ({ default: m.Companies })));
+const Agents = lazy(() => import("./pages/Agents").then((m) => ({ default: m.Agents })));
+const AgentDetail = lazy(() => import("./pages/AgentDetail").then((m) => ({ default: m.AgentDetail })));
+const Projects = lazy(() => import("./pages/Projects").then((m) => ({ default: m.Projects })));
+const ProjectDetail = lazy(() => import("./pages/ProjectDetail").then((m) => ({ default: m.ProjectDetail })));
+const ProjectWorkspaceDetail = lazy(() => import("./pages/ProjectWorkspaceDetail").then((m) => ({ default: m.ProjectWorkspaceDetail })));
+const Workspaces = lazy(() => import("./pages/Workspaces").then((m) => ({ default: m.Workspaces })));
+const Issues = lazy(() => import("./pages/Issues").then((m) => ({ default: m.Issues })));
+const IssueDetail = lazy(() => import("./pages/IssueDetail").then((m) => ({ default: m.IssueDetail })));
+const IssueChatLongThreadPerf = lazy(() => import("./pages/IssueChatLongThreadPerf").then((m) => ({ default: m.IssueChatLongThreadPerf })));
+const Routines = lazy(() => import("./pages/Routines").then((m) => ({ default: m.Routines })));
+const RoutineDetail = lazy(() => import("./pages/RoutineDetail").then((m) => ({ default: m.RoutineDetail })));
+const UserProfile = lazy(() => import("./pages/UserProfile").then((m) => ({ default: m.UserProfile })));
+const ExecutionWorkspaceDetail = lazy(() => import("./pages/ExecutionWorkspaceDetail").then((m) => ({ default: m.ExecutionWorkspaceDetail })));
+const Goals = lazy(() => import("./pages/Goals").then((m) => ({ default: m.Goals })));
+const GoalDetail = lazy(() => import("./pages/GoalDetail").then((m) => ({ default: m.GoalDetail })));
+const Approvals = lazy(() => import("./pages/Approvals").then((m) => ({ default: m.Approvals })));
+const ApprovalDetail = lazy(() => import("./pages/ApprovalDetail").then((m) => ({ default: m.ApprovalDetail })));
+const Costs = lazy(() => import("./pages/Costs").then((m) => ({ default: m.Costs })));
+const Activity = lazy(() => import("./pages/Activity").then((m) => ({ default: m.Activity })));
+const Inbox = lazy(() => import("./pages/Inbox").then((m) => ({ default: m.Inbox })));
+const CompanySettings = lazy(() => import("./pages/CompanySettings").then((m) => ({ default: m.CompanySettings })));
+const CompanyEnvironments = lazy(() => import("./pages/CompanyEnvironments").then((m) => ({ default: m.CompanyEnvironments })));
+const CompanyAccess = lazy(() => import("./pages/CompanyAccess").then((m) => ({ default: m.CompanyAccess })));
+const CompanyInvites = lazy(() => import("./pages/CompanyInvites").then((m) => ({ default: m.CompanyInvites })));
+const CompanySkills = lazy(() => import("./pages/CompanySkills").then((m) => ({ default: m.CompanySkills })));
+const CompanyExport = lazy(() => import("./pages/CompanyExport").then((m) => ({ default: m.CompanyExport })));
+const CompanyImport = lazy(() => import("./pages/CompanyImport").then((m) => ({ default: m.CompanyImport })));
+const DesignGuide = lazy(() => import("./pages/DesignGuide").then((m) => ({ default: m.DesignGuide })));
+const InstanceGeneralSettings = lazy(() => import("./pages/InstanceGeneralSettings").then((m) => ({ default: m.InstanceGeneralSettings })));
+const InstanceAccess = lazy(() => import("./pages/InstanceAccess").then((m) => ({ default: m.InstanceAccess })));
+const InstanceSettings = lazy(() => import("./pages/InstanceSettings").then((m) => ({ default: m.InstanceSettings })));
+const InstanceExperimentalSettings = lazy(() => import("./pages/InstanceExperimentalSettings").then((m) => ({ default: m.InstanceExperimentalSettings })));
+const ProfileSettings = lazy(() => import("./pages/ProfileSettings").then((m) => ({ default: m.ProfileSettings })));
+const PluginManager = lazy(() => import("./pages/PluginManager").then((m) => ({ default: m.PluginManager })));
+const PluginSettings = lazy(() => import("./pages/PluginSettings").then((m) => ({ default: m.PluginSettings })));
+const AdapterManager = lazy(() => import("./pages/AdapterManager").then((m) => ({ default: m.AdapterManager })));
+const PluginPage = lazy(() => import("./pages/PluginPage").then((m) => ({ default: m.PluginPage })));
+const OrgChart = lazy(() => import("./pages/OrgChart").then((m) => ({ default: m.OrgChart })));
+const NewAgent = lazy(() => import("./pages/NewAgent").then((m) => ({ default: m.NewAgent })));
+const AuthPage = lazy(() => import("./pages/Auth").then((m) => ({ default: m.AuthPage })));
+const BoardClaimPage = lazy(() => import("./pages/BoardClaim").then((m) => ({ default: m.BoardClaimPage })));
+const CliAuthPage = lazy(() => import("./pages/CliAuth").then((m) => ({ default: m.CliAuthPage })));
+const InviteLandingPage = lazy(() => import("./pages/InviteLanding").then((m) => ({ default: m.InviteLandingPage })));
+const JoinRequestQueue = lazy(() => import("./pages/JoinRequestQueue").then((m) => ({ default: m.JoinRequestQueue })));
+const NotFoundPage = lazy(() => import("./pages/NotFound").then((m) => ({ default: m.NotFoundPage })));
+
+function RouteLoading() {
+  return <div className="px-4 py-6 text-sm text-muted-foreground">Loading...</div>;
+}
 
 function boardRoutes() {
   return (
@@ -258,62 +264,66 @@ function NoCompaniesStartPage() {
 export function App() {
   return (
     <>
-      <Routes>
-        <Route path="auth" element={<AuthPage />} />
-        <Route path="board-claim/:token" element={<BoardClaimPage />} />
-        <Route path="cli-auth/:id" element={<CliAuthPage />} />
-        <Route path="invite/:token" element={<InviteLandingPage />} />
-        <Route path="tests/perf/long-thread" element={<IssueChatLongThreadPerf />} />
+      <Suspense fallback={<RouteLoading />}>
+        <Routes>
+          <Route path="auth" element={<AuthPage />} />
+          <Route path="board-claim/:token" element={<BoardClaimPage />} />
+          <Route path="cli-auth/:id" element={<CliAuthPage />} />
+          <Route path="invite/:token" element={<InviteLandingPage />} />
+          {import.meta.env.DEV ? (
+            <Route path="tests/perf/long-thread" element={<IssueChatLongThreadPerf />} />
+          ) : null}
 
-        <Route element={<CloudAccessGate />}>
-          <Route index element={<CompanyRootRedirect />} />
-          <Route path="onboarding" element={<OnboardingRoutePage />} />
-          <Route path="instance" element={<Navigate to="/instance/settings/general" replace />} />
-          <Route path="instance/settings" element={<Layout />}>
-            <Route index element={<Navigate to="general" replace />} />
-            <Route path="profile" element={<ProfileSettings />} />
-            <Route path="general" element={<InstanceGeneralSettings />} />
-            <Route path="access" element={<InstanceAccess />} />
-            <Route path="heartbeats" element={<InstanceSettings />} />
-            <Route path="experimental" element={<InstanceExperimentalSettings />} />
-            <Route path="plugins" element={<PluginManager />} />
-            <Route path="plugins/:pluginId" element={<PluginSettings />} />
-            <Route path="adapters" element={<AdapterManager />} />
+          <Route element={<CloudAccessGate />}>
+            <Route index element={<CompanyRootRedirect />} />
+            <Route path="onboarding" element={<OnboardingRoutePage />} />
+            <Route path="instance" element={<Navigate to="/instance/settings/general" replace />} />
+            <Route path="instance/settings" element={<Layout />}>
+              <Route index element={<Navigate to="general" replace />} />
+              <Route path="profile" element={<ProfileSettings />} />
+              <Route path="general" element={<InstanceGeneralSettings />} />
+              <Route path="access" element={<InstanceAccess />} />
+              <Route path="heartbeats" element={<InstanceSettings />} />
+              <Route path="experimental" element={<InstanceExperimentalSettings />} />
+              <Route path="plugins" element={<PluginManager />} />
+              <Route path="plugins/:pluginId" element={<PluginSettings />} />
+              <Route path="adapters" element={<AdapterManager />} />
+            </Route>
+            <Route path="companies" element={<UnprefixedBoardRedirect />} />
+            <Route path="issues" element={<UnprefixedBoardRedirect />} />
+            <Route path="issues/:issueId" element={<UnprefixedBoardRedirect />} />
+            <Route path="routines" element={<UnprefixedBoardRedirect />} />
+            <Route path="routines/:routineId" element={<UnprefixedBoardRedirect />} />
+            <Route path="u/:userSlug" element={<UnprefixedBoardRedirect />} />
+            <Route path="skills/*" element={<UnprefixedBoardRedirect />} />
+            <Route path="settings" element={<LegacySettingsRedirect />} />
+            <Route path="settings/*" element={<LegacySettingsRedirect />} />
+            <Route path="agents" element={<UnprefixedBoardRedirect />} />
+            <Route path="agents/new" element={<UnprefixedBoardRedirect />} />
+            <Route path="agents/:agentId" element={<UnprefixedBoardRedirect />} />
+            <Route path="agents/:agentId/:tab" element={<UnprefixedBoardRedirect />} />
+            <Route path="agents/:agentId/runs/:runId" element={<UnprefixedBoardRedirect />} />
+            <Route path="projects" element={<UnprefixedBoardRedirect />} />
+            <Route path="projects/:projectId" element={<UnprefixedBoardRedirect />} />
+            <Route path="projects/:projectId/overview" element={<UnprefixedBoardRedirect />} />
+            <Route path="projects/:projectId/issues" element={<UnprefixedBoardRedirect />} />
+            <Route path="projects/:projectId/issues/:filter" element={<UnprefixedBoardRedirect />} />
+            <Route path="projects/:projectId/workspaces" element={<UnprefixedBoardRedirect />} />
+            <Route path="projects/:projectId/workspaces/:workspaceId" element={<UnprefixedBoardRedirect />} />
+            <Route path="projects/:projectId/configuration" element={<UnprefixedBoardRedirect />} />
+            <Route path="workspaces" element={<UnprefixedBoardRedirect />} />
+            <Route path="execution-workspaces/:workspaceId" element={<UnprefixedBoardRedirect />} />
+            <Route path="execution-workspaces/:workspaceId/configuration" element={<UnprefixedBoardRedirect />} />
+            <Route path="execution-workspaces/:workspaceId/runtime-logs" element={<UnprefixedBoardRedirect />} />
+            <Route path="execution-workspaces/:workspaceId/issues" element={<UnprefixedBoardRedirect />} />
+            <Route path="execution-workspaces/:workspaceId/routines" element={<UnprefixedBoardRedirect />} />
+            <Route path=":companyPrefix" element={<Layout />}>
+              {boardRoutes()}
+            </Route>
+            <Route path="*" element={<NotFoundPage scope="global" />} />
           </Route>
-          <Route path="companies" element={<UnprefixedBoardRedirect />} />
-          <Route path="issues" element={<UnprefixedBoardRedirect />} />
-          <Route path="issues/:issueId" element={<UnprefixedBoardRedirect />} />
-          <Route path="routines" element={<UnprefixedBoardRedirect />} />
-          <Route path="routines/:routineId" element={<UnprefixedBoardRedirect />} />
-          <Route path="u/:userSlug" element={<UnprefixedBoardRedirect />} />
-          <Route path="skills/*" element={<UnprefixedBoardRedirect />} />
-          <Route path="settings" element={<LegacySettingsRedirect />} />
-          <Route path="settings/*" element={<LegacySettingsRedirect />} />
-          <Route path="agents" element={<UnprefixedBoardRedirect />} />
-          <Route path="agents/new" element={<UnprefixedBoardRedirect />} />
-          <Route path="agents/:agentId" element={<UnprefixedBoardRedirect />} />
-          <Route path="agents/:agentId/:tab" element={<UnprefixedBoardRedirect />} />
-          <Route path="agents/:agentId/runs/:runId" element={<UnprefixedBoardRedirect />} />
-          <Route path="projects" element={<UnprefixedBoardRedirect />} />
-          <Route path="projects/:projectId" element={<UnprefixedBoardRedirect />} />
-          <Route path="projects/:projectId/overview" element={<UnprefixedBoardRedirect />} />
-          <Route path="projects/:projectId/issues" element={<UnprefixedBoardRedirect />} />
-          <Route path="projects/:projectId/issues/:filter" element={<UnprefixedBoardRedirect />} />
-          <Route path="projects/:projectId/workspaces" element={<UnprefixedBoardRedirect />} />
-          <Route path="projects/:projectId/workspaces/:workspaceId" element={<UnprefixedBoardRedirect />} />
-          <Route path="projects/:projectId/configuration" element={<UnprefixedBoardRedirect />} />
-          <Route path="workspaces" element={<UnprefixedBoardRedirect />} />
-          <Route path="execution-workspaces/:workspaceId" element={<UnprefixedBoardRedirect />} />
-          <Route path="execution-workspaces/:workspaceId/configuration" element={<UnprefixedBoardRedirect />} />
-          <Route path="execution-workspaces/:workspaceId/runtime-logs" element={<UnprefixedBoardRedirect />} />
-          <Route path="execution-workspaces/:workspaceId/issues" element={<UnprefixedBoardRedirect />} />
-          <Route path="execution-workspaces/:workspaceId/routines" element={<UnprefixedBoardRedirect />} />
-          <Route path=":companyPrefix" element={<Layout />}>
-            {boardRoutes()}
-          </Route>
-          <Route path="*" element={<NotFoundPage scope="global" />} />
-        </Route>
-      </Routes>
+        </Routes>
+      </Suspense>
       <OnboardingWizard />
     </>
   );

--- a/ui/src/components/ActiveAgentsPanel.test.tsx
+++ b/ui/src/components/ActiveAgentsPanel.test.tsx
@@ -12,6 +12,7 @@ const mockHeartbeatsApi = vi.hoisted(() => ({
 
 const mockIssuesApi = vi.hoisted(() => ({
   list: vi.fn(),
+  get: vi.fn(),
 }));
 
 vi.mock("@/lib/router", () => ({
@@ -79,6 +80,7 @@ describe("ActiveAgentsPanel", () => {
     document.body.appendChild(container);
     mockHeartbeatsApi.liveRunsForCompany.mockResolvedValue([1, 2, 3, 4, 5].map(createRun));
     mockIssuesApi.list.mockResolvedValue([]);
+    mockIssuesApi.get.mockResolvedValue(null);
   });
 
   afterEach(() => {

--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo } from "react";
 import { Link } from "@/lib/router";
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
 import type { Issue } from "@paperclipai/shared";
 import { heartbeatsApi, type LiveRunForIssue } from "../api/heartbeats";
 import type { TranscriptEntry } from "../adapters";
@@ -11,6 +11,7 @@ import { ExternalLink } from "lucide-react";
 import { Identity } from "./Identity";
 import { RunChatSurface } from "./RunChatSurface";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
+import { usePageForegrounded } from "../hooks/usePageForegrounded";
 
 const MIN_DASHBOARD_RUNS = 4;
 const DASHBOARD_RUN_CARD_LIMIT = 4;
@@ -48,27 +49,36 @@ export function ActiveAgentsPanel({
   queryScope = "dashboard",
   showMoreLink = true,
 }: ActiveAgentsPanelProps) {
+  const isForegrounded = usePageForegrounded();
   const { data: liveRuns } = useQuery({
     queryKey: [...queryKeys.liveRuns(companyId), queryScope, { minRunCount, fetchLimit }],
     queryFn: () => heartbeatsApi.liveRunsForCompany(companyId, { minCount: minRunCount, limit: fetchLimit }),
+    enabled: isForegrounded,
   });
 
   const runs = liveRuns ?? [];
   const visibleRuns = useMemo(() => runs.slice(0, cardLimit), [cardLimit, runs]);
   const hiddenRunCount = Math.max(0, runs.length - visibleRuns.length);
-  const { data: issues } = useQuery({
-    queryKey: [...queryKeys.issues.list(companyId), "with-routine-executions"],
-    queryFn: () => issuesApi.list(companyId, { includeRoutineExecutions: true }),
-    enabled: visibleRuns.length > 0,
+  const visibleIssueIds = useMemo(
+    () => [...new Set(visibleRuns.map((run) => run.issueId).filter((id): id is string => Boolean(id)))],
+    [visibleRuns],
+  );
+  const issueQueries = useQueries({
+    queries: visibleIssueIds.map((issueId) => ({
+      queryKey: queryKeys.issues.detail(issueId),
+      queryFn: () => issuesApi.get(issueId),
+      enabled: isForegrounded,
+      staleTime: 30_000,
+    })),
   });
 
   const issueById = useMemo(() => {
     const map = new Map<string, Issue>();
-    for (const issue of issues ?? []) {
-      map.set(issue.id, issue);
+    for (const query of issueQueries) {
+      if (query.data) map.set(query.data.id, query.data);
     }
     return map;
-  }, [issues]);
+  }, [issueQueries]);
 
   const { transcriptByRun, hasOutputForRun } = useLiveRunTranscripts({
     runs: visibleRuns,

--- a/ui/src/components/CompanySettingsSidebar.test.tsx
+++ b/ui/src/components/CompanySettingsSidebar.test.tsx
@@ -78,6 +78,8 @@ describe("CompanySettingsSidebar", () => {
       approvals: 0,
       failedRuns: 0,
       joinRequests: 2,
+      mineIssues: 0,
+      alerts: 0,
     });
   });
 

--- a/ui/src/context/LiveUpdatesProvider.test.ts
+++ b/ui/src/context/LiveUpdatesProvider.test.ts
@@ -74,6 +74,31 @@ describe("LiveUpdatesProvider issue invalidation", () => {
     });
   });
 
+  it("does not refetch issue queries for live activity while the tab is backgrounded", () => {
+    const invalidations: unknown[] = [];
+    const queryClient = {
+      invalidateQueries: (input: unknown) => {
+        invalidations.push(input);
+      },
+      getQueryData: () => undefined,
+    };
+
+    __liveUpdatesTestUtils.invalidateActivityQueries(
+      queryClient as never,
+      "company-1",
+      {
+        entityType: "issue",
+        entityId: "issue-1",
+        action: "issue.updated",
+        details: null,
+      },
+      { userId: null, agentId: null },
+      { pathname: "/PTG/issues/PTG-3653", isForegrounded: false },
+    );
+
+    expect(invalidations).toEqual([]);
+  });
+
   it("still refreshes comments when a comment activity event arrives", () => {
     const invalidations: unknown[] = [];
     const queryClient = {

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -634,12 +634,18 @@ function invalidateHeartbeatQueries(
 type ThrottleSlot = { lastFired: number; trailingTimer: ReturnType<typeof setTimeout> | null };
 const invalidationThrottleSlots = new Map<string, ThrottleSlot>();
 const INVALIDATION_THROTTLE_MS = 1500;
+// issues.list refetch is the bandwidth heavyweight (~226 KB/response on a busy
+// company). At the 1500 ms cadence it saturates a thin VPN link and stalls
+// every other concurrent fetch (issue detail open, agent detail, etc.).
+// Bumping the window to 5000 ms keeps the inbox live but cuts background draw
+// to ~45 KB/s during sustained agent activity.
+const INVALIDATION_THROTTLE_MS_LIST = 5000;
 
-function throttledInvalidate(key: string, run: () => void) {
+function throttledInvalidate(key: string, run: () => void, windowMs: number = INVALIDATION_THROTTLE_MS) {
   const slot: ThrottleSlot = invalidationThrottleSlots.get(key) ?? { lastFired: 0, trailingTimer: null };
   const now = Date.now();
   const elapsed = now - slot.lastFired;
-  if (elapsed >= INVALIDATION_THROTTLE_MS) {
+  if (elapsed >= windowMs) {
     slot.lastFired = now;
     if (slot.trailingTimer) {
       clearTimeout(slot.trailingTimer);
@@ -653,7 +659,7 @@ function throttledInvalidate(key: string, run: () => void) {
       slot.trailingTimer = null;
       invalidationThrottleSlots.set(key, slot);
       run();
-    }, INVALIDATION_THROTTLE_MS - elapsed);
+    }, windowMs - elapsed);
     invalidationThrottleSlots.set(key, slot);
   }
 }
@@ -683,7 +689,7 @@ function invalidateActivityQueries(
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.listMineByMe(companyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.listTouchedByMe(companyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.listUnreadTouchedByMe(companyId) });
-    });
+    }, INVALIDATION_THROTTLE_MS_LIST);
     if (entityId) {
       const details = readRecord(payload.details);
       const selfCommentActivity =

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -671,6 +671,9 @@ function invalidateActivityQueries(
   currentActor: { userId: string | null; agentId: string | null },
   options?: { pathname?: string; isForegrounded?: boolean },
 ) {
+  const isForegrounded = options?.isForegrounded ?? true;
+  if (!isForegrounded) return;
+
   throttledInvalidate(`activity.bulk:${companyId}`, () => {
     queryClient.invalidateQueries({ queryKey: queryKeys.activity(companyId) });
     queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(companyId) });
@@ -835,6 +838,9 @@ function handleLiveEvent(
     return;
   }
 
+  const isForegrounded = isPageForegrounded();
+  if (!isForegrounded) return;
+
   if (event.type === "heartbeat.run.queued" || event.type === "heartbeat.run.status") {
     invalidateHeartbeatQueries(queryClient, expectedCompanyId, payload);
     invalidateVisibleIssueRunQueries(queryClient, pathname, payload);
@@ -871,8 +877,8 @@ function handleLiveEvent(
   }
 
   if (event.type === "activity.logged") {
-    invalidateActivityQueries(queryClient, expectedCompanyId, payload, currentActor, { pathname });
-    if (shouldDeferVisibleIssueCommentActivity(queryClient, pathname, payload)) {
+    invalidateActivityQueries(queryClient, expectedCompanyId, payload, currentActor, { pathname, isForegrounded });
+    if (shouldDeferVisibleIssueCommentActivity(queryClient, pathname, payload, { isForegrounded })) {
       void hydrateVisibleIssueComment(queryClient, pathname, payload);
     }
     const action = readString(payload.action);
@@ -881,7 +887,7 @@ function handleLiveEvent(
       buildJoinRequestToast(payload);
     if (
       toast &&
-      !shouldSuppressActivityToastForVisibleIssue(queryClient, pathname, payload)
+      !shouldSuppressActivityToastForVisibleIssue(queryClient, pathname, payload, { isForegrounded })
     ) {
       gatedPushToast(gate, pushToast, `activity:${action ?? "unknown"}`, toast);
     }

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -625,6 +625,39 @@ function invalidateHeartbeatQueries(
   }
 }
 
+// Leading+trailing throttle for high-frequency invalidations.
+// activity.logged events arrive ~10/sec per running agent; with 2+ agents
+// every event used to fan out to 7+ react-query refetches (incl. the
+// 215 KB issues.list), saturating the node event loop until the UI froze.
+// Coalesce by key: fire immediately on leading edge, drop within window,
+// schedule one trailing-edge fire so the final state is consistent.
+type ThrottleSlot = { lastFired: number; trailingTimer: ReturnType<typeof setTimeout> | null };
+const invalidationThrottleSlots = new Map<string, ThrottleSlot>();
+const INVALIDATION_THROTTLE_MS = 1500;
+
+function throttledInvalidate(key: string, run: () => void) {
+  const slot: ThrottleSlot = invalidationThrottleSlots.get(key) ?? { lastFired: 0, trailingTimer: null };
+  const now = Date.now();
+  const elapsed = now - slot.lastFired;
+  if (elapsed >= INVALIDATION_THROTTLE_MS) {
+    slot.lastFired = now;
+    if (slot.trailingTimer) {
+      clearTimeout(slot.trailingTimer);
+      slot.trailingTimer = null;
+    }
+    invalidationThrottleSlots.set(key, slot);
+    run();
+  } else if (!slot.trailingTimer) {
+    slot.trailingTimer = setTimeout(() => {
+      slot.lastFired = Date.now();
+      slot.trailingTimer = null;
+      invalidationThrottleSlots.set(key, slot);
+      run();
+    }, INVALIDATION_THROTTLE_MS - elapsed);
+    invalidationThrottleSlots.set(key, slot);
+  }
+}
+
 function invalidateActivityQueries(
   queryClient: ReturnType<typeof useQueryClient>,
   companyId: string,
@@ -632,9 +665,11 @@ function invalidateActivityQueries(
   currentActor: { userId: string | null; agentId: string | null },
   options?: { pathname?: string; isForegrounded?: boolean },
 ) {
-  queryClient.invalidateQueries({ queryKey: queryKeys.activity(companyId) });
-  queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(companyId) });
-  queryClient.invalidateQueries({ queryKey: queryKeys.sidebarBadges(companyId) });
+  throttledInvalidate(`activity.bulk:${companyId}`, () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.activity(companyId) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(companyId) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.sidebarBadges(companyId) });
+  });
 
   const entityType = readString(payload.entityType);
   const entityId = readString(payload.entityId);
@@ -643,10 +678,12 @@ function invalidateActivityQueries(
   const actorId = readString(payload.actorId);
 
   if (entityType === "issue") {
-    queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(companyId) });
-    queryClient.invalidateQueries({ queryKey: queryKeys.issues.listMineByMe(companyId) });
-    queryClient.invalidateQueries({ queryKey: queryKeys.issues.listTouchedByMe(companyId) });
-    queryClient.invalidateQueries({ queryKey: queryKeys.issues.listUnreadTouchedByMe(companyId) });
+    throttledInvalidate(`issues.list:${companyId}`, () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(companyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.listMineByMe(companyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.listTouchedByMe(companyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.listUnreadTouchedByMe(companyId) });
+    });
     if (entityId) {
       const details = readRecord(payload.details);
       const selfCommentActivity =

--- a/ui/src/hooks/useInboxBadge.ts
+++ b/ui/src/hooks/useInboxBadge.ts
@@ -1,28 +1,16 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { accessApi } from "../api/access";
-import { ApiError } from "../api/client";
 import { inboxDismissalsApi } from "../api/inboxDismissals";
-import { approvalsApi } from "../api/approvals";
-import { authApi } from "../api/auth";
-import { dashboardApi } from "../api/dashboard";
-import { heartbeatsApi } from "../api/heartbeats";
-import { issuesApi } from "../api/issues";
+import { sidebarBadgesApi } from "../api/sidebarBadges";
 import { queryKeys } from "../lib/queryKeys";
 import {
   buildInboxDismissedAtByKey,
-  computeInboxBadgeData,
-  getRecentTouchedIssues,
   loadDismissedInboxAlerts,
   saveDismissedInboxAlerts,
   loadReadInboxItems,
   saveReadInboxItems,
   READ_ITEMS_KEY,
 } from "../lib/inbox";
-
-const INBOX_ISSUE_STATUSES = "backlog,todo,in_progress,in_review,blocked,done";
-const INBOX_BADGE_ISSUE_LIMIT = 500;
-const INBOX_BADGE_HEARTBEAT_RUN_LIMIT = 200;
 
 export function useDismissedInboxAlerts() {
   const [dismissed, setDismissed] = useState<Set<string>>(loadDismissedInboxAlerts);
@@ -139,74 +127,18 @@ export function useReadInboxItems() {
 }
 
 export function useInboxBadge(companyId: string | null | undefined) {
-  const { dismissed: dismissedAlerts } = useDismissedInboxAlerts();
-  const { dismissedAtByKey } = useInboxDismissals(companyId);
-  const { data: session } = useQuery({
-    queryKey: queryKeys.auth.session,
-    queryFn: () => authApi.getSession(),
-  });
-
-  const { data: approvals = [] } = useQuery({
-    queryKey: queryKeys.approvals.list(companyId!),
-    queryFn: () => approvalsApi.list(companyId!),
+  const { data: badges } = useQuery({
+    queryKey: companyId ? queryKeys.sidebarBadges(companyId) : ["sidebar-badges", "__disabled__"] as const,
+    queryFn: () => sidebarBadgesApi.get(companyId!),
     enabled: !!companyId,
   });
 
-  const { data: joinRequests = [] } = useQuery({
-    queryKey: queryKeys.access.joinRequests(companyId!),
-    queryFn: async () => {
-      try {
-        return await accessApi.listJoinRequests(companyId!, "pending_approval");
-      } catch (err) {
-        if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
-          return [];
-        }
-        throw err;
-      }
-    },
-    enabled: !!companyId,
-    retry: false,
-  });
-
-  const { data: dashboard } = useQuery({
-    queryKey: queryKeys.dashboard(companyId!),
-    queryFn: () => dashboardApi.summary(companyId!),
-    enabled: !!companyId,
-  });
-
-  const { data: mineIssuesRaw = [] } = useQuery({
-    queryKey: queryKeys.issues.listMineByMe(companyId!),
-    queryFn: () =>
-      issuesApi.list(companyId!, {
-        touchedByUserId: "me",
-        inboxArchivedByUserId: "me",
-        status: INBOX_ISSUE_STATUSES,
-        limit: INBOX_BADGE_ISSUE_LIMIT,
-      }),
-    enabled: !!companyId,
-  });
-
-  const mineIssues = useMemo(() => getRecentTouchedIssues(mineIssuesRaw), [mineIssuesRaw]);
-  const currentUserId = session?.user.id ?? session?.session.userId ?? null;
-
-  const { data: heartbeatRuns = [] } = useQuery({
-    queryKey: [...queryKeys.heartbeats(companyId!), "limit", INBOX_BADGE_HEARTBEAT_RUN_LIMIT],
-    queryFn: () => heartbeatsApi.list(companyId!, undefined, INBOX_BADGE_HEARTBEAT_RUN_LIMIT),
-    enabled: !!companyId,
-  });
-
-  return useMemo(
-    () =>
-      computeInboxBadgeData({
-        approvals,
-        joinRequests,
-        dashboard,
-        heartbeatRuns,
-        mineIssues,
-        dismissedAlerts,
-        dismissedAtByKey,
-        currentUserId,
-      }),
-    [approvals, joinRequests, dashboard, heartbeatRuns, mineIssues, dismissedAlerts, dismissedAtByKey, currentUserId],
-  );
+  return badges ?? {
+    inbox: 0,
+    approvals: 0,
+    failedRuns: 0,
+    joinRequests: 0,
+    mineIssues: 0,
+    alerts: 0,
+  };
 }

--- a/ui/src/hooks/usePageForegrounded.ts
+++ b/ui/src/hooks/usePageForegrounded.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+function readPageForegrounded() {
+  if (typeof document === "undefined") return true;
+  return document.visibilityState !== "hidden";
+}
+
+export function usePageForegrounded() {
+  const [isForegrounded, setIsForegrounded] = useState(readPageForegrounded);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setIsForegrounded(readPageForegrounded());
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, []);
+
+  return isForegrounded;
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -26,8 +26,10 @@ import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRa
 import { PageSkeleton } from "../components/PageSkeleton";
 import type { Agent, Issue } from "@paperclipai/shared";
 import { PluginSlotOutlet } from "@/plugins/slots";
+import { usePageForegrounded } from "../hooks/usePageForegrounded";
 
 const DASHBOARD_ACTIVITY_LIMIT = 10;
+const DASHBOARD_RECENT_ISSUE_LIMIT = 25;
 
 function getRecentIssues(issues: Issue[]): Issue[] {
   return [...issues]
@@ -38,6 +40,7 @@ export function Dashboard() {
   const { selectedCompanyId, companies } = useCompany();
   const { openOnboarding } = useDialogActions();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const isForegrounded = usePageForegrounded();
   const [animatedActivityIds, setAnimatedActivityIds] = useState<Set<string>>(new Set());
   const seenActivityIdsRef = useRef<Set<string>>(new Set());
   const hydratedActivityRef = useRef(false);
@@ -46,7 +49,7 @@ export function Dashboard() {
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
     queryFn: () => agentsApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
 
   useEffect(() => {
@@ -56,31 +59,31 @@ export function Dashboard() {
   const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.dashboard(selectedCompanyId!),
     queryFn: () => dashboardApi.summary(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
 
   const { data: activity } = useQuery({
     queryKey: [...queryKeys.activity(selectedCompanyId!), { limit: DASHBOARD_ACTIVITY_LIMIT }],
     queryFn: () => activityApi.list(selectedCompanyId!, { limit: DASHBOARD_ACTIVITY_LIMIT }),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
 
   const { data: issues } = useQuery({
-    queryKey: queryKeys.issues.list(selectedCompanyId!),
-    queryFn: () => issuesApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    queryKey: [...queryKeys.issues.list(selectedCompanyId!), "dashboard-recent", DASHBOARD_RECENT_ISSUE_LIMIT],
+    queryFn: () => issuesApi.list(selectedCompanyId!, { limit: DASHBOARD_RECENT_ISSUE_LIMIT }),
+    enabled: !!selectedCompanyId && isForegrounded,
   });
 
   const { data: projects } = useQuery({
     queryKey: queryKeys.projects.list(selectedCompanyId!),
     queryFn: () => projectsApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
 
   const { data: companyMembers } = useQuery({
     queryKey: queryKeys.access.companyUserDirectory(selectedCompanyId!),
     queryFn: () => accessApi.listUserDirectory(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
 
   const userProfileMap = useMemo(

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation, useNavigate } from "@/lib/router";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { INBOX_MINE_ISSUE_STATUS_FILTER } from "@paperclipai/shared";
 import { approvalsApi } from "../api/approvals";
 import { accessApi } from "../api/access";
@@ -95,7 +95,7 @@ import {
 } from "lucide-react";
 
 const INBOX_HEARTBEAT_RUN_LIMIT = 50;
-const INBOX_ISSUE_LIST_LIMIT = 100;
+const INBOX_ISSUE_PAGE_SIZE = 50;
 import { Input } from "@/components/ui/input";
 import { PageTabBar } from "../components/PageTabBar";
 import type { Approval, HeartbeatRun, Issue, JoinRequest } from "@paperclipai/shared";
@@ -187,6 +187,28 @@ function readIssueIdFromRun(run: HeartbeatRun): string | null {
   if (typeof taskId === "string" && taskId.length > 0) return taskId;
 
   return null;
+}
+
+function getNextInboxIssuePageOffset(
+  loadedPageSize: number,
+  currentOffset: number,
+): number | undefined {
+  return loadedPageSize >= INBOX_ISSUE_PAGE_SIZE ? currentOffset + INBOX_ISSUE_PAGE_SIZE : undefined;
+}
+
+function mergeInboxIssuePages(pages: Issue[][]): Issue[] {
+  const seenIssueIds = new Set<string>();
+  const merged: Issue[] = [];
+
+  for (const page of pages) {
+    for (const issue of page) {
+      if (seenIssueIds.has(issue.id)) continue;
+      seenIssueIds.add(issue.id);
+      merged.push(issue);
+    }
+  }
+
+  return merged;
 }
 
 function nonEmptyLabel(value: string | null | undefined): string | null {
@@ -798,37 +820,51 @@ export function Inbox() {
     queryFn: () =>
       issuesApi.list(selectedCompanyId!, {
         includeRoutineExecutions: true,
-        limit: INBOX_ISSUE_LIST_LIMIT,
+        limit: INBOX_ISSUE_PAGE_SIZE,
       }),
     enabled: !!selectedCompanyId && shouldLoadIssueLookup,
   });
   const {
-    data: mineIssuesRaw = [],
+    data: mineIssuePages,
     isLoading: isMineIssuesLoading,
-  } = useQuery({
-    queryKey: [...queryKeys.issues.listMineByMe(selectedCompanyId!), "with-routine-executions", issueStatusRequestFilter],
-    queryFn: () =>
+    isFetchingNextPage: isFetchingNextMineIssues,
+    hasNextPage: hasNextMineIssuesPage,
+    fetchNextPage: fetchNextMineIssuesPage,
+  } = useInfiniteQuery({
+    queryKey: [...queryKeys.issues.listMineByMe(selectedCompanyId!), "with-routine-executions", issueStatusRequestFilter, "infinite", INBOX_ISSUE_PAGE_SIZE],
+    queryFn: ({ pageParam }) =>
       issuesApi.list(selectedCompanyId!, {
         touchedByUserId: "me",
         inboxArchivedByUserId: "me",
         status: issueStatusRequestFilter,
         includeRoutineExecutions: true,
-        limit: INBOX_ISSUE_LIST_LIMIT,
+        limit: INBOX_ISSUE_PAGE_SIZE,
+        offset: pageParam,
       }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) =>
+      getNextInboxIssuePageOffset(lastPage.length, lastPageParam),
     enabled: !!selectedCompanyId && shouldLoadMineIssues,
   });
   const {
-    data: touchedIssuesRaw = [],
+    data: touchedIssuePages,
     isLoading: isTouchedIssuesLoading,
-  } = useQuery({
-    queryKey: [...queryKeys.issues.listTouchedByMe(selectedCompanyId!), "with-routine-executions", issueStatusRequestFilter],
-    queryFn: () =>
+    isFetchingNextPage: isFetchingNextTouchedIssues,
+    hasNextPage: hasNextTouchedIssuesPage,
+    fetchNextPage: fetchNextTouchedIssuesPage,
+  } = useInfiniteQuery({
+    queryKey: [...queryKeys.issues.listTouchedByMe(selectedCompanyId!), "with-routine-executions", issueStatusRequestFilter, "infinite", INBOX_ISSUE_PAGE_SIZE],
+    queryFn: ({ pageParam }) =>
       issuesApi.list(selectedCompanyId!, {
         touchedByUserId: "me",
         status: issueStatusRequestFilter,
         includeRoutineExecutions: true,
-        limit: INBOX_ISSUE_LIST_LIMIT,
+        limit: INBOX_ISSUE_PAGE_SIZE,
+        offset: pageParam,
       }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) =>
+      getNextInboxIssuePageOffset(lastPage.length, lastPageParam),
     enabled: !!selectedCompanyId && shouldLoadTouchedIssues,
   });
 
@@ -861,6 +897,14 @@ export function Inbox() {
     [companyMembers?.users],
   );
 
+  const mineIssuesRaw = useMemo(
+    () => mergeInboxIssuePages(mineIssuePages?.pages ?? []),
+    [mineIssuePages],
+  );
+  const touchedIssuesRaw = useMemo(
+    () => mergeInboxIssuePages(touchedIssuePages?.pages ?? []),
+    [touchedIssuePages],
+  );
   const mineIssues = useMemo(() => getRecentTouchedIssues(mineIssuesRaw), [mineIssuesRaw]);
   const touchedIssues = useMemo(() => getRecentTouchedIssues(touchedIssuesRaw), [touchedIssuesRaw]);
   const visibleMineIssues = useMemo(
@@ -1872,6 +1916,38 @@ export function Inbox() {
     !isMineIssuesLoading &&
     !isTouchedIssuesLoading &&
     !isRunsLoading;
+  const hasMoreInboxIssues =
+    normalizedSearchQuery.length === 0 &&
+    (
+      (tab === "mine" && hasNextMineIssuesPage === true) ||
+      ((tab === "recent" || tab === "unread" || (tab === "all" && showTouchedCategory)) && hasNextTouchedIssuesPage === true)
+    );
+  const isLoadingMoreInboxIssues =
+    tab === "mine"
+      ? isFetchingNextMineIssues
+      : (tab === "recent" || tab === "unread" || (tab === "all" && showTouchedCategory))
+        ? isFetchingNextTouchedIssues
+        : false;
+  const loadMoreInboxIssues = useCallback(() => {
+    if (tab === "mine") {
+      if (!hasNextMineIssuesPage || isFetchingNextMineIssues) return;
+      void fetchNextMineIssuesPage({ cancelRefetch: false });
+      return;
+    }
+
+    if (!(tab === "recent" || tab === "unread" || (tab === "all" && showTouchedCategory))) return;
+    if (!hasNextTouchedIssuesPage || isFetchingNextTouchedIssues) return;
+    void fetchNextTouchedIssuesPage({ cancelRefetch: false });
+  }, [
+    fetchNextMineIssuesPage,
+    fetchNextTouchedIssuesPage,
+    hasNextMineIssuesPage,
+    hasNextTouchedIssuesPage,
+    isFetchingNextMineIssues,
+    isFetchingNextTouchedIssues,
+    showTouchedCategory,
+    tab,
+  ]);
 
   const showSeparatorBefore = (key: SectionKey) => visibleSections.indexOf(key) > 0;
   const markAllReadIssues = (tab === "mine" ? visibleMineIssues : unreadTouchedIssues)
@@ -2526,6 +2602,19 @@ export function Inbox() {
                 });
               })()}
             </div>
+            {hasMoreInboxIssues && (
+              <div className="mt-3 flex justify-center">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={loadMoreInboxIssues}
+                  disabled={isLoadingMoreInboxIssues}
+                >
+                  {isLoadingMoreInboxIssues ? "Loading..." : `Load ${INBOX_ISSUE_PAGE_SIZE} more`}
+                </Button>
+              </div>
+            )}
           </div>
         </>
       )}

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -697,6 +697,8 @@ export function Inbox() {
   const shouldLoadMineIssues = isForegrounded && tab === "mine";
   const shouldLoadTouchedIssues = isForegrounded && (tab === "recent" || tab === "unread" || (tab === "all" && showTouchedCategory));
   const shouldLoadHeartbeatRuns = isForegrounded && tab === "all" && showFailedRunsCategory;
+  const issueStatusRequestFilter =
+    issueFilters.statuses.length > 0 ? issueFilters.statuses.join(",") : INBOX_MINE_ISSUE_STATUS_FILTER;
   const issueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(
@@ -804,12 +806,12 @@ export function Inbox() {
     data: mineIssuesRaw = [],
     isLoading: isMineIssuesLoading,
   } = useQuery({
-    queryKey: [...queryKeys.issues.listMineByMe(selectedCompanyId!), "with-routine-executions"],
+    queryKey: [...queryKeys.issues.listMineByMe(selectedCompanyId!), "with-routine-executions", issueStatusRequestFilter],
     queryFn: () =>
       issuesApi.list(selectedCompanyId!, {
         touchedByUserId: "me",
         inboxArchivedByUserId: "me",
-        status: INBOX_MINE_ISSUE_STATUS_FILTER,
+        status: issueStatusRequestFilter,
         includeRoutineExecutions: true,
         limit: INBOX_ISSUE_LIST_LIMIT,
       }),
@@ -819,11 +821,11 @@ export function Inbox() {
     data: touchedIssuesRaw = [],
     isLoading: isTouchedIssuesLoading,
   } = useQuery({
-    queryKey: [...queryKeys.issues.listTouchedByMe(selectedCompanyId!), "with-routine-executions"],
+    queryKey: [...queryKeys.issues.listTouchedByMe(selectedCompanyId!), "with-routine-executions", issueStatusRequestFilter],
     queryFn: () =>
       issuesApi.list(selectedCompanyId!, {
         touchedByUserId: "me",
-        status: INBOX_MINE_ISSUE_STATUS_FILTER,
+        status: issueStatusRequestFilter,
         includeRoutineExecutions: true,
         limit: INBOX_ISSUE_LIST_LIMIT,
       }),

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -94,8 +94,8 @@ import {
   ListTree,
 } from "lucide-react";
 
-const INBOX_HEARTBEAT_RUN_LIMIT = 200;
-const INBOX_ISSUE_LIST_LIMIT = 500;
+const INBOX_HEARTBEAT_RUN_LIMIT = 50;
+const INBOX_ISSUE_LIST_LIMIT = 100;
 import { Input } from "@/components/ui/input";
 import { PageTabBar } from "../components/PageTabBar";
 import type { Approval, HeartbeatRun, Issue, JoinRequest } from "@paperclipai/shared";
@@ -693,10 +693,10 @@ export function Inbox() {
   const showFailedRunsCategory =
     allCategoryFilter === "everything" || allCategoryFilter === "failed_runs";
   const showAlertsCategory = allCategoryFilter === "everything" || allCategoryFilter === "alerts";
-  const shouldLoadIssueLookup = isForegrounded && (tab !== "all" || showFailedRunsCategory);
+  const shouldLoadIssueLookup = isForegrounded && tab === "all" && showFailedRunsCategory;
   const shouldLoadMineIssues = isForegrounded && tab === "mine";
   const shouldLoadTouchedIssues = isForegrounded && (tab === "recent" || tab === "unread" || (tab === "all" && showTouchedCategory));
-  const shouldLoadHeartbeatRuns = isForegrounded && (tab !== "all" || showFailedRunsCategory);
+  const shouldLoadHeartbeatRuns = isForegrounded && tab === "all" && showFailedRunsCategory;
   const issueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -84,8 +84,10 @@ import {
   Inbox as InboxIcon,
   AlertTriangle,
   Check,
+  ChevronDown,
   ChevronRight,
   Layers,
+  LoaderCircle,
   XCircle,
   X,
   RotateCcw,
@@ -2603,16 +2605,24 @@ export function Inbox() {
               })()}
             </div>
             {hasMoreInboxIssues && (
-              <div className="mt-3 flex justify-center">
+              <div className="mt-2 flex items-center gap-3 px-1 text-muted-foreground">
+                <div className="h-px flex-1 bg-border" />
                 <Button
                   type="button"
-                  variant="outline"
-                  size="sm"
+                  variant="ghost"
+                  size="xs"
+                  className="h-7 shrink-0 px-2 text-xs font-medium text-muted-foreground hover:text-foreground"
                   onClick={loadMoreInboxIssues}
                   disabled={isLoadingMoreInboxIssues}
                 >
-                  {isLoadingMoreInboxIssues ? "Loading..." : `Load ${INBOX_ISSUE_PAGE_SIZE} more`}
+                  {isLoadingMoreInboxIssues ? (
+                    <LoaderCircle className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <ChevronDown className="h-3 w-3" />
+                  )}
+                  {isLoadingMoreInboxIssues ? "Loading" : `Load ${INBOX_ISSUE_PAGE_SIZE} more`}
                 </Button>
+                <div className="h-px flex-1 bg-border" />
               </div>
             )}
           </div>

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -17,6 +17,7 @@ import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useGeneralSettings } from "../context/GeneralSettingsContext";
 import { useSidebar } from "../context/SidebarContext";
+import { usePageForegrounded } from "../hooks/usePageForegrounded";
 import { queryKeys } from "../lib/queryKeys";
 import {
   applyIssueFilters,
@@ -653,6 +654,7 @@ export function Inbox() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const { isMobile } = useSidebar();
+  const isForegrounded = usePageForegrounded();
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
@@ -691,10 +693,10 @@ export function Inbox() {
   const showFailedRunsCategory =
     allCategoryFilter === "everything" || allCategoryFilter === "failed_runs";
   const showAlertsCategory = allCategoryFilter === "everything" || allCategoryFilter === "alerts";
-  const shouldLoadIssueLookup = tab !== "all" || showFailedRunsCategory;
-  const shouldLoadMineIssues = tab === "mine";
-  const shouldLoadTouchedIssues = tab === "recent" || tab === "unread" || (tab === "all" && showTouchedCategory);
-  const shouldLoadHeartbeatRuns = tab !== "all" || showFailedRunsCategory;
+  const shouldLoadIssueLookup = isForegrounded && (tab !== "all" || showFailedRunsCategory);
+  const shouldLoadMineIssues = isForegrounded && tab === "mine";
+  const shouldLoadTouchedIssues = isForegrounded && (tab === "recent" || tab === "unread" || (tab === "all" && showTouchedCategory));
+  const shouldLoadHeartbeatRuns = isForegrounded && (tab !== "all" || showFailedRunsCategory);
   const issueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(
@@ -713,18 +715,18 @@ export function Inbox() {
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
     queryFn: () => agentsApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
 
   const { data: projects } = useQuery({
     queryKey: queryKeys.projects.list(selectedCompanyId!),
     queryFn: () => projectsApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
   const { data: labels } = useQuery({
     queryKey: queryKeys.issues.labels(selectedCompanyId!),
     queryFn: () => issuesApi.listLabels(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
   const isolatedWorkspacesEnabled = experimentalSettings?.enableIsolatedWorkspaces === true;
   const { data: executionWorkspaces = [] } = useQuery({
@@ -732,7 +734,7 @@ export function Inbox() {
       ? queryKeys.executionWorkspaces.summaryList(selectedCompanyId)
       : ["execution-workspaces", "__disabled__"],
     queryFn: () => executionWorkspacesApi.listSummaries(selectedCompanyId!),
-    enabled: !!selectedCompanyId && isolatedWorkspacesEnabled,
+    enabled: !!selectedCompanyId && isolatedWorkspacesEnabled && isForegrounded,
   });
 
   useEffect(() => {
@@ -761,7 +763,7 @@ export function Inbox() {
   } = useQuery({
     queryKey: queryKeys.approvals.list(selectedCompanyId!),
     queryFn: () => approvalsApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
 
   const {
@@ -779,14 +781,14 @@ export function Inbox() {
         throw err;
       }
     },
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
     retry: false,
   });
 
   const { data: dashboard, isLoading: isDashboardLoading } = useQuery({
     queryKey: queryKeys.dashboard(selectedCompanyId!),
     queryFn: () => dashboardApi.summary(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
 
   const { data: issues, isLoading: isIssuesLoading } = useQuery({
@@ -837,14 +839,14 @@ export function Inbox() {
   const { data: liveRuns } = useQuery({
     queryKey: queryKeys.liveRuns(selectedCompanyId!),
     queryFn: () => heartbeatsApi.liveRunsForCompany(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
     refetchInterval: 5000,
   });
   const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
   const { data: companyMembers } = useQuery({
     queryKey: queryKeys.access.companyUserDirectory(selectedCompanyId!),
     queryFn: () => accessApi.listUserDirectory(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
   const currentUserId = session?.user.id ?? session?.session.userId ?? null;
 

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -682,6 +682,19 @@ export function Inbox() {
       ? pathSegment
       : "mine";
   const canArchiveFromTab = isMineInboxTab(tab);
+  const showJoinRequestsCategory =
+    allCategoryFilter === "everything" || allCategoryFilter === "join_requests";
+  const showTouchedCategory =
+    allCategoryFilter === "everything" || allCategoryFilter === "issues_i_touched";
+  const showApprovalsCategory =
+    allCategoryFilter === "everything" || allCategoryFilter === "approvals";
+  const showFailedRunsCategory =
+    allCategoryFilter === "everything" || allCategoryFilter === "failed_runs";
+  const showAlertsCategory = allCategoryFilter === "everything" || allCategoryFilter === "alerts";
+  const shouldLoadIssueLookup = tab !== "all" || showFailedRunsCategory;
+  const shouldLoadMineIssues = tab === "mine";
+  const shouldLoadTouchedIssues = tab === "recent" || tab === "unread" || (tab === "all" && showTouchedCategory);
+  const shouldLoadHeartbeatRuns = tab !== "all" || showFailedRunsCategory;
   const issueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(
@@ -783,7 +796,7 @@ export function Inbox() {
         includeRoutineExecutions: true,
         limit: INBOX_ISSUE_LIST_LIMIT,
       }),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && shouldLoadIssueLookup,
   });
   const {
     data: mineIssuesRaw = [],
@@ -798,7 +811,7 @@ export function Inbox() {
         includeRoutineExecutions: true,
         limit: INBOX_ISSUE_LIST_LIMIT,
       }),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && shouldLoadMineIssues,
   });
   const {
     data: touchedIssuesRaw = [],
@@ -812,13 +825,13 @@ export function Inbox() {
         includeRoutineExecutions: true,
         limit: INBOX_ISSUE_LIST_LIMIT,
       }),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && shouldLoadTouchedIssues,
   });
 
   const { data: heartbeatRuns, isLoading: isRunsLoading } = useQuery({
     queryKey: [...queryKeys.heartbeats(selectedCompanyId!), "limit", INBOX_HEARTBEAT_RUN_LIMIT],
     queryFn: () => heartbeatsApi.list(selectedCompanyId!, undefined, INBOX_HEARTBEAT_RUN_LIMIT),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && shouldLoadHeartbeatRuns,
   });
 
   const { data: liveRuns } = useQuery({
@@ -935,9 +948,11 @@ export function Inbox() {
 
   const issueById = useMemo(() => {
     const map = new Map<string, Issue>();
+    for (const issue of mineIssuesRaw) map.set(issue.id, issue);
+    for (const issue of touchedIssuesRaw) map.set(issue.id, issue);
     for (const issue of issues ?? []) map.set(issue.id, issue);
     return map;
-  }, [issues]);
+  }, [issues, mineIssuesRaw, touchedIssuesRaw]);
   const projectById = useMemo(() => {
     const map = new Map<string, { name: string; color: string | null }>();
     for (const project of projects ?? []) {
@@ -1015,15 +1030,6 @@ export function Inbox() {
     }
     return filtered;
   }, [approvals, tab, allApprovalFilter, currentUserId, dismissedAtByKey]);
-  const showJoinRequestsCategory =
-    allCategoryFilter === "everything" || allCategoryFilter === "join_requests";
-  const showTouchedCategory =
-    allCategoryFilter === "everything" || allCategoryFilter === "issues_i_touched";
-  const showApprovalsCategory =
-    allCategoryFilter === "everything" || allCategoryFilter === "approvals";
-  const showFailedRunsCategory =
-    allCategoryFilter === "everything" || allCategoryFilter === "failed_runs";
-  const showAlertsCategory = allCategoryFilter === "everything" || allCategoryFilter === "alerts";
   const failedRunsForTab = useMemo(() => {
     if (tab === "all" && !showFailedRunsCategory) return [];
     return failedRuns;

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -2620,7 +2620,7 @@ export function Inbox() {
                   ) : (
                     <ChevronDown className="h-3 w-3" />
                   )}
-                  {isLoadingMoreInboxIssues ? "Loading" : `Load ${INBOX_ISSUE_PAGE_SIZE} more`}
+                  {isLoadingMoreInboxIssues ? "Loading" : "Load more"}
                 </Button>
                 <div className="h-px flex-1 bg-border" />
               </div>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -59,6 +59,7 @@ import {
   type OptimisticIssueComment,
 } from "../lib/optimistic-issue-comments";
 import { clearIssueExecutionRun, removeLiveRunById, upsertInterruptedRun } from "../lib/optimistic-issue-runs";
+import { usePageForegrounded } from "../hooks/usePageForegrounded";
 import { useProjectOrder } from "../hooks/useProjectOrder";
 import { relativeTime, cn, formatTokens, visibleRunCostUsd } from "../lib/utils";
 import { ApprovalCard } from "../components/ApprovalCard";
@@ -907,19 +908,23 @@ function IssueDetailActivityTab({
   onApprovalAction,
   handoffFocusSignal = 0,
 }: IssueDetailActivityTabProps) {
+  const isForegrounded = usePageForegrounded();
   const { data: activity, isLoading: activityLoading } = useQuery({
     queryKey: queryKeys.issues.activity(issueId),
     queryFn: () => activityApi.forIssue(issueId),
+    enabled: isForegrounded,
     placeholderData: keepPreviousDataForSameQueryTail<ActivityEvent[]>(issueId),
   });
   const { data: linkedRuns, isLoading: linkedRunsLoading } = useQuery({
     queryKey: queryKeys.issues.runs(issueId),
     queryFn: () => activityApi.runsForIssue(issueId),
+    enabled: isForegrounded,
     placeholderData: keepPreviousDataForSameQueryTail<RunForIssue[]>(issueId),
   });
   const { data: linkedApprovals } = useQuery({
     queryKey: queryKeys.issues.approvals(issueId),
     queryFn: () => issuesApi.listApprovals(issueId),
+    enabled: isForegrounded,
     placeholderData: keepPreviousDataForSameQueryTail<Awaited<ReturnType<typeof issuesApi.listApprovals>>>(issueId),
   });
   const { data: continuationHandoff } = useQuery({
@@ -932,6 +937,7 @@ function IssueDetailActivityTab({
         throw error;
       }
     },
+    enabled: isForegrounded,
     retry: false,
     placeholderData: keepPreviousDataForSameQueryTail<Awaited<ReturnType<typeof issuesApi.getDocument>> | null>(
       issueId,
@@ -1107,6 +1113,7 @@ export function IssueDetail() {
   const location = useLocation();
   const { pushToast } = useToastActions();
   const { isMobile } = useSidebar();
+  const isForegrounded = usePageForegrounded();
   const [moreOpen, setMoreOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [mobilePropsOpen, setMobilePropsOpen] = useState(false);
@@ -1149,7 +1156,7 @@ export function IssueDetail() {
         identifier: issueHeaderSeed.identifier,
       } : null,
     }),
-    enabled: !!issueId,
+    enabled: !!issueId && isForegrounded,
   });
   const resolvedCompanyId = issue?.companyId ?? selectedCompanyId;
   const commentComposerDisabledReason = useMemo(() => {
@@ -1174,7 +1181,7 @@ export function IssueDetail() {
         limit: ISSUE_COMMENT_PAGE_SIZE,
         ...(pageParam ? { after: pageParam } : {}),
       }),
-    enabled: !!issueId,
+    enabled: !!issueId && isForegrounded,
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) =>
       getNextIssueCommentPageParam(lastPage, ISSUE_COMMENT_PAGE_SIZE),
@@ -1199,21 +1206,21 @@ export function IssueDetail() {
   const { data: interactions = [] } = useQuery({
     queryKey: queryKeys.issues.interactions(issueId!),
     queryFn: () => issuesApi.listInteractions(issueId!),
-    enabled: !!issueId,
+    enabled: !!issueId && isForegrounded,
     placeholderData: keepPreviousDataForSameQueryTail<IssueThreadInteraction[]>(issueId ?? "pending"),
   });
 
   const { data: attachments, isLoading: attachmentsLoading } = useQuery({
     queryKey: queryKeys.issues.attachments(issueId!),
     queryFn: () => issuesApi.listAttachments(issueId!),
-    enabled: !!issueId,
+    enabled: !!issueId && isForegrounded,
     placeholderData: keepPreviousDataForSameQueryTail<IssueAttachment[]>(issueId ?? "pending"),
   });
 
   const { data: liveRunCount = 0 } = useQuery<LiveRunForIssue[], Error, number>({
     queryKey: queryKeys.issues.liveRuns(issueId!),
     queryFn: () => heartbeatsApi.liveRunsForIssue(issueId!),
-    enabled: !!issueId,
+    enabled: !!issueId && isForegrounded,
     refetchInterval: 3000,
     select: (runs) => runs.length,
     placeholderData: keepPreviousDataForSameQueryTail<LiveRunForIssue[]>(issueId ?? "pending"),
@@ -1222,7 +1229,7 @@ export function IssueDetail() {
   const { data: hasActiveRun = false } = useQuery<ActiveRunForIssue | null, Error, boolean>({
     queryKey: queryKeys.issues.activeRun(issueId!),
     queryFn: () => heartbeatsApi.activeRunForIssue(issueId!),
-    enabled: !!issueId && (!!issue?.executionRunId || issue?.status === "in_progress"),
+    enabled: !!issueId && isForegrounded && (!!issue?.executionRunId || issue?.status === "in_progress"),
     refetchInterval: liveRunCount > 0 ? false : 3000,
     select: (run) => !!run,
     placeholderData: keepPreviousDataForSameQueryTail<ActiveRunForIssue | null>(issueId ?? "pending"),
@@ -1245,13 +1252,13 @@ export function IssueDetail() {
         ? queryKeys.issues.listByDescendantRoot(resolvedCompanyId, issue.id)
         : ["issues", "parent", "pending"],
     queryFn: () => issuesApi.list(resolvedCompanyId!, { descendantOf: issue!.id, includeBlockedBy: true }),
-    enabled: !!resolvedCompanyId && !!issue?.id,
+    enabled: !!resolvedCompanyId && !!issue?.id && isForegrounded,
     placeholderData: keepPreviousDataForSameQueryTail<Issue[]>(issue?.id ?? "pending"),
   });
   const { data: companyLiveRuns } = useQuery({
     queryKey: resolvedCompanyId ? queryKeys.liveRuns(resolvedCompanyId) : ["live-runs", "pending"],
     queryFn: () => heartbeatsApi.liveRunsForCompany(resolvedCompanyId!),
-    enabled: !!resolvedCompanyId,
+    enabled: !!resolvedCompanyId && isForegrounded,
     refetchInterval: 5000,
     placeholderData: keepPreviousDataForSameQueryTail<LiveRunForIssue[]>(resolvedCompanyId ?? "pending"),
   });
@@ -1259,12 +1266,12 @@ export function IssueDetail() {
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
     queryFn: () => agentsApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
   const { data: companyMembers } = useQuery({
     queryKey: queryKeys.access.companyUserDirectory(selectedCompanyId!),
     queryFn: () => accessApi.listUserDirectory(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
 
   const { data: session } = useQuery({
@@ -1275,13 +1282,13 @@ export function IssueDetail() {
   const { data: projects } = useQuery({
     queryKey: queryKeys.projects.list(selectedCompanyId!),
     queryFn: () => projectsApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && isForegrounded,
   });
   const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
   const { data: boardAccess } = useQuery({
     queryKey: queryKeys.access.currentBoardAccess,
     queryFn: () => accessApi.getCurrentBoardAccess(),
-    enabled: !!session?.user?.id,
+    enabled: !!session?.user?.id && isForegrounded,
     retry: false,
   });
   const canManageTreeControl = Boolean(
@@ -1291,12 +1298,12 @@ export function IssueDetail() {
   const { data: feedbackVotes } = useQuery({
     queryKey: queryKeys.issues.feedbackVotes(issueId!),
     queryFn: () => issuesApi.listFeedbackVotes(issueId!),
-    enabled: !!issueId && !!currentUserId,
+    enabled: !!issueId && !!currentUserId && isForegrounded,
   });
   const { data: instanceGeneralSettings } = useQuery({
     queryKey: queryKeys.instance.generalSettings,
     queryFn: () => instanceSettingsApi.getGeneral(),
-    enabled: !!issueId,
+    enabled: !!issueId && isForegrounded,
     retry: false,
   });
   const keyboardShortcutsEnabled = instanceGeneralSettings?.keyboardShortcuts === true;
@@ -1310,7 +1317,7 @@ export function IssueDetail() {
     slotTypes: ["detailTab"],
     entityType: "issue",
     companyId: resolvedCompanyId,
-    enabled: !!resolvedCompanyId,
+    enabled: !!resolvedCompanyId && isForegrounded,
   });
   const issuePluginTabItems = useMemo(
     () => issuePluginDetailSlots.map((slot) => ({
@@ -1340,14 +1347,14 @@ export function IssueDetail() {
           strategy: "manual",
         },
       }),
-    enabled: treeControlOpen && !!issueId && canManageTreeControl,
+    enabled: treeControlOpen && !!issueId && canManageTreeControl && isForegrounded,
     staleTime: 0,
     retry: false,
   });
   const { data: treeControlState } = useQuery({
     queryKey: ["issues", "tree-control-state", issueId ?? "pending"],
     queryFn: () => issuesApi.getTreeControlState(issueId!),
-    enabled: !!issueId && canManageTreeControl,
+    enabled: !!issueId && canManageTreeControl && isForegrounded,
     retry: false,
   });
   const { data: activeRootPauseHolds = [] } = useQuery({
@@ -1358,7 +1365,7 @@ export function IssueDetail() {
         mode: "pause",
         includeMembers: true,
       }),
-    enabled: !!issueId && treeControlState?.activePauseHold?.isRoot === true,
+    enabled: !!issueId && treeControlState?.activePauseHold?.isRoot === true && isForegrounded,
   });
   const { data: activeCancelHolds = [] } = useQuery({
     queryKey: ["issues", "tree-holds", issueId ?? "pending", "active-cancel"],
@@ -1367,7 +1374,7 @@ export function IssueDetail() {
         status: "active",
         mode: "cancel",
       }),
-    enabled: !!issueId && canManageTreeControl,
+    enabled: !!issueId && canManageTreeControl && isForegrounded,
   });
 
   const agentMap = useMemo(() => {

--- a/ui/storybook/fixtures/paperclipData.ts
+++ b/ui/storybook/fixtures/paperclipData.ts
@@ -1236,6 +1236,8 @@ export const storybookSidebarBadges: SidebarBadges = {
   approvals: 2,
   failedRuns: 1,
   joinRequests: 1,
+  mineIssues: 3,
+  alerts: 1,
 };
 
 export const storybookDashboardSummary: DashboardSummary = {


### PR DESCRIPTION
## Summary
- throttle activity-driven query invalidations to coalesce live update bursts
- use a longer throttle for expensive issue-list invalidations
- make the global sidebar inbox badge use the lightweight sidebar badge endpoint instead of fetching the full touched-issues list
- compute unread touched issue count server-side for the sidebar badge

## Verification
- docker compose build for the server image completed successfully locally
- recreated local server container and verified the rebuilt UI uses sidebarBadgesApi instead of issuesApi in useInboxBadge
