### PR TITLE
SEC: redact rejected secret-ref values in plugin host error path (PLA-190 / PLA-187)

### DIFF
--- a/server/src/__tests__/plugin-secrets-handler-redaction.test.ts
+++ b/server/src/__tests__/plugin-secrets-handler-redaction.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression tests for PLA-190 / PLA-187:
+ * the host `secrets.resolve` rejection path must NOT echo the caller-supplied
+ * value back into the error message. Inputs that look like GitHub PATs,
+ * Bearer tokens, or other opaque secret-shaped strings must be redacted to a
+ * `kind=opaque len=<N>` descriptor.
+ *
+ * Synthetic, shape-valid test fixtures only — never use real PAT prefixes
+ * recovered from incident logs.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Db } from "@paperclipai/db";
+import { createPluginSecretsHandler } from "../services/plugin-secrets-handler.ts";
+
+// Stub Db — none of these test cases exercise db reads. Validation rejects
+// before the handler reaches the database layer.
+const stubDb = {} as unknown as Db;
+
+function makeHandler() {
+  return createPluginSecretsHandler({ db: stubDb, pluginId: "test-plugin" });
+}
+
+async function captureRejection(
+  fn: () => Promise<unknown>,
+): Promise<Error> {
+  try {
+    await fn();
+  } catch (err) {
+    return err as Error;
+  }
+  throw new Error("expected the call to reject");
+}
+
+describe("plugin-secrets-handler — rejected ref redaction (PLA-190)", () => {
+  it("redacts a ghp_-shaped value as opaque with no prefix leak", async () => {
+    const handler = makeHandler();
+    // Synthetic, shape-valid GitHub PAT — never use a real one in fixtures.
+    const value = "ghp_" + "A".repeat(36);
+
+    const err = await captureRejection(() =>
+      handler.resolve({ secretRef: value }),
+    );
+
+    expect(err.name).toBe("InvalidSecretRefError");
+    expect(err.message).toContain("kind=opaque");
+    expect(err.message).toContain(`len=${value.length}`);
+    // The classic and the prefix alone must both stay out of the message.
+    expect(err.message).not.toContain(value);
+    expect(err.message).not.toContain("ghp_");
+  });
+
+  it("redacts a github_pat_-shaped value as opaque with no prefix leak", async () => {
+    const handler = makeHandler();
+    // Synthetic fine-grained PAT shape: github_pat_<22>_<59>.
+    const value = "github_pat_" + "A".repeat(22) + "_" + "B".repeat(59);
+
+    const err = await captureRejection(() =>
+      handler.resolve({ secretRef: value }),
+    );
+
+    expect(err.name).toBe("InvalidSecretRefError");
+    expect(err.message).toContain("kind=opaque");
+    expect(err.message).toContain(`len=${value.length}`);
+    expect(err.message).not.toContain(value);
+    expect(err.message).not.toContain("github_pat_");
+  });
+
+  it("redacts a Bearer header value as opaque with no value leak", async () => {
+    const handler = makeHandler();
+    const value = "Bearer " + "x".repeat(48);
+
+    const err = await captureRejection(() =>
+      handler.resolve({ secretRef: value }),
+    );
+
+    expect(err.name).toBe("InvalidSecretRefError");
+    expect(err.message).toContain("kind=opaque");
+    expect(err.message).toContain(`len=${value.length}`);
+    expect(err.message).not.toContain(value);
+    // The literal "Bearer " prefix is suggestive enough that it must not
+    // round-trip into the error text either.
+    expect(err.message).not.toContain("Bearer ");
+  });
+
+  it("describes empty / null / non-string inputs without echoing them", async () => {
+    {
+      const handler = makeHandler();
+      const err = await captureRejection(() =>
+        handler.resolve({ secretRef: "" }),
+      );
+      expect(err.name).toBe("InvalidSecretRefError");
+      expect(err.message).toMatch(/kind=(empty|whitespace)/);
+    }
+    {
+      const handler = makeHandler();
+      const err = await captureRejection(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        handler.resolve({ secretRef: null as any }),
+      );
+      expect(err.name).toBe("InvalidSecretRefError");
+      expect(err.message).toContain("kind=null");
+      expect(err.message).not.toContain("<empty>");
+    }
+    {
+      const handler = makeHandler();
+      const err = await captureRejection(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        handler.resolve({ secretRef: undefined as any }),
+      );
+      expect(err.name).toBe("InvalidSecretRefError");
+      // Either "kind=undefined" (non-string path) or empty-equivalent —
+      // both are acceptable; the invariant is "no raw value echo".
+      expect(err.message).toMatch(/kind=(undefined|empty)/);
+    }
+    {
+      const handler = makeHandler();
+      const err = await captureRejection(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        handler.resolve({ secretRef: 42 as any }),
+      );
+      expect(err.name).toBe("InvalidSecretRefError");
+      expect(err.message).toContain("kind=non-string");
+      expect(err.message).toContain("type=number");
+      expect(err.message).not.toContain("42");
+    }
+  });
+});

--- a/server/src/services/plugin-secrets-handler.ts
+++ b/server/src/services/plugin-secrets-handler.ts
@@ -50,23 +50,53 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
- * Create a sanitised error that never leaks secret material.
- * Only the ref identifier is included; never the resolved value.
+ * Produce a redacted, log-safe descriptor for an arbitrary secret-ref input.
+ *
+ * Callers reach the error path with caller-controlled values that may be
+ * secret-shaped (e.g. a raw GitHub PAT mistakenly passed as a ref). To prevent
+ * those values from being echoed into log lines or JSON-RPC `error.message`
+ * payloads, this helper never returns the raw input. It returns one of:
+ *
+ *   - `kind=undefined` / `kind=null`
+ *   - `kind=non-string type=<typeof>`
+ *   - `kind=empty`
+ *   - `kind=uuid value=<uuid>`  (UUID-shaped refs are the legitimate format
+ *     and are safe to echo back; they are not secret material.)
+ *   - `kind=opaque len=<N>`     (everything else — redacts secret-shaped input.)
+ *
+ * @see PLA-190 — host `secrets.resolve` rejected raw input echo defect.
  */
-function secretNotFound(secretRef: string): Error {
-  const err = new Error(`Secret not found: ${secretRef}`);
+function describeOpaqueRef(value: unknown): string {
+  if (value === undefined) return "kind=undefined";
+  if (value === null) return "kind=null";
+  if (typeof value !== "string") return `kind=non-string type=${typeof value}`;
+  if (value.length === 0) return "kind=empty";
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return `kind=whitespace len=${value.length}`;
+  if (isUuidSecretRef(trimmed)) return `kind=uuid value=${trimmed}`;
+  return `kind=opaque len=${value.length}`;
+}
+
+/**
+ * Create a sanitised error that never leaks secret material.
+ * The error message uses {@link describeOpaqueRef} to emit a length/kind
+ * descriptor instead of the raw input, so that secret-shaped refs that reach
+ * the rejection path are not echoed into logs or JSON-RPC error responses.
+ */
+function secretNotFound(secretRef: unknown): Error {
+  const err = new Error(`Secret not found: ${describeOpaqueRef(secretRef)}`);
   err.name = "SecretNotFoundError";
   return err;
 }
 
-function secretVersionNotFound(secretRef: string): Error {
-  const err = new Error(`No version found for secret: ${secretRef}`);
+function secretVersionNotFound(secretRef: unknown): Error {
+  const err = new Error(`No version found for secret: ${describeOpaqueRef(secretRef)}`);
   err.name = "SecretVersionNotFoundError";
   return err;
 }
 
-function invalidSecretRef(secretRef: string): Error {
-  const err = new Error(`Invalid secret reference: ${secretRef}`);
+function invalidSecretRef(secretRef: unknown): Error {
+  const err = new Error(`Invalid secret reference: ${describeOpaqueRef(secretRef)}`);
   err.name = "InvalidSecretRefError";
   return err;
 }
@@ -232,7 +262,7 @@ export function createPluginSecretsHandler(
       // 1. Validate the ref format
       // ---------------------------------------------------------------
       if (!secretRef || typeof secretRef !== "string" || secretRef.trim().length === 0) {
-        throw invalidSecretRef(secretRef ?? "<empty>");
+        throw invalidSecretRef(secretRef);
       }
 
       const trimmedRef = secretRef.trim();

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -49,6 +49,7 @@ import type {
   InitializeParams,
 } from "@paperclipai/plugin-sdk";
 import { logger } from "../middleware/logger.js";
+import { redactSensitiveText } from "../redaction.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -508,7 +509,11 @@ export function createPluginWorkerHandle(
         result: result ?? null,
       });
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
+      // Defense-in-depth: even though the secrets handler now redacts
+      // rejected refs at the source (PLA-190), wrap any error message
+      // through redactSensitiveText before it reaches logs or the worker.
+      const rawErrorMessage = err instanceof Error ? err.message : String(err);
+      const errorMessage = redactSensitiveText(rawErrorMessage);
       log.error({ method, err: errorMessage }, "host handler error");
       try {
         sendMessage(


### PR DESCRIPTION
## Summary

The plugin host `secrets.resolve` rejection path interpolated the caller-supplied `secretRef` directly into `Error.message`, which `plugin-worker-manager` then both `log.error`'d (→ `server.log`) **and** shipped back to the worker via JSON-RPC `error.message`. When a plugin worker mistakenly passed a raw secret-shaped string into a secret-ref slot during iteration, that value leaked into both surfaces. Defect found during PLA-58 AC7 review (PLA-190); root-caused to plugin-secrets-handler.ts:68-72.

This PR scopes only to the error-message redaction (PLA-190 AC2/AC3 / PLA-193). It does not change `extractSecretRefsFromConfig`, the rate limiter, or the resolve happy path.

### Source-side fix — `server/src/services/plugin-secrets-handler.ts`

- Replace the three error helpers (`secretNotFound`, `secretVersionNotFound`, `invalidSecretRef`) with a `describeOpaqueRef`-backed length/kind descriptor:
  - `kind=opaque len=N` for arbitrary opaque strings (the dangerous path: secret-shaped input)
  - `kind=uuid value=<uuid>` for legitimate UUID-shaped refs (not secret material)
  - `kind=null` / `kind=undefined` / `kind=non-string type=<typeof>` / `kind=empty` / `kind=whitespace` for the validation-failure branches
- Drop the `?? "<empty>"` fallback at the call site; `describeOpaqueRef` handles non-strings safely.

### Defense-in-depth — `server/src/services/plugin-worker-manager.ts`

- Wrap host-handler `errorMessage` through `redactSensitiveText` before both `log.error` and the JSON-RPC `error.message` response. Any future host handler that interpolates caller input into `Error.message` will still be redacted at this chokepoint, matching the run-log-store invariant from PLA-40.

### Regression tests — `server/src/__tests__/plugin-secrets-handler-redaction.test.ts`

Synthetic, shape-valid fixtures only (no real PAT material in commits or fixtures):

1. `ghp_` + 36 chars → `kind=opaque len=40`, no prefix leak
2. `github_pat_` shape (22 + `_` + 59 chars) → `kind=opaque len=N`, no prefix leak
3. `Bearer ` + 48 chars → `kind=opaque len=N`, no `Bearer ` echo
4. empty / null / undefined / non-string (number) → explicit kind descriptors, no raw value echo

Closes PLA-187 as duplicate.

## Test plan

- [x] `vitest run src/__tests__/plugin-secrets-handler-redaction.test.ts` — 4/4 pass
- [x] `vitest run src/__tests__/plugin- src/__tests__/redaction.test.ts src/__tests__/json-schema-secret-refs.test.ts` — 60/60 pass (no regression)
- [x] `tsc --noEmit` clean on `server`
- [ ] SecurityEngineer review + merge per PLA-193 hand-off