### PR TITLE
Fix service worker respondWith returning undefined

### DIFF
--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -1,13 +1,25 @@
-const CACHE_NAME = "paperclip-v2";
+const CACHE_NAME = "paperclip-v3";
+const PRECACHE_URLS = ["/", "/index.html"];
 
-self.addEventListener("install", () => {
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
   self.skipWaiting();
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
 });
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
     caches.keys().then((keys) =>
-      Promise.all(keys.map((key) => caches.delete(key)))
+      Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+      )
     )
   );
   self.clients.claim();
@@ -17,26 +29,33 @@ self.addEventListener("fetch", (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
-  // Skip non-GET requests and API calls
   if (request.method !== "GET" || url.pathname.startsWith("/api")) {
     return;
   }
+  if (url.origin !== self.location.origin) {
+    return;
+  }
 
-  // Network-first for everything — cache is only an offline fallback
-  event.respondWith(
-    fetch(request)
-      .then((response) => {
-        if (response.ok && url.origin === self.location.origin) {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
-        }
-        return response;
-      })
-      .catch(() => {
-        if (request.mode === "navigate") {
-          return caches.match("/") || new Response("Offline", { status: 503 });
-        }
-        return caches.match(request);
-      })
-  );
+  event.respondWith((async () => {
+    try {
+      const response = await fetch(request);
+      if (response.ok) {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+      }
+      return response;
+    } catch {
+      if (request.mode === "navigate") {
+        const shell = await caches.match("/index.html") || await caches.match("/");
+        if (shell) return shell;
+        return new Response(
+          "<!doctype html><meta charset=utf-8><title>Offline</title><h1>Offline</h1>",
+          { status: 503, headers: { "Content-Type": "text/html; charset=utf-8" } }
+        );
+      }
+      const cached = await caches.match(request);
+      if (cached) return cached;
+      return new Response("", { status: 504, statusText: "SW offline fallback" });
+    }
+  })());
 });

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -23,8 +23,37 @@ import "./index.css";
 initPluginBridge(React, ReactDOM);
 
 if ("serviceWorker" in navigator) {
-  window.addEventListener("load", () => {
-    navigator.serviceWorker.register("/sw.js");
+  window.addEventListener("load", async () => {
+    let reloading = false;
+    navigator.serviceWorker.addEventListener("controllerchange", () => {
+      if (reloading) return;
+      reloading = true;
+      window.location.reload();
+    });
+
+    try {
+      const registration = await navigator.serviceWorker.register("/sw.js");
+
+      const promoteWaiting = (worker: ServiceWorker | null) => {
+        if (worker && worker.state === "installed" && navigator.serviceWorker.controller) {
+          worker.postMessage({ type: "SKIP_WAITING" });
+        }
+      };
+
+      promoteWaiting(registration.waiting);
+
+      registration.addEventListener("updatefound", () => {
+        const newWorker = registration.installing;
+        if (!newWorker) return;
+        newWorker.addEventListener("statechange", () => promoteWaiting(newWorker));
+      });
+
+      setInterval(() => {
+        registration.update().catch(() => {});
+      }, 60 * 60 * 1000);
+    } catch {
+      // SW registration failed — app works fine without it
+    }
   });
 }
 


### PR DESCRIPTION
The fetch handler in sw.js v2 had two paths that resolved to undefined, triggering "TypeError: Failed to convert value to 'Response'" in the browser and rendering a black/blank screen on routes like /<companyPrefix>/company/settings/invites.

Concretely:
- caches.match("/") returns a Promise (always truthy), so `caches.match("/") || new Response(...)` never fell back to the Response.
- Cache miss for non-navigate requests resolved to undefined.
- The activate handler also wiped its own cache, so the offline fallback was empty on first activation.

Service worker (paperclip-v3):
- Every respondWith branch is guaranteed to return a Response.
- Activate keeps the current cache, deletes only stale ones.
- Precache "/" and "/index.html" on install for navigation fallback.
- Skip cross-origin requests so the SW does not interfere with plugin loaders or third-party origins.
- Add a SKIP_WAITING message handler for client-driven update flows.

Client (main.tsx):
- Auto-reload once on controllerchange so users stuck on the broken v2 pick up v3 immediately after activation.
- On updatefound, message the new worker to skipWaiting once installed.
- Periodically call registration.update() so version bumps propagate without requiring a manual reload.

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The web UI registers a service worker (`ui/public/sw.js`) that intercepts every GET navigation request
> - The deployed `sw.js` (v2) had a fetch handler whose `respondWith` promise could resolve to `undefined`, causing the browser to throw `TypeError: Failed to convert value to 'Response'` and render a blank page
> - This blocked any user from reaching tenant routes such as `/<companyPrefix>/company/settings/invites` — they saw a black screen with the SW error in the console
> - This pull request rewrites the SW so every `respondWith` path returns a real `Response`, precaches the app shell, and adds a `SKIP_WAITING` + `controllerchange` handshake so users stuck on the broken v2 auto-recover when v3 deploys
> - The benefit is the invites page (and every other navigation route) loads again, and future SW version bumps propagate without forcing users to clear site data manually

## What Changed

- `ui/public/sw.js`: bumped cache name to `paperclip-v3`; rewrote fetch handler so every branch returns a `Response` (no more `undefined` from `caches.match` Promise vs Response confusion); precache `/` and `/index.html` on install for navigation fallback; activate now keeps the current cache and only deletes stale ones; skip cross-origin requests so the SW does not interfere with plugin loaders or third-party origins; add a `SKIP_WAITING` message handler for client-driven update flows
- `ui/src/main.tsx`: SW registration now listens for `controllerchange` (auto-reload once so users stuck on v2 pick up v3 immediately), `updatefound` (postMessage `SKIP_WAITING` to the new worker once installed), and calls `registration.update()` hourly so future version bumps propagate without manual reload

## Verification

- CI: `tsc -b && vite build` (`verify`), `e2e` workflow
- Manual smoke after deploy:
  - `curl -s https://paperclip.cole.ai.vn/sw.js | head -1` → expect `const CACHE_NAME = "paperclip-v3";`
  - In a tab stuck on v2: reload → `controllerchange` should fire, page auto-reloads, new SW takes over, app renders
  - Fresh tab: navigate to `/<companyPrefix>/company/settings/invites` → page renders, no console errors
  - DevTools → Network: no `Failed to convert value to 'Response'` in console
- Regression check: open root `/`, dashboard, and an agents detail route → all render normally

## Risks

- Low. SW v3 is strictly safer than the broken v2 (v2 currently returns `undefined` from `respondWith` for navigations, which is exactly the failure mode this PR fixes). Worst-case post-merge: a user whose tab was already stuck on v2 still sees a black screen until they hard-refresh — but the new `controllerchange` handler in `main.tsx` auto-reloads them once v3 activates.
- Follow-up needed (separate PR): `/sw.js` is currently served with `Cache-Control: public, max-age=3600`. That means new SW versions take up to an hour to reach users via HTTP cache. Should be `Cache-Control: no-cache` (Caddy or Express side) for `sw.js` so future fixes propagate immediately.

## Model Used

- Claude Opus 4.7 (1M context), via Claude Code CLI. Tool use enabled for Read/Edit/Bash. No extended thinking mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
