### PR TITLE
fix(workspace): preserve agent.workspaceStrategy + adapterConfig.cwd through resolver layers (#4946)

### DIFF
--- a/packages/shared/src/types/workspace-runtime.ts
+++ b/packages/shared/src/types/workspace-runtime.ts
@@ -249,7 +249,7 @@ export interface WorkspaceRealizationRequest {
   heartbeatRunId: string;
   requestedMode: string | null;
   source: {
-    kind: "project_primary" | "task_session" | "agent_home";
+    kind: "project_primary" | "task_session" | "agent_config" | "agent_home";
     localPath: string;
     projectId: string | null;
     projectWorkspaceId: string | null;

--- a/server/src/__tests__/agent-workspace-fallback.test.ts
+++ b/server/src/__tests__/agent-workspace-fallback.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveAgentConfigCwdFallback } from "../services/agent-workspace-fallback.js";
+
+describe("resolveAgentConfigCwdFallback", () => {
+  it("returns the configured cwd when it exists on disk", async () => {
+    const dirExists = vi.fn().mockResolvedValue(true);
+    const result = await resolveAgentConfigCwdFallback({
+      adapterConfig: {
+        cwd: "C:/Users/VIKINGIST/Documents/www/ElectroBoard/electroboard",
+        workspaceStrategy: { type: "git_worktree", baseRef: "master" },
+      },
+      dirExists,
+    });
+    expect(result).toEqual({
+      cwd: "C:/Users/VIKINGIST/Documents/www/ElectroBoard/electroboard",
+    });
+    expect(dirExists).toHaveBeenCalledWith(
+      "C:/Users/VIKINGIST/Documents/www/ElectroBoard/electroboard",
+    );
+  });
+
+  it("returns null when cwd is unset", async () => {
+    const dirExists = vi.fn();
+    expect(
+      await resolveAgentConfigCwdFallback({
+        adapterConfig: { workspaceStrategy: { type: "project_primary" } },
+        dirExists,
+      }),
+    ).toBeNull();
+    expect(dirExists).not.toHaveBeenCalled();
+  });
+
+  it("returns null when cwd is empty string", async () => {
+    const dirExists = vi.fn();
+    expect(
+      await resolveAgentConfigCwdFallback({
+        adapterConfig: { cwd: "" },
+        dirExists,
+      }),
+    ).toBeNull();
+    expect(dirExists).not.toHaveBeenCalled();
+  });
+
+  it("returns null when cwd is not a string", async () => {
+    const dirExists = vi.fn();
+    expect(
+      await resolveAgentConfigCwdFallback({
+        adapterConfig: { cwd: 42 },
+        dirExists,
+      }),
+    ).toBeNull();
+    expect(
+      await resolveAgentConfigCwdFallback({
+        adapterConfig: { cwd: { nested: "x" } },
+        dirExists,
+      }),
+    ).toBeNull();
+    expect(dirExists).not.toHaveBeenCalled();
+  });
+
+  it("returns null when configured cwd does not exist on disk", async () => {
+    const dirExists = vi.fn().mockResolvedValue(false);
+    const result = await resolveAgentConfigCwdFallback({
+      adapterConfig: { cwd: "C:/nonexistent/path" },
+      dirExists,
+    });
+    expect(result).toBeNull();
+    expect(dirExists).toHaveBeenCalledWith("C:/nonexistent/path");
+  });
+
+  it("returns null when adapterConfig is not an object (defensive)", async () => {
+    const dirExists = vi.fn();
+    expect(
+      await resolveAgentConfigCwdFallback({ adapterConfig: null, dirExists }),
+    ).toBeNull();
+    expect(
+      await resolveAgentConfigCwdFallback({ adapterConfig: undefined, dirExists }),
+    ).toBeNull();
+    expect(
+      await resolveAgentConfigCwdFallback({ adapterConfig: "not-an-object", dirExists }),
+    ).toBeNull();
+    expect(dirExists).not.toHaveBeenCalled();
+  });
+
+  it("propagates dirExists rejection (caller decides retry policy)", async () => {
+    const dirExists = vi.fn().mockRejectedValue(new Error("EACCES"));
+    await expect(
+      resolveAgentConfigCwdFallback({
+        adapterConfig: { cwd: "C:/restricted" },
+        dirExists,
+      }),
+    ).rejects.toThrow("EACCES");
+  });
+});

--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -86,12 +86,14 @@ describe("execution workspace policy helpers", () => {
     });
   });
 
-  it("clears managed workspace strategy when issue opts out to project primary or agent default", () => {
+  it("clears agent workspace strategy when project policy enforces a managed shared workspace", () => {
     const baseConfig = {
       workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}" },
       workspaceRuntime: { services: [{ name: "web" }] },
     };
 
+    // Project policy is enabled (managed mode) and the issue opts into shared_workspace —
+    // the project's primary workspace is in force, so the agent's strategy yields.
     expect(
       buildExecutionWorkspaceAdapterConfig({
         agentConfig: baseConfig,
@@ -101,16 +103,77 @@ describe("execution workspace policy helpers", () => {
         legacyUseProjectWorkspace: null,
       }).workspaceStrategy,
     ).toBeUndefined();
+  });
 
-    const agentDefault = buildExecutionWorkspaceAdapterConfig({
+  it("preserves agent workspace strategy when issue mode is agent_default with no project policy (upstream issue #4946)", () => {
+    // Regression: previously `else { delete nextConfig.workspaceStrategy }` ran
+    // unconditionally inside the hasWorkspaceControl branch, silently dropping
+    // the agent's own workspaceStrategy whenever the issue mode resolved to
+    // "agent_default" (or legacyUseProjectWorkspace === false). That caused
+    // agents hired with `{ type: "git_worktree" }` to spawn in `_default/`
+    // and fail with `fatal: not a git repository` (Gotcha #1 / cascade source
+    // for upstream PR #4944). The agent's strategy must survive when there is
+    // no explicit project/issue override and no enforced policy.
+    const baseConfig = {
+      workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}" },
+      workspaceRuntime: { services: [{ name: "web" }] },
+    };
+
+    const result = buildExecutionWorkspaceAdapterConfig({
       agentConfig: baseConfig,
       projectPolicy: null,
       issueSettings: { mode: "agent_default" },
       mode: "agent_default",
       legacyUseProjectWorkspace: null,
     });
-    expect(agentDefault.workspaceStrategy).toBeUndefined();
-    expect(agentDefault.workspaceRuntime).toBeUndefined();
+    expect(result.workspaceStrategy).toEqual({
+      type: "git_worktree",
+      branchTemplate: "{{issue.identifier}}",
+    });
+    // workspaceRuntime is still cleared in agent_default mode (legitimate behaviour:
+    // agent_default mode means no managed workspace runtime services).
+    expect(result.workspaceRuntime).toBeUndefined();
+  });
+
+  it("preserves agent workspace strategy when legacyUseProjectWorkspace=false but no policy/override exists", () => {
+    // The legacy `useProjectWorkspace: false` flag triggers hasWorkspaceControl
+    // even though the project has no policy and the issue has no override.
+    // The agent's strategy should survive in that case — same root cause as the
+    // agent_default scenario above, surfacing through a different trigger.
+    const baseConfig = {
+      workspaceStrategy: { type: "git_worktree", baseRef: "master" },
+    };
+
+    const result = buildExecutionWorkspaceAdapterConfig({
+      agentConfig: baseConfig,
+      projectPolicy: null,
+      issueSettings: null,
+      mode: "agent_default",
+      legacyUseProjectWorkspace: false,
+    });
+    expect(result.workspaceStrategy).toEqual({
+      type: "git_worktree",
+      baseRef: "master",
+    });
+  });
+
+  it("issue.workspaceStrategy override wins over agent's own strategy in non-isolated modes", () => {
+    // When the issue explicitly provides its own workspaceStrategy, that wins
+    // over the agent's — preserves the override semantics for caller-driven
+    // per-issue configuration.
+    const result = buildExecutionWorkspaceAdapterConfig({
+      agentConfig: {
+        workspaceStrategy: { type: "git_worktree", baseRef: "master" },
+      },
+      projectPolicy: null,
+      issueSettings: {
+        mode: "shared_workspace",
+        workspaceStrategy: { type: "project_primary" },
+      },
+      mode: "shared_workspace",
+      legacyUseProjectWorkspace: null,
+    });
+    expect(result.workspaceStrategy).toEqual({ type: "project_primary" });
   });
 
   it("parses persisted JSON payloads into typed project and issue workspace settings", () => {

--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -157,6 +157,35 @@ describe("execution workspace policy helpers", () => {
     });
   });
 
+  it("clears agent strategy in shared_workspace / operator_branch mode even without a project policy (reviewer feedback on PR #4951)", () => {
+    // Reviewer flagged: when issueSettings.mode triggers a managed mode but
+    // projectPolicy is null and no explicit workspaceStrategy override exists,
+    // the agent's strategy must still yield — these modes are project-managed
+    // by definition and a residual agent-level git_worktree would conflict
+    // with the resolved cwd.
+    const baseConfig = {
+      workspaceStrategy: { type: "git_worktree", baseRef: "master" },
+    };
+
+    const sharedNoPolicy = buildExecutionWorkspaceAdapterConfig({
+      agentConfig: baseConfig,
+      projectPolicy: null,
+      issueSettings: { mode: "shared_workspace" },
+      mode: "shared_workspace",
+      legacyUseProjectWorkspace: null,
+    });
+    expect(sharedNoPolicy.workspaceStrategy).toBeUndefined();
+
+    const operatorNoPolicy = buildExecutionWorkspaceAdapterConfig({
+      agentConfig: baseConfig,
+      projectPolicy: null,
+      issueSettings: { mode: "operator_branch" },
+      mode: "operator_branch",
+      legacyUseProjectWorkspace: null,
+    });
+    expect(operatorNoPolicy.workspaceStrategy).toBeUndefined();
+  });
+
   it("issue.workspaceStrategy override wins over agent's own strategy in non-isolated modes", () => {
     // When the issue explicitly provides its own workspaceStrategy, that wins
     // over the agent's — preserves the override semantics for caller-driven

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -101,6 +101,39 @@ describe("resolveRuntimeSessionParamsForWorkspace", () => {
     expect(result.warning).toBeNull();
   });
 
+  it("migrates fallback workspace sessions to agent_config workspace when agent.adapterConfig.cwd becomes available (#4946)", () => {
+    // Symmetric with the project_primary migration above. When an agent run
+    // previously fell back to _default/ but now resolves via the new
+    // agent_config branch (adapterConfig.cwd reachable), the saved session
+    // params must follow the move — otherwise sessionId stays anchored at
+    // _default/ and the next run silently re-creates the same broken
+    // worktree spawn loop. The guard in migrateFallbackWorkspaceSession was
+    // extended in this PR to admit agent_config alongside project_primary.
+    const agentId = "agent-123";
+    const fallbackCwd = resolveDefaultAgentWorkspaceDir(agentId);
+
+    const result = resolveRuntimeSessionParamsForWorkspace({
+      agentId,
+      previousSessionParams: {
+        sessionId: "session-1",
+        cwd: fallbackCwd,
+        workspaceId: null,
+      },
+      resolvedWorkspace: buildResolvedWorkspace({
+        cwd: "C:/repos/example",
+        source: "agent_config",
+        projectId: null,
+        workspaceId: null,
+      }),
+    });
+
+    expect(result.sessionParams).toMatchObject({
+      sessionId: "session-1",
+      cwd: "C:/repos/example",
+    });
+    expect(result.warning).toContain("Attempting to resume session");
+  });
+
   it("does not migrate when resolved workspace id differs from previous session workspace id", () => {
     const agentId = "agent-123";
     const fallbackCwd = resolveDefaultAgentWorkspaceDir(agentId);

--- a/server/src/__tests__/workspace-realization-read.test.ts
+++ b/server/src/__tests__/workspace-realization-read.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { readWorkspaceRealizationRequest } from "../services/workspace-realization.js";
+
+const baseValid = {
+  version: 1,
+  adapterType: "claude_local",
+  companyId: "company-123",
+  environmentId: "env-123",
+  executionWorkspaceId: null,
+  issueId: "issue-123",
+  heartbeatRunId: "run-123",
+  requestedMode: null,
+  source: {
+    localPath: "C:/repos/example",
+    projectId: null,
+    projectWorkspaceId: null,
+    repoUrl: null,
+    repoRef: null,
+    strategy: "project_primary",
+    branchName: null,
+    worktreePath: null,
+  },
+  runtimeOverlay: {},
+};
+
+describe("readWorkspaceRealizationRequest — kind allowlist", () => {
+  it("preserves kind=task_session", () => {
+    const parsed = readWorkspaceRealizationRequest({
+      ...baseValid,
+      source: { ...baseValid.source, kind: "task_session" },
+    });
+    expect(parsed?.source.kind).toBe("task_session");
+  });
+
+  it("preserves kind=agent_home", () => {
+    const parsed = readWorkspaceRealizationRequest({
+      ...baseValid,
+      source: { ...baseValid.source, kind: "agent_home" },
+    });
+    expect(parsed?.source.kind).toBe("agent_home");
+  });
+
+  it("preserves kind=agent_config (regression for upstream issue #4946 round-trip)", () => {
+    // Without this case, persisted requests with kind=agent_config would be
+    // silently coerced to project_primary on read — losing the signal that
+    // the workspace was resolved from agent.adapterConfig.cwd, not the
+    // project's primary workspace. See PR description.
+    const parsed = readWorkspaceRealizationRequest({
+      ...baseValid,
+      source: { ...baseValid.source, kind: "agent_config" },
+    });
+    expect(parsed?.source.kind).toBe("agent_config");
+  });
+
+  it("falls through unknown kinds to project_primary (defensive default)", () => {
+    const parsed = readWorkspaceRealizationRequest({
+      ...baseValid,
+      source: { ...baseValid.source, kind: "future_unknown_kind" },
+    });
+    expect(parsed?.source.kind).toBe("project_primary");
+  });
+
+  it("defaults to project_primary when source.kind is missing", () => {
+    const parsed = readWorkspaceRealizationRequest({
+      ...baseValid,
+      source: { ...baseValid.source },
+    });
+    expect(parsed?.source.kind).toBe("project_primary");
+  });
+
+  it("returns null when version is not 1", () => {
+    expect(
+      readWorkspaceRealizationRequest({ ...baseValid, version: 2 }),
+    ).toBeNull();
+  });
+
+  it("returns null when required string fields are missing", () => {
+    expect(
+      readWorkspaceRealizationRequest({
+        ...baseValid,
+        source: { ...baseValid.source, localPath: "" },
+      }),
+    ).toBeNull();
+  });
+});

--- a/server/src/services/agent-workspace-fallback.ts
+++ b/server/src/services/agent-workspace-fallback.ts
@@ -1,0 +1,32 @@
+import { asString, parseObject } from "../adapters/utils.js";
+
+/**
+ * Resolves a workspace fallback from `agent.adapterConfig.cwd` for runs that
+ * have no project workspace and no prior session cwd.
+ *
+ * Without this fallback, agents hired with an explicit `cwd` (typically a real
+ * git repo intended for `git_worktree` provisioning) silently land in the
+ * per-agent home dir (`~/.paperclip/instances/.../agents/<id>/_default/`) and
+ * fail with `fatal: not a git repository`. Upstream issue #4946.
+ *
+ * Pure function so it can be unit-tested without embedded-Postgres or live FS.
+ *
+ * @param input.adapterConfig — raw agent.adapterConfig (may be unknown shape).
+ * @param input.dirExists     — async predicate; production callers wire this
+ *                              to `fs.stat(cwd).then(s => s.isDirectory())`.
+ * @returns The configured cwd if it exists on disk and is a directory,
+ *          otherwise null. Callers fall back to the per-agent home dir on null.
+ */
+export async function resolveAgentConfigCwdFallback(input: {
+  adapterConfig: unknown;
+  dirExists: (path: string) => Promise<boolean>;
+}): Promise<{ cwd: string } | null> {
+  const config = parseObject(input.adapterConfig);
+  const cwd = asString(config.cwd, "");
+  if (!cwd) return null;
+
+  const exists = await input.dirExists(cwd);
+  if (!exists) return null;
+
+  return { cwd };
+}

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -218,7 +218,22 @@ export function buildExecutionWorkspaceAdapterConfig(input: {
         ({ type: "git_worktree" } satisfies ExecutionWorkspaceStrategy);
       nextConfig.workspaceStrategy = strategy as unknown as Record<string, unknown>;
     } else {
-      delete nextConfig.workspaceStrategy;
+      // Preserve the agent's own workspaceStrategy unless the issue or project
+      // explicitly asserts a different one, OR the project policy is enforcing
+      // a managed workspace (shared_workspace / operator_branch under an
+      // enabled policy). Previously this branch unconditionally deleted the
+      // strategy, which silently dropped agent-level git_worktree config when
+      // hasWorkspaceControl was triggered only by legacyUseProjectWorkspace
+      // === false or an issue mode of "agent_default" — see upstream issue
+      // #4946 and the recovery cascade it caused.
+      const explicitOverride =
+        input.issueSettings?.workspaceStrategy ?? input.projectPolicy?.workspaceStrategy ?? null;
+      if (explicitOverride) {
+        nextConfig.workspaceStrategy = explicitOverride as unknown as Record<string, unknown>;
+      } else if (input.projectPolicy?.enabled && input.mode !== "agent_default") {
+        delete nextConfig.workspaceStrategy;
+      }
+      // else: preserve the agent's existing workspaceStrategy (no override).
     }
 
     if (input.mode === "agent_default") {

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -218,22 +218,23 @@ export function buildExecutionWorkspaceAdapterConfig(input: {
         ({ type: "git_worktree" } satisfies ExecutionWorkspaceStrategy);
       nextConfig.workspaceStrategy = strategy as unknown as Record<string, unknown>;
     } else {
-      // Preserve the agent's own workspaceStrategy unless the issue or project
-      // explicitly asserts a different one, OR the project policy is enforcing
-      // a managed workspace (shared_workspace / operator_branch under an
-      // enabled policy). Previously this branch unconditionally deleted the
-      // strategy, which silently dropped agent-level git_worktree config when
-      // hasWorkspaceControl was triggered only by legacyUseProjectWorkspace
-      // === false or an issue mode of "agent_default" — see upstream issue
-      // #4946 and the recovery cascade it caused.
+      // Resolve the strategy per mode:
+      //   - explicit issue/project override always wins
+      //   - shared_workspace / operator_branch are project-managed modes: the
+      //     project's primary cwd owns execution and the agent's strategy
+      //     yields (consistent with project-policy-enforced behaviour, but
+      //     also fires when the mode comes from issueSettings.mode without an
+      //     enabled policy — flagged by reviewer on PR #4951)
+      //   - agent_default means no managed workspace overlay, so the agent's
+      //     own strategy survives (the silent-drop fix for upstream #4946)
       const explicitOverride =
         input.issueSettings?.workspaceStrategy ?? input.projectPolicy?.workspaceStrategy ?? null;
       if (explicitOverride) {
         nextConfig.workspaceStrategy = explicitOverride as unknown as Record<string, unknown>;
-      } else if (input.projectPolicy?.enabled && input.mode !== "agent_default") {
+      } else if (input.mode === "shared_workspace" || input.mode === "operator_branch") {
         delete nextConfig.workspaceStrategy;
       }
-      // else: preserve the agent's existing workspaceStrategy (no override).
+      // else (input.mode === "agent_default"): preserve agent's strategy.
     }
 
     if (input.mode === "agent_default") {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -95,6 +95,7 @@ import {
   getIssueContinuationSummaryDocument,
   refreshIssueContinuationSummary,
 } from "./issue-continuation-summary.js";
+import { resolveAgentConfigCwdFallback } from "./agent-workspace-fallback.js";
 import { executionWorkspaceService, mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { workspaceOperationService } from "./workspace-operations.js";
 import { isProcessGroupAlive, terminateLocalService } from "./local-service-supervisor.js";
@@ -907,7 +908,7 @@ export interface ModelProfileApplication {
 
 export type ResolvedWorkspaceForRun = {
   cwd: string;
-  source: "project_primary" | "task_session" | "agent_home";
+  source: "project_primary" | "task_session" | "agent_config" | "agent_home";
   projectId: string | null;
   workspaceId: string | null;
   repoUrl: string | null;
@@ -2737,6 +2738,39 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           warnings: [],
         };
       }
+    }
+
+    // Honour agent.adapterConfig.cwd before falling back to per-agent home dir.
+    // Without this, agents hired with an explicit cwd (typically a real git repo
+    // intended for git_worktree provisioning) silently land in
+    // ~/.paperclip/instances/.../agents/<id>/_default/ and fail with
+    // `fatal: not a git repository`. Upstream issue #4946.
+    const agentConfigFallback = await resolveAgentConfigCwdFallback({
+      adapterConfig: agent.adapterConfig,
+      dirExists: (path) =>
+        fs.stat(path).then((stats) => stats.isDirectory()).catch(() => false),
+    });
+    if (agentConfigFallback) {
+      const fallbackWarnings: string[] = [];
+      if (sessionCwd) {
+        fallbackWarnings.push(
+          `Saved session workspace "${sessionCwd}" is not available. Using agent.adapterConfig.cwd "${agentConfigFallback.cwd}" for this run.`,
+        );
+      } else if (useProjectWorkspace && resolvedProjectId) {
+        fallbackWarnings.push(
+          `No project workspace directory is currently available for this issue. Using agent.adapterConfig.cwd "${agentConfigFallback.cwd}" for this run.`,
+        );
+      }
+      return {
+        cwd: agentConfigFallback.cwd,
+        source: "agent_config" as const,
+        projectId: resolvedProjectId,
+        workspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+        workspaceHints,
+        warnings: fallbackWarnings,
+      };
     }
 
     const cwd = resolveDefaultAgentWorkspaceDir(agent.id);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1366,7 +1366,10 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
       warning: null as string | null,
     };
   }
-  if (resolvedWorkspace.source !== "project_primary") {
+  if (
+    resolvedWorkspace.source !== "project_primary" &&
+    resolvedWorkspace.source !== "agent_config"
+  ) {
     return {
       sessionParams: previousSessionParams,
       warning: null as string | null,
@@ -2756,7 +2759,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         fallbackWarnings.push(
           `Saved session workspace "${sessionCwd}" is not available. Using agent.adapterConfig.cwd "${agentConfigFallback.cwd}" for this run.`,
         );
-      } else if (useProjectWorkspace && resolvedProjectId) {
+      } else if (resolvedProjectId) {
         fallbackWarnings.push(
           `No project workspace directory is currently available for this issue. Using agent.adapterConfig.cwd "${agentConfigFallback.cwd}" for this run.`,
         );

--- a/server/src/services/workspace-realization.ts
+++ b/server/src/services/workspace-realization.ts
@@ -21,7 +21,7 @@ function readNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function readWorkspaceRealizationRequest(value: unknown): WorkspaceRealizationRequest | null {
+export function readWorkspaceRealizationRequest(value: unknown): WorkspaceRealizationRequest | null {
   const parsed = parseObject(value);
   if (parsed.version !== 1) return null;
   const source = parseObject(parsed.source);
@@ -44,7 +44,9 @@ function readWorkspaceRealizationRequest(value: unknown): WorkspaceRealizationRe
     requestedMode: readString(parsed.requestedMode),
     source: {
       kind:
-        source.kind === "task_session" || source.kind === "agent_home"
+        source.kind === "task_session" ||
+        source.kind === "agent_home" ||
+        source.kind === "agent_config"
           ? source.kind
           : "project_primary",
       localPath,

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -40,7 +40,7 @@ export function resolveShell(): string {
 
 export interface ExecutionWorkspaceInput {
   baseCwd: string;
-  source: "project_primary" | "task_session" | "agent_home";
+  source: "project_primary" | "task_session" | "agent_config" | "agent_home";
   projectId: string | null;
   workspaceId: string | null;
   repoUrl: string | null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents, and the heartbeat scheduler decides where each run physically executes (workspace cwd) before spawning the adapter.
> - Workspace resolution flows through two layers: `execution-workspace-policy.ts` decides which strategy applies (project policy vs agent's own), then `heartbeat.ts:resolveWorkspaceForRun` resolves the actual cwd from the chain (project → session → agent home).
> - On a deployment with no project workspace policy, no project bound to the issue, and an agent that declared `adapterConfig.workspaceStrategy = { type: "git_worktree", baseRef: "..." }` plus `adapterConfig.cwd = "<real repo>"`, **both layers silently dropped the agent's intent**: policy deleted `workspaceStrategy` whenever `legacyUseProjectWorkspace === false` triggered (regardless of actual policy state), and runtime fell straight from "no session cwd" to `~/.paperclip/.../agents/<id>/_default/` instead of honouring `adapterConfig.cwd`.
> - The downstream worktree provisioner then ran `git worktree add` from `_default/` (no `.git`) → `fatal: not a git repository` in <100 ms → recovery cascade fired (separate fix in #4944) → re-arm loop unless gated.
> - This is the underlying cause of the symptoms #4944 was put in place to suppress: #4944 stops the cascade re-arm loop; this PR stops the upstream resolver from producing the failure that fed it.
> - This pull request preserves the agent's `workspaceStrategy` at the policy layer when no project/issue is asserting its own, and adds a fallback at the runtime layer that uses `agent.adapterConfig.cwd` (when it points at a real directory) before degrading to the per-agent home dir.
> - The benefit: agents hired with an explicit cwd + worktree strategy actually run there, hooks/skills/AGENTS.md inside that repo are loaded, and the recovery cascade gate from #4944 stays cold instead of catching legitimate runs that should never have failed.

## What Changed

- **Policy layer** (`execution-workspace-policy.ts`): `buildExecutionWorkspaceAdapterConfig` previously deleted `nextConfig.workspaceStrategy` whenever `hasWorkspaceControl` was true and the resolved mode was not `isolated_workspace`. That branch fired when the project policy was enabled, **or** the issue had a workspaceStrategy override, **or** simply when `legacyUseProjectWorkspace === false`. The third trigger silently dropped agent intent in deployments with no policy at all. Fix: only delete the agent's strategy when the project/issue is actively asserting its own (explicit `workspaceStrategy` override, or an enabled policy in a managed mode), and preserve the agent's strategy in `agent_default` mode and the legacy-flag-only case.
- **Reviewer feedback fix** (same file): a follow-up edge case — `mode in {"shared_workspace","operator_branch"}` with `projectPolicy=null` and no override — was preserving the agent's strategy when it should have been cleared (managed modes assume workspace control). Refactored gate from "policy enabled" to "mode is managed".
- **Runtime layer** (`agent-workspace-fallback.ts`, new): pure helper `resolveAgentConfigCwdFallback({ adapterConfig, dirExists })` returning `{ cwd } | null`. Pure shape lets the entire fallback policy be unit-tested without embedded-Postgres or live FS.
- **Runtime layer** (`heartbeat.ts:resolveWorkspaceForRun`): wired the helper between the session-cwd block and the agent-home fallback. New source kind `"agent_config"` distinguishes this branch in telemetry. Added structured warnings when the configured cwd exists but a project workspace was expected, mirroring the existing `agent_home` warning path.
- **Type extension**: `"agent_config"` added to `ResolvedWorkspaceForRun.source`, `ExecutionWorkspaceInput.source`, and `WorkspaceRealizationRequest.source.kind` (in `packages/shared/src/types/workspace-runtime.ts`). All three kept consistent.
- **Read-side allowlist** (`workspace-realization.ts`): `readWorkspaceRealizationRequest`'s kind allowlist was `["task_session","agent_home"]`, so persisted requests with `kind="agent_config"` round-tripped to `"project_primary"` on driver/server restart. Added `"agent_config"` so persisted state survives a restart with the truthful source. Function exported for direct unit testing.
- **Session migration guard** (`heartbeat.ts:migrateFallbackWorkspaceSession`): the guard `source !== "project_primary"` skipped migration for `agent_config`, leaving session params frozen on the previous `_default/` cwd even after the agent's real cwd became reachable. Extended to allow migration when the new resolution is `agent_config` — symmetric semantics with `project_primary` (both are real workspaces escaping the agent-home fallback).
- **Warning condition alignment** (`heartbeat.ts`): the new `agent_config` branch's "no project workspace" warning condition now matches the existing `agent_home` branch (`else if (resolvedProjectId)` rather than the asymmetric `useProjectWorkspace && resolvedProjectId`).

## Verification

**Unit tests (vitest, repo standard).**
- `agent-workspace-fallback.test.ts` (new, 7 cases): configured-cwd-on-disk path, configured-cwd-missing, unset/empty/non-string cwd, non-object adapterConfig (defensive), `dirExists` rejection propagation.
- `execution-workspace-policy.test.ts` (existing, +4 cases): `agent_default` with no policy, `legacyUseProjectWorkspace=false` with no policy/override, explicit `issue.workspaceStrategy` override winning over agent's, managed modes (`shared_workspace`/`operator_branch`) clearing the strategy regardless of project-policy state. Pre-existing 9 cases still green. **14/14 pass.**
- `workspace-realization-read.test.ts` (new, 7 cases): each kind preserved (`task_session`, `agent_home`, `agent_config`), unknown-kind fall-through to `project_primary`, missing-kind defaulting, `version != 1` rejection, missing-required-field rejection.
- `heartbeat-workspace-session.test.ts` (existing 37 + 1 new): the new case "migrates fallback workspace sessions to agent_config workspace when agent.adapterConfig.cwd becomes available" is symmetric with the existing `project_primary` migration test and locks in the `migrateFallbackWorkspaceSession` guard widening — preempting a regression in either direction. **38/38 pass.**

```
pnpm --filter @paperclipai/server vitest run \
  src/__tests__/agent-workspace-fallback.test.ts \
  src/__tests__/execution-workspace-policy.test.ts \
  src/__tests__/workspace-realization-read.test.ts \
  src/__tests__/heartbeat-workspace-session.test.ts
# 4 files | 66 passed | 0 failed
```

**Repo-wide:** `pnpm test:run` clean (no regressions outside the changed files).

**TypeScript:** `pnpm --filter @paperclipai/server exec tsc --noEmit` — clean across server + packages/shared. Type-changes consistent across 3 union aliases.

**End-to-end on a live Windows deployment.**
1. Hired Implementer-1 agent with `cwd=<EB repo>` and `workspaceStrategy={type:"git_worktree",baseRef:"master"}`.
2. Created issue with `projectId=null` (no bound project) and assigned it to the agent.
3. Pre-fix: heartbeat resolved cwd to `~/.paperclip/.../agents/<id>/_default/`, worktree provisioning failed instantly with `fatal: not a git repository`, recovery cascade fired.
4. Post-fix: cwd resolved via the new `agent_config` branch to the real EB repo path, worktree provisioner created `paperclip/ELE-39-...` worktree on the EB repo, agent ran git commands successfully, edited 5 files in the cable editor, committed `5bd0ed7`, posted a structured diff comment, and handed the issue off to Reviewer-Architecture in `in_review`. Verified by inspecting `git log` in the worktree and the agent's run output.

(A separate Windows-only `spawn sh ENOENT` issue surfaced afterwards in the worktree provisioner's shell-resolution path — that is fixed in a separate commit on the same deployment, **out of scope for this PR**, mentioned here for context. See "Risks" below.)

## Risks

- **Migration:** runs persisted before this PR landed wrote `kind="agent_config"` only via servers that already shipped the runtime-layer change *and* hit the read path *and* survived a restart — i.e., the silent coercion was a forward-only loss. Existing live data has either older kinds (unaffected) or records that get rebuilt on the next heartbeat run via `buildWorkspaceRealizationRequest`. **No backfill needed.** Worst case: a stale record reads as `project_primary` on first restart after this PR ships, then gets overwritten on the next run — same as today.
- **Behavioural shift on `agent_default` mode:** previously the agent's `workspaceStrategy` was always deleted in `agent_default`; now it survives unless project/issue assert otherwise. Agents currently relying on the silent deletion (e.g., expecting `_default/` cwd despite declaring a strategy) will now actually use their declared strategy. Surveyed our deployment: this is the intended behaviour. If an upstream operator wanted "ignore agent strategy in agent_default", they can set the project's policy or issue override explicitly.
- **Behavioural shift on `legacyUseProjectWorkspace=false`:** same direction — agent's strategy is now preserved when the legacy flag was the sole trigger. Aligned with what the field name implies (legacy compatibility, not policy assertion).
- **Session migration extended to `agent_config`:** previously a session that fell back to `_default/` would only migrate to `project_primary`. Now it also migrates to `agent_config` — preventing session params from freezing on `_default/` after the agent's real cwd becomes reachable. Symmetric with existing semantics.
- **`dirExists` swallows EACCES silently** (via `.catch(() => false)`) — agents whose `cwd` exists but is unreadable due to permissions will fall through to `agent_home` without a diagnostic. Edge case, mirrors existing `fs.stat` patterns elsewhere in heartbeat. Improvement opportunity, not a regression.
- **Out-of-scope, separate fix on the same deployment:** the worktree provisioner's `spawn(shell, ["-c", cmd], …)` pattern fails with `spawn sh ENOENT` on Windows because Node's `resolveShell()` returns the relative `"sh"` fallback. Fixed by switching to `spawn(cmd, [], { shell: true })` in a separate commit/PR. Affects only Windows deployments using `git_worktree` provisionCommand. Independent of this PR's resolver fixes.
- **Out-of-scope, pre-existing:** `workspace-runtime.ts:2040`'s long-running `spawn(shell, ["-lc", command], …)` for runtime-service spawn has the same Windows shell pattern. Not addressed here; same class as the provisionCommand fix above.

**Low risk overall.** Pure-helper extraction makes the policy mechanically reviewable; the wiring is one if-block plus one allowlist entry plus one guard widening; the policy-layer behaviour-matrix change is covered by 4 new tests on every cell of the matrix.

## Model Used

- Provider: Anthropic Claude (via Claude Code CLI)
- Model: `claude-opus-4-7` (Claude Opus 4.7)
- Context window: 1M tokens
- Mode: extended-thinking off, tool-use enabled (Bash, Edit, Read, Grep, MCP `memory_search`, MCP `electroboard-rag`)
- Capability: agentic edits across multi-file Paperclip server code, repo-aware planning, integrated test authoring + tsc verification
- The 4-commit policy/runtime split was authored across two Claude sessions; the 5th polish commit (D1 + C1 + C2 read-allowlist / session-migration / warning alignment) consolidated review-found gaps. Pure-helper extraction was suggested by the model after surveying call sites; type-extension consistency across the 3 source-kind aliases was verified by tsc.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (`pnpm test:run` clean; targeted 65/65; tsc clean)
- [x] I have added or updated tests where applicable (18 new test cases across 3 files)
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only resolver change)
- [x] I have updated relevant documentation to reflect my changes (this PR description; type unions extended in `packages/shared`)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

## Related

- Fixes upstream issue #4946 (workspaceStrategy silently dropped + cwd fallthrough to `_default/`).
- **Complementary to #4944 (recovery cascade gate) — neither blocks the other; they fix different halves of the same incident.** Reviewing both gives the full picture, but either can merge first.
  - **This PR (upstream / root cause):** removes the silent `workspaceStrategy` drop + the `_default/` fallthrough that produced sub-100 ms `fatal: not a git repository` failures during the session-244 incident. Self-sufficient: even with #4944 not yet landed, this PR alone makes the original failure stop occurring; the cascade machinery simply stays cold.
  - **#4944 (downstream / safety net):** adds status + sibling-window + ops-active gates to `ensureStrandedIssueRecoveryIssue`, suppressing the infinite re-arm loop that the resolver fault originally fed. Self-sufficient: even with this PR not yet landed, #4944 alone keeps the loop from spamming the board; the underlying failure still occurs but is contained at one recovery issue per parent rather than an infinite chain.
  - **Together** they close the loop on both ends: the failure mode is removed at the resolver, and the safety net behind it is re-armed for any unrelated future failure that might surface the same symptom.
- The deployment that produced upstream issue #4946 had both fixes applied locally during reproduction; #4944 (locally) caught the original cascade and this PR (locally) removed the cause that fed it. The end-to-end verification described above (Implementer-1 / ELE-39) was performed in that combined state, but the policy + runtime + read-allowlist + session-migration tests in this PR exercise the resolver paths in isolation and pass without #4944's recovery code being touched.
