### PR TITLE
feat(routines): add consumption tracking + dormancy alarm thresholds (CHE-43)

### DIFF
--- a/packages/db/src/migrations/0075_routine_runs_consumption_and_dormancy_thresholds.sql
+++ b/packages/db/src/migrations/0075_routine_runs_consumption_and_dormancy_thresholds.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "routine_runs" ADD COLUMN IF NOT EXISTS "consumed_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "routine_runs" ADD COLUMN IF NOT EXISTS "consumed_by_heartbeat_run_id" uuid;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "routine_runs" ADD CONSTRAINT "routine_runs_consumed_by_heartbeat_run_id_heartbeat_runs_id_fk" FOREIGN KEY ("consumed_by_heartbeat_run_id") REFERENCES "public"."heartbeat_runs"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "routine_runs_routine_consumed_idx"
+  ON "routine_runs" USING btree ("routine_id","consumed_at");
+--> statement-breakpoint
+ALTER TABLE "companies" ADD COLUMN IF NOT EXISTS "dormancy_alarm_fire_count_threshold" integer DEFAULT 3 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "companies" ADD COLUMN IF NOT EXISTS "dormancy_alarm_stale_hours" integer DEFAULT 12 NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1777384535070,
       "tag": "0074_striped_genesis",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1777395000000,
+      "tag": "0075_routine_runs_consumption_and_dormancy_thresholds",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/companies.ts
+++ b/packages/db/src/schema/companies.ts
@@ -26,6 +26,8 @@ export const companies = pgTable(
     feedbackDataSharingConsentByUserId: text("feedback_data_sharing_consent_by_user_id"),
     feedbackDataSharingTermsVersion: text("feedback_data_sharing_terms_version"),
     brandColor: text("brand_color"),
+    dormancyAlarmFireCountThreshold: integer("dormancy_alarm_fire_count_threshold").notNull().default(3),
+    dormancyAlarmStaleHours: integer("dormancy_alarm_stale_hours").notNull().default(12),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/db/src/schema/routines.ts
+++ b/packages/db/src/schema/routines.ts
@@ -12,6 +12,7 @@ import {
 import { agents } from "./agents.js";
 import { companies } from "./companies.js";
 import { companySecrets } from "./company_secrets.js";
+import { heartbeatRuns } from "./heartbeat_runs.js";
 import { issues } from "./issues.js";
 import { projects } from "./projects.js";
 import { goals } from "./goals.js";
@@ -101,6 +102,10 @@ export const routineRuns = pgTable(
     coalescedIntoRunId: uuid("coalesced_into_run_id"),
     failureReason: text("failure_reason"),
     completedAt: timestamp("completed_at", { withTimezone: true }),
+    consumedAt: timestamp("consumed_at", { withTimezone: true }),
+    consumedByHeartbeatRunId: uuid("consumed_by_heartbeat_run_id").references(() => heartbeatRuns.id, {
+      onDelete: "set null",
+    }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -110,5 +115,6 @@ export const routineRuns = pgTable(
     dispatchFingerprintIdx: index("routine_runs_dispatch_fingerprint_idx").on(table.routineId, table.dispatchFingerprint),
     linkedIssueIdx: index("routine_runs_linked_issue_idx").on(table.linkedIssueId),
     idempotencyIdx: index("routine_runs_trigger_idempotency_idx").on(table.triggerId, table.idempotencyKey),
+    routineConsumedIdx: index("routine_runs_routine_consumed_idx").on(table.routineId, table.consumedAt),
   }),
 );

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -273,6 +273,92 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     ]);
   });
 
+  it("stamps consumed_at and consumed_by_heartbeat_run_id when the routine's linked issue is checked out (first-consumption-wins)", async () => {
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("issue_created");
+    expect(run.linkedIssueId).toBeTruthy();
+    const linkedIssueId = run.linkedIssueId!;
+
+    // Before checkout: routine_run is unconsumed.
+    const before = await db
+      .select({
+        consumedAt: routineRuns.consumedAt,
+        consumedByHeartbeatRunId: routineRuns.consumedByHeartbeatRunId,
+      })
+      .from(routineRuns)
+      .where(eq(routineRuns.id, run.id))
+      .then((rows) => rows[0] ?? null);
+    expect(before).toEqual({ consumedAt: null, consumedByHeartbeatRunId: null });
+
+    // Clear the issue's executionRunId so a fresh checkout can succeed cleanly
+    // (the seedFixture wakeup mock pre-locked it on a queued heartbeat run).
+    await db
+      .update(issues)
+      .set({ executionRunId: null, executionLockedAt: null, checkoutRunId: null, status: "todo" })
+      .where(eq(issues.id, linkedIssueId));
+
+    const firstHeartbeatRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: firstHeartbeatRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId: linkedIssueId },
+      startedAt: new Date(),
+    });
+
+    const checkedOut = await issueSvc.checkout(linkedIssueId, agentId, ["todo", "backlog", "in_progress"], firstHeartbeatRunId);
+    expect(checkedOut.status).toBe("in_progress");
+    expect(checkedOut.checkoutRunId).toBe(firstHeartbeatRunId);
+
+    const afterFirstCheckout = await db
+      .select({
+        consumedAt: routineRuns.consumedAt,
+        consumedByHeartbeatRunId: routineRuns.consumedByHeartbeatRunId,
+      })
+      .from(routineRuns)
+      .where(eq(routineRuns.id, run.id))
+      .then((rows) => rows[0] ?? null);
+    expect(afterFirstCheckout?.consumedAt).toBeInstanceOf(Date);
+    expect(afterFirstCheckout?.consumedByHeartbeatRunId).toBe(firstHeartbeatRunId);
+
+    // Release and re-checkout under a different heartbeat run.
+    await issueSvc.release(linkedIssueId, agentId, firstHeartbeatRunId);
+
+    const secondHeartbeatRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: secondHeartbeatRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId: linkedIssueId },
+      startedAt: new Date(),
+    });
+
+    const reCheckedOut = await issueSvc.checkout(linkedIssueId, agentId, ["todo", "backlog", "in_progress"], secondHeartbeatRunId);
+    expect(reCheckedOut.status).toBe("in_progress");
+    expect(reCheckedOut.checkoutRunId).toBe(secondHeartbeatRunId);
+
+    const afterReCheckout = await db
+      .select({
+        consumedAt: routineRuns.consumedAt,
+        consumedByHeartbeatRunId: routineRuns.consumedByHeartbeatRunId,
+      })
+      .from(routineRuns)
+      .where(eq(routineRuns.id, run.id))
+      .then((rows) => rows[0] ?? null);
+
+    // First-consumption-wins: re-checkout must NOT overwrite consumed_at or consumed_by_heartbeat_run_id.
+    expect(afterReCheckout?.consumedAt?.getTime()).toBe(afterFirstCheckout?.consumedAt?.getTime());
+    expect(afterReCheckout?.consumedByHeartbeatRunId).toBe(firstHeartbeatRunId);
+  });
+
   it("records the manual board runner on fresh routine issues so they appear in that user's inbox", async () => {
     const { companyId, agentId, issueSvc, routine, svc } = await seedFixture();
     const userId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -26,6 +26,7 @@ import {
   labels,
   projectWorkspaces,
   projects,
+  routineRuns,
 } from "@paperclipai/db";
 import type {
   IssueBlockerAttention,
@@ -3096,6 +3097,19 @@ export function issueService(db: Db) {
       }),
 
     checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
+      const recordRoutineRunConsumption = async () => {
+        if (!checkoutRunId) return;
+        // First-consumption-wins: only set when consumed_at IS NULL.
+        // Idempotent on re-checkout — re-acquiring the same issue does not overwrite.
+        await db
+          .update(routineRuns)
+          .set({
+            consumedAt: new Date(),
+            consumedByHeartbeatRunId: checkoutRunId,
+          })
+          .where(and(eq(routineRuns.linkedIssueId, id), isNull(routineRuns.consumedAt)));
+      };
+
       const issueCompany = await db
         .select({ companyId: issues.companyId })
         .from(issues)
@@ -3159,6 +3173,7 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (updated) {
+        await recordRoutineRunConsumption();
         const [enriched] = await withIssueLabels(db, [updated]);
         return enriched;
       }
@@ -3202,7 +3217,10 @@ export function issueService(db: Db) {
           )
           .returning()
           .then((rows) => rows[0] ?? null);
-        if (adopted) return adopted;
+        if (adopted) {
+          await recordRoutineRunConsumption();
+          return adopted;
+        }
       }
 
       if (
@@ -3219,6 +3237,7 @@ export function issueService(db: Db) {
           expectedCheckoutRunId: current.checkoutRunId,
         });
         if (adopted) {
+          await recordRoutineRunConsumption();
           const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
           if (!row) throw notFound("Issue not found");
           const [enriched] = await withIssueLabels(db, [row]);
@@ -3232,6 +3251,7 @@ export function issueService(db: Db) {
         current.status === "in_progress" &&
         sameRunLock(current.checkoutRunId, checkoutRunId)
       ) {
+        await recordRoutineRunConsumption();
         const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
         if (!row) throw notFound("Issue not found");
         const [enriched] = await withIssueLabels(db, [row]);


### PR DESCRIPTION
## Summary

- New migration `0075_routine_runs_consumption_and_dormancy_thresholds.sql` adds `consumed_at` + `consumed_by_heartbeat_run_id` to `routine_runs` (with index on `(routine_id, consumed_at)`), and `dormancy_alarm_fire_count_threshold` (default 3) + `dormancy_alarm_stale_hours` (default 12) to `companies`.
- Drizzle schema files updated to match (`packages/db/src/schema/routines.ts`, `companies.ts`).
- Checkout path (`server/src/services/issues.ts` `issueService.checkout`) now stamps the routine_run row idempotently when a checkout consumes a routine-linked issue. First-consumption-wins semantics — `consumed_at IS NULL` guard.

## Verification

- `pnpm --filter @paperclipai/db check:migrations` ✅
- `pnpm --filter @paperclipai/db typecheck` ✅
- `pnpm --filter @paperclipai/db build` ✅
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/routines-service.test.ts`: **23/23 pass** (1339ms). New test `stamps consumed_at and consumed_by_heartbeat_run_id when the routine's linked issue is checked out (first-consumption-wins)` verifies the first checkout stamps both columns and a release+re-checkout under a different heartbeat run does NOT overwrite them.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-service.test.ts src/__tests__/issues-checkout-wakeup.test.ts`: **42/42 pass**.

## Context

Foundation for the dormancy alarm. Parent issue CHE-30 (`Platform: silent agent-dormancy alarm + per-routine heartbeat liveness`); blocks CHE-44 (service + dashboard + API enrichment) and a Child C UI task. Decomposition follows the plan attached to CHE-30.

## Out of scope

- API surface (CHE-44).
- Dashboard / UI changes (Child C).

## Reviewer

@CTO PR gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)