### PR TITLE
ELEAAA-457: enforce placeholder comment cap

### DIFF
--- a/packages/shared/src/__tests__/placeholder.test.ts
+++ b/packages/shared/src/__tests__/placeholder.test.ts
@@ -44,6 +44,8 @@ describe("placeholder comments", () => {
     "No operation performed because the API was unavailable.",
     "Continuing with implementation after reading the plan.",
     "Polling Paperclip would be wrong here, so I am exiting.",
+    "Self-wake: implemented rate-limiting for ELEAAA-462 and verified all edge cases.",
+    "Self-wake — actually pausing because the Redis pool is exhausted; investigating now",
     "....",
   ])("rejects non-placeholder body %j", (body) => {
     expect(isPlaceholderCommentBody(body)).toBe(false);

--- a/packages/shared/src/__tests__/placeholder.test.ts
+++ b/packages/shared/src/__tests__/placeholder.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_PLACEHOLDER_PATTERNS, isPlaceholderCommentBody } from "../placeholder.js";
+
+describe("placeholder comments", () => {
+  it("ships the approved 9-pattern default set", () => {
+    expect(DEFAULT_PLACEHOLDER_PATTERNS).toHaveLength(9);
+  });
+
+  it.each([
+    "Parked",
+    "parked.",
+    "  Parking  ",
+    "Silent",
+    "Silent.",
+    "Silent exit",
+    "silent exit.",
+    "Self-wake waiting for review",
+    "selfwake loop",
+    "Done for this heartbeat",
+    "Noop.",
+    "Blocked",
+    ".",
+    "..",
+    "...",
+    "Heartbeat over",
+    "Continuing.",
+    "Working",
+    "Idle",
+    "Polling.",
+  ])("matches default placeholder body %j", (body) => {
+    expect(isPlaceholderCommentBody(body)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "   ",
+    null,
+    undefined,
+    "Done: implemented the placeholder detector.",
+    "Parked. Investigating M2 dashboard outage.",
+    "Blocked by ELEAAA-457: waiting for CTO review.",
+    "Working on the failing test now.",
+    "Parking lot update: route guard still needs a child issue.",
+    "No operation performed because the API was unavailable.",
+    "Continuing with implementation after reading the plan.",
+    "Polling Paperclip would be wrong here, so I am exiting.",
+    "....",
+  ])("rejects non-placeholder body %j", (body) => {
+    expect(isPlaceholderCommentBody(body)).toBe(false);
+  });
+
+  it("accepts an explicit regex set override", () => {
+    expect(isPlaceholderCommentBody("ship it", [/^ship it$/i])).toBe(true);
+    expect(isPlaceholderCommentBody("ship it")).toBe(false);
+  });
+});

--- a/packages/shared/src/__tests__/placeholder.test.ts
+++ b/packages/shared/src/__tests__/placeholder.test.ts
@@ -1,58 +1,49 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_PLACEHOLDER_PATTERNS, isPlaceholderCommentBody } from "../placeholder.js";
+import { PLACEHOLDER_COMMENT_PREFIXES, isPlaceholderCommentBody, stripMarkdown } from "../placeholder.js";
 
 describe("placeholder comments", () => {
-  it("ships the approved 9-pattern default set", () => {
-    expect(DEFAULT_PLACEHOLDER_PATTERNS).toHaveLength(9);
+  it("ships the approved v2 prefix list", () => {
+    expect(PLACEHOLDER_COMMENT_PREFIXES).toEqual([
+      "acknowledg",
+      "working on",
+      "continuing",
+      "stale",
+      "pure self-comment",
+      "heartbeat handled",
+    ]);
   });
 
   it.each([
-    "Parked",
-    "parked.",
-    "  Parking  ",
-    "Silent",
-    "Silent.",
-    "Silent exit",
-    "silent exit.",
-    "Self-wake waiting for review",
-    "selfwake loop",
-    "Done for this heartbeat",
-    "Noop.",
-    "Blocked",
-    ".",
-    "..",
-    "...",
-    "Heartbeat over",
-    "Continuing.",
-    "Working",
-    "Idle",
-    "Polling.",
-  ])("matches default placeholder body %j", (body) => {
+    "Ack",
+    "Acknowledged, continuing.",
+    "Working on the next step after this wake.",
+    "Continuing with the planned route guard update.",
+    "Stale wake with no new information.",
+    "Pure self-comment to keep the issue warm.",
+    "Heartbeat handled, no external context changed.",
+    "There is no external context change since the previous wake.",
+    "PR #4977 merged.",
+    "**Ack**",
+  ])("matches v2 placeholder body %j", (body) => {
     expect(isPlaceholderCommentBody(body)).toBe(true);
   });
 
   it.each([
-    "",
-    "   ",
     null,
     undefined,
+    "Done: implemented the placeholder detector and verified the route guard.",
+    "Parked. Investigating M2 dashboard outage with root-cause notes attached.",
+    "Blocked by ELEAAA-457: waiting for CTO review on the upstream dependency.",
     "Done: implemented the placeholder detector.",
-    "Parked. Investigating M2 dashboard outage.",
-    "Blocked by ELEAAA-457: waiting for CTO review.",
-    "Working on the failing test now.",
-    "Parking lot update: route guard still needs a child issue.",
-    "No operation performed because the API was unavailable.",
-    "Continuing with implementation after reading the plan.",
-    "Polling Paperclip would be wrong here, so I am exiting.",
+    "A real update with enough detail about tests, files changed, and remaining risk.",
     "Self-wake: implemented rate-limiting for ELEAAA-462 and verified all edge cases.",
-    "Self-wake — actually pausing because the Redis pool is exhausted; investigating now",
-    "....",
   ])("rejects non-placeholder body %j", (body) => {
     expect(isPlaceholderCommentBody(body)).toBe(false);
   });
 
-  it("accepts an explicit regex set override", () => {
-    expect(isPlaceholderCommentBody("ship it", [/^ship it$/i])).toBe(true);
-    expect(isPlaceholderCommentBody("ship it")).toBe(false);
+  it("strips markdown before applying the length threshold", () => {
+    expect(stripMarkdown("**Ack**")).toBe("Ack");
+    expect(stripMarkdown("[real update](https://example.com)")).toBe("real update");
+    expect(isPlaceholderCommentBody("**Detailed implementation note with real verification context.**")).toBe(false);
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -220,6 +220,8 @@ export {
   validateConfiguredBindMode,
 } from "./network-bind.js";
 
+export { DEFAULT_PLACEHOLDER_PATTERNS, isPlaceholderCommentBody } from "./placeholder.js";
+
 export type {
   Company,
   Environment,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -220,7 +220,7 @@ export {
   validateConfiguredBindMode,
 } from "./network-bind.js";
 
-export { DEFAULT_PLACEHOLDER_PATTERNS, isPlaceholderCommentBody } from "./placeholder.js";
+export { PLACEHOLDER_COMMENT_PREFIXES, isPlaceholderCommentBody, stripMarkdown } from "./placeholder.js";
 
 export type {
   Company,

--- a/packages/shared/src/placeholder.ts
+++ b/packages/shared/src/placeholder.ts
@@ -2,7 +2,7 @@ export const DEFAULT_PLACEHOLDER_PATTERNS: ReadonlyArray<RegExp> = Object.freeze
   /^\s*Parked\.?\s*$/i,
   /^\s*Parking\.?\s*$/i,
   /^\s*Silent(?:\.|\s+exit\.?)?\s*$/i,
-  /^\s*Self-?wake.*$/i,
+  /^\s*Self-?wake(?:\s+(?:loop|exit|waiting(?:\s+for\s+\w+)?))?\.?\s*$/i,
   /^\s*Done for this heartbeat\.?\s*$/i,
   /^\s*Noop\.?\s*$/i,
   /^\s*Blocked\.?\s*$/i,

--- a/packages/shared/src/placeholder.ts
+++ b/packages/shared/src/placeholder.ts
@@ -1,0 +1,25 @@
+export const DEFAULT_PLACEHOLDER_PATTERNS: ReadonlyArray<RegExp> = Object.freeze([
+  /^\s*Parked\.?\s*$/i,
+  /^\s*Parking\.?\s*$/i,
+  /^\s*Silent(?:\.|\s+exit\.?)?\s*$/i,
+  /^\s*Self-?wake.*$/i,
+  /^\s*Done for this heartbeat\.?\s*$/i,
+  /^\s*Noop\.?\s*$/i,
+  /^\s*Blocked\.?\s*$/i,
+  /^\s*\.{1,3}\s*$/,
+  /^\s*(?:Heartbeat over|Continuing|Working|Idle|Polling)\.?\s*$/i,
+]);
+
+export function isPlaceholderCommentBody(
+  body: string | null | undefined,
+  regexSet: ReadonlyArray<RegExp> = DEFAULT_PLACEHOLDER_PATTERNS,
+): boolean {
+  const normalizedBody = body?.trim();
+  if (!normalizedBody) return false;
+
+  for (const pattern of regexSet) {
+    pattern.lastIndex = 0;
+    if (pattern.test(normalizedBody)) return true;
+  }
+  return false;
+}

--- a/packages/shared/src/placeholder.ts
+++ b/packages/shared/src/placeholder.ts
@@ -1,25 +1,31 @@
-export const DEFAULT_PLACEHOLDER_PATTERNS: ReadonlyArray<RegExp> = Object.freeze([
-  /^\s*Parked\.?\s*$/i,
-  /^\s*Parking\.?\s*$/i,
-  /^\s*Silent(?:\.|\s+exit\.?)?\s*$/i,
-  /^\s*Self-?wake(?:\s+(?:loop|exit|waiting(?:\s+for\s+\w+)?))?\.?\s*$/i,
-  /^\s*Done for this heartbeat\.?\s*$/i,
-  /^\s*Noop\.?\s*$/i,
-  /^\s*Blocked\.?\s*$/i,
-  /^\s*\.{1,3}\s*$/,
-  /^\s*(?:Heartbeat over|Continuing|Working|Idle|Polling)\.?\s*$/i,
-]);
+export const PLACEHOLDER_COMMENT_PREFIXES = [
+  "acknowledg",
+  "working on",
+  "continuing",
+  "stale",
+  "pure self-comment",
+  "heartbeat handled",
+] as const;
 
-export function isPlaceholderCommentBody(
-  body: string | null | undefined,
-  regexSet: ReadonlyArray<RegExp> = DEFAULT_PLACEHOLDER_PATTERNS,
-): boolean {
-  const normalizedBody = body?.trim();
-  if (!normalizedBody) return false;
+export function stripMarkdown(body: string): string {
+  return body
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[*_~>#]/g, "")
+    .replace(/^\s*[-+]\s+/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
 
-  for (const pattern of regexSet) {
-    pattern.lastIndex = 0;
-    if (pattern.test(normalizedBody)) return true;
-  }
+export function isPlaceholderCommentBody(body: string | null | undefined): boolean {
+  if (body == null) return false;
+  const stripped = stripMarkdown(body).trim();
+  if (stripped.length < 30) return true;
+
+  const lc = stripped.toLowerCase();
+  if (PLACEHOLDER_COMMENT_PREFIXES.some((prefix) => lc.startsWith(prefix))) return true;
+  if (lc.includes("no external context change")) return true;
   return false;
 }

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -202,6 +202,7 @@ export const addIssueCommentSchema = z.object({
   reopen: z.boolean().optional(),
   resume: z.boolean().optional(),
   interrupt: z.boolean().optional(),
+  forceCommentAllow: z.boolean().optional(),
 });
 
 export type AddIssueComment = z.infer<typeof addIssueCommentSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: 0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -258,7 +258,7 @@ importers:
         version: link:../shared
       drizzle-orm:
         specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -553,7 +553,7 @@ importers:
         version: 3.0.1(ajv@8.18.0)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -568,7 +568,7 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -596,9 +596,6 @@ importers:
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
-      prom-client:
-        specifier: ^15.1.3
-        version: 15.1.3
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -2299,10 +2296,6 @@ packages:
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
-
-  '@opentelemetry/api@1.9.1':
-    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
-    engines: {node: '>=8.0.0'}
 
   '@paperclipai/adapter-utils@2026.325.0':
     resolution: {integrity: sha512-YDVSAgjkeJ0PvxXDJVN9MZDX7oYRzidLtGHmGgRGd6gSk/bF2ygAKvND4FI1YxDc/cRLQjqAFCpCYaC/9wqIEA==}
@@ -4164,9 +4157,6 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  bintrees@1.0.2:
-    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
-
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -5831,10 +5821,6 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
-  prom-client@15.1.3:
-    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
-    engines: {node: ^16 || ^18 || >=20}
-
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -6260,9 +6246,6 @@ packages:
 
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
-
-  tdigest@0.1.2:
-    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -8685,8 +8668,6 @@ snapshots:
 
   '@open-draft/deferred-promise@2.2.0': {}
 
-  '@opentelemetry/api@1.9.1': {}
-
   '@paperclipai/adapter-utils@2026.325.0': {}
 
   '@paralleldrive/cuid2@2.3.1':
@@ -10621,7 +10602,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
+  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -10637,7 +10618,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -10655,8 +10636,6 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-
-  bintrees@1.0.2: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -11169,10 +11148,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4):
+  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
-      '@opentelemetry/api': 1.9.1
       '@types/react': 19.2.14
       kysely: 0.28.11
       pg: 8.18.0
@@ -12638,11 +12616,6 @@ snapshots:
 
   process-warning@5.0.0: {}
 
-  prom-client@15.1.3:
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      tdigest: 0.1.2
-
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -13252,10 +13225,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-
-  tdigest@0.1.2:
-    dependencies:
-      bintrees: 1.0.2
 
   teex@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: 0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -258,7 +258,7 @@ importers:
         version: link:../shared
       drizzle-orm:
         specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -553,7 +553,7 @@ importers:
         version: 3.0.1(ajv@8.18.0)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -568,7 +568,7 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -596,6 +596,9 @@ importers:
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -2296,6 +2299,10 @@ packages:
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@paperclipai/adapter-utils@2026.325.0':
     resolution: {integrity: sha512-YDVSAgjkeJ0PvxXDJVN9MZDX7oYRzidLtGHmGgRGd6gSk/bF2ygAKvND4FI1YxDc/cRLQjqAFCpCYaC/9wqIEA==}
@@ -4157,6 +4164,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -5821,6 +5831,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -6246,6 +6260,9 @@ packages:
 
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -8668,6 +8685,8 @@ snapshots:
 
   '@open-draft/deferred-promise@2.2.0': {}
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@paperclipai/adapter-utils@2026.325.0': {}
 
   '@paralleldrive/cuid2@2.3.1':
@@ -10602,7 +10621,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
+  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -10618,7 +10637,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -10636,6 +10655,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bintrees@1.0.2: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -11148,9 +11169,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4):
+  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
+      '@opentelemetry/api': 1.9.1
       '@types/react': 19.2.14
       kysely: 0.28.11
       pg: 8.18.0
@@ -12616,6 +12638,11 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -13225,6 +13252,10 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   teex@1.0.1:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -40,6 +40,7 @@
     "postpack": "rm -rf ui-dist",
     "clean": "rm -rf dist",
     "start": "node dist/index.js",
+    "test": "vitest run",
     "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit"
   },
   "dependencies": {
@@ -73,6 +74,7 @@
     "pino": "^9.6.0",
     "pino-http": "^10.4.0",
     "pino-pretty": "^13.1.3",
+    "prom-client": "^15.1.3",
     "sharp": "^0.34.5",
     "ws": "^8.19.0",
     "zod": "^3.24.2"

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -7,6 +7,7 @@ const mockIssueService = vi.hoisted(() => ({
   assertCheckoutOwner: vi.fn(),
   update: vi.fn(),
   addComment: vi.fn(),
+  countOwnRecentPlaceholderComments: vi.fn(),
   getDependencyReadiness: vi.fn(),
   findMentionedAgents: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
@@ -213,6 +214,7 @@ describe.sequential("issue comment reopen routes", () => {
     mockIssueService.assertCheckoutOwner.mockReset();
     mockIssueService.update.mockReset();
     mockIssueService.addComment.mockReset();
+    mockIssueService.countOwnRecentPlaceholderComments.mockReset();
     mockIssueService.getDependencyReadiness.mockReset();
     mockIssueService.findMentionedAgents.mockReset();
     mockIssueService.listWakeableBlockedDependents.mockReset();
@@ -271,6 +273,11 @@ describe.sequential("issue comment reopen routes", () => {
       updatedAt: new Date(),
       authorAgentId: null,
       authorUserId: "local-board",
+    });
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue({
+      count: 0,
+      windowComments: 3,
+      oldestPlaceholderAt: null,
     });
     mockIssueService.findMentionedAgents.mockResolvedValue([]);
     mockIssueService.getDependencyReadiness.mockResolvedValue({

--- a/server/src/__tests__/issue-placeholder-comment-cap.test.ts
+++ b/server/src/__tests__/issue-placeholder-comment-cap.test.ts
@@ -310,6 +310,8 @@ describe.sequential("issue placeholder comment cap route", () => {
 
     const res = await postComment(agentActor(), { body: "Ack" });
 
+    // The request-time guard is best effort: parallel posts can race count+insert,
+    // but the approved v2 bound is <=4 placeholders before the next attempt blocks.
     expect(res.status).toBe(409);
     expect(res.headers["content-type"]).toMatch(/^application\/json/);
     expect(res.body).toEqual({
@@ -400,7 +402,9 @@ describe.sequential("issue placeholder comment cap route", () => {
     const res = await postComment(agentActor(), { body: "Ack", forceCommentAllow: true });
 
     expect(res.status).toBe(409);
-    await expect(metricText()).resolves.not.toContain("paperclip_placeholder_cap_overrides_total");
+    await expect(metricText()).resolves.not.toContain(
+      'paperclip_placeholder_cap_overrides_total{agent_id="22222222-2222-4222-8222-222222222222"}',
+    );
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/issue-placeholder-comment-cap.test.ts
+++ b/server/src/__tests__/issue-placeholder-comment-cap.test.ts
@@ -1,0 +1,390 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { register } from "../observability/prom.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  assertCheckoutOwner: vi.fn(),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  countOwnRecentPlaceholderComments: vi.fn(),
+  getDependencyReadiness: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  list: vi.fn(),
+  resolveByReference: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockDb = vi.hoisted(() => ({
+  transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn({})),
+}));
+const mockFeedbackService = vi.hoisted(() => ({
+  listIssueVotesForUser: vi.fn(async () => []),
+  saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+}));
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  get: vi.fn(async () => ({
+    id: "instance-settings-1",
+    general: {
+      censorUsernameInLogs: false,
+      feedbackDataSharingPreference: "prompt",
+    },
+  })),
+  listCompanyIds: vi.fn(async () => ["company-1"]),
+}));
+const mockRoutineService = vi.hoisted(() => ({
+  syncRunStatusForIssue: vi.fn(async () => undefined),
+}));
+const mockIssueThreadInteractionService = vi.hoisted(() => ({
+  expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+  expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+}));
+const mockIssueTreeControlService = vi.hoisted(() => ({
+  getActivePauseHoldGate: vi.fn(async () => null),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentTaskCompleted: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+}));
+
+vi.mock("../services/access.js", () => ({
+  accessService: () => mockAccessService,
+}));
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+}));
+
+vi.mock("../services/agents.js", () => ({
+  agentService: () => mockAgentService,
+}));
+
+vi.mock("../services/feedback.js", () => ({
+  feedbackService: () => mockFeedbackService,
+}));
+
+vi.mock("../services/heartbeat.js", () => ({
+  heartbeatService: () => mockHeartbeatService,
+}));
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: () => mockInstanceSettingsService,
+}));
+
+vi.mock("../services/issues.js", () => ({
+  issueService: () => mockIssueService,
+}));
+
+vi.mock("../services/routines.js", () => ({
+  routineService: () => mockRoutineService,
+}));
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => mockFeedbackService,
+  goalService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  instanceSettingsService: () => mockInstanceSettingsService,
+  issueApprovalService: () => ({}),
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueService: () => mockIssueService,
+  issueThreadInteractionService: () => mockIssueThreadInteractionService,
+  issueTreeControlService: () => mockIssueTreeControlService,
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  routineService: () => mockRoutineService,
+  workProductService: () => ({}),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  return app;
+}
+
+async function installActor(app: express.Express, actor?: Record<string, unknown>) {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/issues.js"),
+    import("../middleware/index.js"),
+  ]);
+  app.use((req, _res, next) => {
+    (req as any).actor = actor ?? {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes(mockDb as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue() {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    companyId: "company-1",
+    status: "todo",
+    assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+    assigneeUserId: null,
+    createdByUserId: "local-board",
+    identifier: "PAP-580",
+    title: "Placeholder comment cap",
+  };
+}
+
+function agentActor(agentId = "22222222-2222-4222-8222-222222222222") {
+  return {
+    type: "agent",
+    agentId,
+    companyId: "company-1",
+    source: "agent_key",
+    runId: "run-1",
+  };
+}
+
+function commentBody(body: string, agentId: string | null = "22222222-2222-4222-8222-222222222222") {
+  return {
+    id: "comment-1",
+    issueId: "11111111-1111-4111-8111-111111111111",
+    companyId: "company-1",
+    body,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    authorAgentId: agentId,
+    authorUserId: agentId ? null : "local-board",
+  };
+}
+
+function placeholderCount(count: number) {
+  return { count, windowSeconds: 1800, windowComments: 5 };
+}
+
+async function postComment(actor: Record<string, unknown>, body: Record<string, unknown>) {
+  return request(await installActor(createApp(), actor))
+    .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+    .send(body);
+}
+
+async function metricText() {
+  return register.metrics();
+}
+
+describe.sequential("issue placeholder comment cap route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    register.resetMetrics();
+    mockIssueService.getById.mockResolvedValue(makeIssue());
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue(),
+      ...patch,
+    }));
+    mockIssueService.addComment.mockImplementation(async (_id: string, body: string, actor: { agentId?: string }) =>
+      commentBody(body, actor.agentId ?? null),
+    );
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(0));
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "11111111-1111-4111-8111-111111111111",
+      blockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockAccessService.canUser.mockResolvedValue(false);
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAgentService.getById.mockResolvedValue(null);
+    mockAgentService.list.mockResolvedValue([
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        reportsTo: null,
+        permissions: { canCreateAgents: false },
+      },
+      {
+        id: "44444444-4444-4444-8444-444444444444",
+        reportsTo: null,
+        permissions: { canCreateAgents: false },
+      },
+    ]);
+    mockRoutineService.syncRunStatusForIssue.mockResolvedValue(undefined);
+    mockIssueTreeControlService.getActivePauseHoldGate.mockResolvedValue(null);
+  });
+
+  it("allows agent non-placeholder comments", async () => {
+    const res = await postComment(agentActor(), { body: "I found the failing route and am adding a focused test." });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "I found the failing route and am adding a focused test.",
+      expect.objectContaining({ agentId: "22222222-2222-4222-8222-222222222222" }),
+    );
+  });
+
+  it("allows the first agent placeholder comment in the window", async () => {
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(0));
+
+    const res = await postComment(agentActor(), { body: "Parked." });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.countOwnRecentPlaceholderComments).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+  });
+
+  it("blocks the second agent placeholder comment in the window", async () => {
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(1));
+
+    const res = await postComment(agentActor(), { body: "Parked." });
+
+    expect(res.status).toBe(409);
+    expect(res.headers["content-type"]).toMatch(/^application\/json/);
+    expect(res.body).toEqual({
+      error: "placeholder_comment_cap",
+      message:
+        "Comment blocked: prior placeholder comment(s) already posted in window. Flip status (blocked / done / in_review with a real comment) or exit silent instead.",
+      windowSeconds: 1800,
+      windowComments: 5,
+      priorPlaceholderCount: 1,
+      alternatives: [
+        'PATCH /api/issues/{id} {"status":"blocked","unblockOwner":"..."}',
+        'PATCH /api/issues/{id} {"status":"in_review","assigneeUserId":"local-board"}',
+        "exit run silently -- no post",
+      ],
+    });
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("allows a placeholder when the service window has expired", async () => {
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(0));
+
+    const res = await postComment(agentActor(), { body: "Idle." });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+  });
+
+  it("does not count another agent's placeholders against the actor", async () => {
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(0));
+
+    const res = await postComment(agentActor(), { body: "Noop." });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.countOwnRecentPlaceholderComments).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+    );
+  });
+
+  it("lets board users force a placeholder comment override and logs it", async () => {
+    const res = await postComment(
+      {
+        type: "board",
+        userId: "local-board",
+        companyIds: ["company-1"],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      },
+      { body: "Parked.", forceCommentAllow: true },
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.placeholder_cap_overridden",
+        entityId: "11111111-1111-4111-8111-111111111111",
+        details: expect.objectContaining({
+          overriddenAgentId: "22222222-2222-4222-8222-222222222222",
+          forceCommentAllow: true,
+        }),
+      }),
+    );
+    await expect(metricText()).resolves.toContain(
+      'paperclip_placeholder_cap_overrides_total{agent_id="22222222-2222-4222-8222-222222222222"} 1',
+    );
+  });
+
+  it("ignores agent supplied forceCommentAllow", async () => {
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(1));
+
+    const res = await postComment(agentActor(), { body: "Parked.", forceCommentAllow: true });
+
+    expect(res.status).toBe(409);
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("increments the cap-hit metric and activity log when blocking", async () => {
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(1));
+
+    const res = await postComment(agentActor(), { body: "Parked." });
+
+    expect(res.status).toBe(409);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.placeholder_cap_hit",
+        entityId: "11111111-1111-4111-8111-111111111111",
+        details: expect.objectContaining({
+          priorPlaceholderCount: 1,
+          windowSeconds: 1800,
+          windowComments: 5,
+        }),
+      }),
+    );
+    await expect(metricText()).resolves.toContain(
+      'paperclip_placeholder_cap_hits_total{agent_id="22222222-2222-4222-8222-222222222222"} 1',
+    );
+  });
+});

--- a/server/src/__tests__/issue-placeholder-comment-cap.test.ts
+++ b/server/src/__tests__/issue-placeholder-comment-cap.test.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import request from "supertest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { register } from "../observability/prom.js";
 
 const mockIssueService = vi.hoisted(() => ({
@@ -201,8 +201,11 @@ function commentBody(body: string, agentId: string | null = "22222222-2222-4222-
   };
 }
 
+const ORIGINAL_PLACEHOLDER_CAP_ENABLED = process.env.PAPERCLIP_PLACEHOLDER_CAP_ENABLED;
+const OLDEST_PLACEHOLDER_AT = "2026-05-04T16:00:00.000Z";
+
 function placeholderCount(count: number) {
-  return { count, windowSeconds: 1800, windowComments: 5 };
+  return { count, windowComments: 3, oldestPlaceholderAt: count > 0 ? OLDEST_PLACEHOLDER_AT : null };
 }
 
 async function postComment(actor: Record<string, unknown>, body: Record<string, unknown>) {
@@ -218,6 +221,7 @@ async function metricText() {
 describe.sequential("issue placeholder comment cap route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.PAPERCLIP_PLACEHOLDER_CAP_ENABLED;
     register.resetMetrics();
     mockIssueService.getById.mockResolvedValue(makeIssue());
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
@@ -259,10 +263,19 @@ describe.sequential("issue placeholder comment cap route", () => {
     mockIssueTreeControlService.getActivePauseHoldGate.mockResolvedValue(null);
   });
 
+  afterEach(() => {
+    if (ORIGINAL_PLACEHOLDER_CAP_ENABLED === undefined) {
+      delete process.env.PAPERCLIP_PLACEHOLDER_CAP_ENABLED;
+    } else {
+      process.env.PAPERCLIP_PLACEHOLDER_CAP_ENABLED = ORIGINAL_PLACEHOLDER_CAP_ENABLED;
+    }
+  });
+
   it("allows agent non-placeholder comments", async () => {
     const res = await postComment(agentActor(), { body: "I found the failing route and am adding a focused test." });
 
     expect(res.status).toBe(201);
+    expect(mockIssueService.countOwnRecentPlaceholderComments).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
       "I found the failing route and am adding a focused test.",
@@ -270,10 +283,10 @@ describe.sequential("issue placeholder comment cap route", () => {
     );
   });
 
-  it("allows the first agent placeholder comment in the window", async () => {
+  it("allows the first agent placeholder comment", async () => {
     mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(0));
 
-    const res = await postComment(agentActor(), { body: "Parked." });
+    const res = await postComment(agentActor(), { body: "Ack" });
 
     expect(res.status).toBe(201);
     expect(mockIssueService.countOwnRecentPlaceholderComments).toHaveBeenCalledWith(
@@ -283,33 +296,58 @@ describe.sequential("issue placeholder comment cap route", () => {
     expect(mockIssueService.addComment).toHaveBeenCalled();
   });
 
-  it("blocks the second agent placeholder comment in the window", async () => {
+  it("allows the second agent placeholder comment", async () => {
     mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(1));
 
-    const res = await postComment(agentActor(), { body: "Parked." });
+    const res = await postComment(agentActor(), { body: "Ack" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+  });
+
+  it("blocks the third consecutive agent placeholder comment", async () => {
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(2));
+
+    const res = await postComment(agentActor(), { body: "Ack" });
 
     expect(res.status).toBe(409);
     expect(res.headers["content-type"]).toMatch(/^application\/json/);
     expect(res.body).toEqual({
-      error: "placeholder_comment_cap",
+      error: "placeholder_cap",
       message:
-        "Comment blocked: prior placeholder comment(s) already posted in window. Flip status (blocked / done / in_review with a real comment) or exit silent instead.",
-      windowSeconds: 1800,
-      windowComments: 5,
-      priorPlaceholderCount: 1,
+        "Comment blocked: this would be your 3rd consecutive placeholder on this issue. Flip status (blocked / in_review / done with a real comment) or exit silent.",
+      cap: 3,
+      last_n_placeholders: 3,
+      oldest_placeholder_at: OLDEST_PLACEHOLDER_AT,
       alternatives: [
         'PATCH /api/issues/{id} {"status":"blocked","unblockOwner":"..."}',
-        'PATCH /api/issues/{id} {"status":"in_review","assigneeUserId":"local-board"}',
-        "exit run silently -- no post",
+        'PATCH /api/issues/{id} {"status":"in_review"}',
+        "exit run silently — no post",
       ],
     });
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.placeholder_cap_hit",
+        entityId: "11111111-1111-4111-8111-111111111111",
+        details: expect.objectContaining({
+          cap: 3,
+          priorPlaceholderCount: 2,
+          windowComments: 3,
+          oldestPlaceholderAt: OLDEST_PLACEHOLDER_AT,
+        }),
+      }),
+    );
+    await expect(metricText()).resolves.toContain(
+      'paperclip_placeholder_cap_hits_total{agent_id="22222222-2222-4222-8222-222222222222",issue_id="11111111-1111-4111-8111-111111111111"} 1',
+    );
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
-  it("allows a placeholder when the service window has expired", async () => {
-    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(0));
+  it("allows a placeholder when a real comment resets the sliding window", async () => {
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(1));
 
-    const res = await postComment(agentActor(), { body: "Idle." });
+    const res = await postComment(agentActor(), { body: "Ack" });
 
     expect(res.status).toBe(201);
     expect(mockIssueService.addComment).toHaveBeenCalled();
@@ -318,7 +356,7 @@ describe.sequential("issue placeholder comment cap route", () => {
   it("does not count another agent's placeholders against the actor", async () => {
     mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(0));
 
-    const res = await postComment(agentActor(), { body: "Noop." });
+    const res = await postComment(agentActor(), { body: "Ack" });
 
     expect(res.status).toBe(201);
     expect(mockIssueService.countOwnRecentPlaceholderComments).toHaveBeenCalledWith(
@@ -336,7 +374,7 @@ describe.sequential("issue placeholder comment cap route", () => {
         source: "local_implicit",
         isInstanceAdmin: false,
       },
-      { body: "Parked.", forceCommentAllow: true },
+      { body: "Ack", forceCommentAllow: true },
     );
 
     expect(res.status).toBe(201);
@@ -357,34 +395,40 @@ describe.sequential("issue placeholder comment cap route", () => {
   });
 
   it("ignores agent supplied forceCommentAllow", async () => {
-    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(1));
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(2));
 
-    const res = await postComment(agentActor(), { body: "Parked.", forceCommentAllow: true });
+    const res = await postComment(agentActor(), { body: "Ack", forceCommentAllow: true });
 
     expect(res.status).toBe(409);
+    await expect(metricText()).resolves.not.toContain("paperclip_placeholder_cap_overrides_total");
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
-  it("increments the cap-hit metric and activity log when blocking", async () => {
-    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(1));
+  it("allows board actors to post placeholders without the agent guard", async () => {
+    const actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
 
-    const res = await postComment(agentActor(), { body: "Parked." });
+    const first = await postComment(actor, { body: "Ack" });
+    const second = await postComment(actor, { body: "Ack" });
+    const third = await postComment(actor, { body: "Ack" });
 
-    expect(res.status).toBe(409);
-    expect(mockLogActivity).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        action: "issue.placeholder_cap_hit",
-        entityId: "11111111-1111-4111-8111-111111111111",
-        details: expect.objectContaining({
-          priorPlaceholderCount: 1,
-          windowSeconds: 1800,
-          windowComments: 5,
-        }),
-      }),
-    );
-    await expect(metricText()).resolves.toContain(
-      'paperclip_placeholder_cap_hits_total{agent_id="22222222-2222-4222-8222-222222222222"} 1',
-    );
+    expect([first.status, second.status, third.status]).toEqual([201, 201, 201]);
+    expect(mockIssueService.countOwnRecentPlaceholderComments).not.toHaveBeenCalled();
+  });
+
+  it("skips the placeholder guard when PAPERCLIP_PLACEHOLDER_CAP_ENABLED is false", async () => {
+    process.env.PAPERCLIP_PLACEHOLDER_CAP_ENABLED = "false";
+    mockIssueService.countOwnRecentPlaceholderComments.mockResolvedValue(placeholderCount(2));
+
+    const res = await postComment(agentActor(), { body: "Ack" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.countOwnRecentPlaceholderComments).not.toHaveBeenCalled();
+    await expect(metricText()).resolves.not.toContain("paperclip_placeholder_cap_hits_total{");
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -208,6 +208,117 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(resultIds.has(excludedIssueId)).toBe(false);
   });
 
+  it("counts only the current placeholder streak from an agent's recent comments", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const otherAgentId = randomUUID();
+    const resetIssueId = randomUUID();
+    const cappedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: agentId,
+        companyId,
+        name: "Backend",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: otherAgentId,
+        companyId,
+        name: "Other",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(issues).values([
+      {
+        id: resetIssueId,
+        companyId,
+        title: "Reset issue",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: cappedIssueId,
+        companyId,
+        title: "Capped issue",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    await db.insert(issueComments).values([
+      {
+        companyId,
+        issueId: resetIssueId,
+        authorAgentId: agentId,
+        body: "Ack",
+        createdAt: new Date("2026-05-04T16:00:00.000Z"),
+        updatedAt: new Date("2026-05-04T16:00:00.000Z"),
+      },
+      {
+        companyId,
+        issueId: resetIssueId,
+        authorAgentId: agentId,
+        body: "Detailed implementation update with enough context to reset the placeholder streak.",
+        createdAt: new Date("2026-05-04T16:01:00.000Z"),
+        updatedAt: new Date("2026-05-04T16:01:00.000Z"),
+      },
+      {
+        companyId,
+        issueId: cappedIssueId,
+        authorAgentId: agentId,
+        body: "Ack",
+        createdAt: new Date("2026-05-04T16:00:00.000Z"),
+        updatedAt: new Date("2026-05-04T16:00:00.000Z"),
+      },
+      {
+        companyId,
+        issueId: cappedIssueId,
+        authorAgentId: otherAgentId,
+        body: "Ack",
+        createdAt: new Date("2026-05-04T16:01:00.000Z"),
+        updatedAt: new Date("2026-05-04T16:01:00.000Z"),
+      },
+      {
+        companyId,
+        issueId: cappedIssueId,
+        authorAgentId: agentId,
+        body: "Ack",
+        createdAt: new Date("2026-05-04T16:02:00.000Z"),
+        updatedAt: new Date("2026-05-04T16:02:00.000Z"),
+      },
+    ]);
+
+    await expect(svc.countOwnRecentPlaceholderComments(resetIssueId, agentId)).resolves.toEqual({
+      count: 0,
+      windowComments: 3,
+      oldestPlaceholderAt: null,
+    });
+    await expect(svc.countOwnRecentPlaceholderComments(cappedIssueId, agentId)).resolves.toEqual({
+      count: 2,
+      windowComments: 3,
+      oldestPlaceholderAt: "2026-05-04T16:00:00.000Z",
+    });
+  });
+
   it("combines participation filtering with search", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/metrics-endpoint.test.ts
+++ b/server/src/__tests__/metrics-endpoint.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import request from "supertest";
+import type { Db } from "@paperclipai/db";
+import { createApp } from "../app.js";
+import type { StorageService } from "../storage/types.js";
+
+const { loadAllMock, schedulerStartMock, coordinatorStartMock, dispatcherInitializeMock } = vi.hoisted(() => ({
+  loadAllMock: vi.fn().mockResolvedValue({ total: 0, succeeded: 0, failed: 0, results: [] }),
+  schedulerStartMock: vi.fn(),
+  coordinatorStartMock: vi.fn(),
+  dispatcherInitializeMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../services/plugin-loader.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/plugin-loader.js")>("../services/plugin-loader.js");
+  return {
+    ...actual,
+    pluginLoader: vi.fn(() => ({
+      loadAll: loadAllMock,
+    })),
+  };
+});
+
+vi.mock("../services/plugin-job-scheduler.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/plugin-job-scheduler.js")>(
+    "../services/plugin-job-scheduler.js",
+  );
+  return {
+    ...actual,
+    createPluginJobScheduler: vi.fn(() => ({
+      start: schedulerStartMock,
+      stop: vi.fn(),
+    })),
+  };
+});
+
+vi.mock("../services/plugin-job-coordinator.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/plugin-job-coordinator.js")>(
+    "../services/plugin-job-coordinator.js",
+  );
+  return {
+    ...actual,
+    createPluginJobCoordinator: vi.fn(() => ({
+      start: coordinatorStartMock,
+      stop: vi.fn(),
+    })),
+  };
+});
+
+vi.mock("../services/plugin-tool-dispatcher.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/plugin-tool-dispatcher.js")>(
+    "../services/plugin-tool-dispatcher.js",
+  );
+  return {
+    ...actual,
+    createPluginToolDispatcher: vi.fn(() => ({
+      initialize: dispatcherInitializeMock,
+      listToolsForAgent: vi.fn(() => []),
+      getTool: vi.fn(() => null),
+      executeTool: vi.fn(),
+    })),
+  };
+});
+
+function createStorageService(): StorageService {
+  return {
+    provider: "local_disk",
+    putFile: vi.fn(),
+    getObject: vi.fn(),
+    headObject: vi.fn(),
+    deleteObject: vi.fn(),
+  };
+}
+
+describe("GET /metrics", () => {
+  it("returns Prometheus text with placeholder cap counters registered", async () => {
+    const app = await createApp({} as Db, {
+      uiMode: "none",
+      serverPort: 0,
+      storageService: createStorageService(),
+      deploymentMode: "local_trusted",
+      deploymentExposure: "public",
+      allowedHostnames: [],
+      bindHost: "127.0.0.1",
+      authReady: true,
+      companyDeletionEnabled: false,
+    });
+
+    const res = await request(app).get("/metrics");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/^text\/plain;\s*version=0\.0\.4/);
+    expect(res.text).toContain(
+      "# HELP paperclip_placeholder_cap_hits_total Times the placeholder-comment cap blocked an agent comment post.",
+    );
+    expect(res.text).toContain("# TYPE paperclip_placeholder_cap_hits_total counter");
+    expect(res.text).toContain(
+      "# HELP paperclip_placeholder_cap_overrides_total Times a board override bypassed the placeholder-comment cap.",
+    );
+    expect(res.text).toContain("# TYPE paperclip_placeholder_cap_overrides_total counter");
+  });
+});

--- a/server/src/__tests__/metrics-endpoint.test.ts
+++ b/server/src/__tests__/metrics-endpoint.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import request from "supertest";
 import type { Db } from "@paperclipai/db";
 import { createApp } from "../app.js";
@@ -73,33 +73,104 @@ function createStorageService(): StorageService {
   };
 }
 
-describe("GET /metrics", () => {
-  it("returns Prometheus text with placeholder cap counters registered", async () => {
-    const app = await createApp({} as Db, {
-      uiMode: "none",
-      serverPort: 0,
-      storageService: createStorageService(),
-      deploymentMode: "local_trusted",
-      deploymentExposure: "public",
-      allowedHostnames: [],
-      bindHost: "127.0.0.1",
-      authReady: true,
-      companyDeletionEnabled: false,
-    });
+type CreateAppOptions = Parameters<typeof createApp>[1];
 
-    const res = await request(app).get("/metrics");
+const ORIGINAL_METRICS_TOKEN = process.env.PAPERCLIP_METRICS_TOKEN;
+const METRICS_TOKEN = "test-secret-token-32chars-min!";
+
+function createMetricsAppOptions(overrides: Partial<CreateAppOptions> = {}): CreateAppOptions {
+  return {
+    uiMode: "none",
+    serverPort: 0,
+    storageService: createStorageService(),
+    deploymentMode: "local_trusted",
+    deploymentExposure: "public",
+    allowedHostnames: [],
+    bindHost: "127.0.0.1",
+    authReady: true,
+    companyDeletionEnabled: false,
+    ...overrides,
+  };
+}
+
+function expectPrometheusCounters(text: string) {
+  expect(text).toContain(
+    "# HELP paperclip_placeholder_cap_hits_total Times the placeholder-comment cap blocked an agent comment post.",
+  );
+  expect(text).toContain("# TYPE paperclip_placeholder_cap_hits_total counter");
+  expect(text).toContain(
+    "# HELP paperclip_placeholder_cap_overrides_total Times a board override bypassed the placeholder-comment cap.",
+  );
+  expect(text).toContain("# TYPE paperclip_placeholder_cap_overrides_total counter");
+  expect((placeholderCapHits as unknown as { labelNames: string[] }).labelNames).toEqual(["agent_id"]);
+  expect((placeholderCapOverrides as unknown as { labelNames: string[] }).labelNames).toEqual(["agent_id"]);
+}
+
+describe("GET /metrics", () => {
+  beforeEach(() => {
+    delete process.env.PAPERCLIP_METRICS_TOKEN;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_METRICS_TOKEN === undefined) {
+      delete process.env.PAPERCLIP_METRICS_TOKEN;
+    } else {
+      process.env.PAPERCLIP_METRICS_TOKEN = ORIGINAL_METRICS_TOKEN;
+    }
+  });
+
+  it("returns Prometheus text with placeholder cap counters registered in private deployments", async () => {
+    const app = await createApp(
+      {} as Db,
+      createMetricsAppOptions({
+        deploymentMode: "local_trusted",
+        deploymentExposure: "private",
+        allowedHostnames: ["127.0.0.1"],
+        bindHost: "127.0.0.1",
+      }),
+    );
+
+    const res = await request(app).get("/metrics").set("Host", "127.0.0.1");
 
     expect(res.status).toBe(200);
     expect(res.headers["content-type"]).toMatch(/^text\/plain;\s*version=0\.0\.4/);
-    expect(res.text).toContain(
-      "# HELP paperclip_placeholder_cap_hits_total Times the placeholder-comment cap blocked an agent comment post.",
-    );
-    expect(res.text).toContain("# TYPE paperclip_placeholder_cap_hits_total counter");
-    expect(res.text).toContain(
-      "# HELP paperclip_placeholder_cap_overrides_total Times a board override bypassed the placeholder-comment cap.",
-    );
-    expect(res.text).toContain("# TYPE paperclip_placeholder_cap_overrides_total counter");
-    expect((placeholderCapHits as unknown as { labelNames: string[] }).labelNames).toEqual(["agent_id"]);
-    expect((placeholderCapOverrides as unknown as { labelNames: string[] }).labelNames).toEqual(["agent_id"]);
+    expectPrometheusCounters(res.text);
+  });
+
+  it("does not mount metrics in public deployments without a metrics token", async () => {
+    const app = await createApp({} as Db, createMetricsAppOptions());
+
+    const res = await request(app).get("/metrics");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("requires authorization in public deployments with a metrics token", async () => {
+    process.env.PAPERCLIP_METRICS_TOKEN = METRICS_TOKEN;
+    const app = await createApp({} as Db, createMetricsAppOptions());
+
+    const res = await request(app).get("/metrics");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns Prometheus text in public deployments with a matching bearer token", async () => {
+    process.env.PAPERCLIP_METRICS_TOKEN = METRICS_TOKEN;
+    const app = await createApp({} as Db, createMetricsAppOptions());
+
+    const res = await request(app).get("/metrics").set("Authorization", `Bearer ${METRICS_TOKEN}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/^text\/plain;\s*version=0\.0\.4/);
+    expectPrometheusCounters(res.text);
+  });
+
+  it("rejects non-matching public metrics bearer tokens", async () => {
+    process.env.PAPERCLIP_METRICS_TOKEN = METRICS_TOKEN;
+    const app = await createApp({} as Db, createMetricsAppOptions());
+
+    const res = await request(app).get("/metrics").set("Authorization", "Bearer wrong-token");
+
+    expect(res.status).toBe(401);
   });
 });

--- a/server/src/__tests__/metrics-endpoint.test.ts
+++ b/server/src/__tests__/metrics-endpoint.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import request from "supertest";
 import type { Db } from "@paperclipai/db";
 import { createApp } from "../app.js";
+import { placeholderCapHits, placeholderCapOverrides } from "../observability/prom.js";
 import type { StorageService } from "../storage/types.js";
 
 const { loadAllMock, schedulerStartMock, coordinatorStartMock, dispatcherInitializeMock } = vi.hoisted(() => ({
@@ -98,5 +99,7 @@ describe("GET /metrics", () => {
       "# HELP paperclip_placeholder_cap_overrides_total Times a board override bypassed the placeholder-comment cap.",
     );
     expect(res.text).toContain("# TYPE paperclip_placeholder_cap_overrides_total counter");
+    expect((placeholderCapHits as unknown as { labelNames: string[] }).labelNames).toEqual(["agent_id"]);
+    expect((placeholderCapOverrides as unknown as { labelNames: string[] }).labelNames).toEqual(["agent_id"]);
   });
 });

--- a/server/src/__tests__/metrics-endpoint.test.ts
+++ b/server/src/__tests__/metrics-endpoint.test.ts
@@ -102,7 +102,7 @@ function expectPrometheusCounters(text: string) {
     "# HELP paperclip_placeholder_cap_overrides_total Times a board override bypassed the placeholder-comment cap.",
   );
   expect(text).toContain("# TYPE paperclip_placeholder_cap_overrides_total counter");
-  expect((placeholderCapHits as unknown as { labelNames: string[] }).labelNames).toEqual(["agent_id"]);
+  expect((placeholderCapHits as unknown as { labelNames: string[] }).labelNames).toEqual(["agent_id", "issue_id"]);
   expect((placeholderCapOverrides as unknown as { labelNames: string[] }).labelNames).toEqual(["agent_id"]);
 }
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -41,6 +41,7 @@ import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
+import { register as metricsRegister } from "./observability/prom.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
 import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
@@ -160,6 +161,15 @@ export async function createApp(
       bindHost: opts.bindHost,
     }),
   );
+  // Intentionally unauthenticated so Prometheus can scrape it; the private hostname guard still applies.
+  app.get("/metrics", async (_req, res, next) => {
+    try {
+      res.set("Content-Type", metricsRegister.contentType);
+      res.end(await metricsRegister.metrics());
+    } catch (err) {
+      next(err);
+    }
+  });
   app.use(
     actorMiddleware(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,4 +1,5 @@
 import express, { Router, type Request as ExpressRequest } from "express";
+import crypto from "node:crypto";
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -150,6 +151,8 @@ export async function createApp(
     deploymentMode: opts.deploymentMode,
     deploymentExposure: opts.deploymentExposure,
   });
+  const metricsToken = process.env.PAPERCLIP_METRICS_TOKEN?.trim() || null;
+  const mountMetrics = privateHostnameGateEnabled || metricsToken !== null;
   const privateHostnameAllowSet = resolvePrivateHostnameAllowSet({
     allowedHostnames: opts.allowedHostnames,
     bindHost: opts.bindHost,
@@ -161,15 +164,32 @@ export async function createApp(
       bindHost: opts.bindHost,
     }),
   );
-  // Intentionally unauthenticated so Prometheus can scrape it; the private hostname guard still applies.
-  app.get("/metrics", async (_req, res, next) => {
-    try {
-      res.set("Content-Type", metricsRegister.contentType);
-      res.end(await metricsRegister.metrics());
-    } catch (err) {
-      next(err);
-    }
-  });
+  // Metrics are unauthenticated in private deployments because the hostname allowlist is the gate.
+  // Public deployments must opt in with PAPERCLIP_METRICS_TOKEN and present a matching bearer token.
+  // Without either gate, /metrics is not mounted so the route does not advertise its existence.
+  // This stays before actor middleware so Prometheus scrape jobs do not need an agent identity.
+  if (mountMetrics) {
+    app.get("/metrics", async (req, res, next) => {
+      if (metricsToken !== null && !privateHostnameGateEnabled) {
+        const auth = req.header("authorization") ?? "";
+        const provided = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length) : "";
+        const expected = Buffer.from(metricsToken, "utf8");
+        const got = Buffer.from(provided, "utf8");
+
+        if (got.length !== expected.length || !crypto.timingSafeEqual(got, expected)) {
+          res.status(401).end();
+          return;
+        }
+      }
+
+      try {
+        res.set("Content-Type", metricsRegister.contentType);
+        res.end(await metricsRegister.metrics());
+      } catch (err) {
+        next(err);
+      }
+    });
+  }
   app.use(
     actorMiddleware(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/observability/prom.ts
+++ b/server/src/observability/prom.ts
@@ -4,10 +4,10 @@ export const register = new Registry();
 
 collectDefaultMetrics({ register });
 
-export const placeholderCapHits = new Counter<"agent_id">({
+export const placeholderCapHits = new Counter<"agent_id" | "issue_id">({
   name: "paperclip_placeholder_cap_hits_total",
   help: "Times the placeholder-comment cap blocked an agent comment post.",
-  labelNames: ["agent_id"] as const,
+  labelNames: ["agent_id", "issue_id"] as const,
   registers: [register],
 });
 

--- a/server/src/observability/prom.ts
+++ b/server/src/observability/prom.ts
@@ -1,0 +1,19 @@
+import { collectDefaultMetrics, Counter, Registry } from "prom-client";
+
+export const register = new Registry();
+
+collectDefaultMetrics({ register });
+
+export const placeholderCapHits = new Counter<"agent_id">({
+  name: "paperclip_placeholder_cap_hits_total",
+  help: "Times the placeholder-comment cap blocked an agent comment post.",
+  labelNames: ["agent_id"] as const,
+  registers: [register],
+});
+
+export const placeholderCapOverrides = new Counter<"agent_id">({
+  name: "paperclip_placeholder_cap_overrides_total",
+  help: "Times a board override bypassed the placeholder-comment cap.",
+  labelNames: ["agent_id"] as const,
+  registers: [register],
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -30,6 +30,7 @@ import {
   updateIssueSchema,
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
+  isPlaceholderCommentBody,
   type ExecutionWorkspace,
 } from "@paperclipai/shared";
 import { trackAgentTaskCompleted } from "@paperclipai/shared/telemetry";
@@ -83,11 +84,32 @@ import {
   parseIssueExecutionState,
 } from "../services/issue-execution-policy.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { placeholderCapHits, placeholderCapOverrides } from "../observability/prom.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
+
+function placeholderCommentCapResponse(input: {
+  priorPlaceholderCount: number;
+  windowSeconds: number;
+  windowComments: number;
+}) {
+  return {
+    error: "placeholder_comment_cap",
+    message:
+      "Comment blocked: prior placeholder comment(s) already posted in window. Flip status (blocked / done / in_review with a real comment) or exit silent instead.",
+    windowSeconds: input.windowSeconds,
+    windowComments: input.windowComments,
+    priorPlaceholderCount: input.priorPlaceholderCount,
+    alternatives: [
+      'PATCH /api/issues/{id} {"status":"blocked","unblockOwner":"..."}',
+      'PATCH /api/issues/{id} {"status":"in_review","assigneeUserId":"local-board"}',
+      "exit run silently -- no post",
+    ],
+  };
+}
 
 type ParsedExecutionState = NonNullable<ReturnType<typeof parseIssueExecutionState>>;
 type NormalizedExecutionPolicy = NonNullable<ReturnType<typeof normalizeIssueExecutionPolicy>>;
@@ -3414,6 +3436,61 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
+    const commentIsPlaceholder = isPlaceholderCommentBody(req.body.body);
+    const forceCommentAllow = req.actor.type === "board" ? req.body.forceCommentAllow === true : undefined;
+    if (actor.actorType === "agent" && actor.agentId && commentIsPlaceholder) {
+      const placeholderWindow = await svc.countOwnRecentPlaceholderComments(id, actor.agentId);
+
+      // Best-effort request-time guard: concurrent POSTs can both pass before either insert commits,
+      // so worst case is bounded to two placeholders before the next attempt observes the prior insert.
+      if (placeholderWindow.count >= 1) {
+        placeholderCapHits.labels(actor.agentId).inc();
+        await logActivity(db, {
+          companyId: issue.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "issue.placeholder_cap_hit",
+          entityType: "issue",
+          entityId: issue.id,
+          details: {
+            identifier: issue.identifier,
+            issueTitle: issue.title,
+            priorPlaceholderCount: placeholderWindow.count,
+            windowSeconds: placeholderWindow.windowSeconds,
+            windowComments: placeholderWindow.windowComments,
+          },
+        });
+        res.status(409).json(
+          placeholderCommentCapResponse({
+            priorPlaceholderCount: placeholderWindow.count,
+            windowSeconds: placeholderWindow.windowSeconds,
+            windowComments: placeholderWindow.windowComments,
+          }),
+        );
+        return;
+      }
+    } else if (forceCommentAllow === true && commentIsPlaceholder) {
+      const overriddenAgentId = issue.assigneeAgentId ?? "unassigned";
+      placeholderCapOverrides.labels(overriddenAgentId).inc();
+      await logActivity(db, {
+        companyId: issue.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "issue.placeholder_cap_overridden",
+        entityType: "issue",
+        entityId: issue.id,
+        details: {
+          identifier: issue.identifier,
+          issueTitle: issue.title,
+          forceCommentAllow: true,
+          overriddenAgentId,
+        },
+      });
+    }
     const reopenRequested = req.body.reopen === true;
     const resumeRequested = req.body.resume === true;
     const interruptRequested = req.body.interrupt === true;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -87,27 +87,30 @@ import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 import { placeholderCapHits, placeholderCapOverrides } from "../observability/prom.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
+const PLACEHOLDER_COMMENT_CAP = 3;
+const PLACEHOLDER_COMMENT_CAP_MESSAGE =
+  "Comment blocked: this would be your 3rd consecutive placeholder on this issue. Flip status (blocked / in_review / done with a real comment) or exit silent.";
+const PLACEHOLDER_COMMENT_CAP_ALTERNATIVES = [
+  'PATCH /api/issues/{id} {"status":"blocked","unblockOwner":"..."}',
+  'PATCH /api/issues/{id} {"status":"in_review"}',
+  "exit run silently — no post",
+] as const;
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
 
-function placeholderCommentCapResponse(input: {
-  priorPlaceholderCount: number;
-  windowSeconds: number;
-  windowComments: number;
-}) {
+function isPlaceholderCapEnabled() {
+  return process.env.PAPERCLIP_PLACEHOLDER_CAP_ENABLED !== "false";
+}
+
+function placeholderCommentCapResponse(input: { oldestPlaceholderAt: string | null }) {
   return {
-    error: "placeholder_comment_cap",
-    message:
-      "Comment blocked: prior placeholder comment(s) already posted in window. Flip status (blocked / done / in_review with a real comment) or exit silent instead.",
-    windowSeconds: input.windowSeconds,
-    windowComments: input.windowComments,
-    priorPlaceholderCount: input.priorPlaceholderCount,
-    alternatives: [
-      'PATCH /api/issues/{id} {"status":"blocked","unblockOwner":"..."}',
-      'PATCH /api/issues/{id} {"status":"in_review","assigneeUserId":"local-board"}',
-      "exit run silently -- no post",
-    ],
+    error: "placeholder_cap",
+    message: PLACEHOLDER_COMMENT_CAP_MESSAGE,
+    cap: PLACEHOLDER_COMMENT_CAP,
+    last_n_placeholders: PLACEHOLDER_COMMENT_CAP,
+    oldest_placeholder_at: input.oldestPlaceholderAt,
+    alternatives: [...PLACEHOLDER_COMMENT_CAP_ALTERNATIVES],
   };
 }
 
@@ -3436,15 +3439,16 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
-    const commentIsPlaceholder = isPlaceholderCommentBody(req.body.body);
+    const placeholderCapEnabled = isPlaceholderCapEnabled();
+    const commentIsPlaceholder = placeholderCapEnabled ? isPlaceholderCommentBody(req.body.body) : false;
     const forceCommentAllow = req.actor.type === "board" ? req.body.forceCommentAllow === true : undefined;
-    if (actor.actorType === "agent" && actor.agentId && commentIsPlaceholder) {
+    if (placeholderCapEnabled && actor.actorType === "agent" && actor.agentId && commentIsPlaceholder) {
       const placeholderWindow = await svc.countOwnRecentPlaceholderComments(id, actor.agentId);
 
       // Best-effort request-time guard: concurrent POSTs can both pass before either insert commits,
-      // so worst case is bounded to two placeholders before the next attempt observes the prior insert.
-      if (placeholderWindow.count >= 1) {
-        placeholderCapHits.labels(actor.agentId).inc();
+      // so worst case is bounded to <=4 placeholders before the next attempt observes the prior inserts.
+      if (placeholderWindow.count >= PLACEHOLDER_COMMENT_CAP - 1) {
+        placeholderCapHits.labels(actor.agentId, issue.id).inc();
         await logActivity(db, {
           companyId: issue.companyId,
           actorType: actor.actorType,
@@ -3457,21 +3461,20 @@ export function issueRoutes(
           details: {
             identifier: issue.identifier,
             issueTitle: issue.title,
+            cap: PLACEHOLDER_COMMENT_CAP,
             priorPlaceholderCount: placeholderWindow.count,
-            windowSeconds: placeholderWindow.windowSeconds,
             windowComments: placeholderWindow.windowComments,
+            oldestPlaceholderAt: placeholderWindow.oldestPlaceholderAt,
           },
         });
         res.status(409).json(
           placeholderCommentCapResponse({
-            priorPlaceholderCount: placeholderWindow.count,
-            windowSeconds: placeholderWindow.windowSeconds,
-            windowComments: placeholderWindow.windowComments,
+            oldestPlaceholderAt: placeholderWindow.oldestPlaceholderAt,
           }),
         );
         return;
       }
-    } else if (forceCommentAllow === true && commentIsPlaceholder) {
+    } else if (placeholderCapEnabled && forceCommentAllow === true && commentIsPlaceholder) {
       const overriddenAgentId = issue.assigneeAgentId ?? "unassigned";
       placeholderCapOverrides.labels(overriddenAgentId).inc();
       await logActivity(db, {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -62,8 +62,7 @@ import { parseIssueGraphLivenessIncidentKey } from "./recovery/origins.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
-const PLACEHOLDER_COMMENT_WINDOW_SECONDS = 30 * 60;
-const PLACEHOLDER_COMMENT_WINDOW_COMMENTS = 5;
+const PLACEHOLDER_COMMENT_WINDOW_COMMENTS = 3;
 export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
 const ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE = 500;
@@ -3515,20 +3514,26 @@ export function issueService(db: Db) {
     countOwnRecentPlaceholderComments: async (
       issueId: string,
       agentId: string,
-      opts?: { windowSeconds?: number; windowComments?: number; patterns?: readonly RegExp[] },
+      opts?: { windowComments?: number },
     ) => {
-      const windowSeconds = opts?.windowSeconds ?? PLACEHOLDER_COMMENT_WINDOW_SECONDS;
       const windowComments = opts?.windowComments ?? PLACEHOLDER_COMMENT_WINDOW_COMMENTS;
-      const cutoffMs = Date.now() - windowSeconds * 1000;
       const comments = await listComments(issueId, { order: "desc", limit: MAX_ISSUE_COMMENT_PAGE_LIMIT });
       const recentOwnComments = comments
-        .filter((comment) => comment.authorAgentId === agentId && new Date(comment.createdAt).getTime() > cutoffMs)
+        .filter((comment) => comment.authorAgentId === agentId)
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
         .slice(0, windowComments);
+      const placeholders: typeof recentOwnComments = [];
+      for (const comment of recentOwnComments) {
+        if (!isPlaceholderCommentBody(comment.body)) break;
+        placeholders.push(comment);
+      }
 
       return {
-        count: recentOwnComments.filter((comment) => isPlaceholderCommentBody(comment.body, opts?.patterns)).length,
-        windowSeconds,
+        count: placeholders.length,
         windowComments,
+        oldestPlaceholderAt: placeholders.length
+          ? new Date(placeholders[placeholders.length - 1]!.createdAt).toISOString()
+          : null,
       };
     },
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -33,7 +33,13 @@ import type {
   IssueProductivityReviewTrigger,
   IssueRelationIssueSummary,
 } from "@paperclipai/shared";
-import { clampIssueRequestDepth, extractAgentMentionIds, extractProjectMentionIds, isUuidLike } from "@paperclipai/shared";
+import {
+  clampIssueRequestDepth,
+  extractAgentMentionIds,
+  extractProjectMentionIds,
+  isPlaceholderCommentBody,
+  isUuidLike,
+} from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import {
   defaultIssueExecutionWorkspaceSettingsForProject,
@@ -56,6 +62,8 @@ import { parseIssueGraphLivenessIncidentKey } from "./recovery/origins.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
+const PLACEHOLDER_COMMENT_WINDOW_SECONDS = 30 * 60;
+const PLACEHOLDER_COMMENT_WINDOW_COMMENTS = 5;
 export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
 const ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE = 500;
@@ -1655,6 +1663,60 @@ export function issueService(db: Db) {
       ...comment,
       body: redactCurrentUserText(comment.body, { enabled: censorUsernameInLogs }),
     };
+  }
+
+  async function listComments(
+    issueId: string,
+    opts?: {
+      afterCommentId?: string | null;
+      order?: "asc" | "desc";
+      limit?: number | null;
+    },
+  ) {
+    const order = opts?.order === "asc" ? "asc" : "desc";
+    const afterCommentId = opts?.afterCommentId?.trim() || null;
+    const limit =
+      opts?.limit && opts.limit > 0
+        ? Math.min(Math.floor(opts.limit), MAX_ISSUE_COMMENT_PAGE_LIMIT)
+        : null;
+
+    const conditions = [eq(issueComments.issueId, issueId)];
+    if (afterCommentId) {
+      const anchor = await db
+        .select({
+          id: issueComments.id,
+          createdAt: issueComments.createdAt,
+        })
+        .from(issueComments)
+        .where(and(eq(issueComments.issueId, issueId), eq(issueComments.id, afterCommentId)))
+        .then((rows) => rows[0] ?? null);
+
+      if (!anchor) return [];
+      conditions.push(
+        order === "asc"
+          ? or(
+              gt(issueComments.createdAt, anchor.createdAt),
+              and(eq(issueComments.createdAt, anchor.createdAt), gt(issueComments.id, anchor.id)),
+            )!
+          : or(
+              lt(issueComments.createdAt, anchor.createdAt),
+              and(eq(issueComments.createdAt, anchor.createdAt), lt(issueComments.id, anchor.id)),
+            )!,
+      );
+    }
+
+    const query = db
+      .select()
+      .from(issueComments)
+      .where(and(...conditions))
+      .orderBy(
+        order === "asc" ? asc(issueComments.createdAt) : desc(issueComments.createdAt),
+        order === "asc" ? asc(issueComments.id) : desc(issueComments.id),
+      );
+
+    const comments = limit ? await query.limit(limit) : await query;
+    const { censorUsernameInLogs } = await instanceSettings.getGeneral();
+    return comments.map((comment) => redactIssueComment(comment, censorUsernameInLogs));
   }
 
   async function assertAssignableAgent(companyId: string, agentId: string) {
@@ -3448,58 +3510,26 @@ export function issueService(db: Db) {
         .returning()
         .then((rows) => rows[0] ?? null),
 
-    listComments: async (
+    listComments,
+
+    countOwnRecentPlaceholderComments: async (
       issueId: string,
-      opts?: {
-        afterCommentId?: string | null;
-        order?: "asc" | "desc";
-        limit?: number | null;
-      },
+      agentId: string,
+      opts?: { windowSeconds?: number; windowComments?: number; patterns?: readonly RegExp[] },
     ) => {
-      const order = opts?.order === "asc" ? "asc" : "desc";
-      const afterCommentId = opts?.afterCommentId?.trim() || null;
-      const limit =
-        opts?.limit && opts.limit > 0
-          ? Math.min(Math.floor(opts.limit), MAX_ISSUE_COMMENT_PAGE_LIMIT)
-          : null;
+      const windowSeconds = opts?.windowSeconds ?? PLACEHOLDER_COMMENT_WINDOW_SECONDS;
+      const windowComments = opts?.windowComments ?? PLACEHOLDER_COMMENT_WINDOW_COMMENTS;
+      const cutoffMs = Date.now() - windowSeconds * 1000;
+      const comments = await listComments(issueId, { order: "desc", limit: MAX_ISSUE_COMMENT_PAGE_LIMIT });
+      const recentOwnComments = comments
+        .filter((comment) => comment.authorAgentId === agentId && new Date(comment.createdAt).getTime() > cutoffMs)
+        .slice(0, windowComments);
 
-      const conditions = [eq(issueComments.issueId, issueId)];
-      if (afterCommentId) {
-        const anchor = await db
-          .select({
-            id: issueComments.id,
-            createdAt: issueComments.createdAt,
-          })
-          .from(issueComments)
-          .where(and(eq(issueComments.issueId, issueId), eq(issueComments.id, afterCommentId)))
-          .then((rows) => rows[0] ?? null);
-
-        if (!anchor) return [];
-        conditions.push(
-          order === "asc"
-            ? or(
-                gt(issueComments.createdAt, anchor.createdAt),
-                and(eq(issueComments.createdAt, anchor.createdAt), gt(issueComments.id, anchor.id)),
-              )!
-            : or(
-                lt(issueComments.createdAt, anchor.createdAt),
-                and(eq(issueComments.createdAt, anchor.createdAt), lt(issueComments.id, anchor.id)),
-              )!,
-        );
-      }
-
-      const query = db
-        .select()
-        .from(issueComments)
-        .where(and(...conditions))
-        .orderBy(
-          order === "asc" ? asc(issueComments.createdAt) : desc(issueComments.createdAt),
-          order === "asc" ? asc(issueComments.id) : desc(issueComments.id),
-        );
-
-      const comments = limit ? await query.limit(limit) : await query;
-      const { censorUsernameInLogs } = await instanceSettings.getGeneral();
-      return comments.map((comment) => redactIssueComment(comment, censorUsernameInLogs));
+      return {
+        count: recentOwnComments.filter((comment) => isPlaceholderCommentBody(comment.body, opts?.patterns)).length,
+        windowSeconds,
+        windowComments,
+      };
     },
 
     getCommentCursor: async (issueId: string) => {


### PR DESCRIPTION
## Diff Summary

Implements the ratified ELEAAA-457 v2 placeholder-comment cap on `POST /api/issues/:id/comments`.

- Replaces the v1 regex detector with the v2 length-first shared detector: `stripMarkdown(body).trim().length < 30`, exported readonly prefix list, and `no external context change` substring match.
- Updates `countOwnRecentPlaceholderComments(...)` to use the last 3 comments by `(agent_id, issue_id)` and count the current consecutive placeholder streak from newest backwards, stopping on the first real comment.
- Enforces agent-only blocking at cap=3: incoming placeholder + 2 prior consecutive placeholders returns `409` JSON with `error: "placeholder_cap"` and the approved alternatives list.
- Preserves board/user bypass, makes `forceCommentAllow` board-only, and logs both `issue.placeholder_cap_hit` and `issue.placeholder_cap_overridden` activity entries.
- Updates Prom counters to `paperclip_placeholder_cap_hits_total{agent_id,issue_id}` and `paperclip_placeholder_cap_overrides_total{agent_id}`.
- Adds `PAPERCLIP_PLACEHOLDER_CAP_ENABLED=false` rollback flag that skips detection, count, guard, activity, and metric increments.

Scope note: the request-time guard is intentionally best-effort. The route comment and cap test document the accepted TOCTOU bound: under contention the worst case is <=4 placeholders before the next observed attempt blocks.

## Current Blocker

This PR still depends on #4787 (`chore/refresh-lockfile`) landing first. This branch adds `prom-client` to `server/package.json`; normal feature PRs cannot carry `pnpm-lock.yaml`, but CI installs with `pnpm install --frozen-lockfile`.

Current upstream state:

- #4787 is open, all 4 checks are green, `mergeStateStatus: BLOCKED` by branch protection/review.
- #4977 head is `8520dc23`; `policy` and Snyk pass.
- #4977 `verify`, serialized server suites, canary dry run, and `e2e` all fail during install with `ERR_PNPM_OUTDATED_LOCKFILE` because master does not yet include #4787's lockfile metadata for `prom-client`.

## Rollback

Runtime rollback after merge:

```bash
PAPERCLIP_PLACEHOLDER_CAP_ENABLED=false
```

Code rollback for a normal branch merge:

```bash
git revert --no-commit 43a5a3c5^..8520dc23 && git commit -m "revert: placeholder comment cap"
```

If GitHub squash-merges the PR, revert the resulting PR merge/squash commit instead.

## Test Output

TDD red commit: `c3acbec9 test: cover placeholder cap v2 contract` failed against the old implementation as expected.

Local verification on current head `8520dc23`:

```bash
pnpm exec vitest run packages/shared/src/__tests__/placeholder.test.ts server/src/__tests__/issue-placeholder-comment-cap.test.ts server/src/__tests__/metrics-endpoint.test.ts server/src/__tests__/issues-service.test.ts server/src/__tests__/issue-comment-reopen-routes.test.ts -t "placeholder|metrics|GET /metrics|issue placeholder comment cap route|placeholder streak|issue comment reopen routes"
# PASS: 5 files, 64 tests passed, 38 skipped

pnpm --filter @paperclipai/server typecheck && pnpm --filter @paperclipai/shared typecheck
# PASS

pnpm --filter @paperclipai/server test
# FAIL locally before the final route-mock patch with 4 issue-comment-reopen mock failures plus 2 pre-existing local worktree-config port assertions.
# After patch, issue-comment-reopen-routes.test.ts passes 28/28.

pnpm --filter @paperclipai/server exec vitest run --exclude src/__tests__/worktree-config.test.ts
# 218 files passed, 1 cross-suite FK failure in heartbeat-process-recovery.test.ts.

pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts
# PASS: 1 file, 37 tests

git diff --check
# PASS
```

The two raw-rollup `worktree-config.test.ts` failures are the known local port-selection mismatch (`54331` vs expected `54335`) and are unrelated to this diff.

## CTO Review Request

CTO: once #4787 is merged, please re-run CI on #4977 and run `/plan-eng-review` + `/review`. Review focus should be v2 reset semantics, board-only override behavior, structured 409 contract, activity log details, metric labels/cardinality, and the documented best-effort race bound.

## Tech-Debt Log Reference

Updated brain page: `concepts/eleaaa-457-placeholder-comment-cap-contract-2026-05-04`.
