### PR TITLE
feat(ui): strengthen pending confirmation cards

### DIFF
--- a/ui/src/components/IssueThreadInteractionCard.test.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.test.tsx
@@ -203,6 +203,18 @@ describe("IssueThreadInteractionCard", () => {
     );
   });
 
+  it("emphasizes pending confirmation cards as decision-blocked work", () => {
+    const host = renderCard({
+      interaction: pendingRequestConfirmationInteraction,
+    });
+
+    expect(host.textContent).toContain("Decision needed");
+    expect(host.textContent).toContain("Review target");
+    expect(host.textContent).toContain("Open target");
+    expect(host.textContent).toContain("Assignee resumes after confirmation");
+    expect(host.textContent).toContain("Review context");
+  });
+
   it("labels accept-only continuation policies in the card header", () => {
     const host = renderCard({
       interaction: {

--- a/ui/src/components/IssueThreadInteractionCard.test.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.test.tsx
@@ -12,6 +12,7 @@ import {
   commentExpiredRequestConfirmationInteraction,
   disabledDeclineReasonRequestConfirmationInteraction,
   failedRequestConfirmationInteraction,
+  genericPendingRequestConfirmationInteraction,
   pendingRequestConfirmationInteraction,
   pendingSuggestedTasksInteraction,
   staleTargetRequestConfirmationInteraction,
@@ -213,6 +214,17 @@ describe("IssueThreadInteractionCard", () => {
     expect(host.textContent).toContain("Open target");
     expect(host.textContent).toContain("Assignee resumes after confirmation");
     expect(host.textContent).toContain("Review context");
+  });
+
+  it("hides target and continuation cues when the confirmation is lightweight", () => {
+    const host = renderCard({
+      interaction: genericPendingRequestConfirmationInteraction,
+    });
+
+    expect(host.textContent).toContain("Decision needed");
+    expect(host.textContent).not.toContain("Review target");
+    expect(host.textContent).not.toContain("Open target");
+    expect(host.textContent).not.toContain("Assignee resumes after confirmation");
   });
 
   it("labels accept-only continuation policies in the card header", () => {

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -1046,6 +1046,10 @@ function RequestConfirmationCard({
   const trimmedRejectReason = rejectReason.trim();
   const canReject = !rejectRequiresReason || trimmedRejectReason.length > 0;
   const declineReasonInvalid = rejectRequiresReason && !canReject;
+  const target = interaction.payload.target ?? null;
+  const targetHref = target ? requestConfirmationTargetHref({ interaction, target }) : null;
+  const wakesAssignee = interaction.continuationPolicy === "wake_assignee"
+    || interaction.continuationPolicy === "wake_assignee_on_accept";
   const declineReasonPlaceholder =
     interaction.payload.declineReasonPlaceholder
     ?? (interaction.payload.acceptLabel === "Approve plan"
@@ -1093,19 +1097,82 @@ function RequestConfirmationCard({
   return (
     <div className="space-y-4">
       {interaction.status === "pending" ? (
-        <div className="space-y-3 rounded-sm border border-border/70 bg-background/75 p-4">
-          <div className="text-sm leading-6 text-foreground">
-            {interaction.payload.prompt}
+        <div className="space-y-4 rounded-lg border border-amber-500/60 bg-amber-500/10 p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-800 dark:text-amber-200">
+                <AlertTriangle className="h-3.5 w-3.5" />
+                Decision needed
+              </div>
+              <div className="mt-2 text-sm leading-6 text-foreground">
+                {interaction.payload.prompt}
+              </div>
+            </div>
+            {target ? (
+              <div className="min-w-[12rem] rounded-md border border-amber-500/40 bg-background/80 px-3 py-2">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                  Review target
+                </div>
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <RequestConfirmationTargetChip interaction={interaction} target={target} />
+                  {targetHref ? (
+                    /^https?:\/\//i.test(targetHref) ? (
+                      <a
+                        href={targetHref}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-xs font-medium text-foreground underline underline-offset-4"
+                      >
+                        Open target
+                      </a>
+                    ) : (
+                      <Link to={targetHref} className="text-xs font-medium text-foreground underline underline-offset-4">
+                        Open target
+                      </Link>
+                    )
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
           </div>
+
+          <div className={cn("grid gap-3", wakesAssignee ? "md:grid-cols-2" : "md:grid-cols-1")}>
+            <div className="rounded-md border border-border/70 bg-background/80 px-3 py-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Next action
+              </div>
+              <div className="mt-1 text-sm font-medium text-foreground">
+                {interaction.payload.acceptLabel ?? "Confirm"}
+              </div>
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                This request is holding the thread until someone confirms or declines it.
+              </p>
+            </div>
+            {wakesAssignee ? (
+              <div className="rounded-md border border-border/70 bg-background/80 px-3 py-3">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                  Continuation
+                </div>
+                <div className="mt-1 text-sm font-medium text-foreground">
+                  Assignee resumes after confirmation
+                </div>
+                <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                  Accepting this request wakes the assignee so work can continue without another manual nudge.
+                </p>
+              </div>
+            ) : null}
+          </div>
+
           {interaction.payload.detailsMarkdown ? (
-            <div className="border-t border-border/60 pt-3 text-sm">
-              <MarkdownBody>{interaction.payload.detailsMarkdown}</MarkdownBody>
+            <div className="rounded-md border border-border/70 bg-background/75 px-3 py-3">
+              <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Review context
+              </div>
+              <div className="text-sm">
+                <MarkdownBody>{interaction.payload.detailsMarkdown}</MarkdownBody>
+              </div>
             </div>
           ) : null}
-          <RequestConfirmationTargetChip
-            interaction={interaction}
-            target={interaction.payload.target}
-          />
         </div>
       ) : null}
 

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -1050,6 +1050,7 @@ function RequestConfirmationCard({
   const targetHref = target ? requestConfirmationTargetHref({ interaction, target }) : null;
   const wakesAssignee = interaction.continuationPolicy === "wake_assignee"
     || interaction.continuationPolicy === "wake_assignee_on_accept";
+  const canDecline = Boolean(onRejectInteraction);
   const declineReasonPlaceholder =
     interaction.payload.declineReasonPlaceholder
     ?? (interaction.payload.acceptLabel === "Approve plan"
@@ -1136,7 +1137,7 @@ function RequestConfirmationCard({
             ) : null}
           </div>
 
-          <div className={cn("grid gap-3", wakesAssignee ? "md:grid-cols-2" : "md:grid-cols-1")}>
+          <div className={cn("space-y-3", wakesAssignee && "md:grid md:grid-cols-2 md:gap-3 md:space-y-0")}>
             <div className="rounded-md border border-border/70 bg-background/80 px-3 py-3">
               <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                 Next action
@@ -1145,7 +1146,7 @@ function RequestConfirmationCard({
                 {interaction.payload.acceptLabel ?? "Confirm"}
               </div>
               <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                This request is holding the thread until someone confirms or declines it.
+                This request is holding the thread until someone {canDecline ? "confirms or declines" : "confirms"} it.
               </p>
             </div>
             {wakesAssignee ? (


### PR DESCRIPTION
## Thinking Path

> - Paperclip relies on issue-thread interactions to keep agent execution aligned with explicit board decisions.
> - Request-confirmation cards are the main UI for moments where work is blocked on a yes/no decision.
> - The underlying interaction model already carries the right information, but the pending state can still blend into the rest of the thread.
> - When a decision is holding work, the operator should be able to spot the requested action, target, and continuation effect immediately.
> - The best place to improve that is the pending confirmation card itself, without changing interaction semantics.
> - This pull request strengthens the visual treatment of pending confirmation cards and promotes the target/review context.
> - The benefit is fewer stalled threads caused by easy-to-miss pending decisions.

## What Changed

- Reworked the pending request-confirmation surface to use a stronger decision-blocked treatment.
- Added clearer emphasis for the requested action, review target, and continuation behavior.
- Added an explicit `Open target` affordance for confirmation targets.
- Promoted `detailsMarkdown` into a labeled `Review context` area for easier scanning.
- Added a focused test that verifies the new decision-blocked cues render in the pending state.
- Follow-up review fix: tightened the pending-state copy for confirm-only flows, removed the no-op responsive class, and added negative-path coverage for cards without a target or wake-on-confirm continuation.

## Verification

- `pnpm -r typecheck`
- `pnpm vitest run ui/src/components/IssueThreadInteractionCard.test.tsx`
- `pnpm --filter @paperclipai/ui build`

## Screenshots

Before — pending confirmation blends into the thread with a compact target chip:

![Pending confirmation before emphasis](https://raw.githubusercontent.com/wair56/paperclip/pr-review-screenshots/report/pr-review-screenshots/confirmation-before.png)

After — decision-blocked treatment with explicit target, continuation, and review context:

![Pending confirmation after emphasis](https://raw.githubusercontent.com/wair56/paperclip/pr-review-screenshots/report/pr-review-screenshots/confirmation-after.png)

## Risks

- Low risk: this is a UI-only emphasis change that preserves the existing accept / decline semantics and interaction payloads.
- The biggest behavioral shift is stronger visual prominence for pending confirmations, which is the intended outcome for decision-blocked work.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 Codex via Codex desktop/CLI agent, medium reasoning, with shell/git/test execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #4908.
