### PR TITLE
fix(gemini-local): classify ENOTFOUND as transient network error

### DIFF
--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -48,6 +48,7 @@ import { DEFAULT_GEMINI_LOCAL_MODEL } from "../index.js";
 import {
   describeGeminiFailure,
   detectGeminiAuthRequired,
+  isGeminiTransientNetworkError,
   isGeminiTurnLimitResult,
   isGeminiUnknownSessionError,
   parseGeminiJsonl,
@@ -520,13 +521,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       stderr: attempt.proc.stderr,
     });
 
+    const networkUnavailable = isGeminiTransientNetworkError(attempt.proc.stdout, attempt.proc.stderr);
+
     if (attempt.proc.timedOut) {
       return {
         exitCode: attempt.proc.exitCode,
         signal: attempt.proc.signal,
         timedOut: true,
         errorMessage: `Timed out after ${timeoutSec}s`,
-        errorCode: authMeta.requiresAuth ? "gemini_auth_required" : null,
+        errorCode: authMeta.requiresAuth
+          ? "gemini_auth_required"
+          : networkUnavailable
+            ? "gemini_network_unavailable"
+            : null,
         clearSession: clearSessionOnMissingSession,
       };
     }
@@ -567,7 +574,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       signal: attempt.proc.signal,
       timedOut: false,
       errorMessage: (attempt.proc.exitCode ?? 0) === 0 ? null : fallbackErrorMessage,
-      errorCode: (attempt.proc.exitCode ?? 0) !== 0 && authMeta.requiresAuth ? "gemini_auth_required" : null,
+      errorCode:
+        (attempt.proc.exitCode ?? 0) !== 0 && authMeta.requiresAuth
+          ? "gemini_auth_required"
+          : (attempt.proc.exitCode ?? 0) !== 0 && networkUnavailable
+            ? "gemini_network_unavailable"
+            : null,
       usage: attempt.parsed.usage,
       sessionId: resolvedSessionId,
       sessionParams: resolvedSessionParams,

--- a/packages/adapters/gemini-local/src/server/index.ts
+++ b/packages/adapters/gemini-local/src/server/index.ts
@@ -4,6 +4,7 @@ export { testEnvironment } from "./test.js";
 export {
   parseGeminiJsonl,
   isGeminiUnknownSessionError,
+  isGeminiTransientNetworkError,
   describeGeminiFailure,
   detectGeminiAuthRequired,
   isGeminiTurnLimitResult,

--- a/packages/adapters/gemini-local/src/server/parse.test.ts
+++ b/packages/adapters/gemini-local/src/server/parse.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import { isGeminiTransientNetworkError, isGeminiUnknownSessionError } from "./parse.js";
+
+describe("isGeminiUnknownSessionError", () => {
+  test("matches 'unknown session'", () => {
+    expect(isGeminiUnknownSessionError("", "Error: unknown session 'abc-123'")).toBe(true);
+  });
+
+  test("matches 'session ... not found'", () => {
+    expect(isGeminiUnknownSessionError("", "Resumed session abc-123 not found on disk")).toBe(true);
+  });
+
+  test("does not match unrelated stderr", () => {
+    expect(isGeminiUnknownSessionError("", "Some other error")).toBe(false);
+  });
+
+  test("does not match transient network errors (those go to isGeminiTransientNetworkError)", () => {
+    expect(
+      isGeminiUnknownSessionError(
+        "",
+        "_GaxiosError: getaddrinfo ENOTFOUND oauth2.googleapis.com",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isGeminiTransientNetworkError", () => {
+  test("matches DNS failure on oauth2.googleapis.com", () => {
+    const stderr =
+      "_GaxiosError: request to https://oauth2.googleapis.com/token failed, reason: getaddrinfo ENOTFOUND oauth2.googleapis.com";
+    expect(isGeminiTransientNetworkError("", stderr)).toBe(true);
+  });
+
+  test("matches EAI_AGAIN", () => {
+    expect(isGeminiTransientNetworkError("", "Error: getaddrinfo EAI_AGAIN sts.googleapis.com")).toBe(true);
+  });
+
+  test("matches _UserRefreshClient ENOTFOUND", () => {
+    const stderr =
+      "at _UserRefreshClient.refreshTokenNoCache (.../google-auth-library/...)\n" +
+      "  caused by: ENOTFOUND oauth2.googleapis.com";
+    expect(isGeminiTransientNetworkError("", stderr)).toBe(true);
+  });
+
+  test("does not match unrelated stderr", () => {
+    expect(isGeminiTransientNetworkError("", "Some other error")).toBe(false);
+  });
+
+  test("does not match unknown-session errors (those go to isGeminiUnknownSessionError)", () => {
+    expect(isGeminiTransientNetworkError("", "Error: unknown session 'abc-123'")).toBe(false);
+  });
+});

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -190,6 +190,18 @@ export function isGeminiUnknownSessionError(stdout: string, stderr: string): boo
   );
 }
 
+export function isGeminiTransientNetworkError(stdout: string, stderr: string): boolean {
+  const haystack = `${stdout}\n${stderr}`
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+
+  return /ENOTFOUND\s+oauth2\.googleapis\.com|ENOTFOUND\s+sts\.googleapis\.com|EAI_AGAIN|_GaxiosError.*ENOTFOUND|_UserRefreshClient.*ENOTFOUND/i.test(
+    haystack,
+  );
+}
+
 function extractGeminiErrorMessages(parsed: Record<string, unknown>): string[] {
   const messages: string[] = [];
   const errorMsg = asString(parsed.error, "").trim();


### PR DESCRIPTION
## Thinking Path

A 2026-04-30 audit (4 parallel subagents querying `heartbeat_runs` over the prior 7 days) surfaced a **1 → 42 occurrence week-over-week spike** for a single stderr pattern across gemini-local agents (Ernest, Dhalia, Nada). All 42 stderrs are variants of:

```
_GaxiosError: request to https://oauth2.googleapis.com/token failed,
reason: getaddrinfo ENOTFOUND oauth2.googleapis.com
```

This is a transient host-network condition (DNS / VPN flap) hit by gemini-cli's internal `_UserRefreshClient.refreshTokenNoCache` during OAuth refresh. gemini-cli retries internally (visible in stderr as `Attempt N failed. Retrying with backoff...`) and ultimately fails the run.

Today the adapter classifies the resulting non-zero exit as a generic adapter failure with `errorCode=null`, so the heartbeat runner cannot distinguish a transient network blip from a real adapter bug. This change introduces a dedicated classifier and surfaces a `gemini_network_unavailable` errorCode for runner-side handling.

## What Changed

- New `isGeminiTransientNetworkError(stdout, stderr): boolean` classifier in `parse.ts`, mirroring the structure of `isGeminiUnknownSessionError` (PR #4118). Matches `ENOTFOUND oauth2.googleapis.com`, `ENOTFOUND sts.googleapis.com`, `EAI_AGAIN`, `_GaxiosError ... ENOTFOUND`, `_UserRefreshClient ... ENOTFOUND`.
- Wired into `execute.ts`: when the gemini-cli child times out OR exits non-zero AND the classifier matches, set `errorCode = "gemini_network_unavailable"`. Existing `gemini_auth_required` classification still wins (auth precedence).
- Public export added to `index.ts` so the runner can use the classifier directly if needed.
- New `parse.test.ts` — first unit-test coverage for these classifiers. 4 tests for the existing `isGeminiUnknownSessionError` (regression for PR #4118 + cross-classifier exclusion) and 5 for the new function.

## Verification

- `npx vitest run --project @paperclipai/adapter-gemini-local` → 12/12 pass (9 new + 3 existing)
- `pnpm --filter @paperclipai/adapter-gemini-local typecheck` → clean
- Audit query against the last-7d `heartbeat_runs.stderr_excerpt` corpus confirms the regex matches all 42 occurrences with zero false positives elsewhere

## Risks

- **Low.** Pure additive change. Two new exported symbols, no behavioral change to existing code paths beyond errorCode assignment. The classifier is read-only against stderr/stdout and runs after the gemini-cli child has exited (or timed out), so it cannot affect process lifecycle or session state.
- The `errorCode` field is opaque to upstream code that doesn't recognize the new value; only consumers that explicitly switch on `gemini_network_unavailable` will react, and there are none today. This PR is **infrastructure for runner-side handling in a follow-up**.

## Model Used

Claude Opus 4.7 (1M context), Anthropic SDK via Claude Code CLI, extended thinking for the audit-to-fix trace.

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model specified (with version and capability details)
- [x] Checked ROADMAP.md — does not duplicate planned core work
- [x] Tests pass locally
- [x] Tests added or updated where applicable
- [x] N/A — server-side regex, no UI
- [x] Internal pattern; no docs change
- [x] Risks documented above
- [x] Will address Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)