### PR TITLE
fix: apply hire approval payload fields to existing pending agent on approval (TEC-1308)

### DIFF
--- a/server/src/__tests__/approvals-service.test.ts
+++ b/server/src/__tests__/approvals-service.test.ts
@@ -101,7 +101,28 @@ describe("approvalService resolution idempotency", () => {
     const result = await svc.approve("approval-1", "board", "ship it");
 
     expect(result.applied).toBe(true);
-    expect(mockAgentService.activatePendingApproval).toHaveBeenCalledWith("agent-1");
+    expect(mockAgentService.activatePendingApproval).toHaveBeenCalledWith("agent-1", expect.any(Object));
     expect(mockNotifyHireApproved).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies adapterConfig from approval payload to existing pending agent on approval", async () => {
+    const adapterConfig = { model: "claude-opus-4-7", instructionsFilePath: "AGENTS.md" };
+    const approvalWithConfig: ApprovalRecord = {
+      ...createApproval("approved"),
+      payload: { agentId: "agent-1", adapterConfig, role: "developer", title: "Dev Agent" },
+    };
+    const dbStub = createDbStub([[createApproval("pending")]], [approvalWithConfig]);
+    mockAgentService.activatePendingApproval.mockResolvedValue({
+      agent: { id: "agent-1" },
+      activated: true,
+    });
+
+    const svc = approvalService(dbStub.db as any);
+    await svc.approve("approval-1", "board", "ship it");
+
+    expect(mockAgentService.activatePendingApproval).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({ adapterConfig, role: "developer", title: "Dev Agent" }),
+    );
   });
 });

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -531,10 +531,26 @@ export function agentService(db: Db) {
       });
     },
 
-    activatePendingApproval: async (id: string) => {
+    activatePendingApproval: async (id: string, overrides?: {
+      role?: string;
+      title?: string | null;
+      reportsTo?: string | null;
+      capabilities?: string | null;
+      adapterType?: string;
+      adapterConfig?: Record<string, unknown>;
+    }) => {
+      const patch: Record<string, unknown> = { status: "idle", updatedAt: new Date() };
+      if (overrides) {
+        if (overrides.role !== undefined) patch.role = overrides.role;
+        if (overrides.title !== undefined) patch.title = overrides.title;
+        if (overrides.reportsTo !== undefined) patch.reportsTo = overrides.reportsTo;
+        if (overrides.capabilities !== undefined) patch.capabilities = overrides.capabilities;
+        if (overrides.adapterType !== undefined) patch.adapterType = overrides.adapterType;
+        if (overrides.adapterConfig !== undefined) patch.adapterConfig = overrides.adapterConfig;
+      }
       const updated = await db
         .update(agents)
-        .set({ status: "idle", updatedAt: new Date() })
+        .set(patch)
         .where(and(eq(agents.id, id), eq(agents.status, "pending_approval")))
         .returning()
         .then((rows) => rows[0] ?? null);

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -113,7 +113,17 @@ export function approvalService(db: Db) {
         const payload = updated.payload as Record<string, unknown>;
         const payloadAgentId = typeof payload.agentId === "string" ? payload.agentId : null;
         if (payloadAgentId) {
-          await agentsSvc.activatePendingApproval(payloadAgentId);
+          await agentsSvc.activatePendingApproval(payloadAgentId, {
+            role: typeof payload.role === "string" ? payload.role : undefined,
+            title: typeof payload.title === "string" ? payload.title : undefined,
+            reportsTo: typeof payload.reportsTo === "string" ? payload.reportsTo : undefined,
+            capabilities: typeof payload.capabilities === "string" ? payload.capabilities : undefined,
+            adapterType: typeof payload.adapterType === "string" ? payload.adapterType : undefined,
+            adapterConfig:
+              typeof payload.adapterConfig === "object" && payload.adapterConfig !== null
+                ? (payload.adapterConfig as Record<string, unknown>)
+                : undefined,
+          });
           hireApprovedAgentId = payloadAgentId;
         } else {
           const created = await agentsSvc.create(updated.companyId, {


### PR DESCRIPTION
## Summary

Fixes [TEC-1308]: When a `hire_agent` approval resolves, the `adapterConfig`, `role`, `title`, `reportsTo`, and `capabilities` fields from the approval payload were only applied to newly-created agents. Existing pending agents only had their status updated via `activatePendingApproval`, which skipped those fields.

## Changes

- `server/src/services/approvals.ts`: Pass full approval payload fields to `activatePendingApproval` (Case A — existing pending agent path)
- `server/src/services/agents.ts`: Extend `activatePendingApproval` to accept and apply the patch fields atomically in a single `.set()` call
- `server/src/__tests__/approvals-service.test.ts`: Add regression test verifying `adapterConfig` is applied on approval of an existing pending agent

## Test plan

- [x] `hire-hook.test.ts` — 5/5 pass
- [x] `approvals-service.test.ts` — 4/4 pass including new regression test
- [x] QA review approved (TEC-1310)

🤖 Generated with [Claude Code](https://claude.com/claude-code)