### PR TITLE
Fix PR 4859 CI timer cleanup

### DIFF
--- a/ui/src/components/IssueChatThread.test.tsx
+++ b/ui/src/components/IssueChatThread.test.tsx
@@ -539,6 +539,52 @@ describe("IssueChatThread", () => {
     });
   });
 
+  it("clears latest-row settle timers when unmounted", () => {
+    vi.useFakeTimers();
+    const root = createRoot(container);
+    const scrollToMock = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    const clearTimeoutMock = vi.spyOn(window, "clearTimeout");
+
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <IssueChatThread
+            comments={issueChatLongThreadComments}
+            linkedRuns={issueChatLongThreadLinkedRuns}
+            timelineEvents={issueChatLongThreadEvents}
+            liveRuns={[]}
+            agentMap={issueChatLongThreadAgentMap}
+            currentUserId="user-board"
+            onAdd={async () => {}}
+            enableLiveTranscriptPolling={false}
+            transcriptsByRunId={issueChatLongThreadTranscriptsByRunId}
+            hasOutputForRun={(runId) => issueChatLongThreadTranscriptsByRunId.has(runId)}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    const jump = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Jump to latest",
+    ) as HTMLButtonElement | undefined;
+    expect(jump).toBeDefined();
+
+    act(() => {
+      jump?.click();
+    });
+
+    clearTimeoutMock.mockClear();
+
+    act(() => {
+      root.unmount();
+    });
+
+    expect(clearTimeoutMock).toHaveBeenCalledTimes(3);
+
+    clearTimeoutMock.mockRestore();
+    scrollToMock.mockRestore();
+  });
+
   // Regression for PAP-2660: on the real issue page the chat thread is wrapped
   // in `<main id="main-content" overflow-auto>`, so the virtualizer must bind
   // to that ancestor's scroll instead of `window` (which never moves on

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -3101,6 +3101,11 @@ export function IssueChatThread({
   const lastUserMessageIdRef = useRef<string | null>(null);
   const spacerBaselineAnchorRef = useRef<string | null>(null);
   const spacerInitialReserveRef = useRef(0);
+  const latestSettleTimeoutsRef = useRef<number[]>([]);
+  const clearLatestSettleTimeouts = useCallback(() => {
+    latestSettleTimeoutsRef.current.forEach((timeout) => window.clearTimeout(timeout));
+    latestSettleTimeoutsRef.current = [];
+  }, []);
   const [bottomSpacerHeight, setBottomSpacerHeight] = useState(0);
   const displayLiveRuns = useMemo(() => {
     const deduped = new Map<string, LiveRunForIssue>();
@@ -3317,6 +3322,10 @@ export function IssueChatThread({
   }, [messages]);
 
   useEffect(() => {
+    return clearLatestSettleTimeouts;
+  }, [clearLatestSettleTimeouts]);
+
+  useEffect(() => {
     const hash = location.hash || (typeof window !== "undefined" ? window.location.hash : "");
     if (
       !(
@@ -3383,9 +3392,11 @@ export function IssueChatThread({
 
     if (typeof window === "undefined") return;
 
+    clearLatestSettleTimeouts();
     const settleDelays = [380, 760, 1140];
-    settleDelays.forEach((delay) => {
+    latestSettleTimeoutsRef.current = settleDelays.map((delay) => (
       window.setTimeout(() => {
+        if (typeof document === "undefined") return;
         const el = document.getElementById(latestCommentAnchor);
         if (el) {
           el.scrollIntoView({ behavior: "smooth", block: "end" });
@@ -3398,8 +3409,8 @@ export function IssueChatThread({
           align: "end",
           behavior: "auto",
         });
-      }, delay);
-    });
+      }, delay)
+    ));
   }
 
   function handleJumpToLatest() {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The board UI issue thread virtualizes long comment timelines and uses delayed settle passes for Jump to latest.
> - PR #4859 CI is failing because one of those delayed callbacks survives test teardown and touches `document` after jsdom is gone.
> - The scroll settle timers need to be lifecycle-owned by the component, just like other async UI work.
> - This pull request records the latest-row settle timer IDs and clears them before rescheduling and on unmount.
> - The benefit is stable CI without changing the visible Jump to latest behavior.

## What Changed

- Track latest-row settle timeout IDs in `IssueChatThread`.
- Clear previous settle timers before scheduling a new batch.
- Clear outstanding settle timers during component unmount.
- Add a regression test proving unmount clears the three scheduled settle timers.

## Verification

- `pnpm exec vitest run ui/src/components/IssueChatThread.test.tsx -t "clears latest-row settle timers when unmounted"`
- `pnpm exec vitest run ui/src/components/IssueChatThread.test.tsx`
- `pnpm --filter @paperclipai/ui typecheck`

## Risks

- Low risk. The change only cancels pending delayed scroll settle passes when they are stale or the component is gone. The immediate scroll behavior remains unchanged.

## Model Used

- OpenAI Codex, GPT-5 coding agent, tool-using session with terminal and GitHub CLI access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: lifecycle-only fix, no visual UI change)
- [x] I have updated relevant documentation to reflect my changes (N/A: no user-facing behavior or workflow change)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge