### PR TITLE
feat: per-cwd workspace mutex for heartbeat runs (RUN-21)

### DIFF
--- a/packages/db/src/migrations/0075_workspace_locks.sql
+++ b/packages/db/src/migrations/0075_workspace_locks.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS "workspace_locks" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "company_id" uuid NOT NULL,
+  "cwd_path" text NOT NULL,
+  "run_id" uuid NOT NULL,
+  "agent_id" uuid NOT NULL,
+  "issue_id" uuid,
+  "acquired_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "workspace_locks" ADD CONSTRAINT "workspace_locks_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "workspace_locks" ADD CONSTRAINT "workspace_locks_run_id_heartbeat_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."heartbeat_runs"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "workspace_locks" ADD CONSTRAINT "workspace_locks_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "workspace_locks" ADD CONSTRAINT "workspace_locks_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "workspace_locks_cwd_path_uq" ON "workspace_locks" USING btree ("cwd_path");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "workspace_locks_run_id_uq" ON "workspace_locks" USING btree ("run_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workspace_locks_expires_at_idx" ON "workspace_locks" USING btree ("expires_at");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1777384535070,
       "tag": "0074_striped_genesis",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1777396800000,
+      "tag": "0075_workspace_locks",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -24,6 +24,7 @@ export { projectWorkspaces } from "./project_workspaces.js";
 export { executionWorkspaces } from "./execution_workspaces.js";
 export { environments } from "./environments.js";
 export { environmentLeases } from "./environment_leases.js";
+export { workspaceLocks } from "./workspace_locks.js";
 export { workspaceOperations } from "./workspace_operations.js";
 export { workspaceRuntimeServices } from "./workspace_runtime_services.js";
 export { projectGoals } from "./project_goals.js";

--- a/packages/db/src/schema/workspace_locks.ts
+++ b/packages/db/src/schema/workspace_locks.ts
@@ -1,0 +1,26 @@
+import { pgTable, uuid, text, timestamp, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { agents } from "./agents.js";
+import { heartbeatRuns } from "./heartbeat_runs.js";
+import { issues } from "./issues.js";
+
+export const workspaceLocks = pgTable(
+  "workspace_locks",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id),
+    cwdPath: text("cwd_path").notNull(),
+    runId: uuid("run_id").notNull().references(() => heartbeatRuns.id, { onDelete: "cascade" }),
+    agentId: uuid("agent_id").notNull().references(() => agents.id),
+    issueId: uuid("issue_id").references(() => issues.id, { onDelete: "set null" }),
+    acquiredAt: timestamp("acquired_at", { withTimezone: true }).notNull().defaultNow(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    cwdPathUq: uniqueIndex("workspace_locks_cwd_path_uq").on(table.cwdPath),
+    runIdUq: uniqueIndex("workspace_locks_run_id_uq").on(table.runId),
+    expiresAtIdx: index("workspace_locks_expires_at_idx").on(table.expiresAt),
+  }),
+);

--- a/server/src/__tests__/heartbeat-workspace-mutex.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-mutex.test.ts
@@ -1,0 +1,338 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { and, asc, eq, sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+  projectWorkspaces,
+  projects,
+  workspaceLocks,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { runningProcesses } from "../adapters/index.ts";
+
+// Controllable mock adapter: each call resolves only when test code calls `releaseAdapter()`.
+// This lets us hold a heartbeat run in `running` state long enough to deterministically
+// race a second heartbeat against the same workspace cwd.
+type Deferred = { promise: Promise<void>; resolve: () => void };
+function defer(): Deferred {
+  let resolveFn!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    resolveFn = resolve;
+  });
+  return { promise, resolve: resolveFn };
+}
+
+const adapterDeferreds: Deferred[] = [];
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "workspace mutex test run",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat workspace-mutex tests: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function waitFor<T>(fn: () => Promise<T | null | false | undefined>, timeoutMs = 5_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await fn();
+    if (result) return result as T;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  const last = await fn();
+  if (!last) throw new Error("waitFor timed out");
+  return last as T;
+}
+
+describeEmbeddedPostgres("heartbeat per-cwd workspace mutex (RUN-21)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let sharedCwd!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-workspace-mutex-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+    sharedCwd = await mkdtemp(path.join(os.tmpdir(), "paperclip-workspace-mutex-"));
+  }, 30_000);
+
+  afterAll(async () => {
+    runningProcesses.clear();
+    await tempDb?.cleanup();
+    if (sharedCwd) {
+      await rm(sharedCwd, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("serializes two heartbeats targeting the same project workspace cwd", async () => {
+    // Each adapter execution gets its own deferred; tests resolve them in order to control timing.
+    adapterDeferreds.length = 0;
+    mockAdapterExecute.mockImplementation(async () => {
+      const slot = defer();
+      adapterDeferreds.push(slot);
+      await slot.promise;
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "workspace mutex test run",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Mutex Co",
+      slug: `mutex-${companyId.slice(0, 8)}`,
+    });
+
+    const projectId = randomUUID();
+    await db.insert(projects).values({ id: projectId, companyId, name: "Shared Site" });
+
+    const projectWorkspaceId = randomUUID();
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Shared Workspace",
+      sourceType: "local_path",
+      cwd: sharedCwd,
+      isPrimary: true,
+    });
+
+    const agentA = randomUUID();
+    const agentB = randomUUID();
+    await db.insert(agents).values([
+      {
+        id: agentA,
+        companyId,
+        name: "AgentA",
+        role: "engineer",
+        status: "active",
+        adapterType: "noop",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+        permissions: {},
+      },
+      {
+        id: agentB,
+        companyId,
+        name: "AgentB",
+        role: "engineer",
+        status: "active",
+        adapterType: "noop",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+        permissions: {},
+      },
+    ]);
+
+    const issueA = randomUUID();
+    const issueB = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: issueA,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        title: "Issue A",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: agentA,
+      },
+      {
+        id: issueB,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        title: "Issue B",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: agentB,
+      },
+    ]);
+
+    // Wake AgentA first; it'll claim the workspace lock and block on the deferred adapter.
+    const wakeA = await heartbeat.wakeup(agentA, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: issueA, projectId, projectWorkspaceId },
+      contextSnapshot: {
+        issueId: issueA,
+        projectId,
+        projectWorkspaceId,
+        wakeReason: "issue_assigned",
+      },
+    });
+    expect(wakeA).not.toBeNull();
+
+    // Wait until AgentA's adapter has been entered (proves the lock is held).
+    await waitFor(async () => adapterDeferreds.length >= 1);
+    expect(await db.select({ n: sql<number>`count(*)::int` }).from(workspaceLocks).then((r) => r[0]?.n))
+      .toBe(1);
+
+    // Wake AgentB on the SAME cwd; it must defer.
+    const wakeB = await heartbeat.wakeup(agentB, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: issueB, projectId, projectWorkspaceId },
+      contextSnapshot: {
+        issueId: issueB,
+        projectId,
+        projectWorkspaceId,
+        wakeReason: "issue_assigned",
+      },
+    });
+    expect(wakeB).not.toBeNull();
+
+    // The adapter for AgentB should NEVER have been entered.
+    const failedRunB = await waitFor(async () => {
+      const row = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, wakeB!.id))
+        .then((rows) => rows[0] ?? null);
+      return row && row.status === "failed" ? row : null;
+    });
+    expect(failedRunB.errorCode).toBe("workspace_busy");
+    expect(failedRunB.error).toContain("is held by run");
+
+    // A deferred wake row should be present for AgentB's cwd.
+    const deferredWake = await waitFor(async () => {
+      const row = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.status, "deferred_workspace_lock"),
+            sql`${agentWakeupRequests.payload} ->> 'cwdPath' = ${sharedCwd}`,
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      return row;
+    });
+    expect(deferredWake.agentId).toBe(agentB);
+    expect(adapterDeferreds.length).toBe(1);
+
+    // Release AgentA's run; the workspace lock should drop and the deferred wake should be promoted.
+    adapterDeferreds[0].resolve();
+
+    // AgentA's run should reach `succeeded`.
+    await waitFor(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, wakeA!.id))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded" ? run : null;
+    });
+
+    // The lock row should be gone.
+    await waitFor(async () => {
+      const n = await db.select({ n: sql<number>`count(*)::int` }).from(workspaceLocks).then((r) => r[0]?.n);
+      return n === 0 ? true : null;
+    });
+
+    // The deferred wake should have been promoted (status no longer `deferred_workspace_lock`)
+    // and a fresh wakeupRequest with reason `workspace_lock_released` should have been created.
+    await waitFor(async () => {
+      const promoted = await db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, deferredWake.id))
+        .then((rows) => rows[0]?.status ?? null);
+      return promoted === "promoted" ? true : null;
+    });
+
+    const followUpWake = await waitFor(async () => {
+      const row = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.agentId, agentB),
+            eq(agentWakeupRequests.reason, "workspace_lock_released"),
+          ),
+        )
+        .orderBy(asc(agentWakeupRequests.requestedAt))
+        .then((rows) => rows[0] ?? null);
+      return row;
+    });
+    expect(followUpWake.payload).toMatchObject({
+      cwdPath: sharedCwd,
+      releasedByRunId: wakeA!.id,
+      issueId: issueB,
+    });
+
+    // The promoted wake schedules AgentB's next run; release its adapter and verify it succeeds.
+    await waitFor(async () => adapterDeferreds.length >= 2);
+    adapterDeferreds[1].resolve();
+
+    const followUpRun = await waitFor(async () => {
+      const row = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, companyId),
+            eq(heartbeatRuns.agentId, agentB),
+            sql`${heartbeatRuns.id} <> ${wakeB!.id}`,
+          ),
+        )
+        .orderBy(asc(heartbeatRuns.createdAt))
+        .then((rows) => rows[rows.length - 1] ?? null);
+      return row && row.status === "succeeded" ? row : null;
+    });
+    expect(followUpRun.status).toBe("succeeded");
+
+    // No leftover locks at the end.
+    expect(await db.select({ n: sql<number>`count(*)::int` }).from(workspaceLocks).then((r) => r[0]?.n))
+      .toBe(0);
+
+    // No per-test row cleanup — afterAll() drops the embedded postgres instance.
+  }, 30_000);
+});

--- a/server/src/__tests__/workspace-lock.test.ts
+++ b/server/src/__tests__/workspace-lock.test.ts
@@ -1,0 +1,274 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { agents, companies, createDb, heartbeatRuns, workspaceLocks } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  acquireWorkspaceLock,
+  countActiveWorkspaceLocks,
+  getWorkspaceLockHolder,
+  normalizeWorkspaceCwd,
+  releaseWorkspaceLock,
+  sweepStaleWorkspaceLockForCwd,
+} from "../services/workspace-lock.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres workspace-lock tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("workspace-lock service (RUN-21)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId!: string;
+  let agentId!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-workspace-lock-");
+    db = createDb(tempDb.connectionString);
+
+    companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "WS Lock Co",
+      slug: `wslock-${companyId.slice(0, 8)}`,
+    });
+
+    agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "WS Lock Agent",
+      adapterType: "noop",
+    });
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  afterEach(async () => {
+    await db.delete(workspaceLocks);
+    await db.delete(heartbeatRuns);
+  });
+
+  async function makeRun(): Promise<string> {
+    const id = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id,
+      companyId,
+      agentId,
+      status: "running",
+      contextSnapshot: {},
+    });
+    return id;
+  }
+
+  it("normalizeWorkspaceCwd resolves relative paths to absolute paths", () => {
+    expect(normalizeWorkspaceCwd("/abs/path")).toBe("/abs/path");
+    expect(normalizeWorkspaceCwd("/abs/path/")).toBe("/abs/path");
+    expect(normalizeWorkspaceCwd("/abs/path/.")).toBe("/abs/path");
+    expect(normalizeWorkspaceCwd("/abs/foo/../bar")).toBe("/abs/bar");
+    expect(() => normalizeWorkspaceCwd("")).toThrow();
+  });
+
+  it("acquires a lock for a fresh cwd and rejects a sibling on the same cwd", async () => {
+    const cwd = "/test/repo/site";
+    const expiresAt = new Date(Date.now() + 60_000);
+
+    const runA = await makeRun();
+    const runB = await makeRun();
+
+    const first = await acquireWorkspaceLock(db, {
+      companyId,
+      cwdPath: cwd,
+      runId: runA,
+      agentId,
+      issueId: null,
+      expiresAt,
+    });
+    expect(first.acquired).toBe(true);
+
+    const second = await acquireWorkspaceLock(db, {
+      companyId,
+      cwdPath: cwd,
+      runId: runB,
+      agentId,
+      issueId: null,
+      expiresAt,
+    });
+    expect(second.acquired).toBe(false);
+    if (!second.acquired) {
+      expect(second.holder.runId).toBe(runA);
+      expect(second.holder.cwdPath).toBe(cwd);
+    }
+
+    expect(await countActiveWorkspaceLocks(db)).toBe(1);
+  });
+
+  it("releases a lock and lets the next run acquire", async () => {
+    const cwd = "/test/repo/release";
+    const expiresAt = new Date(Date.now() + 60_000);
+
+    const runA = await makeRun();
+    const runB = await makeRun();
+
+    const acquireA = await acquireWorkspaceLock(db, {
+      companyId,
+      cwdPath: cwd,
+      runId: runA,
+      agentId,
+      issueId: null,
+      expiresAt,
+    });
+    expect(acquireA.acquired).toBe(true);
+
+    const released = await releaseWorkspaceLock(db, runA);
+    expect(released?.cwdPath).toBe(cwd);
+
+    expect(await getWorkspaceLockHolder(db, cwd)).toBeNull();
+
+    const acquireB = await acquireWorkspaceLock(db, {
+      companyId,
+      cwdPath: cwd,
+      runId: runB,
+      agentId,
+      issueId: null,
+      expiresAt,
+    });
+    expect(acquireB.acquired).toBe(true);
+  });
+
+  it("releaseWorkspaceLock is idempotent when no lock is held", async () => {
+    const runA = await makeRun();
+    const released = await releaseWorkspaceLock(db, runA);
+    expect(released).toBeNull();
+  });
+
+  it("reclaims an expired lock on the next acquire (stale-sweep)", async () => {
+    const cwd = "/test/repo/stale";
+    const longGone = new Date(Date.now() - 5 * 60_000);
+    const fresh = new Date(Date.now() + 60_000);
+
+    const staleRun = await makeRun();
+    const freshRun = await makeRun();
+
+    // Insert a stale lock manually so we don't need to fake a clock for the sweep.
+    await db.insert(workspaceLocks).values({
+      companyId,
+      cwdPath: cwd,
+      runId: staleRun,
+      agentId,
+      issueId: null,
+      acquiredAt: new Date(Date.now() - 60 * 60_000),
+      expiresAt: longGone,
+    });
+
+    const reclaimed = await sweepStaleWorkspaceLockForCwd(db, cwd);
+    expect(reclaimed?.runId).toBe(staleRun);
+
+    const acquired = await acquireWorkspaceLock(db, {
+      companyId,
+      cwdPath: cwd,
+      runId: freshRun,
+      agentId,
+      issueId: null,
+      expiresAt: fresh,
+    });
+    expect(acquired.acquired).toBe(true);
+  });
+
+  it("acquireWorkspaceLock auto-sweeps stale locks before contention check", async () => {
+    const cwd = "/test/repo/auto-sweep";
+    const longGone = new Date(Date.now() - 5 * 60_000);
+    const fresh = new Date(Date.now() + 60_000);
+
+    const staleRun = await makeRun();
+    const newRun = await makeRun();
+
+    await db.insert(workspaceLocks).values({
+      companyId,
+      cwdPath: cwd,
+      runId: staleRun,
+      agentId,
+      issueId: null,
+      acquiredAt: new Date(Date.now() - 60 * 60_000),
+      expiresAt: longGone,
+    });
+
+    const acquired = await acquireWorkspaceLock(db, {
+      companyId,
+      cwdPath: cwd,
+      runId: newRun,
+      agentId,
+      issueId: null,
+      expiresAt: fresh,
+    });
+    expect(acquired.acquired).toBe(true);
+    if (acquired.acquired) {
+      expect(acquired.staleReclaimed?.runId).toBe(staleRun);
+    }
+  });
+
+  it("does not reclaim a still-fresh lock", async () => {
+    const cwd = "/test/repo/fresh";
+    const fresh = new Date(Date.now() + 60_000);
+
+    const runA = await makeRun();
+    const runB = await makeRun();
+
+    await acquireWorkspaceLock(db, {
+      companyId,
+      cwdPath: cwd,
+      runId: runA,
+      agentId,
+      issueId: null,
+      expiresAt: fresh,
+    });
+
+    const reclaimed = await sweepStaleWorkspaceLockForCwd(db, cwd);
+    expect(reclaimed).toBeNull();
+
+    const second = await acquireWorkspaceLock(db, {
+      companyId,
+      cwdPath: cwd,
+      runId: runB,
+      agentId,
+      issueId: null,
+      expiresAt: fresh,
+    });
+    expect(second.acquired).toBe(false);
+  });
+
+  it("the same run cannot hold two locks (run_id unique)", async () => {
+    const runA = await makeRun();
+    const fresh = new Date(Date.now() + 60_000);
+
+    const first = await acquireWorkspaceLock(db, {
+      companyId,
+      cwdPath: "/test/repo/path-1",
+      runId: runA,
+      agentId,
+      issueId: null,
+      expiresAt: fresh,
+    });
+    expect(first.acquired).toBe(true);
+
+    await expect(
+      acquireWorkspaceLock(db, {
+        companyId,
+        cwdPath: "/test/repo/path-2",
+        runId: runA,
+        agentId,
+        issueId: null,
+        expiresAt: fresh,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -32,6 +32,7 @@ import {
   issueWorkProducts,
   projects,
   projectWorkspaces,
+  workspaceLocks,
   workspaceOperations,
 } from "@paperclipai/db";
 import { conflict, HttpError, notFound } from "../errors.js";
@@ -112,6 +113,11 @@ import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-
 import { recoveryService } from "./recovery/service.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
+import {
+  acquireWorkspaceLock,
+  normalizeWorkspaceCwd,
+  releaseWorkspaceLock,
+} from "./workspace-lock.js";
 import { redactCurrentUserText, redactCurrentUserValue } from "../log-redaction.js";
 import {
   hasSessionCompactionThresholds,
@@ -148,6 +154,14 @@ const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
+// Workspace mutex (RUN-21): TTL chosen as max plausible heartbeat run + grace.
+// Stale-sweep reclaims locks past this window so a crashed holder cannot block
+// siblings forever. Lock release on the run's `finally` is the primary path;
+// this is the safety net.
+const WORKSPACE_LOCK_DEFAULT_TTL_MS = 60 * 60 * 1000;
+const WORKSPACE_LOCK_STALE_GRACE_MS = 60 * 1000;
+const DEFERRED_WORKSPACE_LOCK_STATUS = "deferred_workspace_lock";
+const WORKSPACE_LOCK_RELEASED_REASON = "workspace_lock_released";
 const MAX_INLINE_WAKE_COMMENTS = 8;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
@@ -2029,6 +2043,94 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       logger.warn(
         { err: releaseError.error, leaseId: releaseError.leaseId, runId: input.runId },
         "failed to release environment lease for heartbeat run",
+      );
+    }
+  }
+
+  /**
+   * Release the workspace mutex held by `runId`, then wake the oldest deferred waiter
+   * for that cwd. Mirrors the "deferred_issue_execution" promotion pattern: each release
+   * promotes one waiter, and waiters re-defer if the freshly-promoted run loses the next
+   * acquire race. Idempotent — safe to call when no lock is held.
+   */
+  async function releaseWorkspaceLockAndPromoteWaiter(runId: string) {
+    let released: { cwdPath: string; companyId: string } | null = null;
+    try {
+      released = await releaseWorkspaceLock(db, runId);
+    } catch (err) {
+      logger.warn({ err, runId }, "failed to release workspace lock");
+      return;
+    }
+    if (!released) return;
+
+    const cwdPath = released.cwdPath;
+    let waiter: typeof agentWakeupRequests.$inferSelect | null = null;
+    try {
+      waiter = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, released.companyId),
+            eq(agentWakeupRequests.status, DEFERRED_WORKSPACE_LOCK_STATUS),
+            sql`${agentWakeupRequests.payload} ->> 'cwdPath' = ${cwdPath}`,
+          ),
+        )
+        .orderBy(asc(agentWakeupRequests.requestedAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+    } catch (err) {
+      logger.warn({ err, runId, cwdPath }, "failed to query workspace lock waiters");
+      return;
+    }
+    if (!waiter) return;
+
+    try {
+      const waiterPayload = parseObject(waiter.payload);
+      const seedContext = parseObject(waiterPayload[DEFERRED_WAKE_CONTEXT_KEY]);
+      const promotedContext: Record<string, unknown> = {
+        ...seedContext,
+        wakeReason: WORKSPACE_LOCK_RELEASED_REASON,
+        workspaceLockReleased: {
+          cwdPath,
+          releasedByRunId: runId,
+        },
+      };
+      const issueId = readNonEmptyString(promotedContext.issueId);
+      await enqueueWakeup(waiter.agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: WORKSPACE_LOCK_RELEASED_REASON,
+        payload: {
+          issueId: issueId ?? null,
+          cwdPath,
+          deferredWakeRequestId: waiter.id,
+          releasedByRunId: runId,
+        },
+        contextSnapshot: promotedContext,
+      });
+      await db
+        .update(agentWakeupRequests)
+        .set({
+          status: "promoted",
+          finishedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(agentWakeupRequests.id, waiter.id));
+      logger.info(
+        {
+          event: "paperclip.workspace_lock.released",
+          cwdPath,
+          releasedByRunId: runId,
+          promotedWaiterAgentId: waiter.agentId,
+          promotedWaiterIssueId: issueId ?? null,
+        },
+        "promoted workspace lock waiter",
+      );
+    } catch (err) {
+      logger.warn(
+        { err, runId, cwdPath, waiterId: waiter.id },
+        "failed to promote workspace lock waiter; will retry on next release",
       );
     }
   }
@@ -4849,6 +4951,99 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       previousSessionParams,
       { useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default" },
     );
+
+    // RUN-21: Per-cwd workspace mutex. Two heartbeats whose `cwd` resolves to the same
+    // physical directory must not run concurrently — see RUN-15 for the original
+    // silent-data-loss near-miss. We acquire the lock here, before any expensive
+    // workspace realization (git worktrees, runtime services) and adapter spawn.
+    // The lock is released on every termination path in the run's `finally` block.
+    const workspaceLockCwd = normalizeWorkspaceCwd(resolvedWorkspace.cwd);
+    const workspaceLockExpiresAt = new Date(
+      Date.now() + WORKSPACE_LOCK_DEFAULT_TTL_MS + WORKSPACE_LOCK_STALE_GRACE_MS,
+    );
+    const acquireResult = await acquireWorkspaceLock(db, {
+      companyId: agent.companyId,
+      cwdPath: workspaceLockCwd,
+      runId: run.id,
+      agentId: agent.id,
+      issueId,
+      expiresAt: workspaceLockExpiresAt,
+    });
+    if (!acquireResult.acquired) {
+      const holder = acquireResult.holder;
+      const deferralPayload: Record<string, unknown> = {
+        ...(parseObject(context).issueId ? { issueId } : {}),
+        cwdPath: workspaceLockCwd,
+        holderRunId: holder.runId,
+        holderAgentId: holder.agentId,
+        holderIssueId: holder.issueId,
+        holderExpiresAt: holder.expiresAt.toISOString(),
+        [DEFERRED_WAKE_CONTEXT_KEY]: context,
+      };
+      try {
+        await db.insert(agentWakeupRequests).values({
+          companyId: agent.companyId,
+          agentId: agent.id,
+          source: "automation",
+          triggerDetail: "system",
+          reason: "workspace_busy_deferred",
+          payload: deferralPayload,
+          status: DEFERRED_WORKSPACE_LOCK_STATUS,
+        });
+      } catch (err) {
+        logger.warn(
+          { err, runId: run.id, cwdPath: workspaceLockCwd },
+          "failed to record workspace lock deferral",
+        );
+      }
+      const deferralMessage =
+        `Workspace ${workspaceLockCwd} is held by run ${holder.runId}` +
+        (holder.issueId ? ` (issue ${holder.issueId})` : "") +
+        `; deferring this run until the lock releases.`;
+      logger.info(
+        {
+          event: "paperclip.workspace_lock.deferred",
+          runId: run.id,
+          agentId: agent.id,
+          issueId: issueId ?? null,
+          cwdPath: workspaceLockCwd,
+          holderRunId: holder.runId,
+          holderAgentId: holder.agentId,
+          holderIssueId: holder.issueId,
+        },
+        "deferred heartbeat run for workspace lock contention",
+      );
+      await setRunStatus(run.id, "failed", {
+        error: deferralMessage,
+        errorCode: "workspace_busy",
+        finishedAt: new Date(),
+      });
+      await setWakeupStatus(run.wakeupRequestId, "failed", {
+        finishedAt: new Date(),
+        error: deferralMessage,
+      });
+      // Clear executionRunId we stamped on the issue at claim-time. We deliberately
+      // do NOT call releaseIssueExecutionAndPromote here because the deferred
+      // workspace-lock wake IS the continuation path; firing recovery on top would
+      // create a recovery wake that re-defers, doubling the queue depth per release.
+      if (issueId) {
+        await db
+          .update(issues)
+          .set({
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(issues.id, issueId), eq(issues.executionRunId, run.id)));
+      }
+      await finalizeAgentStatus(agent.id, "failed");
+      // The outer try's `finally` block handles environment lease, runtime
+      // service, active-run-set, and queue-resume cleanup, plus the no-op
+      // workspace lock release (we never acquired). Just exit cleanly.
+      return;
+    }
+
     const issueRef = issueContext
       ? {
           id: issueContext.id,
@@ -5944,6 +6139,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             failureReason: latestRun?.error ?? undefined,
           });
           await releaseRuntimeServicesForRun(run.id).catch(() => undefined);
+          // RUN-21: release the per-cwd workspace mutex (if held) and promote
+          // the oldest deferred waiter for that cwd. Idempotent — safe even
+          // when this run never acquired a lock (e.g. setup failed before acquire).
+          await releaseWorkspaceLockAndPromoteWaiter(run.id).catch((err) => {
+            logger.warn({ err, runId: run.id }, "failed to release workspace lock and promote waiter");
+          });
           activeRunExecutions.delete(run.id);
           await startNextQueuedRunForAgent(run.agentId);
         }

--- a/server/src/services/workspace-lock.ts
+++ b/server/src/services/workspace-lock.ts
@@ -1,0 +1,176 @@
+import path from "node:path";
+import { and, eq, lt, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { workspaceLocks } from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+
+export type WorkspaceLockHolder = {
+  runId: string;
+  agentId: string;
+  issueId: string | null;
+  cwdPath: string;
+  acquiredAt: Date;
+  expiresAt: Date;
+};
+
+export type AcquireWorkspaceLockInput = {
+  companyId: string;
+  cwdPath: string;
+  runId: string;
+  agentId: string;
+  issueId: string | null;
+  expiresAt: Date;
+};
+
+export type AcquireWorkspaceLockResult =
+  | { acquired: true; lock: typeof workspaceLocks.$inferSelect; staleReclaimed: WorkspaceLockHolder | null }
+  | { acquired: false; holder: WorkspaceLockHolder };
+
+/**
+ * Resolves a workspace cwd to its absolute, canonical form.
+ * Two heartbeats targeting the same physical directory must produce the same key,
+ * even if one passes a relative path and another an absolute one.
+ */
+export function normalizeWorkspaceCwd(cwd: string): string {
+  if (typeof cwd !== "string" || cwd.length === 0) {
+    throw new Error("normalizeWorkspaceCwd requires a non-empty string");
+  }
+  return path.resolve(cwd);
+}
+
+function rowToHolder(row: typeof workspaceLocks.$inferSelect): WorkspaceLockHolder {
+  return {
+    runId: row.runId,
+    agentId: row.agentId,
+    issueId: row.issueId,
+    cwdPath: row.cwdPath,
+    acquiredAt: row.acquiredAt,
+    expiresAt: row.expiresAt,
+  };
+}
+
+/**
+ * Lazily reclaim any expired lock for `cwdPath`. Returns the reclaimed holder if one was deleted.
+ * Emits a structured warning so the `paperclip.workspace_lock.stale_reclaim` event is visible
+ * in telemetry/log dashboards.
+ */
+export async function sweepStaleWorkspaceLockForCwd(
+  db: Db,
+  cwdPath: string,
+  now: Date = new Date(),
+): Promise<WorkspaceLockHolder | null> {
+  const reclaimed = await db
+    .delete(workspaceLocks)
+    .where(and(eq(workspaceLocks.cwdPath, cwdPath), lt(workspaceLocks.expiresAt, now)))
+    .returning()
+    .then((rows) => rows[0] ?? null);
+
+  if (reclaimed) {
+    const holder = rowToHolder(reclaimed);
+    logger.warn(
+      {
+        event: "paperclip.workspace_lock.stale_reclaim",
+        cwdPath: holder.cwdPath,
+        reclaimedRunId: holder.runId,
+        reclaimedAgentId: holder.agentId,
+        reclaimedIssueId: holder.issueId,
+        acquiredAt: holder.acquiredAt.toISOString(),
+        expiredAt: holder.expiresAt.toISOString(),
+        now: now.toISOString(),
+      },
+      "reclaimed stale workspace lock",
+    );
+    return holder;
+  }
+  return null;
+}
+
+/**
+ * Try to acquire the lock for `cwdPath`. Atomic via a unique index on `cwd_path`.
+ *
+ * Behavior:
+ *   - First, lazy-sweep any stale lock on this cwd (expires_at < now).
+ *   - INSERT new lock. On UNIQUE conflict, SELECT the live holder and return acquired:false.
+ *   - Caller is responsible for releasing the lock on every termination path.
+ */
+export async function acquireWorkspaceLock(
+  db: Db,
+  input: AcquireWorkspaceLockInput,
+  now: Date = new Date(),
+): Promise<AcquireWorkspaceLockResult> {
+  const staleReclaimed = await sweepStaleWorkspaceLockForCwd(db, input.cwdPath, now);
+
+  try {
+    const inserted = await db
+      .insert(workspaceLocks)
+      .values({
+        companyId: input.companyId,
+        cwdPath: input.cwdPath,
+        runId: input.runId,
+        agentId: input.agentId,
+        issueId: input.issueId,
+        acquiredAt: now,
+        expiresAt: input.expiresAt,
+      })
+      .returning()
+      .then((rows) => rows[0] ?? null);
+
+    if (!inserted) {
+      throw new Error("workspace_locks insert returned no rows");
+    }
+
+    return { acquired: true, lock: inserted, staleReclaimed };
+  } catch (err) {
+    const holderRow = await db
+      .select()
+      .from(workspaceLocks)
+      .where(eq(workspaceLocks.cwdPath, input.cwdPath))
+      .then((rows) => rows[0] ?? null);
+
+    if (!holderRow) {
+      // Conflict raced with a concurrent release; surface the underlying error.
+      throw err;
+    }
+
+    return { acquired: false, holder: rowToHolder(holderRow) };
+  }
+}
+
+/**
+ * Release the lock held by `runId`. Returns the released cwd_path so callers can
+ * promote queued waiters for that path.
+ */
+export async function releaseWorkspaceLock(
+  db: Db,
+  runId: string,
+): Promise<{ cwdPath: string; companyId: string } | null> {
+  const released = await db
+    .delete(workspaceLocks)
+    .where(eq(workspaceLocks.runId, runId))
+    .returning({ cwdPath: workspaceLocks.cwdPath, companyId: workspaceLocks.companyId })
+    .then((rows) => rows[0] ?? null);
+  return released ?? null;
+}
+
+/**
+ * Test/debug helper: returns the holder for a cwd, if any.
+ */
+export async function getWorkspaceLockHolder(
+  db: Db,
+  cwdPath: string,
+): Promise<WorkspaceLockHolder | null> {
+  const row = await db
+    .select()
+    .from(workspaceLocks)
+    .where(eq(workspaceLocks.cwdPath, cwdPath))
+    .then((rows) => rows[0] ?? null);
+  return row ? rowToHolder(row) : null;
+}
+
+/**
+ * Test/debug helper: count of locks held company-wide. Useful for assertions.
+ */
+export async function countActiveWorkspaceLocks(db: Db): Promise<number> {
+  const rows = await db.select({ n: sql<number>`count(*)` }).from(workspaceLocks);
+  return Number(rows[0]?.n ?? 0);
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Heartbeat runs spawn out of `executeRun` in `services/heartbeat.ts`, gated by per-issue checkout — but **not** by per-`cwd` mutex
> - When two agents in the same company resolve to the same physical workspace directory (e.g. three agents sharing `/Users/patrick/runclubs.ca`), two heartbeats can land in that cwd concurrently and clobber each other's working tree
> - That happened: see RUN-15 — a CTO heartbeat stashed a sibling agent's WIP under their issue id, a silent-data-loss near-miss
> - This pull request adds a defensive workspace-level lock keyed by the absolute resolved cwd path, releases it on every termination path, and queues contended runs with a `workspace_lock_released` wake so they resume FIFO when the holder finishes
> - The benefit is that the platform now enforces serialization per physical workspace, independent of any per-agent guardrails. Per-issue worktrees (RUN-15 Level 3) are still deferred; this PR is the durable Level-2 fix

## What Changed

- New `workspace_locks` table (Drizzle migration `0075_workspace_locks.sql`) with unique indexes on `cwd_path` and `run_id` plus an `expires_at` for stale reclamation.
- `services/workspace-lock.ts`: `acquireWorkspaceLock` (atomic via the unique index, with lazy stale-sweep), `releaseWorkspaceLock`, `sweepStaleWorkspaceLockForCwd`, `normalizeWorkspaceCwd` plus debug helpers.
- `executeRun` in `services/heartbeat.ts` now acquires the lock immediately after `resolveWorkspaceForRun` returns. On contention the run fails with `errorCode: workspace_busy`, a `deferred_workspace_lock` row is recorded in `agent_wakeup_requests` carrying the original context, and the run exits early.
- The outer `finally` block calls `releaseWorkspaceLockAndPromoteWaiter`, which deletes the lock row and (FIFO) wakes the oldest deferred waiter for that cwd via `enqueueWakeup` with reason `workspace_lock_released` — mirroring the existing `deferred_issue_execution` promotion pattern.
- Stale-sweep emits a `paperclip.workspace_lock.stale_reclaim` structured warning so the safety-net reclaim is visible in telemetry.
- Tests: 8 unit tests in `__tests__/workspace-lock.test.ts` (acquire/release/sweep, run_id uniqueness, fresh-lock not reclaimed) and an integration test in `__tests__/heartbeat-workspace-mutex.test.ts` that drives two heartbeats through the full `executeRun` path against a shared `project_workspaces.cwd` and asserts: lock row count = 1 while held; second run fails with `errorCode: workspace_busy`; deferred wake is recorded; on release the deferred wake is promoted to status `promoted` and a fresh `workspace_lock_released` wake fires for the second agent; second run then succeeds.

## Verification

- `pnpm exec vitest run server/src/__tests__/workspace-lock.test.ts server/src/__tests__/heartbeat-workspace-mutex.test.ts` — 9 tests, all green.
- `pnpm --filter @paperclipai/server typecheck` — clean.
- Migration check: `pnpm --filter @paperclipai/db check:migrations` — clean.
- Sanity: `pnpm exec vitest run server/src/__tests__/heartbeat-dependency-scheduling.test.ts` still passes alongside the new tests.

Pre-existing failures on this dev box (verified on master with the same env): `workspace-runtime.test.ts` provision-script tests fail due to a missing `~/.npm/_npx/.../paperclipai/dist/migrations` path, `network-bind.test.ts` and `onboard.test.ts` fail because the host has Tailscale active, and `heartbeat-comment-wake-batching.test.ts` "promotes deferred comment wakes" times out on master too. None are caused by this PR.

## Risks

- **Deadlock risk**: the lock holder's `finally` block always runs and releases the row. The stale-sweep on every acquire (with TTL = 60min + 60s grace) guarantees a crashed holder cannot block siblings forever.
- **Migration safety**: `0075_workspace_locks.sql` is a forward-only `CREATE TABLE IF NOT EXISTS`. No data backfill, no schema rename, no FK against existing rows. Rollback is a single `DROP TABLE`.
- **Behavior regression for solo workspaces**: agents whose cwd is per-agent (`agent_home` source) acquire and release a unique lock — harmless overhead, no contention possible.
- **`workspaceStrategy: command-managed-runtime`**: the lock is purely additive; runtimes that already serialize at the adapter layer simply re-acquire/release on every run, no observable change.
- The deferred-wake promotion piggybacks on `enqueueWakeup`, so it inherits its existing budget/pause-hold/dependency gating. If those would have suppressed the original wake, they suppress the promoted one too — same as the issue-execution-deferred path.

## Model Used

- Claude Opus 4.7 (1M context), running as the runclubs.ca CTO agent inside Paperclip.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only change
- [ ] I have updated relevant documentation to reflect my changes — internal heartbeat plumbing; no doc-facing surface
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge