### PR TITLE
fix: harden database backups and process run tracing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR /app
 COPY --chown=node:node --from=build /app /app
 RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
   && apt-get update \
-  && apt-get install -y --no-install-recommends openssh-client jq \
+  && apt-get install -y --no-install-recommends openssh-client jq postgresql-client \
   && rm -rf /var/lib/apt/lists/* \
   && mkdir -p /paperclip \
   && chown node:node /paperclip

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -19,7 +19,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const args = asStringArray(config.args);
   const cwd = asString(config.cwd, process.cwd());
   const envConfig = parseObject(config.env);
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent), PAPERCLIP_RUN_ID: runId };
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -533,6 +533,10 @@ export async function startServer(): Promise<StartedServer> {
     shareClient: createFeedbackTraceShareClientFromConfig(config),
   });
   const backupSettingsSvc = instanceSettingsService(db);
+  const databaseBackupTimeoutMs = Math.max(
+    60_000,
+    Number(process.env.PAPERCLIP_DATABASE_BACKUP_TIMEOUT_MS ?? 15 * 60 * 1000),
+  );
   let databaseBackupInFlight = false;
   const runServerDatabaseBackup = async (
     trigger: InstanceDatabaseBackupTrigger,
@@ -550,8 +554,16 @@ export async function startServer(): Promise<StartedServer> {
     const startedAt = new Date();
     const startedAtMs = Date.now();
     const label = trigger === "scheduled" ? "Automatic" : "Manual";
+    const backupWatchdog = setTimeout(() => {
+      logger.error(
+        { backupDir: config.databaseBackupDir, trigger, timeoutMs: databaseBackupTimeoutMs },
+        label + " database backup exceeded timeout; exiting process to clear stuck backup state",
+      );
+      process.exit(1);
+    }, databaseBackupTimeoutMs);
+    backupWatchdog.unref?.();
     try {
-      logger.info({ backupDir: config.databaseBackupDir, trigger }, `${label} database backup starting`);
+      logger.info({ backupDir: config.databaseBackupDir, trigger }, label + " database backup starting");
       // Read retention from Instance Settings (DB) so changes take effect without restart.
       const generalSettings = await backupSettingsSvc.getGeneral();
       const retention = generalSettings.backupRetention;
@@ -582,13 +594,14 @@ export async function startServer(): Promise<StartedServer> {
           trigger,
           durationMs: response.durationMs,
         },
-        `${label} database backup complete: ${formatDatabaseBackupResult(result)}`,
+        label + " database backup complete: " + formatDatabaseBackupResult(result),
       );
       return response;
     } catch (err) {
-      logger.error({ err, backupDir: config.databaseBackupDir, trigger }, `${label} database backup failed`);
+      logger.error({ err, backupDir: config.databaseBackupDir, trigger }, label + " database backup failed");
       throw err;
     } finally {
+      clearTimeout(backupWatchdog);
       databaseBackupInFlight = false;
     }
   };


### PR DESCRIPTION
## Summary
- harden database backups with a watchdog that exits the process if a backup gets stuck
- install postgresql-client in the production image so pg_dump is available at runtime
- inject PAPERCLIP_RUN_ID into the process adapter environment for write-trace parity with other local adapters

## Validation
- rebuilt the CINA deployment after the backup changes
- verified /api/health returned ok after rebuild
- verified pg_dump was present in the runtime container
- executed a manual database backup successfully and validated the resulting gzip artifact

## Notes
- an unrelated local Dockerfile drift adding docker.io was intentionally left out of this change
- these commits were first validated operationally on the Cintra VPS before being published here