### PR TITLE
fix(workspace): skip git worktree creation when baseCwd is the agent home directory

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -2043,6 +2043,43 @@ describe("realizeExecutionWorkspace", () => {
       cleanupAction: "branch_delete",
     });
   });
+
+  it("skips git worktree creation when source is agent_home (interval heartbeat with no project context)", async () => {
+    const agentHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-agent-home-"));
+
+    const result = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: agentHomeDir,
+        source: "agent_home",
+        projectId: null,
+        workspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: null,
+      agent: {
+        id: "agent-1",
+        name: "Interval Agent",
+        companyId: "company-1",
+      },
+    });
+
+    expect(result.strategy).toBe("project_primary");
+    expect(result.cwd).toBe(agentHomeDir);
+    expect(result.branchName).toBeNull();
+    expect(result.worktreePath).toBeNull();
+    expect(result.created).toBe(false);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/No project workspace/);
+
+    await fs.rm(agentHomeDir, { recursive: true, force: true });
+  });
 });
 
 describe("ensureRuntimeServicesForRun", () => {

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -999,6 +999,21 @@ export async function realizeExecutionWorkspace(input: {
     };
   }
 
+  if (input.base.source === "agent_home") {
+    return {
+      ...input.base,
+      strategy: "project_primary",
+      cwd: input.base.baseCwd,
+      branchName: null,
+      worktreePath: null,
+      warnings: [
+        "No project workspace is available for this run; skipping git worktree creation. " +
+        "Configure a project workspace or trigger this run from an issue to enable worktree isolation.",
+      ],
+      created: false,
+    };
+  }
+
   const repoRoot = await resolveGitOwnerRepoRoot(input.base.baseCwd);
   const branchTemplate = asString(rawStrategy.branchTemplate, "{{issue.identifier}}-{{slug}}");
   const renderedBranch = renderWorkspaceTemplate(branchTemplate, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and manages their execution workspaces, including git worktree isolation per issue.
> - The workspace-runtime subsystem is responsible for translating an agent's workspace strategy into a concrete working directory before the adapter runs.
> - When a `git_worktree`-strategy agent fires an **interval heartbeat** with no issue context, `resolveWorkspaceForRun` returns `source: "agent_home"` — the agent's home directory, which is an empty non-git folder.
> - `realizeExecutionWorkspace` then unconditionally calls `resolveGitOwnerRepoRoot(baseCwd)` → `git rev-parse --show-toplevel` on that empty dir, crashing with `fatal: not a git repository` before the adapter runs at all.
> - The fix adds an early-return guard: when `source === "agent_home"`, skip worktree creation entirely and return the fallback dir via the `project_primary` path (with a descriptive warning).
> - The benefit is that interval heartbeats can now co-exist with `git_worktree` agents; issue-driven and project-workspace-backed wakes are unaffected. The host-side stopgap (disabling interval wakes on affected agents) can be reverted once this ships.

## What Changed

- `server/src/services/workspace-runtime.ts` — in `realizeExecutionWorkspace`, added a guard after the `strategyType !== "git_worktree"` check: if `input.base.source === "agent_home"`, return the passthrough result immediately without attempting `resolveGitOwnerRepoRoot`.
- `server/src/__tests__/workspace-runtime.test.ts` — added a regression test: `realizeExecutionWorkspace` with `git_worktree` strategy and `source: "agent_home"` resolves without crashing, returns `strategy: "project_primary"`, the fallback cwd, and a non-empty warning array.

## Verification

```
# Run the targeted regression test
npx vitest run server/src/__tests__/workspace-runtime.test.ts -t "skips git worktree creation when source is agent_home"

# Full typecheck
pnpm typecheck
```

Both pass locally.

## Risks

Low risk. The guard only fires when `source === "agent_home"`, a path that previously always crashed. Existing `git_worktree` wakes driven by issues (which resolve `source: "project_primary"`) are unaffected — the guard is unreachable for them.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Mode: Tool-use / agentic (Paperclip-Builder agent heartbeat)
- Context: full repo read access, 200k context window

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge