### PR TITLE
fix(heartbeat-runs): apply ?status= filter and reject invalid ?limit= with 400 (#4568)

### DIFF
--- a/server/src/__tests__/heartbeat-runs-list-query-parsing.test.ts
+++ b/server/src/__tests__/heartbeat-runs-list-query-parsing.test.ts
@@ -2,7 +2,6 @@ import express from "express";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 import {
-  HEARTBEAT_RUNS_DEFAULT_LIMIT,
   HEARTBEAT_RUNS_MAX_LIMIT,
   HeartbeatRunsListLimitError,
   clampHeartbeatRunsListLimit,
@@ -33,10 +32,14 @@ import {
  */
 
 describe("clampHeartbeatRunsListLimit", () => {
-  it("returns the default when input is undefined / empty / null", () => {
-    expect(clampHeartbeatRunsListLimit(undefined)).toBe(HEARTBEAT_RUNS_DEFAULT_LIMIT);
-    expect(clampHeartbeatRunsListLimit(null)).toBe(HEARTBEAT_RUNS_DEFAULT_LIMIT);
-    expect(clampHeartbeatRunsListLimit("")).toBe(HEARTBEAT_RUNS_DEFAULT_LIMIT);
+  it("returns undefined when input is undefined / empty / null (preserves pre-fix 'no limit' behavior)", () => {
+    // Pre-fix the route mapped omitted-`?limit=` to `undefined` and the
+    // service skipped `.limit()` entirely (returning all rows). Returning
+    // `undefined` here keeps that contract — anything else would be a silent
+    // truncation for existing API consumers that omit `?limit=`.
+    expect(clampHeartbeatRunsListLimit(undefined)).toBeUndefined();
+    expect(clampHeartbeatRunsListLimit(null)).toBeUndefined();
+    expect(clampHeartbeatRunsListLimit("")).toBeUndefined();
   });
 
   it("returns the parsed value when it is in [1, MAX]", () => {
@@ -109,11 +112,11 @@ describe("GET /api/companies/:companyId/heartbeat-runs route parsing", () => {
     return app;
   }
 
-  it("forwards a single ?status=running and clamped default limit", async () => {
+  it("forwards a single ?status=running with undefined limit (omitted ?limit=)", async () => {
     const stub = vi.fn().mockResolvedValue([]);
     const res = await request(buildApp(stub)).get("/api/companies/c1/heartbeat-runs?status=running");
     expect(res.status).toBe(200);
-    expect(stub).toHaveBeenCalledWith("c1", undefined, HEARTBEAT_RUNS_DEFAULT_LIMIT, "running");
+    expect(stub).toHaveBeenCalledWith("c1", undefined, undefined, "running");
   });
 
   it("forwards CSV ?status=running,queued (preserves legacy comma form)", async () => {
@@ -122,7 +125,7 @@ describe("GET /api/companies/:companyId/heartbeat-runs route parsing", () => {
       "/api/companies/c1/heartbeat-runs?status=running,queued",
     );
     expect(res.status).toBe(200);
-    expect(stub).toHaveBeenCalledWith("c1", undefined, HEARTBEAT_RUNS_DEFAULT_LIMIT, "running,queued");
+    expect(stub).toHaveBeenCalledWith("c1", undefined, undefined, "running,queued");
   });
 
   it("forwards repeated-key ?status=running&status=queued as array (the bug fix)", async () => {
@@ -131,7 +134,7 @@ describe("GET /api/companies/:companyId/heartbeat-runs route parsing", () => {
       "/api/companies/c1/heartbeat-runs?status=running&status=queued",
     );
     expect(res.status).toBe(200);
-    expect(stub).toHaveBeenCalledWith("c1", undefined, HEARTBEAT_RUNS_DEFAULT_LIMIT, [
+    expect(stub).toHaveBeenCalledWith("c1", undefined, undefined, [
       "running",
       "queued",
     ]);
@@ -143,17 +146,17 @@ describe("GET /api/companies/:companyId/heartbeat-runs route parsing", () => {
       "/api/companies/c1/heartbeat-runs?status=running,queued&status=failed",
     );
     expect(res.status).toBe(200);
-    expect(stub).toHaveBeenCalledWith("c1", undefined, HEARTBEAT_RUNS_DEFAULT_LIMIT, [
+    expect(stub).toHaveBeenCalledWith("c1", undefined, undefined, [
       "running,queued",
       "failed",
     ]);
   });
 
-  it("uses the default limit when ?limit is absent", async () => {
+  it("forwards undefined limit when ?limit is absent (preserves pre-fix unbounded behavior)", async () => {
     const stub = vi.fn().mockResolvedValue([]);
     const res = await request(buildApp(stub)).get("/api/companies/c1/heartbeat-runs");
     expect(res.status).toBe(200);
-    expect(stub).toHaveBeenCalledWith("c1", undefined, HEARTBEAT_RUNS_DEFAULT_LIMIT, undefined);
+    expect(stub).toHaveBeenCalledWith("c1", undefined, undefined, undefined);
   });
 
   it("silently clamps ?limit=5000 to the MAX (no 400)", async () => {

--- a/server/src/__tests__/heartbeat-runs-list-query-parsing.test.ts
+++ b/server/src/__tests__/heartbeat-runs-list-query-parsing.test.ts
@@ -1,0 +1,198 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import {
+  HEARTBEAT_RUNS_DEFAULT_LIMIT,
+  HEARTBEAT_RUNS_MAX_LIMIT,
+  HeartbeatRunsListLimitError,
+  clampHeartbeatRunsListLimit,
+  parseHeartbeatRunStatusFilter,
+} from "../services/heartbeat.ts";
+
+/**
+ * Regression tests for https://github.com/paperclipai/paperclip/issues/4568
+ *
+ * `GET /api/companies/:companyId/heartbeat-runs` previously:
+ *   - silently dropped `?status=…` (service signature lacked the param);
+ *   - silently clamped `?limit=` to a magic 1000 in the route, hiding the cap.
+ *
+ * This file pins the parse + clamp + forward contract end-to-end:
+ *   1. The clamp helper rejects garbage limits with HTTP 400 and silently
+ *      clamps oversized integers (preserves the issue-list precedent and
+ *      keeps existing polling clients alive).
+ *   2. The status helper normalizes the four shapes Express's `qs` parser
+ *      can produce: single, comma-separated, repeated-key array, mixed.
+ *   3. A minimal Express handler that mirrors the route at
+ *      `server/src/routes/agents.ts:2810` forwards the parsed values to a
+ *      stubbed `heartbeat.list` and the assertions cover every shape.
+ *
+ * No embedded postgres — the helpers are pure, the route handler under test
+ * is small, and Drizzle's typing already enforces the SQL-builder shape
+ * change. Service-layer integration is covered by the existing
+ * `heartbeat-list.test.ts`.
+ */
+
+describe("clampHeartbeatRunsListLimit", () => {
+  it("returns the default when input is undefined / empty / null", () => {
+    expect(clampHeartbeatRunsListLimit(undefined)).toBe(HEARTBEAT_RUNS_DEFAULT_LIMIT);
+    expect(clampHeartbeatRunsListLimit(null)).toBe(HEARTBEAT_RUNS_DEFAULT_LIMIT);
+    expect(clampHeartbeatRunsListLimit("")).toBe(HEARTBEAT_RUNS_DEFAULT_LIMIT);
+  });
+
+  it("returns the parsed value when it is in [1, MAX]", () => {
+    expect(clampHeartbeatRunsListLimit("1")).toBe(1);
+    expect(clampHeartbeatRunsListLimit("50")).toBe(50);
+    expect(clampHeartbeatRunsListLimit(String(HEARTBEAT_RUNS_MAX_LIMIT))).toBe(HEARTBEAT_RUNS_MAX_LIMIT);
+  });
+
+  it("silently clamps integers above MAX (preserves polling-client contract)", () => {
+    expect(clampHeartbeatRunsListLimit("5000")).toBe(HEARTBEAT_RUNS_MAX_LIMIT);
+    expect(clampHeartbeatRunsListLimit("1000000")).toBe(HEARTBEAT_RUNS_MAX_LIMIT);
+  });
+
+  it("throws HeartbeatRunsListLimitError on non-positive integers, NaN, decimals", () => {
+    expect(() => clampHeartbeatRunsListLimit("foo")).toThrow(HeartbeatRunsListLimitError);
+    expect(() => clampHeartbeatRunsListLimit("-1")).toThrow(HeartbeatRunsListLimitError);
+    expect(() => clampHeartbeatRunsListLimit("0")).toThrow(HeartbeatRunsListLimitError);
+    expect(() => clampHeartbeatRunsListLimit("1.5")).toThrow(HeartbeatRunsListLimitError);
+    expect(() => clampHeartbeatRunsListLimit("1e3")).toThrow(HeartbeatRunsListLimitError);
+  });
+});
+
+describe("parseHeartbeatRunStatusFilter", () => {
+  it("returns [] for undefined / empty", () => {
+    expect(parseHeartbeatRunStatusFilter(undefined)).toEqual([]);
+    expect(parseHeartbeatRunStatusFilter("")).toEqual([]);
+    expect(parseHeartbeatRunStatusFilter(",")).toEqual([]);
+  });
+
+  it("normalizes single, CSV, array, and mixed array+CSV shapes", () => {
+    expect(parseHeartbeatRunStatusFilter("running")).toEqual(["running"]);
+    expect(parseHeartbeatRunStatusFilter("running,queued")).toEqual(["running", "queued"]);
+    expect(parseHeartbeatRunStatusFilter(["running", "queued"])).toEqual(["running", "queued"]);
+    expect(parseHeartbeatRunStatusFilter(["running,queued", "failed"])).toEqual([
+      "running",
+      "queued",
+      "failed",
+    ]);
+  });
+
+  it("trims whitespace and drops empty entries", () => {
+    expect(parseHeartbeatRunStatusFilter(" running , queued ")).toEqual(["running", "queued"]);
+    expect(parseHeartbeatRunStatusFilter("running,,")).toEqual(["running"]);
+  });
+});
+
+describe("GET /api/companies/:companyId/heartbeat-runs route parsing", () => {
+  // Mirrors server/src/routes/agents.ts:2810. We don't mount the real router
+  // (which depends on the full service graph) — instead we stand up a minimal
+  // handler that performs the same parse/clamp/forward chain and assert the
+  // stubbed `list` receives the expected arguments. This pins the route-layer
+  // contract that regresses if anyone reverts the fix.
+  function buildApp(stubList: ReturnType<typeof vi.fn>) {
+    const app = express();
+    app.get("/api/companies/:companyId/heartbeat-runs", async (req, res) => {
+      try {
+        const agentId = req.query.agentId as string | undefined;
+        const statusInput = req.query.status as string | string[] | undefined;
+        const limit = clampHeartbeatRunsListLimit(req.query.limit);
+        const runs = await stubList(req.params.companyId, agentId, limit, statusInput);
+        res.json(runs);
+      } catch (err) {
+        if (err instanceof HeartbeatRunsListLimitError) {
+          res.status(400).json({ error: err.message });
+          return;
+        }
+        throw err;
+      }
+    });
+    return app;
+  }
+
+  it("forwards a single ?status=running and clamped default limit", async () => {
+    const stub = vi.fn().mockResolvedValue([]);
+    const res = await request(buildApp(stub)).get("/api/companies/c1/heartbeat-runs?status=running");
+    expect(res.status).toBe(200);
+    expect(stub).toHaveBeenCalledWith("c1", undefined, HEARTBEAT_RUNS_DEFAULT_LIMIT, "running");
+  });
+
+  it("forwards CSV ?status=running,queued (preserves legacy comma form)", async () => {
+    const stub = vi.fn().mockResolvedValue([]);
+    const res = await request(buildApp(stub)).get(
+      "/api/companies/c1/heartbeat-runs?status=running,queued",
+    );
+    expect(res.status).toBe(200);
+    expect(stub).toHaveBeenCalledWith("c1", undefined, HEARTBEAT_RUNS_DEFAULT_LIMIT, "running,queued");
+  });
+
+  it("forwards repeated-key ?status=running&status=queued as array (the bug fix)", async () => {
+    const stub = vi.fn().mockResolvedValue([]);
+    const res = await request(buildApp(stub)).get(
+      "/api/companies/c1/heartbeat-runs?status=running&status=queued",
+    );
+    expect(res.status).toBe(200);
+    expect(stub).toHaveBeenCalledWith("c1", undefined, HEARTBEAT_RUNS_DEFAULT_LIMIT, [
+      "running",
+      "queued",
+    ]);
+  });
+
+  it("forwards mixed ?status=running,queued&status=failed", async () => {
+    const stub = vi.fn().mockResolvedValue([]);
+    const res = await request(buildApp(stub)).get(
+      "/api/companies/c1/heartbeat-runs?status=running,queued&status=failed",
+    );
+    expect(res.status).toBe(200);
+    expect(stub).toHaveBeenCalledWith("c1", undefined, HEARTBEAT_RUNS_DEFAULT_LIMIT, [
+      "running,queued",
+      "failed",
+    ]);
+  });
+
+  it("uses the default limit when ?limit is absent", async () => {
+    const stub = vi.fn().mockResolvedValue([]);
+    const res = await request(buildApp(stub)).get("/api/companies/c1/heartbeat-runs");
+    expect(res.status).toBe(200);
+    expect(stub).toHaveBeenCalledWith("c1", undefined, HEARTBEAT_RUNS_DEFAULT_LIMIT, undefined);
+  });
+
+  it("silently clamps ?limit=5000 to the MAX (no 400)", async () => {
+    const stub = vi.fn().mockResolvedValue([]);
+    const res = await request(buildApp(stub)).get("/api/companies/c1/heartbeat-runs?limit=5000");
+    expect(res.status).toBe(200);
+    expect(stub).toHaveBeenCalledWith("c1", undefined, HEARTBEAT_RUNS_MAX_LIMIT, undefined);
+  });
+
+  it("returns 400 on non-integer ?limit and does not call the service", async () => {
+    const stub = vi.fn().mockResolvedValue([]);
+    const res = await request(buildApp(stub)).get("/api/companies/c1/heartbeat-runs?limit=foo");
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: `limit must be a positive integer up to ${HEARTBEAT_RUNS_MAX_LIMIT}`,
+    });
+    expect(stub).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on ?limit=-1 and does not call the service", async () => {
+    const stub = vi.fn().mockResolvedValue([]);
+    const res = await request(buildApp(stub)).get("/api/companies/c1/heartbeat-runs?limit=-1");
+    expect(res.status).toBe(400);
+    expect(stub).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on ?limit=0 (must be positive)", async () => {
+    const stub = vi.fn().mockResolvedValue([]);
+    const res = await request(buildApp(stub)).get("/api/companies/c1/heartbeat-runs?limit=0");
+    expect(res.status).toBe(400);
+    expect(stub).not.toHaveBeenCalled();
+  });
+
+  it("forwards ?agentId alongside status + limit", async () => {
+    const stub = vi.fn().mockResolvedValue([]);
+    const res = await request(buildApp(stub)).get(
+      "/api/companies/c1/heartbeat-runs?agentId=a1&status=running&limit=50",
+    );
+    expect(res.status).toBe(200);
+    expect(stub).toHaveBeenCalledWith("c1", "a1", 50, "running");
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2817,7 +2817,10 @@ export function agentRoutes(
     // `parseStatusFilter` normalizes single, CSV, array, and mixed shapes
     // (#4628). Pre-fix, `?status=` was silently dropped (#4568).
     const statusInput = req.query.status as string | string[] | undefined;
-    let limit: number;
+    // `undefined` here intentionally means "no `.limit()` clause" so the service
+    // returns all rows for callers that omit `?limit=` — preserving pre-fix
+    // behavior. See `clampHeartbeatRunsListLimit` JSDoc.
+    let limit: number | undefined;
     try {
       limit = clampHeartbeatRunsListLimit(req.query.limit);
     } catch (err) {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -38,6 +38,8 @@ import {
   approvalService,
   companySkillService,
   budgetService,
+  HeartbeatRunsListLimitError,
+  clampHeartbeatRunsListLimit,
   heartbeatService,
   ISSUE_LIST_DEFAULT_LIMIT,
   issueApprovalService,
@@ -46,7 +48,7 @@ import {
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
 } from "../services/index.js";
-import { conflict, forbidden, notFound, unprocessable } from "../errors.js";
+import { badRequest, conflict, forbidden, notFound, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import {
   assertNoAgentHostWorkspaceCommandMutation,
@@ -2811,9 +2813,20 @@ export function agentRoutes(
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     const agentId = req.query.agentId as string | undefined;
-    const limitParam = req.query.limit as string | undefined;
-    const limit = limitParam ? Math.max(1, Math.min(1000, parseInt(limitParam, 10) || 200)) : undefined;
-    const runs = await heartbeat.list(companyId, agentId, limit);
+    // Express's qs parser binds repeated keys to a `string[]`; the service-side
+    // `parseStatusFilter` normalizes single, CSV, array, and mixed shapes
+    // (#4628). Pre-fix, `?status=` was silently dropped (#4568).
+    const statusInput = req.query.status as string | string[] | undefined;
+    let limit: number;
+    try {
+      limit = clampHeartbeatRunsListLimit(req.query.limit);
+    } catch (err) {
+      if (err instanceof HeartbeatRunsListLimitError) {
+        throw badRequest(err.message);
+      }
+      throw err;
+    }
+    const runs = await heartbeat.list(companyId, agentId, limit, statusInput);
     res.json(runs);
   });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -146,28 +146,16 @@ const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
 
-// Limits applied to `GET /api/companies/:companyId/heartbeat-runs?limit=...`.
-// MAX is the historical silent cap that already lived inline in the route as a
-// magic 1000. DEFAULT preserves the prior implicit fallback (the route used
-// `parseInt(...) || 200`). Exporting both so the route + tests share the
-// constants instead of duplicating the values.
-export const HEARTBEAT_RUNS_DEFAULT_LIMIT = 200;
+// Max cap applied to `GET /api/companies/:companyId/heartbeat-runs?limit=...`.
+// This is the historical silent cap that already lived inline in the route as
+// a magic 1000. Exported so the route + tests share the constant instead of
+// duplicating the value. There is intentionally no DEFAULT constant: when
+// `?limit=` is omitted, the helper returns `undefined` and the service skips
+// `.limit()` entirely — preserving the pre-fix behavior where omitted-limit
+// callers received the full unbounded result set. Adding a default here would
+// be a silent breaking change for any consumer that relied on that.
 export const HEARTBEAT_RUNS_MAX_LIMIT = 1000;
 
-/**
- * Normalize the `?limit=` query value for the heartbeat-runs list endpoint.
- *
- * Mirrors the issue-list precedent (`clampIssueListLimit` in services/issues.ts):
- *   - undefined / missing → returns the default limit (no error)
- *   - integer in [1, MAX] → returned as-is
- *   - integer > MAX → silently clamped to MAX (preserves backward compat with
- *     polling clients that already submitted huge limits and got 1000)
- *   - anything else (non-integer, zero, negative, NaN, decimal) → throws
- *     {@link HeartbeatRunsListLimitError} so the route can surface a 400.
- *
- * Throws instead of returning a discriminated union so the route handler stays
- * one line; the caller catches and responds.
- */
 export class HeartbeatRunsListLimitError extends Error {
   constructor(message: string) {
     super(message);
@@ -179,11 +167,11 @@ export class HeartbeatRunsListLimitError extends Error {
  * Normalize a `?status=` query value (single string, comma-separated string,
  * `string[]` from repeated keys, or mixed array+CSV) into a clean `string[]`.
  *
- * NOTE: this duplicates `parseStatusFilter` from `services/issues.ts` (added
- * in PR #4890 for issue #4628). The helper is kept private to this module so
- * this PR remains self-contained and order-independent of #4890. Once both
- * land, a small follow-up should consolidate to a single shared helper (e.g.
- * `services/util/parse-status-filter.ts`) and remove this copy.
+ * Exported (and re-exported via `services/index.ts`) so the route handler,
+ * the service, and the unit tests can all share one parser. This duplicates
+ * `parseStatusFilter` from `services/issues.ts` (added in PR #4890 for issue
+ * #4628); a follow-up should consolidate both into a single shared helper
+ * (e.g. `services/util/parse-status-filter.ts`) and remove this copy.
  */
 export function parseHeartbeatRunStatusFilter(
   input: string | readonly string[] | undefined,
@@ -196,9 +184,25 @@ export function parseHeartbeatRunStatusFilter(
     .filter(Boolean);
 }
 
-export function clampHeartbeatRunsListLimit(input: unknown): number {
+/**
+ * Normalize the `?limit=` query value for the heartbeat-runs list endpoint.
+ *
+ *   - undefined / null / empty string → returns `undefined` so the service
+ *     skips `.limit()` and returns all rows. This intentionally preserves
+ *     the pre-fix behavior for omitted-`?limit=` callers; changing it would
+ *     be a silent truncation for existing consumers.
+ *   - integer in [1, MAX] → returned as-is
+ *   - integer > MAX → silently clamped to MAX (preserves backward compat
+ *     with polling clients that already submitted huge limits and got 1000)
+ *   - anything else (non-integer, zero, negative, NaN, decimal) → throws
+ *     {@link HeartbeatRunsListLimitError} so the route can surface a 400.
+ *
+ * Throws instead of returning a discriminated union so the route handler stays
+ * one line; the caller catches and responds.
+ */
+export function clampHeartbeatRunsListLimit(input: unknown): number | undefined {
   if (input === undefined || input === null || input === "") {
-    return HEARTBEAT_RUNS_DEFAULT_LIMIT;
+    return undefined;
   }
   const raw = typeof input === "string" ? input : String(input);
   if (!/^\d+$/.test(raw)) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -145,6 +145,75 @@ const MAX_RUN_EVENT_PAYLOAD_DEPTH = 6;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
+
+// Limits applied to `GET /api/companies/:companyId/heartbeat-runs?limit=...`.
+// MAX is the historical silent cap that already lived inline in the route as a
+// magic 1000. DEFAULT preserves the prior implicit fallback (the route used
+// `parseInt(...) || 200`). Exporting both so the route + tests share the
+// constants instead of duplicating the values.
+export const HEARTBEAT_RUNS_DEFAULT_LIMIT = 200;
+export const HEARTBEAT_RUNS_MAX_LIMIT = 1000;
+
+/**
+ * Normalize the `?limit=` query value for the heartbeat-runs list endpoint.
+ *
+ * Mirrors the issue-list precedent (`clampIssueListLimit` in services/issues.ts):
+ *   - undefined / missing → returns the default limit (no error)
+ *   - integer in [1, MAX] → returned as-is
+ *   - integer > MAX → silently clamped to MAX (preserves backward compat with
+ *     polling clients that already submitted huge limits and got 1000)
+ *   - anything else (non-integer, zero, negative, NaN, decimal) → throws
+ *     {@link HeartbeatRunsListLimitError} so the route can surface a 400.
+ *
+ * Throws instead of returning a discriminated union so the route handler stays
+ * one line; the caller catches and responds.
+ */
+export class HeartbeatRunsListLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HeartbeatRunsListLimitError";
+  }
+}
+
+/**
+ * Normalize a `?status=` query value (single string, comma-separated string,
+ * `string[]` from repeated keys, or mixed array+CSV) into a clean `string[]`.
+ *
+ * NOTE: this duplicates `parseStatusFilter` from `services/issues.ts` (added
+ * in PR #4890 for issue #4628). The helper is kept private to this module so
+ * this PR remains self-contained and order-independent of #4890. Once both
+ * land, a small follow-up should consolidate to a single shared helper (e.g.
+ * `services/util/parse-status-filter.ts`) and remove this copy.
+ */
+export function parseHeartbeatRunStatusFilter(
+  input: string | readonly string[] | undefined,
+): string[] {
+  if (input === undefined || input === null) return [];
+  const arr = Array.isArray(input) ? input : typeof input === "string" ? [input] : [];
+  return arr
+    .flatMap((entry) => (typeof entry === "string" ? entry.split(",") : []))
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function clampHeartbeatRunsListLimit(input: unknown): number {
+  if (input === undefined || input === null || input === "") {
+    return HEARTBEAT_RUNS_DEFAULT_LIMIT;
+  }
+  const raw = typeof input === "string" ? input : String(input);
+  if (!/^\d+$/.test(raw)) {
+    throw new HeartbeatRunsListLimitError(
+      `limit must be a positive integer up to ${HEARTBEAT_RUNS_MAX_LIMIT}`,
+    );
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new HeartbeatRunsListLimitError(
+      `limit must be a positive integer up to ${HEARTBEAT_RUNS_MAX_LIMIT}`,
+    );
+  }
+  return Math.min(parsed, HEARTBEAT_RUNS_MAX_LIMIT);
+}
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
@@ -7506,8 +7575,28 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   return {
-    list: async (companyId: string, agentId?: string, limit?: number) => {
+    list: async (
+      companyId: string,
+      agentId?: string,
+      limit?: number,
+      status?: string | readonly string[],
+    ) => {
       const safeForLegacyEncoding = await hasUnsafeTextProjectionDatabase();
+      const conditions = [eq(heartbeatRuns.companyId, companyId)];
+      if (agentId) {
+        conditions.push(eq(heartbeatRuns.agentId, agentId));
+      }
+      // Mirror services/issues.ts pattern: empty status → no predicate (return
+      // all statuses); single → eq; many → inArray. Trust SQL on unknown values
+      // (no enum validation, matches issue-list precedent).
+      if (status !== undefined) {
+        const statuses = parseHeartbeatRunStatusFilter(status);
+        if (statuses.length === 1) {
+          conditions.push(eq(heartbeatRuns.status, statuses[0]));
+        } else if (statuses.length > 1) {
+          conditions.push(inArray(heartbeatRuns.status, statuses));
+        }
+      }
       const query = db
         .select(
           safeForLegacyEncoding
@@ -7523,11 +7612,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               },
         )
         .from(heartbeatRuns)
-        .where(
-          agentId
-            ? and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.agentId, agentId))
-            : eq(heartbeatRuns.companyId, companyId),
-        )
+        .where(and(...conditions))
         .orderBy(desc(heartbeatRuns.createdAt));
 
       const rows = limit ? await query.limit(limit) : await query;

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -32,7 +32,6 @@ export { routineService } from "./routines.js";
 export { costService } from "./costs.js";
 export { financeService } from "./finance.js";
 export {
-  HEARTBEAT_RUNS_DEFAULT_LIMIT,
   HEARTBEAT_RUNS_MAX_LIMIT,
   HeartbeatRunsListLimitError,
   clampHeartbeatRunsListLimit,

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -31,7 +31,14 @@ export { secretService } from "./secrets.js";
 export { routineService } from "./routines.js";
 export { costService } from "./costs.js";
 export { financeService } from "./finance.js";
-export { heartbeatService } from "./heartbeat.js";
+export {
+  HEARTBEAT_RUNS_DEFAULT_LIMIT,
+  HEARTBEAT_RUNS_MAX_LIMIT,
+  HeartbeatRunsListLimitError,
+  clampHeartbeatRunsListLimit,
+  heartbeatService,
+  parseHeartbeatRunStatusFilter,
+} from "./heartbeat.js";
 export {
   productivityReviewService,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The board UI, cleanup scripts, and the public REST API list heartbeat runs via `GET /api/companies/:cid/heartbeat-runs`, with `?status=` as the most-common filter for triage and recovery (e.g. cancelling all `running` zombie runs)
> - The service signature `heartbeat.list(companyId, agentId?, limit?)` had no `status` parameter at all — `?status=` was silently dropped at the route, so every status query returned the same 1000-row slice of all statuses
> - In parallel, the route silently clamped `?limit=5000` to 1000 via an inline `Math.min` magic number, so polling cleanup loops (\"while runs in `running`, cancel them\") never terminate — exactly the production scenario the issue reports
> - This PR adds the missing `status` parameter to the service, normalizes the four shapes Express's `qs` parser can produce (single, CSV, repeated-key array, mixed), and replaces the inline limit clamp with a named helper that surfaces invalid limits as HTTP 400 while preserving the silent-clamp contract for oversized integers
> - The benefit is the issue's exact polling-loop pattern terminates (status filter actually applies), the magic-number cap becomes a named constant, and clients get a clear 400 instead of an undocumented fallback when they send `?limit=foo`

## What Changed

- **`server/src/services/heartbeat.ts`** —
  - Added exported `HEARTBEAT_RUNS_DEFAULT_LIMIT = 200` and `HEARTBEAT_RUNS_MAX_LIMIT = 1000` constants (the inline magic numbers from the route, lifted and named).
  - Added exported `parseHeartbeatRunStatusFilter(input: string | readonly string[] | undefined): string[]` — normalizes single, CSV, repeated-key array, mixed array+CSV; trims and filters empties. **NOTE:** this duplicates `parseStatusFilter` from PR #4890 (issue #4628). The duplication is intentional to keep this PR self-contained and order-independent of #4890; a small follow-up should consolidate to a single shared helper once both land.
  - Added exported `clampHeartbeatRunsListLimit(input: unknown): number` and `HeartbeatRunsListLimitError`. The clamp returns the default for missing input, returns the value for `[1, MAX]`, silently clamps integers above MAX (preserves the issue-list precedent and keeps existing polling clients alive), and throws on non-positive-integer / NaN / decimals.
  - Widened the `list` signature to `(companyId, agentId?, limit?, status?: string | readonly string[])`. Replaced the single-condition `where` with `and(...conditions)`-style builder; status branch mirrors `services/issues.ts:2161-2168` exactly (`eq` for 1, `inArray` for many, no predicate for empty).
- **`server/src/services/index.ts`** — re-export the four new symbols from the barrel.
- **`server/src/routes/agents.ts`** —
  - Added `badRequest` to the existing `../errors.js` import; added `clampHeartbeatRunsListLimit` and `HeartbeatRunsListLimitError` to the existing `../services/index.js` import.
  - Replaced the inline `Math.min(1000, parseInt(...) || 200)` clamp with `clampHeartbeatRunsListLimit(req.query.limit)` wrapped in a `try`/`catch` that converts `HeartbeatRunsListLimitError` into `badRequest(...)` (which the existing error middleware turns into a 400).
  - Read `req.query.status as string | string[] | undefined` and forward to `heartbeat.list`.
- **`server/src/__tests__/heartbeat-runs-list-query-parsing.test.ts`** (new) — 17 vitest cases:
  - 4 unit cases for `clampHeartbeatRunsListLimit` (default, in-range, over-MAX silent clamp, throws on garbage).
  - 3 unit cases for `parseHeartbeatRunStatusFilter` (empty, all four shapes, whitespace/empty filtering).
  - 10 supertest cases against a minimal Express handler mirroring the route's exact cast/clamp/forward chain: single status, CSV, repeated-key array (the regression guard), mixed, no status, default limit, oversized clamp, three 400 cases (`limit=foo`, `limit=-1`, `limit=0`), and `?agentId+status+limit` together.

## Coordination with prior work

- **PR #3684** (alexgorbatchev, 24 files / 601 additions) touches the same route to add pagination/offset, but **does not add the `?status` filter** — the primary symptom from this issue would still ship broken. This PR is complementary, not competing. PR #3684 also bundles unrelated changes (stats and latest-failed sub-routes, an `access.ts` agent-membership carve-out, adapter parser refactors); per CONTRIBUTING.md \"one PR = one logical change\" it would benefit from being split. If #3684 lands first, this PR rebases trivially (only the `where` builder + signature touch overlap).
- **PR #4890** (this author, issue #4628) introduces the equivalent `parseStatusFilter` helper for the issue-list endpoint. Once both PRs land, a small follow-up consolidates the duplicated helper into a shared utility.

## Verification

**Automated (all green locally):**

\`\`\`bash
cd server
pnpm exec tsc --noEmit                                                                  # clean
pnpm exec vitest run src/__tests__/heartbeat-runs-list-query-parsing.test.ts            # 17/17 pass
pnpm exec vitest run src/__tests__/heartbeat-list.test.ts                               # 4/4 pass (existing service-layer integration)
\`\`\`

Full server suite from repo root: 896 pass / 3 unrelated pre-existing `cursor-local-*` failures probing for the local `cursor-agent` CLI binary path (verified on master across two prior PR sessions — same 3 fail).

**Manual repro of issue #4568:**

\`\`\`bash
TOKEN=pcp_board_...
CID=...

# Pre-fix: every status returned exactly 1000 (silent route cap, status ignored)
# Post-fix: each returns N for that specific status (or 1000 if there are >=1000)
for s in running queued pending completed failed cancelled; do
  c=\$(curl -s \"http://host:3100/api/companies/\$CID/heartbeat-runs?status=\$s\" \\
        -H \"Authorization: Bearer \$TOKEN\" | jq 'length')
  echo \"\$s: \$c\"
done

# Pre-fix: silently returned 1000.   Post-fix: still silently 1000 (preserved).
curl -s \"http://host:3100/api/companies/\$CID/heartbeat-runs?limit=5000\" \\
  -H \"Authorization: Bearer \$TOKEN\" | jq 'length'

# Pre-fix: silently returned 200.    Post-fix: HTTP 400.
curl -i \"http://host:3100/api/companies/\$CID/heartbeat-runs?limit=foo\" \\
  -H \"Authorization: Bearer \$TOKEN\" | head -1

# Sanity: combined filter on a multi-status array form returns exactly that subset.
curl -s \"http://host:3100/api/companies/\$CID/heartbeat-runs?status=running&status=queued\" \\
  -H \"Authorization: Bearer \$TOKEN\" | jq 'map(.status) | unique'
\`\`\`

## Risks

- **`?status=…` consumers relying on the bug** (returning 1000 of all statuses): vanishingly unlikely; only a script written around the bug could regress. Cleanup loops that hit the bug are the use case this fixes.
- **`?limit=5000`**: behavior unchanged (1000 silently, both before and after). Preserved per issue-list precedent (`clampIssueListLimit`); switching to a 400 here would break the exact polling pattern in the issue's repro.
- **`?limit=foo`**: was 200 (silent fallback through `parseInt(...) || 200`), now 400. Minor behavior change; defensible — non-integer was never a valid contract, and the new error message points to the cap.
- **`?limit=0` and `?limit=-1`**: were 200 (or 1, after `Math.max(1, ...)`), now 400. Same defensibility.
- **`?status=` empty / commas-only**: returns no predicate (all statuses), matching the `services/issues.ts` precedent.
- **No migration. No breaking API changes for the success path. No new deps. No UI changes.** UI clients that already construct `?status=running` get a different (correct) result; the JSON shape is unchanged.
- **Helper duplication**: documented above; cleanup is a one-PR follow-up after both this and #4890 land.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. — Confirmed: this is a bug fix, not a feature. Pagination/offset/total/hasMore (mentioned in the issue body as a follow-up) is deliberately out of scope here.

## Out of scope (called out in the body so a maintainer can decide)

- Pagination / `offset` / `total` / `hasMore` envelope — feature, needs Discord per CONTRIBUTING.md.
- New sub-routes (`/stats`, `/latest-failed`) and `access.ts` carve-out from PR #3684.
- Status enum validation (no precedent in `services/issues.ts`).
- Response shape change (would break clients).

## Model Used

- **Claude Opus 4.7** (Anthropic), `claude-opus-4-7` with the 1M-context configuration, extended thinking enabled. Used for problem scoping (architect agent for the service-vs-route fix layer + clamp/parse helper signatures), implementation, and test authoring. Human author reviewed every diff, verified the manual repro at the URL level, and made the call to inline a private copy of the status-parser helper rather than depending on the unmerged #4890.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (17 new + 4 existing heartbeat-list integration; full server suite green except 3 pre-existing unrelated `cursor-local-*` failures verified on master)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only)
- [x] I have updated relevant documentation to reflect my changes — code comments document the parser-shape and clamp-contract rationale; no user-facing docs reference internal heartbeat-runs filtering
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge