### PR TITLE
Redact secret-shaped retained run logs

### DIFF
--- a/packages/adapter-utils/src/command-redaction.ts
+++ b/packages/adapter-utils/src/command-redaction.ts
@@ -3,8 +3,10 @@ export const REDACTED_COMMAND_TEXT_VALUE = "***REDACTED***";
 const COMMAND_CLI_SECRET_OPTION_RE =
   /(\B-{1,2}(?:api[-_]?key|(?:access[-_]?|auth[-_]?)?token|token|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)(?:\s+|=)(["']?))[^\s"'`]+(\2)/gi;
 const COMMAND_ENV_SECRET_ASSIGNMENT_RE =
-  /(\b[A-Za-z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|AUTHORIZATION|JWT)[A-Za-z0-9_]*\s*=\s*)[^\s"'`]+/gi;
+  /(\b[A-Za-z0-9_]*(?:API_KEY|TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|JWT|COOKIE|SESSION|AUTH)[A-Za-z0-9_]*\s*=\s*)[^\s"'`]+/gi;
 const COMMAND_AUTHORIZATION_BEARER_RE = /(\bAuthorization\s*:\s*Bearer\s+)[^\s"'`]+/gi;
+const COMMAND_JWT_BEARER_RE =
+  /(\bBearer\s+)[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?\b/gi;
 const COMMAND_OPENAI_KEY_RE = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
 const COMMAND_GITHUB_TOKEN_RE = /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g;
 const COMMAND_JWT_RE =
@@ -13,6 +15,7 @@ const COMMAND_JWT_RE =
 export function redactCommandText(command: string, redactedValue = REDACTED_COMMAND_TEXT_VALUE): string {
   return command
     .replace(COMMAND_AUTHORIZATION_BEARER_RE, `$1${redactedValue}`)
+    .replace(COMMAND_JWT_BEARER_RE, `$1${redactedValue}`)
     .replace(COMMAND_CLI_SECRET_OPTION_RE, `$1${redactedValue}$3`)
     .replace(COMMAND_ENV_SECRET_ASSIGNMENT_RE, `$1${redactedValue}`)
     .replace(COMMAND_OPENAI_KEY_RE, redactedValue)

--- a/packages/adapter-utils/src/command-redaction.ts
+++ b/packages/adapter-utils/src/command-redaction.ts
@@ -3,7 +3,7 @@ export const REDACTED_COMMAND_TEXT_VALUE = "***REDACTED***";
 const COMMAND_CLI_SECRET_OPTION_RE =
   /(\B-{1,2}(?:api[-_]?key|(?:access[-_]?|auth[-_]?)?token|token|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)(?:\s+|=)(["']?))[^\s"'`]+(\2)/gi;
 const COMMAND_ENV_SECRET_ASSIGNMENT_RE =
-  /(\b[A-Za-z0-9_]*(?:API_KEY|TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|JWT|COOKIE|SESSION|AUTH)[A-Za-z0-9_]*\s*=\s*)[^\s"'`]+/gi;
+  /(\b[A-Za-z0-9_]*(?:API_KEY|TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|JWT|COOKIE|SESSION|AUTH)[A-Za-z0-9_]*\s*=\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"'`]+)/gi;
 const COMMAND_AUTHORIZATION_BEARER_RE = /(\bAuthorization\s*:\s*Bearer\s+)[^\s"'`]+/gi;
 const COMMAND_JWT_BEARER_RE =
   /(\bBearer\s+)[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?\b/gi;
@@ -17,7 +17,14 @@ export function redactCommandText(command: string, redactedValue = REDACTED_COMM
     .replace(COMMAND_AUTHORIZATION_BEARER_RE, `$1${redactedValue}`)
     .replace(COMMAND_JWT_BEARER_RE, `$1${redactedValue}`)
     .replace(COMMAND_CLI_SECRET_OPTION_RE, `$1${redactedValue}$3`)
-    .replace(COMMAND_ENV_SECRET_ASSIGNMENT_RE, `$1${redactedValue}`)
+    .replace(COMMAND_ENV_SECRET_ASSIGNMENT_RE, (match: string, prefix: string) => {
+      const value = match.slice(prefix.length);
+      const quote = value[0];
+      if ((quote === `"` || quote === `'`) && value.endsWith(quote)) {
+        return `${prefix}${quote}${redactedValue}${quote}`;
+      }
+      return `${prefix}${redactedValue}`;
+    })
     .replace(COMMAND_OPENAI_KEY_RE, redactedValue)
     .replace(COMMAND_GITHUB_TOKEN_RE, redactedValue)
     .replace(COMMAND_JWT_RE, redactedValue);

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -77,6 +77,15 @@ describe("redaction", () => {
       "CREDENTIAL_PATH=credential-path-value",
       "SESSION_TOKEN=session-token-value",
       "CUSTOM_AUTH=custom-auth-value",
+      'PAPERCLIP_API_KEY="quoted-api-key-value"',
+      "ACCESS_TOKEN='quoted-token-value'",
+      'APP_SECRET="quoted-secret-value"',
+      "POSTGRES_PASSWORD='quoted-password-value'",
+      'SERVICE_CREDENTIAL="quoted-credential-value"',
+      "SIGNED_JWT='quoted-jwt-value'",
+      'SESSION_COOKIE="quoted-cookie-value"',
+      "USER_SESSION='quoted-session-value'",
+      'AUTH_HEADER="quoted-auth-value"',
       `Bearer ${jwt}`,
     ].join("\n");
 
@@ -92,6 +101,24 @@ describe("redaction", () => {
     expect(result).not.toContain("credential-path-value");
     expect(result).not.toContain("session-token-value");
     expect(result).not.toContain("custom-auth-value");
+    expect(result).toContain(`PAPERCLIP_API_KEY="${REDACTED_EVENT_VALUE}"`);
+    expect(result).toContain(`ACCESS_TOKEN='${REDACTED_EVENT_VALUE}'`);
+    expect(result).toContain(`APP_SECRET="${REDACTED_EVENT_VALUE}"`);
+    expect(result).toContain(`POSTGRES_PASSWORD='${REDACTED_EVENT_VALUE}'`);
+    expect(result).toContain(`SERVICE_CREDENTIAL="${REDACTED_EVENT_VALUE}"`);
+    expect(result).toContain(`SIGNED_JWT='${REDACTED_EVENT_VALUE}'`);
+    expect(result).toContain(`SESSION_COOKIE="${REDACTED_EVENT_VALUE}"`);
+    expect(result).toContain(`USER_SESSION='${REDACTED_EVENT_VALUE}'`);
+    expect(result).toContain(`AUTH_HEADER="${REDACTED_EVENT_VALUE}"`);
+    expect(result).not.toContain("quoted-api-key-value");
+    expect(result).not.toContain("quoted-token-value");
+    expect(result).not.toContain("quoted-secret-value");
+    expect(result).not.toContain("quoted-password-value");
+    expect(result).not.toContain("quoted-credential-value");
+    expect(result).not.toContain("quoted-jwt-value");
+    expect(result).not.toContain("quoted-cookie-value");
+    expect(result).not.toContain("quoted-session-value");
+    expect(result).not.toContain("quoted-auth-value");
   });
 
   it("redacts inline secrets from command metadata without hiding safe command text", () => {

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -73,6 +73,11 @@ describe("redaction", () => {
       `escaped {\\"apiKey\\":\\"escaped-json-secret\\"}`,
       `GITHUB_TOKEN=${githubToken}`,
       `session=${jwt}`,
+      "COOKIE_VALUE=session-cookie-value",
+      "CREDENTIAL_PATH=credential-path-value",
+      "SESSION_TOKEN=session-token-value",
+      "CUSTOM_AUTH=custom-auth-value",
+      `Bearer ${jwt}`,
     ].join("\n");
 
     const result = redactSensitiveText(input);
@@ -83,6 +88,10 @@ describe("redaction", () => {
     expect(result).not.toContain("escaped-json-secret");
     expect(result).not.toContain(githubToken);
     expect(result).not.toContain(jwt);
+    expect(result).not.toContain("session-cookie-value");
+    expect(result).not.toContain("credential-path-value");
+    expect(result).not.toContain("session-token-value");
+    expect(result).not.toContain("custom-auth-value");
   });
 
   it("redacts inline secrets from command metadata without hiding safe command text", () => {

--- a/server/src/__tests__/run-log-store.test.ts
+++ b/server/src/__tests__/run-log-store.test.ts
@@ -32,17 +32,18 @@ describe("run log store", () => {
       stream: "stdout",
       ts: "2026-05-02T00:00:00.000Z",
       chunk: [
-        "PAPERCLIP_API_KEY=paperclip-api-key-value",
-        "POSTGRES_PASSWORD=postgres-password-value",
+        'PAPERCLIP_API_KEY="paperclip-api-key-value"',
+        "POSTGRES_PASSWORD='postgres-password-value'",
         "SAFE_VALUE=visible",
       ].join("\n"),
     });
 
     const result = await store.read(handle);
+    const storedEvent = JSON.parse(result.content.trim()) as { chunk: string };
 
-    expect(result.content).toContain(`PAPERCLIP_API_KEY=${REDACTED_EVENT_VALUE}`);
-    expect(result.content).toContain(`POSTGRES_PASSWORD=${REDACTED_EVENT_VALUE}`);
-    expect(result.content).toContain("SAFE_VALUE=visible");
+    expect(storedEvent.chunk).toContain(`PAPERCLIP_API_KEY="${REDACTED_EVENT_VALUE}"`);
+    expect(storedEvent.chunk).toContain(`POSTGRES_PASSWORD='${REDACTED_EVENT_VALUE}'`);
+    expect(storedEvent.chunk).toContain("SAFE_VALUE=visible");
     expect(result.content).not.toContain("paperclip-api-key-value");
     expect(result.content).not.toContain("postgres-password-value");
   });

--- a/server/src/__tests__/run-log-store.test.ts
+++ b/server/src/__tests__/run-log-store.test.ts
@@ -1,0 +1,49 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { REDACTED_EVENT_VALUE } from "../redaction.js";
+import { createLocalFileRunLogStore } from "../services/run-log-store.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempRunLogDir() {
+  const dir = await mkdtemp(join(tmpdir(), "paperclip-run-log-store-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("run log store", () => {
+  it("redacts secret-shaped command output before storing retained log content", async () => {
+    const root = await makeTempRunLogDir();
+    await mkdir(root, { recursive: true });
+    const store = createLocalFileRunLogStore(root);
+    const handle = await store.begin({
+      companyId: "company-1",
+      agentId: "agent-1",
+      runId: "run-1",
+    });
+
+    await store.append(handle, {
+      stream: "stdout",
+      ts: "2026-05-02T00:00:00.000Z",
+      chunk: [
+        "PAPERCLIP_API_KEY=paperclip-api-key-value",
+        "POSTGRES_PASSWORD=postgres-password-value",
+        "SAFE_VALUE=visible",
+      ].join("\n"),
+    });
+
+    const result = await store.read(handle);
+
+    expect(result.content).toContain(`PAPERCLIP_API_KEY=${REDACTED_EVENT_VALUE}`);
+    expect(result.content).toContain(`POSTGRES_PASSWORD=${REDACTED_EVENT_VALUE}`);
+    expect(result.content).toContain("SAFE_VALUE=visible");
+    expect(result.content).not.toContain("paperclip-api-key-value");
+    expect(result.content).not.toContain("postgres-password-value");
+  });
+});

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1,7 +1,7 @@
 import { redactCommandText } from "@paperclipai/adapter-utils";
 
 const SECRET_PAYLOAD_KEY_RE =
-  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)/i;
+  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|session|connectionstring)/i;
 const COMMAND_PAYLOAD_KEY_RE =
   /(^command$|^cmd$|command[-_]?line|resolved[-_]?command|PAPERCLIP_RESOLVED_COMMAND)/i;
 const COMMAND_ARGS_PAYLOAD_KEY_RE = /^(commandArgs|command_?args|argv)$/i;
@@ -9,9 +9,9 @@ const JWT_VALUE_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-
 const CLI_SECRET_FLAG_RE =
   /^-{1,2}(?:api[-_]?key|(?:access[-_]?|auth[-_]?)?token|token|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)$/i;
 const JSON_SECRET_FIELD_TEXT_RE =
-  /((?:"|')?(?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)(?:"|')?\s*:\s*(?:"|'))[^"'`\r\n]+((?:"|'))/gi;
+  /((?:"|')?(?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|session|connectionstring)(?:"|')?\s*:\s*(?:"|'))[^"'`\r\n]+((?:"|'))/gi;
 const ESCAPED_JSON_SECRET_FIELD_TEXT_RE =
-  /((?:\\")?(?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)(?:\\")?\s*:\s*(?:\\"))[^\\\r\n]+((?:\\"))/gi;
+  /((?:\\")?(?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|session|connectionstring)(?:\\")?\s*:\s*(?:\\"))[^\\\r\n]+((?:\\"))/gi;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import { notFound } from "../errors.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+import { redactSensitiveText } from "../redaction.js";
 
 export type RunLogStoreType = "local_file";
 
@@ -50,7 +51,7 @@ function resolveWithin(basePath: string, relativePath: string) {
   return resolved;
 }
 
-function createLocalFileRunLogStore(basePath: string): RunLogStore {
+export function createLocalFileRunLogStore(basePath: string): RunLogStore {
   async function ensureDir(relativeDir: string) {
     const dir = resolveWithin(basePath, relativeDir);
     await fs.mkdir(dir, { recursive: true });
@@ -112,7 +113,7 @@ function createLocalFileRunLogStore(basePath: string): RunLogStore {
       const line = JSON.stringify({
         ts: event.ts,
         stream: event.stream,
-        chunk: event.chunk,
+        chunk: redactSensitiveText(event.chunk),
       });
       const persisted = `${line}\n`;
       await fs.appendFile(absPath, persisted, "utf8");


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Heartbeat runs retain stdout/stderr chunks so users can inspect agent execution logs, recovery evidence, and feedback exports
> - Those retained logs are a storage boundary, not just a display boundary
> - Secret-shaped command output can include environment assignments or bearer values even when invocation metadata is sanitized
> - This pull request redacts those secret-shaped chunks before they are appended to the run-log store
> - The benefit is that `/api/heartbeat-runs/:runId/log`, recovery tails, and feedback/export artifacts inherit already-redacted retained content

## What Changed

- Redact retained run-log chunks at the local run-log store append boundary before writing NDJSON to disk.
- Broaden command-text redaction for secret-shaped env assignments whose names include API_KEY, TOKEN, SECRET, PASSWORD, CREDENTIAL, JWT, COOKIE, SESSION, or AUTH.
- Add JWT-shaped bare bearer value redaction while preserving useful prefixes such as variable names and `Bearer`.
- Add focused regression coverage for retained run-log storage containing `PAPERCLIP_API_KEY` and `POSTGRES_PASSWORD` output.

## Verification

- `corepack pnpm run preflight:workspace-links && corepack pnpm exec vitest run server/src/__tests__/redaction.test.ts server/src/__tests__/run-log-store.test.ts`
- `corepack pnpm --filter @paperclipai/adapter-utils typecheck`
- `corepack pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && cd server && ../node_modules/.bin/tsc --noEmit`
- Note: `corepack pnpm --filter @paperclipai/server typecheck` could not complete in this shell because the package script invokes bare `pnpm`, which is not on PATH here; I ran the same underlying plugin-SDK build-deps step and server `tsc --noEmit` explicitly.

## Risks

- Low behavioral risk: this only makes retained logs more conservative before persistence.
- Some non-secret values whose variable names include broad terms like `SESSION` or `AUTH` may now be redacted in retained logs.
- No migration required; existing retained logs are not rewritten by this change.

## Model Used

- OpenAI GPT-5 Codex, tool-enabled coding session, medium reasoning effort.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
