### PR TITLE
plugins: make e2b template default explicit

### DIFF
--- a/packages/plugins/sandbox-providers/e2b/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/e2b/src/manifest.ts
@@ -28,7 +28,7 @@ const manifest: PaperclipPluginManifestV1 = {
         properties: {
           template: {
             type: "string",
-            description: "E2B sandbox template name.",
+            description: "E2B sandbox template name. Defaults to base when omitted.",
             default: "base",
           },
           apiKey: {
@@ -48,7 +48,6 @@ const manifest: PaperclipPluginManifestV1 = {
             default: false,
           },
         },
-        required: ["template"],
       },
     },
   ],

--- a/packages/plugins/sandbox-providers/e2b/src/plugin.test.ts
+++ b/packages/plugins/sandbox-providers/e2b/src/plugin.test.ts
@@ -131,6 +131,26 @@ describe("E2B sandbox provider plugin", () => {
     });
   });
 
+  it("defaults a missing template to base", async () => {
+    const result = await plugin.definition.onEnvironmentValidateConfig?.({
+      driverKey: "e2b",
+      config: {
+        timeoutMs: "450000.9",
+        reuseLease: true,
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      normalizedConfig: {
+        template: "base",
+        apiKey: null,
+        timeoutMs: 450000,
+        reuseLease: true,
+      },
+    });
+  });
+
   it("rejects empty template strings instead of silently normalizing them", async () => {
     await expect(plugin.definition.onEnvironmentValidateConfig?.({
       driverKey: "e2b",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Remote execution environments are part of that control plane, including sandbox-provider plugins like E2B
> - The E2B provider already normalizes config and runtime behavior around a `base` template default
> - But the manifest still presented `template` as required, which forces redundant operator input and makes the UI contract stricter than runtime behavior
> - That mismatch showed up while building a repeatable QA workflow for sandbox testing
> - This pull request makes the manifest and validation contract line up with the existing `base` default
> - The benefit is a simpler and more accurate E2B environment setup experience

## What Changed

- Removed the E2B manifest's `required: ["template"]` requirement so the config schema matches runtime behavior
- Clarified the manifest description to say the template defaults to `base` when omitted
- Added a focused unit test proving that validation normalizes a missing template to `base`

## Verification

- Ran the focused E2B plugin test for the new behavior:
  - `cd packages/plugins/sandbox-providers/e2b && pnpm test -- --testNamePattern "defaults a missing template to base"`

## Risks

- Low risk. This only loosens the schema to match the plugin's existing runtime normalization and adds a test for that path.
- The broader E2B plugin suite currently has unrelated existing failures outside this change; this PR does not modify those paths.

## Model Used

- OpenAI Codex, GPT-5 Codex via Codex CLI agent tooling, large-context coding workflow with terminal tool use and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
