### PR TITLE
Allow same-company agents to post issue comments (ANKA-364)

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -358,7 +358,6 @@ describe("agent issue mutation checkout ownership", () => {
   it.each([
     ["patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked" })],
     ["delete", (app: express.Express) => request(app).delete(`/api/issues/${issueId}`)],
-    ["comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "blocked" })],
     [
       "document upsert",
       (app: express.Express) =>
@@ -439,7 +438,6 @@ describe("agent issue mutation checkout ownership", () => {
 
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
-    ["todo", "comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo noise" })],
     ["blocked", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked update" })],
   ])("rejects peer agent %s issue %s mutations outside active checkout ownership", async (status, _kind, sendRequest) => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: status as "todo" | "blocked", assigneeAgentId: ownerAgentId }));
@@ -451,6 +449,82 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  // ANKA-364: comments are append-only evidence and must be writable by any same-company agent,
+  // even when the issue is assigned to (and checked out by) someone else. The AGENTS.md
+  // mention-wake protocol depends on this channel for stranded triage notes. Mutating endpoints
+  // (PATCH, checkout) keep their assignee-only guards — they are covered by the rejection cases
+  // above and the dedicated checkout test below.
+  describe("non-assignee comment posting (ANKA-364)", () => {
+    it.each([
+      ["in_progress", "the issue is checked out by the owner"],
+      ["in_review", "a reviewer holds the issue"],
+      ["todo", "the issue is queued for the assignee"],
+      ["blocked", "the issue is waiting on a blocker"],
+      ["done", "the issue is closed"],
+    ])(
+      "allows a same-company peer to POST a comment when status is %s (%s)",
+      async (status) => {
+        mockIssueService.getById.mockResolvedValue(
+          makeIssue({ status, assigneeAgentId: ownerAgentId }),
+        );
+
+        const res = await request(await createApp(peerActor()))
+          .post(`/api/issues/${issueId}/comments`)
+          .send({ body: "evidence from mention-wake" });
+
+        expect(res.status, JSON.stringify(res.body)).toBe(201);
+        expect(mockIssueService.addComment).toHaveBeenCalledWith(
+          issueId,
+          "evidence from mention-wake",
+          expect.objectContaining({ agentId: peerAgentId }),
+        );
+        expect(mockIssueService.update).not.toHaveBeenCalled();
+        expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+      },
+    );
+
+    it("still rejects peer PATCH on the same in_review issue", async () => {
+      mockIssueService.getById.mockResolvedValue(
+        makeIssue({ status: "in_review", assigneeAgentId: ownerAgentId }),
+      );
+
+      const res = await request(await createApp(peerActor()))
+        .patch(`/api/issues/${issueId}`)
+        .send({ title: "should be blocked" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+      expect(mockIssueService.update).not.toHaveBeenCalled();
+    });
+
+    it("still rejects peer POST /checkout on the same in_review issue", async () => {
+      mockIssueService.getById.mockResolvedValue(
+        makeIssue({ status: "in_review", assigneeAgentId: ownerAgentId }),
+      );
+
+      const res = await request(await createApp(peerActor()))
+        .post(`/api/issues/${issueId}/checkout`)
+        .send({
+          agentId: ownerAgentId,
+          expectedStatuses: ["in_review"],
+        });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Agent can only checkout as itself");
+    });
+
+    it("rejects cross-company agent comments via assertCompanyAccess", async () => {
+      const res = await request(
+        await createApp(peerActor({ companyId: "99999999-9999-4999-8999-999999999999" })),
+      )
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: "wrong tenant" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    });
   });
 
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -480,7 +480,10 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
-  it("rejects non-assignee agent POST comments on closed issues", async () => {
+  // ANKA-364: non-assignee agents may post comments (append-only evidence) but must NOT
+  // implicitly reopen a closed issue. Implicit reopen is restricted to human board comments
+  // by shouldImplicitlyMoveCommentedIssueToTodo; agent comments stay communicative.
+  it("accepts non-assignee agent POST comments on closed issues without reopening", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.addComment.mockResolvedValue({
       id: "comment-1",
@@ -503,10 +506,13 @@ describe.sequential("issue comment reopen routes", () => {
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "hello" });
 
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "hello",
+      expect.objectContaining({ agentId: "33333333-3333-4333-8333-333333333333" }),
+    );
     expect(mockIssueService.update).not.toHaveBeenCalled();
-    expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
@@ -875,7 +881,10 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "restart someone else's work", resume: true });
 
     expect(res.status).toBe(403);
-    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    // ANKA-364 dropped the generic mutation guard from POST /comments, so non-assignee resume
+    // intent is now caught one layer down by assertExplicitResumeIntentAllowed, whose message
+    // more accurately describes the action that was rejected.
+    expect(res.body.error).toBe("Agent cannot request follow-up for another agent's issue");
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3353,7 +3353,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    // Comments are append-only evidence and explicitly do not mutate status, ownership, or fields,
+    // so any same-company agent may post even if the issue is assigned to someone else. The
+    // AGENTS.md mention-wake protocol depends on this channel for stranded triage notes.
+    // Reopen / resume / interrupt intents are still gated by assertExplicitResumeIntentAllowed and
+    // the board-only interrupt branch below; implicit reopen is restricted to board users in
+    // shouldImplicitlyMoveCommentedIssueToTodo.
     const closedExecutionWorkspace = await getClosedIssueExecutionWorkspace(issue);
     if (closedExecutionWorkspace) {
       respondClosedIssueExecutionWorkspace(res, closedExecutionWorkspace);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies through a control plane that routes work between assignee and non-assignee agents.
> - The agents subsystem documents a "mention-wake" protocol in `AGENTS.md`: when an agent is woken on an issue assigned to someone else, it must post one comment with its evidence and an escalation tag so the work isn't stranded.
> - The control plane currently rejects that comment with `403 Agent cannot mutate another agent's issue` (`POST /api/issues/:id/comments`), which directly contradicts the documented protocol.
> - I hit this concretely while running an Ankit company on this control plane: QAEngineer was mention-woken on a `CodeReviewer`-assigned issue, had clean local-test evidence to post, and the control plane silently strangled the handoff.
> - This pull request loosens the auth check on the comment route so any same-company agent can post a comment, even if the issue is assigned elsewhere — the runtime now matches the documented behaviour.
> - The benefit is that AGENTS.md mention-wake handoffs actually land instead of stranding evidence; reviewers stop being forced to manually relay comments on stranded agents' behalf.

## What Changed

- `server/src/routes/issues.ts`: drop the `assertAgentIssueMutationAllowed` call from the `POST /api/issues/:id/comments` handler only. Replaced with a comment block explaining why comments are exempt. `assertCompanyAccess` stays in place so cross-company writes still 403, and every other mutating call site (PATCH issue, `/checkout`, interactions, follow-up, dependency edits, attachments, documents, work products) keeps its assignee guard.
- Reopen / resume / interrupt intent is unchanged: explicit `resume:true` / `reopen:true` from a non-assignee agent is still rejected by `assertExplicitResumeIntentAllowed` ("Agent cannot request follow-up for another agent's issue"), and implicit reopen via `shouldImplicitlyMoveCommentedIssueToTodo` was already restricted to human board comments.
- Activity log attribution via `actor.agentId` is preserved (the `comment.author_agent_id` and `issue.comment_added` activity event already use the actual caller).
- `server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`: removed the `comment` rows from the in_progress 409 and todo 403 parameter lists (those expectations no longer apply); added a new `non-assignee comment posting (ANKA-364)` block that asserts:
  - same-company peer can POST a comment when status is `in_progress`, `in_review`, `todo`, `blocked`, `done` -> 201, no reopen, no checkout assertion;
  - same-company peer PATCH on the same `in_review` issue still 403;
  - same-company peer POST `/checkout` still 403 ("Agent can only checkout as itself");
  - cross-company peer POST `/comments` still 403 (assertCompanyAccess).
- `server/src/__tests__/issue-comment-reopen-routes.test.ts`: replaced the "rejects non-assignee agent POST comments on closed issues" case with one that asserts the non-assignee comment now succeeds (201) without triggering a reopen or wakeup. Updated the "rejects explicit agent resume intent from a non-assignee" case to expect the more accurate "Agent cannot request follow-up for another agent's issue" error string that is now surfaced when `resume:true` is sent.

## Verification

- `pnpm --filter @paperclipai/server typecheck` -> green.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-agent-mutation-ownership-routes.test.ts src/__tests__/issue-comment-reopen-routes.test.ts src/__tests__/issue-comment-cancel-routes.test.ts src/__tests__/issue-closed-workspace-routes.test.ts` -> 4 files, 55 tests, all passing.
- Manual acceptance scenario (to be replayed after deploy): non-assignee agent `POST /api/issues/{id}/comments` against an issue another agent holds in `in_review` returns 201 and lands the comment with the caller's `agentId` attribution; PATCH and `/checkout` against the same issue still return 403/409.

## Risks

- Low risk. The change is one branch removal in a single handler; every other guard call site is untouched, including the four tested rejection paths (PATCH, /checkout, interactions, follow-up). The behavioural shift is explicitly bounded to comments, which were already append-only and do not mutate issue state. No migrations, no schema changes, no external-API surface change beyond the new permitted 201s.

## Notes

This change was authorised as a scoped exception by the board running this control plane in the Ankit company (Paperclip task ANKA-364). I'm not a member of the `paperclipai` org, so this PR comes from a personal fork; happy to take review feedback the usual way.