### PR TITLE
fix(workspace-policy): preserve agent.workspaceStrategy when no override exists (#4946)

### DIFF
--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -86,12 +86,14 @@ describe("execution workspace policy helpers", () => {
     });
   });
 
-  it("clears managed workspace strategy when issue opts out to project primary or agent default", () => {
+  it("clears agent workspace strategy when project policy enforces a managed shared workspace", () => {
     const baseConfig = {
       workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}" },
       workspaceRuntime: { services: [{ name: "web" }] },
     };
 
+    // Project policy is enabled (managed mode) and the issue opts into shared_workspace —
+    // the project's primary workspace is in force, so the agent's strategy yields.
     expect(
       buildExecutionWorkspaceAdapterConfig({
         agentConfig: baseConfig,
@@ -101,16 +103,77 @@ describe("execution workspace policy helpers", () => {
         legacyUseProjectWorkspace: null,
       }).workspaceStrategy,
     ).toBeUndefined();
+  });
 
-    const agentDefault = buildExecutionWorkspaceAdapterConfig({
+  it("preserves agent workspace strategy when issue mode is agent_default with no project policy (upstream issue #4946)", () => {
+    // Regression: previously `else { delete nextConfig.workspaceStrategy }` ran
+    // unconditionally inside the hasWorkspaceControl branch, silently dropping
+    // the agent's own workspaceStrategy whenever the issue mode resolved to
+    // "agent_default" (or legacyUseProjectWorkspace === false). That caused
+    // agents hired with `{ type: "git_worktree" }` to spawn in `_default/`
+    // and fail with `fatal: not a git repository` (Gotcha #1 / cascade source
+    // for upstream PR #4944). The agent's strategy must survive when there is
+    // no explicit project/issue override and no enforced policy.
+    const baseConfig = {
+      workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}" },
+      workspaceRuntime: { services: [{ name: "web" }] },
+    };
+
+    const result = buildExecutionWorkspaceAdapterConfig({
       agentConfig: baseConfig,
       projectPolicy: null,
       issueSettings: { mode: "agent_default" },
       mode: "agent_default",
       legacyUseProjectWorkspace: null,
     });
-    expect(agentDefault.workspaceStrategy).toBeUndefined();
-    expect(agentDefault.workspaceRuntime).toBeUndefined();
+    expect(result.workspaceStrategy).toEqual({
+      type: "git_worktree",
+      branchTemplate: "{{issue.identifier}}",
+    });
+    // workspaceRuntime is still cleared in agent_default mode (legitimate behaviour:
+    // agent_default mode means no managed workspace runtime services).
+    expect(result.workspaceRuntime).toBeUndefined();
+  });
+
+  it("preserves agent workspace strategy when legacyUseProjectWorkspace=false but no policy/override exists", () => {
+    // The legacy `useProjectWorkspace: false` flag triggers hasWorkspaceControl
+    // even though the project has no policy and the issue has no override.
+    // The agent's strategy should survive in that case — same root cause as the
+    // agent_default scenario above, surfacing through a different trigger.
+    const baseConfig = {
+      workspaceStrategy: { type: "git_worktree", baseRef: "master" },
+    };
+
+    const result = buildExecutionWorkspaceAdapterConfig({
+      agentConfig: baseConfig,
+      projectPolicy: null,
+      issueSettings: null,
+      mode: "agent_default",
+      legacyUseProjectWorkspace: false,
+    });
+    expect(result.workspaceStrategy).toEqual({
+      type: "git_worktree",
+      baseRef: "master",
+    });
+  });
+
+  it("issue.workspaceStrategy override wins over agent's own strategy in non-isolated modes", () => {
+    // When the issue explicitly provides its own workspaceStrategy, that wins
+    // over the agent's — preserves the override semantics for caller-driven
+    // per-issue configuration.
+    const result = buildExecutionWorkspaceAdapterConfig({
+      agentConfig: {
+        workspaceStrategy: { type: "git_worktree", baseRef: "master" },
+      },
+      projectPolicy: null,
+      issueSettings: {
+        mode: "shared_workspace",
+        workspaceStrategy: { type: "project_primary" },
+      },
+      mode: "shared_workspace",
+      legacyUseProjectWorkspace: null,
+    });
+    expect(result.workspaceStrategy).toEqual({ type: "project_primary" });
   });
 
   it("parses persisted JSON payloads into typed project and issue workspace settings", () => {

--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -157,6 +157,35 @@ describe("execution workspace policy helpers", () => {
     });
   });
 
+  it("clears agent strategy in shared_workspace / operator_branch mode even without a project policy (reviewer feedback on PR #4951)", () => {
+    // Reviewer flagged: when issueSettings.mode triggers a managed mode but
+    // projectPolicy is null and no explicit workspaceStrategy override exists,
+    // the agent's strategy must still yield — these modes are project-managed
+    // by definition and a residual agent-level git_worktree would conflict
+    // with the resolved cwd.
+    const baseConfig = {
+      workspaceStrategy: { type: "git_worktree", baseRef: "master" },
+    };
+
+    const sharedNoPolicy = buildExecutionWorkspaceAdapterConfig({
+      agentConfig: baseConfig,
+      projectPolicy: null,
+      issueSettings: { mode: "shared_workspace" },
+      mode: "shared_workspace",
+      legacyUseProjectWorkspace: null,
+    });
+    expect(sharedNoPolicy.workspaceStrategy).toBeUndefined();
+
+    const operatorNoPolicy = buildExecutionWorkspaceAdapterConfig({
+      agentConfig: baseConfig,
+      projectPolicy: null,
+      issueSettings: { mode: "operator_branch" },
+      mode: "operator_branch",
+      legacyUseProjectWorkspace: null,
+    });
+    expect(operatorNoPolicy.workspaceStrategy).toBeUndefined();
+  });
+
   it("issue.workspaceStrategy override wins over agent's own strategy in non-isolated modes", () => {
     // When the issue explicitly provides its own workspaceStrategy, that wins
     // over the agent's — preserves the override semantics for caller-driven

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -218,7 +218,22 @@ export function buildExecutionWorkspaceAdapterConfig(input: {
         ({ type: "git_worktree" } satisfies ExecutionWorkspaceStrategy);
       nextConfig.workspaceStrategy = strategy as unknown as Record<string, unknown>;
     } else {
-      delete nextConfig.workspaceStrategy;
+      // Preserve the agent's own workspaceStrategy unless the issue or project
+      // explicitly asserts a different one, OR the project policy is enforcing
+      // a managed workspace (shared_workspace / operator_branch under an
+      // enabled policy). Previously this branch unconditionally deleted the
+      // strategy, which silently dropped agent-level git_worktree config when
+      // hasWorkspaceControl was triggered only by legacyUseProjectWorkspace
+      // === false or an issue mode of "agent_default" — see upstream issue
+      // #4946 and the recovery cascade it caused.
+      const explicitOverride =
+        input.issueSettings?.workspaceStrategy ?? input.projectPolicy?.workspaceStrategy ?? null;
+      if (explicitOverride) {
+        nextConfig.workspaceStrategy = explicitOverride as unknown as Record<string, unknown>;
+      } else if (input.projectPolicy?.enabled && input.mode !== "agent_default") {
+        delete nextConfig.workspaceStrategy;
+      }
+      // else: preserve the agent's existing workspaceStrategy (no override).
     }
 
     if (input.mode === "agent_default") {

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -218,22 +218,23 @@ export function buildExecutionWorkspaceAdapterConfig(input: {
         ({ type: "git_worktree" } satisfies ExecutionWorkspaceStrategy);
       nextConfig.workspaceStrategy = strategy as unknown as Record<string, unknown>;
     } else {
-      // Preserve the agent's own workspaceStrategy unless the issue or project
-      // explicitly asserts a different one, OR the project policy is enforcing
-      // a managed workspace (shared_workspace / operator_branch under an
-      // enabled policy). Previously this branch unconditionally deleted the
-      // strategy, which silently dropped agent-level git_worktree config when
-      // hasWorkspaceControl was triggered only by legacyUseProjectWorkspace
-      // === false or an issue mode of "agent_default" — see upstream issue
-      // #4946 and the recovery cascade it caused.
+      // Resolve the strategy per mode:
+      //   - explicit issue/project override always wins
+      //   - shared_workspace / operator_branch are project-managed modes: the
+      //     project's primary cwd owns execution and the agent's strategy
+      //     yields (consistent with project-policy-enforced behaviour, but
+      //     also fires when the mode comes from issueSettings.mode without an
+      //     enabled policy — flagged by reviewer on PR #4951)
+      //   - agent_default means no managed workspace overlay, so the agent's
+      //     own strategy survives (the silent-drop fix for upstream #4946)
       const explicitOverride =
         input.issueSettings?.workspaceStrategy ?? input.projectPolicy?.workspaceStrategy ?? null;
       if (explicitOverride) {
         nextConfig.workspaceStrategy = explicitOverride as unknown as Record<string, unknown>;
-      } else if (input.projectPolicy?.enabled && input.mode !== "agent_default") {
+      } else if (input.mode === "shared_workspace" || input.mode === "operator_branch") {
         delete nextConfig.workspaceStrategy;
       }
-      // else: preserve the agent's existing workspaceStrategy (no override).
+      // else (input.mode === "agent_default"): preserve agent's strategy.
     }
 
     if (input.mode === "agent_default") {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and each agent's `adapterConfig.workspaceStrategy` controls whether the agent runs in a per-issue worktree, a project-managed shared workspace, or an adapter-managed sandbox
> - We hire agents with `{ type: "git_worktree", baseRef: "master" }` to give each issue its own working tree, expecting the runtime to honour that
> - In our deployment the strategy was silently dropped before reaching `realizeExecutionWorkspace` — agents spawned in `_default/` instead, immediately failed with `fatal: not a git repository`, and triggered the auto-recovery cascade we fixed in #4944
> - I traced the drop to `buildExecutionWorkspaceAdapterConfig` in `server/src/services/execution-workspace-policy.ts`: a `delete nextConfig.workspaceStrategy` call ran whenever `hasWorkspaceControl` was true and the mode was non-isolated — but `hasWorkspaceControl` also fires for `legacyUseProjectWorkspace === false` and `issueSettings.mode === "agent_default"`, neither of which represent an actual override of the agent's strategy
> - This pull request narrows the deletion to the cases where the project/issue is genuinely asserting a different strategy: explicit `workspaceStrategy` override OR an enabled project policy in a managed mode. Otherwise the agent's strategy is preserved
> - The benefit is hires that explicitly request `git_worktree` actually get a worktree, eliminating the structural failure mode that filed issue #4946 and reducing one common trigger of the recovery cascade fixed in #4944

## What Changed

- `server/src/services/execution-workspace-policy.ts` — `buildExecutionWorkspaceAdapterConfig`:
  - **Old behaviour**: inside `hasWorkspaceControl` and a non-isolated mode, `delete nextConfig.workspaceStrategy` ran unconditionally.
  - **New behaviour**: agent's `workspaceStrategy` is preserved unless either (a) the issue or project provides an explicit `workspaceStrategy` override (in which case that override wins), or (b) the project policy is `enabled` AND the resolved mode is non-isolated and non-`agent_default` (in which case the project's primary workspace owns the cwd and the agent's strategy yields). The `agent_default` mode and the `legacyUseProjectWorkspace === false` trigger no longer wipe the agent's strategy.
- `server/src/__tests__/execution-workspace-policy.test.ts`:
  - Existing test `"clears managed workspace strategy when issue opts out to project primary or agent default"` split into two:
    - `"clears agent workspace strategy when project policy enforces a managed shared workspace"` — kept the project-policy-enabled deletion assertion (unchanged behaviour).
    - `"preserves agent workspace strategy when issue mode is agent_default with no project policy (upstream issue #4946)"` — the regression test for the silent-drop bug.
  - Added two more tests:
    - `"preserves agent workspace strategy when legacyUseProjectWorkspace=false but no policy/override exists"` — the second trigger path of the same bug.
    - `"issue.workspaceStrategy override wins over agent's own strategy in non-isolated modes"` — the override semantics now consistent across modes.

## Verification

```bash
cd server
pnpm exec vitest run src/__tests__/execution-workspace-policy.test.ts
pnpm exec tsc --noEmit
```

`vitest`: 13/13 tests pass.
`tsc`: clean.

End-to-end: I haven't replayed the full session-242 cascade scenario against this branch on a clean instance — that would require re-creating the agent + a stranded run before the recovery-gate fix on PR #4944 lands, which is risky on a shared instance. The unit tests cover the resolver semantics in isolation; downstream `realizeExecutionWorkspace` in `workspace-runtime.ts` already reads the strategy correctly when present.

## Risks

- **Behaviour change for `agent_default` mode without a project policy.** Previously the agent's `workspaceStrategy` was dropped in this case; now it survives. If anyone relied on the implicit drop (for example: agents intentionally configured with a strategy that becomes harmful in `agent_default` mode), they would see the strategy take effect now. I think the implicit drop was always the bug, but flagging the risk for review.
- **Behaviour change for `legacyUseProjectWorkspace === false`.** Same shape — agent's strategy now survives. This is the trigger we hit; preserving the agent's intent matches the field name (it's a legacy compatibility flag, not a strategy override).
- **No DB migration, no public-API change, no schema change.** The function is a pure resolver that runs once per heartbeat.
- **Adjacent behaviour preserved**: `workspaceRuntime` is still cleared in `agent_default` mode (separate, legitimate signal that there is no managed runtime in that mode). `isolated_workspace` mode's fallback chain is unchanged. Project-policy-enabled `shared_workspace` / `operator_branch` still wipes the agent's strategy.

## Model Used

- Anthropic Claude Opus 4.7 (`claude-opus-4-7`), 1M context window, extended thinking + tool use enabled.
- The bug was triaged in a parent session (242, 2026-04-30) where the silent drop was first observed but not patched. This PR is the follow-up surgical fix, separated from the recovery-cascade fix on PR #4944 because the two address different layers (policy resolver here, recovery-creation gate there) and should land independently.
- Greptile-review feedback (if any) on this PR will be applied via the same model in follow-up commits, same workflow used for #4944 and #4945.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — `workspace-strategy resolver fix` is not on the roadmap; this is a bug fix on existing code path
- [x] I have run tests locally and they pass (`execution-workspace-policy.test.ts`: 13/13)
- [x] I have added or updated tests where applicable (3 new test cases + 1 split for clarity)
- [x] If this change affects the UI, I have included before/after screenshots — N/A, server-only resolver change
- [x] I have updated relevant documentation to reflect my changes — N/A, internal resolver behaviour
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

Closes #4946 (the diagnostic-only issue I filed earlier today against this same root cause).
Adjacent: #4944 (recovery-cascade gate, currently in review) — that PR fixes the *symptom* (cascade after a structural failure); this PR fixes one of the *triggers* (the structural failure when `git_worktree` was silently dropped).
