### PR TITLE
[adapter-codex-local] add idle watchdog + non-zero default timeoutSec

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -78,6 +78,13 @@ export interface AdapterExecutionTargetProcessOptions {
   stdin?: string;
   timeoutSec: number;
   graceSec: number;
+  /**
+   * Idle watchdog: terminate the child if no stdout/stderr chunk arrives
+   * within this many seconds. 0 disables (default). Local execution only;
+   * sandbox runners ignore this option since their runtimes provide their
+   * own liveness handling.
+   */
+  idleTimeoutSec?: number;
   onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
   onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
   terminalResultCleanup?: TerminalResultCleanupOptions;
@@ -271,6 +278,7 @@ export async function runAdapterExecutionTargetProcess(
     stdin: options.stdin,
     timeoutSec: options.timeoutSec,
     graceSec: options.graceSec,
+    idleTimeoutSec: options.idleTimeoutSec,
     onLog: options.onLog,
     onSpawn: options.onSpawn,
     terminalResultCleanup: options.terminalResultCleanup,

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -330,6 +330,76 @@ describe("runChildProcess", () => {
       }
     }
   });
+
+  it.skipIf(process.platform === "win32")("kills a silent child via idle watchdog and tags timeoutReason=idle", async () => {
+    const start = Date.now();
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      ["-e", "setInterval(() => {}, 1000);"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 30,
+        graceSec: 1,
+        idleTimeoutSec: 0.5,
+        onLog: async () => {},
+      },
+    );
+    const elapsedMs = Date.now() - start;
+    expect(result.timedOut).toBe(true);
+    expect(result.timeoutReason).toBe("idle");
+    expect(elapsedMs).toBeLessThan(5_000);
+  });
+
+  it.skipIf(process.platform === "win32")("does not fire idle watchdog while child emits output", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      [
+        "-e",
+        [
+          "let n = 0;",
+          "const id = setInterval(() => { process.stdout.write(`tick ${++n}\\n`); if (n >= 4) { clearInterval(id); process.exit(0); } }, 100);",
+        ].join(" "),
+      ],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 30,
+        graceSec: 1,
+        idleTimeoutSec: 1,
+        onLog: async () => {},
+      },
+    );
+    expect(result.timedOut).toBe(false);
+    expect(result.timeoutReason).toBeFalsy();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it.skipIf(process.platform === "win32")("tags timeoutReason=wall when wall-clock timer fires first", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      [
+        "-e",
+        [
+          "const id = setInterval(() => process.stdout.write('alive\\n'), 50);",
+          "setTimeout(() => clearInterval(id), 5000);",
+        ].join(" "),
+      ],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0.5,
+        graceSec: 1,
+        idleTimeoutSec: 5,
+        onLog: async () => {},
+      },
+    );
+    expect(result.timedOut).toBe(true);
+    expect(result.timeoutReason).toBe("wall");
+  });
 });
 
 describe("renderPaperclipWakePrompt", () => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -13,6 +13,12 @@ export interface RunProcessResult {
   exitCode: number | null;
   signal: string | null;
   timedOut: boolean;
+  /**
+   * Reason for `timedOut`: `"wall"` for `timeoutSec` cap, `"idle"` for
+   * `idleTimeoutSec` watchdog. Absent for non-timeout exits or callers
+   * that don't track this distinction.
+   */
+  timeoutReason?: "wall" | "idle" | null;
   stdout: string;
   stderr: string;
   pid: number | null;
@@ -1663,6 +1669,12 @@ export async function runChildProcess(
     env: Record<string, string>;
     timeoutSec: number;
     graceSec: number;
+    /**
+     * Idle watchdog: terminate child if no stdout/stderr chunk arrives
+     * within this many seconds. 0 disables (default). Independent of
+     * `timeoutSec` (wall-clock cap).
+     */
+    idleTimeoutSec?: number;
     onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
     onLogError?: (err: unknown, runId: string, message: string) => void;
     onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
@@ -1719,6 +1731,8 @@ export async function runChildProcess(
         runningProcesses.set(runId, { child, graceSec: opts.graceSec, processGroupId });
 
         let timedOut = false;
+        let timeoutReason: "wall" | "idle" | null = null;
+        let killEscalationTimer: NodeJS.Timeout | null = null;
         let stdout = "";
         let stderr = "";
         let logChain: Promise<void> = Promise.resolve();
@@ -1771,17 +1785,39 @@ export async function runChildProcess(
           }, graceMs);
         };
 
+        const idleTimeoutSec = Math.max(0, opts.idleTimeoutSec ?? 0);
+        let idleTimer: NodeJS.Timeout | null = null;
+
+        const triggerTimeout = (reason: "wall" | "idle") => {
+          if (timedOut) return;
+          timedOut = true;
+          timeoutReason = reason;
+          clearTerminalCleanupTimers();
+          if (idleTimer) {
+            clearTimeout(idleTimer);
+            idleTimer = null;
+          }
+          signalRunningProcess({ child, processGroupId }, "SIGTERM");
+          killEscalationTimer = setTimeout(() => {
+            killEscalationTimer = null;
+            signalRunningProcess({ child, processGroupId }, "SIGKILL");
+          }, Math.max(1, opts.graceSec) * 1000);
+        };
+
+        const armIdleTimer = () => {
+          if (idleTimeoutSec <= 0 || timedOut) return;
+          if (idleTimer) clearTimeout(idleTimer);
+          idleTimer = setTimeout(() => {
+            idleTimer = null;
+            triggerTimeout("idle");
+          }, idleTimeoutSec * 1000);
+        };
+
         const timeout =
           opts.timeoutSec > 0
-            ? setTimeout(() => {
-                timedOut = true;
-                clearTerminalCleanupTimers();
-                signalRunningProcess({ child, processGroupId }, "SIGTERM");
-                setTimeout(() => {
-                  signalRunningProcess({ child, processGroupId }, "SIGKILL");
-                }, Math.max(1, opts.graceSec) * 1000);
-              }, opts.timeoutSec * 1000)
+            ? setTimeout(() => triggerTimeout("wall"), opts.timeoutSec * 1000)
             : null;
+        armIdleTimer();
 
         child.stdout?.on("data", (chunk: unknown) => {
           const readable = child.stdout;
@@ -1789,6 +1825,7 @@ export async function runChildProcess(
           readable.pause();
           const text = String(chunk);
           stdout = appendWithCap(stdout, text);
+          armIdleTimer();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stdout", text))
@@ -1805,6 +1842,7 @@ export async function runChildProcess(
           readable.pause();
           const text = String(chunk);
           stderr = appendWithCap(stderr, text);
+          armIdleTimer();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stderr", text))
@@ -1826,6 +1864,14 @@ export async function runChildProcess(
 
         child.on("error", (err: Error) => {
           if (timeout) clearTimeout(timeout);
+          if (idleTimer) {
+            clearTimeout(idleTimer);
+            idleTimer = null;
+          }
+          if (killEscalationTimer) {
+            clearTimeout(killEscalationTimer);
+            killEscalationTimer = null;
+          }
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
           void target.cleanup?.();
@@ -1844,6 +1890,14 @@ export async function runChildProcess(
 
         child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
           if (timeout) clearTimeout(timeout);
+          if (idleTimer) {
+            clearTimeout(idleTimer);
+            idleTimer = null;
+          }
+          if (killEscalationTimer) {
+            clearTimeout(killEscalationTimer);
+            killEscalationTimer = null;
+          }
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
           void logChain.finally(() => {
@@ -1854,6 +1908,7 @@ export async function runChildProcess(
                 exitCode: code,
                 signal,
                 timedOut,
+                timeoutReason,
                 stdout,
                 stderr,
                 pid: child.pid ?? null,

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -76,8 +76,9 @@ Core fields:
 - workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
 
 Operational fields:
-- timeoutSec (number, optional): run timeout in seconds
-- graceSec (number, optional): SIGTERM grace period in seconds
+- timeoutSec (number, optional): wall-clock run timeout in seconds. Defaults to 1800 (30min). Set to 0 to disable.
+- idleTimeoutSec (number, optional): idle watchdog in seconds. Terminate the run if no stdout/stderr arrives within this window. Defaults to 300 (5min). Set to 0 to disable. Independent of timeoutSec; whichever fires first wins. On expiry the result carries errorCode=codex_idle_timeout (or codex_wall_timeout for wall-clock) and errorMeta.timeoutReason="idle"|"wall".
+- graceSec (number, optional): SIGTERM grace period in seconds before SIGKILL escalation
 
 Notes:
 - Prompts are piped via stdin (Codex receives "-" prompt argument).

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -487,8 +487,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     resolvedCommand,
   });
 
-  const timeoutSec = asNumber(config.timeoutSec, 0);
+  // Wall-clock cap. Default 30min so a wedged child cannot hang a heartbeat
+  // forever. Operators can opt out by setting `timeoutSec: 0` in adapter config.
+  const timeoutSec = asNumber(config.timeoutSec, 1800);
   const graceSec = asNumber(config.graceSec, 20);
+  // Idle watchdog: terminate the child if no stdout/stderr arrives within
+  // this window. Default 5min so genuinely silent hangs (no JSONL events)
+  // surface as a timeout instead of accumulating wall-clock time.
+  // Set to 0 to disable.
+  const idleTimeoutSec = asNumber(config.idleTimeoutSec, 300);
 
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
@@ -666,6 +673,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       stdin: prompt,
       timeoutSec,
       graceSec,
+      idleTimeoutSec,
       onSpawn,
       onLog: async (stream, chunk) => {
         if (stream !== "stderr") {
@@ -689,16 +697,38 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const toResult = (
-    attempt: { proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string }; rawStderr: string; parsed: ReturnType<typeof parseCodexJsonl> },
+    attempt: {
+      proc: {
+        exitCode: number | null;
+        signal: string | null;
+        timedOut: boolean;
+        timeoutReason?: "wall" | "idle" | null;
+        stdout: string;
+        stderr: string;
+      };
+      rawStderr: string;
+      parsed: ReturnType<typeof parseCodexJsonl>;
+    },
     clearSessionOnMissingSession = false,
     isRetry = false,
   ): AdapterExecutionResult => {
     if (attempt.proc.timedOut) {
+      const isIdle = attempt.proc.timeoutReason === "idle";
+      const errorCode = isIdle ? "codex_idle_timeout" : "codex_wall_timeout";
+      const errorMessage = isIdle
+        ? `Timed out after ${idleTimeoutSec}s of no output (idle watchdog)`
+        : `Timed out after ${timeoutSec}s wall-clock`;
       return {
         exitCode: attempt.proc.exitCode,
         signal: attempt.proc.signal,
         timedOut: true,
-        errorMessage: `Timed out after ${timeoutSec}s`,
+        errorCode,
+        errorMessage,
+        errorMeta: {
+          timeoutReason: isIdle ? "idle" : "wall",
+          timeoutSec,
+          idleTimeoutSec,
+        },
         clearSession: clearSessionOnMissingSession,
       };
     }


### PR DESCRIPTION
## Summary
- Silent codex_local runs (no JSONL output, child never exits) could previously hang a heartbeat indefinitely. The wall-clock cap defaulted to `0` (disabled) and there was no idle watchdog driven by child output.
- This patch adds an idle watchdog in `adapter-utils.runChildProcess`, threads it through `runAdapterExecutionTargetProcess` for local targets, and turns on sane defaults for `codex_local`.
- Termination reason is surfaced so heartbeat operators / runbooks can tell silent hangs apart from genuinely long runs.

## Behaviour change
- `codex_local`: `timeoutSec` defaults to `1800` (30min) and `idleTimeoutSec` defaults to `300` (5min). Both still honour `0` to disable; the two timers are independent and whichever fires first wins.
- On expiry the run record carries `errorCode = codex_idle_timeout` (or `codex_wall_timeout`) and `errorMeta.timeoutReason = "idle" | "wall"`.

## Implementation
- `adapter-utils/src/server-utils.ts`: add `idleTimeoutSec` opt to `runChildProcess`. Idle timer is (re)armed on every `stdout`/`stderr` chunk; on expiry it triggers the same SIGTERM → `graceSec` → SIGKILL escalation as the wall-clock path.
- `adapter-utils/src/server-utils.ts`: add optional `timeoutReason: "wall" | "idle" | null` to `RunProcessResult`. Optional so synthetic constructions in other adapters keep compiling.
- `adapter-utils/src/execution-target.ts`: thread `idleTimeoutSec` through `AdapterExecutionTargetProcessOptions`. Sandbox runners ignore it (their host has its own liveness).
- `adapters/codex-local/src/server/execute.ts`: read both timeouts from adapter config with the new defaults, pass through, and translate `timedOut` results into `codex_idle_timeout`/`codex_wall_timeout` error codes with a structured `errorMeta`.
- `adapters/codex-local/src/index.ts`: update `agentConfigurationDoc` to document the new defaults and the error-code/meta contract.

## Tests
- `adapter-utils` server-utils tests cover three cases:
  - silent child terminated by idle watchdog with `timeoutReason="idle"`.
  - emitting child does not trip idle watchdog (chunks reset the timer).
  - wall-clock timer fires first when emission is faster than `idleTimeoutSec`.
- All adapter projects pass: `pnpm vitest run --project @paperclipai/adapter-utils --project @paperclipai/adapter-codex-local --project @paperclipai/adapter-claude-local --project @paperclipai/adapter-pi-local --project @paperclipai/adapter-gemini-local --project @paperclipai/adapter-cursor-local --project @paperclipai/adapter-opencode-local` ⇒ 120/120 green.

## Migration / breaking-default note
- `timeoutSec` for `codex_local` was previously `0` (disabled by default). Operators with runs intentionally longer than 30 minutes must set `timeoutSec: 0` (or a higher explicit value) in adapter config.
- Adapters other than `codex_local` are unaffected: `runChildProcess`/`runAdapterExecutionTargetProcess` only act on `idleTimeoutSec` when callers pass one, and `RunProcessResult.timeoutReason` is optional.

## Test plan
- [x] `pnpm vitest run --project @paperclipai/adapter-utils ...` (all adapters) ⇒ 120 passed
- [x] `pnpm typecheck` for both modified packages
- [ ] Wire a deliberately silent codex_local job in staging to confirm `errorCode=codex_idle_timeout` surfaces in the run record

Tracking: BOT-27 (BOTS internal).