### PR TITLE
feat(heartbeat): add hermes_local to SESSIONED_LOCAL_ADAPTERS

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -97,6 +97,7 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "codex_local",
   "cursor",
   "gemini_local",
+  "hermes_local",
   "opencode_local",
   "pi_local",
 ]);


### PR DESCRIPTION
## Summary

- Adds `hermes_local` to the `SESSIONED_LOCAL_ADAPTERS` set in `heartbeat.ts` so the orphan-process reaper tracks Hermes child processes for liveness checks.

## Problem

`hermes_local` was missing from the tracked-adapters set. As a result, `isTrackedLocalChildProcessAdapter("hermes_local")` returned `false`, and the reaper at heartbeat.ts:2584-2587 short-circuited the `processPidAlive` check. Even when `process_pid` was recorded (requires the sister fix in hermes-paperclip-adapter — see NousResearch/hermes-paperclip-adapter#TBD), the reaper couldn't use it for Hermes runs.

When the in-memory `runningProcesses` Map lost a Hermes run entry, the reaper had no fallback path. After the 5-minute staleness threshold the run was marked `process_lost` even though the Hermes child was alive. The stranded-issue self-heal then auto-retries, sometimes spawning a second concurrent Hermes process while the first was still running.

## Verified

Live on ao-sh-derper (2026-04-25): AUT-9 — Hermes Kimi was 5 minutes into investigating sshd_config + git remotes when reaped. Two Kimi processes ended up running simultaneously against the same issue, both consuming Moonshot quota.

## Related

- Sister fix: onSpawn wiring in hermes-paperclip-adapter (separate PR)
- Paperclip issue: AIW-186