### PR TITLE
fix(server): improve issue search query planning

### DIFF
--- a/packages/db/src/issue-activity-search-sort-index-migration.test.ts
+++ b/packages/db/src/issue-activity-search-sort-index-migration.test.ts
@@ -1,0 +1,61 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import postgres from "postgres";
+import { applyPendingMigrations, inspectMigrations } from "./client.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./test-embedded-postgres.js";
+
+const MIGRATION_FILE = "0226_issue_activity_search_sort_idx.sql";
+const INDEX_NAME = "activity_log_issue_entity_sort_idx";
+const cleanups: Array<() => Promise<void>> = [];
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function migrationHash(): Promise<string> {
+  const content = await fs.promises.readFile(new URL(`./migrations/${MIGRATION_FILE}`, import.meta.url), "utf8");
+  return createHash("sha256").update(content).digest("hex");
+}
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue activity search index migration tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue activity search sort index migration", () => {
+  afterEach(async () => Promise.all(cleanups.splice(0).map((cleanup) => cleanup())));
+
+  async function createMigratedDatabase() {
+    const database = await startEmbeddedPostgresTestDatabase("paperclip-issue-activity-search-index-");
+    cleanups.push(database.cleanup);
+    const sql = postgres(database.connectionString, { max: 1, onnotice: () => {} });
+    cleanups.push(async () => sql.end());
+    return { database, sql };
+  }
+
+  async function makeMigrationPending(sql: ReturnType<typeof postgres>): Promise<void> {
+    await sql`DELETE FROM "drizzle"."__drizzle_migrations" WHERE "hash" = ${await migrationHash()}`;
+  }
+
+  it("replays when the exact index definition already exists", async () => {
+    const { database, sql } = await createMigratedDatabase();
+    await makeMigrationPending(sql);
+
+    await expect(applyPendingMigrations(database.connectionString)).resolves.toBeUndefined();
+    await expect(inspectMigrations(database.connectionString)).resolves.toMatchObject({ status: "upToDate" });
+  }, 30_000);
+
+  it("rejects a divergent index that reuses the migration index name", async () => {
+    const { database, sql } = await createMigratedDatabase();
+    await sql.unsafe(`DROP INDEX "${INDEX_NAME}"`);
+    await sql.unsafe(`CREATE INDEX "${INDEX_NAME}" ON "activity_log" ("company_id")`);
+    await makeMigrationPending(sql);
+
+    await expect(applyPendingMigrations(database.connectionString)).rejects.toThrow(
+      "activity_log_issue_entity_sort_idx exists with an incompatible definition",
+    );
+  }, 30_000);
+});

--- a/packages/db/src/migrations/0075_issue_activity_search_sort_idx.sql
+++ b/packages/db/src/migrations/0075_issue_activity_search_sort_idx.sql
@@ -1,0 +1,3 @@
+CREATE INDEX "activity_log_issue_entity_sort_idx" ON "activity_log" USING btree ("entity_id","company_id","created_at" DESC)
+WHERE "entity_type" = 'issue'
+  AND "action" NOT IN ('issue.read_marked', 'issue.read_unmarked', 'issue.inbox_archived', 'issue.inbox_unarchived');

--- a/packages/db/src/migrations/0226_issue_activity_search_sort_idx.sql
+++ b/packages/db/src/migrations/0226_issue_activity_search_sort_idx.sql
@@ -1,0 +1,30 @@
+-- A copied worktree can retain this index after its migration journal entry is lost.
+-- Replay only the exact expected index so migration history repair cannot hide schema drift.
+-- paperclip:migration-safety-ignore large-create-index-not-concurrently: this block only compares pg_get_indexdef text; it does not create an index.
+DO $$
+DECLARE
+  expected_definition constant text := 'CREATE INDEX activity_log_issue_entity_sort_idx ON public.activity_log USING btree (entity_id, company_id, created_at DESC) WHERE ((entity_type = ''issue''::text) AND (action <> ALL (ARRAY[''issue.read_marked''::text, ''issue.read_unmarked''::text, ''issue.inbox_archived''::text, ''issue.inbox_unarchived''::text])))';
+  existing_definition text;
+  existing_is_valid boolean;
+BEGIN
+  IF to_regclass('public.activity_log_issue_entity_sort_idx') IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT pg_get_indexdef(index_meta.indexrelid), index_meta.indisvalid AND index_meta.indisready
+  INTO existing_definition, existing_is_valid
+  FROM pg_index AS index_meta
+  WHERE index_meta.indexrelid = to_regclass('public.activity_log_issue_entity_sort_idx');
+
+  IF existing_definition IS NULL OR NOT COALESCE(existing_is_valid, false)
+    OR existing_definition <> expected_definition THEN
+    RAISE EXCEPTION
+      'activity_log_issue_entity_sort_idx exists with an incompatible definition: %',
+      COALESCE(existing_definition, '<not an index>');
+  END IF;
+END $$;
+--> statement-breakpoint
+-- paperclip:migration-safety-ignore large-create-index-not-concurrently: embedded migrations run transactionally, so CONCURRENTLY is not usable here and the partial predicate limits the index to issue activity rows needed for issue search ordering.
+CREATE INDEX IF NOT EXISTS "activity_log_issue_entity_sort_idx" ON "activity_log" USING btree ("entity_id","company_id","created_at" DESC)
+WHERE "entity_type" = 'issue'
+  AND "action" NOT IN ('issue.read_marked', 'issue.read_unmarked', 'issue.inbox_archived', 'issue.inbox_unarchived');

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1777384535070,
       "tag": "0074_striped_genesis",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1777553168000,
+      "tag": "0075_issue_activity_search_sort_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1569,6 +1569,13 @@
       "when": 1787101144413,
       "tag": "0225_drop_claude_setup_token_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 226,
+      "version": "7",
+      "when": 1787120060000,
+      "tag": "0226_issue_activity_search_sort_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/activity_log.ts
+++ b/packages/db/src/schema/activity_log.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { pgTable, uuid, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
@@ -33,5 +34,11 @@ export const activityLog = pgTable(
     ),
     runIdIdx: index("activity_log_run_id_idx").on(table.runId),
     entityIdx: index("activity_log_entity_type_id_idx").on(table.entityType, table.entityId),
+    issueEntitySortIdx: index("activity_log_issue_entity_sort_idx")
+      .on(table.entityId, table.companyId, table.createdAt.desc())
+      .where(
+        sql`${table.entityType} = 'issue'
+          and ${table.action} not in ('issue.read_marked', 'issue.read_unmarked', 'issue.inbox_archived', 'issue.inbox_unarchived')`,
+      ),
   }),
 );

--- a/packages/db/src/schema/activity_log.ts
+++ b/packages/db/src/schema/activity_log.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { pgTable, uuid, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
@@ -22,5 +23,11 @@ export const activityLog = pgTable(
     companyCreatedIdx: index("activity_log_company_created_idx").on(table.companyId, table.createdAt),
     runIdIdx: index("activity_log_run_id_idx").on(table.runId),
     entityIdx: index("activity_log_entity_type_id_idx").on(table.entityType, table.entityId),
+    issueEntitySortIdx: index("activity_log_issue_entity_sort_idx")
+      .on(table.entityId, table.companyId, table.createdAt.desc())
+      .where(
+        sql`${table.entityType} = 'issue'
+          and ${table.action} not in ('issue.read_marked', 'issue.read_unmarked', 'issue.inbox_archived', 'issue.inbox_unarchived')`,
+      ),
   }),
 );

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -313,7 +313,9 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
   it("treats escaped wildcard characters as literals in issue search", async () => {
     const companyId = randomUUID();
     const percentMatchId = randomUUID();
-    const wildcardOnlyId = randomUUID();
+    const percentWildcardOnlyId = randomUUID();
+    const underscoreMatchId = randomUUID();
+    const underscoreWildcardOnlyId = randomUUID();
 
     await db.insert(companies).values({
       id: companyId,
@@ -331,20 +333,40 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
         priority: "medium",
       },
       {
-        id: wildcardOnlyId,
+        id: percentWildcardOnlyId,
         companyId,
         title: "CPU reached 100x during search",
         status: "todo",
         priority: "medium",
       },
+      {
+        id: underscoreMatchId,
+        companyId,
+        title: "CPU reached 200_ during search",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: underscoreWildcardOnlyId,
+        companyId,
+        title: "CPU reached 200x during search",
+        status: "todo",
+        priority: "medium",
+      },
     ]);
 
-    const result = await svc.list(companyId, {
+    const percentResult = await svc.list(companyId, {
       q: "100%",
       limit: 2,
     });
 
-    expect(result.map((issue) => issue.id)).toEqual([percentMatchId]);
+    const underscoreResult = await svc.list(companyId, {
+      q: "200_",
+      limit: 2,
+    });
+
+    expect(percentResult.map((issue) => issue.id)).toEqual([percentMatchId]);
+    expect(underscoreResult.map((issue) => issue.id)).toEqual([underscoreMatchId]);
   });
 
   it("ranks comment matches ahead of description-only matches", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -310,6 +310,43 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(result.map((issue) => issue.id)).toEqual([titleMatchId, descriptionMatchId]);
   });
 
+  it("treats escaped wildcard characters as literals in issue search", async () => {
+    const companyId = randomUUID();
+    const percentMatchId = randomUUID();
+    const wildcardOnlyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values([
+      {
+        id: percentMatchId,
+        companyId,
+        title: "CPU reached 100% during search",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: wildcardOnlyId,
+        companyId,
+        title: "CPU reached 100x during search",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    const result = await svc.list(companyId, {
+      q: "100%",
+      limit: 2,
+    });
+
+    expect(result.map((issue) => issue.id)).toEqual([percentMatchId]);
+  });
+
   it("ranks comment matches ahead of description-only matches", async () => {
     const companyId = randomUUID();
     const commentMatchId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1224,6 +1224,65 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(result.map((issue) => issue.id)).toEqual([titleMatchId, descriptionMatchId]);
   });
 
+  it("treats escaped wildcard characters as literals in issue search", async () => {
+    const companyId = randomUUID();
+    const percentMatchId = randomUUID();
+    const percentWildcardOnlyId = randomUUID();
+    const underscoreMatchId = randomUUID();
+    const underscoreWildcardOnlyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values([
+      {
+        id: percentMatchId,
+        companyId,
+        title: "CPU reached 100% during search",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: percentWildcardOnlyId,
+        companyId,
+        title: "CPU reached 100x during search",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: underscoreMatchId,
+        companyId,
+        title: "CPU reached 200_ during search",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: underscoreWildcardOnlyId,
+        companyId,
+        title: "CPU reached 200x during search",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    const percentResult = await svc.list(companyId, {
+      q: "100%",
+      limit: 2,
+    });
+
+    const underscoreResult = await svc.list(companyId, {
+      q: "200_",
+      limit: 2,
+    });
+
+    expect(percentResult.map((issue) => issue.id)).toEqual([percentMatchId]);
+    expect(underscoreResult.map((issue) => issue.id)).toEqual([underscoreMatchId]);
+  });
+
   it("filters issues by whether they have a plan document", async () => {
     const companyId = randomUUID();
     const withPlanId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { and, asc, desc, eq, gt, inArray, isNull, lt, ne, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, ilike, inArray, isNull, lt, ne, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -2111,18 +2111,18 @@ export function issueService(db: Db) {
       const escapedSearch = hasSearch ? escapeLikePattern(rawSearch) : "";
       const startsWithPattern = `${escapedSearch}%`;
       const containsPattern = `%${escapedSearch}%`;
-      const titleStartsWithMatch = sql<boolean>`${issues.title} ILIKE ${startsWithPattern} ESCAPE '\\'`;
-      const titleContainsMatch = sql<boolean>`${issues.title} ILIKE ${containsPattern} ESCAPE '\\'`;
-      const identifierStartsWithMatch = sql<boolean>`${issues.identifier} ILIKE ${startsWithPattern} ESCAPE '\\'`;
-      const identifierContainsMatch = sql<boolean>`${issues.identifier} ILIKE ${containsPattern} ESCAPE '\\'`;
-      const descriptionContainsMatch = sql<boolean>`${issues.description} ILIKE ${containsPattern} ESCAPE '\\'`;
+      const titleStartsWithMatch = ilike(issues.title, startsWithPattern);
+      const titleContainsMatch = ilike(issues.title, containsPattern);
+      const identifierStartsWithMatch = ilike(issues.identifier, startsWithPattern);
+      const identifierContainsMatch = ilike(issues.identifier, containsPattern);
+      const descriptionContainsMatch = ilike(issues.description, containsPattern);
       const commentContainsMatch = sql<boolean>`
         EXISTS (
           SELECT 1
           FROM ${issueComments}
           WHERE ${issueComments.issueId} = ${issues.id}
             AND ${issueComments.companyId} = ${companyId}
-            AND ${issueComments.body} ILIKE ${containsPattern} ESCAPE '\\'
+            AND ${ilike(issueComments.body, containsPattern)}
         )
       `;
       if (filters?.descendantOf) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import { createHash, randomUUID } from "node:crypto";
-import { and, asc, desc, eq, gt, gte, inArray, isNull, like, lt, ne, notInArray, or, sql, type SQL } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, ilike, inArray, isNull, like, lt, ne, notInArray, or, sql, type SQL } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -5485,11 +5485,11 @@ export function issueService(db: Db) {
       const escapedSearch = hasSearch ? escapeLikePattern(rawSearch) : "";
       const startsWithPattern = `${escapedSearch}%`;
       const containsPattern = `%${escapedSearch}%`;
-      const titleStartsWithMatch = sql<boolean>`${issues.title} ILIKE ${startsWithPattern} ESCAPE '\\'`;
-      const titleContainsMatch = sql<boolean>`${issues.title} ILIKE ${containsPattern} ESCAPE '\\'`;
-      const identifierStartsWithMatch = sql<boolean>`${issues.identifier} ILIKE ${startsWithPattern} ESCAPE '\\'`;
-      const identifierContainsMatch = sql<boolean>`${issues.identifier} ILIKE ${containsPattern} ESCAPE '\\'`;
-      const descriptionContainsMatch = sql<boolean>`${issues.description} ILIKE ${containsPattern} ESCAPE '\\'`;
+      const titleStartsWithMatch = ilike(issues.title, startsWithPattern);
+      const titleContainsMatch = ilike(issues.title, containsPattern);
+      const identifierStartsWithMatch = ilike(issues.identifier, startsWithPattern);
+      const identifierContainsMatch = ilike(issues.identifier, containsPattern);
+      const descriptionContainsMatch = ilike(issues.description, containsPattern);
       const commentContainsMatch = sql<boolean>`
         EXISTS (
           SELECT 1
@@ -5497,7 +5497,7 @@ export function issueService(db: Db) {
           WHERE ${issueComments.issueId} = ${issues.id}
             AND ${issueComments.companyId} = ${companyId}
             AND ${issueComments.deletedAt} IS NULL
-            AND ${issueComments.body} ILIKE ${containsPattern} ESCAPE '\\'
+            AND ${ilike(issueComments.body, containsPattern)}
         )
       `;
       if (filters?.descendantOf) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The issue list/search API is a primary board interaction for finding current work.
> - Issue list ordering depends on canonical activity, which includes `activity_log` lookups per issue.
> - Current search used raw `ILIKE ... ESCAPE` expressions and the activity lookup lacked a partial sort index for issue activity.
> - That can make search slower on instances with moderate activity history despite existing trigram indexes.
> - This pull request keeps search semantics the same while making predicates and indexes friendlier to PostgreSQL planning.
> - The benefit is faster, more predictable issue search/list ordering without changing the API shape.

## Linked Issues or Issue Description

Fixes #4778.

Duplicate/related PR search completed before opening: searched for `activity_log_issue_entity_sort_idx`, `canonicalLastActivityAt`, `trigram`, and `random_page_cost`; no direct open PR duplicate was found.

## What Changed

- Adds `activity_log_issue_entity_sort_idx`, a partial covering index for issue activity ordering.
- Adds the matching Drizzle schema index plus migration metadata.
- Uses Drizzle `ilike()` for issue title, identifier, description, and comment search predicates instead of raw `ILIKE ... ESCAPE` SQL.
- Adds regression coverage that `%` and `_` in issue search remain literal wildcard characters after the predicate change.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @paperclipai/db run check:migrations`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run server/src/__tests__/issues-service.test.ts`
- `pnpm --filter @paperclipai/db exec vitest run src/client.test.ts`
- `pnpm typecheck`
- `git diff --check`

Earlier pre-rebase verification also included `pnpm test`.

## Risks

- Index migrations can take time on very large `activity_log` tables, but this does not change stored data.
- Search semantics are intended to stay unchanged; literal wildcard behavior is covered by the new test.
- PostgreSQL planner improvements are workload-dependent, so the exact performance impact depends on table size and statistics.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex based on GPT-5, via Codex desktop on April 30 and June 14, 2026, with repository inspection, code editing, local test execution, rebase/conflict resolution, and GitHub CLI workflow. Exact model ID/context window were not surfaced by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: server/database only)
- [x] I have updated relevant documentation to reflect my changes (N/A: no public API or operator docs changed)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5\/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge