### PR TITLE
[adapter-utils] write child stdin without waiting on onSpawn

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -222,10 +222,13 @@ describe("runChildProcess", () => {
     expect(result.stdout).toBe("done");
   });
 
-  it("waits for onSpawn before sending stdin to the child", async () => {
-    const spawnDelayMs = 150;
+  it("delivers stdin to the child even when onSpawn never resolves (JAC-1941 regression)", async () => {
+    // Regression test for JAC-1941 / JAC-1942: codex_local runs `codex exec ... -`
+    // and blocks on stdin. If stdin delivery waits on onSpawn metadata persistence
+    // and that persistence stalls, the child stays alive forever in the `Ss` state.
+    // stdin must be written immediately, independent of the onSpawn promise.
     const startedAt = Date.now();
-    let onSpawnCompletedAt = 0;
+    let onSpawnInvoked = false;
 
     const result = await runChildProcess(
       randomUUID(),
@@ -241,18 +244,22 @@ describe("runChildProcess", () => {
         timeoutSec: 5,
         graceSec: 1,
         onLog: async () => {},
-        onSpawn: async () => {
-          await new Promise((resolve) => setTimeout(resolve, spawnDelayMs));
-          onSpawnCompletedAt = Date.now();
+        onSpawn: () => {
+          onSpawnInvoked = true;
+          // Simulates a stalled metadata persistence (e.g. heartbeat process
+          // table write that never settles). The child must still complete.
+          return new Promise<void>(() => {});
         },
       },
     );
-    const finishedAt = Date.now();
+    const elapsedMs = Date.now() - startedAt;
 
+    expect(onSpawnInvoked).toBe(true);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe("hello from stdin");
-    expect(onSpawnCompletedAt).toBeGreaterThanOrEqual(startedAt + spawnDelayMs);
-    expect(finishedAt - startedAt).toBeGreaterThanOrEqual(spawnDelayMs);
+    // Child read stdin and exited well within the test timeout, despite onSpawn
+    // never resolving. Generous bound to absorb CI noise.
+    expect(elapsedMs).toBeLessThan(4_000);
   });
 
   it.skipIf(process.platform === "win32")("kills descendant processes on timeout via the process group", async () => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1940,11 +1940,19 @@ export async function runChildProcess(
 
         const stdin = child.stdin;
         if (opts.stdin != null && stdin) {
-          void spawnPersistPromise.finally(() => {
-            if (child.killed || stdin.destroyed) return;
+          // Write stdin immediately. Do NOT wait for spawnPersistPromise:
+          // adapters like codex_local run `codex exec ... -` and block on stdin.
+          // If onSpawn metadata persistence stalls, deferring the write here
+          // strands the child forever waiting on stdin (see JAC-1941).
+          if (!child.killed && !stdin.destroyed) {
             stdin.write(opts.stdin as string);
             stdin.end();
-          });
+          }
+          // Reference spawnPersistPromise so the linter does not flag the
+          // floating promise above. Errors are already routed through the
+          // .catch on its construction (-> onLogError); this is purely a
+          // marker that we intentionally don't await it on the stdin path.
+          void spawnPersistPromise;
         }
 
         child.on("error", (err: Error) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Local CLI adapters (e.g. `codex_local`) shell out via `runChildProcess` in `@paperclipai/adapter-utils`
> - Several adapters pass `-` as the prompt argument (e.g. `codex exec ... -`) so the child blocks until stdin is written and closed
> - Today `runChildProcess` defers the stdin write until `opts.onSpawn` (the heartbeat process-metadata persistence promise) settles
> - When that persistence stalls — e.g. an instance whose process tracking is slow — the deferred write never fires, the child sits forever in `Ss` waiting on stdin, and Paperclip accumulates stuck `resume … -` descendants
> - This pull request decouples stdin delivery from `onSpawn`: stdin is written immediately and the persistence promise is allowed to settle independently
> - The benefit is that stdin-driven adapters can no longer be stranded by a slow onSpawn callback

## What Changed

- `packages/adapter-utils/src/server-utils.ts`: in `runChildProcess`, when `opts.stdin` is provided, write and end the child's stdin synchronously after spawn instead of inside `spawnPersistPromise.finally(...)`. Keep the persistence promise alive with `void spawnPersistPromise` so failures still flow through `onLogError`.
- `packages/adapter-utils/src/server-utils.test.ts`: replace the previous "waits for onSpawn before sending stdin to the child" test (which encoded the now-broken ordering) with a regression test that supplies an `onSpawn` returning a never-resolving promise and asserts the child still receives stdin and exits with the expected output well within the per-test timeout.

## Verification

```bash
pnpm install --filter @paperclipai/adapter-utils...
pnpm --filter @paperclipai/adapter-utils typecheck
node_modules/.bin/vitest run --project @paperclipai/adapter-utils packages/adapter-utils/src/server-utils.test.ts
```

Local result: typecheck clean; `server-utils.test.ts` 18/18 tests pass, including the new `delivers stdin to the child even when onSpawn never resolves (JAC-1941 regression)` case.

The hotfix has also been live in `~/.npm/_npx/.../@paperclipai/adapter-utils/dist/server-utils.js` on the operator's instance for several heartbeat cycles without observing new stuck `codex exec resume … -` descendants.

## Risks

- Low risk. The change only affects ordering between an internal persistence promise and the stdin write for callers that pass `opts.stdin`. `onSpawn` still runs and its failures are still logged via `onLogError`. Callers that do not pass stdin are unaffected.
- The replaced test asserted the inverse ordering and so previously locked in the bug; behavioural callers who were depending on stdin being delayed until onSpawn finished do not exist in-tree.

## Model Used

- Provider/model: Anthropic Claude, model id `claude-opus-4-7` (Opus 4.7), running inside the Paperclip Claude Code adapter
- Capabilities used: extended reasoning, tool use (filesystem edits, shell), no code execution sandbox beyond the local repo

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge