### PR TITLE
Show subscription token activity on dashboard

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -419,6 +419,7 @@ export type {
   InstanceSchedulerHeartbeatAgent,
   LiveEvent,
   DashboardRunActivityDay,
+  DashboardTokenActivity,
   DashboardSummary,
   ActivityEvent,
   UserProfileActivitySummary,

--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -6,6 +6,17 @@ export interface DashboardRunActivityDay {
   total: number;
 }
 
+export interface DashboardTokenActivity {
+  recentSuccessfulRuns: number;
+  tokenizedRuns: number;
+  subscriptionIncludedRuns: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  lastTokenAt: string | null;
+}
+
 export interface DashboardSummary {
   companyId: string;
   agents: {
@@ -33,4 +44,5 @@ export interface DashboardSummary {
     pausedProjects: number;
   };
   runActivity: DashboardRunActivityDay[];
+  tokenActivity: DashboardTokenActivity;
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -242,7 +242,7 @@ export type {
   InstanceSchedulerHeartbeatAgent,
 } from "./heartbeat.js";
 export type { LiveEvent } from "./live.js";
-export type { DashboardRunActivityDay, DashboardSummary } from "./dashboard.js";
+export type { DashboardRunActivityDay, DashboardTokenActivity, DashboardSummary } from "./dashboard.js";
 export type { ActivityEvent } from "./activity.js";
 export type {
   UserProfileActivitySummary,

--- a/server/src/__tests__/dashboard-service.test.ts
+++ b/server/src/__tests__/dashboard-service.test.ts
@@ -166,4 +166,79 @@ describeEmbeddedPostgres("dashboard service", () => {
       total: 3,
     });
   });
+
+  it("surfaces zero-cost subscription token activity without adding spend", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const today = utcDay(0);
+    const yesterday = utcDay(-1);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "succeeded",
+        createdAt: yesterday,
+        finishedAt: yesterday,
+        usageJson: {
+          billingType: "subscription_included",
+          inputTokens: 1200,
+          outputTokens: 300,
+          cachedInputTokens: 80,
+          costUsd: 0,
+        },
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "succeeded",
+        createdAt: today,
+        finishedAt: today,
+        usageJson: {
+          billing_type: "subscription_included",
+          input_tokens: 45,
+          output_tokens: 12,
+          cache_read_input_tokens: 7,
+          cost_usd: 0,
+        },
+      },
+    ]);
+
+    const summary = await dashboardService(db).summary(companyId);
+
+    expect(summary.costs.monthSpendCents).toBe(0);
+    expect(summary.tokenActivity).toMatchObject({
+      recentSuccessfulRuns: 2,
+      tokenizedRuns: 2,
+      subscriptionIncludedRuns: 2,
+      inputTokens: 1245,
+      outputTokens: 312,
+      cachedInputTokens: 87,
+      totalTokens: 1644,
+      lastTokenAt: today.toISOString(),
+    });
+  });
 });

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -10,6 +10,12 @@ function formatUtcDateKey(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
+function formatIsoDateTime(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
 export function getUtcMonthStart(date: Date): Date {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
 }
@@ -97,6 +103,32 @@ export function dashboardService(db: Db) {
 
       const monthSpendCents = Number(monthSpend);
       const runActivityDayExpr = sql<string>`to_char(${heartbeatRuns.createdAt} at time zone 'UTC', 'YYYY-MM-DD')`;
+      const inputTokensExpr = sql<number>`
+        coalesce(
+          (${heartbeatRuns.usageJson} ->> 'inputTokens')::double precision,
+          (${heartbeatRuns.usageJson} ->> 'input_tokens')::double precision,
+          0
+        )
+      `;
+      const outputTokensExpr = sql<number>`
+        coalesce(
+          (${heartbeatRuns.usageJson} ->> 'outputTokens')::double precision,
+          (${heartbeatRuns.usageJson} ->> 'output_tokens')::double precision,
+          0
+        )
+      `;
+      const cachedInputTokensExpr = sql<number>`
+        coalesce(
+          (${heartbeatRuns.usageJson} ->> 'cachedInputTokens')::double precision,
+          (${heartbeatRuns.usageJson} ->> 'cached_input_tokens')::double precision,
+          (${heartbeatRuns.usageJson} ->> 'cache_read_input_tokens')::double precision,
+          0
+        )
+      `;
+      const totalTokensExpr = sql<number>`(${inputTokensExpr} + ${outputTokensExpr} + ${cachedInputTokensExpr})`;
+      const billingTypeExpr = sql<string | null>`
+        coalesce(${heartbeatRuns.usageJson} ->> 'billingType', ${heartbeatRuns.usageJson} ->> 'billing_type')
+      `;
       const runActivityRows = await db
         .select({
           date: runActivityDayExpr,
@@ -111,6 +143,32 @@ export function dashboardService(db: Db) {
           ),
         )
         .groupBy(runActivityDayExpr, heartbeatRuns.status);
+
+      const [tokenActivityRow] = await db
+        .select({
+          recentSuccessfulRuns: sql<number>`count(*) filter (where ${heartbeatRuns.status} = 'succeeded')::double precision`,
+          tokenizedRuns: sql<number>`count(*) filter (where ${totalTokensExpr} > 0)::double precision`,
+          subscriptionIncludedRuns: sql<number>`
+            count(*) filter (
+              where ${billingTypeExpr} = 'subscription_included'
+                and ${totalTokensExpr} > 0
+            )::double precision
+          `,
+          inputTokens: sql<number>`coalesce(sum(${inputTokensExpr}), 0)::double precision`,
+          cachedInputTokens: sql<number>`coalesce(sum(${cachedInputTokensExpr}), 0)::double precision`,
+          outputTokens: sql<number>`coalesce(sum(${outputTokensExpr}), 0)::double precision`,
+          lastTokenAt: sql<Date | null>`
+            max(coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}))
+              filter (where ${totalTokensExpr} > 0)
+          `,
+        })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, companyId),
+            gte(heartbeatRuns.createdAt, runActivityStart),
+          ),
+        );
 
       const runActivity = new Map(
         runActivityDays.map((date) => [
@@ -156,6 +214,19 @@ export function dashboardService(db: Db) {
           pausedProjects: budgetOverview.pausedProjectCount,
         },
         runActivity: Array.from(runActivity.values()),
+        tokenActivity: {
+          recentSuccessfulRuns: Number(tokenActivityRow?.recentSuccessfulRuns ?? 0),
+          tokenizedRuns: Number(tokenActivityRow?.tokenizedRuns ?? 0),
+          subscriptionIncludedRuns: Number(tokenActivityRow?.subscriptionIncludedRuns ?? 0),
+          inputTokens: Number(tokenActivityRow?.inputTokens ?? 0),
+          cachedInputTokens: Number(tokenActivityRow?.cachedInputTokens ?? 0),
+          outputTokens: Number(tokenActivityRow?.outputTokens ?? 0),
+          totalTokens:
+            Number(tokenActivityRow?.inputTokens ?? 0)
+            + Number(tokenActivityRow?.cachedInputTokens ?? 0)
+            + Number(tokenActivityRow?.outputTokens ?? 0),
+          lastTokenAt: formatIsoDateTime(tokenActivityRow?.lastTokenAt),
+        },
       };
     },
   };

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -300,6 +300,16 @@ const dashboard: DashboardSummary = {
     pausedProjects: 0,
   },
   runActivity: [],
+  tokenActivity: {
+    recentSuccessfulRuns: 0,
+    tokenizedRuns: 0,
+    subscriptionIncludedRuns: 0,
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    lastTokenAt: null,
+  },
 };
 
 describe("inbox helpers", () => {

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -19,12 +19,12 @@ import { StatusIcon } from "../components/StatusIcon";
 import { ActivityRow } from "../components/ActivityRow";
 import { Identity } from "../components/Identity";
 import { timeAgo } from "../lib/timeAgo";
-import { cn, formatCents } from "../lib/utils";
-import { Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard, PauseCircle } from "lucide-react";
+import { formatCents, formatTokens } from "../lib/utils";
+import { Activity, Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard, PauseCircle } from "lucide-react";
 import { ActiveAgentsPanel } from "../components/ActiveAgentsPanel";
 import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRateChart } from "../components/ActivityCharts";
 import { PageSkeleton } from "../components/PageSkeleton";
-import type { Agent, Issue } from "@paperclipai/shared";
+import type { Agent, DashboardTokenActivity, Issue } from "@paperclipai/shared";
 import { PluginSlotOutlet } from "@/plugins/slots";
 
 const DASHBOARD_ACTIVITY_LIMIT = 10;
@@ -32,6 +32,58 @@ const DASHBOARD_ACTIVITY_LIMIT = 10;
 function getRecentIssues(issues: Issue[]): Issue[] {
   return [...issues]
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+}
+
+function TokenActivityPanel({ activity }: { activity: DashboardTokenActivity }) {
+  const lastTokenLabel = activity.lastTokenAt ? timeAgo(activity.lastTokenAt) : "No token flow";
+  const hasSubscriptionIncluded = activity.subscriptionIncludedRuns > 0;
+  const stats = [
+    { label: "Successful runs", value: activity.recentSuccessfulRuns.toLocaleString("en-US") },
+    { label: "Last token", value: lastTokenLabel },
+    { label: "Input", value: formatTokens(activity.inputTokens) },
+    { label: "Output", value: formatTokens(activity.outputTokens) },
+    { label: "Cached", value: formatTokens(activity.cachedInputTokens) },
+  ];
+
+  return (
+    <div className="rounded-lg border border-border p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Activity className="h-4 w-4 shrink-0 text-muted-foreground/70" />
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold text-foreground">Token Activity</h3>
+            <p className="text-xs text-muted-foreground">Last 14 days</p>
+          </div>
+        </div>
+        <div className="text-right">
+          <p className="font-mono text-2xl font-semibold leading-none tabular-nums">
+            {formatTokens(activity.totalTokens)}
+          </p>
+          <p className="mt-1 text-[10px] uppercase text-muted-foreground">tokens</p>
+        </div>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-5">
+        {stats.map((stat) => (
+          <div key={stat.label} className="min-w-0">
+            <p className="truncate font-mono text-sm font-medium tabular-nums">{stat.value}</p>
+            <p className="mt-1 truncate text-[10px] uppercase text-muted-foreground">
+              {stat.label}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {hasSubscriptionIncluded && (
+        <div className="mt-3 inline-flex max-w-full items-center rounded-full border border-emerald-500/25 bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-700 dark:text-emerald-300">
+          <span className="truncate">
+            Subscription included: {activity.subscriptionIncludedRuns.toLocaleString("en-US")} run
+            {activity.subscriptionIncludedRuns === 1 ? "" : "s"}
+          </span>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function Dashboard() {
@@ -290,6 +342,8 @@ export function Dashboard() {
               }
             />
           </div>
+
+          <TokenActivityPanel activity={data.tokenActivity} />
 
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
             <ChartCard title="Run Activity" subtitle="Last 14 days">

--- a/ui/storybook/fixtures/paperclipData.ts
+++ b/ui/storybook/fixtures/paperclipData.ts
@@ -1280,6 +1280,16 @@ export const storybookDashboardSummary: DashboardSummary = {
     { date: "2026-04-19", succeeded: 5, failed: 0, other: 1, total: 6 },
     { date: "2026-04-20", succeeded: 4, failed: 0, other: 2, total: 6 },
   ],
+  tokenActivity: {
+    recentSuccessfulRuns: 64,
+    tokenizedRuns: 52,
+    subscriptionIncludedRuns: 19,
+    inputTokens: 684_000,
+    cachedInputTokens: 148_000,
+    outputTokens: 96_000,
+    totalTokens: 928_000,
+    lastTokenAt: recent(42).toISOString(),
+  },
 };
 
 export const storybookLiveRuns: LiveRunForIssue[] = [


### PR DESCRIPTION
## Summary

- Aggregates token activity from `heartbeat_runs.usage_json` so subscription-included Codex runs show dashboard activity even when cost is $0.
- Adds `tokenActivity` to the shared dashboard response shape and dashboard UI.
- Keeps monthly spend sourced from `cost_events` only.

## Verification

- `pnpm exec vitest run server/src/__tests__/dashboard-service.test.ts`
- `pnpm build`
- `pnpm check:tokens`
- `git diff --check`
- Built UI preview HTTP check: `GET http://127.0.0.1:4173/ -> 200`


## Dashboard Screenshots

Captured from fixture-backed Storybook because the local dashboard API is in authenticated mode. Base `origin/master` and PR head `68b8263e` used the same dashboard fixture data, dark theme, and 1366px viewport.

**Before (base `master`)**

![Dashboard before TokenActivityPanel](https://raw.githubusercontent.com/michaeljgrimm/paperclip/dat-4094-pr-4980-screenshots/pr-assets/4980/dashboard-before.png)

**After (PR `68b8263e`)**

![Dashboard after TokenActivityPanel](https://raw.githubusercontent.com/michaeljgrimm/paperclip/dat-4094-pr-4980-screenshots/pr-assets/4980/dashboard-after.png)

Paperclip issue: [DAT-3615](/DAT/issues/DAT-3615)
