### PR TITLE
fix(ui): filter sidebar live agent counts

### DIFF
--- a/ui/src/components/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar.test.tsx
@@ -92,6 +92,24 @@ async function flushReact() {
   });
 }
 
+function makeLiveRun(overrides: { id: string; status: string }) {
+  return {
+    id: overrides.id,
+    status: overrides.status,
+    invocationSource: "manual",
+    triggerDetail: null,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    finishedAt: overrides.status === "running" || overrides.status === "queued"
+      ? null
+      : "2026-01-01T00:01:00.000Z",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    agentId: "agent-1",
+    agentName: "Alpha",
+    adapterType: "process",
+    issueId: null,
+  };
+}
+
 describe("Sidebar", () => {
   let container: HTMLDivElement;
 
@@ -99,6 +117,7 @@ describe("Sidebar", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     mockHeartbeatsApi.liveRunsForCompany.mockResolvedValue([]);
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableIsolatedWorkspaces: false });
   });
 
   afterEach(() => {
@@ -148,6 +167,38 @@ describe("Sidebar", () => {
 
     const link = [...container.querySelectorAll("a")].find((anchor) => anchor.textContent === "Workspaces");
     expect(link?.getAttribute("href")).toBe("/workspaces");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("counts only running and queued runs in the dashboard live badge", async () => {
+    mockHeartbeatsApi.liveRunsForCompany.mockResolvedValue([
+      makeLiveRun({ id: "run-1", status: "succeeded" }),
+      makeLiveRun({ id: "run-2", status: "failed" }),
+      makeLiveRun({ id: "run-3", status: "cancelled" }),
+      makeLiveRun({ id: "run-4", status: "running" }),
+      makeLiveRun({ id: "run-5", status: "queued" }),
+    ]);
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Sidebar />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    const dashboardLink = [...container.querySelectorAll("a")]
+      .find((anchor) => anchor.getAttribute("href") === "/dashboard");
+    expect(dashboardLink?.textContent).toContain("2 live");
+    expect(dashboardLink?.textContent).not.toContain("5 live");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -42,7 +42,7 @@ export function Sidebar() {
     enabled: !!selectedCompanyId,
     refetchInterval: 10_000,
   });
-  const liveRunCount = liveRuns?.length ?? 0;
+  const liveRunCount = liveRuns?.filter((run) => run.status === "running" || run.status === "queued").length ?? 0;
   const showWorkspacesLink = experimentalSettings?.enableIsolatedWorkspaces === true;
 
   function openSearch() {

--- a/ui/src/components/SidebarAgents.test.tsx
+++ b/ui/src/components/SidebarAgents.test.tsx
@@ -127,6 +127,24 @@ function makeAgent(overrides: Partial<Agent>): Agent {
   };
 }
 
+function makeLiveRun(overrides: { id: string; agentId: string; status: string }) {
+  return {
+    id: overrides.id,
+    status: overrides.status,
+    invocationSource: "manual",
+    triggerDetail: null,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    finishedAt: overrides.status === "running" || overrides.status === "queued"
+      ? null
+      : "2026-01-01T00:01:00.000Z",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    agentId: overrides.agentId,
+    agentName: overrides.agentId === "agent-1" ? "Alpha" : "Beta",
+    adapterType: "process",
+    issueId: null,
+  };
+}
+
 async function flushReact() {
   await act(async () => {
     await Promise.resolve();
@@ -312,5 +330,39 @@ describe("SidebarAgents", () => {
     await flushReact();
 
     expect(mockAgentsApi.resume).not.toHaveBeenCalled();
+  });
+
+  it("counts only running and queued runs as live in sidebar badges", async () => {
+    mockAgentsApi.list.mockResolvedValue([
+      makeAgent({ id: "agent-1", name: "Alpha", urlKey: "alpha" }),
+      makeAgent({ id: "agent-2", name: "Beta", urlKey: "beta" }),
+    ]);
+    mockHeartbeatsApi.liveRunsForCompany.mockResolvedValue([
+      makeLiveRun({ id: "run-1", agentId: "agent-1", status: "succeeded" }),
+      makeLiveRun({ id: "run-2", agentId: "agent-1", status: "failed" }),
+      makeLiveRun({ id: "run-3", agentId: "agent-1", status: "cancelled" }),
+      makeLiveRun({ id: "run-4", agentId: "agent-2", status: "running" }),
+      makeLiveRun({ id: "run-5", agentId: "agent-2", status: "queued" }),
+      makeLiveRun({ id: "run-6", agentId: "agent-2", status: "succeeded" }),
+    ]);
+    const currentRoot = createRoot(container);
+    root = currentRoot;
+
+    await act(async () => {
+      currentRoot.render(
+        <QueryClientProvider client={queryClient}>
+          <SidebarAgents />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    const alphaLink = Array.from(container.querySelectorAll("a"))
+      .find((element) => element.getAttribute("href") === "/agents/alpha");
+    const betaLink = Array.from(container.querySelectorAll("a"))
+      .find((element) => element.getAttribute("href") === "/agents/beta");
+
+    expect(alphaLink?.textContent).toBe("Alpha");
+    expect(betaLink?.textContent).toContain("2 live");
   });
 });

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -183,6 +183,7 @@ export function SidebarAgents() {
   const liveCountByAgent = useMemo(() => {
     const counts = new Map<string, number>();
     for (const run of liveRuns ?? []) {
+      if (run.status !== "running" && run.status !== "queued") continue;
       counts.set(run.agentId, (counts.get(run.agentId) ?? 0) + 1);
     }
     return counts;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The sidebar helps human operators understand which agents and boards are currently active.
> - The live-runs API can include recent completed fallback rows when there are not enough queued/running rows.
> - The main dashboard live badge and per-agent sidebar badges were counting endpoint rows as `live` even when some rows were succeeded, failed, or cancelled.
> - This made the board or agents appear live/stuck even when there were no active queued/running executions.
> - This pull request filters sidebar live badges to only count queued and running runs.
> - The benefit is a more trustworthy operator sidebar without changing the existing activity API behavior.

## What Changed

- Updated the main `Sidebar` dashboard badge to count only `running` and `queued` heartbeat runs.
- Updated `SidebarAgents` to ignore non-live heartbeat statuses when computing per-agent live badge counts.
- Added regression tests covering mixed `succeeded`, `failed`, `cancelled`, `running`, and `queued` rows from `liveRunsForCompany`.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @paperclipai/ui exec vitest run src/components/Sidebar.test.tsx src/components/SidebarAgents.test.tsx`
- `pnpm --filter @paperclipai/ui typecheck`

Before/after screenshots: not included because this is a conditional badge-count logic fix covered by focused component regression tests rather than a visual layout/style change.

## Risks

- Low risk. The change only affects sidebar badge counts and narrows them to the statuses already implied by the `live` label.
- The underlying `live-runs` endpoint behavior is unchanged, so other activity panels can continue using its recent fallback rows.
- No documentation update is needed because this is a targeted bug fix to existing sidebar behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI was delegated to inspect the repo and draft the initial regression test. The local Codex CLI output did not expose an exact model ID.
- OpenAI GPT-5.5, tool-using coding assistant session, completed the production fixes, verification, and PR preparation.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
