### PR TITLE
Skip stale-run review when source issue is blocked (BLO-2568)

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -215,6 +215,25 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(evaluations[0]?.description).not.toContain("sk-test-secret-value");
   });
 
+  it("does not file a review when the source issue is already blocked", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    await db.update(issues).set({ status: "blocked" }).where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result).toMatchObject({ created: 0, escalated: 0, skipped: 1 });
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+  });
+
   it("redacts sensitive values from actual run-log evidence", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const leakedJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -934,6 +934,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runningAgent = await getAgent(input.run.agentId);
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
+
+    if (sourceIssue && sourceIssue.status === "blocked") {
+      logger.info(
+        {
+          runId: input.run.id,
+          sourceIssueId: sourceIssue.id,
+          sourceIssueIdentifier: sourceIssue.identifier,
+        },
+        "stale-run watchdog skipped: source issue is blocked",
+      );
+      return { kind: "skipped" as const };
+    }
+
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
     const evidence = await collectStaleRunEvidence({
       run: input.run,


### PR DESCRIPTION
## Summary

- Adds an early-skip guard in `createOrUpdateStaleRunEvaluation` so the silent-run watchdog does not file `originKind=stale_active_run_evaluation` review tickets when the source issue is already `blocked`.
- Silent runs on a blocked issue are expected (the agent has nothing to do until the blocker clears), not stuck. The next blocker-resolved wake re-engages normally; the existing snooze/decision flow still applies to non-blocked issues.

This is **Path B** from the [BLO-2568 plan document](https://blockcast.app.paperclipai.com/BLO/issues/BLO-2568#document-plan):

| Path | Where | Why not |
|---|---|---|
| A — scheduler refuses to spawn runs on `blocked` issues | run scheduler | Many wake reasons fire regardless of status; risks starving legitimate wakes (comments, blocker-resolved, reviewer feedback). |
| **B — detector skips when source is `blocked`** (this PR) | `createOrUpdateStaleRunEvaluation` | Two-line guard, low risk, only suppresses *review-ticket creation*. |

## Why

The BLO-1479 chain produced **8 false-positive** "Review silent active run" tickets against CTO ([BLO-2507](https://blockcast.app.paperclipai.com/BLO/issues/BLO-2507) → [BLO-2565](https://blockcast.app.paperclipai.com/BLO/issues/BLO-2565)) while it sat `blocked` on a manual kubectl gate ([BLO-2502](https://blockcast.app.paperclipai.com/BLO/issues/BLO-2502)). Each cycle costs heartbeat budget and pollutes the source issue's blocker list with cancelled-issue invariants.

The deeper "stop spawning runs on blocked issues" cleanup is out of scope here and tracked under [BLO-2418](https://blockcast.app.paperclipai.com/BLO/issues/BLO-2418).

## Test plan

- [x] New `does not file a review when the source issue is already blocked` test in `server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts` — passes.
- [x] All 9 watchdog tests pass locally (`pnpm exec vitest run server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`).
- [ ] **Post-merge verification (AC #1, 14d window):** CTO will spot-check the BLO-1479 chain on 2026-05-15; expect 0 new `stale_active_run_evaluation` tickets while [BLO-2502](https://blockcast.app.paperclipai.com/BLO/issues/BLO-2502) remains open.

## Acceptance criteria

| AC | Met by |
|---|---|
| #1 No new stale-run reviews on `blocked` source issues for 14d | New guard — manual verification on 2026-05-15 |
| #2 Detector skips runs whose source is `blocked` waiting on a human-gated blocker | Path B — implemented |
| #3 Documented decision in plan doc | [BLO-2568#document-plan](https://blockcast.app.paperclipai.com/BLO/issues/BLO-2568#document-plan) |

Refs BLO-2568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)