### PR TITLE
fix(adapters): preserve external adapter capabilities during registration

### DIFF
--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -517,6 +517,44 @@ describe("resolveExternalAdapterRegistration", () => {
 
     const resolved = resolveExternalAdapterRegistration(adapter);
 
+    expect(resolved).toBe(adapter);
     expect(resolved.sessionManagement).toBeUndefined();
+  });
+
+  it("preserves prototype adapter capabilities when adding fallback sessionManagement", () => {
+    class ExternalClaudeAdapter implements ServerAdapterModule {
+      type = "claude_local";
+
+      async execute() {
+        return { exitCode: 0, signal: null, timedOut: false };
+      }
+
+      async testEnvironment() {
+        return {
+          adapterType: "claude_local",
+          status: "pass" as const,
+          checks: [],
+          testedAt: new Date(0).toISOString(),
+        };
+      }
+
+      getConfigSchema() {
+        return {
+          version: 1,
+          fields: [{ key: "url", type: "text" as const, label: "URL" }],
+        };
+      }
+    }
+
+    const adapter = new ExternalClaudeAdapter();
+    const resolved = resolveExternalAdapterRegistration(adapter);
+
+    expect(resolved).not.toBe(adapter);
+    expect(resolved).toBeInstanceOf(ExternalClaudeAdapter);
+    expect(resolved.sessionManagement).toBeDefined();
+    expect(typeof resolved.getConfigSchema).toBe("function");
+    expect(resolved.getConfigSchema?.()).toMatchObject({
+      fields: [{ key: "url" }],
+    });
   });
 });

--- a/server/src/__tests__/adapter-routes.test.ts
+++ b/server/src/__tests__/adapter-routes.test.ts
@@ -278,4 +278,45 @@ describe("adapter routes", () => {
 
     unregisterServerAdapter(HOT_INSTALL_TYPE);
   });
+
+  it("preserves prototype getConfigSchema when reloading an external builtin override", async () => {
+    class PrototypeSchemaAdapter implements ServerAdapterModule {
+      type = "claude_local";
+
+      async execute() {
+        return { exitCode: 0, signal: null, timedOut: false };
+      }
+
+      async testEnvironment() {
+        return {
+          adapterType: "claude_local",
+          status: "pass" as const,
+          checks: [],
+          testedAt: new Date(0).toISOString(),
+        };
+      }
+
+      getConfigSchema() {
+        return {
+          version: 1,
+          fields: [{ key: "url", type: "text" as const, label: "URL" }],
+        };
+      }
+    }
+
+    mockAdapterPluginStore.getAdapterPluginByType.mockReturnValue({
+      packageName: "prototype-schema-adapter",
+      type: "claude_local",
+      installedAt: new Date(0).toISOString(),
+    });
+    mockPluginLoader.reloadExternalAdapter.mockResolvedValue(new PrototypeSchemaAdapter());
+
+    const app = createApp({ isInstanceAdmin: true });
+    const reload = await request(app).post("/api/adapters/claude_local/reload");
+    expect(reload.status, JSON.stringify(reload.body)).toBe(200);
+
+    const schema = await request(app).get("/api/adapters/claude_local/config-schema");
+    expect(schema.status, JSON.stringify(schema.body)).toBe(200);
+    expect(schema.body).toMatchObject({ fields: [{ key: "url" }] });
+  });
 });

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -386,13 +386,30 @@ function getDisabledAdapterTypesFromStore(): string[] {
 export function resolveExternalAdapterRegistration(
   externalAdapter: ServerAdapterModule,
 ): ServerAdapterModule {
-  return {
-    ...externalAdapter,
-    sessionManagement:
-      externalAdapter.sessionManagement
-        ?? getAdapterSessionManagement(externalAdapter.type)
-        ?? undefined,
+  const registrySessionManagement =
+    getAdapterSessionManagement(externalAdapter.type) ?? undefined;
+  const resolvedSessionManagement =
+    externalAdapter.sessionManagement ?? registrySessionManagement;
+
+  // Preserve the adapter object's full shape while applying the host-provided
+  // session-management fallback. A plain object spread drops prototype methods
+  // and non-enumerable properties, which can make externally supplied adapter
+  // capabilities (for example getConfigSchema()) disappear from the registry.
+  if (resolvedSessionManagement === externalAdapter.sessionManagement) {
+    return externalAdapter;
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(externalAdapter);
+  descriptors.sessionManagement = {
+    value: resolvedSessionManagement,
+    enumerable: true,
+    configurable: true,
+    writable: true,
   };
+
+  const resolved = Object.create(Object.getPrototypeOf(externalAdapter)) as ServerAdapterModule;
+  Object.defineProperties(resolved, descriptors);
+  return resolved;
 }
 
 /**

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -874,7 +874,13 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             </Field>
           )}
 
-          {/* Adapter-specific fields are rendered inside Permissions & Configuration */}
+          {/*
+            Local adapters render their adapter-specific fields in the
+            Permissions & Configuration section below. Non-local external
+            adapters, such as OpenClaw Bridge, do not get that section, so
+            render their schema-backed fields here instead.
+          */}
+          {!isLocal && <uiAdapter.ConfigFields {...adapterFieldProps} />}
         </div>
 
       </div>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Agent adapters are the bridge between Paperclip's control plane and external runtimes/packages.
> - External adapters can provide optional capabilities such as `getConfigSchema()` so the API/UI can render adapter-specific configuration fields.
> - Paperclip's external-adapter registry also applies host-side `sessionManagement` fallbacks for some adapter types.
> - That fallback path used a plain object spread, which preserves enumerable own properties but drops prototype methods and non-enumerable properties.
> - As a result, an externally loaded adapter could look installed and active while methods such as `getConfigSchema()` disappeared before `GET /api/adapters/:type/config-schema` inspected it.
> - This pull request preserves the external adapter object's full shape while still applying the session-management fallback.
> - The benefit is that external adapter capabilities survive registration/reload consistently, so adapter authors do not have to work around Paperclip's registry clone behavior.

## What Changed

- Updated `resolveExternalAdapterRegistration()` so fallback `sessionManagement` is applied without object-spreading the adapter.
- Preserved adapter prototypes and property descriptors via `Object.create(Object.getPrototypeOf(adapter))` plus `Object.getOwnPropertyDescriptors(adapter)` when a fallback value must be applied.
- Kept the original adapter object unchanged when no fallback is needed.
- Normalized `getAdapterSessionManagement(type)` from `null` to `undefined` before assigning it to `ServerAdapterModule.sessionManagement`.
- Added registry coverage for a prototype-based external adapter with `getConfigSchema()`.
- Added route-level coverage for reloading an external builtin override and then resolving its config schema.
- Render schema-backed config fields for non-local external adapters in the Adapter section, because those adapters do not show the local-only Permissions & Configuration section.

## Verification

- `NODE_ENV=development COREPACK_HOME=/tmp/corepack-home pnpm exec vitest run server/src/__tests__/adapter-registry.test.ts server/src/__tests__/adapter-routes.test.ts ui/src/components/NewIssueDialog.test.tsx`
  - 3 files passed
  - 29 tests passed
- `NODE_ENV=development COREPACK_HOME=/tmp/corepack-home pnpm --filter @paperclipai/server typecheck`
  - passed
- `NODE_ENV=development COREPACK_HOME=/tmp/corepack-home pnpm --filter @paperclipai/ui typecheck`
  - passed
- Live patched deploy validation on `paperclip.cap.gregagi.com`
  - schema endpoint returns OpenClaw Bridge fields
  - Rasul confirmed the fields are visible in the New Agent UI after the frontend render patch
- GitHub Actions after the latest push are green:
  - `verify`: passed
  - `e2e`: passed
  - `policy`: passed
  - `security/snyk`: passed

## Risks

- Low risk. Plain-object adapters keep the same behavior.
- The server behavior change is limited to preserving additional external adapter capabilities that were previously lost when a fallback `sessionManagement` value was applied.
- The UI behavior change is limited to rendering schema-backed fields for non-local external adapters that otherwise have no configuration section. Local adapters continue rendering their config fields in the existing Permissions & Configuration section.
- No database migration or runtime configuration change is required.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Provider/model: OpenAI Codex via OpenClaw
- Exact model ID: `openai-codex/gpt-5.5`
- Reasoning mode: medium hidden reasoning in OpenClaw
- Capabilities used: repository inspection, file editing, shell execution, GitHub CLI/API, local test/typecheck execution
- Human direction: Rasul requested the upstream issue and implementation PR; Forge/OpenClaw produced the code change and PR updates.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (validated on live patched deploy; screenshot unavailable from this runtime)
- [x] I have updated relevant documentation to reflect my changes (not applicable; no docs/user-facing behavior changed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #4851.
