### PR TITLE
feat(rbac): add scoped agents:recover_from_error permission

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -509,6 +509,7 @@ export type JoinRequestStatus = (typeof JOIN_REQUEST_STATUSES)[number];
 
 export const PERMISSION_KEYS = [
   "agents:create",
+  "agents:recover_from_error",
   "environments:manage",
   "users:invite",
   "users:manage_permissions",

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -3,6 +3,7 @@ import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const agentId = "11111111-1111-4111-8111-111111111111";
+const watchdogAgentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const companyId = "22222222-2222-4222-8222-222222222222";
 
 const baseAgent = {
@@ -1352,5 +1353,148 @@ describe.sequential("agent permission routes", () => {
 
     expect(res.status).toBe(403);
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
+  });
+
+  describe("agents:recover_from_error permission", () => {
+    const errorAgent = { ...baseAgent, status: "error", pauseReason: null };
+    const pausedErrorAgent = { ...baseAgent, status: "error", pauseReason: "budget_exceeded" };
+    const idleAgent = { ...baseAgent, status: "idle", pauseReason: null };
+
+    it("allows recovery PATCH when target is in error status, has no pauseReason, and body is exactly { status: idle }", async () => {
+      mockAgentService.getById
+        .mockResolvedValueOnce({ ...baseAgent, id: watchdogAgentId, role: "engineer" })
+        .mockResolvedValueOnce(errorAgent);
+      mockAccessService.hasPermission.mockResolvedValue(true);
+      mockAgentService.update.mockResolvedValue({ ...errorAgent, status: "idle" });
+
+      const app = await createApp({
+        type: "agent",
+        agentId: watchdogAgentId,
+        companyId,
+        source: "agent_key",
+        runId: "run-wd-1",
+      });
+
+      const res = await requestApp(app, (baseUrl) => request(baseUrl)
+        .patch(`/api/agents/${agentId}`)
+        .send({ status: "idle" }));
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(mockAgentService.update).toHaveBeenCalledWith(
+        agentId,
+        expect.objectContaining({ status: "idle" }),
+        expect.anything(),
+      );
+    });
+
+    it("blocks recovery PATCH with extra body fields even when permission is held", async () => {
+      mockAgentService.getById
+        .mockResolvedValueOnce({ ...baseAgent, id: watchdogAgentId, role: "engineer" })
+        .mockResolvedValueOnce(errorAgent);
+      mockAccessService.hasPermission.mockResolvedValue(true);
+
+      const app = await createApp({
+        type: "agent",
+        agentId: watchdogAgentId,
+        companyId,
+        source: "agent_key",
+        runId: "run-wd-1",
+      });
+
+      const res = await requestApp(app, (baseUrl) => request(baseUrl)
+        .patch(`/api/agents/${agentId}`)
+        .send({ status: "idle", adapterConfig: {} }));
+
+      expect(res.status).toBe(403);
+      expect(mockAgentService.update).not.toHaveBeenCalled();
+    });
+
+    it("blocks recovery PATCH when target has a non-null pauseReason", async () => {
+      mockAgentService.getById
+        .mockResolvedValueOnce({ ...baseAgent, id: watchdogAgentId, role: "engineer" })
+        .mockResolvedValueOnce(pausedErrorAgent);
+      mockAccessService.hasPermission.mockResolvedValue(true);
+
+      const app = await createApp({
+        type: "agent",
+        agentId: watchdogAgentId,
+        companyId,
+        source: "agent_key",
+        runId: "run-wd-1",
+      });
+
+      const res = await requestApp(app, (baseUrl) => request(baseUrl)
+        .patch(`/api/agents/${agentId}`)
+        .send({ status: "idle" }));
+
+      expect(res.status).toBe(403);
+      expect(mockAgentService.update).not.toHaveBeenCalled();
+    });
+
+    it("blocks recovery PATCH when target status is not error", async () => {
+      mockAgentService.getById
+        .mockResolvedValueOnce({ ...baseAgent, id: watchdogAgentId, role: "engineer" })
+        .mockResolvedValueOnce(idleAgent);
+      mockAccessService.hasPermission.mockResolvedValue(true);
+
+      const app = await createApp({
+        type: "agent",
+        agentId: watchdogAgentId,
+        companyId,
+        source: "agent_key",
+        runId: "run-wd-1",
+      });
+
+      const res = await requestApp(app, (baseUrl) => request(baseUrl)
+        .patch(`/api/agents/${agentId}`)
+        .send({ status: "idle" }));
+
+      expect(res.status).toBe(403);
+      expect(mockAgentService.update).not.toHaveBeenCalled();
+    });
+
+    it("blocks PATCH with status active even when recovery permission is held", async () => {
+      mockAgentService.getById
+        .mockResolvedValueOnce({ ...baseAgent, id: watchdogAgentId, role: "engineer" })
+        .mockResolvedValueOnce(errorAgent);
+      mockAccessService.hasPermission.mockResolvedValue(true);
+
+      const app = await createApp({
+        type: "agent",
+        agentId: watchdogAgentId,
+        companyId,
+        source: "agent_key",
+        runId: "run-wd-1",
+      });
+
+      const res = await requestApp(app, (baseUrl) => request(baseUrl)
+        .patch(`/api/agents/${agentId}`)
+        .send({ status: "active" }));
+
+      expect(res.status).toBe(403);
+      expect(mockAgentService.update).not.toHaveBeenCalled();
+    });
+
+    it("blocks recovery when agent does not hold the permission", async () => {
+      mockAgentService.getById
+        .mockResolvedValueOnce({ ...baseAgent, id: watchdogAgentId, role: "engineer" })
+        .mockResolvedValueOnce(errorAgent);
+      mockAccessService.hasPermission.mockResolvedValue(false);
+
+      const app = await createApp({
+        type: "agent",
+        agentId: watchdogAgentId,
+        companyId,
+        source: "agent_key",
+        runId: "run-wd-1",
+      });
+
+      const res = await requestApp(app, (baseUrl) => request(baseUrl)
+        .patch(`/api/agents/${agentId}`)
+        .send({ status: "idle" }));
+
+      expect(res.status).toBe(403);
+      expect(mockAgentService.update).not.toHaveBeenCalled();
+    });
   });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -525,6 +525,29 @@ export function agentRoutes(
     throw forbidden("Only CEO or agent creators can modify other agents");
   }
 
+  function isExactRecoveryBody(body: Record<string, unknown>): boolean {
+    const keys = Object.keys(body);
+    return keys.length === 1 && body.status === "idle";
+  }
+
+  async function assertCanRecoverFromError(
+    req: Request,
+    targetAgent: { id: string; companyId: string; status: string | null; pauseReason: string | null },
+  ): Promise<boolean> {
+    if (targetAgent.status !== "error" || targetAgent.pauseReason !== null) return false;
+    const body = req.body as Record<string, unknown>;
+    if (!isExactRecoveryBody(body)) return false;
+    if (!req.actor.agentId) return false;
+    const actorAgent = await svc.getById(req.actor.agentId);
+    if (!actorAgent || actorAgent.companyId !== targetAgent.companyId) return false;
+    return access.hasPermission(
+      targetAgent.companyId,
+      "agent",
+      actorAgent.id,
+      "agents:recover_from_error",
+    );
+  }
+
   async function assertCanReadAgent(req: Request, targetAgent: { companyId: string }) {
     assertCompanyAccess(req, targetAgent.companyId);
     if (req.actor.type === "board") {
@@ -2350,7 +2373,10 @@ export function agentRoutes(
       res.status(404).json({ error: "Agent not found" });
       return;
     }
-    await assertCanUpdateAgent(req, existing);
+    const canRecover = await assertCanRecoverFromError(req, existing);
+    if (!canRecover) {
+      await assertCanUpdateAgent(req, existing);
+    }
 
     if (hasOwn(req.body as object, "permissions")) {
       res.status(422).json({ error: "Use /api/agents/:id/permissions for permission changes" });


### PR DESCRIPTION
## Summary

Adds a narrowly scoped `agents:recover_from_error` RBAC permission that allows authorized agents to recover error-stuck agents by setting their status to `idle` — without holding broader `agents:create` or CEO privileges.

### Problem

Currently, automated watchdog loops that recover stuck agents must run under the CEO API key (overly broad credential) or hold the `agents:create` grant (strictly broader than needed — the watchdog never creates agents, only flips one status field). There is no narrow permission that authorizes only error recovery.

### Changes

1. **`packages/shared/src/constants.ts`**: Added `"agents:recover_from_error"` to `PERMISSION_KEYS` enum
2. **`server/src/routes/agents.ts`**: 
   - Added `isExactRecoveryBody()` — strict body validation (must be exactly `{ status: "idle" }`)
   - Added `assertCanRecoverFromError()` — checks tri-condition before authorizing:
     - Target agent `status === "error"`
     - Target agent `pauseReason === null`  
     - Request body is exactly `{ status: "idle" }`
   - Integrated recovery check into `PATCH /api/agents/:id` handler
3. **`server/src/__tests__/agent-permissions-routes.test.ts`**: 6 new integration tests

### Security properties

The grant does NOT allow:
- `DELETE` operations
- Status transitions to anything other than `idle`
- Updates to `adapterConfig`, `permissions`, `pauseReason`, or any other field
- Any operation on agents not in `error` status
- Any operation on agents with a non-null `pauseReason`

### Test coverage

| Test | Expected |
|---|---|
| Recovery with all tri-conditions met | 200 OK |
| Recovery with extra body fields | 403 |
| Recovery against paused agent | 403 |
| Recovery against non-error agent | 403 |
| PATCH with `status: "active"` | 403 (no privilege escalation) |
| Recovery without permission grant | 403 |

All 47 tests in the test file pass (41 existing + 6 new, zero regressions).

### Motivation

Filed by Svetia Veritas Chile SpA. Our automated watchdog (SVE-570) currently runs under the CEO key as a workaround. This permission would let us re-home the watchdog to a DevOps agent identity with only the recovery grant, following least-privilege principles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)