### PR TITLE
[codex] Enforce agent mutation boundaries for user-owned work

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -387,6 +387,31 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockStorageService.deleteObject).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked" })],
+    ["comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "blocked" })],
+    [
+      "document upsert",
+      (app: express.Express) =>
+        request(app).put(`/api/issues/${issueId}/documents/plan`).send({ format: "markdown", body: "# blocked" }),
+    ],
+  ])("rejects peer agent %s mutations on user-assigned issues", async (_name, sendRequest) => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      status: "in_review",
+      assigneeAgentId: null,
+      assigneeUserId: "board-user",
+    }));
+
+    const res = await sendRequest(await createApp(peerActor()));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate a user-assigned issue");
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockDocumentService.upsertIssueDocument).not.toHaveBeenCalled();
+  });
+
   it("allows the checked-out owner with the matching run id to patch and update documents", async () => {
     const app = await createApp(ownerActor());
 

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -6,6 +6,7 @@ import { normalizeIssueExecutionPolicy } from "../services/issue-execution-polic
 const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   assertCheckoutOwner: vi.fn(),
+  create: vi.fn(),
   createChild: vi.fn(),
   update: vi.fn(),
   addComment: vi.fn(),
@@ -285,6 +286,46 @@ describe("issue execution policy routes", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toBe("Agents cannot author execution policies with user participants");
+    expect(mockIssueService.createChild).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent-created issues assigned directly to users", async () => {
+    const res = await request(await createApp(agentActor()))
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "User assignment issue",
+        assigneeUserId: "local-board",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot assign issues to users");
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent-created child issues assigned directly to users", async () => {
+    const parent = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-999",
+      title: "Parent issue",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(parent);
+
+    const res = await request(await createApp(agentActor()))
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/children")
+      .send({
+        title: "User assignment child issue",
+        assigneeUserId: "local-board",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot assign issues to users");
     expect(mockIssueService.createChild).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -6,6 +6,7 @@ import { normalizeIssueExecutionPolicy } from "../services/issue-execution-polic
 const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   assertCheckoutOwner: vi.fn(),
+  createChild: vi.fn(),
   update: vi.fn(),
   addComment: vi.fn(),
   findMentionedAgents: vi.fn(),
@@ -248,6 +249,80 @@ describe("issue execution policy routes", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toBe("Agents cannot author execution policies with user participants");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent-created child issues with user-participant execution policies", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "approval",
+          participants: [{ type: "user", userId: "local-board" }],
+        },
+      ],
+    })!;
+    const parent = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-999",
+      title: "Parent issue",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(parent);
+
+    const res = await request(await createApp(agentActor()))
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/children")
+      .send({
+        title: "Escalation child issue",
+        executionPolicy: policy,
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot author execution policies with user participants");
+    expect(mockIssueService.createChild).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent attempts to clear existing user-participant execution policies", async () => {
+    const existingPolicy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "approval",
+          participants: [{ type: "user", userId: "local-board" }],
+        },
+      ],
+    })!;
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-999",
+      title: "Board approval issue",
+      executionPolicy: existingPolicy,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const res = await request(await createApp(agentActor()))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ executionPolicy: null });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot author execution policies with user participants");
+    expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      "22222222-2222-4222-8222-222222222222",
+      "33333333-3333-4333-8333-333333333333",
+    );
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -390,4 +390,37 @@ describe("issue execution policy routes", () => {
     expect(res.body.error).toBe("Agents cannot assign issues to users");
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
+
+  it("rejects agent-triggered execution policy transitions that assign issues to users", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "approval",
+          participants: [{ type: "user", userId: "local-board" }],
+        },
+      ],
+    })!;
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-999",
+      title: "Workflow user assignment",
+      executionPolicy: policy,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const res = await request(await createApp(agentActor()))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot assign issues to users");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -25,7 +25,11 @@ const mockHeartbeatService = vi.hoisted(() => ({
 function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     companyService: () => ({
-      getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+      getById: vi.fn(async () => ({
+        id: "company-1",
+        attachmentMaxBytes: 10 * 1024 * 1024,
+        issuePrefix: "PAP",
+      })),
     }),
     accessService: () => ({
       canUser: vi.fn(async () => false),
@@ -76,7 +80,27 @@ function registerModuleMocks() {
   }));
 }
 
-async function createApp() {
+function boardActor() {
+  return {
+    type: "board",
+    userId: "local-board",
+    companyIds: ["company-1"],
+    source: "local_implicit",
+    isInstanceAdmin: false,
+  };
+}
+
+function agentActor() {
+  return {
+    type: "agent",
+    agentId: "22222222-2222-4222-8222-222222222222",
+    companyId: "company-1",
+    source: "agent_key",
+    runId: "33333333-3333-4333-8333-333333333333",
+  };
+}
+
+async function createApp(actor: Record<string, unknown> = boardActor()) {
   const [{ errorHandler }, { issueRoutes }] = await Promise.all([
     import("../middleware/index.js"),
     import("../routes/issues.js"),
@@ -84,13 +108,7 @@ async function createApp() {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "local-board",
-      companyIds: ["company-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api", issueRoutes({} as any, {} as any));
@@ -161,5 +179,99 @@ describe("issue execution policy routes", () => {
     expect(updatePatch.assigneeUserId).toBeUndefined();
     expect(updatePatch.executionState).toBeUndefined();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent-authored execution policies with user participants", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "approval",
+          participants: [{ type: "user", userId: "local-board" }],
+        },
+      ],
+    })!;
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-999",
+      title: "Execution policy escalation",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp(agentActor()))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        executionPolicy: policy,
+        status: "in_review",
+        comment: "Escalate to the board.",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot author execution policies with user participants");
+    expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      "22222222-2222-4222-8222-222222222222",
+      "33333333-3333-4333-8333-333333333333",
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent-created issues with user-participant execution policies", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "approval",
+          participants: [{ type: "user", userId: "local-board" }],
+        },
+      ],
+    })!;
+
+    const res = await request(await createApp(agentActor()))
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Escalation issue",
+        executionPolicy: policy,
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot author execution policies with user participants");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent PATCH attempts to assign issues directly to users", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-999",
+      title: "Direct user assignment",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const res = await request(await createApp(agentActor()))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ assigneeAgentId: null, assigneeUserId: "local-board" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents cannot assign issues to users");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -111,6 +111,10 @@ type ExecutionStageWakeContext = {
   allowedActions: string[];
 };
 
+function executionPolicyHasUserParticipants(policy: NormalizedExecutionPolicy | null): boolean {
+  return Boolean(policy?.stages.some((stage) => stage.participants.some((participant) => participant.type === "user")));
+}
+
 function executionPrincipalsEqual(
   left: ParsedExecutionState["currentParticipant"] | null,
   right: ParsedExecutionState["currentParticipant"] | null,
@@ -596,12 +600,25 @@ export function issueRoutes(
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
-    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
+    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null; assigneeUserId: string | null },
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
     if (!actorAgentId) {
       res.status(403).json({ error: "Agent authentication required" });
+      return false;
+    }
+    if (issue.assigneeUserId) {
+      res.status(403).json({
+        error: "Agent cannot mutate a user-assigned issue",
+        details: {
+          issueId: issue.id,
+          assigneeUserId: issue.assigneeUserId,
+          actorAgentId,
+          status: issue.status,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
       return false;
     }
     if (issue.assigneeAgentId === null) {
@@ -1813,6 +1830,16 @@ export function issueRoutes(
 
     const actor = getActorInfo(req);
     const executionPolicy = normalizeIssueExecutionPolicy(req.body.executionPolicy);
+    if (req.actor.type === "agent" && executionPolicyHasUserParticipants(executionPolicy)) {
+      res.status(403).json({
+        error: "Agents cannot author execution policies with user participants",
+        details: {
+          companyId,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return;
+    }
     const issue = await svc.create(companyId, {
       ...req.body,
       executionPolicy,
@@ -1880,6 +1907,16 @@ export function issueRoutes(
 
     const actor = getActorInfo(req);
     const executionPolicy = normalizeIssueExecutionPolicy(req.body.executionPolicy);
+    if (req.actor.type === "agent" && executionPolicyHasUserParticipants(executionPolicy)) {
+      res.status(403).json({
+        error: "Agents cannot author execution policies with user participants",
+        details: {
+          parentIssueId: parent.id,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return;
+    }
     const { issue, parentBlockerAdded } = await svc.createChild(parent.id, {
       ...req.body,
       executionPolicy,
@@ -2050,6 +2087,35 @@ export function issueRoutes(
       updateFields.executionPolicy !== undefined
         ? (updateFields.executionPolicy as NormalizedExecutionPolicy | null)
         : previousExecutionPolicy;
+    if (
+      req.actor.type === "agent" &&
+      req.body.executionPolicy !== undefined &&
+      executionPolicyHasUserParticipants(nextExecutionPolicy)
+    ) {
+      res.status(403).json({
+        error: "Agents cannot author execution policies with user participants",
+        details: {
+          issueId: existing.id,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return;
+    }
+    if (
+      req.actor.type === "agent" &&
+      req.body.assigneeUserId !== undefined &&
+      req.body.assigneeUserId !== existing.assigneeUserId
+    ) {
+      res.status(403).json({
+        error: "Agents cannot assign issues to users",
+        details: {
+          issueId: existing.id,
+          assigneeUserId: req.body.assigneeUserId ?? null,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return;
+    }
     if (normalizedAssigneeAgentId !== undefined) {
       updateFields.assigneeAgentId = normalizedAssigneeAgentId;
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2090,7 +2090,8 @@ export function issueRoutes(
     if (
       req.actor.type === "agent" &&
       req.body.executionPolicy !== undefined &&
-      executionPolicyHasUserParticipants(nextExecutionPolicy)
+      (executionPolicyHasUserParticipants(previousExecutionPolicy) ||
+        executionPolicyHasUserParticipants(nextExecutionPolicy))
     ) {
       res.status(403).json({
         error: "Agents cannot author execution policies with user participants",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2155,6 +2155,14 @@ export function issueRoutes(
       reviewRequest: reviewRequest === undefined ? undefined : reviewRequest,
     });
     if (
+      !assertAgentUserAssignmentAllowed(req, res, {
+        issueId: existing.id,
+        assigneeUserId: typeof transition.patch.assigneeUserId === "string" ? transition.patch.assigneeUserId : null,
+      })
+    ) {
+      return;
+    }
+    if (
       !transition.workflowControlledAssignment &&
       req.body.assigneeUserId !== undefined &&
       req.body.assigneeUserId !== existing.assigneeUserId &&

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -538,6 +538,22 @@ export function issueRoutes(
     return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
   }
 
+  function assertAgentUserAssignmentAllowed(
+    req: Request,
+    res: Response,
+    details: { issueId?: string; companyId?: string; parentIssueId?: string; assigneeUserId: string | null },
+  ) {
+    if (req.actor.type !== "agent" || !details.assigneeUserId) return true;
+    res.status(403).json({
+      error: "Agents cannot assign issues to users",
+      details: {
+        ...details,
+        securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+      },
+    });
+    return false;
+  }
+
   async function assertCanAssignTasks(req: Request, companyId: string) {
     assertCompanyAccess(req, companyId);
     if (req.actor.type === "board") {
@@ -1823,6 +1839,14 @@ export function issueRoutes(
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
+    if (
+      !assertAgentUserAssignmentAllowed(req, res, {
+        companyId,
+        assigneeUserId: req.body.assigneeUserId ?? null,
+      })
+    ) {
+      return;
+    }
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
       await assertCanAssignTasks(req, companyId);
     }
@@ -1900,6 +1924,14 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, parent.companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
+    if (
+      !assertAgentUserAssignmentAllowed(req, res, {
+        parentIssueId: parent.id,
+        assigneeUserId: req.body.assigneeUserId ?? null,
+      })
+    ) {
+      return;
+    }
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
       await assertCanAssignTasks(req, parent.companyId);
     }
@@ -2102,21 +2134,6 @@ export function issueRoutes(
       });
       return;
     }
-    if (
-      req.actor.type === "agent" &&
-      req.body.assigneeUserId !== undefined &&
-      req.body.assigneeUserId !== existing.assigneeUserId
-    ) {
-      res.status(403).json({
-        error: "Agents cannot assign issues to users",
-        details: {
-          issueId: existing.id,
-          assigneeUserId: req.body.assigneeUserId ?? null,
-          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
-        },
-      });
-      return;
-    }
     if (normalizedAssigneeAgentId !== undefined) {
       updateFields.assigneeAgentId = normalizedAssigneeAgentId;
     }
@@ -2137,6 +2154,17 @@ export function issueRoutes(
       commentBody,
       reviewRequest: reviewRequest === undefined ? undefined : reviewRequest,
     });
+    if (
+      !transition.workflowControlledAssignment &&
+      req.body.assigneeUserId !== undefined &&
+      req.body.assigneeUserId !== existing.assigneeUserId &&
+      !assertAgentUserAssignmentAllowed(req, res, {
+        issueId: existing.id,
+        assigneeUserId: req.body.assigneeUserId ?? null,
+      })
+    ) {
+      return;
+    }
     const decisionId = transition.decision ? randomUUID() : null;
     if (decisionId) {
       const nextExecutionState = transition.patch.executionState;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issue assignment and execution policies are part of the control-plane security boundary
> - Agents should not be able to take over user-assigned work or author approval policies that route to humans
> - Without explicit guards, agent-authenticated calls could mutate work that was intentionally handed to a board user
> - This pull request hardens agent issue mutation rules around user assignees and user-participant execution policies
> - The benefit is clearer least-privilege behavior for agent API keys and safer board handoffs

## What Changed

- Reject agent mutations against issues assigned to a user.
- Reject agent-authored execution policies that include user participants on create, child create, and patch.
- Reject direct agent attempts to assign an issue to a user.
- Added route tests for the new mutation and policy boundaries.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-execution-policy-routes.test.ts`
- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`
- Note: an earlier combined run of both files had one test exceed the 5s per-test timeout under parallel load; the same file passed immediately in isolation.

## Risks

- Medium risk: this intentionally blocks agent flows that previously relied on assigning work directly to users. Those flows should use request confirmations, approvals, or explicit review handoff paths instead.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 coding agent, tool use and local command execution. Exact context window was not exposed in the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
