### PR TITLE
fix: prevent done/cancelled issues from auto-reopening on routine board comments

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -341,7 +341,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
+  it("does NOT implicitly reopen closed issues via the PATCH comment path when reassigning to an agent", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
@@ -353,24 +353,24 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ comment: "hello", assigneeAgentId: "33333333-3333-4333-8333-333333333333" });
 
     expect(res.status).toBe(200);
+    // assigneeAgentId is updated but status stays done — no implicit reopen
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({
         assigneeAgentId: "33333333-3333-4333-8333-333333333333",
-        status: "todo",
         actorAgentId: null,
         actorUserId: "local-board",
       }),
     );
-    expect(mockLogActivity).toHaveBeenCalledWith(
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: "todo" }),
+    );
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         action: "issue.updated",
-        details: expect.objectContaining({
-          reopened: true,
-          reopenedFrom: "done",
-          status: "todo",
-        }),
+        details: expect.objectContaining({ reopened: true }),
       }),
     );
   });
@@ -453,31 +453,27 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via POST comments when an agent is assigned", async () => {
+  it("does NOT implicitly reopen done issues via POST comments when an agent is assigned", async () => {
+    // Regression guard for CON-134: routine board check-in comments must not
+    // auto-reopen completed issues and trigger an agent execution loop.
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
-    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
-      ...makeIssue("done"),
-      ...patch,
-    }));
 
     const res = await request(await installActor(createApp()))
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "hello" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+    // status must NOT be changed — issue stays done
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: "todo" }),
     );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+    // assignee must NOT be woken — isClosed suppresses the wake
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
       "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          reopenedFrom: "done",
-        }),
-      }),
-    ));
+      expect.objectContaining({ reason: expect.stringMatching(/reopened|commented/) }),
+    );
   });
 
   it("rejects non-assignee agent POST comments on closed issues", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -193,10 +193,12 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   actorType: "agent" | "user";
   actorId: string;
 }) {
-  // Only human comments should implicitly reopen finished work.
-  // Agent-authored comments remain communicative unless reopen was explicit.
+  // Only human comments on blocked issues should implicitly resume work.
+  // Done/cancelled issues require explicit reopen=true or resume=true so that
+  // routine board check-in comments (e.g. heartbeat wakes) cannot re-enter a
+  // completed issue into the execution loop. Agent comments never reopen implicitly.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  if (input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }


### PR DESCRIPTION
## Problem

`shouldImplicitlyMoveCommentedIssueToTodo` in `server/src/routes/issues.ts` returned `true` for any user comment on a `done`/`cancelled` issue with an assigned agent. This caused board heartbeat check-in comments (e.g. "Mac Mini Paperclip check-in: pulling backlog into today's clearance lane") to silently trigger an infinite reopen loop:

1. Comment posted → issue implicitly set to `todo`
2. `issue_reopened_via_comment` wake fires → assignee checks out → `in_progress`
3. Agent does work → marks `done` again
4. Next check-in → repeat indefinitely

## Fix

1-line logic change in `shouldImplicitlyMoveCommentedIssueToTodo`:

- Now only returns `true` for `blocked` issues — the only case where a routine user comment should resume execution
- `done`/`cancelled` issues require explicit `reopen: true` or `resume: true` in the request body to be reopened
- `blocked` issues still auto-resume on user comment (intended unblocking behaviour preserved)

## Tests

- 28/28 pass
- Two existing tests updated to verify the corrected behaviour
- One test is now a named regression guard for the done-issue reopen loop

## Files changed

- `server/src/routes/issues.ts` — 1-line logic fix with inline comment explaining the invariant
- `server/src/__tests__/issue-comment-reopen-routes.test.ts` — test coverage updated

No migration required — runtime logic change only.