### PR TITLE
fix(routines): break the orphan-checkout loop after a run is reaped

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -233,7 +233,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBeNull();
-    expect(issue?.checkoutRunId).toBe(runId);
+    expect(issue?.checkoutRunId).toBeNull();
+    expect(issue?.status).toBe("todo");
+    expect(issue?.assigneeAgentId).not.toBeNull();
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5,6 +5,7 @@ import {
   agents,
   companies,
   createDb,
+  heartbeatRuns,
   issueComments,
   issueInboxArchives,
   issues,
@@ -40,6 +41,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -312,5 +314,61 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       archivedIssueId,
       resurfacedIssueId,
     ]));
+  });
+
+  it("forceRelease clears stale checkout state and reverts in_progress to todo", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const deadRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CMO",
+      role: "general",
+      status: "active",
+      adapterType: "opencode_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: deadRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "failed",
+      contextSnapshot: { issueId },
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Check gmail",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: deadRunId,
+      executionRunId: deadRunId,
+      executionAgentNameKey: "cmo",
+      executionLockedAt: new Date(),
+    });
+
+    const released = await svc.forceRelease(issueId);
+    expect(released?.status).toBe("todo");
+    expect(released?.checkoutRunId).toBeNull();
+    expect(released?.executionRunId).toBeNull();
+    expect(released?.executionAgentNameKey).toBeNull();
+    expect(released?.executionLockedAt).toBeNull();
+    expect(released?.assigneeAgentId).toBe(agentId);
   });
 });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -167,7 +167,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     return { companyId, agentId, issueSvc, projectId, routine, svc, wakeups };
   }
 
-  it("creates a fresh execution issue when the previous routine issue is open but idle", async () => {
+  it("coalesces a new fire onto a previous routine issue that is open but idle", async () => {
     const { companyId, issueSvc, routine, svc } = await seedFixture();
     const previousRunId = randomUUID();
     const previousIssue = await issueSvc.create(companyId, {
@@ -194,24 +194,18 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       completedAt: new Date("2026-03-20T12:00:00.000Z"),
     });
 
-    const detailBefore = await svc.getDetail(routine.id);
-    expect(detailBefore?.activeIssue).toBeNull();
-
     const run = await svc.runRoutine(routine.id, { source: "manual" });
-    expect(run.status).toBe("issue_created");
-    expect(run.linkedIssueId).not.toBe(previousIssue.id);
+    expect(run.status).toBe("coalesced");
+    expect(run.linkedIssueId).toBe(previousIssue.id);
+    expect(run.coalescedIntoRunId).toBe(previousRunId);
 
     const routineIssues = await db
-      .select({
-        id: issues.id,
-        originRunId: issues.originRunId,
-      })
+      .select({ id: issues.id })
       .from(issues)
       .where(eq(issues.originId, routine.id));
 
-    expect(routineIssues).toHaveLength(2);
-    expect(routineIssues.map((issue) => issue.id)).toContain(previousIssue.id);
-    expect(routineIssues.map((issue) => issue.id)).toContain(run.linkedIssueId);
+    expect(routineIssues).toHaveLength(1);
+    expect(routineIssues[0]?.id).toBe(previousIssue.id);
   });
 
   it("wakes the assignee when a routine creates a fresh execution issue", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1242,6 +1242,54 @@ export function issueRoutes(db: Db, storage: StorageService) {
     res.json(released);
   });
 
+  router.post("/issues/:id/force-release", async (req, res) => {
+    const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
+
+    if (req.actor.type === "agent") {
+      if (!req.actor.agentId) {
+        res.status(403).json({ error: "Agent authentication required" });
+        return;
+      }
+      const actorAgent = await agentsSvc.getById(req.actor.agentId);
+      if (!actorAgent || actorAgent.companyId !== existing.companyId || actorAgent.role !== "ceo") {
+        res.status(403).json({ error: "Only the CEO agent can force-release issues" });
+        return;
+      }
+    }
+
+    const released = await svc.forceRelease(id);
+    if (!released) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: released.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "issue.force_released",
+      entityType: "issue",
+      entityId: released.id,
+      details: {
+        previousStatus: existing.status,
+        previousCheckoutRunId: existing.checkoutRunId,
+        previousExecutionRunId: existing.executionRunId,
+        previousAssigneeAgentId: existing.assigneeAgentId,
+      },
+    });
+
+    res.json(released);
+  });
+
   router.get("/issues/:id/comments", async (req, res) => {
     const id = req.params.id as string;
     const issue = await svc.getById(id);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1801,7 +1801,7 @@ export function heartbeatService(db: Db) {
           retriedRun = await enqueueProcessLossRetry(finalizedRun, agent, now);
         }
       } else {
-        await releaseIssueExecutionAndPromote(finalizedRun);
+        await releaseIssueExecutionAndPromote(finalizedRun, { aborted: true });
       }
 
       await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
@@ -1961,7 +1961,7 @@ export function heartbeatService(db: Db) {
         error: "Agent not found",
       });
       const failedRun = await getRun(runId);
-      if (failedRun) await releaseIssueExecutionAndPromote(failedRun);
+      if (failedRun) await releaseIssueExecutionAndPromote(failedRun, { aborted: true });
       return;
     }
 
@@ -2687,7 +2687,7 @@ export function heartbeatService(db: Db) {
             exitCode: adapterResult.exitCode,
           },
         });
-        await releaseIssueExecutionAndPromote(finalizedRun);
+        await releaseIssueExecutionAndPromote(finalizedRun, { aborted: outcome !== "succeeded" });
       }
 
       if (finalizedRun) {
@@ -2753,7 +2753,7 @@ export function heartbeatService(db: Db) {
           level: "error",
           message,
         });
-        await releaseIssueExecutionAndPromote(failedRun);
+        await releaseIssueExecutionAndPromote(failedRun, { aborted: true });
 
         await updateRuntimeState(agent, failedRun, {
           exitCode: null,
@@ -2804,7 +2804,7 @@ export function heartbeatService(db: Db) {
               level: "error",
               message,
             }).catch(() => undefined);
-            await releaseIssueExecutionAndPromote(failedRun).catch(() => undefined);
+            await releaseIssueExecutionAndPromote(failedRun, { aborted: true }).catch(() => undefined);
           }
           // Ensure the agent is not left stuck in "running" if the inner catch handler's
           // DB calls threw (e.g. a transient DB error in finalizeAgentStatus).
@@ -2816,7 +2816,11 @@ export function heartbeatService(db: Db) {
         }
   }
 
-  async function releaseIssueExecutionAndPromote(run: typeof heartbeatRuns.$inferSelect) {
+  async function releaseIssueExecutionAndPromote(
+    run: typeof heartbeatRuns.$inferSelect,
+    options: { aborted?: boolean } = {},
+  ) {
+    const aborted = options.aborted ?? false;
     const promotedRun = await db.transaction(async (tx) => {
       await tx.execute(
         sql`select id from issues where company_id = ${run.companyId} and execution_run_id = ${run.id} for update`,
@@ -2826,6 +2830,8 @@ export function heartbeatService(db: Db) {
         .select({
           id: issues.id,
           companyId: issues.companyId,
+          status: issues.status,
+          checkoutRunId: issues.checkoutRunId,
         })
         .from(issues)
         .where(and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)))
@@ -2833,12 +2839,27 @@ export function heartbeatService(db: Db) {
 
       if (!issue) return;
 
+      // When the run aborted (process loss, adapter failure, cancellation) the agent never
+      // got to release its checkout. Roll the issue back to a recoverable "todo" so the
+      // routine scheduler can coalesce future fires onto it and the assignee can re-claim
+      // it via adoptStaleCheckoutRun. Without this reset the orphan loses its slot in
+      // issues_open_routine_execution_uq (which requires execution_run_id IS NOT NULL)
+      // and the routine creates duplicate fires every tick.
+      const issueResetPatch =
+        aborted && issue.status === "in_progress"
+          ? {
+              status: "todo" as const,
+              checkoutRunId: null,
+            }
+          : {};
+
       await tx
         .update(issues)
         .set({
           executionRunId: null,
           executionAgentNameKey: null,
           executionLockedAt: null,
+          ...issueResetPatch,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, issue.id));
@@ -3598,7 +3619,7 @@ export function heartbeatService(db: Db) {
         level: "warn",
         message: "run cancelled",
       });
-      await releaseIssueExecutionAndPromote(cancelled);
+      await releaseIssueExecutionAndPromote(cancelled, { aborted: true });
     }
 
     runningProcesses.delete(run.id);
@@ -3630,7 +3651,7 @@ export function heartbeatService(db: Db) {
         running.child.kill("SIGTERM");
         runningProcesses.delete(run.id);
       }
-      await releaseIssueExecutionAndPromote(run);
+      await releaseIssueExecutionAndPromote(run, { aborted: true });
     }
 
     return runs.length;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1281,6 +1281,32 @@ export function issueService(db: Db) {
       });
     },
 
+    forceRelease: async (id: string) => {
+      const existing = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, id))
+        .then((rows) => rows[0] ?? null);
+      if (!existing) return null;
+
+      const updated = await db
+        .update(issues)
+        .set({
+          status: existing.status === "in_progress" ? "todo" : existing.status,
+          checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!updated) return null;
+      const [enriched] = await withIssueLabels(db, [updated]);
+      return enriched;
+    },
+
     release: async (id: string, actorAgentId?: string, actorRunId?: string | null) => {
       const existing = await db
         .select()

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -442,7 +442,7 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
       .then((rows) => rows[0]?.issues ?? null);
     if (executionBoundIssue) return executionBoundIssue;
 
-    return executor
+    const wakeBoundIssue = await executor
       .select()
       .from(issues)
       .innerJoin(
@@ -465,6 +465,27 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
       .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
       .limit(1)
       .then((rows) => rows[0]?.issues ?? null);
+    if (wakeBoundIssue) return wakeBoundIssue;
+
+    // Fallback: an open routine_execution issue with no live heartbeat run is still a
+    // valid coalesce target (e.g. its run was reaped but the issue was reset to todo).
+    // Without this lookup the routine would create a duplicate issue every tick until
+    // the orphan was completed manually.
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, "routine_execution"),
+          eq(issues.originId, routine.id),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
   }
 
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {


### PR DESCRIPTION
## Summary

Fixes a server-side bug where CMO (and any `opencode_local`-style agent) ends up with a duplicate routine issue every cron tick after its run gets killed mid-flight. The orphan checkout state piles up indefinitely because the assignee can no longer self-recover (release endpoint requires `assignee + checkoutRunId` ownership) and the routine's `coalesce_if_active` policy stops firing once the dead heartbeat run leaves `(queued, running)`.

Reported and root-caused in MAT-1135. Symptoms in this org: 4+ consecutive hang-sweep cycles where the CEO had to manually `PATCH` orphans clear ([sweeps MAT-1127](https://example/MAT/issues/MAT-1127), MAT-1130, MAT-1133).

### Chain of events the patch breaks

1. `opencode_local` run dies abruptly (kill -9, OOM, host restart).
2. `reapOrphanedRuns` flips heartbeatRun.status to `failed` and calls `releaseIssueExecutionAndPromote`, which **only cleared `executionRunId`** — the issue stayed `in_progress` with a now-dead `checkoutRunId`.
3. Partial unique index `issues_open_routine_execution_uq` requires `execution_run_id IS NOT NULL`, so the orphan stops reserving the routine slot.
4. Next routine fire's `findLiveExecutionIssue` joins on `heartbeat_runs.status IN ('queued','running')` — the reaped run is `failed`, so coalesce_if_active doesn't fire and a brand-new issue is created.
5. The new issue + assignment never routes the agent back to the orphan, so `adoptStaleCheckoutRun` (which would heal it) is unreachable.
6. Repeat hourly.

## What changed

- **`releaseIssueExecutionAndPromote(run, { aborted })`** (`server/src/services/heartbeat.ts`) — when an aborted run releases an `in_progress` issue (process loss, adapter error, cancellation, agent_not_found), additionally clears `checkoutRunId` and reverts `status` to `todo` (preserves `assigneeAgentId`). Successful-completion path is unchanged. All 7 callers updated to pass `aborted` explicitly so the success/cancel intent is local to each call site rather than re-derived.
- **`findLiveExecutionIssue`** (`server/src/services/routines.ts`) — adds a third lookup that returns any open routine_execution issue regardless of heartbeatRun status. Combined with the reset above, the next `coalesce_if_active` fire merges into the orphan rather than spawning a duplicate, and the existing `adoptStaleCheckoutRun` path lets the assignee re-claim the issue with its new run id.
- **`POST /api/issues/:id/force-release`** (`server/src/routes/issues.ts` + `issueService.forceRelease`) — explicit incident lever. CEO agent or board admin only. Logs `issue.force_released` activity with the previous status / checkoutRunId / executionRunId / assignee. Replaces the ad-hoc `PATCH` workaround the operator has been using.

## Behavior trade-off worth flagging in review

`coalesce_if_active` is now slightly more aggressive: a previous routine_execution issue in any open status (`backlog | todo | in_progress | in_review | blocked`) — even with no live worker — coalesces future fires onto itself. The previous behavior of "fire anyway when no live worker is running" is what produced the duplicate cascade. Routines that should ignore stuck previous instances should use `concurrencyPolicy: 'always_enqueue'`. The `routines-service.test.ts` test covering the open-but-idle case was rewritten — the prior assertion encoded the buggy behavior.

## Test plan

- [x] `pnpm --filter @paperclipai/server exec tsc --noEmit` — clean
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts src/__tests__/routines-service.test.ts src/__tests__/issues-service.test.ts` — 15/15 pass (including the rewritten coalesce assertion and a new `forceRelease` test)
- [x] Full server suite: 492 pass / 1 skip / 1 pre-existing master failure (`workspace-runtime.test.ts` env contamination — fails on master too, unrelated to this change)
- [ ] Reviewer to confirm the open-but-idle coalesce semantics shift is acceptable for any routines currently relying on the prior fire-anyway-after-reap behavior

Fixes MAT-1135.