### PR TITLE
fix(recovery): suppress stale-run watchdog re-fires on recovered source issues

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -405,6 +405,61 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(evaluations.filter((issue) => !["done", "cancelled"].includes(issue.status))).toHaveLength(1);
   });
 
+  it("suppresses re-firing once the source issue has been recovered after a prior terminal evaluation (SWI-98)", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first.created).toBe(1);
+    const firstEvaluationIssueId = first.evaluationIssueIds[0];
+    expect(firstEvaluationIssueId).toBeTruthy();
+
+    // Simulate operator-driven recovery: triage the first evaluation to done
+    // and release the source-issue execution lock back to a startable state.
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, firstEvaluationIssueId!));
+    await db
+      .update(issues)
+      .set({ status: "todo", checkoutRunId: null })
+      .where(eq(issues.id, issueId));
+
+    // Subsequent scans must not re-fire — the dead run has already been triaged.
+    const second = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    const third = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(second).toMatchObject({ created: 0, existing: 0, escalated: 0, skipped: 1 });
+    expect(third).toMatchObject({ created: 0, existing: 0, escalated: 0, skipped: 1 });
+
+    const allEvaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(allEvaluations).toHaveLength(1);
+    expect(allEvaluations[0]?.id).toBe(firstEvaluationIssueId);
+  });
+
+  it("still fires when the source issue is recovered but no prior evaluation exists yet", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    // Source issue happens to be in `todo` with cleared lock at scan time, but
+    // no prior evaluation has been triaged yet — the watchdog must still fire
+    // so the operator gets a first signal.
+    await db
+      .update(issues)
+      .set({ status: "todo", checkoutRunId: null })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(result.created).toBe(1);
+  });
+
   it("rejects agent watchdog decisions using issues not bound to the target run", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const { companyId, managerId, coderId, runId, issuePrefix } = await seedRunningRun({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -621,6 +621,40 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  // Returns a previously-closed evaluation issue for the same run, if any.
+  // Used to suppress re-firing once the source issue has clearly been
+  // recovered (operator already triaged a prior evaluation to terminal).
+  async function findTerminalStaleRunEvaluation(companyId: string, runId: string) {
+    const [row] = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.originId, runId),
+          isNull(issues.hiddenAt),
+          inArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  }
+
+  // The watchdog scan keys off `heartbeatRuns.status = 'running'` and a
+  // suspicious silence age. When a source issue has already been recovered
+  // (lock released, status returned to a startable state) and a prior
+  // evaluation for the same dead run was already closed, the operator has
+  // implicitly decided the run is dead. Re-firing burns CEO heartbeats on
+  // duplicate-closures, so suppress it.
+  function isSourceIssueRecoveredFromStaleRun(
+    sourceIssue: typeof issues.$inferSelect | null,
+  ) {
+    if (!sourceIssue) return false;
+    if (sourceIssue.checkoutRunId !== null) return false;
+    return sourceIssue.status === "todo" || sourceIssue.status === "backlog";
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
@@ -936,6 +970,21 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     });
     const level = (evidence.silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS ? "critical" : "suspicious";
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
+
+    // Suppress duplicate evaluations once the source issue has clearly been
+    // recovered (lock released + back to a startable status) AND a prior
+    // evaluation for the same run id was already triaged to a terminal state.
+    // Without this, every recovery scan re-fires on the same dead run because
+    // the heartbeat run row stays in `status='running'` indefinitely.
+    if (!existing && isSourceIssueRecoveredFromStaleRun(sourceIssue)) {
+      const priorTerminal = await findTerminalStaleRunEvaluation(
+        input.run.companyId,
+        input.run.id,
+      );
+      if (priorTerminal) {
+        return { kind: "skipped" as const };
+      }
+    }
     if (existing) {
       if (level === "critical" && existing.priority !== "high") {
         await issuesSvc.update(existing.id, {


### PR DESCRIPTION
## Summary

Fixes SWI-98: the stale-active-run evaluator was re-firing on source issues that had already been recovered, creating duplicate review tickets each scan cycle.

The scan keys off `heartbeatRuns.status = 'running'` rather than the source issue state, so once a heartbeat run is orphaned (status stuck at `running` because the orphan reaper never marks it terminal in this flow), every scan cycle re-creates a fresh evaluation issue against the same `(originKind, originFingerprint)` even though the source is already back in `todo`/`backlog` with `checkoutRunId = null`.

## Fix

In `services/recovery/service.ts`, after the existing-evaluation lookup, add a guard that skips creation when **all three** conditions hold:

1. No active (non-terminal) evaluation issue exists for this fingerprint.
2. The source issue has been recovered: `checkoutRunId === null` and `status ∈ {todo, backlog}`.
3. A prior evaluation issue for the same `(originKind, originId)` exists in a terminal state (`done` / `cancelled` / `archived`).

This preserves the first-time signal (operator still gets one ticket if they recover the source before the watchdog fires) while suppressing duplicate re-fires after a human has already triaged the incident.

## Changes

- `server/src/services/recovery/service.ts` — added `findTerminalStaleRunEvaluation` and `isSourceIssueRecoveredFromStaleRun` helpers; added early-exit guard inside `createOrUpdateStaleRunEvaluation`.
- `server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts` — added two regression tests:
  - Suppresses re-firing once the source has been recovered after a prior terminal evaluation.
  - Still fires on the first scan when the source is recovered but no prior evaluation exists yet.

## Test plan

- [x] `pnpm vitest run heartbeat-active-run-output-watchdog` — 10/10 pass (8 existing + 2 new)
- [x] Existing "re-arms continue decisions after the default quiet window" test still passes (it keeps source at `in_progress`, so the new guard returns false there)
- [ ] Verify in staging that no new `stale_active_run_evaluation` issues are created for already-recovered sources