### PR TITLE
fix(live-runs): default minCount to 0 — no backfill when nothing is queued/running

### DIFF
--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -344,7 +344,20 @@ describe("agent live run routes", () => {
     expect(mockHeartbeatService.buildRunOutputSilence).toHaveBeenCalledTimes(50);
   });
 
-  it("returns empty array by default when no runs are queued or running", async () => {
+  it("does not backfill terminal runs when no active runs exist (default minCount=0)", async () => {
+    // Pre-fix behaviour (default minCount=50):
+    //   1. live query → [] (no queued/running)
+    //   2. backfill block fires because 50 > 0 && 0 < 50
+    //   3. db.select called twice
+    // Post-fix behaviour (default minCount=0):
+    //   1. live query → []
+    //   2. backfill block SKIPPED because 0 > 0 is false
+    //   3. db.select called exactly once
+    //
+    // Asserting on db.select call count is the only stub-friendly way to
+    // distinguish the two code paths: the existing stub doesn't model the
+    // status filter, so we can't rely on row-shape alone to prove the
+    // backfill branch wasn't entered.
     const { db } = createLiveRunsDbStub([]);
 
     const res = await requestApp(
@@ -354,6 +367,51 @@ describe("agent live run routes", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body).toHaveLength(0);
+    // Critical: exactly one db.select call. Two calls would mean the backfill
+    // path was entered (the regression this PR fixes).
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it("DOES backfill terminal runs when caller explicitly passes minCount=50", async () => {
+    // Verifies the activity-feed use case still works when callers opt in.
+    // Stub doesn't model the status filter, so the live query and the
+    // backfill query both return the same `rows` — but db.select call count
+    // proves the backfill branch was entered.
+    const terminalRow = {
+      id: "run-done",
+      companyId: "company-1",
+      status: "succeeded",
+      invocationSource: "automation",
+      triggerDetail: "system",
+      startedAt: new Date("2026-04-10T09:30:00.000Z"),
+      finishedAt: new Date("2026-04-10T09:31:00.000Z"),
+      createdAt: new Date("2026-04-10T09:30:00.000Z"),
+      agentId: "agent-1",
+      agentName: "Builder",
+      adapterType: "codex_local",
+      logBytes: 0,
+      livenessState: "healthy",
+      livenessReason: null,
+      continuationAttempt: 0,
+      lastUsefulActionAt: null,
+      nextAction: null,
+      lastOutputAt: null,
+      lastOutputSeq: null,
+      lastOutputStream: null,
+      lastOutputBytes: 0,
+      processStartedAt: null,
+      issueId: "issue-1",
+    };
+    const { db } = createLiveRunsDbStub([terminalRow]);
+
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) => request(baseUrl).get("/api/companies/company-1/live-runs?minCount=50"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    // Two db.select calls = live query + backfill query.
+    expect(db.select).toHaveBeenCalledTimes(2);
   });
 
   it("treats explicit zero live run limits as the capped default", async () => {

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -344,6 +344,18 @@ describe("agent live run routes", () => {
     expect(mockHeartbeatService.buildRunOutputSilence).toHaveBeenCalledTimes(50);
   });
 
+  it("returns empty array by default when no runs are queued or running", async () => {
+    const { db } = createLiveRunsDbStub([]);
+
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) => request(baseUrl).get("/api/companies/company-1/live-runs"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toHaveLength(0);
+  });
+
   it("treats explicit zero live run limits as the capped default", async () => {
     const rows = Array.from({ length: 75 }, (_, index) => ({
       id: `run-${index}`,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2844,7 +2844,7 @@ export function agentRoutes(
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
 
-    const minCount = readLiveRunsQueryInt(req.query.minCount, 50, 50);
+    const minCount = readLiveRunsQueryInt(req.query.minCount, 50, 0);
     const limit = readLiveRunsQueryInt(req.query.limit, 50, 50);
 
     const columns = {


### PR DESCRIPTION
# `/api/companies/:id/live-runs` returns terminal runs as "live" via backfill — UI mislabel

## Severity

**Low–medium** — cosmetic but pervasive: agent sidebar badges and Dashboard counter show non-zero "X live" indefinitely even when 0 runs are queued or running. Misleads operators into thinking work is in flight.

## Reproduction

1. Pause all agents, or simply wait until all runs reach a terminal state.
2. Verify in DB: `SELECT count(*) FROM heartbeat_runs WHERE status IN ('queued','running')` → `0`.
3. Open the UI. Sidebar shows `Dashboard 50 live`, `Agent-X 13 live`, `Agent-Y 17 live`, etc.

The badges should show 0. They do not, ever, until you delete enough rows from `heartbeat_runs` to drop total below 50.

## Root cause

`server/src/routes/agents.ts` (~line 2843, route `/api/companies/:companyId/live-runs`):

```ts
const minCount = readLiveRunsQueryInt(req.query.minCount, 50, 50);
// ...
const liveRunsQuery = db.select(...).from(heartbeatRuns)
  .where(inArray(heartbeatRuns.status, ['queued', 'running']));
const liveRuns = await liveRunsQuery.limit(limit);

if (targetRunCount > 0 && liveRuns.length < targetRunCount) {
  // FILLS REMAINDER WITH RECENT TERMINAL RUNS UP TO 50
  const recentRuns = await db.select(...)
    .where(not(inArray(heartbeatRuns.status, ['queued', 'running'])))
    .orderBy(desc(heartbeatRuns.createdAt))
    .limit(targetRunCount - liveRuns.length);
  res.json([...liveRuns, ...recentRuns]);
  return;
}
```

Default `minCount=50` means: even when 0 truly-live runs exist, the route always returns 50 rows of "recent activity" labeled in UI as `X live`.

## Proposed fix — three options

### Option A — server default change (smallest diff)

```ts
const minCount = readLiveRunsQueryInt(req.query.minCount, 0, 50)
```

Default becomes 0 (no backfill). UI callers that genuinely want recent-activity behavior pass `?minCount=50`. Audit callers and update.

### Option B — separate route

Keep `/live-runs` unchanged for activity-feed usage. Add `/live-runs/active-only` returning only `queued|running`. UI sidebar / dashboard badge calls the new route.

### Option C — query param toggle

Add `?onlyActive=true` to suppress backfill. UI sidebar passes it; activity feed default-backfills.

We're shipping option A on a local fork. Happy to send a PR if you'd like.

## DoD on our side

- After fix, all agent badges show 0 when no `queued|running` runs exist.
- Badge ticks to 1 when a single run is dispatched, then back to 0 when it completes.
- No regression on any "Activity" page that genuinely wants the recent-runs feed (passes `?minCount=50`).

## Out of scope

- Renaming `live` → `recent` in UI strings (cosmetic; semantic fix is preferred).
- Heartbeat-run pruning policy. Pruning historical rows doesn't help — backfill always finds 50 recent rows. Only the route semantics matter.
