### PR TITLE
[BOT-29] cap silent-run reviews per subject + reviewer

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -546,4 +546,178 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     });
     expect(decision.createdByRunId).toBe(managerRunId);
   });
+
+  async function seedAdditionalSilentRunForAgent(opts: {
+    companyId: string;
+    agentId: string;
+    issuePrefix: string;
+    issueNumber: number;
+    now: Date;
+    ageMs: number;
+  }) {
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const startedAt = new Date(opts.now.getTime() - opts.ageMs);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: opts.companyId,
+      title: `Extra silent issue ${opts.issueNumber}`,
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: opts.agentId,
+      issueNumber: opts.issueNumber,
+      identifier: `${opts.issuePrefix}-${opts.issueNumber}`,
+      updatedAt: startedAt,
+      createdAt: startedAt,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: opts.companyId,
+      agentId: opts.agentId,
+      status: "running",
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      startedAt,
+      processStartedAt: startedAt,
+      lastOutputAt: null,
+      lastOutputSeq: 0,
+      lastOutputStream: null,
+      contextSnapshot: { issueId },
+      logBytes: 0,
+    });
+    await db.update(issues).set({ executionRunId: runId }).where(eq(issues.id, issueId));
+    return { issueId, runId };
+  }
+
+  it("caps open silent-run reviews at one per subject agent", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const seed = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const second = await seedAdditionalSilentRunForAgent({
+      companyId: seed.companyId,
+      agentId: seed.coderId,
+      issuePrefix: seed.issuePrefix,
+      issueNumber: 50,
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 90_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const scan = await heartbeat.scanSilentActiveRuns({ now, companyId: seed.companyId });
+
+    expect(scan.scanned).toBe(2);
+    expect(scan.created).toBe(1);
+    expect(scan.appended).toBe(1);
+    expect(scan.evaluationIssueIds).toHaveLength(2);
+    expect(new Set(scan.evaluationIssueIds).size).toBe(1);
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(
+        eq(issues.companyId, seed.companyId),
+        eq(issues.originKind, "stale_active_run_evaluation"),
+      ));
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0]?.assigneeAgentId).toBe(seed.managerId);
+    expect([seed.runId, second.runId]).toContain(evaluations[0]?.originId);
+  });
+
+  it("escalates priority and blocks the cascaded source issue when critical", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const seed = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const second = await seedAdditionalSilentRunForAgent({
+      companyId: seed.companyId,
+      agentId: seed.coderId,
+      issuePrefix: seed.issuePrefix,
+      issueNumber: 70,
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const scan = await heartbeat.scanSilentActiveRuns({ now, companyId: seed.companyId });
+
+    expect(scan.scanned).toBe(2);
+    expect(scan.created).toBe(1);
+    expect(scan.appended).toBe(1);
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(
+        eq(issues.companyId, seed.companyId),
+        eq(issues.originKind, "stale_active_run_evaluation"),
+      ));
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0]?.priority).toBe("high");
+
+    const evaluationId = evaluations[0]?.id;
+    expect(evaluationId).toBeTruthy();
+    const blockerLinks = await db
+      .select()
+      .from(issueRelations)
+      .where(and(
+        eq(issueRelations.companyId, seed.companyId),
+        eq(issueRelations.relatedIssueId, second.issueId),
+      ));
+    expect(blockerLinks).toHaveLength(1);
+    expect(blockerLinks[0]?.issueId).toBe(evaluationId);
+
+    const [secondSource] = await db.select().from(issues).where(eq(issues.id, second.issueId));
+    expect(secondSource?.status).toBe("blocked");
+  });
+
+  it("does not load a reviewer with parallel silent-run reviews", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const seed = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+
+    const otherCoderId = randomUUID();
+    await db.insert(agents).values({
+      id: otherCoderId,
+      companyId: seed.companyId,
+      name: "Coder Two",
+      role: "engineer",
+      status: "running",
+      reportsTo: seed.managerId,
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    const second = await seedAdditionalSilentRunForAgent({
+      companyId: seed.companyId,
+      agentId: otherCoderId,
+      issuePrefix: seed.issuePrefix,
+      issueNumber: 60,
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 90_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const scan = await heartbeat.scanSilentActiveRuns({ now, companyId: seed.companyId });
+
+    expect(scan.scanned).toBe(2);
+    expect(scan.created).toBe(1);
+    expect(scan.appended).toBe(1);
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(
+        eq(issues.companyId, seed.companyId),
+        eq(issues.originKind, "stale_active_run_evaluation"),
+      ));
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0]?.assigneeAgentId).toBe(seed.managerId);
+    expect([seed.runId, second.runId]).toContain(evaluations[0]?.originId);
+  });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -629,6 +629,72 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  // Find the most-recent open stale-run evaluation whose linked run belongs to
+  // the given subject agent, excluding the run being evaluated. Used to cap
+  // open reviews to one per subject agent so cascading silence does not spawn
+  // a new issue per silent run.
+  async function findOpenStaleRunEvaluationForSubjectAgent(
+    companyId: string,
+    subjectAgentId: string,
+    excludeRunId: string,
+  ) {
+    const [row] = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        priority: issues.priority,
+        assigneeAgentId: issues.assigneeAgentId,
+        updatedAt: issues.updatedAt,
+      })
+      .from(issues)
+      .innerJoin(heartbeatRuns, sql`${heartbeatRuns.id}::text = ${issues.originId}`)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+          eq(heartbeatRuns.agentId, subjectAgentId),
+          sql`${issues.originId} <> ${excludeRunId}`,
+        ),
+      )
+      .orderBy(desc(issues.updatedAt))
+      .limit(1);
+    return row ?? null;
+  }
+
+  // Find the most-recent open stale-run evaluation already assigned to the
+  // prospective reviewer. Used to avoid loading a single reviewer with two or
+  // more open silent-run reviews at once.
+  async function findOpenStaleRunEvaluationForReviewer(
+    companyId: string,
+    reviewerAgentId: string,
+  ) {
+    const [row] = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        priority: issues.priority,
+        assigneeAgentId: issues.assigneeAgentId,
+        updatedAt: issues.updatedAt,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.assigneeAgentId, reviewerAgentId),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt))
+      .limit(1);
+    return row ?? null;
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
@@ -927,6 +993,72 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return true;
   }
 
+  async function appendStaleRunCascadeNote(input: {
+    existing: { id: string; identifier: string | null; priority: string | null };
+    reason: "subject_cap" | "reviewer_loaded";
+    run: typeof heartbeatRuns.$inferSelect;
+    runningAgent: typeof agents.$inferSelect;
+    sourceIssue: typeof issues.$inferSelect | null;
+    level: "suspicious" | "critical";
+    evidence: { silenceAgeMs: number | null };
+  }) {
+    const headline = input.reason === "subject_cap"
+      ? `Additional silent run detected for the same subject agent (${input.runningAgent.name}).`
+      : `Additional silent run detected while this reviewer is already mid-evaluation.`;
+    const folded = input.reason === "subject_cap"
+      ? "Folded into this evaluation to keep one open review per subject agent."
+      : "Folded into this evaluation to avoid loading the reviewer with parallel review issues.";
+    const sourceLabel = input.sourceIssue?.identifier ?? input.sourceIssue?.id ?? "none";
+    await issuesSvc.addComment(input.existing.id, [
+      headline,
+      "",
+      `- Run: \`${input.run.id}\``,
+      `- Subject agent: ${input.runningAgent.name} (\`${input.runningAgent.id}\`)`,
+      `- Source issue: ${sourceLabel}`,
+      `- Silent for: ${formatDuration(input.evidence.silenceAgeMs)}`,
+      `- Level: ${input.level}`,
+      `- Last output at: ${input.run.lastOutputAt?.toISOString() ?? "none recorded"}`,
+      "",
+      folded,
+    ].join("\n"), { runId: input.run.id });
+
+    if (input.level === "critical" && input.existing.priority !== "high") {
+      await issuesSvc.update(input.existing.id, { priority: "high" });
+      await issuesSvc.addComment(input.existing.id, [
+        "Critical output silence threshold crossed on cascaded run.",
+        "",
+        `- Run: \`${input.run.id}\``,
+        `- Silent for: ${formatDuration(input.evidence.silenceAgeMs)}`,
+      ].join("\n"), { runId: input.run.id });
+    }
+    if (input.level === "critical") {
+      await ensureSourceIssueBlockedByStaleEvaluation({
+        sourceIssue: input.sourceIssue,
+        evaluationIssue: input.existing,
+        run: input.run,
+      });
+    }
+
+    await logActivity(db, {
+      companyId: input.run.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: input.run.id,
+      action: "heartbeat.output_stale_appended",
+      entityType: "issue",
+      entityId: input.existing.id,
+      details: {
+        source: "recovery.scan_silent_active_runs",
+        reason: input.reason,
+        level: input.level,
+        sourceIssueId: input.sourceIssue?.id ?? null,
+        silenceAgeMs: input.evidence.silenceAgeMs,
+        lastOutputAt: input.run.lastOutputAt?.toISOString() ?? null,
+      },
+    });
+  }
+
   async function createOrUpdateStaleRunEvaluation(input: {
     run: typeof heartbeatRuns.$inferSelect;
     now: Date;
@@ -973,7 +1105,53 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       return { kind: "existing" as const, evaluationIssueId: existing.id };
     }
 
-    const ownerAgentId = await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });
+    // Per-subject-agent cap: if this subject agent already has an open
+    // stale-run evaluation tied to a different run, append to it instead of
+    // spawning a parallel review. Breaks the single-agent run-flapping case.
+    const subjectExisting = await findOpenStaleRunEvaluationForSubjectAgent(
+      input.run.companyId,
+      runningAgent.id,
+      input.run.id,
+    );
+    if (subjectExisting) {
+      await appendStaleRunCascadeNote({
+        existing: subjectExisting,
+        reason: "subject_cap",
+        run: input.run,
+        runningAgent,
+        sourceIssue,
+        level,
+        evidence,
+      });
+      return { kind: "appended" as const, evaluationIssueId: subjectExisting.id };
+    }
+
+    let ownerAgentId = await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });
+    if (ownerAgentId === runningAgent.id) ownerAgentId = null;
+
+    // Reviewer-already-loaded guard: if the prospective reviewer already has an
+    // open silent-run review, surface the new run as a comment on that issue
+    // rather than creating a parallel review. Breaks the cross-agent cascade
+    // (reviewer A spawns review for B, B spawns review for A).
+    if (ownerAgentId) {
+      const reviewerExisting = await findOpenStaleRunEvaluationForReviewer(
+        input.run.companyId,
+        ownerAgentId,
+      );
+      if (reviewerExisting) {
+        await appendStaleRunCascadeNote({
+          existing: reviewerExisting,
+          reason: "reviewer_loaded",
+          run: input.run,
+          runningAgent,
+          sourceIssue,
+          level,
+          evidence,
+        });
+        return { kind: "appended" as const, evaluationIssueId: reviewerExisting.id };
+      }
+    }
+
     const description = buildStaleRunEvaluationDescription({
       run: input.run,
       runningAgent,
@@ -1076,6 +1254,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       scanned: candidates.length,
       created: 0,
       existing: 0,
+      appended: 0,
       escalated: 0,
       snoozed: 0,
       skipped: 0,
@@ -1090,6 +1269,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       const outcome = await createOrUpdateStaleRunEvaluation({ run, now });
       if (outcome.kind === "created") result.created += 1;
       else if (outcome.kind === "existing") result.existing += 1;
+      else if (outcome.kind === "appended") result.appended += 1;
       else if (outcome.kind === "escalated") result.escalated += 1;
       else result.skipped += 1;
       if ("evaluationIssueId" in outcome && outcome.evaluationIssueId) {


### PR DESCRIPTION
## Summary

Adds two guards to `createOrUpdateStaleRunEvaluation` so silent-run cascades stop at one open review per subject agent and never recurse onto a reviewer who is already loaded.

- **Per-subject cap**: when an open stale-run evaluation already targets the subject agent's prior run, append a cascade comment to it instead of creating a new evaluation issue.
- **Reviewer-loaded guard**: when the prospective reviewer already has an open stale-run evaluation, surface the new run as a comment on that evaluation rather than recursively assigning the reviewer a parallel review.
- Cascade append mirrors the create path: critical-aged runs bump priority to `high` and block the source issue via `ensureSourceIssueBlockedByStaleEvaluation`.
- `scanSilentActiveRuns` now reports an `appended` counter alongside `created`/`skipped`.

## Test plan

- [x] `node_modules/.bin/vitest run server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts` (11 tests, all pass)
  - Existing single-silent-run flow unchanged
  - New: caps open silent-run reviews at one per subject agent
  - New: escalates priority and blocks the cascaded source issue when critical
  - New: does not load a reviewer with parallel silent-run reviews