### PR TITLE
test(MarkdownEditor): wrap second flush around delayed mount setContent

### DIFF
--- a/ui/src/components/MarkdownEditor.test.tsx
+++ b/ui/src/components/MarkdownEditor.test.tsx
@@ -369,6 +369,10 @@ describe("MarkdownEditor", () => {
       );
     });
 
+    // Two flushes: the mock's mount effect schedules a setTimeout that calls
+    // setContent("") *after* the first flush settles. Without the second flush,
+    // that state update lands outside any act() boundary and React warns.
+    await flush();
     await flush();
     await vi.waitFor(() => {
       expect(container.querySelector("textarea")).not.toBeNull();


### PR DESCRIPTION
Closes [TES-102](/TES/issues/TES-102).

The "falls back to a raw textarea when the rich editor mounts into the placeholder without callbacks" test in `MarkdownEditor.test.tsx` was emitting one `act()` warning because the mock's mount `useEffect` schedules a `setTimeout` that calls `setContent("")` *after* the first `flush()` resolves — so that state update landed outside any `act()` boundary.

Fix: add a second `flush()`, matching the existing precedent in the sibling "image-only markdown is settling" test. +4/-0.

### Before / after evidence

`pnpm exec vitest run` from `ui/`:

| Branch | Test files | Tests | Failures | `act()` warnings |
|---|---|---|---|---|
| `master` (`685ee84e`) | 124 | 734 | 0 | **1** |
| `feat/tes-102-act-migration` | 124 | 734 | 0 | **0** |