### PR TITLE
Enforce agent mutation boundaries

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -387,6 +387,31 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockStorageService.deleteObject).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked" })],
+    ["comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "blocked" })],
+    [
+      "document upsert",
+      (app: express.Express) =>
+        request(app).put(`/api/issues/${issueId}/documents/plan`).send({ format: "markdown", body: "# blocked" }),
+    ],
+  ])("rejects peer agent %s mutations on user-assigned issues", async (_name, sendRequest) => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      status: "in_review",
+      assigneeAgentId: null,
+      assigneeUserId: "board-user",
+    }));
+
+    const res = await sendRequest(await createApp(peerActor()));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate a user-assigned issue");
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockDocumentService.upsertIssueDocument).not.toHaveBeenCalled();
+  });
+
   it("allows the checked-out owner with the matching run id to patch and update documents", async () => {
     const app = await createApp(ownerActor());
 

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -292,6 +292,39 @@ describe("issue execution policy routes", () => {
     );
   });
 
+  it("rejects agent attempts to remove existing execution policies with user participants", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "approval",
+          participants: [{ type: "user", userId: "local-board" }],
+        },
+      ],
+    })!;
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-999",
+      title: "Policy removal attempt",
+      executionPolicy: policy,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const res = await request(await createApp(agentActor()))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ executionPolicy: null });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot author execution policies with user participants");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("rejects agent PATCH attempts to assign issues directly to users", async () => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -247,6 +247,51 @@ describe("issue execution policy routes", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("allows workflow-controlled assignment to user participants from an existing policy", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "approval",
+          participants: [{ type: "user", userId: "local-board" }],
+        },
+      ],
+    })!;
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-999",
+      title: "Policy-controlled user review",
+      executionPolicy: policy,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp(agentActor()))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        status: "in_review",
+        assigneeAgentId: null,
+        assigneeUserId: "local-board",
+        actorAgentId: "22222222-2222-4222-8222-222222222222",
+      }),
+    );
+  });
+
   it("rejects agent PATCH attempts to assign issues directly to users", async () => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -25,7 +25,7 @@ const mockHeartbeatService = vi.hoisted(() => ({
 function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     companyService: () => ({
-      getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+      getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024, issuePrefix: "PAP" })),
     }),
     accessService: () => ({
       canUser: vi.fn(async () => false),
@@ -76,7 +76,27 @@ function registerModuleMocks() {
   }));
 }
 
-async function createApp() {
+function boardActor() {
+  return {
+    type: "board",
+    userId: "local-board",
+    companyIds: ["company-1"],
+    source: "local_implicit",
+    isInstanceAdmin: false,
+  };
+}
+
+function agentActor() {
+  return {
+    type: "agent",
+    agentId: "22222222-2222-4222-8222-222222222222",
+    companyId: "company-1",
+    source: "agent_key",
+    runId: "33333333-3333-4333-8333-333333333333",
+  };
+}
+
+async function createApp(actor: Record<string, unknown> = boardActor()) {
   const [{ errorHandler }, { issueRoutes }] = await Promise.all([
     import("../middleware/index.js"),
     import("../routes/issues.js"),
@@ -84,13 +104,7 @@ async function createApp() {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "local-board",
-      companyIds: ["company-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api", issueRoutes({} as any, {} as any));
@@ -161,5 +175,99 @@ describe("issue execution policy routes", () => {
     expect(updatePatch.assigneeUserId).toBeUndefined();
     expect(updatePatch.executionState).toBeUndefined();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent-authored execution policies with user participants", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "approval",
+          participants: [{ type: "user", userId: "local-board" }],
+        },
+      ],
+    })!;
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-999",
+      title: "Execution policy escalation",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp(agentActor()))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        executionPolicy: policy,
+        status: "in_review",
+        comment: "Escalate to the board.",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot author execution policies with user participants");
+    expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      "22222222-2222-4222-8222-222222222222",
+      "33333333-3333-4333-8333-333333333333",
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent-created issues with user-participant execution policies", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "approval",
+          participants: [{ type: "user", userId: "local-board" }],
+        },
+      ],
+    })!;
+
+    const res = await request(await createApp(agentActor()))
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Escalation issue",
+        executionPolicy: policy,
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot author execution policies with user participants");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent PATCH attempts to assign issues directly to users", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-999",
+      title: "Direct user assignment",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const res = await request(await createApp(agentActor()))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ assigneeAgentId: null, assigneeUserId: "local-board" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot assign issues to users");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2089,7 +2089,8 @@ export function issueRoutes(
     if (
       req.actor.type === "agent" &&
       req.body.executionPolicy !== undefined &&
-      executionPolicyHasUserParticipants(nextExecutionPolicy)
+      (executionPolicyHasUserParticipants(nextExecutionPolicy) ||
+        executionPolicyHasUserParticipants(previousExecutionPolicy))
     ) {
       res.status(403).json({
         error: "Agents cannot author execution policies with user participants",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -110,6 +110,10 @@ type ExecutionStageWakeContext = {
   allowedActions: string[];
 };
 
+function executionPolicyHasUserParticipants(policy: NormalizedExecutionPolicy | null): boolean {
+  return Boolean(policy?.stages.some((stage) => stage.participants.some((participant) => participant.type === "user")));
+}
+
 function executionPrincipalsEqual(
   left: ParsedExecutionState["currentParticipant"] | null,
   right: ParsedExecutionState["currentParticipant"] | null,
@@ -595,12 +599,25 @@ export function issueRoutes(
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
-    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
+    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null; assigneeUserId: string | null },
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
     if (!actorAgentId) {
       res.status(403).json({ error: "Agent authentication required" });
+      return false;
+    }
+    if (issue.assigneeUserId) {
+      res.status(403).json({
+        error: "Agent cannot mutate a user-assigned issue",
+        details: {
+          issueId: issue.id,
+          assigneeUserId: issue.assigneeUserId,
+          actorAgentId,
+          status: issue.status,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
       return false;
     }
     if (issue.assigneeAgentId === null) {
@@ -1812,6 +1829,16 @@ export function issueRoutes(
 
     const actor = getActorInfo(req);
     const executionPolicy = normalizeIssueExecutionPolicy(req.body.executionPolicy);
+    if (req.actor.type === "agent" && executionPolicyHasUserParticipants(executionPolicy)) {
+      res.status(403).json({
+        error: "Agents cannot author execution policies with user participants",
+        details: {
+          companyId,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return;
+    }
     const issue = await svc.create(companyId, {
       ...req.body,
       executionPolicy,
@@ -1879,6 +1906,16 @@ export function issueRoutes(
 
     const actor = getActorInfo(req);
     const executionPolicy = normalizeIssueExecutionPolicy(req.body.executionPolicy);
+    if (req.actor.type === "agent" && executionPolicyHasUserParticipants(executionPolicy)) {
+      res.status(403).json({
+        error: "Agents cannot author execution policies with user participants",
+        details: {
+          parentIssueId: parent.id,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return;
+    }
     const { issue, parentBlockerAdded } = await svc.createChild(parent.id, {
       ...req.body,
       executionPolicy,
@@ -2049,6 +2086,20 @@ export function issueRoutes(
       updateFields.executionPolicy !== undefined
         ? (updateFields.executionPolicy as NormalizedExecutionPolicy | null)
         : previousExecutionPolicy;
+    if (
+      req.actor.type === "agent" &&
+      req.body.executionPolicy !== undefined &&
+      executionPolicyHasUserParticipants(nextExecutionPolicy)
+    ) {
+      res.status(403).json({
+        error: "Agents cannot author execution policies with user participants",
+        details: {
+          issueId: existing.id,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return;
+    }
     if (normalizedAssigneeAgentId !== undefined) {
       updateFields.assigneeAgentId = normalizedAssigneeAgentId;
     }
@@ -2081,6 +2132,22 @@ export function issueRoutes(
       };
     }
     Object.assign(updateFields, transition.patch);
+    if (
+      req.actor.type === "agent" &&
+      req.body.assigneeUserId !== undefined &&
+      req.body.assigneeUserId !== existing.assigneeUserId &&
+      !transition.workflowControlledAssignment
+    ) {
+      res.status(403).json({
+        error: "Agents cannot assign issues to users",
+        details: {
+          issueId: existing.id,
+          assigneeUserId: req.body.assigneeUserId ?? null,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return;
+    }
     if (reviewRequest !== undefined && transition.patch.executionState === undefined) {
       const existingExecutionState = parseIssueExecutionState(existing.executionState);
       if (!existingExecutionState || existingExecutionState.status !== "pending") {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies, so issue mutation boundaries are part of the product safety model.
> - Agents work through company-scoped issues, comments, documents, and execution policies using API-key authentication.
> - Closed PR #4860 mixed this safety work with recovery, liveness, and live-run polling changes.
> - This replacement PR isolates only the mutation-boundary policy portion so it can be reviewed independently.
> - The backend now rejects unsafe agent attempts to mutate user-assigned issues, directly assign work to users, or author user-participant execution policies.
> - The benefit is a smaller governance PR with focused route coverage and no unrelated recovery or UI changes.

## What Changed

- Added an agent mutation guard that rejects patch, comment, and document mutations on user-assigned issues.
- Rejected agent-authored execution policies containing user participants on issue create, child create, and patch.
- Rejected direct agent PATCH attempts to assign issues to users unless the assignment comes from workflow-controlled execution-policy transitions.
- Added focused route tests for user-assigned issue mutation denial and user-participant execution-policy denial.

## Verification

- `pnpm install --frozen-lockfile`
- `git diff --check`
- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-execution-policy-routes.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Existing agent integrations that relied on direct user assignment will now receive `403` and must use board/user auth or workflow-controlled execution-policy transitions.
- Existing agent integrations that attempted to create board/user approval policies directly will need to ask the board through the supported issue-thread interaction or approval paths instead.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5, local code execution and GitHub CLI tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
