### PR TITLE
fix(ui): External adapters - Remove isLocal restriction on configuration form fields

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -696,7 +696,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 }}
               />
             </Field>
-            {isLocal && !props.hidePromptTemplate && (
+            {!props.hidePromptTemplate && (
               <>
                 <Field label="Prompt Template" hint={help.promptTemplate}>
                   <MarkdownEditor
@@ -880,7 +880,6 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       </div>
 
       {/* ---- Permissions & Configuration ---- */}
-      {isLocal && (
         <div className={cn(!cards && "border-b border-border")}>
           {cards
             ? <h3 className="text-sm font-medium mb-3">Permissions &amp; Configuration</h3>
@@ -1096,7 +1095,6 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               )}
           </div>
         </div>
-      )}
 
       {/* ---- Run Policy ---- */}
       {isCreate && showCreateRunPolicySection ? (

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -886,6 +886,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">Permissions &amp; Configuration</div>
           }
           <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
+            {isLocal && (
               <Field label="Command" hint={help.localCommand}>
                 <DraftInput
                   value={
@@ -920,6 +921,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   }
                 />
               </Field>
+            )}
 
               {supportsModelProfiles && (
                 <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Primary model</div>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - There are many types of adapters, including local and external gateway adapters
> - But the UI artificially hides configuration sections like the prompt template, environment variables, timeouts, and custom dynamic fields for any adapter that doesn't advertise "local" execution capabilities
> - So external/gateway adapters completely lose the ability to present custom configuration fields and vital execution settings
> - This pull request removes the `isLocal` discrimination from the Prompt Template and "Permissions & Configuration" blocks
> - The benefit is that external adapters can now natively render their configuration fields and use standard execution parameters, creating a consistent experience across all adapter types

## What Changed

- **Remove Conditional Rendering for Permissions & Configuration:** Removed the `isLocal` wrapper from the "Permissions & Configuration" section in `AgentConfigForm.tsx` to allow all adapters to present execution settings and custom schema configuration fields (`<uiAdapter.ConfigFields />`).
- **Remove Conditional Rendering for Prompt Template:** Removed the `isLocal` requirement from the "Prompt Template" block inside the Identity section in `AgentConfigForm.tsx`.

## Verification

- Run Paperclip with an external adapter installed (e.g. `paperclip-openclaw-bridge`).
- Go to "Add new agent" and select the external adapter type.
- Verify that standard configuration fields (Models, Env Vars, Timeout) and custom dynamic fields from the adapter's schema are visible and editable in the UI.

## Risks

- Low risk. Gateway adapters that do not specify custom models or do not use the extra fields will safely ignore them. The dynamic parser gracefully falls back if no schema fields are defined. This change strictly expands visibility.

## Model Used

- Human assisted by Antigravity powered by Gemini 2.5 Pro (experimental), using agentic coding, context reasoning workflows, and deep codebase search.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge


## Screenshots

Before:
<img width="1616" height="995" alt="New Agent · Agents · Paperclip - Before" src="https://github.com/user-attachments/assets/eec30f56-6815-4fbf-8158-be068f140f8c" />


After:
<img width="1614" height="995" alt="New Agent · Agents · Paperclip - After" src="https://github.com/user-attachments/assets/e27acfb1-adf2-46c2-a289-c41207507dd9" />


