### PR TITLE
feat(ui): surface issue work products with inline review

### DIFF
--- a/ui/src/components/IssueWorkProductsSection.test.tsx
+++ b/ui/src/components/IssueWorkProductsSection.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import type { ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { IssueWorkProduct } from "@paperclipai/shared";
+import { ThemeProvider } from "../context/ThemeContext";
+import { buildIssueWorkProductComment, IssueWorkProductsSection } from "./IssueWorkProductsSection";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+const originalFetch = globalThis.fetch;
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("./MarkdownBody", () => ({
+  MarkdownBody: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+function createWorkProduct(overrides: Partial<IssueWorkProduct> = {}): IssueWorkProduct {
+  return {
+    id: "work-product-1",
+    companyId: "company-1",
+    projectId: null,
+    issueId: "issue-1",
+    executionWorkspaceId: null,
+    runtimeServiceId: null,
+    type: "document",
+    provider: "paperclip",
+    externalId: null,
+    title: "Execution summary",
+    url: null,
+    status: "ready_for_review",
+    reviewState: "needs_board_review",
+    isPrimary: true,
+    healthStatus: "healthy",
+    summary: "Review the latest markdown output from the assignee.",
+    metadata: null,
+    createdByRunId: null,
+    createdAt: new Date("2026-05-01T02:00:00.000Z"),
+    updatedAt: new Date("2026-05-01T02:10:00.000Z"),
+    ...overrides,
+  };
+}
+
+function renderSection(props: {
+  workProducts: readonly IssueWorkProduct[];
+  onAddComment?: (body: string) => Promise<void>;
+}) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  act(() => {
+    root?.render(
+      <ThemeProvider>
+        <IssueWorkProductsSection {...props} />
+      </ThemeProvider>,
+    );
+  });
+
+  return container;
+}
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+  }
+  container?.remove();
+  document.body.innerHTML = "";
+  root = null;
+  container = null;
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("IssueWorkProductsSection", () => {
+  it("builds a contextual issue comment for work product review", () => {
+    const comment = buildIssueWorkProductComment(
+      { title: "Plan draft", url: "https://example.com/plan.md" },
+      "Looks good overall.",
+    );
+
+    expect(comment).toBe(
+      "**Work product review — Plan draft**\nSource: https://example.com/plan.md\nLooks good overall.",
+    );
+  });
+
+  it("opens an inline review dialog and posts feedback back to the issue", async () => {
+    const onAddComment = vi.fn(async () => undefined);
+    const host = renderSection({
+      workProducts: [createWorkProduct({ metadata: { markdown: "# Review me" }, url: "https://example.com/review.md" })],
+      onAddComment,
+    });
+
+    const reviewButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Review"),
+    );
+    expect(reviewButton).toBeTruthy();
+
+    await act(async () => {
+      reviewButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(document.body.textContent).toContain("Review me");
+    expect(document.body.textContent).toContain("Comment back to the issue");
+
+    const textarea = document.body.querySelector("textarea") as HTMLTextAreaElement | null;
+    expect(textarea).toBeTruthy();
+
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      valueSetter?.call(textarea, "Please tighten the acceptance criteria.");
+      textarea?.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const postButton = Array.from(document.body.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Post comment"),
+    );
+    expect(postButton).toBeTruthy();
+
+    await act(async () => {
+      postButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onAddComment).toHaveBeenCalledWith(
+      "**Work product review — Execution summary**\nSource: https://example.com/review.md\nPlease tighten the acceptance criteria.",
+    );
+  });
+
+  it("fetches markdown previews from markdown URLs when inline content is missing", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      text: async () => "# Remote preview",
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const host = renderSection({
+      workProducts: [createWorkProduct({ url: "https://example.com/output.md", metadata: null })],
+    });
+
+    const reviewButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("View"),
+    );
+    expect(reviewButton).toBeTruthy();
+
+    await act(async () => {
+      reviewButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/output.md");
+    expect(document.body.textContent).toContain("Remote preview");
+  });
+});

--- a/ui/src/components/IssueWorkProductsSection.test.tsx
+++ b/ui/src/components/IssueWorkProductsSection.test.tsx
@@ -90,7 +90,7 @@ describe("IssueWorkProductsSection", () => {
     );
 
     expect(comment).toBe(
-      "**Work product review — Plan draft**\nSource: https://example.com/plan.md\nLooks good overall.",
+      "**Work product review — Plan draft**\nSource: https://example.com/plan.md\n\nLooks good overall.",
     );
   });
 
@@ -132,9 +132,9 @@ describe("IssueWorkProductsSection", () => {
     });
 
     expect(onAddComment).toHaveBeenCalledWith(
-      "**Work product review — Execution summary**\nSource: https://example.com/review.md\nPlease tighten the acceptance criteria.",
+      "**Work product review — Execution summary**\nSource: https://example.com/review.md\n\nPlease tighten the acceptance criteria.",
     );
-  });
+  }, 10000);
 
   it("fetches markdown previews from markdown URLs when inline content is missing", async () => {
     const fetchMock = vi.fn(async () => ({
@@ -159,5 +159,30 @@ describe("IssueWorkProductsSection", () => {
 
     expect(fetchMock).toHaveBeenCalledWith("https://example.com/output.md");
     expect(document.body.textContent).toContain("Remote preview");
+  });
+
+  it("treats .markdown URLs as inline-previewable markdown", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      text: async () => "# Long form markdown",
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const host = renderSection({
+      workProducts: [createWorkProduct({ url: "https://example.com/output.markdown", metadata: null })],
+    });
+
+    const viewButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("View"),
+    );
+    expect(viewButton).toBeTruthy();
+
+    await act(async () => {
+      viewButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/output.markdown");
+    expect(document.body.textContent).toContain("Long form markdown");
   });
 });

--- a/ui/src/components/IssueWorkProductsSection.tsx
+++ b/ui/src/components/IssueWorkProductsSection.tsx
@@ -69,7 +69,7 @@ function workProductIcon(type: IssueWorkProduct["type"]) {
 
 function looksLikeMarkdownPath(value: string | null | undefined) {
   if (!value) return false;
-  return /\.md(?:own)?(?:[#?].*)?$/i.test(value);
+  return /\.md(?:own|arkdown)?(?:[#?].*)?$/i.test(value);
 }
 
 function isMarkdownWorkProduct(product: IssueWorkProduct) {
@@ -122,12 +122,14 @@ function MetaPill({ label, value, tone = "default" }: { label: string; value: st
 }
 
 export function buildIssueWorkProductComment(product: Pick<IssueWorkProduct, "title" | "url">, comment: string) {
-  return [
+  const header = [
     `**Work product review — ${product.title}**`,
     product.url ? `Source: ${product.url}` : null,
-    "",
-    comment.trim(),
-  ].filter((value): value is string => Boolean(value && value.trim().length > 0)).join("\n");
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+
+  return [header, comment.trim()].join("\n\n");
 }
 
 export function IssueWorkProductsSection({

--- a/ui/src/components/IssueWorkProductsSection.tsx
+++ b/ui/src/components/IssueWorkProductsSection.tsx
@@ -1,0 +1,411 @@
+import { useEffect, useMemo, useState } from "react";
+import type { IssueWorkProduct } from "@paperclipai/shared";
+import { AlertCircle, ExternalLink, FileText, GitBranch, GitPullRequest, Globe, Loader2, MessageSquarePlus, Package } from "lucide-react";
+import { cn, relativeTime } from "../lib/utils";
+import { MarkdownBody } from "./MarkdownBody";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function firstString(source: Record<string, unknown> | null, ...keys: string[]) {
+  if (!source) return null;
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function humanizeToken(value: string) {
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function workProductTypeLabel(type: string) {
+  return humanizeToken(type);
+}
+
+function workProductReviewStateLabel(state: string) {
+  if (state === "none") return "No review state";
+  return humanizeToken(state);
+}
+
+function workProductStatusLabel(status: string) {
+  return humanizeToken(status);
+}
+
+function workProductIcon(type: IssueWorkProduct["type"]) {
+  switch (type) {
+    case "pull_request":
+      return GitPullRequest;
+    case "branch":
+    case "commit":
+      return GitBranch;
+    case "preview_url":
+    case "runtime_service":
+      return Globe;
+    case "artifact":
+    case "document":
+    default:
+      return FileText;
+  }
+}
+
+function looksLikeMarkdownPath(value: string | null | undefined) {
+  if (!value) return false;
+  return /\.md(?:own)?(?:[#?].*)?$/i.test(value);
+}
+
+function isMarkdownWorkProduct(product: IssueWorkProduct) {
+  const metadata = asRecord(product.metadata);
+  const format = firstString(metadata, "format", "contentType", "mimeType")?.toLowerCase() ?? null;
+  const path = firstString(metadata, "path", "filePath", "filename", "name");
+  return product.type === "document"
+    || format === "markdown"
+    || format === "text/markdown"
+    || looksLikeMarkdownPath(product.url)
+    || looksLikeMarkdownPath(path);
+}
+
+function getEmbeddedMarkdownPreview(product: IssueWorkProduct) {
+  const metadata = asRecord(product.metadata);
+  return firstString(
+    metadata,
+    "markdown",
+    "body",
+    "content",
+    "previewMarkdown",
+    "summaryMarkdown",
+  );
+}
+
+function resolveMarkdownPreviewUrl(product: IssueWorkProduct) {
+  const metadata = asRecord(product.metadata);
+  return firstString(metadata, "rawUrl", "downloadUrl", "previewUrl") ?? product.url;
+}
+
+function canReviewInline(product: IssueWorkProduct) {
+  return Boolean(product.summary)
+    || Boolean(getEmbeddedMarkdownPreview(product))
+    || isMarkdownWorkProduct(product);
+}
+
+function MetaPill({ label, value, tone = "default" }: { label: string; value: string; tone?: "default" | "subtle" }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-sm border px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.16em]",
+        tone === "default"
+          ? "border-border/70 bg-transparent text-foreground"
+          : "border-border/60 bg-transparent text-muted-foreground",
+      )}
+    >
+      {label}: {value}
+    </span>
+  );
+}
+
+export function buildIssueWorkProductComment(product: Pick<IssueWorkProduct, "title" | "url">, comment: string) {
+  return [
+    `**Work product review — ${product.title}**`,
+    product.url ? `Source: ${product.url}` : null,
+    "",
+    comment.trim(),
+  ].filter((value): value is string => Boolean(value && value.trim().length > 0)).join("\n");
+}
+
+export function IssueWorkProductsSection({
+  workProducts,
+  onAddComment,
+}: {
+  workProducts: readonly IssueWorkProduct[];
+  onAddComment?: (body: string) => Promise<void>;
+}) {
+  const [selectedProduct, setSelectedProduct] = useState<IssueWorkProduct | null>(null);
+  const [previewState, setPreviewState] = useState<{
+    status: "idle" | "loading" | "ready" | "error";
+    markdown: string | null;
+    error: string | null;
+  }>({ status: "idle", markdown: null, error: null });
+  const [commentDraft, setCommentDraft] = useState("");
+  const [commentPending, setCommentPending] = useState(false);
+  const [commentError, setCommentError] = useState<string | null>(null);
+
+  const sortedProducts = useMemo(
+    () => [...workProducts].sort((left, right) => Number(right.isPrimary) - Number(left.isPrimary)),
+    [workProducts],
+  );
+
+  useEffect(() => {
+    setCommentDraft("");
+    setCommentError(null);
+    if (!selectedProduct) {
+      setPreviewState({ status: "idle", markdown: null, error: null });
+      return;
+    }
+
+    const embeddedPreview = getEmbeddedMarkdownPreview(selectedProduct);
+    if (embeddedPreview) {
+      setPreviewState({ status: "ready", markdown: embeddedPreview, error: null });
+      return;
+    }
+
+    if (!isMarkdownWorkProduct(selectedProduct)) {
+      setPreviewState({ status: "ready", markdown: null, error: null });
+      return;
+    }
+
+    const previewUrl = resolveMarkdownPreviewUrl(selectedProduct);
+    if (!previewUrl) {
+      setPreviewState({ status: "ready", markdown: null, error: null });
+      return;
+    }
+
+    let cancelled = false;
+    setPreviewState({ status: "loading", markdown: null, error: null });
+    void fetch(previewUrl)
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Preview unavailable (${response.status})`);
+        }
+        return response.text();
+      })
+      .then((markdown) => {
+        if (cancelled) return;
+        setPreviewState({ status: "ready", markdown, error: null });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setPreviewState({
+          status: "error",
+          markdown: null,
+          error: error instanceof Error ? error.message : "Preview unavailable.",
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedProduct]);
+
+  if (workProducts.length === 0) return null;
+
+  async function handleAddComment() {
+    if (!selectedProduct || !onAddComment) return;
+    const trimmed = commentDraft.trim();
+    if (!trimmed) {
+      setCommentError("Write a review comment before posting.");
+      return;
+    }
+
+    setCommentPending(true);
+    setCommentError(null);
+    try {
+      await onAddComment(buildIssueWorkProductComment(selectedProduct, trimmed));
+      setCommentDraft("");
+    } catch (error) {
+      setCommentError(error instanceof Error ? error.message : "Failed to post comment.");
+    } finally {
+      setCommentPending(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <h3 className="text-sm font-medium text-muted-foreground">Work products</h3>
+            <p className="text-xs text-muted-foreground">
+              Review assignee outputs without leaving the issue.
+            </p>
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {workProducts.length} item{workProducts.length === 1 ? "" : "s"}
+          </span>
+        </div>
+
+        <div className="space-y-3">
+          {sortedProducts.map((product) => {
+            const ProductIcon = workProductIcon(product.type);
+            const previewable = canReviewInline(product);
+            return (
+              <div key={product.id} className="rounded-lg border border-border bg-background/80 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border/70 bg-accent/20 text-muted-foreground">
+                        <ProductIcon className="h-4 w-4" />
+                      </span>
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-foreground">{product.title}</div>
+                        <div className="text-xs text-muted-foreground">
+                          Updated {relativeTime(product.updatedAt)}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2">
+                      <MetaPill label="Type" value={workProductTypeLabel(product.type)} />
+                      <MetaPill label="Status" value={workProductStatusLabel(product.status)} tone="subtle" />
+                      <MetaPill label="Review" value={workProductReviewStateLabel(product.reviewState)} tone="subtle" />
+                      <MetaPill label="Provider" value={humanizeToken(product.provider)} tone="subtle" />
+                      {product.isPrimary ? <MetaPill label="Primary" value="Yes" /> : null}
+                    </div>
+
+                    {product.summary ? (
+                      <p className="text-sm leading-6 text-muted-foreground">{product.summary}</p>
+                    ) : null}
+                  </div>
+
+                  <div className="flex shrink-0 flex-wrap items-center gap-2">
+                    {previewable ? (
+                      <Button size="sm" variant="outline" onClick={() => setSelectedProduct(product)}>
+                        {onAddComment ? (
+                          <>
+                            <MessageSquarePlus className="mr-1.5 h-3.5 w-3.5" />
+                            Review
+                          </>
+                        ) : (
+                          "View"
+                        )}
+                      </Button>
+                    ) : null}
+                    {product.url ? (
+                      <a
+                        href={product.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex h-9 items-center rounded-md border border-input bg-background px-3 text-sm font-medium text-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground"
+                      >
+                        <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                        Open
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <Dialog open={Boolean(selectedProduct)} onOpenChange={(open) => !open && setSelectedProduct(null)}>
+        <DialogContent className="sm:max-w-4xl">
+          {selectedProduct ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>{selectedProduct.title}</DialogTitle>
+                <DialogDescription>
+                  Review this work product in context and send feedback back to the issue thread.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <MetaPill label="Type" value={workProductTypeLabel(selectedProduct.type)} />
+                  <MetaPill label="Status" value={workProductStatusLabel(selectedProduct.status)} tone="subtle" />
+                  <MetaPill label="Review" value={workProductReviewStateLabel(selectedProduct.reviewState)} tone="subtle" />
+                  {selectedProduct.url ? (
+                    <a
+                      href={selectedProduct.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center rounded-sm border border-border/60 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.16em] text-foreground transition-colors hover:border-sky-500/70 hover:bg-sky-500/10"
+                    >
+                      <ExternalLink className="mr-1 h-3 w-3" />
+                      Open source
+                    </a>
+                  ) : null}
+                </div>
+
+                {selectedProduct.summary ? (
+                  <div className="rounded-lg border border-border/70 bg-accent/10 px-4 py-3 text-sm leading-6 text-muted-foreground">
+                    {selectedProduct.summary}
+                  </div>
+                ) : null}
+
+                <div className="rounded-lg border border-border/70 bg-background/70">
+                  <div className="border-b border-border/60 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                    Preview
+                  </div>
+                  <div className="max-h-[26rem] overflow-y-auto px-4 py-4">
+                    {previewState.status === "loading" ? (
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Loading preview...
+                      </div>
+                    ) : previewState.markdown ? (
+                      <MarkdownBody>{previewState.markdown}</MarkdownBody>
+                    ) : previewState.status === "error" ? (
+                      <div className="flex items-start gap-2 rounded-lg border border-amber-500/50 bg-amber-500/10 px-3 py-3 text-sm text-amber-900 dark:text-amber-100">
+                        <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                        <div>
+                          <div className="font-medium">Preview unavailable</div>
+                          <div className="mt-1">{previewState.error}</div>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex items-start gap-2 rounded-lg border border-border/70 bg-accent/10 px-3 py-3 text-sm text-muted-foreground">
+                        <Package className="mt-0.5 h-4 w-4 shrink-0" />
+                        <div>
+                          This work product does not expose inline markdown content. Use the source link if you need the raw artifact.
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {onAddComment ? (
+                  <div className="space-y-3 rounded-lg border border-border/70 bg-background/70 p-4">
+                    <div>
+                      <div className="text-sm font-medium text-foreground">Comment back to the issue</div>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Paperclip will include the work product title and source link automatically.
+                      </p>
+                    </div>
+                    <Textarea
+                      value={commentDraft}
+                      onChange={(event) => setCommentDraft(event.target.value)}
+                      placeholder="Add review feedback, requested changes, or approval notes"
+                      className="min-h-28 bg-background text-sm"
+                    />
+                    {commentError ? <p className="text-xs text-destructive">{commentError}</p> : null}
+                    <div className="flex justify-end">
+                      <Button size="sm" onClick={() => void handleAddComment()} disabled={commentPending}>
+                        {commentPending ? (
+                          <>
+                            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                            Posting...
+                          </>
+                        ) : (
+                          "Post comment"
+                        )}
+                      </Button>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -66,6 +66,7 @@ import { InlineEditor } from "../components/InlineEditor";
 import { IssueChatThread, type IssueChatComposerHandle } from "../components/IssueChatThread";
 import { IssueContinuationHandoff } from "../components/IssueContinuationHandoff";
 import { IssueDocumentsSection } from "../components/IssueDocumentsSection";
+import { IssueWorkProductsSection } from "../components/IssueWorkProductsSection";
 import { IssuesList } from "../components/IssuesList";
 import { AgentIcon } from "../components/AgentIconPicker";
 import { IssueReferenceActivitySummary } from "../components/IssueReferenceActivitySummary";
@@ -3425,6 +3426,13 @@ export function IssueDetail() {
           </Button>
         </div>
       )}
+
+      <IssueWorkProductsSection
+        workProducts={issue.workProducts ?? []}
+        onAddComment={async (body) => {
+          await handleChatAdd(body);
+        }}
+      />
 
       <IssueDocumentsSection
         issue={issue}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and needs a strong review loop when assignees hand work back to the board.
> - The issue detail page is the main operator surface for reviewing execution output and deciding what happens next.
> - Paperclip already has first-class `workProducts` in the API and issue payload, but the UI does not surface them as a clear review surface.
> - That means markdown-like outputs can degrade into raw links, which adds context switching and slows feedback.
> - Issue-thread comments are already the canonical place to send review feedback back into the work loop.
> - This pull request adds a focused UI layer that makes work products visible, previewable, and commentable from the issue detail page.
> - The benefit is faster review of assignee output without inventing a new workflow outside the existing issue thread.

## What Changed

- Added a new `IssueWorkProductsSection` in the issue detail page.
- Rendered work products with clearer type / status / review / provider metadata.
- Added an inline review dialog for markdown-capable work products, using embedded markdown when available and fetching markdown URLs when needed.
- Added a comment-back flow from the review dialog that posts contextual feedback into the issue thread.
- Added focused tests for inline preview and issue-comment writeback behavior.
- Follow-up review fix: restored the blank paragraph separator in generated review comments and added `.markdown` extension handling.

## Verification

- `pnpm -r typecheck`
- `pnpm vitest run ui/src/components/IssueWorkProductsSection.test.tsx ui/src/pages/IssueDetail.test.tsx`
- `pnpm --filter @paperclipai/ui build`

## Screenshots

After — new work products review surface with inline markdown preview and comment-back flow:

![Work products review surface](https://raw.githubusercontent.com/wair56/paperclip/pr-review-screenshots/report/pr-review-screenshots/work-products-after.png)

## Risks

- Low to moderate risk: this is a new UI surface on issue detail, but it is additive and does not change server contracts.
- Inline preview depends on work-product metadata or a fetchable markdown URL; non-markdown artifacts still fall back to the existing external-link flow.
- I also ran `pnpm test:run` on this host; the repo-wide run currently hits unrelated pre-existing `@paperclipai/adapter-utils` timeout/process-fixture failures on this macOS machine. This PR touches only UI files and the changed-surface checks above pass.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 Codex via Codex desktop/CLI agent, medium reasoning, with shell/git/test execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #4906.
