### PR TITLE
server: honor preset PAPERCLIP_RUNTIME_API_URL during startup

### DIFF
--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -269,6 +269,7 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     loadConfigMock.mockReturnValue(buildTestConfig());
     process.env.BETTER_AUTH_SECRET = "test-secret";
     delete process.env.PAPERCLIP_API_URL;
+    delete process.env.PAPERCLIP_RUNTIME_API_URL;
   });
 
   afterEach(() => {
@@ -339,5 +340,20 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.listenPort).toBe(3110);
     expect(started.apiUrl).toBe("https://paperclip.example");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("https://paperclip.example");
+  });
+
+  it("honors a preset PAPERCLIP_RUNTIME_API_URL instead of recomputing from allowedHostnames", async () => {
+    // Operator-supplied PAPERCLIP_RUNTIME_API_URL must win over the computed default
+    // so launcher scripts can pin spawned agents to a reachable URL even when
+    // allowedHostnames[0] resolves to a hostname not bound to the listen port.
+    loadConfigMock.mockReturnValueOnce(buildTestConfig({
+      port: 3100,
+      allowedHostnames: ["leverage.local"],
+    }));
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://127.0.0.1:3100";
+
+    await startServer();
+
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3100");
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -638,6 +638,7 @@ export async function startServer(): Promise<StartedServer> {
     port: listenPort,
   });
   const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
+  const configuredRuntimeApiUrl = process.env.PAPERCLIP_RUNTIME_API_URL?.trim() || runtimeApiUrl;
   const runtimeApiCandidates = buildRuntimeApiCandidateUrls({
     preferredApiUrl: configuredApiUrl,
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,
@@ -647,7 +648,7 @@ export async function startServer(): Promise<StartedServer> {
   });
   process.env.PAPERCLIP_LISTEN_HOST = runtimeListenHost;
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
-  process.env.PAPERCLIP_RUNTIME_API_URL = runtimeApiUrl;
+  process.env.PAPERCLIP_RUNTIME_API_URL = configuredRuntimeApiUrl;
   process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify(runtimeApiCandidates);
   process.env.PAPERCLIP_API_URL = configuredApiUrl;
   


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents by launching runtime processes with a consistent control-plane API environment.
> - Server startup owns the canonical API URL values that get exported into spawned agents.
> - Operators can pre-set `PAPERCLIP_RUNTIME_API_URL` when the externally advertised hostname is not reachable from local child processes.
> - `startServer` already respected a preset `PAPERCLIP_API_URL`, but it unconditionally replaced `PAPERCLIP_RUNTIME_API_URL` with the computed default.
> - That made spawned agents inherit an unreachable API URL when `allowedHostnames[0]` pointed at a hostname such as `leverage.local` that was not bound directly to the listen port.
> - This pull request gives operator-supplied `PAPERCLIP_RUNTIME_API_URL` the same precedence as `PAPERCLIP_API_URL`, while preserving the computed-default behavior when the env var is unset.
> - The benefit is a durable source fix that removes the need for fragile local `node_modules` patches after cache rebuilds or version bumps.

## What Changed

- Updated `startServer` so a non-empty preset `PAPERCLIP_RUNTIME_API_URL` is honored instead of being overwritten by the URL from `choosePrimaryRuntimeApiUrl`.
- Preserved the existing computed fallback when `PAPERCLIP_RUNTIME_API_URL` is unset.
- Mirrored the existing `PAPERCLIP_API_URL` precedence idiom:

```ts
const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
const configuredRuntimeApiUrl = process.env.PAPERCLIP_RUNTIME_API_URL?.trim() || runtimeApiUrl;
// ...
process.env.PAPERCLIP_RUNTIME_API_URL = configuredRuntimeApiUrl;
process.env.PAPERCLIP_API_URL = configuredApiUrl;
```

- Added a unit test proving `startServer` honors a preset `PAPERCLIP_RUNTIME_API_URL` instead of recomputing from `allowedHostnames`.
- Updated the existing `startServer PAPERCLIP_API_URL handling` test setup to clear `PAPERCLIP_RUNTIME_API_URL` in `beforeEach`, keeping the computed-default path isolated from the parent shell environment.

## Verification

- [x] New unit test: `startServer` honors a preset `PAPERCLIP_RUNTIME_API_URL` instead of recomputing from `allowedHostnames`.
- [x] Existing `startServer PAPERCLIP_API_URL handling` suite updated to clear `PAPERCLIP_RUNTIME_API_URL` in `beforeEach`.
- [x] `pnpm vitest run server-startup-feedback-export.test.ts paperclip-env.test.ts` — 11/11 pass.
- [x] `pnpm typecheck` in `server/` clean.
- [ ] After release: bump local `paperclipai`, drop the local `node_modules` patch, confirm spawned env shows `PAPERCLIP_API_URL=http://127.0.0.1:3100` and `PAPERCLIP_RUNTIME_API_URL=http://127.0.0.1:3100`.

## Risks

- Low behavioral risk: this only changes precedence when `PAPERCLIP_RUNTIME_API_URL` is explicitly set and non-empty.
- Existing behavior is preserved when `PAPERCLIP_RUNTIME_API_URL` is unset.
- The main operational risk is a deliberately configured but incorrect `PAPERCLIP_RUNTIME_API_URL`; in that case this change correctly trusts the operator-provided override.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5, tool-enabled coding agent with shell/test execution access. Used for implementation, tests, and PR description update.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge

Tracks LEV-152.
