### PR TITLE
docs(skill): clarify request_confirmation requires board/user approver

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -289,6 +289,8 @@ If you're asked to make a plan, _do not mark the issue as done_. Re-assign the i
 
 If the plan needs explicit approval before implementation, update the `plan` document, create a `request_confirmation` issue-thread interaction bound to the latest plan revision, and wait for acceptance before creating implementation subtasks. See `references/api-reference.md` for the interaction payload.
 
+> **`request_confirmation` requires a board/user approver** — another agent cannot accept it. For agent-to-agent plan review (e.g. a subordinate asking their manager to approve a plan), use **comment + reassign** instead: post a comment summarising the plan and reassign the issue to the reviewing agent. This leaves no orphaned `pending` interaction on the thread.
+
 When asked to convert a plan into executable Paperclip tasks — depth, assignment, dependencies, parallelization — use the companion skill `paperclip-converting-plans-to-tasks`.
 
 Recommended API flow:


### PR DESCRIPTION
Add a blockquote note immediately after the request_confirmation plan-approval guidance to make it clear that another agent cannot accept a request_confirmation interaction. Prescribe comment + reassign as the correct pattern for agent-to-agent plan review, which leaves no orphaned pending interaction.

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents coordinate through the Paperclip skill — a bundled `paperclip/SKILL.md` that defines the heartbeat procedure and governance rules all agents follow
> - The Planning section of SKILL.md tells agents to use `request_confirmation` interactions when a plan needs explicit approval before implementation
> - But `request_confirmation` can only be accepted by a board/user approver — another agent calling the accept endpoint gets a 403
> - This means any agent-to-agent plan review flow prescribed by the docs silently deadlocks: the confirmation stays `pending` forever
> - This pull request adds a single blockquote note immediately after the `request_confirmation` guidance, making the constraint explicit and prescribing the correct alternative (`comment + reassign`) for agent-to-agent plan review
> - The benefit is that agent authors following the skill won't accidentally create unresolvable pending interactions when implementing agent-to-agent approval workflows

## What Changed

- Added a 2-line blockquote note in `skills/paperclip/SKILL.md` immediately after the `request_confirmation` plan-approval guidance (Planning section)
- The note states that `request_confirmation` requires a board/user approver and cannot be accepted by another agent
- It prescribes `comment + reassign` as the correct pattern for agent-to-agent plan review, and notes that this approach leaves no orphaned `pending` interaction on the thread

## Verification

**Before (misleading — implies any approver can accept):**

```text
If the plan needs explicit approval before implementation, update the `plan` document,
create a `request_confirmation` issue-thread interaction bound to the latest plan
revision, and wait for acceptance before creating implementation subtasks.
```

**After (explicit constraint + correct alternative):**

```text
If the plan needs explicit approval before implementation, update the `plan` document,
create a `request_confirmation` issue-thread interaction bound to the latest plan
revision, and wait for acceptance before creating implementation subtasks.

> **`request_confirmation` requires a board/user approver** — another agent cannot
> accept it. For agent-to-agent plan review (e.g. a subordinate asking their manager
> to approve a plan), use **comment + reassign** instead: post a comment summarising
> the plan and reassign the issue to the reviewing agent. This leaves no orphaned
> `pending` interaction on the thread.
```

This was encountered in production: a subordinate agent created a request_confirmation interaction targeting its manager agent; the manager had no way to accept, leaving the issue permanently blocked.

## Risks

Docs-only change — zero runtime impact.
The only risk is that maintainers prefer a different framing or a runtime fix (e.g. allowing agents to accept request_confirmation in certain roles). Happy to follow their direction and close this PR in favour of a runtime fix.

## Model Used

Provider: Anthropic
Model: Claude Sonnet 4.6 (claude-sonnet-4-6)
Context window: 200k tokens
Mode: standard (no extended thinking)
Tool use: enabled (file edits, shell commands)

## Checklist

- [X] I have included a thinking path that traces from project context to this change
- [X] I have specified the model used (with version and capability details)
- [X] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [X] I have run tests locally and they pass
- [X] I have added or updated tests where applicable
- [X] If this change affects the UI, I have included before/after screenshots
- [X] I have updated relevant documentation to reflect my changes
- [X] I have considered and documented any risks above
- [X] I will address all Greptile and reviewer comments before requesting merge
