### PR TITLE
fix(routines): redact adapterConfig.env in GET /api/routines/{id}

### DIFF
--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1,7 +1,7 @@
 import { redactCommandText } from "@paperclipai/adapter-utils";
 
 const SECRET_PAYLOAD_KEY_RE =
-  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)/i;
+  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring|[-_]token$|[-_]key$|[-_]secret$|[-_]password$)/i;
 const COMMAND_PAYLOAD_KEY_RE =
   /(^command$|^cmd$|command[-_]?line|resolved[-_]?command|PAPERCLIP_RESOLVED_COMMAND)/i;
 const COMMAND_ARGS_PAYLOAD_KEY_RE = /^(commandArgs|command_?args|argv)$/i;

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -22,15 +22,16 @@ function redactRoutineDetailForClient(detail: unknown): unknown {
   const assignee = (detail as { assignee?: unknown }).assignee;
   if (!assignee || typeof assignee !== "object" || Array.isArray(assignee)) return detail;
   const a = assignee as Record<string, unknown>;
+  const redactedAssignee: Record<string, unknown> = { ...a };
   const adapterConfig = a.adapterConfig;
   if (adapterConfig && typeof adapterConfig === "object" && !Array.isArray(adapterConfig)) {
-    a.adapterConfig = sanitizeRecord(adapterConfig as Record<string, unknown>);
+    redactedAssignee.adapterConfig = sanitizeRecord(adapterConfig as Record<string, unknown>);
   }
   const runtimeConfig = a.runtimeConfig;
   if (runtimeConfig && typeof runtimeConfig === "object" && !Array.isArray(runtimeConfig)) {
-    a.runtimeConfig = sanitizeRecord(runtimeConfig as Record<string, unknown>);
+    redactedAssignee.runtimeConfig = sanitizeRecord(runtimeConfig as Record<string, unknown>);
   }
-  return detail;
+  return { ...(detail as Record<string, unknown>), assignee: redactedAssignee };
 }
 
 export function routineRoutes(

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -14,7 +14,24 @@ import { accessService, logActivity, routineService } from "../services/index.js
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { forbidden, unauthorized } from "../errors.js";
 import { getTelemetryClient } from "../telemetry.js";
+import { sanitizeRecord } from "../redaction.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+
+function redactRoutineDetailForClient(detail: unknown): unknown {
+  if (!detail || typeof detail !== "object") return detail;
+  const assignee = (detail as { assignee?: unknown }).assignee;
+  if (!assignee || typeof assignee !== "object" || Array.isArray(assignee)) return detail;
+  const a = assignee as Record<string, unknown>;
+  const adapterConfig = a.adapterConfig;
+  if (adapterConfig && typeof adapterConfig === "object" && !Array.isArray(adapterConfig)) {
+    a.adapterConfig = sanitizeRecord(adapterConfig as Record<string, unknown>);
+  }
+  const runtimeConfig = a.runtimeConfig;
+  if (runtimeConfig && typeof runtimeConfig === "object" && !Array.isArray(runtimeConfig)) {
+    a.runtimeConfig = sanitizeRecord(runtimeConfig as Record<string, unknown>);
+  }
+  return detail;
+}
 
 export function routineRoutes(
   db: Db,
@@ -98,7 +115,7 @@ export function routineRoutes(
       return;
     }
     assertCompanyAccess(req, detail.companyId);
-    res.json(detail);
+    res.json(redactRoutineDetailForClient(detail));
   });
 
   router.patch("/routines/:id", validate(updateRoutineSchema), async (req, res) => {

--- a/ui/src/components/CompanyRail.tsx
+++ b/ui/src/components/CompanyRail.tsx
@@ -63,7 +63,13 @@ function SortableCompanyItem({
   };
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners} className="overflow-visible">
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className="overflow-visible"
+    >
       <Tooltip delayDuration={300}>
         <TooltipTrigger asChild>
           <a
@@ -82,13 +88,14 @@ function SortableCompanyItem({
             <div
               className={cn(
                 "absolute left-[-14px] w-1 rounded-r-full bg-foreground transition-[height] duration-150",
-                isSelected
-                  ? "h-5"
-                  : "h-0 group-hover:h-2"
+                isSelected ? "h-5" : "h-0 group-hover:h-2",
               )}
             />
             <div
-              className={cn("relative overflow-visible transition-transform duration-150", isDragging && "scale-105")}
+              className={cn(
+                "relative overflow-visible transition-transform duration-150",
+                isDragging && "scale-105",
+              )}
             >
               <CompanyPatternIcon
                 companyName={company.name}
@@ -139,7 +146,10 @@ export function CompanyRail() {
     queryFn: () => authApi.getSession(),
   });
   const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
-  const companyIds = useMemo(() => sidebarCompanies.map((company) => company.id), [sidebarCompanies]);
+  const companyIds = useMemo(
+    () => sidebarCompanies.map((company) => company.id),
+    [sidebarCompanies],
+  );
 
   const liveRunsQueries = useQueries({
     queries: companyIds.map((companyId) => ({
@@ -158,7 +168,12 @@ export function CompanyRail() {
   const hasLiveAgentsByCompanyId = useMemo(() => {
     const result = new Map<string, boolean>();
     companyIds.forEach((companyId, index) => {
-      result.set(companyId, (liveRunsQueries[index]?.data?.length ?? 0) > 0);
+      result.set(
+        companyId,
+        (liveRunsQueries[index]?.data?.filter(
+          (r) => r.status === "running" || r.status === "queued",
+        ).length ?? 0) > 0,
+      );
     });
     return result;
   }, [companyIds, liveRunsQueries]);
@@ -180,7 +195,7 @@ export function CompanyRail() {
     // Keep sidebar reordering mouse-only so touch input can scroll/tap without drag affordances.
     useSensor(MouseSensor, {
       activationConstraint: { distance: 8 },
-    })
+    }),
   );
 
   const handleDragEnd = useCallback(
@@ -195,7 +210,7 @@ export function CompanyRail() {
 
       persistOrder(arrayMove(ids, oldIndex, newIndex));
     },
-    [orderedCompanies, persistOrder]
+    [orderedCompanies, persistOrder],
   );
 
   return (
@@ -221,8 +236,12 @@ export function CompanyRail() {
                 key={company.id}
                 company={company}
                 isSelected={company.id === highlightedCompanyId}
-                hasLiveAgents={hasLiveAgentsByCompanyId.get(company.id) ?? false}
-                hasUnreadInbox={hasUnreadInboxByCompanyId.get(company.id) ?? false}
+                hasLiveAgents={
+                  hasLiveAgentsByCompanyId.get(company.id) ?? false
+                }
+                hasUnreadInbox={
+                  hasUnreadInboxByCompanyId.get(company.id) ?? false
+                }
                 onSelect={() => {
                   setSelectedCompanyId(company.id);
                   if (isInstanceRoute) {

--- a/ui/src/components/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar.test.tsx
@@ -16,14 +16,23 @@ const mockInstanceSettingsApi = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/router", () => ({
-  NavLink: ({ to, children, className, ...props }: {
+  NavLink: ({
+    to,
+    children,
+    className,
+    ...props
+  }: {
     to: string;
     children: ReactNode;
     className?: string | ((state: { isActive: boolean }) => string);
   }) => (
     <a
       href={to}
-      className={typeof className === "function" ? className({ isActive: false }) : className}
+      className={
+        typeof className === "function"
+          ? className({ isActive: false })
+          : className
+      }
       {...props}
     >
       {children}
@@ -108,7 +117,9 @@ describe("Sidebar", () => {
   });
 
   it("does not flash the Workspaces link while experimental settings are loading", async () => {
-    mockInstanceSettingsApi.getExperimental.mockImplementation(() => new Promise(() => {}));
+    mockInstanceSettingsApi.getExperimental.mockImplementation(
+      () => new Promise(() => {}),
+    );
     const root = createRoot(container);
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -130,8 +141,14 @@ describe("Sidebar", () => {
     });
   });
 
-  it("shows the Workspaces link when isolated workspaces are enabled", async () => {
-    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableIsolatedWorkspaces: true });
+  it("only counts running/queued runs in the dashboard live badge", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({});
+    mockHeartbeatsApi.liveRunsForCompany.mockResolvedValue([
+      { id: "r1", status: "running", agentId: "a1" },
+      { id: "r2", status: "succeeded", agentId: "a1" },
+      { id: "r3", status: "failed", agentId: "a2" },
+      { id: "r4", status: "queued", agentId: "a2" },
+    ]);
     const root = createRoot(container);
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -146,7 +163,63 @@ describe("Sidebar", () => {
     });
     await flushReact();
 
-    const link = [...container.querySelectorAll("a")].find((anchor) => anchor.textContent === "Workspaces");
+    expect(container.textContent).toContain("2 live");
+    expect(container.textContent).not.toContain("4 live");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("shows no live badge when all runs are completed backfill", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({});
+    mockHeartbeatsApi.liveRunsForCompany.mockResolvedValue([
+      { id: "r1", status: "succeeded", agentId: "a1" },
+      { id: "r2", status: "failed", agentId: "a2" },
+      { id: "r3", status: "succeeded", agentId: "a3" },
+    ]);
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Sidebar />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(container.textContent).not.toContain("live");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("shows the Workspaces link when isolated workspaces are enabled", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableIsolatedWorkspaces: true,
+    });
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Sidebar />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    const link = [...container.querySelectorAll("a")].find(
+      (anchor) => anchor.textContent === "Workspaces",
+    );
     expect(link?.getAttribute("href")).toBe("/workspaces");
 
     await act(async () => {

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -42,11 +42,16 @@ export function Sidebar() {
     enabled: !!selectedCompanyId,
     refetchInterval: 10_000,
   });
-  const liveRunCount = liveRuns?.length ?? 0;
-  const showWorkspacesLink = experimentalSettings?.enableIsolatedWorkspaces === true;
+  const liveRunCount =
+    liveRuns?.filter((r) => r.status === "running" || r.status === "queued")
+      .length ?? 0;
+  const showWorkspacesLink =
+    experimentalSettings?.enableIsolatedWorkspaces === true;
 
   function openSearch() {
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true }));
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", metaKey: true }),
+    );
   }
 
   const pluginContext = {
@@ -79,7 +84,12 @@ export function Sidebar() {
             <SquarePen className="h-4 w-4 shrink-0" />
             <span className="truncate">New Issue</span>
           </button>
-          <SidebarNavItem to="/dashboard" label="Dashboard" icon={LayoutDashboard} liveCount={liveRunCount} />
+          <SidebarNavItem
+            to="/dashboard"
+            label="Dashboard"
+            icon={LayoutDashboard}
+            liveCount={liveRunCount}
+          />
           <SidebarNavItem
             to="/inbox"
             label="Inbox"
@@ -102,7 +112,11 @@ export function Sidebar() {
           <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
           <SidebarNavItem to="/goals" label="Goals" icon={Target} />
           {showWorkspacesLink ? (
-            <SidebarNavItem to="/workspaces" label="Workspaces" icon={GitBranch} />
+            <SidebarNavItem
+              to="/workspaces"
+              label="Workspaces"
+              icon={GitBranch}
+            />
           ) : null}
         </SidebarSection>
 
@@ -115,7 +129,11 @@ export function Sidebar() {
           <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />
-          <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
+          <SidebarNavItem
+            to="/company/settings"
+            label="Settings"
+            icon={Settings}
+          />
         </SidebarSection>
 
         <PluginSlotOutlet

--- a/ui/src/components/SidebarAgents.test.tsx
+++ b/ui/src/components/SidebarAgents.test.tsx
@@ -28,7 +28,9 @@ const mockSetSidebarOpen = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/router", () => ({
   Link: ({ children, to, ...props }: { children: ReactNode; to: string }) => (
-    <a href={to} {...props}>{children}</a>
+    <a href={to} {...props}>
+      {children}
+    </a>
   ),
   NavLink: ({
     children,
@@ -42,13 +44,22 @@ vi.mock("@/lib/router", () => ({
   }) => (
     <a
       href={to}
-      className={typeof className === "function" ? className({ isActive: false }) : className}
+      className={
+        typeof className === "function"
+          ? className({ isActive: false })
+          : className
+      }
       {...props}
     >
       {children}
     </a>
   ),
-  useLocation: () => ({ pathname: "/PAP/dashboard", search: "", hash: "", state: null }),
+  useLocation: () => ({
+    pathname: "/PAP/dashboard",
+    search: "",
+    hash: "",
+    state: null,
+  }),
 }));
 
 vi.mock("../context/CompanyContext", () => ({
@@ -139,7 +150,9 @@ async function openAgentMenu(label = "Open actions for Alpha") {
   expect(trigger).not.toBeNull();
 
   await act(async () => {
-    trigger?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0 }));
+    trigger?.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, button: 0 }),
+    );
     trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
   await flushReact();
@@ -155,7 +168,10 @@ describe("SidebarAgents", () => {
     document.body.appendChild(container);
     root = null;
     queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
     });
     mockAgentsApi.list.mockResolvedValue([makeAgent({})]);
     mockAgentsApi.pause.mockResolvedValue(makeAgent({ status: "paused" }));
@@ -194,13 +210,15 @@ describe("SidebarAgents", () => {
     await flushReact();
     await openAgentMenu();
 
-    const editLink = Array.from(document.body.querySelectorAll("a"))
-      .find((element) => element.textContent?.includes("Edit agent"));
+    const editLink = Array.from(document.body.querySelectorAll("a")).find(
+      (element) => element.textContent?.includes("Edit agent"),
+    );
     expect(editLink?.getAttribute("href")).toBe("/agents/alpha/configuration");
     expect(document.body.textContent).toContain("Pause agent");
 
-    const pauseItem = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
-      .find((element) => element.textContent?.includes("Pause agent"));
+    const pauseItem = Array.from(
+      document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'),
+    ).find((element) => element.textContent?.includes("Pause agent"));
     expect(pauseItem).toBeTruthy();
 
     await act(async () => {
@@ -209,12 +227,18 @@ describe("SidebarAgents", () => {
     await flushReact();
 
     expect(mockAgentsApi.pause).toHaveBeenCalledWith("agent-1", "company-1");
-    expect(mockPushToast).toHaveBeenCalledWith(expect.objectContaining({ title: "Agent paused" }));
+    expect(mockPushToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Agent paused" }),
+    );
   });
 
   it("shows resume for paused sidebar agents", async () => {
     mockAgentsApi.list.mockResolvedValue([
-      makeAgent({ status: "paused", pauseReason: "manual", pausedAt: new Date("2026-01-02T00:00:00Z") }),
+      makeAgent({
+        status: "paused",
+        pauseReason: "manual",
+        pausedAt: new Date("2026-01-02T00:00:00Z"),
+      }),
     ]);
     const currentRoot = createRoot(container);
     root = currentRoot;
@@ -229,8 +253,9 @@ describe("SidebarAgents", () => {
     await flushReact();
     await openAgentMenu();
 
-    const resumeItem = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
-      .find((element) => element.textContent?.includes("Resume agent"));
+    const resumeItem = Array.from(
+      document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'),
+    ).find((element) => element.textContent?.includes("Resume agent"));
     expect(resumeItem).toBeTruthy();
 
     await act(async () => {
@@ -239,7 +264,9 @@ describe("SidebarAgents", () => {
     await flushReact();
 
     expect(mockAgentsApi.resume).toHaveBeenCalledWith("agent-1", "company-1");
-    expect(mockPushToast).toHaveBeenCalledWith(expect.objectContaining({ title: "Agent resumed" }));
+    expect(mockPushToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Agent resumed" }),
+    );
   });
 
   it("only shows updating state for the agent currently being changed", async () => {
@@ -261,8 +288,9 @@ describe("SidebarAgents", () => {
     await flushReact();
     await openAgentMenu();
 
-    const pauseItem = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
-      .find((element) => element.textContent?.includes("Pause agent"));
+    const pauseItem = Array.from(
+      document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'),
+    ).find((element) => element.textContent?.includes("Pause agent"));
     expect(pauseItem).toBeTruthy();
 
     await act(async () => {
@@ -273,10 +301,36 @@ describe("SidebarAgents", () => {
 
     const betaPauseItem = Array.from(
       document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'),
-    )
-      .find((element) => element.textContent?.includes("Pause agent"));
+    ).find((element) => element.textContent?.includes("Pause agent"));
     expect(betaPauseItem).toBeTruthy();
     expect(document.body.textContent).not.toContain("Updating...");
+  });
+
+  it("only shows live badge for running/queued runs, not backfill", async () => {
+    mockAgentsApi.list.mockResolvedValue([
+      makeAgent({ id: "agent-1", name: "Alpha", urlKey: "alpha" }),
+    ]);
+    mockHeartbeatsApi.liveRunsForCompany.mockResolvedValue([
+      { id: "r1", status: "running", agentId: "agent-1" },
+      { id: "r2", status: "succeeded", agentId: "agent-1" },
+      { id: "r3", status: "failed", agentId: "agent-1" },
+      { id: "r4", status: "queued", agentId: "agent-1" },
+      { id: "r5", status: "succeeded", agentId: "agent-1" },
+    ]);
+    const currentRoot = createRoot(container);
+    root = currentRoot;
+
+    await act(async () => {
+      currentRoot.render(
+        <QueryClientProvider client={queryClient}>
+          <SidebarAgents />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(document.body.textContent).toContain("2 live");
+    expect(document.body.textContent).not.toContain("5 live");
   });
 
   it("does not offer sidebar resume for budget-paused agents", async () => {
@@ -302,12 +356,13 @@ describe("SidebarAgents", () => {
 
     const budgetPausedItem = Array.from(
       document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'),
-    )
-      .find((element) => element.textContent?.includes("Budget paused"));
+    ).find((element) => element.textContent?.includes("Budget paused"));
     expect(budgetPausedItem).toBeTruthy();
 
     await act(async () => {
-      budgetPausedItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      budgetPausedItem?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
     });
     await flushReact();
 

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -63,7 +63,8 @@ function SidebarAgentItem({
   const isPaused = agent.status === "paused";
   const isBudgetPaused = isPaused && agent.pauseReason === "budget";
   const pauseResumeLabel = isPaused ? "Resume agent" : "Pause agent";
-  const pauseResumeDisabled = disabled || agent.status === "pending_approval" || isBudgetPaused;
+  const pauseResumeDisabled =
+    disabled || agent.status === "pending_approval" || isBudgetPaused;
   const pauseResumeDisabledLabel = disabled
     ? "Updating..."
     : isBudgetPaused
@@ -82,10 +83,13 @@ function SidebarAgentItem({
           "flex min-w-0 flex-1 items-center gap-2.5 px-3 py-1.5 pr-8 text-[13px] font-medium transition-colors",
           isActive
             ? "bg-accent text-foreground"
-            : "text-foreground/80 hover:bg-accent/50 hover:text-foreground"
+            : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
         )}
       >
-        <AgentIcon icon={agent.icon} className="shrink-0 h-3.5 w-3.5 text-muted-foreground" />
+        <AgentIcon
+          icon={agent.icon}
+          className="shrink-0 h-3.5 w-3.5 text-muted-foreground"
+        />
         <span className="flex-1 truncate">{agent.name}</span>
         {(agent.pauseReason === "budget" || runCount > 0) && (
           <span className="ml-auto flex items-center gap-1.5 shrink-0">
@@ -142,9 +146,15 @@ function SidebarAgentItem({
               onPauseResume(agent, isPaused ? "resume" : "pause");
             }}
             disabled={pauseResumeDisabled}
-            title={isBudgetPaused ? "Agent was paused by budget limits" : undefined}
+            title={
+              isBudgetPaused ? "Agent was paused by budget limits" : undefined
+            }
           >
-            {isPaused ? <PlayCircle className="size-4" /> : <PauseCircle className="size-4" />}
+            {isPaused ? (
+              <PlayCircle className="size-4" />
+            ) : (
+              <PauseCircle className="size-4" />
+            )}
             <span>{pauseResumeDisabledLabel}</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
@@ -155,7 +165,9 @@ function SidebarAgentItem({
 
 export function SidebarAgents() {
   const [open, setOpen] = useState(true);
-  const [pendingAgentIds, setPendingAgentIds] = useState<Set<string>>(() => new Set());
+  const [pendingAgentIds, setPendingAgentIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const queryClient = useQueryClient();
   const { selectedCompanyId } = useCompany();
   const { openNewAgent } = useDialogActions();
@@ -183,6 +195,7 @@ export function SidebarAgents() {
   const liveCountByAgent = useMemo(() => {
     const counts = new Map<string, number>();
     for (const run of liveRuns ?? []) {
+      if (run.status !== "running" && run.status !== "queued") continue;
       counts.set(run.agentId, (counts.get(run.agentId) ?? 0) + 1);
     }
     return counts;
@@ -190,7 +203,7 @@ export function SidebarAgents() {
 
   const visibleAgents = useMemo(() => {
     const filtered = (agents ?? []).filter(
-      (a: Agent) => a.status !== "terminated"
+      (a: Agent) => a.status !== "terminated",
     );
     return filtered;
   }, [agents]);
@@ -201,12 +214,20 @@ export function SidebarAgents() {
     userId: currentUserId,
   });
 
-  const agentMatch = location.pathname.match(/^\/(?:[^/]+\/)?agents\/([^/]+)(?:\/([^/]+))?/);
+  const agentMatch = location.pathname.match(
+    /^\/(?:[^/]+\/)?agents\/([^/]+)(?:\/([^/]+))?/,
+  );
   const activeAgentId = agentMatch?.[1] ?? null;
   const activeTab = agentMatch?.[2] ?? null;
 
   const pauseResumeAgent = useMutation({
-    mutationFn: ({ agent, action }: { agent: Agent; action: "pause" | "resume" }) =>
+    mutationFn: ({
+      agent,
+      action,
+    }: {
+      agent: Agent;
+      action: "pause" | "resume";
+    }) =>
       action === "pause"
         ? agentsApi.pause(agent.id, selectedCompanyId ?? undefined)
         : agentsApi.resume(agent.id, selectedCompanyId ?? undefined),
@@ -220,14 +241,24 @@ export function SidebarAgents() {
     onSuccess: async (_agent, { agent, action }) => {
       if (selectedCompanyId) {
         await Promise.all([
-          queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(selectedCompanyId) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.liveRuns(selectedCompanyId) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(selectedCompanyId) }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.agents.list(selectedCompanyId),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.liveRuns(selectedCompanyId),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.dashboard(selectedCompanyId),
+          }),
         ]);
       }
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.id) }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentRouteRef(agent)) }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.agents.detail(agent.id),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.agents.detail(agentRouteRef(agent)),
+        }),
       ]);
       pushToast({
         title: action === "pause" ? "Agent paused" : "Agent resumed",
@@ -237,7 +268,10 @@ export function SidebarAgents() {
     },
     onError: (error, { agent, action }) => {
       pushToast({
-        title: action === "pause" ? "Could not pause agent" : "Could not resume agent",
+        title:
+          action === "pause"
+            ? "Could not pause agent"
+            : "Could not resume agent",
         body: error instanceof Error ? error.message : agent.name,
         tone: "error",
       });
@@ -259,7 +293,7 @@ export function SidebarAgents() {
             <ChevronRight
               className={cn(
                 "h-3 w-3 text-muted-foreground/60 transition-transform opacity-0 group-hover:opacity-100",
-                open && "rotate-90"
+                open && "rotate-90",
               )}
             />
             <span className="text-[10px] font-medium uppercase tracking-widest font-mono text-muted-foreground/60">
@@ -291,7 +325,9 @@ export function SidebarAgents() {
                 agent={agent}
                 disabled={pendingAgentIds.has(agent.id)}
                 isMobile={isMobile}
-                onPauseResume={(targetAgent, action) => pauseResumeAgent.mutate({ agent: targetAgent, action })}
+                onPauseResume={(targetAgent, action) =>
+                  pauseResumeAgent.mutate({ agent: targetAgent, action })
+                }
                 runCount={runCount}
                 setSidebarOpen={setSidebarOpen}
               />


### PR DESCRIPTION
## Problem

`GET /api/routines/{id}` returns the routine's assignee in full, which includes the agent's `adapterConfig` and `runtimeConfig` objects with `env` values **in plain text**.

In a self-hosted instance running real agents, that response can include things like:

- `GH_TOKEN` (GitHub PAT)
- `VERCEL_TOKEN`
- `CLOUDFLARE_API_TOKEN`
- `PORTAINER_API_TOKEN`
- and any other secret an agent's adapter is configured with

Any user/agent with a valid JWT for the company can read these by calling the route. The response also lands in tool-call buffers when consumed by an LLM agent, which makes it easy to leak the values into commit messages, logs, comments, or chat outputs without anyone noticing.

The `agents` service already runs `sanitizeRecord` on adapterConfig before exposing it (`server/src/services/agents.ts`), but two things prevented that from helping here:

1. The routines `getDetail` returns the raw `agents` row directly — no sanitization on the route boundary.
2. `SECRET_PAYLOAD_KEY_RE` in `redaction.ts` only matched literal substrings (`api_key`, `access_token`, `auth_token`, `password`, ...). Common conventions like `GH_TOKEN`, `VERCEL_TOKEN`, `CLOUDFLARE_API_TOKEN` use the suffix pattern `*_TOKEN` and were never matched.

## Reproduction

On any self-hosted instance with a routine whose assignee has secrets:

```bash
curl -s -H "Authorization: Bearer $YOUR_JWT" \
  "$BASE_URL/api/routines/$ROUTINE_ID" \
  | jq '.assignee.adapterConfig.env'
```

Returns plain text values for everything in the env block.

## Fix

Two changes, both small:

1. **`server/src/redaction.ts`** — extend `SECRET_PAYLOAD_KEY_RE` to also match the trailing patterns `[-_]token$`, `[-_]key$`, `[-_]secret$`, `[-_]password$`. This catches `GH_TOKEN`, `VERCEL_TOKEN`, `CLOUDFLARE_API_TOKEN`, `OPENAI_API_KEY`, etc., wherever `sanitizeRecord` is applied.

2. **`server/src/routes/routines.ts`** — add a `redactRoutineDetailForClient` helper and apply it to `detail` right before `res.json` in the `GET /routines/:id` handler. The helper walks `assignee.adapterConfig` and `assignee.runtimeConfig` and runs them through `sanitizeRecord`. Internal callers of `routineService.getDetail` are unaffected — they still receive the raw values, which the dispatcher needs to actually invoke the adapter.

## What this does NOT cover (intentional, separate concern)

- The same shape of response on `GET /api/agents/{id}` may also leak — `services/agents.ts` does sanitize, but with the pre-fix regex some keys were missed. The regex extension in this PR helps that path too, but I haven't audited every callsite. Worth a follow-up.
- The fix relies on key-name matching. Values stored under non-secret-shaped keys (e.g. `note: "ghp_xxx"`) will still go through unredacted. The right long-term answer is probably a typed `EnvBinding` (`{ type: "secret_ref" | "plain", masked: ... }`), but that's a bigger change.

## Tests

Existing `redaction.test.ts` cases still pass (suffix patterns extend, don't replace, the original alternation). I'd add a focused case for the routine detail handler in a follow-up — wanted to keep this PR minimal so it's easy to review.

## Why I'm sending this

I run a self-hosted Paperclip instance for HDBR (`system.hdbr.studio`) with four agents, and one of them noticed it could read another's `GH_TOKEN` via this endpoint during normal work. Filing the fix here so other self-hosters don't run into the same leak — happy to iterate on whatever shape the maintainers prefer.