### PR TITLE
fix(ui): correct subscription-share denominator in ProviderQuotaCard (TES-81)

### DIFF
--- a/ui/src/components/ProviderQuotaCard.test.ts
+++ b/ui/src/components/ProviderQuotaCard.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { CostByProviderModel } from "@paperclipai/shared";
+import { aggregateProviderTotals } from "./ProviderQuotaCard";
+
+// row factories shaped to match the byProvider SQL aggregate at
+// server/src/services/costs.ts:228-258 (GROUP BY provider, biller, billing_type, model).
+// each row is single-billing-type, so for subscription rows
+//   inputTokens === subscriptionInputTokens and outputTokens === subscriptionOutputTokens,
+// and for metered rows the subscription* fields are 0. the helper must respect that
+// shape — it is what the live cost-aggregation query produces (e.g. for Test2 the
+// anthropic provider returns one subscription_included row whose inputTokens equals
+// subscriptionInputTokens, and the share must render 100%, not 50%).
+
+function subscriptionRow(over: Partial<CostByProviderModel> = {}): CostByProviderModel {
+  return {
+    provider: "anthropic",
+    biller: "anthropic",
+    billingType: "subscription_included",
+    model: "claude-sonnet-4.5",
+    costCents: 0,
+    inputTokens: 1_420_000,
+    cachedInputTokens: 210_000,
+    outputTokens: 385_000,
+    apiRunCount: 0,
+    subscriptionRunCount: 38,
+    subscriptionCachedInputTokens: 210_000,
+    subscriptionInputTokens: 1_420_000,
+    subscriptionOutputTokens: 385_000,
+    ...over,
+  };
+}
+
+function meteredRow(over: Partial<CostByProviderModel> = {}): CostByProviderModel {
+  return {
+    provider: "anthropic",
+    biller: "anthropic",
+    billingType: "metered_api",
+    model: "claude-opus-4.5",
+    costCents: 11_240,
+    inputTokens: 280_000,
+    cachedInputTokens: 35_000,
+    outputTokens: 92_000,
+    apiRunCount: 7,
+    subscriptionRunCount: 0,
+    subscriptionCachedInputTokens: 0,
+    subscriptionInputTokens: 0,
+    subscriptionOutputTokens: 0,
+    ...over,
+  };
+}
+
+describe("aggregateProviderTotals → subSharePct", () => {
+  it("renders 100% when all usage is via subscription", () => {
+    const totals = aggregateProviderTotals([subscriptionRow()]);
+    expect(totals.subSharePct).toBe(100);
+    expect(totals.totalTokens).toBe(1_420_000 + 385_000);
+    expect(totals.totalSubTokens).toBe(1_420_000 + 385_000);
+  });
+
+  it("renders 0% when all usage is API-billed", () => {
+    const totals = aggregateProviderTotals([meteredRow()]);
+    expect(totals.subSharePct).toBe(0);
+    expect(totals.totalTokens).toBe(280_000 + 92_000);
+    expect(totals.totalSubTokens).toBe(0);
+  });
+
+  it("renders the correct fraction in mixed cases (30% sub / 70% API)", () => {
+    // sub row: 300k tokens (all subscription); api row: 700k tokens (none sub).
+    const rows = [
+      subscriptionRow({
+        inputTokens: 200_000,
+        outputTokens: 100_000,
+        subscriptionInputTokens: 200_000,
+        subscriptionOutputTokens: 100_000,
+      }),
+      meteredRow({
+        inputTokens: 500_000,
+        outputTokens: 200_000,
+      }),
+    ];
+    const totals = aggregateProviderTotals(rows);
+    expect(totals.totalTokens).toBe(1_000_000);
+    expect(totals.totalSubTokens).toBe(300_000);
+    expect(totals.subSharePct).toBeCloseTo(30, 6);
+  });
+
+  it("renders 0% (not NaN, not Infinity) when there is no usage", () => {
+    expect(aggregateProviderTotals([]).subSharePct).toBe(0);
+    // also covers rows-present-but-zero-tokens (e.g. empty period for a known provider)
+    const empty = aggregateProviderTotals([
+      meteredRow({ inputTokens: 0, outputTokens: 0, costCents: 0, apiRunCount: 0 }),
+    ]);
+    expect(empty.subSharePct).toBe(0);
+  });
+});

--- a/ui/src/components/ProviderQuotaCard.tsx
+++ b/ui/src/components/ProviderQuotaCard.tsx
@@ -16,6 +16,55 @@ import {
 // ordered display labels for rolling-window rows
 const ROLLING_WINDOWS = ["5h", "24h", "7d"] as const;
 
+export interface ProviderTotals {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalTokens: number;
+  totalCostCents: number;
+  totalApiRuns: number;
+  totalSubRuns: number;
+  totalSubInputTokens: number;
+  totalSubOutputTokens: number;
+  totalSubTokens: number;
+  /** share of total token usage attributable to subscription billing, 0..100 */
+  subSharePct: number;
+}
+
+/**
+ * sums per-(provider,biller,billingType,model) rows into the aggregates the
+ * card renders. each input row is single-billing-type (server groups by it),
+ * so r.inputTokens is the *full* row total and r.subscriptionInputTokens is
+ * a subset that equals r.inputTokens for subscription rows and 0 otherwise.
+ * → totalTokens already includes subscription tokens; do not re-add them.
+ */
+export function aggregateProviderTotals(rows: CostByProviderModel[]): ProviderTotals {
+  let inputTokens = 0, outputTokens = 0, costCents = 0;
+  let apiRunCount = 0, subRunCount = 0, subInputTokens = 0, subOutputTokens = 0;
+  for (const r of rows) {
+    inputTokens += r.inputTokens;
+    outputTokens += r.outputTokens;
+    costCents += r.costCents;
+    apiRunCount += r.apiRunCount;
+    subRunCount += r.subscriptionRunCount;
+    subInputTokens += r.subscriptionInputTokens;
+    subOutputTokens += r.subscriptionOutputTokens;
+  }
+  const totalTokens = inputTokens + outputTokens;
+  const subTokens = subInputTokens + subOutputTokens;
+  return {
+    totalInputTokens: inputTokens,
+    totalOutputTokens: outputTokens,
+    totalTokens,
+    totalCostCents: costCents,
+    totalApiRuns: apiRunCount,
+    totalSubRuns: subRunCount,
+    totalSubInputTokens: subInputTokens,
+    totalSubOutputTokens: subOutputTokens,
+    totalSubTokens: subTokens,
+    subSharePct: totalTokens > 0 ? (subTokens / totalTokens) * 100 : 0,
+  };
+}
+
 interface ProviderQuotaCardProps {
   provider: string;
   rows: CostByProviderModel[];
@@ -48,38 +97,10 @@ export function ProviderQuotaCard({
   quotaSource = null,
   quotaLoading = false,
 }: ProviderQuotaCardProps) {
-  // single-pass aggregation over rows — memoized so the 8 derived values are not
-  // recomputed on every parent render tick (providers tab polls every 30s, and each
-  // card is mounted twice: once in the "all" tab grid and once in its per-provider tab).
-  const totals = useMemo(() => {
-    let inputTokens = 0, outputTokens = 0, costCents = 0;
-    let apiRunCount = 0, subRunCount = 0, subInputTokens = 0, subOutputTokens = 0;
-    for (const r of rows) {
-      inputTokens += r.inputTokens;
-      outputTokens += r.outputTokens;
-      costCents += r.costCents;
-      apiRunCount += r.apiRunCount;
-      subRunCount += r.subscriptionRunCount;
-      subInputTokens += r.subscriptionInputTokens;
-      subOutputTokens += r.subscriptionOutputTokens;
-    }
-    const totalTokens = inputTokens + outputTokens;
-    const subTokens = subInputTokens + subOutputTokens;
-    // denominator: api-billed tokens (from cost_events) + subscription tokens (from heartbeat_runs)
-    const allTokens = totalTokens + subTokens;
-    return {
-      totalInputTokens: inputTokens,
-      totalOutputTokens: outputTokens,
-      totalTokens,
-      totalCostCents: costCents,
-      totalApiRuns: apiRunCount,
-      totalSubRuns: subRunCount,
-      totalSubInputTokens: subInputTokens,
-      totalSubOutputTokens: subOutputTokens,
-      totalSubTokens: subTokens,
-      subSharePct: allTokens > 0 ? (subTokens / allTokens) * 100 : 0,
-    };
-  }, [rows]);
+  // memoized so the derived values are not recomputed on every parent render tick
+  // (providers tab polls every 30s, and each card is mounted twice: once in the
+  // "all" tab grid and once in its per-provider tab).
+  const totals = useMemo(() => aggregateProviderTotals(rows), [rows]);
 
   const {
     totalInputTokens,


### PR DESCRIPTION
## Summary

Fixes the "% of token usage via subscription" bar in `Costs > Providers` collapsing to exactly **50%** for any provider that is 100% subscription-billed. The denominator was double-counting subscription tokens.

```ts
// before
const allTokens   = totalTokens + subTokens;        // <-- double count
subSharePct = subTokens / allTokens * 100;          // collapses to 50% at 100%-sub

// after
subSharePct: totalTokens > 0 ? (subTokens / totalTokens) * 100 : 0,
```

`r.inputTokens` from the `byProvider` aggregation (`server/src/services/costs.ts:228-258`) already includes subscription tokens — the SQL groups by `billing_type` and sums from `cost_events`, so each row is single-billing-type and `r.subscriptionInputTokens` is a subset of `r.inputTokens`, not an independent series. Adding `subTokens` to the denominator a second time was the bug. Trace evidence: see [TES-81 trace comment](#).

This PR also:
- Extracts the inline aggregation into a pure exported helper `aggregateProviderTotals(rows)`, keeping `useMemo` in place.
- Removes the misleading `// denominator: api-billed (from cost_events) + subscription (from heartbeat_runs)` comment that was the seed of the bug. The data layer reads from `cost_events` only.

## Acceptance criteria

| Case | Expected | Result |
|---|---|---|
| 100% subscription | 100% | ✅ unit test passes; live API confirms |
| 100% API | 0% | ✅ unit test passes |
| Mixed (30% sub / 70% API) | 30% | ✅ unit test passes (asserted to 6 decimals) |
| Zero usage | 0% (no NaN) | ✅ unit test passes (empty array + zero-token row) |

Live verification against TES company `/costs/by-provider` (which exhibits the same bug condition — rows where `subscriptionInputTokens === inputTokens`):

```
anthropic: total=3,069,101 sub=3,069,101 share=100.0% (was 50%)
openai:    total=4,214,376 sub=4,214,376 share=100.0% (was 50%)
```

## Test plan

- [x] `pnpm --filter ui exec vitest run src/components/ProviderQuotaCard.test.ts` — 4/4 passing
- [x] `pnpm --filter ui typecheck` — clean
- [x] Live API quote on real `cost_events` rows shows rendered share flip 50% → 100%

## Process notes

**Policy 7 cross-system review skipped** per the trivial-diff rule (one math line + zero-divisor guard + four-case unit test, all in pure helper space). CTO sign-off recorded as the [approval comment on TES-81](#) covering correctness, readability, architecture, security (N/A), performance, and test coverage.

Closes TES-81
