### PR TITLE
fix: harden bounded Paperclip worker completion

### DIFF
--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -22,6 +22,9 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 | `graceSec` | number | No | Grace period before force-kill |
 | `maxTurnsPerRun` | number | No | Max agentic turns per heartbeat (defaults to `300`) |
 | `dangerouslySkipPermissions` | boolean | No | Skip permission prompts (default: `true`); required for headless runs where interactive approval is impossible |
+| `allowedWritePaths` | string[] | No | Enables the Claude mutation guard for these absolute write paths/directories. The adapter passes a per-run `--settings` PreToolUse hook for built-in mutation tools that validates real paths, rejects symlinks, blocks unsupported mutation payloads, and disables session persistence for the guarded run. This is a path guard, not a full OS sandbox; keep scoped workspaces and normal adapter isolation in place. |
+| `allowedBashCommands` | string[] | No | Exact Bash command strings allowed when the mutation guard is active. Bash is denied by default; prefer leaving this empty for mutation pilots. |
+| `autoCompleteIssueOnSuccess` | boolean | No | Server-side heartbeat option: when true, a successful assigned issue run with concrete liveness evidence marks the issue `done` only if the assignee and execution lock still match. Use for bounded one-shot worker calls to avoid completion-comment loops. |
 
 ## Prompt Templates
 

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -40,6 +40,9 @@ Core fields:
 - dangerouslySkipPermissions (boolean, optional, default true): pass --dangerously-skip-permissions to claude; defaults to true because Paperclip runs Claude in headless --print mode where interactive permission prompts cannot be answered
 - command (string, optional): defaults to "claude"
 - extraArgs (string[], optional): additional CLI args
+- allowedWritePaths (string[], optional): enables a Claude Code PreToolUse mutation guard for built-in mutation tools under these absolute write paths/directories; disables session resume for the guarded run. This is a path guard, not a full OS sandbox.
+- allowedBashCommands (string[], optional): exact Bash command strings allowed by the mutation guard; Bash is denied by default when allowedWritePaths is set
+- autoCompleteIssueOnSuccess (boolean, optional): server-side heartbeat option to mark the assigned issue done after a successful run with concrete liveness evidence; useful for bounded one-shot worker calls
 - env (object, optional): KEY=VALUE environment variables
 - workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
 - workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
@@ -110,6 +111,207 @@ function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscri
   if (isBedrockAuth(env)) return "metered_api";
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
 }
+
+type ClaudeMutationGuard = {
+  settingsPath: string;
+  hookPath: string;
+  auditPath: string;
+  tempDir: string;
+  allowedWritePaths: string[];
+  allowedBashCommands: string[];
+};
+
+function uniqueStrings(values: string[]) {
+  return [...new Set(values)];
+}
+
+function assertSafeConfiguredPath(rawPath: string, fieldName: string) {
+  if (rawPath.includes("\0")) {
+    throw new Error(`${fieldName} must not contain NUL bytes`);
+  }
+  if (!path.isAbsolute(rawPath)) {
+    throw new Error(`${fieldName} must be an absolute path: ${rawPath}`);
+  }
+}
+
+async function prepareClaudeMutationGuard(config: Record<string, unknown>, runId: string): Promise<ClaudeMutationGuard | null> {
+  const allowedWritePaths = uniqueStrings(asStringArray(config.allowedWritePaths).map((value) => value.trim()).filter(Boolean));
+  if (allowedWritePaths.length === 0) return null;
+
+  const allowedBashCommands = uniqueStrings(
+    asStringArray(config.allowedBashCommands).map((value) => value.trim()).filter(Boolean),
+  );
+  for (const [index, rawPath] of allowedWritePaths.entries()) {
+    assertSafeConfiguredPath(rawPath, `allowedWritePaths[${index}]`);
+  }
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), `paperclip-claude-guard-${runId}-`));
+  await fs.chmod(tempDir, 0o700);
+  const hookPath = path.join(tempDir, "mutation-guard.cjs");
+  const settingsPath = path.join(tempDir, "settings.json");
+  const auditPath = path.join(tempDir, "audit.jsonl");
+
+  const hookSource = `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+
+const RUN_ID = ${JSON.stringify(runId)};
+const AUDIT_PATH = ${JSON.stringify(auditPath)};
+const ALLOWED_WRITE_PATHS = ${JSON.stringify(allowedWritePaths)};
+const ALLOWED_BASH_COMMANDS = new Set(${JSON.stringify(allowedBashCommands)});
+
+function audit(event) {
+  try {
+    fs.appendFileSync(AUDIT_PATH, JSON.stringify({ ts: new Date().toISOString(), runId: RUN_ID, ...event }) + "\\n", { mode: 0o600 });
+  } catch {}
+}
+
+function decision(decision, reason, extra = {}) {
+  audit({ decision, reason, ...extra });
+  process.stdout.write(JSON.stringify({ decision, reason }));
+}
+
+function safeParts(absPath) {
+  const parsed = path.parse(absPath);
+  return path.resolve(absPath).slice(parsed.root.length).split(path.sep).filter(Boolean);
+}
+
+function symlinkComponents(absPath, { allowMissingFinal }) {
+  const resolved = path.resolve(absPath);
+  const parsed = path.parse(resolved);
+  let current = parsed.root;
+  const parts = safeParts(resolved);
+  const symlinks = [];
+  for (let i = 0; i < parts.length; i++) {
+    current = path.join(current, parts[i]);
+    let st;
+    try {
+      st = fs.lstatSync(current);
+    } catch (err) {
+      if (allowMissingFinal && i === parts.length - 1 && err && err.code === "ENOENT") return symlinks;
+      throw err;
+    }
+    if (st.isSymbolicLink()) symlinks.push(current);
+  }
+  return symlinks;
+}
+
+function assertNoSymlinkComponents(absPath, { allowMissingFinal, toleratedSymlinks = new Set() }) {
+  for (const symlinkPath of symlinkComponents(absPath, { allowMissingFinal })) {
+    if (!toleratedSymlinks.has(symlinkPath)) throw new Error("symlink component rejected: " + symlinkPath);
+  }
+}
+
+const TOLERATED_ALLOWED_PREFIX_SYMLINKS = new Set(
+  ALLOWED_WRITE_PATHS.flatMap((raw) => symlinkComponents(raw, { allowMissingFinal: true })),
+);
+
+function canonicalTarget(rawPath, toleratedSymlinks = TOLERATED_ALLOWED_PREFIX_SYMLINKS) {
+  if (typeof rawPath !== "string" || rawPath.trim().length === 0) throw new Error("path must be a non-empty string");
+  if (rawPath.includes("\\0")) throw new Error("path contains NUL byte");
+  if (!path.isAbsolute(rawPath)) throw new Error("path must be absolute: " + rawPath);
+  const resolved = path.resolve(rawPath);
+  let st = null;
+  try {
+    st = fs.lstatSync(resolved);
+  } catch (err) {
+    if (!err || err.code !== "ENOENT") throw err;
+  }
+  if (st && st.isSymbolicLink()) throw new Error("symlink target rejected: " + rawPath);
+  assertNoSymlinkComponents(resolved, { allowMissingFinal: !st, toleratedSymlinks });
+  if (st) return fs.realpathSync.native(resolved);
+  const parent = path.dirname(resolved);
+  assertNoSymlinkComponents(parent, { allowMissingFinal: false, toleratedSymlinks });
+  const parentReal = fs.realpathSync.native(parent);
+  return path.join(parentReal, path.basename(resolved));
+}
+
+function isSameOrInside(candidate, allowed) {
+  const rel = path.relative(allowed, candidate);
+  return rel === "" || (!!rel && !rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+function allowedTargets() {
+  return ALLOWED_WRITE_PATHS.map((raw) => {
+    const target = canonicalTarget(raw);
+    let isDir = false;
+    try { isDir = fs.statSync(target).isDirectory(); } catch {}
+    return { raw, target, isDir };
+  });
+}
+
+function validateWritePath(rawPath) {
+  const target = canonicalTarget(rawPath);
+  const allowed = allowedTargets();
+  const ok = allowed.some((entry) => entry.isDir ? isSameOrInside(target, entry.target) : target === entry.target);
+  if (!ok) throw new Error("write path not allowed: " + rawPath + " -> " + target);
+  return target;
+}
+
+function collectPaths(toolName, input) {
+  if (!input || typeof input !== "object") throw new Error("tool input must be an object");
+  if (toolName === "NotebookEdit") throw new Error("NotebookEdit is denied until its schema is explicitly supported");
+  const paths = [];
+  for (const key of ["file_path", "path"]) {
+    if (typeof input[key] === "string") paths.push(input[key]);
+  }
+  if (Array.isArray(input.edits)) {
+    for (const edit of input.edits) {
+      if (edit && typeof edit === "object") {
+        for (const key of ["file_path", "path"]) {
+          if (typeof edit[key] === "string") paths.push(edit[key]);
+        }
+      }
+    }
+  }
+  if (paths.length === 0) throw new Error("unknown payload shape for " + toolName);
+  return [...new Set(paths)];
+}
+
+try {
+  const raw = fs.readFileSync(0, "utf8");
+  const event = JSON.parse(raw);
+  const toolName = event.tool_name || event.toolName || "";
+  const input = event.tool_input || event.toolInput || {};
+  if (toolName === "Bash") {
+    const command = typeof input.command === "string" ? input.command : "";
+    if (ALLOWED_BASH_COMMANDS.size > 0 && ALLOWED_BASH_COMMANDS.has(command)) {
+      decision("approve", "allowed exact Bash command", { toolName, command });
+      process.exit(0);
+    }
+    decision("block", "Bash is denied by claude_local mutation guard", { toolName, command });
+    process.exit(0);
+  }
+  if (!["Write", "Edit", "MultiEdit", "NotebookEdit"].includes(toolName)) {
+    decision("block", "unknown mutation tool denied: " + toolName, { toolName });
+    process.exit(0);
+  }
+  const paths = collectPaths(toolName, input);
+  const resolvedPaths = paths.map((targetPath) => ({ raw: targetPath, resolved: validateWritePath(targetPath) }));
+  decision("approve", "mutation guard allowed path", { toolName, paths: resolvedPaths });
+} catch (err) {
+  decision("block", err && err.message ? err.message : String(err));
+}
+`;
+
+  const settings = {
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: "Write|Edit|MultiEdit|NotebookEdit|Bash",
+          hooks: [{ type: "command", command: hookPath }],
+        },
+      ],
+    },
+  };
+
+  await fs.writeFile(hookPath, hookSource, { encoding: "utf8", mode: 0o700 });
+  await fs.writeFile(settingsPath, JSON.stringify(settings), { encoding: "utf8", mode: 0o600 });
+  await fs.writeFile(auditPath, "", { encoding: "utf8", mode: 0o600 });
+
+  return { settingsPath, hookPath, auditPath, tempDir, allowedWritePaths, allowedBashCommands };
+}
+
 
 async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {
   const { runId, agent, config, context, executionTarget, authToken } = input;
@@ -491,6 +693,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       }
     }
   }
+  const mutationGuard = await prepareClaudeMutationGuard(config, runId);
 
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
@@ -500,6 +703,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const hasMatchingPromptBundle =
     runtimePromptBundleKey.length === 0 || runtimePromptBundleKey === promptBundle.bundleKey;
   const canResumeSession =
+    !mutationGuard &&
     runtimeSessionId.length > 0 &&
     hasMatchingPromptBundle &&
     (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(effectiveExecutionCwd)) &&
@@ -586,6 +790,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
     if (effort) args.push("--effort", effort);
     if (maxTurns > 0) args.push("--max-turns", String(maxTurns));
+    if (mutationGuard) {
+      args.push("--settings", mutationGuard.settingsPath);
+      args.push("--no-session-persistence");
+    }
     // On resumed sessions the instructions are already in the session cache;
     // re-injecting them via --append-system-prompt-file wastes 5-10K tokens
     // per heartbeat and the Claude CLI may reject the combination outright.
@@ -623,6 +831,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (attemptInstructionsFilePath && !resumeSessionId) {
       commandNotes.push(
         `Injected agent instructions via --append-system-prompt-file ${instructionsFilePath} (with path directive appended)`,
+      );
+    }
+    if (mutationGuard) {
+      commandNotes.push(
+        `Enabled Claude mutation guard for ${mutationGuard.allowedWritePaths.length} allowed write path(s); audit log ${mutationGuard.auditPath}`,
       );
     }
     if (onMeta) {
@@ -848,6 +1061,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   } finally {
     if (paperclipBridge) {
       await paperclipBridge.stop();
+    }
+    if (mutationGuard) {
+      await onLog("stdout", `[paperclip] Claude mutation guard audit log: ${mutationGuard.auditPath}\n`);
     }
     if (restoreRemoteWorkspace) {
       await onLog(

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -2,8 +2,22 @@ import { describe, expect, it, vi } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { execFile } from "node:child_process";
 import { runChildProcess } from "@paperclipai/adapter-utils/server-utils";
 import { execute } from "@paperclipai/adapter-claude-local/server";
+
+function runHookCommand(hookPath: string, event: Record<string, unknown>): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(process.execPath, [hookPath], (error, stdout) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(JSON.parse(stdout));
+    });
+    child.stdin?.end(JSON.stringify(event));
+  });
+}
 
 async function writeFailingClaudeCommand(
   commandPath: string,
@@ -303,6 +317,121 @@ describe("claude execute", () => {
         onMeta: async (meta) => { capturedNotes = (meta.commandNotes as string[]) ?? []; },
       });
       expect(capturedNotes).toHaveLength(0);
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+
+  it("passes generated mutation guard settings when allowedWritePaths is configured", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-guard-"));
+    const { workspace, commandPath, capturePath, restore } = await setupExecuteEnv(root);
+    const allowedPath = path.join(workspace, "allowed.md");
+    let capturedNotes: string[] = [];
+    try {
+      await execute({
+        runId: "run-guard",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: "existing-session", sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Do work.",
+          allowedWritePaths: [allowedPath],
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+        onMeta: async (meta) => { capturedNotes = (meta.commandNotes as string[]) ?? []; },
+      });
+      const captured = JSON.parse(await fs.readFile(capturePath, "utf-8"));
+      const settingsIndex = captured.argv.indexOf("--settings");
+      expect(settingsIndex).toBeGreaterThanOrEqual(0);
+      expect(captured.argv).toContain("--no-session-persistence");
+      expect(captured.argv).not.toContain("--resume");
+      const settingsPath = captured.argv[settingsIndex + 1];
+      const settings = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+      const hookPath = settings.hooks.PreToolUse[0].hooks[0].command;
+      const hookSource = await fs.readFile(hookPath, "utf-8");
+      expect(hookSource).toContain(allowedPath);
+      expect(hookSource).toContain("Bash is denied by claude_local mutation guard");
+      expect(capturedNotes.some((note) => note.includes("Claude mutation guard"))).toBe(true);
+
+      await fs.mkdir(path.join(workspace, "allowed-dir"));
+      const allowedDirRoot = path.join(workspace, "allowed-dir");
+      const deniedSibling = path.join(workspace, "allowed-dir-sibling", "x.md");
+      const symlinkParent = path.join(workspace, "symlink-parent");
+      await fs.mkdir(path.dirname(deniedSibling));
+      await fs.symlink(allowedDirRoot, symlinkParent);
+
+      // Re-run with a directory allowlist so the generated hook can be exercised directly.
+      await execute({
+        runId: "run-guard-dir",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Do work.",
+          allowedWritePaths: [allowedDirRoot],
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+        onMeta: async () => {},
+      });
+      const dirCaptured = JSON.parse(await fs.readFile(capturePath, "utf-8"));
+      const dirSettingsPath = dirCaptured.argv[dirCaptured.argv.indexOf("--settings") + 1];
+      const dirSettings = JSON.parse(await fs.readFile(dirSettingsPath, "utf-8"));
+      const dirHookPath = dirSettings.hooks.PreToolUse[0].hooks[0].command;
+      await expect(runHookCommand(dirHookPath, {
+        tool_name: "Write",
+        tool_input: { file_path: path.join(allowedDirRoot, "ok.md") },
+      })).resolves.toMatchObject({ decision: "approve" });
+      await expect(runHookCommand(dirHookPath, {
+        tool_name: "Write",
+        tool_input: { file_path: deniedSibling },
+      })).resolves.toMatchObject({ decision: "block" });
+      await expect(runHookCommand(dirHookPath, {
+        tool_name: "Write",
+        tool_input: { file_path: path.join(symlinkParent, "escape.md") },
+      })).resolves.toMatchObject({ decision: "block" });
+      await expect(runHookCommand(dirHookPath, {
+        tool_name: "Bash",
+        tool_input: { command: "git status --short" },
+      })).resolves.toMatchObject({ decision: "block" });
+      await expect(runHookCommand(dirHookPath, {
+        tool_name: "NotebookEdit",
+        tool_input: { file_path: path.join(allowedDirRoot, "nb.ipynb") },
+      })).resolves.toMatchObject({ decision: "block" });
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects relative allowedWritePaths", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-guard-relative-"));
+    const { workspace, commandPath, restore } = await setupExecuteEnv(root);
+    try {
+      await expect(execute({
+        runId: "run-guard-relative",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Do work.",
+          allowedWritePaths: ["relative.md"],
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+        onMeta: async () => {},
+      })).rejects.toThrow(/absolute path/);
     } finally {
       restore();
       await fs.rm(root, { recursive: true, force: true });

--- a/server/src/__tests__/heartbeat-auto-complete.test.ts
+++ b/server/src/__tests__/heartbeat-auto-complete.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { decideAutoCompleteIssueOnSuccessfulRun, type AutoCompleteIssueDecisionInput } from "../services/heartbeat.js";
+
+function input(overrides: Partial<AutoCompleteIssueDecisionInput> = {}): AutoCompleteIssueDecisionInput {
+  return {
+    outcome: "succeeded",
+    autoCompleteIssueOnSuccess: true,
+    livenessState: "advanced",
+    issueStatus: "in_progress",
+    issueAssigneeAgentId: "agent-1",
+    issueExecutionRunId: "run-1",
+    agentId: "agent-1",
+    runId: "run-1",
+    ...overrides,
+  };
+}
+
+describe("decideAutoCompleteIssueOnSuccessfulRun", () => {
+  it("allows opt-in successful live assigned runs to complete their issue", () => {
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input())).toEqual({ shouldComplete: true });
+  });
+
+  it("stays disabled unless autoCompleteIssueOnSuccess is explicitly true", () => {
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input({ autoCompleteIssueOnSuccess: false }))).toEqual({
+      shouldComplete: false,
+      reason: "disabled",
+    });
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input({ autoCompleteIssueOnSuccess: undefined }))).toEqual({
+      shouldComplete: false,
+      reason: "disabled",
+    });
+  });
+
+  it("does not complete non-successful runs", () => {
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input({ outcome: "failed" }))).toEqual({
+      shouldComplete: false,
+      reason: "outcome",
+    });
+  });
+
+  it("does not complete plan-only, empty-response, or follow-up-only runs", () => {
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input({ livenessState: "plan_only" }))).toEqual({
+      shouldComplete: false,
+      reason: "liveness",
+    });
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input({ livenessState: "empty_response" }))).toEqual({
+      shouldComplete: false,
+      reason: "liveness",
+    });
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input({ livenessState: "needs_followup" }))).toEqual({
+      shouldComplete: false,
+      reason: "liveness",
+    });
+  });
+
+  it("does not complete missing or terminal issues", () => {
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input({ issueStatus: null }))).toEqual({
+      shouldComplete: false,
+      reason: "missing_issue",
+    });
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input({ issueStatus: "done" }))).toEqual({
+      shouldComplete: false,
+      reason: "terminal_issue",
+    });
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input({ issueStatus: "cancelled" }))).toEqual({
+      shouldComplete: false,
+      reason: "terminal_issue",
+    });
+  });
+
+  it("does not complete when assignee or execution lock no longer match", () => {
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input({ issueAssigneeAgentId: "agent-2" }))).toEqual({
+      shouldComplete: false,
+      reason: "assignee",
+    });
+    expect(decideAutoCompleteIssueOnSuccessfulRun(input({ issueExecutionRunId: "run-2" }))).toEqual({
+      shouldComplete: false,
+      reason: "execution_lock",
+    });
+  });
+});

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -877,6 +877,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     autoCompleteIssueOnSuccess?: boolean;
     adapterResult?: Awaited<ReturnType<typeof mockAdapterExecute>>;
     seedConcreteActionEvidence?: boolean;
+    waitForCompletedIssue?: boolean;
   }) {
     if (input.adapterResult) {
       mockAdapterExecute.mockResolvedValueOnce(input.adapterResult);
@@ -898,6 +899,16 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await heartbeat.resumeQueuedRuns();
     await waitForRunToSettle(heartbeat, fixture.runId);
     await waitForHeartbeatIdle(db);
+    if (input.waitForCompletedIssue) {
+      await waitForValue(async () => {
+        const completedIssue = await db
+          .select({ status: issues.status })
+          .from(issues)
+          .where(eq(issues.id, fixture.issueId))
+          .then((rows) => rows[0] ?? null);
+        return completedIssue?.status === "done" ? completedIssue : null;
+      });
+    }
 
     const issue = await db.select().from(issues).where(eq(issues.id, fixture.issueId)).then((rows) => rows[0] ?? null);
     const run = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, fixture.runId)).then((rows) => rows[0] ?? null);
@@ -908,6 +919,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const { issue, run } = await executeAutoCompleteFixture({
       autoCompleteIssueOnSuccess: true,
       seedConcreteActionEvidence: true,
+      waitForCompletedIssue: true,
     });
 
     expect(run?.status).toBe("succeeded");

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -858,6 +858,192 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     return { companyId, agentId, runId, wakeupRequestId, issueId };
   }
 
+  async function seedAutoCompleteIssueRunFixture(input?: {
+    autoCompleteIssueOnSuccess?: boolean;
+  }) {
+    const fixture = await seedQueuedIssueRunFixture();
+    await db
+      .update(agents)
+      .set({
+        adapterConfig: input?.autoCompleteIssueOnSuccess === undefined
+          ? {}
+          : { autoCompleteIssueOnSuccess: input.autoCompleteIssueOnSuccess },
+      })
+      .where(eq(agents.id, fixture.agentId));
+    return fixture;
+  }
+
+  async function executeAutoCompleteFixture(input: {
+    autoCompleteIssueOnSuccess?: boolean;
+    adapterResult?: Awaited<ReturnType<typeof mockAdapterExecute>>;
+  }) {
+    if (input.adapterResult) {
+      mockAdapterExecute.mockResolvedValueOnce(input.adapterResult);
+    }
+    const fixture = await seedAutoCompleteIssueRunFixture({
+      autoCompleteIssueOnSuccess: input.autoCompleteIssueOnSuccess,
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForRunToSettle(heartbeat, fixture.runId);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, fixture.issueId)).then((rows) => rows[0] ?? null);
+    const run = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, fixture.runId)).then((rows) => rows[0] ?? null);
+    return { ...fixture, issue, run };
+  }
+
+  it("auto-completes the assigned issue after a successful live-content run when explicitly enabled", async () => {
+    mockAdapterExecute.mockImplementationOnce(async (ctx: { agent: { id: string; companyId: string }; runId: string; context: Record<string, unknown> }) => {
+      await db.insert(issueComments).values({
+        companyId: ctx.agent.companyId,
+        issueId: String(ctx.context.issueId),
+        authorAgentId: ctx.agent.id,
+        createdByRunId: ctx.runId,
+        body: "Implemented the requested fix and verified the targeted behavior.",
+      });
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Implemented the requested fix and verified the targeted behavior.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const { issue, run } = await executeAutoCompleteFixture({
+      autoCompleteIssueOnSuccess: true,
+    });
+
+    expect(run?.status).toBe("succeeded");
+    expect(run?.livenessState).not.toBe("plan_only");
+    expect(run?.livenessState).not.toBe("empty_response");
+    expect(issue?.status).toBe("done");
+  });
+
+  it("does not auto-complete when the run is classified plan-only", async () => {
+    const { issue, run } = await executeAutoCompleteFixture({
+      autoCompleteIssueOnSuccess: true,
+      adapterResult: {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "I will inspect the repo next and then implement the fix.",
+        provider: "test",
+        model: "test-model",
+      },
+    });
+
+    expect(run?.status).toBe("succeeded");
+    expect(run?.livenessState).toBe("plan_only");
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("does not auto-complete when the run has no concrete action evidence", async () => {
+    const { issue, run } = await executeAutoCompleteFixture({
+      autoCompleteIssueOnSuccess: true,
+      adapterResult: {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        provider: "test",
+        model: "test-model",
+      },
+    });
+
+    expect(run?.status).toBe("succeeded");
+    expect(run?.livenessState).not.toBe("advanced");
+    expect(run?.livenessState).not.toBe("completed");
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("does not auto-complete unless the adapter config explicitly enables it", async () => {
+    const absent = await executeAutoCompleteFixture({
+      adapterResult: {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Implemented the requested fix and verified the targeted behavior.",
+        provider: "test",
+        model: "test-model",
+      },
+    });
+    expect(absent.issue?.status).toBe("in_progress");
+  });
+
+  it("does not auto-complete if the issue assignee changes before run completion", async () => {
+    const newAssigneeId = randomUUID();
+    mockAdapterExecute.mockImplementationOnce(async (ctx: { agent: { companyId: string }; context: Record<string, unknown> }) => {
+      await db.insert(agents).values({
+        id: newAssigneeId,
+        companyId: ctx.agent.companyId,
+        name: "NewOwner",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      });
+      await db
+        .update(issues)
+        .set({ assigneeAgentId: newAssigneeId })
+        .where(eq(issues.id, String(ctx.context.issueId)));
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Implemented the requested fix and verified the targeted behavior.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const { issue } = await executeAutoCompleteFixture({ autoCompleteIssueOnSuccess: true });
+
+    expect(issue?.assigneeAgentId).toBe(newAssigneeId);
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("does not auto-complete if the issue execution lock changes before run completion", async () => {
+    const replacementRunId = randomUUID();
+    mockAdapterExecute.mockImplementationOnce(async (ctx: { agent: { id: string; companyId: string }; context: Record<string, unknown> }) => {
+      await db.insert(heartbeatRuns).values({
+        id: replacementRunId,
+        companyId: ctx.agent.companyId,
+        agentId: ctx.agent.id,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId: ctx.context.issueId },
+      });
+      await db
+        .update(issues)
+        .set({ executionRunId: replacementRunId })
+        .where(eq(issues.id, String(ctx.context.issueId)));
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Implemented the requested fix and verified the targeted behavior.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const { issue } = await executeAutoCompleteFixture({ autoCompleteIssueOnSuccess: true });
+
+    expect(issue?.executionRunId).toBe(replacementRunId);
+    expect(issue?.status).toBe("in_progress");
+  });
+
   it("keeps a local run active when the recorded pid is still alive", async () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -876,6 +876,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   async function executeAutoCompleteFixture(input: {
     autoCompleteIssueOnSuccess?: boolean;
     adapterResult?: Awaited<ReturnType<typeof mockAdapterExecute>>;
+    seedConcreteActionEvidence?: boolean;
   }) {
     if (input.adapterResult) {
       mockAdapterExecute.mockResolvedValueOnce(input.adapterResult);
@@ -883,10 +884,20 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const fixture = await seedAutoCompleteIssueRunFixture({
       autoCompleteIssueOnSuccess: input.autoCompleteIssueOnSuccess,
     });
+    if (input.seedConcreteActionEvidence) {
+      await db.insert(issueComments).values({
+        companyId: fixture.companyId,
+        issueId: fixture.issueId,
+        authorAgentId: fixture.agentId,
+        createdByRunId: fixture.runId,
+        body: "Implemented the requested fix and verified the targeted behavior.",
+      });
+    }
     const heartbeat = heartbeatService(db);
 
     await heartbeat.resumeQueuedRuns();
     await waitForRunToSettle(heartbeat, fixture.runId);
+    await waitForHeartbeatIdle(db);
 
     const issue = await db.select().from(issues).where(eq(issues.id, fixture.issueId)).then((rows) => rows[0] ?? null);
     const run = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, fixture.runId)).then((rows) => rows[0] ?? null);
@@ -894,27 +905,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   }
 
   it("auto-completes the assigned issue after a successful live-content run when explicitly enabled", async () => {
-    mockAdapterExecute.mockImplementationOnce(async (ctx: { agent: { id: string; companyId: string }; runId: string; context: Record<string, unknown> }) => {
-      await db.insert(issueComments).values({
-        companyId: ctx.agent.companyId,
-        issueId: String(ctx.context.issueId),
-        authorAgentId: ctx.agent.id,
-        createdByRunId: ctx.runId,
-        body: "Implemented the requested fix and verified the targeted behavior.",
-      });
-      return {
-        exitCode: 0,
-        signal: null,
-        timedOut: false,
-        errorMessage: null,
-        summary: "Implemented the requested fix and verified the targeted behavior.",
-        provider: "test",
-        model: "test-model",
-      };
-    });
-
     const { issue, run } = await executeAutoCompleteFixture({
       autoCompleteIssueOnSuccess: true,
+      seedConcreteActionEvidence: true,
     });
 
     expect(run?.status).toBe("succeeded");

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2149,6 +2149,38 @@ export interface HeartbeatServiceOptions {
   environmentRuntime?: HeartbeatEnvironmentRuntime;
 }
 
+export type AutoCompleteIssueDecisionInput = {
+  outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
+  autoCompleteIssueOnSuccess: unknown;
+  livenessState: RunLivenessState | null;
+  issueStatus: string | null;
+  issueAssigneeAgentId: string | null;
+  issueExecutionRunId: string | null;
+  agentId: string;
+  runId: string;
+};
+
+export type AutoCompleteIssueDecision =
+  | { shouldComplete: true }
+  | { shouldComplete: false; reason: "disabled" | "outcome" | "liveness" | "missing_issue" | "terminal_issue" | "assignee" | "execution_lock" };
+
+export function decideAutoCompleteIssueOnSuccessfulRun(input: AutoCompleteIssueDecisionInput): AutoCompleteIssueDecision {
+  if (input.autoCompleteIssueOnSuccess !== true) return { shouldComplete: false, reason: "disabled" };
+  if (input.outcome !== "succeeded") return { shouldComplete: false, reason: "outcome" };
+  if (input.livenessState !== "advanced" && input.livenessState !== "completed") {
+    return { shouldComplete: false, reason: "liveness" };
+  }
+  if (!input.issueStatus) return { shouldComplete: false, reason: "missing_issue" };
+  if (input.issueStatus === "done" || input.issueStatus === "cancelled") {
+    return { shouldComplete: false, reason: "terminal_issue" };
+  }
+  if (input.issueAssigneeAgentId !== input.agentId) return { shouldComplete: false, reason: "assignee" };
+  if (input.issueExecutionRunId && input.issueExecutionRunId !== input.runId) {
+    return { shouldComplete: false, reason: "execution_lock" };
+  }
+  return { shouldComplete: true };
+}
+
 export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) {
   const instanceSettings = instanceSettingsService(db);
   const getCurrentUserRedactionOptions = async () => ({
@@ -3407,6 +3439,94 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const parsedPayload = parseObject(payload);
       const deferredContext = parseObject(parsedPayload[DEFERRED_WAKE_CONTEXT_KEY]);
       return Boolean(deriveCommentId(deferredContext, parsedPayload));
+    });
+  }
+
+  async function autoCompleteIssueOnSuccessfulRun(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    agent: typeof agents.$inferSelect;
+    issueId: string;
+    config: Record<string, unknown>;
+    outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
+    onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  }) {
+    const livenessState = input.run.livenessState as RunLivenessState | null;
+    if (input.config.autoCompleteIssueOnSuccess !== true || input.outcome !== "succeeded") return;
+
+    const issue = await db
+      .select({
+        id: issues.id,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(and(eq(issues.id, input.issueId), eq(issues.companyId, input.run.companyId)))
+      .then((rows) => rows[0] ?? null);
+    const decision = decideAutoCompleteIssueOnSuccessfulRun({
+      outcome: input.outcome,
+      autoCompleteIssueOnSuccess: input.config.autoCompleteIssueOnSuccess,
+      livenessState,
+      issueStatus: issue?.status ?? null,
+      issueAssigneeAgentId: issue?.assigneeAgentId ?? null,
+      issueExecutionRunId: issue?.executionRunId ?? null,
+      agentId: input.agent.id,
+      runId: input.run.id,
+    });
+    if (!decision.shouldComplete) {
+      if (decision.reason === "liveness") {
+        await input.onLog(
+          "stderr",
+          `[paperclip] Skipped auto-complete: run liveness state is ${livenessState ?? "unknown"}\n`,
+        );
+      } else if (decision.reason === "assignee") {
+        await input.onLog("stderr", "[paperclip] Skipped auto-complete: issue assignee changed before run completion\n");
+      } else if (decision.reason === "execution_lock") {
+        await input.onLog("stderr", "[paperclip] Skipped auto-complete: issue execution lock no longer belongs to this run\n");
+      }
+      return;
+    }
+
+    const completedIssue = await db
+      .update(issues)
+      .set({
+        status: "done",
+        updatedAt: new Date(),
+        completedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(issues.id, input.issueId),
+          eq(issues.companyId, input.run.companyId),
+          eq(issues.status, "in_progress"),
+          eq(issues.assigneeAgentId, input.agent.id),
+          or(isNull(issues.executionRunId), eq(issues.executionRunId, input.run.id)),
+        ),
+      )
+      .returning({ id: issues.id })
+      .then((rows) => rows[0] ?? null);
+    if (!completedIssue) {
+      await input.onLog("stderr", "[paperclip] Skipped auto-complete: issue state changed before completion update\n");
+      return;
+    }
+
+    await logActivity(db, {
+      companyId: input.run.companyId,
+      actorType: "agent",
+      actorId: input.agent.id,
+      agentId: input.agent.id,
+      action: "issue.status.changed",
+      entityType: "issue",
+      entityId: input.issueId,
+      runId: input.run.id,
+      details: { status: "done", source: "auto_complete_issue_on_success" },
+    });
+    await appendRunEvent(input.run, await nextRunEventSeq(input.run.id), {
+      eventType: "lifecycle",
+      stream: "system",
+      level: "info",
+      message: "auto-completed issue after successful run",
+      payload: { issueId: input.issueId },
     });
   }
 
@@ -5996,6 +6116,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           await scheduleBoundedRetryForRun(livenessRun, agent);
         }
         await finalizeIssueCommentPolicy(livenessRun, agent);
+        if (issueId) {
+          await autoCompleteIssueOnSuccessfulRun({
+            run: livenessRun,
+            agent,
+            issueId,
+            config,
+            outcome,
+            onLog,
+          });
+        }
         await releaseIssueExecutionAndPromote(livenessRun);
         await handleRunLivenessContinuation(livenessRun);
       }


### PR DESCRIPTION
## Summary

Makes the Paperclip/Kanban local worker path production-clean ready for bounded execution:

- adds Claude-local scoped mutation guard support for allowed write paths and exact Bash command allowlists
- disables Claude session resume/persistence while guarded settings are active
- preserves current remote runtime/config/bridge handling after rebasing onto latest `master`
- adds opt-in issue auto-completion for successful runs with concrete liveness evidence
- keeps auto-completion race-safe by requiring matching assignee and execution lock at update time
- documents guard behavior and caveats
- adds coverage for guard and auto-completion safety paths

## Verification

Passed locally on Tyler's Mac Mini after rebasing onto latest `paperclipai:master`:

- `git diff --check`
- `pnpm check:tokens`
- targeted server tests: 63 passed
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/adapter-claude-local build`
- `pnpm --filter @paperclipai/adapter-openclaw-gateway build`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:run`

Verification logs:

- `/tmp/paperclip_pr_rebase_verify_1138.log`
- `/tmp/paperclip_pr_rebase_full_test_1139.log`

Earlier pre-rebase verification log:

- `/tmp/paperclip_production_clean_verify_1104.log`

Status artifact:

- `/Users/tm_admin/clawd/shared/hermes-openclaw/status/2026-05-01_1106-paperclip-kanban-production-clean-ready.md`

## Caveats

- The mutation guard is a path/tool guard for Claude Code built-in mutation tools, not a complete OS sandbox.
- This PR is opened from Tyler's fork because `tyad67-netizen` does not have direct push permission to `paperclipai/paperclip`.
