### PR TITLE
[codex] Isolate advanced run liveness continuation

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2180,8 +2180,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeups).toHaveLength(1);
   });
 
-  it("records productive continuation instead of recovery when the latest automatic continuation succeeded", async () => {
-    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+  it("does not treat a productive terminal run as healthy when in-progress work has no live path", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "succeeded",
       retryReason: "issue_continuation_needed",
@@ -2189,27 +2189,41 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     const heartbeat = heartbeatService(db);
 
-    const result = await heartbeat.reconcileStrandedAssignedIssues();
-    expect(result.continuationRequeued).toBe(0);
-    expect(result.productiveContinuationObserved).toBe(1);
-    expect(result.successfulContinuationObserved).toBe(0);
-    expect(result.escalated).toBe(0);
-    expect(result.issueIds).toEqual([]);
+    const sourceIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(sourceIssue).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      assigneeUserId: null,
+      executionRunId: null,
+    });
 
-    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("in_progress");
-
-    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
-    expect(comments).toHaveLength(0);
-
-    const runs = await db
+    const activeRuns = await db
       .select()
       .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.agentId, agentId));
-    expect(runs.map((row) => row.id)).toEqual([runId]);
+      .where(and(eq(heartbeatRuns.companyId, companyId), inArray(heartbeatRuns.status, ["queued", "running"])));
+    expect(activeRuns).toHaveLength(0);
 
-    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
-    expect(wakeups).toHaveLength(1);
+    const liveWakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.companyId, companyId), inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"])));
+    expect(liveWakeups).toHaveLength(0);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.productiveContinuationObserved).toBe(0);
+    expect(result.continuationRequeued + result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    const followupWakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.reason, "issue_continuation_needed")));
+    expect(comments.length + recoveryIssues.length + followupWakeups.length).toBeGreaterThan(0);
   });
 
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {

--- a/server/src/__tests__/run-continuations.test.ts
+++ b/server/src/__tests__/run-continuations.test.ts
@@ -106,6 +106,28 @@ describe("run liveness continuations", () => {
     expect(decision.nextAttempt).toBe(2);
   });
 
+  it("enqueues advanced terminal runs so progress is not mistaken for a live path", () => {
+    const decision = decideRunLivenessContinuation({
+      run: run(),
+      issue: issue(),
+      agent: agent(),
+      livenessState: "advanced",
+      livenessReason: "Run produced concrete action evidence: created an issue comment",
+      nextAction: "Resume the implementation from the remaining acceptance criteria.",
+      budgetBlocked: false,
+      idempotentWakeExists: false,
+    });
+
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.payload).toMatchObject({
+      issueId,
+      sourceRunId: runId,
+      livenessState: "advanced",
+      instruction: "Resume the implementation from the remaining acceptance criteria.",
+    });
+  });
+
   it("does not enqueue a third continuation and returns an exhaustion comment", () => {
     const decision = decideRunLivenessContinuation({
       run: run({ continuationAttempt: 2 }),
@@ -126,7 +148,7 @@ describe("run liveness continuations", () => {
 
   it("skips non-actionable and guarded issues", () => {
     const guardedCases = [
-      { livenessState: "advanced" as const },
+      { livenessState: "needs_followup" as const },
       { issue: issue({ status: "done" }) },
       { issue: issue({ assigneeAgentId: "other-agent" }) },
       { issue: issue({ executionState: { status: "pending" } }) },

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2805,7 +2805,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
   async function handleRunLivenessContinuation(run: typeof heartbeatRuns.$inferSelect) {
     const livenessState = run.livenessState as RunLivenessState | null;
-    if (livenessState !== "plan_only" && livenessState !== "empty_response") return;
+    if (livenessState !== "plan_only" && livenessState !== "empty_response" && livenessState !== "advanced") return;
 
     const context = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(context.issueId);

--- a/server/src/services/recovery/run-liveness-continuations.ts
+++ b/server/src/services/recovery/run-liveness-continuations.ts
@@ -7,7 +7,7 @@ import { RECOVERY_REASON_KINDS } from "./origins.js";
 export const RUN_LIVENESS_CONTINUATION_REASON = RECOVERY_REASON_KINDS.runLivenessContinuation;
 export const DEFAULT_MAX_LIVENESS_CONTINUATION_ATTEMPTS = 2;
 
-const ACTIONABLE_LIVENESS_STATES = new Set<RunLivenessState>(["plan_only", "empty_response"]);
+const ACTIONABLE_LIVENESS_STATES = new Set<RunLivenessState>(["plan_only", "empty_response", "advanced"]);
 const CONTINUATION_ACTIVE_ISSUE_STATUSES = new Set(["todo", "in_progress"]);
 // A prior adapter error should not permanently suppress bounded liveness
 // continuations; the max-attempt/idempotency guards prevent unbounded retries.
@@ -126,6 +126,9 @@ export function decideRunLivenessContinuation(input: {
   }
   if (budgetBlocked) {
     return { kind: "skip", reason: "budget hard stop blocks continuation" };
+  }
+  if (livenessState === "advanced" && !nextAction) {
+    return { kind: "skip", reason: "advanced run has no concrete continuation instruction" };
   }
 
   const currentAttempt = readContinuationAttempt(run.continuationAttempt);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -189,13 +189,12 @@ function isUnsuccessfulTerminalIssueRun(latestRun: LatestIssueRun) {
 }
 
 function isSuccessfulInProgressContinuationRun(latestRun: LatestIssueRun) {
-  return latestRun?.status === "succeeded";
+  return latestRun?.status === "succeeded" && latestRun.livenessState !== "advanced";
 }
 
 function isProductiveContinuationRun(latestRun: LatestIssueRun) {
   return latestRun?.status === "succeeded" &&
-    (latestRun.livenessState === "advanced" ||
-      latestRun.livenessState === "completed" ||
+    (latestRun.livenessState === "completed" ||
       latestRun.livenessState === "blocked" ||
       latestRun.livenessState === "needs_followup");
 }


### PR DESCRIPTION
## Thinking Path

> - [PAP-2981](/PAP/issues/PAP-2981) originally included an `advanced` run-liveness continuation change inside a broader reliability PR.
> - Review asked to keep that behavior out of the main reliability PR and move it into its own worktree and PR.
> - This PR isolates only the `advanced` behavior so it can be discussed independently from escalation dedupe, blocker-attention coverage, and live-run polling caps.
> - The intent is to make terminal `advanced` runs with a concrete next action eligible for bounded continuation instead of being treated as a healthy live path.

## What Changed

- Adds `advanced` to bounded run-liveness continuation actionable states.
- Lets heartbeat continuation handling dispatch `advanced` liveness runs through the same bounded continuation path as `plan_only` and `empty_response`.
- Requires `advanced` runs to have a concrete `nextAction` before enqueueing a continuation.
- Stops stranded-work recovery from treating succeeded `advanced` runs as productive/healthy by default.
- Updates focused continuation and stranded-recovery tests for the isolated behavior.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts server/src/__tests__/run-continuations.test.ts`
- Result: 2 files passed, 39 tests passed.
- `pnpm --filter @paperclipai/server typecheck`
- Result: passed.
- No UI changes; screenshots are not applicable.

## Risks

- `advanced` terminal runs with concrete `nextAction` can now schedule one additional bounded continuation where they previously stopped.
- Runs marked `advanced` without a next action remain skipped, so adapter classification quality still matters.
- This PR intentionally excludes the broader reliability changes from [#4875](https://github.com/paperclipai/paperclip/pull/4875).

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5, code execution and GitHub CLI tool use, medium reasoning effort.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge