### PR TITLE
fix: exclude system-generated children from issue_children_completed wake

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1839,6 +1839,82 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
       childIssueSummaryTruncated: false,
     });
   });
+
+  it("does not wake parent when all children are harness-generated system issues", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const parentId = randomUUID();
+    const productivityChildId = randomUUID();
+    const livenessChildId = randomUUID();
+    const strandedChildId = randomUUID();
+    const staleRunChildId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: parentId,
+        companyId,
+        title: "Parent issue",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId,
+      },
+      {
+        id: productivityChildId,
+        companyId,
+        parentId,
+        title: "Productivity review",
+        status: "done",
+        priority: "medium",
+        originKind: "issue_productivity_review",
+      },
+      {
+        id: livenessChildId,
+        companyId,
+        parentId,
+        title: "Liveness escalation",
+        status: "done",
+        priority: "medium",
+        originKind: "harness_liveness_escalation",
+      },
+      {
+        id: strandedChildId,
+        companyId,
+        parentId,
+        title: "Stranded recovery",
+        status: "done",
+        priority: "medium",
+        originKind: "stranded_issue_recovery",
+      },
+      {
+        id: staleRunChildId,
+        companyId,
+        parentId,
+        title: "Stale run evaluation",
+        status: "done",
+        priority: "medium",
+        originKind: "stale_active_run_evaluation",
+      },
+    ]);
+
+    expect(await svc.getWakeableParentAfterChildCompletion(parentId)).toBeNull();
+  });
 });
 
 describeEmbeddedPostgres("issueService.create workspace inheritance", () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -686,6 +686,12 @@ const BLOCKER_ATTENTION_PENDING_INTERACTION_STATUSES = ["pending"];
 const BLOCKER_ATTENTION_PENDING_APPROVAL_STATUSES = ["pending", "revision_requested"];
 const BLOCKER_ATTENTION_OPEN_RECOVERY_ORIGIN_KIND = "harness_liveness_escalation";
 const PRODUCTIVITY_REVIEW_ORIGIN_KIND = "issue_productivity_review";
+const SYSTEM_HARNESS_CHILD_ORIGIN_KINDS: string[] = [
+  PRODUCTIVITY_REVIEW_ORIGIN_KIND,
+  BLOCKER_ATTENTION_OPEN_RECOVERY_ORIGIN_KIND,
+  "stranded_issue_recovery",
+  "stale_active_run_evaluation",
+];
 const PRODUCTIVITY_REVIEW_TERMINAL_STATUSES = ["done", "cancelled"];
 const PRODUCTIVITY_REVIEW_ACTIVITY_ACTIONS = [
   "issue.productivity_review_created",
@@ -2559,7 +2565,13 @@ export function issueService(db: Db) {
           updatedAt: issues.updatedAt,
         })
         .from(issues)
-        .where(and(eq(issues.companyId, parent.companyId), eq(issues.parentId, parentIssueId)))
+        .where(
+          and(
+            eq(issues.companyId, parent.companyId),
+            eq(issues.parentId, parentIssueId),
+            notInArray(issues.originKind, SYSTEM_HARNESS_CHILD_ORIGIN_KINDS),
+          ),
+        )
         .orderBy(asc(issues.issueNumber), asc(issues.createdAt));
       if (children.length === 0) return null;
       if (!children.every((child) => child.status === "done" || child.status === "cancelled")) {


### PR DESCRIPTION
## Summary

Fixes a harness bug ([BLO-2418](https://github.com/Blockcast/paperclip/issues)) where `issue_children_completed` wakes fired on issues that had only system-generated harness children (productivity reviews, liveness escalations, stranded-issue recovery, stale-run evaluations) — not real work-children.

**Root cause:** `getWakeableParentAfterChildCompletion` queried all rows where `parentId = $issue.id` without filtering out harness-internal origin kinds, so when those system children closed, the parent got a false-positive wake.

## Changes

**`server/src/services/issues.ts`**
- Added `SYSTEM_HARNESS_CHILD_ORIGIN_KINDS` constant listing the 4 harness-internal origin kinds to exclude
- Updated `getWakeableParentAfterChildCompletion` WHERE clause to filter out those origin kinds via `notInArray`

**`server/src/__tests__/issues-service.test.ts`**
- Added test: `"does not wake parent when all children are harness-generated system issues"` — creates a parent with one child of each excluded origin kind (all done), asserts `getWakeableParentAfterChildCompletion` returns `null`

## Verification

```
pnpm --filter @paperclipai/server exec npx vitest run src/__tests__/issues-service.test.ts
```

Result: **39 passed** (39 total, including the new test).

## Replaces

Closes #4941 — that PR was based on a stale Blockcast fork branch (280 commits ahead of upstream) and was CONFLICTING/DIRTY. This PR is cut cleanly from upstream master with exactly 2 files changed (+89/-1 lines).