### PR TITLE
fix(adapter-codex-local): treat terminal turn as authoritative and clean up process tail

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -142,6 +142,128 @@ describe("codex remote execution", () => {
     }));
   });
 
+  it("marks the run as failed when Codex emits turn.failed even with exitCode=0", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-local-turn-failed-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const codexHomeDir = path.join(rootDir, "codex-home");
+    await mkdir(workspaceDir, { recursive: true });
+    await mkdir(codexHomeDir, { recursive: true });
+    await writeFile(path.join(codexHomeDir, "auth.json"), "{}", "utf8");
+
+    runChildProcess.mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        JSON.stringify({ type: "thread.started", thread_id: "thread_123" }),
+        JSON.stringify({ type: "turn.failed", error: { message: "thread not found" } }),
+      ].join("\n"),
+      stderr: "",
+      pid: 321,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await execute({
+      runId: "run-turn-failed",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+        env: {
+          CODEX_HOME: codexHomeDir,
+        },
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(result.errorMessage).toBe("thread not found");
+    expect(result.resultJson).toEqual(expect.objectContaining({
+      turnStatus: "failed",
+    }));
+  });
+
+  it("passes terminal-result cleanup options to process execution", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-terminal-cleanup-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const codexHomeDir = path.join(rootDir, "codex-home");
+    await mkdir(workspaceDir, { recursive: true });
+    await mkdir(codexHomeDir, { recursive: true });
+    await writeFile(path.join(codexHomeDir, "auth.json"), "{}", "utf8");
+
+    runChildProcess.mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } }),
+      stderr: "",
+      pid: 322,
+      startedAt: new Date().toISOString(),
+    });
+
+    await execute({
+      runId: "run-terminal-cleanup",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+        terminalResultCleanupGraceMs: 1234,
+        env: {
+          CODEX_HOME: codexHomeDir,
+        },
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async () => {},
+    });
+
+    const call = runChildProcess.mock.calls[0] as unknown as
+      | [string, string, string[], { terminalResultCleanup?: { graceMs: number; hasTerminalResult: (output: { stdout: string; stderr: string }) => boolean } }]
+      | undefined;
+    expect(call?.[3].terminalResultCleanup?.graceMs).toBe(1234);
+    expect(call?.[3].terminalResultCleanup?.hasTerminalResult({
+      stdout: JSON.stringify({ type: "turn.failed", error: { message: "resume failed" } }),
+      stderr: "",
+    })).toBe(true);
+    expect(call?.[3].terminalResultCleanup?.hasTerminalResult({
+      stdout: JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "Working" } }),
+      stderr: "",
+    })).toBe(false);
+  });
+
   it("does not resume saved Codex sessions for remote SSH execution without a matching remote identity", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-remote-resume-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -35,6 +35,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseCodexJsonl,
+  hasCodexTerminalTurn,
   extractCodexRetryNotBefore,
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
@@ -616,6 +617,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     sessionHandoffChars: sessionHandoffNote.length,
     heartbeatPromptChars: renderedPrompt.length,
   };
+  const terminalResultCleanupGraceMs = Math.max(0, asNumber(config.terminalResultCleanupGraceMs, 5_000));
 
   const runAttempt = async (resumeSessionId: string | null) => {
     const execArgs = buildCodexExecArgs(
@@ -659,6 +661,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         const cleaned = stripCodexRolloutNoise(chunk);
         if (!cleaned.trim()) return;
         await onLog(stream, cleaned);
+      },
+      terminalResultCleanup: {
+        graceMs: terminalResultCleanupGraceMs,
+        hasTerminalResult: ({ stdout }) => hasCodexTerminalTurn(stdout),
       },
     });
     const cleanedStderr = stripCodexRolloutNoise(proc.stderr);
@@ -706,13 +712,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       } as Record<string, unknown>)
       : null;
     const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
+    const turnStatus = attempt.parsed.turnStatus;
+    const terminalTurnFailed = turnStatus === "failed";
+    const processFailed = (attempt.proc.exitCode ?? 0) !== 0;
     const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
     const fallbackErrorMessage =
       parsedError ||
       stderrLine ||
       `Codex exited with code ${attempt.proc.exitCode ?? -1}`;
     const transientRetryNotBefore =
-      (attempt.proc.exitCode ?? 0) !== 0
+      processFailed
         ? extractCodexRetryNotBefore({
             stdout: attempt.proc.stdout,
             stderr: attempt.proc.stderr,
@@ -720,21 +729,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           })
         : null;
     const transientUpstream =
-      (attempt.proc.exitCode ?? 0) !== 0 &&
+      processFailed &&
       isCodexTransientUpstreamError({
         stdout: attempt.proc.stdout,
         stderr: attempt.proc.stderr,
         errorMessage: fallbackErrorMessage,
       });
+    const resolvedErrorMessage = (processFailed || terminalTurnFailed)
+      ? fallbackErrorMessage
+      : null;
 
     return {
       exitCode: attempt.proc.exitCode,
       signal: attempt.proc.signal,
       timedOut: false,
-      errorMessage:
-        (attempt.proc.exitCode ?? 0) === 0
-          ? null
-          : fallbackErrorMessage,
+      errorMessage: resolvedErrorMessage,
       errorCode:
         transientUpstream
           ? "codex_transient_upstream"
@@ -753,6 +762,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       resultJson: {
         stdout: attempt.proc.stdout,
         stderr: attempt.proc.stderr,
+        ...(turnStatus ? { turnStatus } : {}),
         ...(transientUpstream ? { errorFamily: "transient_upstream" } : {}),
         ...(transientRetryNotBefore ? { retryNotBefore: transientRetryNotBefore.toISOString() } : {}),
         ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
@@ -767,7 +777,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (
       sessionId &&
       !initial.proc.timedOut &&
-      (initial.proc.exitCode ?? 0) !== 0 &&
+      ((initial.proc.exitCode ?? 0) !== 0 || initial.parsed.turnStatus === "failed") &&
       isCodexUnknownSessionError(initial.proc.stdout, initial.rawStderr)
     ) {
       await onLog(

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   extractCodexRetryNotBefore,
+  hasCodexTerminalTurn,
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
   parseCodexJsonl,
@@ -30,6 +31,7 @@ describe("parseCodexJsonl", () => {
         outputTokens: 4,
       },
       errorMessage: "resume failed",
+      turnStatus: "failed",
     });
   });
 
@@ -63,7 +65,34 @@ describe("parseCodexJsonl", () => {
         outputTokens: 4,
       },
       errorMessage: null,
+      turnStatus: "completed",
     });
+  });
+});
+
+describe("hasCodexTerminalTurn", () => {
+  it("returns true when stdout includes turn.completed or turn.failed events", () => {
+    const completedStdout = [
+      JSON.stringify({ type: "thread.started", thread_id: "thread_123" }),
+      JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } }),
+    ].join("\n");
+
+    const failedStdout = [
+      JSON.stringify({ type: "thread.started", thread_id: "thread_123" }),
+      JSON.stringify({ type: "turn.failed", error: { message: "upstream error" } }),
+    ].join("\n");
+
+    expect(hasCodexTerminalTurn(completedStdout)).toBe(true);
+    expect(hasCodexTerminalTurn(failedStdout)).toBe(true);
+  });
+
+  it("returns false when stdout has no terminal turn event", () => {
+    const stdout = [
+      JSON.stringify({ type: "thread.started", thread_id: "thread_123" }),
+      JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "Still working" } }),
+    ].join("\n");
+
+    expect(hasCodexTerminalTurn(stdout)).toBe(false);
   });
 });
 

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -11,10 +11,13 @@ const CODEX_REMOTE_COMPACTION_RE = /remote\s+compact\s+task/i;
 const CODEX_USAGE_LIMIT_RE =
   /you(?:'|’)ve hit your usage limit for .+\.\s+switch to another model now,\s+or try again at\s+([^.!\n]+)(?:[.!]|\n|$)/i;
 
+export type CodexTurnStatus = "completed" | "failed";
+
 export function parseCodexJsonl(stdout: string) {
   let sessionId: string | null = null;
   let finalMessage: string | null = null;
   let errorMessage: string | null = null;
+  let turnStatus: CodexTurnStatus | null = null;
   const usage = {
     inputTokens: 0,
     cachedInputTokens: 0,
@@ -54,6 +57,7 @@ export function parseCodexJsonl(stdout: string) {
       usage.inputTokens = asNumber(usageObj.input_tokens, usage.inputTokens);
       usage.cachedInputTokens = asNumber(usageObj.cached_input_tokens, usage.cachedInputTokens);
       usage.outputTokens = asNumber(usageObj.output_tokens, usage.outputTokens);
+      turnStatus = "completed";
       continue;
     }
 
@@ -61,6 +65,7 @@ export function parseCodexJsonl(stdout: string) {
       const err = parseObject(event.error);
       const msg = asString(err.message, "").trim();
       if (msg) errorMessage = msg;
+      turnStatus = "failed";
     }
   }
 
@@ -69,7 +74,23 @@ export function parseCodexJsonl(stdout: string) {
     summary: finalMessage?.trim() ?? "",
     usage,
     errorMessage,
+    turnStatus,
   };
+}
+
+export function hasCodexTerminalTurn(stdout: string): boolean {
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const event = parseJson(line);
+    if (!event) continue;
+
+    const type = asString(event.type, "");
+    if (type === "turn.completed" || type === "turn.failed") return true;
+  }
+
+  return false;
 }
 
 export function isCodexUnknownSessionError(stdout: string, stderr: string): boolean {


### PR DESCRIPTION
## Summary
- treat terminal `turn.completed` as authoritative so adapter run finalization does not depend on stale active-run state
- clean up process tail handling in execute flow to avoid orphaned run behavior after terminal turns
- add/adjust parse + execute tests covering terminal-turn finalization and cleanup behavior

## Scope
- packages/adapters/codex-local/src/server/parse.ts
- packages/adapters/codex-local/src/server/execute.ts
- packages/adapters/codex-local/src/server/parse.test.ts
- packages/adapters/codex-local/src/server/execute.remote.test.ts

## Validation
- patch previously validated in local task flow (BMM-339)
- CI status for this PR will be tracked in issue evidence comment