### PR TITLE
Clarify sandbox provider messaging in company environments

### DIFF
--- a/ui/src/pages/CompanyEnvironments.tsx
+++ b/ui/src/pages/CompanyEnvironments.tsx
@@ -432,6 +432,15 @@ export function CompanyEnvironments() {
           remote-managed adapters, and sandbox environments appear only when a run-capable sandbox provider plugin is
           installed.
         </div>
+        {sandboxCreationEnabled ? (
+          <div className="rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+            Installed sandbox providers:{" "}
+            <span className="font-medium text-foreground">
+              {discoveredPluginSandboxProviders.map((provider) => provider.displayName).join(", ")}
+            </span>
+            . These are not adapter types. They back the Sandbox driver for adapters that support sandbox execution.
+          </div>
+        ) : null}
 
         <div className="overflow-x-auto">
           <table className="w-full min-w-[34rem] text-left text-xs">
@@ -442,7 +451,7 @@ export function CompanyEnvironments() {
                 <th className="px-3 py-2 font-medium">Local</th>
                 <th className="px-3 py-2 font-medium">SSH</th>
                 {sandboxSupportVisible ? (
-                  <th className="px-3 py-2 font-medium">Sandbox</th>
+                  <th className="px-3 py-2 font-medium">Sandbox via plugin</th>
                 ) : null}
               </tr>
             </thead>

--- a/ui/src/pages/CompanySettings.test.tsx
+++ b/ui/src/pages/CompanySettings.test.tsx
@@ -220,6 +220,10 @@ describe("CompanyEnvironments", () => {
     await flushReact();
     await flushReact();
 
+    expect(container.textContent).toContain("Installed sandbox providers:");
+    expect(container.textContent).toContain("Secure Sandbox");
+    expect(container.textContent).toContain("These are not adapter types.");
+
     const editButton = Array.from(container.querySelectorAll("button"))
       .find((button) => button.textContent?.trim() === "Edit");
     expect(editButton).toBeTruthy();


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Company Environments is the operator-facing seam for choosing where compatible adapters execute work.
> - Sandbox provider plugins such as E2B extend that seam, but they are not agent adapters themselves.
> - The current Company Environments copy put adapter capability rows and sandbox-provider enablement on the same page without clearly distinguishing the two concepts.
> - That made it look like installing the E2B sandbox provider caused a new adapter to appear under adapters.
> - This pull request clarifies the UI language so provider plugins are described as backing the Sandbox driver rather than being adapter types.
> - The benefit is a more accurate mental model for operators configuring environments and adapters.

## What Changed

- Added explicit Company Environments copy stating that installed sandbox providers are not adapter types and instead back the Sandbox driver for compatible adapters.
- Renamed the support-matrix column from `Sandbox` to `Sandbox via plugin` to make the provider relationship visible in the table itself.
- Extended the existing environments UI test to assert the new clarification text.

## Verification

- `pnpm test -- --run ui/src/pages/CompanySettings.test.tsx`
  Result: could not complete cleanly in this worktree because the checkout is missing its local workspace install links.
- Direct Vitest fallback against `ui/src/pages/CompanySettings.test.tsx`
  Result: failed before test collection on local dependency resolution (`react/jsx-dev-runtime`), so there is no passing automated signal from this checkout.
- Manual review
  Confirm the Company Environments page now says sandbox providers are not adapter types and labels the table column as `Sandbox via plugin`.

## Risks

- Low risk. This is a copy-only UI clarification plus a matching test assertion; the main risk is wording drift if the product later decides sandbox providers should be surfaced differently.

## Model Used

- OpenAI Codex via the local `codex_local` Paperclip adapter. This run used tool-assisted code editing and shell execution. The exact backend model ID and context window are not exposed in the Paperclip run context for this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge