### PR TITLE
fix: degrade git_worktree to project_primary when baseCwd is not a git repo

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1848,6 +1848,38 @@ describe("realizeExecutionWorkspace", () => {
     expect(worktreeOp!.metadata!.baseRef).toBe("master");
   }, 10_000);
 
+  it("degrades to project_primary when baseCwd is not a git repo (interval heartbeat with no project)", async () => {
+    const nonGitDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-non-git-"));
+
+    const result = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: nonGitDir,
+        source: "agent_home",
+        projectId: null,
+        workspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+      },
+      config: {
+        workspaceStrategy: { type: "git_worktree" },
+      },
+      issue: null,
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(result.strategy).toBe("project_primary");
+    expect(result.cwd).toBe(nonGitDir);
+    expect(result.branchName).toBeNull();
+    expect(result.created).toBe(false);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("not");
+    expect(result.warnings[0]).toContain("project_primary");
+  });
+
   it("removes a created git worktree and branch during cleanup", async () => {
     const repoRoot = await createTempRepo();
 

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -999,6 +999,20 @@ export async function realizeExecutionWorkspace(input: {
     };
   }
 
+  if (!await isGitCheckout(input.base.baseCwd)) {
+    return {
+      ...input.base,
+      strategy: "project_primary",
+      cwd: input.base.baseCwd,
+      branchName: null,
+      worktreePath: null,
+      warnings: [
+        `git_worktree workspace strategy requires a git checkout; "${input.base.baseCwd}" is not one. Falling back to project_primary.`,
+      ],
+      created: false,
+    };
+  }
+
   const repoRoot = await resolveGitOwnerRepoRoot(input.base.baseCwd);
   const branchTemplate = asString(rawStrategy.branchTemplate, "{{issue.identifier}}-{{slug}}");
   const renderedBranch = renderWorkspaceTemplate(branchTemplate, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents that run inside execution workspaces, with a `workspaceStrategy` config that can be set to `git_worktree` to automatically create per-issue git worktrees
> - When an agent has `workspaceStrategy.type = "git_worktree"` and fires an **interval heartbeat** with no assigned issue, `resolveWorkspaceForRun` finds no project context and falls back to the agent-home directory (`~/.paperclip/instances/default/workspaces/<agentId>/`)
> - That directory is not a git checkout, but `realizeExecutionWorkspace` passes it to `resolveGitOwnerRepoRoot` unconditionally, which calls `git rev-parse --show-toplevel` and throws `fatal: not a git repository`
> - The run slot is wasted and an ERROR is logged, even though the agent had nothing meaningful to do — the crash is preventable
> - The file already contains an `isGitCheckout` helper (line 583) that can be used as a guard before the git operations begin
> - This PR adds a guard in `realizeExecutionWorkspace`: when `strategyType === "git_worktree"` but `baseCwd` is not a git checkout, return `project_primary` strategy with a warning instead of throwing
> - The benefit is clean, silent degradation for issueless interval wakes, and the warning gives operators an observable signal if something unexpected sends a non-git path into this code path

## What Changed

- `server/src/services/workspace-runtime.ts`: added an `isGitCheckout(input.base.baseCwd)` guard immediately after the `strategyType !== "git_worktree"` early-return. If `baseCwd` is not a git repository, the function now returns `project_primary` strategy with a warning message instead of throwing.
- `server/src/__tests__/workspace-runtime.test.ts`: added a regression test `"degrades to project_primary when baseCwd is not a git repo (interval heartbeat with no project)"` that creates a plain temp directory (not a git repo), calls `realizeExecutionWorkspace` with `git_worktree` strategy, and asserts `strategy === "project_primary"`, `created === false`, and a non-empty warning.

## Verification

```bash
# Run the targeted new test (passes, was failing before the fix on master)
pnpm run preflight:workspace-links && npx vitest run server/src/__tests__/workspace-runtime.test.ts -t "degrades to project_primary when baseCwd is not a git repo"

# Run the full workspace-runtime test file (53 pass, 4 pre-existing failures
# in provision-script tests that also fail on master due to local CLI env)
npx vitest run server/src/__tests__/workspace-runtime.test.ts

# Typecheck clean
pnpm typecheck
```

All other `realizeExecutionWorkspace` tests continue to pass — the guard is only reached when `baseCwd` is not a git checkout, which no existing test triggers.

## Risks

Low risk. The guard only fires when `isGitCheckout` returns `false` — the path was previously an unconditional crash, so no existing behaviour is changed for valid git checkouts. The degraded return is identical in shape to the `strategyType !== "git_worktree"` early return that already exists above it.

## Model Used

- **Provider:** Anthropic  
- **Model:** Claude Sonnet 4.6 (`claude-sonnet-4-6`)  
- **Context window:** 200k tokens  
- **Capabilities:** tool use, code execution, file read/write  
- **Reasoning mode:** standard (no extended thinking)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge