### PR TITLE
fix: Docker line endings error on a Windows host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:lts-trixie-slim AS base
 ARG USER_UID=1000
 ARG USER_GID=1000
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates gosu curl gh git wget ripgrep python3 dos2unix \
+  && apt-get install -y --no-install-recommends ca-certificates gosu curl gh git wget ripgrep python3 \
   && rm -rf /var/lib/apt/lists/* \
   && corepack enable
 
@@ -60,6 +60,9 @@ RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/cod
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends dos2unix \
+  && rm -rf /var/lib/apt/lists/*
 RUN dos2unix /usr/local/bin/docker-entrypoint.sh
 RUN apt-get -y remove dos2unix && apt-get -y autoremove && apt-get -y autoclean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:lts-trixie-slim AS base
 ARG USER_UID=1000
 ARG USER_GID=1000
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates gosu curl gh git wget ripgrep python3 \
+  && apt-get install -y --no-install-recommends ca-certificates gosu curl gh git wget ripgrep python3 dos2unix \
   && rm -rf /var/lib/apt/lists/* \
   && corepack enable
 
@@ -60,6 +60,8 @@ RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/cod
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN dos2unix /usr/local/bin/docker-entrypoint.sh
+RUN apt-get -y remove dos2unix && apt-get -y autoremove && apt-get -y autoclean
 
 ENV NODE_ENV=production \
   HOME=/paperclip \


### PR DESCRIPTION
## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

- Paperclip is used by users in several different environments, which includes different operational systems.
- This pull request addresses one edge case for users using Docker in a Windows machine
- When the user follows the docker deployment instructions and clones the repository in an environment where files are automatically created with CRLF line endings (such as Windows), the docker container will fail to start with the error message `exec /usr/local/bin/docker-entrypoint.sh: no such file or directory; exited with code 255`
- The error message is unhelpful for the user to debug that what is happening is that this script is being copied over to the docker image which is Debian an it needs files with LF line endings.
- This pull request changes the docker images to use the tool dos2unix to fix the entry point script, ensuring it has correct line endings. The program is later uninstalled as it's used only once in order to decrease image size.
- The benefit is Windows users don't need to perform additional steps to use Paperclip with Docker.

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

- Dockerfile installs dos2unix, change docker-entrypoint.sh line endings in the image - not in the user's filesystem - and then uninstalls dos2unix. All docker images using the repository root as context and using that file as entry point are affected.

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

In a Windows host:

- Check if file `scripts/docker-entrypoint.sh` has incorrect line endings (CRLF);
- Create file `docker/.env` with BETTER_AUTH_SECRET variable set;
- Run `docker compose -f docker\docker-compose.quickstart.yml up --build`

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

- This only handles files created in a Windows filesystem with Windows line endings (CRLF). If the file is on Windows and already has the correct line endings, dos2unix won't change anything and the system will work normally (no destructive behavior).
- This does not install or use mac2unix tool used to convert files with Apple line endings to UNIX line endings. Files with Apple endings are not handled. Mac support has not been tested.

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

- None — human-authored

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
