### PR TITLE
fix(FIG-43): assertValidGoal before transaction

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1716,6 +1716,16 @@ export function issueService(db: Db) {
     }
   }
 
+  async function assertValidGoal(companyId: string, goalId: string) {
+    const goal = await db
+      .select({ id: goals.id, companyId: goals.companyId })
+      .from(goals)
+      .where(eq(goals.id, goalId))
+      .then((rows) => rows[0] ?? null);
+    if (!goal) throw notFound("Goal not found");
+    if (goal.companyId !== companyId) throw unprocessable("Goal must belong to same company");
+  }
+
   async function assertValidProjectWorkspace(
     companyId: string,
     projectId: string | null | undefined,
@@ -2674,6 +2684,9 @@ export function issueService(db: Db) {
       }
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
+      }
+      if (data.goalId) {
+        await assertValidGoal(companyId, data.goalId);
       }
       return db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);


### PR DESCRIPTION
## Summary

When a caller supplies a \`goalId\` that does not exist in the local goals table (e.g. created on a different Paperclip instance or via a different auth path), the INSERT inside \`db.transaction()\` fails at the Postgres FK level. In the incident (FIG-43 / FIG-39 ghost identifier on 2026-04-29) the \`issue_counter\` UPDATE that preceded the INSERT was not cleanly rolled back, causing the counter to drift by +1 and produce a ghost issue number.

## Changes

- **\`server/src/services/issues.ts\`**: Add \`assertValidGoal(companyId, goalId)\` — same pattern as the existing \`assertAssignableAgent()\` — and call it before entering \`db.transaction()\` when \`data.goalId\` is set.
  - Returns \`404 Goal not found\` instead of letting the FK violation reach the DB.
  - Also validates company boundary (\`Goal must belong to same company\`).
  - The counter is never touched on invalid input, so no drift can occur.

The self-correcting counter (\`greatest(counter, max) + 1\`) already handles any previously-drifted counters gracefully; no counter logic is changed.

## Test plan

- [ ] Create a goal via the API, capture \`goalId\`
- [ ] Create an issue with that \`goalId\` → issue created with correct \`goalId\`, no FK error
- [ ] Pass a non-existent \`goalId\` → \`404 Goal not found\` (not a 500 FK error)
- [ ] Pass a \`goalId\` belonging to a different company → \`422 Goal must belong to same company\`
- [ ] \`pnpm --filter @paperclipai/server typecheck\` passes (verified locally)

Fixes: FIG-43

🤖 Generated with [Claude Code](https://claude.com/claude-code)