### PR TITLE
feat(quota): add Sonnet-only weekly utilization to Claude provider quota panel

### DIFF
--- a/packages/adapters/claude-local/src/server/quota.ts
+++ b/packages/adapters/claude-local/src/server/quota.ts
@@ -231,7 +231,7 @@ export async function fetchClaudeQuota(token: string): Promise<QuotaWindow[]> {
   }
   if (body.seven_day != null) {
     windows.push({
-      label: "Current week (all models)",
+      label: "Weekly (all models)",
       usedPercent: toPercent(body.seven_day.utilization),
       resetsAt: body.seven_day.resets_at ?? null,
       valueLabel: null,
@@ -240,7 +240,7 @@ export async function fetchClaudeQuota(token: string): Promise<QuotaWindow[]> {
   }
   if (body.seven_day_sonnet != null) {
     windows.push({
-      label: "Current week (Sonnet only)",
+      label: "Weekly (Sonnet)",
       usedPercent: toPercent(body.seven_day_sonnet.utilization),
       resetsAt: body.seven_day_sonnet.resets_at ?? null,
       valueLabel: null,
@@ -335,8 +335,10 @@ function isQuotaLabel(line: string): boolean {
   const normalized = normalizeForLabelSearch(line);
   return normalized === "currentsession"
     || normalized === "currentweekallmodels"
+    || normalized === "weeklyallmodels"
     || normalized === "currentweeksonnetonly"
     || normalized === "currentweeksonnet"
+    || normalized === "weeklysonnet"
     || normalized === "currentweekopusonly"
     || normalized === "currentweekopus"
     || normalized === "extrausage";
@@ -347,10 +349,12 @@ function canonicalQuotaLabel(line: string): string {
     case "currentsession":
       return "Current session";
     case "currentweekallmodels":
-      return "Current week (all models)";
+    case "weeklyallmodels":
+      return "Weekly (all models)";
     case "currentweeksonnetonly":
     case "currentweeksonnet":
-      return "Current week (Sonnet only)";
+    case "weeklysonnet":
+      return "Weekly (Sonnet)";
     case "currentweekopusonly":
     case "currentweekopus":
       return "Current week (Opus only)";

--- a/packages/adapters/claude-local/src/server/quota.ts
+++ b/packages/adapters/claude-local/src/server/quota.ts
@@ -249,7 +249,7 @@ export async function fetchClaudeQuota(token: string): Promise<QuotaWindow[]> {
   }
   if (body.seven_day_opus != null) {
     windows.push({
-      label: "Current week (Opus only)",
+      label: "Weekly (Opus)",
       usedPercent: toPercent(body.seven_day_opus.utilization),
       resetsAt: body.seven_day_opus.resets_at ?? null,
       valueLabel: null,
@@ -331,33 +331,47 @@ function percentFromLine(line: string): number | null {
   return Math.round(clamped);
 }
 
+// The CLI scrape diagnostic path (`fetchClaudeCliQuota` → `parseClaudeCliUsageText`)
+// receives whatever text Anthropic's `claude` CLI happens to render in its `/usage`
+// TUI panel. We canonicalize it to the same labels `fetchClaudeQuota` emits from the
+// OAuth API, so the UI doesn't have to know which path produced the windows. The
+// `currentweek*` aliases below cover the headings the upstream CLI prints today;
+// the `weekly*` aliases match the labels we now emit ourselves so any internal
+// re-feed (or a future CLI rename) round-trips. These aliases are intended to be
+// permanent for as long as the CLI scrape diagnostic path is maintained.
 function isQuotaLabel(line: string): boolean {
   const normalized = normalizeForLabelSearch(line);
   return normalized === "currentsession"
-    || normalized === "currentweekallmodels"
-    || normalized === "weeklyallmodels"
-    || normalized === "currentweeksonnetonly"
-    || normalized === "currentweeksonnet"
-    || normalized === "weeklysonnet"
-    || normalized === "currentweekopusonly"
-    || normalized === "currentweekopus"
+    || normalized === "currentweekallmodels" // upstream CLI heading
+    || normalized === "weeklyallmodels"      // our renamed label, round-trip safety
+    || normalized === "currentweeksonnetonly" // upstream CLI heading
+    || normalized === "currentweeksonnet"     // upstream CLI heading (older form)
+    || normalized === "weeklysonnet"          // our renamed label, round-trip safety
+    || normalized === "currentweekopusonly"   // upstream CLI heading
+    || normalized === "currentweekopus"       // upstream CLI heading (older form)
+    || normalized === "weeklyopus"            // our renamed label, round-trip safety
     || normalized === "extrausage";
 }
 
+// Mirrors the alias set in `isQuotaLabel`. Each `case` block maps a recognized
+// upstream/legacy form onto the single canonical label the UI renders. Keeping
+// both old and new normalized forms is intentional and permanent for as long as
+// the CLI scrape diagnostic path is maintained — see the comment above `isQuotaLabel`.
 function canonicalQuotaLabel(line: string): string {
   switch (normalizeForLabelSearch(line)) {
     case "currentsession":
       return "Current session";
-    case "currentweekallmodels":
-    case "weeklyallmodels":
+    case "currentweekallmodels": // upstream CLI heading
+    case "weeklyallmodels":      // our renamed label, round-trip safety
       return "Weekly (all models)";
-    case "currentweeksonnetonly":
-    case "currentweeksonnet":
-    case "weeklysonnet":
+    case "currentweeksonnetonly": // upstream CLI heading
+    case "currentweeksonnet":     // upstream CLI heading (older form)
+    case "weeklysonnet":          // our renamed label, round-trip safety
       return "Weekly (Sonnet)";
-    case "currentweekopusonly":
-    case "currentweekopus":
-      return "Current week (Opus only)";
+    case "currentweekopusonly": // upstream CLI heading
+    case "currentweekopus":     // upstream CLI heading (older form)
+    case "weeklyopus":          // our renamed label, round-trip safety
+      return "Weekly (Opus)";
     case "extrausage":
       return "Extra usage";
     default:

--- a/server/src/__tests__/quota-windows.test.ts
+++ b/server/src/__tests__/quota-windows.test.ts
@@ -329,14 +329,14 @@ describe("parseClaudeCliUsageText", () => {
         detail: "Resets 5pm (America/Chicago)",
       },
       {
-        label: "Current week (all models)",
+        label: "Weekly (all models)",
         usedPercent: 47,
         resetsAt: null,
         valueLabel: null,
         detail: "Resets Mar 18 at 7:59am (America/Chicago)",
       },
       {
-        label: "Current week (Sonnet only)",
+        label: "Weekly (Sonnet)",
         usedPercent: 0,
         resetsAt: null,
         valueLabel: null,
@@ -542,7 +542,7 @@ describe("fetchClaudeQuota", () => {
     const windows = await fetchClaudeQuota("token");
     expect(windows).toHaveLength(1);
     expect(windows[0]).toMatchObject({
-      label: "Current week (all models)",
+      label: "Weekly (all models)",
       usedPercent: 91,
       resetsAt: null,
     });
@@ -564,7 +564,7 @@ describe("fetchClaudeQuota", () => {
     });
     const windows = await fetchClaudeQuota("token");
     expect(windows).toHaveLength(2);
-    expect(windows[0]!.label).toBe("Current week (Sonnet only)");
+    expect(windows[0]!.label).toBe("Weekly (Sonnet)");
     expect(windows[0]!.usedPercent).toBe(23);
     expect(windows[1]!.label).toBe("Current week (Opus only)");
     expect(windows[1]!.usedPercent).toBe(85);
@@ -588,8 +588,8 @@ describe("fetchClaudeQuota", () => {
     const labels = windows.map((w: QuotaWindow) => w.label);
     expect(labels).toEqual([
       "Current session",
-      "Current week (all models)",
-      "Current week (Sonnet only)",
+      "Weekly (all models)",
+      "Weekly (Sonnet)",
       "Current week (Opus only)",
     ]);
     expect(windows.map((w: QuotaWindow) => w.usedPercent)).toEqual([10, 20, 30, 40]);

--- a/server/src/__tests__/quota-windows.test.ts
+++ b/server/src/__tests__/quota-windows.test.ts
@@ -566,7 +566,7 @@ describe("fetchClaudeQuota", () => {
     expect(windows).toHaveLength(2);
     expect(windows[0]!.label).toBe("Weekly (Sonnet)");
     expect(windows[0]!.usedPercent).toBe(23);
-    expect(windows[1]!.label).toBe("Current week (Opus only)");
+    expect(windows[1]!.label).toBe("Weekly (Opus)");
     expect(windows[1]!.usedPercent).toBe(85);
   });
 
@@ -590,7 +590,7 @@ describe("fetchClaudeQuota", () => {
       "Current session",
       "Weekly (all models)",
       "Weekly (Sonnet)",
-      "Current week (Opus only)",
+      "Weekly (Opus)",
     ]);
     expect(windows.map((w: QuotaWindow) => w.usedPercent)).toEqual([10, 20, 30, 40]);
   });

--- a/ui/src/components/ClaudeSubscriptionPanel.test.tsx
+++ b/ui/src/components/ClaudeSubscriptionPanel.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { flushSync } from "react-dom";
+import type { QuotaWindow } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ClaudeSubscriptionPanel } from "./ClaudeSubscriptionPanel";
+
+function render(container: HTMLElement, ui: ReactNode): void {
+  // The panel is a pure render with no effects, so a flushSync render gives us
+  // a settled DOM tree without needing React's `act`. (React 19 dropped the
+  // `react` re-export of `act`; the codebase's other component tests are mid-
+  // migration to RTL, so we keep this file standalone.)
+  const root = createRoot(container);
+  flushSync(() => {
+    root.render(ui);
+  });
+}
+
+function rowLabels(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll(".text-sm.font-medium.text-foreground")).map(
+    (node) => node.textContent?.trim() ?? "",
+  );
+}
+
+const fullWindows: QuotaWindow[] = [
+  { label: "Current session", usedPercent: 46, resetsAt: null, valueLabel: null, detail: null },
+  { label: "Weekly (all models)", usedPercent: 74, resetsAt: null, valueLabel: null, detail: null },
+  { label: "Weekly (Sonnet)", usedPercent: 58, resetsAt: null, valueLabel: null, detail: null },
+  { label: "Weekly (Opus)", usedPercent: 92, resetsAt: null, valueLabel: null, detail: null },
+  { label: "Extra usage", usedPercent: null, resetsAt: null, valueLabel: "$0.00", detail: null },
+];
+
+describe("ClaudeSubscriptionPanel", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it("renders the Sonnet row when seven_day_sonnet is present in the payload", () => {
+    render(container, <ClaudeSubscriptionPanel windows={fullWindows} source="anthropic-oauth" />);
+    const labels = rowLabels(container);
+    expect(labels).toContain("Weekly (Sonnet)");
+    expect(labels).toContain("Weekly (all models)");
+    expect(labels).toContain("Weekly (Opus)");
+  });
+
+  it("hides the Sonnet row when seven_day_sonnet is absent from the payload", () => {
+    const noSonnet = fullWindows.filter((w) => w.label !== "Weekly (Sonnet)");
+    render(container, <ClaudeSubscriptionPanel windows={noSonnet} source="anthropic-oauth" />);
+    const labels = rowLabels(container);
+    expect(labels).not.toContain("Weekly (Sonnet)");
+    expect(labels).toContain("Weekly (all models)");
+    expect(labels).toContain("Weekly (Opus)");
+  });
+
+  it("renders without crashing when Sonnet utilization exceeds all-models utilization", () => {
+    // Anthropic shouldn't return this shape, but the panel must not throw if
+    // upstream ever ships a payload where the per-model meter is higher than
+    // the aggregate. Both rows render; clamp/warn behavior is not asserted here.
+    const sonnetExceedsAll = fullWindows.map((w) => {
+      if (w.label === "Weekly (all models)") return { ...w, usedPercent: 30 };
+      if (w.label === "Weekly (Sonnet)") return { ...w, usedPercent: 80 };
+      return w;
+    });
+    expect(() => {
+      render(container, <ClaudeSubscriptionPanel windows={sonnetExceedsAll} source="anthropic-oauth" />);
+    }).not.toThrow();
+    const labels = rowLabels(container);
+    expect(labels).toContain("Weekly (all models)");
+    expect(labels).toContain("Weekly (Sonnet)");
+  });
+});

--- a/ui/src/components/ClaudeSubscriptionPanel.tsx
+++ b/ui/src/components/ClaudeSubscriptionPanel.tsx
@@ -9,7 +9,9 @@ interface ClaudeSubscriptionPanelProps {
 
 const WINDOW_ORDER = [
   "currentsession",
+  "weeklyallmodels",
   "currentweekallmodels",
+  "weeklysonnet",
   "currentweeksonnetonly",
   "currentweeksonnet",
   "currentweekopusonly",

--- a/ui/src/components/ClaudeSubscriptionPanel.tsx
+++ b/ui/src/components/ClaudeSubscriptionPanel.tsx
@@ -7,16 +7,22 @@ interface ClaudeSubscriptionPanelProps {
   error?: string | null;
 }
 
+// Sort order for the windows rendered inside the panel. Each slot has at most
+// one "live" key (the label our parser emits today) and zero or more legacy
+// keys retained for back-compat with older CLI scrape headings or pre-rename
+// payloads. Unknown keys (e.g. a hypothetical future `weeklyhaiku`) fall to
+// the bottom of the list — see `orderedWindows` below.
 const WINDOW_ORDER = [
-  "currentsession",
-  "weeklyallmodels",
-  "currentweekallmodels",
-  "weeklysonnet",
-  "currentweeksonnetonly",
-  "currentweeksonnet",
-  "currentweekopusonly",
-  "currentweekopus",
-  "extrausage",
+  "currentsession",            // live
+  "weeklyallmodels",           // live
+  "currentweekallmodels",      // legacy — back-compat for pre-rename payloads
+  "weeklysonnet",              // live
+  "currentweeksonnetonly",     // legacy — back-compat for pre-rename payloads
+  "currentweeksonnet",         // legacy — older CLI scrape heading
+  "weeklyopus",                // live
+  "currentweekopusonly",       // legacy — back-compat for pre-rename payloads
+  "currentweekopus",           // legacy — older CLI scrape heading
+  "extrausage",                // live
 ] as const;
 
 function normalizeLabel(text: string): string {

--- a/ui/storybook/stories/budget-finance.stories.tsx
+++ b/ui/storybook/stories/budget-finance.stories.tsx
@@ -264,7 +264,18 @@ const claudeQuotaWindows: QuotaWindow[] = [
   { label: "Current session", usedPercent: 46, resetsAt: at(-180).toISOString(), valueLabel: null, detail: "Healthy session headroom for review tasks." },
   { label: "Weekly (all models)", usedPercent: 74, resetsAt: at(-5_300).toISOString(), valueLabel: null, detail: "Warning threshold after the release documentation run." },
   { label: "Weekly (Sonnet)", usedPercent: 58, resetsAt: at(-5_300).toISOString(), valueLabel: null, detail: "Sonnet-only weekly utilization, separate from the all-models meter." },
-  { label: "Current week (Opus only)", usedPercent: 92, resetsAt: at(-5_300).toISOString(), valueLabel: null, detail: "Critical model-specific budget: route default work to Sonnet." },
+  { label: "Weekly (Opus)", usedPercent: 92, resetsAt: at(-5_300).toISOString(), valueLabel: null, detail: "Critical model-specific budget: route default work to Sonnet." },
+  { label: "Extra usage", usedPercent: null, resetsAt: null, valueLabel: "$18.40 overage", detail: "Overage billing is enabled for board-approved release checks." },
+];
+
+// Mirrors the live payload when Anthropic's `/usage` response omits
+// `seven_day_sonnet` (e.g. plan tier without Sonnet utilization metering).
+// The Sonnet row is intentionally absent — verifies the panel degrades cleanly
+// rather than synthesizing a 0%/empty row. See TES-82 punch list item #4.
+const claudeQuotaWindowsNoSonnet: QuotaWindow[] = [
+  { label: "Current session", usedPercent: 46, resetsAt: at(-180).toISOString(), valueLabel: null, detail: "Healthy session headroom for review tasks." },
+  { label: "Weekly (all models)", usedPercent: 74, resetsAt: at(-5_300).toISOString(), valueLabel: null, detail: "Warning threshold after the release documentation run." },
+  { label: "Weekly (Opus)", usedPercent: 92, resetsAt: at(-5_300).toISOString(), valueLabel: null, detail: "Critical model-specific budget: route default work to Sonnet." },
   { label: "Extra usage", usedPercent: null, resetsAt: null, valueLabel: "$18.40 overage", detail: "Overage billing is enabled for board-approved release checks." },
 ];
 
@@ -748,6 +759,11 @@ function BudgetFinanceMatrix() {
               source="codex-wham"
               error="Codex app server is unavailable, so live subscription windows cannot be refreshed."
             />
+          </div>
+          {/* Plan tier without Sonnet metering — the Sonnet row should not render
+              when `seven_day_sonnet` is absent from the upstream payload. */}
+          <div className="mt-5 grid gap-5 xl:grid-cols-2">
+            <ClaudeSubscriptionPanel windows={claudeQuotaWindowsNoSonnet} source="anthropic-oauth" />
           </div>
         </Section>
       </main>

--- a/ui/storybook/stories/budget-finance.stories.tsx
+++ b/ui/storybook/stories/budget-finance.stories.tsx
@@ -262,8 +262,9 @@ const providerWindowRows: Record<string, CostWindowSpendRow[]> = {
 
 const claudeQuotaWindows: QuotaWindow[] = [
   { label: "Current session", usedPercent: 46, resetsAt: at(-180).toISOString(), valueLabel: null, detail: "Healthy session headroom for review tasks." },
-  { label: "Current week all models", usedPercent: 74, resetsAt: at(-5_300).toISOString(), valueLabel: null, detail: "Warning threshold after the release documentation run." },
-  { label: "Current week Opus only", usedPercent: 92, resetsAt: at(-5_300).toISOString(), valueLabel: null, detail: "Critical model-specific budget: route default work to Sonnet." },
+  { label: "Weekly (all models)", usedPercent: 74, resetsAt: at(-5_300).toISOString(), valueLabel: null, detail: "Warning threshold after the release documentation run." },
+  { label: "Weekly (Sonnet)", usedPercent: 58, resetsAt: at(-5_300).toISOString(), valueLabel: null, detail: "Sonnet-only weekly utilization, separate from the all-models meter." },
+  { label: "Current week (Opus only)", usedPercent: 92, resetsAt: at(-5_300).toISOString(), valueLabel: null, detail: "Critical model-specific budget: route default work to Sonnet." },
   { label: "Extra usage", usedPercent: null, resetsAt: null, valueLabel: "$18.40 overage", detail: "Overage billing is enabled for board-approved release checks." },
 ];
 


### PR DESCRIPTION
Closes Paperclip [TES-82](/TES/issues/TES-82).

## What this changes

- Surfaces Anthropic's `seven_day_sonnet` 1-week utilization window in the Claude provider panel as a new `Weekly (Sonnet)` row, alongside the existing `Weekly (all models)` row.
- Renames the all-models and Opus rows from `Current week (...)` to `Weekly (...)` for naming consistency. Back-compat: the CLI scrape diagnostic path still recognizes the upstream `Current week …` heading and canonicalizes it to the new label.
- Adds component-level test coverage for `ClaudeSubscriptionPanel` (Sonnet present / Sonnet absent / sonnet > all-models).
- Storybook fixture updated for both data-present and Sonnet-absent states.

## Reviews

- Five-axis code review: Paperclip TES-94
- Devils-advocate review: Paperclip TES-93
- CTO ratification: TES-82 thread

## Verification

- 75/75 server quota tests pass.
- 3/3 new `ClaudeSubscriptionPanel` component tests pass.
- `pnpm --filter @paperclipai/ui typecheck` clean.
- Storybook screenshots in TES-95 (data-present + Sonnet-absent).
