### PR TITLE
feat(ui): render approval payload markdown like comments

### DIFF
--- a/ui/src/components/ApprovalPayload.tsx
+++ b/ui/src/components/ApprovalPayload.tsx
@@ -1,5 +1,6 @@
 import { UserPlus, Lightbulb, ShieldAlert, ShieldCheck } from "lucide-react";
 import { formatCents } from "../lib/utils";
+import { MarkdownBody } from "./MarkdownBody";
 
 export const typeLabel: Record<string, string> = {
   hire_agent: "Hire Agent",
@@ -185,7 +186,7 @@ function BoardApprovalPayloadContent({ payload }: { payload: Record<string, unkn
       {summary && (
         <div className="space-y-1">
           <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">Summary</p>
-          <p className="leading-6 text-foreground/90">{summary}</p>
+          <MarkdownBody className="leading-6 text-foreground/90" softBreaks>{summary}</MarkdownBody>
         </div>
       )}
       {recommendedAction && (
@@ -193,13 +194,13 @@ function BoardApprovalPayloadContent({ payload }: { payload: Record<string, unkn
           <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-amber-700 dark:text-amber-300">
             Recommended action
           </p>
-          <p className="mt-1 leading-6 text-foreground">{recommendedAction}</p>
+          <MarkdownBody className="mt-1 leading-6 text-foreground" softBreaks>{recommendedAction}</MarkdownBody>
         </div>
       )}
       {nextActionOnApproval && (
         <div className="rounded-lg border border-border/60 bg-background/60 px-3.5 py-3">
           <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">On approval</p>
-          <p className="mt-1 leading-6 text-foreground">{nextActionOnApproval}</p>
+          <MarkdownBody className="mt-1 leading-6 text-foreground" softBreaks>{nextActionOnApproval}</MarkdownBody>
         </div>
       )}
       {risks.length > 0 && (
@@ -208,8 +209,8 @@ function BoardApprovalPayloadContent({ payload }: { payload: Record<string, unkn
           <ul className="space-y-1 text-sm text-muted-foreground">
             {risks.map((risk) => (
               <li key={risk} className="flex items-start gap-2">
-                <span className="mt-2 h-1.5 w-1.5 rounded-full bg-muted-foreground/60" />
-                <span className="leading-6">{risk}</span>
+                <span className="mt-2 h-1.5 w-1.5 rounded-full bg-muted-foreground/60 shrink-0" />
+                <MarkdownBody className="leading-6" softBreaks>{risk}</MarkdownBody>
               </li>
             ))}
           </ul>

--- a/ui/src/components/ApprovalPayload.tsx
+++ b/ui/src/components/ApprovalPayload.tsx
@@ -166,7 +166,7 @@ function BoardApprovalPayloadContent({ payload }: { payload: Record<string, unkn
   const risks = Array.isArray(payload.risks)
     ? payload.risks
         .filter((value): value is string => typeof value === "string")
-        .map((value) => value.trim())
+        .map((value) => value.trim().replace(/^[-*•]\s+/, ""))
         .filter(Boolean)
     : [];
   const title = firstNonEmptyString(payload.title);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The approval queue is the canonical channel by which agents surface human-needed decisions to the operator (CEO/board)
> - Agents author rich, structured approval payloads — `summary`, `recommendedAction`, `nextActionOnApproval`, and `risks` — and they naturally write them in markdown (lists, links, inline code, **bold**, headings) because that's what they produce everywhere else
> - However `ApprovalPayload.tsx` renders these fields as plain `<p>{value}</p>` while `CommentThread` renders comments via `<MarkdownBody softBreaks>` — same author-pool, two different renderers
> - Result: operators see literal `**bold**`, `- list items`, and `[link](url)` syntax in approval cards instead of formatted output, which makes high-stakes approvals harder to scan than free-form comments on the same approval
> - This pull request swaps the four affected fields onto the existing `MarkdownBody` component (same softBreaks behavior as comments) so authoring style stays consistent across the surface
> - The benefit is operators get the formatting agents already author, with zero new dependencies and no schema change

## What Changed

- `ui/src/components/ApprovalPayload.tsx`: import `MarkdownBody` and render `summary`, `recommendedAction`, `nextActionOnApproval`, and each entry of `risks` via `<MarkdownBody softBreaks>` instead of plain `<p>` / `<span>` text nodes
- `title` continues to render as plain text (one-liner; markdown there would be noise)
- `proposedComment` continues to render in a `<pre>` block (intentionally verbatim — it's a draft to be sent elsewhere)

## Verification

- Manual: open any approval whose `payload.summary` contains markdown (e.g. a `request_board_approval` whose summary uses `**Blocking:**` / `**Waited:**` / bullet lists). Before this PR the asterisks render literally; after, they render as bold + bullets — matching how the same operator sees a markdown comment on the same approval.
- Build: `pnpm --filter @paperclipai/ui build` succeeds (no new types, only re-uses `MarkdownBody` which is already imported elsewhere in the same directory).
- No new tests added — `MarkdownBody` is the same component already covering the comment thread path; this PR is a one-line-per-field renderer swap, not a new code path.

## Risks

- Low risk. Same component the comment thread already renders untrusted agent text through, so the XSS / sanitization surface is unchanged.
- One behavioral shift: payloads that previously contained literal `_underscores_` or `*asterisks*` as part of plain prose will now render as italics/emphasis. In practice agents already use markdown intentionally, and operators were previously seeing the raw syntax — this matches author intent.
- No schema change, no migration, no API change.

## Model Used

- Claude Opus 4.7 (1M context), extended thinking + tool use (Edit / Bash). Authored against a local fork of paperclipai/paperclip master.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (build succeeds; no new test path)
- [ ] I have added or updated tests where applicable (renderer swap onto existing covered component)
- [ ] I have included before/after screenshots — happy to add on request; the change is one-component, summary/risks fields only
- [x] I have updated relevant documentation to reflect my changes (no doc impact)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge