### PR TITLE
feat(routes): GET /heartbeat-runs/:runId honours ?include=resultJson for full JSONB

### DIFF
--- a/server/src/__tests__/heartbeat-runs-result-json-projection.test.ts
+++ b/server/src/__tests__/heartbeat-runs-result-json-projection.test.ts
@@ -1,0 +1,161 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  getRun: vi.fn(),
+  getRetryExhaustedReason: vi.fn(),
+  buildRunOutputSilence: vi.fn(),
+}));
+
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  get: vi.fn(),
+  getExperimental: vi.fn(),
+  getGeneral: vi.fn(),
+  listCompanyIds: vi.fn(),
+}));
+
+function registerModuleMocks() {
+  vi.doMock("../routes/authz.js", async () => vi.importActual("../routes/authz.js"));
+
+  vi.doMock("../services/heartbeat.js", () => ({
+    heartbeatService: () => mockHeartbeatService,
+  }));
+
+  vi.doMock("../services/instance-settings.js", () => ({
+    instanceSettingsService: () => mockInstanceSettingsService,
+  }));
+
+  vi.doMock("../services/index.js", () => ({
+    agentService: () => ({}),
+    agentInstructionsService: () => ({}),
+    accessService: () => ({}),
+    approvalService: () => ({}),
+    companySkillService: () => ({ listRuntimeSkillEntries: vi.fn() }),
+    budgetService: () => ({}),
+    heartbeatService: () => mockHeartbeatService,
+    issueApprovalService: () => ({}),
+    issueService: () => ({}),
+    logActivity: vi.fn(),
+    secretService: () => ({}),
+    syncInstructionsBundleConfigFromFilePath: vi.fn((_agent, config) => config),
+    workspaceOperationService: () => ({}),
+  }));
+
+  vi.doMock("../adapters/index.js", () => ({
+    findServerAdapter: vi.fn(),
+    listAdapterModels: vi.fn(),
+    detectAdapterModel: vi.fn(),
+    findActiveServerAdapter: vi.fn(),
+    requireServerAdapter: vi.fn(),
+  }));
+}
+
+async function createApp() {
+  const [{ agentRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+const SAMPLE_RUN = {
+  id: "run-1",
+  companyId: "company-1",
+  agentId: "agent-1",
+  status: "succeeded",
+  invocationSource: "on_demand",
+  resultJson: {
+    adapterVersion: "1.2.3",
+    toolCallCount: 4,
+  },
+  createdAt: new Date("2026-04-10T09:29:59.000Z"),
+  startedAt: new Date("2026-04-10T09:30:00.000Z"),
+  finishedAt: new Date("2026-04-10T09:31:00.000Z"),
+};
+
+describe("GET /heartbeat-runs/:runId — result_json projection", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/heartbeat.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../services/instance-settings.js");
+    vi.doUnmock("../adapters/index.js");
+    vi.doUnmock("../routes/agents.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    mockHeartbeatService.getRun.mockResolvedValue(SAMPLE_RUN);
+    mockHeartbeatService.getRetryExhaustedReason.mockResolvedValue(null);
+    mockHeartbeatService.buildRunOutputSilence.mockResolvedValue(null);
+    mockInstanceSettingsService.get.mockResolvedValue({
+      id: "instance-settings-1",
+      general: { censorUsernameInLogs: false, feedbackDataSharingPreference: "prompt" },
+    });
+    mockInstanceSettingsService.getExperimental.mockResolvedValue({});
+    mockInstanceSettingsService.getGeneral.mockResolvedValue({
+      censorUsernameInLogs: false,
+      feedbackDataSharingPreference: "prompt",
+    });
+    mockInstanceSettingsService.listCompanyIds.mockResolvedValue(["company-1"]);
+  });
+
+  it("calls getRun without options by default (preserves the safe projection)", async () => {
+    const app = await createApp();
+    const res = await request(app).get("/api/heartbeat-runs/run-1").expect(200);
+
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledWith("run-1", undefined);
+    expect(res.body.id).toBe("run-1");
+  });
+
+  it("passes { unsafeFullResultJson: true } when ?include=resultJson is set", async () => {
+    const app = await createApp();
+    await request(app).get("/api/heartbeat-runs/run-1?include=resultJson").expect(200);
+
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledWith("run-1", {
+      unsafeFullResultJson: true,
+    });
+  });
+
+  it("treats ?expand=full as equivalent to ?include=resultJson", async () => {
+    const app = await createApp();
+    await request(app).get("/api/heartbeat-runs/run-1?expand=full").expect(200);
+
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledWith("run-1", {
+      unsafeFullResultJson: true,
+    });
+  });
+
+  it("treats arbitrary ?include values as absence and preserves the safe projection", async () => {
+    const app = await createApp();
+    await request(app).get("/api/heartbeat-runs/run-1?include=somethingElse").expect(200);
+
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledWith("run-1", undefined);
+  });
+
+  it("preserves a 404 when getRun returns null, regardless of include flag", async () => {
+    mockHeartbeatService.getRun.mockResolvedValue(null);
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/heartbeat-runs/run-missing?include=resultJson")
+      .expect(404);
+    expect(res.body.error).toBe("Heartbeat run not found");
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2927,7 +2927,20 @@ export function agentRoutes(
 
   router.get("/heartbeat-runs/:runId", async (req, res) => {
     const runId = req.params.runId as string;
-    const run = await heartbeat.getRun(runId);
+    // Caller can request the full `result_json` JSONB (instead of the
+    // safe projection that summarises oversized payloads) by passing
+    // `?include=resultJson` or `?expand=full`. Useful for dashboards
+    // / smoke tests / external-adapter consumers that need the
+    // adapter's structured telemetry (tool-call audit, retry history,
+    // MCP server health, etc.) which lives only in the persisted
+    // JSONB. Auth (`assertCompanyAccess`) and redaction
+    // (`redactCurrentUserValue`) below run unchanged.
+    const includeFullResultJson =
+      req.query.include === "resultJson" || req.query.expand === "full";
+    const run = await heartbeat.getRun(
+      runId,
+      includeFullResultJson ? { unsafeFullResultJson: true } : undefined,
+    );
     if (!run) {
       res.status(404).json({ error: "Heartbeat run not found" });
       return;


### PR DESCRIPTION
## Summary

External adapters (and dashboards / smoke tests / agent consumers) sometimes need the full `result_json` JSONB on a heartbeat run. Today the user-facing `GET /heartbeat-runs/:runId` route projects through `heartbeatRunSafeColumns`, which collapses oversized JSONB (>64 KiB) to `{summary, result, message, error, costUsd, truncated: true}` — losing rich adapter telemetry like tool-call audit, retry history, MCP server health, transcript-cap state, and (for adapters that emit them) liveness state / progressBeats.

Paperclip already supports `getRun(runId, { unsafeFullResultJson: true })` internally for retry-decision logic in `services/heartbeat.ts`. This PR exposes the same flag through the user-facing route via a query parameter, gated by the existing `assertCompanyAccess` auth check and the existing `redactCurrentUserValue` redactor. No new auth surface, no new endpoint, no new policy — just a more inclusive projection on demand.

## API

```
GET /api/heartbeat-runs/:runId?include=resultJson
GET /api/heartbeat-runs/:runId?expand=full
```

Either query key turns the safe projection off and returns the full `result_json` JSONB. Anything else (or absence) preserves today's safe-projection behaviour.

## Why this matters

- Dashboards reading liveness / cost / tool-call telemetry without ECS-exec + psql.
- Smoke-test scripts asserting `result_json.adapterVersion`.
- A future Staff Engineer agent inspecting full run records via HTTP rather than shelling out to a DB.

For external adapters that emit verbose telemetry (e.g. our hermes-paperclip-adapter fork), the safe-projection collapse is the difference between "the adapter is observable" and "the adapter is a black box".

## Test plan

- [x] Unit test in `server/src/__tests__/heartbeat-runs-result-json-projection.test.ts`: `GET /heartbeat-runs/:runId` returns safe-projection by default; same endpoint with `?include=resultJson` returns full JSONB; `?expand=full` is equivalent; arbitrary `?include=foo` is treated as absence; 404 still fires when the run is missing.
- [x] Existing route tests still pass.
- [x] Auth boundary: `?include=resultJson` from a non-board user is still gated by `assertCompanyAccess`.