### PR TITLE
fix(server): redact request bodies and sensitive headers in HTTP logger (#4759)

### DIFF
--- a/server/src/__tests__/logger-redaction.test.ts
+++ b/server/src/__tests__/logger-redaction.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression tests for https://github.com/paperclipai/paperclip/issues/4759
+ *
+ * The HTTP logger middleware writes the entire request body to logs (stdout
+ * and on-disk server.log) on any 4xx/5xx response. The original config only
+ * redacted `req.headers.authorization`, so plaintext passwords from failed
+ * sign-ins, password-reset tokens, adapter API keys, and other secrets in
+ * request bodies / query strings / sensitive headers were persisted to disk.
+ *
+ * These tests pin the redaction contract:
+ *   - Sensitive fields in `reqBody` / `reqParams` / `reqQuery` are scrubbed.
+ *   - Sensitive headers and query-string params are scrubbed.
+ *   - `/api/auth/*` failures drop `reqBody` entirely (the upstream library's
+ *     body shape evolves, so an allowlist of field names is fragile).
+ *   - Non-sensitive fields are preserved so logs remain useful for debugging.
+ *   - Oversized bodies are sentinel-replaced rather than walked, bounding the
+ *     cost of redaction and the risk of log-flood DoS.
+ */
+
+// Mirror logger-tz.test.ts: stub the transport machinery so importing the
+// module does not spawn pino worker threads or touch the filesystem.
+const mockTransport = vi.hoisted(() => vi.fn(() => ({ write: vi.fn() })));
+const mockPino = vi.hoisted(() => {
+  const fn = vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    child: vi.fn(),
+  }));
+  (fn as any).transport = mockTransport;
+  return fn;
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, mkdirSync: vi.fn() };
+});
+
+vi.mock("pino", () => ({
+  default: mockPino,
+  stdSerializers: {
+    req: (req: any) => ({
+      id: req.id,
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+    }),
+  },
+}));
+vi.mock("pino-http", () => ({
+  pinoHttp: vi.fn(() => vi.fn()),
+}));
+vi.mock("../config-file.js", () => ({
+  readConfigFile: vi.fn(() => null),
+}));
+vi.mock("../home-paths.js", () => ({
+  resolveHomeAwarePath: vi.fn((p: string) => p),
+  resolveDefaultLogsDir: vi.fn(() => "/tmp/paperclip-test-logs"),
+}));
+
+const REDACTED = "***REDACTED***";
+
+async function loadModule() {
+  return await import("../middleware/logger.js");
+}
+
+describe("scrubUrl", () => {
+  it("redacts sensitive query-string params (token, access_token, api_key, password, code, state)", async () => {
+    const { scrubUrl } = await loadModule();
+    expect(scrubUrl("/api/auth/reset?token=eyJabc.def.ghi")).toContain(REDACTED);
+    expect(scrubUrl("/api/auth/reset?token=eyJabc.def.ghi")).not.toContain("eyJabc");
+    expect(scrubUrl("/x?access_token=abc&keep=1")).toContain(REDACTED);
+    expect(scrubUrl("/x?access_token=abc&keep=1")).toContain("keep=1");
+    expect(scrubUrl("/x?api_key=sk-secret123456789012345")).toContain(REDACTED);
+    expect(scrubUrl("/x?password=hunter2")).toContain(REDACTED);
+    expect(scrubUrl("/oauth/cb?code=abc&state=xyz")).not.toMatch(/code=abc|state=xyz/);
+  });
+
+  it("preserves the path and non-sensitive params", async () => {
+    const { scrubUrl } = await loadModule();
+    const out = scrubUrl("/api/issues?status=open&limit=10");
+    expect(out).toBe("/api/issues?status=open&limit=10");
+  });
+
+  it("scrubs JWT-shaped tokens embedded anywhere in the URL via redactSensitiveText", async () => {
+    const { scrubUrl } = await loadModule();
+    const url = "/cb/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payloadclaim.signaturepart";
+    expect(scrubUrl(url)).toContain(REDACTED);
+    expect(scrubUrl(url)).not.toContain("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+  });
+
+  it("returns input unchanged on empty / unparseable URL without throwing", async () => {
+    const { scrubUrl } = await loadModule();
+    expect(scrubUrl("")).toBe("");
+    expect(typeof scrubUrl("not a url at all")).toBe("string");
+  });
+});
+
+describe("redactHeaders", () => {
+  it("scrubs authorization, cookie, set-cookie, x-api-key, proxy-authorization (case-insensitive)", async () => {
+    const { redactHeaders } = await loadModule();
+    const out = redactHeaders({
+      Authorization: "Bearer abc123",
+      cookie: "session=xyz",
+      "Set-Cookie": "id=1",
+      "X-API-Key": "sk-secret-key-123",
+      "Proxy-Authorization": "Basic abc",
+      "user-agent": "vitest",
+      host: "localhost",
+    }) as Record<string, unknown>;
+    expect(out.Authorization).toBe(REDACTED);
+    expect(out.cookie).toBe(REDACTED);
+    expect(out["Set-Cookie"]).toBe(REDACTED);
+    expect(out["X-API-Key"]).toBe(REDACTED);
+    expect(out["Proxy-Authorization"]).toBe(REDACTED);
+    expect(out["user-agent"]).toBe("vitest");
+    expect(out.host).toBe("localhost");
+  });
+
+  it("returns input unchanged for non-object input", async () => {
+    const { redactHeaders } = await loadModule();
+    expect(redactHeaders(undefined)).toBeUndefined();
+    expect(redactHeaders(null)).toBeNull();
+    expect(redactHeaders("nope")).toBe("nope");
+  });
+});
+
+describe("isAuthPath", () => {
+  it("matches /api/auth/* and rejects unrelated paths", async () => {
+    const { isAuthPath } = await loadModule();
+    expect(isAuthPath("/api/auth/sign-in/email")).toBe(true);
+    expect(isAuthPath("/api/auth/reset-password")).toBe(true);
+    expect(isAuthPath("/api/auth/")).toBe(true);
+    expect(isAuthPath("/api/issues")).toBe(false);
+    expect(isAuthPath("/auth/sign-in")).toBe(false);
+    expect(isAuthPath(undefined)).toBe(false);
+  });
+});
+
+describe("redactBodyForLog", () => {
+  it("redacts top-level password, currentPassword, newPassword, token, apiKey, secret", async () => {
+    const { redactBodyForLog } = await loadModule();
+    const out = redactBodyForLog({
+      email: "user@example.com",
+      password: "hunter2",
+      currentPassword: "old-pass",
+      newPassword: "new-pass",
+      token: "reset-token-abc",
+      apiKey: "sk-secret",
+      secret: "shh",
+    }) as Record<string, unknown>;
+    expect(out.email).toBe("user@example.com");
+    expect(out.password).toBe(REDACTED);
+    expect(out.currentPassword).toBe(REDACTED);
+    expect(out.newPassword).toBe(REDACTED);
+    expect(out.token).toBe(REDACTED);
+    expect(out.apiKey).toBe(REDACTED);
+    expect(out.secret).toBe(REDACTED);
+  });
+
+  it("redacts deeply nested adapter env API keys", async () => {
+    const { redactBodyForLog } = await loadModule();
+    const out = redactBodyForLog({
+      config: {
+        adapters: [
+          { name: "openai", env: { OPENAI_API_KEY: "sk-abc-very-secret-1234567890" } },
+          { name: "claude", env: { ANTHROPIC_API_KEY: "sk-ant-abc-1234567890" } },
+        ],
+      },
+    });
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("sk-abc-very-secret-1234567890");
+    expect(serialized).not.toContain("sk-ant-abc-1234567890");
+    expect(serialized).toContain(REDACTED);
+  });
+
+  it("preserves non-sensitive fields (email, name, ids)", async () => {
+    const { redactBodyForLog } = await loadModule();
+    const out = redactBodyForLog({
+      email: "user@example.com",
+      name: "Alice",
+      id: "abc-123",
+    }) as Record<string, unknown>;
+    expect(out.email).toBe("user@example.com");
+    expect(out.name).toBe("Alice");
+    expect(out.id).toBe("abc-123");
+  });
+
+  it("returns sentinel for bodies larger than the size cap (no walk, no throw)", async () => {
+    const { redactBodyForLog, MAX_LOGGED_BODY_BYTES } = await loadModule();
+    const padding = "x".repeat(MAX_LOGGED_BODY_BYTES + 1);
+    const out = redactBodyForLog({ password: "hunter2", padding });
+    expect(out).toBe("[omitted: body too large]");
+  });
+
+  it("passes through null, undefined, and primitives", async () => {
+    const { redactBodyForLog } = await loadModule();
+    expect(redactBodyForLog(null)).toBeNull();
+    expect(redactBodyForLog(undefined)).toBeUndefined();
+    expect(redactBodyForLog("plain string")).toBe("plain string");
+    expect(redactBodyForLog(42)).toBe(42);
+  });
+
+  it("walks array bodies and redacts records inside them", async () => {
+    const { redactBodyForLog } = await loadModule();
+    const out = redactBodyForLog([
+      { id: 1, password: "p1" },
+      { id: 2, apiKey: "sk-2" },
+    ]) as Array<Record<string, unknown>>;
+    expect(out[0].password).toBe(REDACTED);
+    expect(out[0].id).toBe(1);
+    expect(out[1].apiKey).toBe(REDACTED);
+  });
+});
+
+describe("buildErrorLogProps", () => {
+  it("returns empty object for 2xx/3xx responses", async () => {
+    const { buildErrorLogProps } = await loadModule();
+    expect(buildErrorLogProps({ url: "/x", body: { password: "p" } }, { statusCode: 200 })).toEqual({});
+    expect(buildErrorLogProps({ url: "/x", body: { password: "p" } }, { statusCode: 302 })).toEqual({});
+  });
+
+  it("redacts password in 401 sign-in body via the auth-path bypass (omits reqBody entirely)", async () => {
+    const { buildErrorLogProps } = await loadModule();
+    const out = buildErrorLogProps(
+      {
+        originalUrl: "/api/auth/sign-in/email",
+        url: "/api/auth/sign-in/email",
+        body: { email: "user@example.com", password: "hunter2" },
+      },
+      { statusCode: 401 },
+    );
+    expect(out.reqBody).toBeUndefined();
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("hunter2");
+  });
+
+  it("redacts deeply nested apiKey on a 400 outside /api/auth/*", async () => {
+    const { buildErrorLogProps } = await loadModule();
+    const out = buildErrorLogProps(
+      {
+        originalUrl: "/api/companies/abc/agents",
+        url: "/api/companies/abc/agents",
+        body: {
+          adapterConfig: { env: { OPENAI_API_KEY: "sk-leaky-key-1234567890" } },
+        },
+      },
+      { statusCode: 400 },
+    );
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("sk-leaky-key-1234567890");
+    expect(serialized).toContain(REDACTED);
+  });
+
+  it("omits reqBody entirely on /api/auth/reset-password 4xx (skipBody applies)", async () => {
+    const { buildErrorLogProps } = await loadModule();
+    const out = buildErrorLogProps(
+      {
+        originalUrl: "/api/auth/reset-password",
+        url: "/api/auth/reset-password",
+        body: { token: "reset-abc", currentPassword: "old", newPassword: "new" },
+      },
+      { statusCode: 400 },
+    );
+    expect(out.reqBody).toBeUndefined();
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("reset-abc");
+  });
+
+  it("redacts via __errorContext path on 500 (preserves error message)", async () => {
+    const { buildErrorLogProps } = await loadModule();
+    const out = buildErrorLogProps(
+      { originalUrl: "/api/x", url: "/api/x" },
+      {
+        statusCode: 500,
+        __errorContext: {
+          error: { message: "boom", name: "Error" },
+          reqBody: { password: "leak-me" },
+          reqParams: {},
+          reqQuery: { token: "qs-leak" },
+        },
+      },
+    );
+    expect(out.errorContext).toEqual({ message: "boom", name: "Error" });
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("leak-me");
+    expect(serialized).not.toContain("qs-leak");
+    expect(serialized).toContain("boom");
+  });
+
+  it("preserves non-sensitive fields and routePath in 4xx props", async () => {
+    const { buildErrorLogProps } = await loadModule();
+    const out = buildErrorLogProps(
+      {
+        originalUrl: "/api/issues",
+        url: "/api/issues",
+        body: { email: "a@b.com", name: "Alice" },
+        route: { path: "/api/issues" },
+      },
+      { statusCode: 400 },
+    ) as Record<string, unknown>;
+    expect(out.routePath).toBe("/api/issues");
+    const reqBody = out.reqBody as Record<string, unknown>;
+    expect(reqBody.email).toBe("a@b.com");
+    expect(reqBody.name).toBe("Alice");
+  });
+
+  it("redacts reqQuery containing sensitive params on non-auth paths", async () => {
+    const { buildErrorLogProps } = await loadModule();
+    const out = buildErrorLogProps(
+      {
+        originalUrl: "/api/x",
+        url: "/api/x",
+        query: { token: "qs-token-abc", limit: "10" },
+      },
+      { statusCode: 400 },
+    ) as Record<string, unknown>;
+    const reqQuery = out.reqQuery as Record<string, unknown>;
+    expect(reqQuery.token).toBe(REDACTED);
+    expect(reqQuery.limit).toBe("10");
+  });
+});

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -1,10 +1,12 @@
 import path from "node:path";
 import fs from "node:fs";
-import pino from "pino";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import pino, { stdSerializers } from "pino";
 import { pinoHttp } from "pino-http";
 import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
 import { shouldSilenceHttpSuccessLog } from "./http-log-policy.js";
+import { sanitizeRecord, redactSensitiveText, REDACTED_EVENT_VALUE } from "../redaction.js";
 
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
@@ -27,9 +29,141 @@ const sharedOpts = {
   singleLine: true,
 };
 
+// 64 KiB cap on logged request bodies. Bodies above this size are replaced
+// with a sentinel rather than walked; prevents log-flood DoS via large payloads
+// and bounds the cost of `sanitizeRecord` on pathological input.
+export const MAX_LOGGED_BODY_BYTES = 64 * 1024;
+
+const SENSITIVE_HEADER_NAMES = new Set([
+  "authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "proxy-authorization",
+]);
+
+const SENSITIVE_QUERY_KEYS = new Set([
+  "token",
+  "access_token",
+  "api_key",
+  "apikey",
+  "password",
+  "code",
+  "state",
+]);
+
+export function scrubUrl(rawUrl: string): string {
+  if (!rawUrl) return rawUrl;
+  try {
+    // req.url is path-relative; supply a dummy absolute base so URL parses it.
+    const parsed = new URL(rawUrl, "http://internal.invalid");
+    let mutated = false;
+    for (const key of [...parsed.searchParams.keys()]) {
+      if (SENSITIVE_QUERY_KEYS.has(key.toLowerCase())) {
+        parsed.searchParams.set(key, REDACTED_EVENT_VALUE);
+        mutated = true;
+      }
+    }
+    if (mutated) {
+      // Once we've structurally redacted, skip the text-based scrub: its
+      // ENV_SECRET_ASSIGNMENT_TEXT_RE is greedy on `[^\s]+` and would swallow
+      // the `&other_param=...` tail that follows our `***REDACTED***` value.
+      return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    }
+    return redactSensitiveText(rawUrl);
+  } catch {
+    return redactSensitiveText(rawUrl);
+  }
+}
+
+export function redactHeaders(headers: unknown): unknown {
+  if (!headers || typeof headers !== "object") return headers;
+  const out: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(headers as Record<string, unknown>)) {
+    out[name] = SENSITIVE_HEADER_NAMES.has(name.toLowerCase()) ? REDACTED_EVENT_VALUE : value;
+  }
+  return out;
+}
+
+// Better-auth mounts at /api/auth/*. Body shapes (passwords, OAuth codes,
+// reset tokens, callback URLs) evolve with the upstream library, so an
+// allowlist of field names is fragile — drop the body entirely on failures
+// and rely on status code + error message for diagnosis.
+export function isAuthPath(url: string | undefined): boolean {
+  return typeof url === "string" && url.startsWith("/api/auth/");
+}
+
+// `sanitizeRecord` (from redaction.ts) catches `password`, `apiKey`,
+// `authToken`, `access_token`, etc. — but its regex `auth(?:_?token)?`
+// requires the `auth` prefix on `token` and so misses bare `token`. The
+// logger needs broader coverage because we surface arbitrary user-submitted
+// bodies on every 4xx/5xx; widen with the keys below as a Layer B-only scrub.
+const LOGGER_EXTRA_SECRET_KEY_RE = /^token$/i;
+
+function scrubExtraSecretKeys(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(scrubExtraSecretKeys);
+  if (typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = LOGGER_EXTRA_SECRET_KEY_RE.test(k) ? REDACTED_EVENT_VALUE : scrubExtraSecretKeys(v);
+  }
+  return out;
+}
+
+export function redactBodyForLog(body: unknown): unknown {
+  if (body === null || body === undefined) return body;
+  if (typeof body !== "object") return body;
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(body);
+  } catch {
+    return "[unserializable]";
+  }
+  if (serialized.length > MAX_LOGGED_BODY_BYTES) return "[omitted: body too large]";
+  const sanitized = Array.isArray(body)
+    ? body.map((entry) =>
+        entry && typeof entry === "object" && !Array.isArray(entry)
+          ? sanitizeRecord(entry as Record<string, unknown>)
+          : entry,
+      )
+    : sanitizeRecord(body as Record<string, unknown>);
+  return scrubExtraSecretKeys(sanitized);
+}
+
 export const logger = pino({
   level: "debug",
-  redact: ["req.headers.authorization"],
+  // Layer A — structural: pino-level scrub for known sensitive paths so any
+  // future code path that attaches these fields is safe by default. Layer B
+  // (sanitizeRecord in customProps below) handles deep recursion that pino's
+  // path syntax cannot express.
+  redact: {
+    paths: [
+      "req.headers.authorization",
+      "req.headers.cookie",
+      'req.headers["set-cookie"]',
+      'req.headers["x-api-key"]',
+      'req.headers["proxy-authorization"]',
+      'res.headers["set-cookie"]',
+      "reqBody.password",
+      "reqBody.currentPassword",
+      "reqBody.newPassword",
+      "reqBody.token",
+      "reqBody.apiKey",
+      "reqBody.api_key",
+      "reqBody.accessToken",
+      "reqBody.refreshToken",
+      "reqBody.secret",
+      "reqBody.*.password",
+      "reqBody.*.token",
+      "reqBody.*.apiKey",
+      "reqQuery.token",
+      "reqQuery.access_token",
+      "reqQuery.api_key",
+    ],
+    censor: REDACTED_EVENT_VALUE,
+    remove: false,
+  },
 }, pino.transport({
   targets: [
     {
@@ -47,6 +181,21 @@ export const logger = pino({
 
 export const httpLogger = pinoHttp({
   logger,
+  serializers: {
+    // pino-http's default req serializer dumps full req.url (including query
+    // string) and req.headers. Wrap pino's standard serializer to scrub
+    // sensitive query params and headers before they hit the file transport.
+    req: (req: Parameters<typeof stdSerializers.req>[0]) => {
+      const serialized = stdSerializers.req(req);
+      if (typeof serialized.url === "string") {
+        serialized.url = scrubUrl(serialized.url);
+      }
+      if (serialized.headers && typeof serialized.headers === "object") {
+        serialized.headers = redactHeaders(serialized.headers) as typeof serialized.headers;
+      }
+      return serialized;
+    },
+  },
   customLogLevel(_req, res, err) {
     if (shouldSilenceHttpSuccessLog(_req.method, _req.url, res.statusCode)) {
       return "silent";
@@ -56,40 +205,52 @@ export const httpLogger = pinoHttp({
     return "info";
   },
   customSuccessMessage(req, res) {
-    return `${req.method} ${req.url} ${res.statusCode}`;
+    return `${req.method} ${scrubUrl(req.url ?? "")} ${res.statusCode}`;
   },
   customErrorMessage(req, res, err) {
     const ctx = (res as any).__errorContext;
     const errMsg = ctx?.error?.message || err?.message || (res as any).err?.message || "unknown error";
-    return `${req.method} ${req.url} ${res.statusCode} — ${errMsg}`;
+    return `${req.method} ${scrubUrl(req.url ?? "")} ${res.statusCode} — ${errMsg}`;
   },
-  customProps(req, res) {
-    if (res.statusCode >= 400) {
-      const ctx = (res as any).__errorContext;
-      if (ctx) {
-        return {
-          errorContext: ctx.error,
-          reqBody: ctx.reqBody,
-          reqParams: ctx.reqParams,
-          reqQuery: ctx.reqQuery,
-        };
-      }
-      const props: Record<string, unknown> = {};
-      const { body, params, query } = req as any;
-      if (body && typeof body === "object" && Object.keys(body).length > 0) {
-        props.reqBody = body;
-      }
-      if (params && typeof params === "object" && Object.keys(params).length > 0) {
-        props.reqParams = params;
-      }
-      if (query && typeof query === "object" && Object.keys(query).length > 0) {
-        props.reqQuery = query;
-      }
-      if ((req as any).route?.path) {
-        props.routePath = (req as any).route.path;
-      }
-      return props;
-    }
-    return {};
-  },
+  customProps: buildErrorLogProps,
 });
+
+export function buildErrorLogProps(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Record<string, unknown> {
+  const statusCode = res.statusCode ?? 0;
+  if (statusCode < 400) return {};
+  const r = req as IncomingMessage & Record<string, unknown>;
+  const requestUrl = (r.originalUrl as string | undefined) ?? (r.url as string | undefined) ?? "";
+  const skipBody = isAuthPath(requestUrl);
+  const ctx = (res as ServerResponse & {
+    __errorContext?: { error?: unknown; reqBody?: unknown; reqParams?: unknown; reqQuery?: unknown };
+  }).__errorContext;
+  if (ctx) {
+    const props: Record<string, unknown> = {};
+    if (ctx.error !== undefined) props.errorContext = ctx.error;
+    if (!skipBody && ctx.reqBody !== undefined) props.reqBody = redactBodyForLog(ctx.reqBody);
+    if (ctx.reqParams !== undefined) props.reqParams = redactBodyForLog(ctx.reqParams);
+    if (ctx.reqQuery !== undefined) props.reqQuery = redactBodyForLog(ctx.reqQuery);
+    return props;
+  }
+  const props: Record<string, unknown> = {};
+  const body = r.body;
+  const params = r.params;
+  const query = r.query;
+  if (!skipBody && body && typeof body === "object" && Object.keys(body as object).length > 0) {
+    props.reqBody = redactBodyForLog(body);
+  }
+  if (params && typeof params === "object" && Object.keys(params as object).length > 0) {
+    props.reqParams = redactBodyForLog(params);
+  }
+  if (query && typeof query === "object" && Object.keys(query as object).length > 0) {
+    props.reqQuery = redactBodyForLog(query);
+  }
+  const route = r.route as { path?: string } | undefined;
+  if (route?.path) {
+    props.routePath = route.path;
+  }
+  return props;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The server exposes a multi-tenant HTTP API and writes a structured pino log to stdout and `<logDir>/server.log` for operator observability
> - On any 4xx/5xx response, the HTTP logger middleware (`server/src/middleware/logger.ts`) attaches the full `req.body`, `req.params`, and `req.query` to the log record
> - Pino was configured with only `redact: [\"req.headers.authorization\"]`, so plaintext passwords from failed sign-ins, password-reset tokens, adapter API keys, and cookies were persisted to disk on routine errors (mistyped passwords, validation failures, FK violations, etc.). Issue #4759 reproduces this on `v2026.428.0`
> - This PR redacts request bodies, sensitive headers, and sensitive query-string params at the logger sink — defense in depth: pino-level structural `redact.paths`, plus `sanitizeRecord` from the existing `server/src/redaction.ts` for deep recursion, plus an explicit `/api/auth/*` body bypass since better-auth's body shape evolves and an allowlist of field names is fragile
> - The benefit is that logs stop persisting plaintext credentials by default, closing a passive secret-leak that fires on every mistyped password and on every adapter-config validation error

## What Changed

- **`server/src/middleware/logger.ts`** — expanded pino top-level `redact` from a single header path to a `{ paths, censor }` config covering `authorization`, `cookie`, `set-cookie`, `x-api-key`, `proxy-authorization`, and well-known body/query field names. Added a `serializers.req` override that wraps `pino.stdSerializers.req` to scrub URLs (sensitive query params + JWT/sk-* text patterns) and headers, since pino-http's default serializer logs `req.url` and `req.headers` independently of `customProps`. Extracted `customProps` into a named `buildErrorLogProps` so the redaction contract is unit-testable. Added Layer B `sanitizeRecord`-based scrub of `reqBody`, `reqParams`, `reqQuery`, and the `__errorContext` variants — pino's path syntax can't recurse into nested objects (e.g. `reqBody.adapterConfig.env.OPENAI_API_KEY`). Added `/api/auth/*` body bypass and a 64 KiB body-size cap (replaces oversized bodies with a sentinel; bounds redaction cost and prevents log-flood DoS).
- **`server/src/__tests__/logger-redaction.test.ts`** — 20 regression tests pinning the contract: URL/query scrub, header scrub (case-insensitive), body redaction (top-level + deeply nested), `/api/auth/*` bypass, `__errorContext` 500 path, size cap, array-body walking, non-sensitive field preservation.

This PR reuses `sanitizeRecord` / `redactSensitiveText` / `REDACTED_EVENT_VALUE` from `server/src/redaction.ts` (already used in `routes/agents.ts`, `routes/approvals.ts`, and `services/issue-approvals.ts`) — keeping redaction behavior consistent with merged PR #4856 (which fixed the same class of leak in agent API responses). No changes to `redaction.ts`, no changes to routes/services.

## Verification

**Automated (all green locally):**

\`\`\`bash
cd server
pnpm exec tsc --noEmit                                                  # clean
pnpm exec vitest run src/__tests__/logger-redaction.test.ts             # 20/20 pass
pnpm exec vitest run src/__tests__/logger-tz.test.ts \\
                    src/__tests__/redaction.test.ts \\
                    src/__tests__/error-handler.test.ts                 # 8/8 pass (related)
\`\`\`

Full server suite: 899 pass / 3 unrelated pre-existing failures in `cursor-local-*` tests probing for the local `cursor-agent` CLI binary path (verified by re-running on master without this branch — same 3 fail).

**Manual repro of the original CVE (issue #4759):**

\`\`\`bash
PAPERCLIP_LOG_DIR=/tmp/pc-logs pnpm dev:server &
curl -i -X POST http://localhost:PORT/api/auth/sign-in/email \\
  -H 'Content-Type: application/json' \\
  -d '{\"email\":\"a@b.com\",\"password\":\"hunter2\"}'

grep -F 'hunter2'  /tmp/pc-logs/server.log   # before: matches; after: empty
grep -F 'REDACTED' /tmp/pc-logs/server.log   # after: matches
\`\`\`

Repeat with `?token=eyJabc.def.ghi` in the URL and with a body containing nested `OPENAI_API_KEY: sk-...`.

## Risks

- **Log-shipping consumers** parsing exact body values will see `***REDACTED***` instead. This is the intended outcome and matches the precedent set by PR #4856 (which redacted the same fields in agent API responses).
- **Behavioral shift** for operators who relied on tailing `server.log` to debug failed requests by inspecting the body: sensitive fields are masked, but non-sensitive fields (`email`, `name`, `routePath`, status, error message) remain. `/api/auth/*` failures no longer surface the body at all — auth failures are diagnosed by status + error message. Acceptable trade-off given the severity of the underlying leak.
- **Performance:** `sanitizeRecord` only runs on 4xx/5xx. The 64 KiB cap bounds worst-case work on large bodies. No measurable impact on success-path latency.
- **No migration. No breaking API changes. No new deps.** `sanitizeRecord` and `pino` are already in use.
- **Pino path typos fail silently** — Layer B (`sanitizeRecord` walker) catches anything Layer A misses; the test suite asserts the union of both layers.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. — Confirmed: this is a security bug fix, not a feature. ROADMAP.md grep shows no overlap.

## Model Used

- **Claude Opus 4.7** (Anthropic), `claude-opus-4-7` with the 1M-context configuration, extended thinking enabled. Used for problem scoping, design (architect agent for the defense-in-depth approach), implementation, and test authoring. Human author reviewed every diff and verified the manual repro.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (20 new + 8 related; 3 pre-existing unrelated `cursor-local-*` failures verified on master)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only)
- [x] I have updated relevant documentation to reflect my changes — code comments document the layered approach; no user-facing docs reference logger internals
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge