### PR TITLE
test: add regression for git_worktree branchTemplate variable resolution (BRA-129)

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -634,6 +634,76 @@ describe("realizeExecutionWorkspace", () => {
     expect(path.basename(realized.cwd)).toBe("PAP-992.hotfix-april-1");
   });
 
+  it("creates unique per-issue worktrees using the {{issue.identifier}} template variable (regression: BRA-129)", async () => {
+    // BRA-129: branchTemplate used {{issueIdentifier}} which does not exist in the render
+    // context — the correct dotted-path form is {{issue.identifier}}. The wrong name silently
+    // rendered to the static prefix only ("fix"), causing all issues to collide on the same path.
+    const repoRoot = await createTempRepo();
+
+    const first = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "fix-{{issue.identifier}}",
+        },
+      },
+      issue: {
+        id: "bra-129",
+        identifier: "BRA-129",
+        title: "First issue",
+      },
+      agent: {
+        id: "agent-builder",
+        name: "Paperclip-Builder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(first.branchName).toBe("fix-BRA-129");
+    expect(path.basename(first.cwd)).toBe("fix-BRA-129");
+    await expect(fs.stat(path.join(first.cwd, ".git"))).resolves.toBeTruthy();
+
+    await execFileAsync("git", ["worktree", "remove", "--force", first.cwd], { cwd: repoRoot });
+
+    const second = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "fix-{{issue.identifier}}",
+        },
+      },
+      issue: {
+        id: "bra-130",
+        identifier: "BRA-130",
+        title: "Second issue",
+      },
+      agent: {
+        id: "agent-builder",
+        name: "Paperclip-Builder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(second.branchName).toBe("fix-BRA-130");
+    expect(second.cwd).not.toBe(first.cwd);
+  });
+
   it("runs a configured provision command inside the derived worktree", async () => {
     const repoRoot = await createTempRepo();
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });


### PR DESCRIPTION
## Thinking Path

Investigated [BRA-129](/BRA/issues/BRA-129): every Paperclip-Builder worktree materialization collapsed to the same path (`paperclip-worktrees/fix`) regardless of issue.

Traced `realizeExecutionWorkspace` in `server/src/services/workspace-runtime.ts` (lines 988–1015):

1. `branchTemplate` is rendered by `renderWorkspaceTemplate` (line 362), which calls `renderTemplate` from `adapter-utils/server-utils.ts`.
2. `renderTemplate` resolves `{{foo.bar}}` via `resolvePathValue` — dotted-path traversal of the data object.
3. The data object exposes `issue.identifier`, **not** a flat `issueIdentifier` key.
4. With the config `branchTemplate: "fix/{{issueIdentifier}}"`, the variable can never resolve → rendered string is `"fix/"`.
5. `sanitizeBranchName("fix/")` strips the trailing slash → `"fix"`.
6. All issues land on `worktreeParentDir/fix` — the same collision path.

The runtime code is correct; the bug was purely the agent config using the wrong template variable name.

## What Changed

- **Agent config** (via Paperclip API, not in-tree): updated `branchTemplate` from `fix/{{issueIdentifier}}` to `fix-{{issue.identifier}}`. Slash-free form chosen to avoid worktree nesting — the `fix` directory would remain as BRA-N's worktree while BRA-(N+1) runs, creating a nested-worktree situation with the slashed form.
- **`server/src/__tests__/workspace-runtime.test.ts`**: added regression test documenting that `{{issue.identifier}}` (dotted-path) is the correct template variable, and that two sequential issues each get a distinct `fix-BRA-XXX` worktree path.

## Verification

Manual trace of the corrected template for BRA-129:
```
branchTemplate = "fix-{{issue.identifier}}"
renderedBranch = "fix-BRA-129"          # {{issue.identifier}} → data.issue.identifier ✓
branchName     = "fix-BRA-129"          # sanitizeBranchName: no change needed
worktreePath   = .../paperclip-worktrees/fix-BRA-129   # unique per issue ✓
```

The existing test at line 603 (`"preserves intentional slashes and dots from the branch template"`) already validates the runtime handles dotted template variables and slash-containing branch names correctly. The new test additionally verifies two sequential issues produce distinct, non-colliding worktree paths.

## Risks

Low. Test-only change against an already-correct runtime code path. The agent config fix is live (updated via API before this PR).

## Model Used

claude-sonnet-4-6

## Checklist

- [x] Root cause identified with file/line citations
- [x] No speculative guessing — all code paths read and traced
- [x] Regression test added
- [x] Agent config fix applied and verified via API before PR
- [x] No unrelated changes bundled