### PR TITLE
fix(runs): wake assignee on interaction-resolved (Bug B coalesce)

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -269,6 +269,136 @@ describe("heartbeat comment wake batching", () => {
     expect(runs[0]?.id).toBe(runId);
   });
 
+  it("defers interaction-resolved wakes for a running issue so the assignee resumes after the run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CTO",
+      role: "engineer",
+      status: "running",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Confirm plan",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+      executionAgentNameKey: "cto",
+      executionLockedAt: new Date(),
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    const followupRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "interaction_resolved",
+      payload: {
+        issueId,
+        interactionId: "interaction-1",
+        interactionKind: "request_confirmation",
+        interactionStatus: "accepted",
+        sourceCommentId: null,
+        sourceRunId: runId,
+        mutation: "interaction",
+      },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        interactionId: "interaction-1",
+        interactionKind: "request_confirmation",
+        interactionStatus: "accepted",
+        sourceCommentId: null,
+        sourceRunId: runId,
+        wakeReason: "interaction_resolved",
+        source: "issue.interaction.accept",
+      },
+      requestedByActorType: "user",
+      requestedByActorId: "local-board",
+    });
+
+    expect(followupRun).toBeNull();
+
+    const deferred = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.status, "deferred_issue_execution"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+
+    expect(deferred).not.toBeNull();
+    expect(deferred?.reason).toBe("issue_execution_deferred");
+    expect(deferred?.payload).toMatchObject({
+      issueId,
+      interactionId: "interaction-1",
+      interactionKind: "request_confirmation",
+      interactionStatus: "accepted",
+    });
+    expect((deferred?.payload as Record<string, unknown>)._paperclipWakeContext).toMatchObject({
+      issueId,
+      taskId: issueId,
+      interactionId: "interaction-1",
+      interactionStatus: "accepted",
+      wakeReason: "interaction_resolved",
+    });
+
+    const coalesced = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.status, "coalesced"),
+        ),
+      );
+    expect(coalesced).toHaveLength(0);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.id).toBe(runId);
+  });
+
   it("batches deferred comment wakes and forwards the ordered batch to the next run", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -350,7 +350,7 @@ describe.sequential("issue thread interaction routes", () => {
       ASSIGNEE_AGENT_ID,
       expect.objectContaining({
         source: "automation",
-        reason: "issue_commented",
+        reason: "interaction_resolved",
         payload: expect.objectContaining({
           issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
           interactionId: "interaction-1",
@@ -376,7 +376,7 @@ describe.sequential("issue thread interaction routes", () => {
     expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       ASSIGNEE_AGENT_ID,
       expect.objectContaining({
-        reason: "issue_commented",
+        reason: "interaction_resolved",
         payload: expect.objectContaining({
           interactionId: "interaction-2",
           interactionKind: "ask_user_questions",
@@ -412,7 +412,7 @@ describe.sequential("issue thread interaction routes", () => {
     expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       ASSIGNEE_AGENT_ID,
       expect.objectContaining({
-        reason: "issue_commented",
+        reason: "interaction_resolved",
         payload: expect.objectContaining({
           interactionId: "interaction-2",
           interactionKind: "ask_user_questions",
@@ -467,7 +467,7 @@ describe.sequential("issue thread interaction routes", () => {
     expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       ASSIGNEE_AGENT_ID,
       expect.objectContaining({
-        reason: "issue_commented",
+        reason: "interaction_resolved",
         payload: expect.objectContaining({
           interactionId: "interaction-3",
           interactionKind: "request_confirmation",
@@ -526,7 +526,7 @@ describe.sequential("issue thread interaction routes", () => {
       CREATED_AGENT_ID,
       expect.objectContaining({
         source: "automation",
-        reason: "issue_commented",
+        reason: "interaction_resolved",
         payload: expect.objectContaining({
           issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
           interactionId: "interaction-4",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -233,7 +233,7 @@ function queueResolvedInteractionContinuationWakeup(input: {
   void input.heartbeat.wakeup(input.issue.assigneeAgentId, {
     source: "automation",
     triggerDetail: "system",
-    reason: "issue_commented",
+    reason: "interaction_resolved",
     payload: {
       issueId: input.issue.id,
       interactionId: input.interaction.id,
@@ -253,7 +253,7 @@ function queueResolvedInteractionContinuationWakeup(input: {
       interactionStatus: input.interaction.status,
       sourceCommentId: input.interaction.sourceCommentId ?? null,
       sourceRunId: input.interaction.sourceRunId ?? null,
-      wakeReason: "issue_commented",
+      wakeReason: "interaction_resolved",
       source: input.source,
     },
   }).catch((err) => logger.warn({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -248,7 +248,10 @@ function mergeAdapterRecoveryMetadata(input: {
       : {}),
   };
 }
-const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set(["approval_approved"]);
+const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set([
+  "approval_approved",
+  "interaction_resolved",
+]);
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The heartbeat scheduler decides when an assignee is woken after issue events (comments, approvals, interactions)
> - Issue-thread interactions (`request_confirmation`, `ask_user_questions`, `suggest_tasks`) declare a `continuationPolicy` such as `wake_assignee_on_accept` so the assignee resumes work once the human has decided
> - But when the assignee already has a heartbeat run executing on the same issue at the moment the interaction resolves, the wakeup is silently coalesced into the in-flight run and no follow-up run is scheduled — the agent never observes the resolution
> - This pull request introduces a dedicated `interaction_resolved` wake reason and adds it to `RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP` so the same defer-and-resume behaviour that already exists for `approval_approved` applies to interaction wakes
> - The benefit is that `wake_assignee[_on_accept]` becomes race-free without changing the public API or interaction contract: `continuationPolicy` semantics are preserved, only the internal scheduler classification changes

Closes #4996.

## What Changed

- `server/src/services/heartbeat.ts`: add `"interaction_resolved"` to `RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP` so `shouldQueueFollowupForRunningIssueWake` returns `true` for that reason and the deferred-followup branch fires instead of the silent-coalesce branch.
- `server/src/routes/issues.ts`: in `queueResolvedInteractionContinuationWakeup`, change the emitted wake `reason` and `contextSnapshot.wakeReason` from `"issue_commented"` to `"interaction_resolved"`. The new reason is dedicated to interaction acceptance/answer/cancel/rejection so adding it to the follow-up set does not accidentally force follow-up runs for arbitrary comments.
- `server/src/__tests__/heartbeat-comment-wake-batching.test.ts`: new test `defers interaction-resolved wakes for a running issue so the assignee resumes after the run`, mirroring the existing `approval_approved` defer test. Asserts that the wake produces a `deferred_issue_execution` row (not `coalesced`) and that no new heartbeat run is started while the previous one is still active.
- `server/src/__tests__/issue-thread-interaction-routes.test.ts`: update the five wake-shape assertions for the suggest-tasks accept, ask-user-questions respond/cancel, request-confirmation accept and the board-review accept paths to expect `reason: "interaction_resolved"` instead of `reason: "issue_commented"`.

No changes to db schema, public API, or `continuationPolicy` semantics. The wake `reason` field on `agent_wakeup_requests` is free text (no enum), so the new value does not require a migration.

## Verification

Targeted vitest runs (these cover both the unit-mock route path and the embedded-postgres scheduler path):

```sh
pnpm -F @paperclipai/server vitest run \
  src/__tests__/issue-thread-interaction-routes.test.ts \
  src/__tests__/heartbeat-comment-wake-batching.test.ts
```

Repro before/after (squad telemetry on a downstream `@paperclipai/server@2026.428.0` instance, see issue #4996 for the full timeline):

1. Assign an issue to a long-lived local-adapter agent (e.g. `cursor`).
2. Post a `request_confirmation` interaction with `continuationPolicy: "wake_assignee_on_accept"` while the agent is mid-heartbeat on the same issue.
3. `POST /api/issues/{id}/interactions/{interactionId}/accept`.
4. Wait for the agent run to finish.
   - **Before:** `agent_wakeup_requests` row with `status: "coalesced"`; no new `heartbeat_runs` row; agent never reacts to the accept.
   - **After:** `agent_wakeup_requests` row with `status: "deferred_issue_execution"` and `reason: "issue_execution_deferred"`; a new `heartbeat_runs` row is enqueued shortly after the previous run finishes; agent picks up the resolved interaction on the next heartbeat.

The reporter (Zekai squad) does not have a local sandbox capable of running `pnpm -r typecheck && pnpm test:run && pnpm build` in this PR turnaround. The patch is mechanical (one new entry in a Set; two string-literal substitutions; mirrored test of an existing pattern) — please rely on CI for the full matrix.

## Risks

- **Behavioural shift, scoped:** Any downstream that relied on receiving `reason: "issue_commented"` for interaction wakes will now observe `reason: "interaction_resolved"`. There are no such consumers in this repo (greppable: only the route emitter, the new gate, and the route-mock tests reference these literals together). External adapters that key off the wake reason for prompt enrichment will see a more accurate reason than before.
- **Defer instead of coalesce:** Interaction wakes that previously merged into the running run's `contextSnapshot` will now spawn a single follow-up run after the in-flight run completes. This is the desired behaviour and matches `approval_approved`. The deferred branch already deduplicates per `(agent, issue)` so a burst of interaction resolutions on the same issue still produces at most one extra run.
- **No schema change.** `agent_wakeup_requests.reason` is `text`, no enum constraint.
- **Tree-control wake-source whitelist (`ISSUE_TREE_CONTROL_INTERACTION_WAKE_REASONS`) deliberately not extended** in this PR. Whether accepting an interaction should release a tree-control pause hold is a separate semantic call; out of scope for this fix. Open to extending it in a follow-up if the maintainers prefer.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7
- Capabilities: extended-context reasoning, tool use (file reads/edits, shell, GitHub API)
- Mode: Cursor agent in a Paperclip squad heartbeat (Zekai Corp CTO agent)
- Human reviewer/operator: Bruno Alves França (`@obrunuaf`), who approved the PR contents end-to-end before submission

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass — see Verification: targeted commands listed; full local run was not possible in the contributor sandbox; relying on CI
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — n/a (server-only)
- [x] I have updated relevant documentation to reflect my changes — n/a (no public API/doc surface changed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
