### PR TITLE
feat(agents): reject claude_k8s configs missing tolerations/nodeSelector/serviceAccountName (BLO-2657)

### DIFF
--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -112,6 +112,26 @@ const externalAdapter: ServerAdapterModule = {
   }),
 };
 
+const claudeK8sStub: ServerAdapterModule = {
+  type: "claude_k8s",
+  execute: async () => ({ exitCode: 0, signal: null, timedOut: false }),
+  testEnvironment: async () => ({
+    adapterType: "claude_k8s",
+    status: "pass",
+    checks: [],
+    testedAt: new Date(0).toISOString(),
+  }),
+};
+
+const validClaudeK8sAdapterConfig = {
+  model: "claude-sonnet-4-5-20250929",
+  tolerations: [
+    { key: "dedicated", value: "paperclip", effect: "NoSchedule", operator: "Equal" },
+  ],
+  nodeSelector: { workload: "paperclip" },
+  serviceAccountName: "paperclip",
+};
+
 const missingAdapterType = "missing_adapter_validation_test";
 
 async function createApp() {
@@ -222,11 +242,13 @@ describe("agent routes adapter validation", () => {
     }));
     await unregisterTestAdapter("external_test");
     await unregisterTestAdapter(missingAdapterType);
+    await unregisterTestAdapter("claude_k8s");
   });
 
   afterEach(async () => {
     await unregisterTestAdapter("external_test");
     await unregisterTestAdapter(missingAdapterType);
+    await unregisterTestAdapter("claude_k8s");
   });
 
   it("creates agents for dynamically registered external adapter types", async () => {
@@ -260,5 +282,108 @@ describe("agent routes adapter validation", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(422);
     expect(String(res.body.error ?? res.body.message ?? "")).toContain(`Unknown adapter type: ${missingAdapterType}`);
+  });
+
+  describe("claude_k8s schedulability validation (BLO-2657)", () => {
+    async function postClaudeK8sAgent(adapterConfig: Record<string, unknown>) {
+      const { registerServerAdapter } = await import("../adapters/index.js");
+      registerServerAdapter(claudeK8sStub);
+      const app = await createApp();
+      return requestApp(app, (baseUrl) =>
+        request(baseUrl)
+          .post("/api/companies/company-1/agents")
+          .send({
+            name: "Test K8s Agent",
+            adapterType: "claude_k8s",
+            adapterConfig,
+          }),
+      );
+    }
+
+    it("accepts a claude_k8s POST that has all schedulability fields (passes validation)", async () => {
+      // Mock the instructions-bundle pipeline so the request gets past the
+      // claude_k8s schedulability check and through agent creation. The point
+      // of this test is to confirm the validation does NOT reject a complete
+      // config — the downstream wiring is not the focus.
+      mockAgentInstructionsService.materializeManagedBundle.mockResolvedValue({
+        adapterConfig: { ...validClaudeK8sAdapterConfig, instructionsFilePath: "/paperclip/agents/test/AGENTS.md" },
+      });
+      const res = await postClaudeK8sAgent(validClaudeK8sAdapterConfig);
+      // 201 (success) is the intended outcome; the assertion is "not 422 from
+      // the new claude_k8s schedulability check". Anything other than 422 with
+      // a "tolerations|nodeSelector|serviceAccountName" message means the
+      // validation accepted the config.
+      expect(res.status, JSON.stringify(res.body)).not.toBe(422);
+      const errorMessage = String(res.body.error ?? res.body.message ?? "");
+      expect(errorMessage).not.toMatch(/tolerations|nodeSelector|serviceAccountName/i);
+    });
+
+    it("rejects POST with missing tolerations", async () => {
+      const { tolerations: _drop, ...rest } = validClaudeK8sAdapterConfig;
+      const res = await postClaudeK8sAgent(rest);
+      expect(res.status, JSON.stringify(res.body)).toBe(422);
+      expect(String(res.body.error ?? res.body.message ?? "")).toContain("tolerations");
+    });
+
+    it("rejects POST with empty tolerations array", async () => {
+      const res = await postClaudeK8sAgent({ ...validClaudeK8sAdapterConfig, tolerations: [] });
+      expect(res.status, JSON.stringify(res.body)).toBe(422);
+      expect(String(res.body.error ?? res.body.message ?? "")).toContain("tolerations");
+    });
+
+    it("rejects POST with missing nodeSelector", async () => {
+      const { nodeSelector: _drop, ...rest } = validClaudeK8sAdapterConfig;
+      const res = await postClaudeK8sAgent(rest);
+      expect(res.status, JSON.stringify(res.body)).toBe(422);
+      expect(String(res.body.error ?? res.body.message ?? "")).toContain("nodeSelector");
+    });
+
+    it("rejects POST with empty nodeSelector object", async () => {
+      const res = await postClaudeK8sAgent({ ...validClaudeK8sAdapterConfig, nodeSelector: {} });
+      expect(res.status, JSON.stringify(res.body)).toBe(422);
+      expect(String(res.body.error ?? res.body.message ?? "")).toContain("nodeSelector");
+    });
+
+    it("rejects POST with missing serviceAccountName", async () => {
+      const { serviceAccountName: _drop, ...rest } = validClaudeK8sAdapterConfig;
+      const res = await postClaudeK8sAgent(rest);
+      expect(res.status, JSON.stringify(res.body)).toBe(422);
+      expect(String(res.body.error ?? res.body.message ?? "")).toContain("serviceAccountName");
+    });
+
+    it("rejects POST with blank serviceAccountName", async () => {
+      const res = await postClaudeK8sAgent({ ...validClaudeK8sAdapterConfig, serviceAccountName: "  " });
+      expect(res.status, JSON.stringify(res.body)).toBe(422);
+      expect(String(res.body.error ?? res.body.message ?? "")).toContain("serviceAccountName");
+    });
+
+    it("rejects PATCH that drops tolerations + nodeSelector via replaceAdapterConfig", async () => {
+      // The validation throws unprocessable before svc.update is reached, so we
+      // only need getById to find the existing claude_k8s agent.
+      const { registerServerAdapter } = await import("../adapters/index.js");
+      registerServerAdapter(claudeK8sStub);
+      const existingAgent = {
+        id: "22222222-2222-4222-8222-222222222222",
+        companyId: "company-1",
+        adapterType: "claude_k8s",
+        adapterConfig: { ...validClaudeK8sAdapterConfig },
+        permissions: { canCreateAgents: false },
+      };
+      mockAgentService.getById.mockResolvedValue(existingAgent);
+
+      const app = await createApp();
+      const { tolerations: _t, nodeSelector: _n, ...partial } = validClaudeK8sAdapterConfig;
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl)
+          .patch(`/api/agents/${existingAgent.id}`)
+          .send({
+            adapterConfig: partial,
+            replaceAdapterConfig: true,
+          }),
+      );
+
+      expect(res.status, JSON.stringify(res.body)).toBe(422);
+      expect(String(res.body.error ?? res.body.message ?? "")).toContain("tolerations");
+    });
   });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -871,11 +871,42 @@ export function agentRoutes(
     return ensureGatewayDeviceKey(adapterType, next);
   }
 
+  function assertClaudeK8sSchedulability(adapterConfig: Record<string, unknown>) {
+    // claude_k8s pods only schedule on a paperclip-tainted node, run as the
+    // `paperclip` service account, and need a node selector to land on the
+    // workload pool. Without these, the Job is either unschedulable or comes up
+    // broken and the run fails with `claude exited 128 (StartError)` on every
+    // assignment. See BLO-2653 / BLO-2657 for the recovery cascade this caused.
+    // The exact values are operator-supplied (cluster-specific); we only
+    // assert the shape so the foot-gun cannot land an empty config.
+    const tolerations = adapterConfig.tolerations;
+    if (!Array.isArray(tolerations) || tolerations.length === 0) {
+      throw unprocessable(
+        "Invalid claude_k8s adapterConfig: tolerations must be a non-empty array (Job pods need to tolerate the paperclip-workload taint)",
+      );
+    }
+    const nodeSelector = asRecord(adapterConfig.nodeSelector);
+    if (!nodeSelector || Object.keys(nodeSelector).length === 0) {
+      throw unprocessable(
+        "Invalid claude_k8s adapterConfig: nodeSelector must be a non-empty object (Job pods need a selector to land on the paperclip workload pool)",
+      );
+    }
+    if (!asNonEmptyString(adapterConfig.serviceAccountName)) {
+      throw unprocessable(
+        "Invalid claude_k8s adapterConfig: serviceAccountName must be a non-empty string (Job pods bootstrap claude as this service account)",
+      );
+    }
+  }
+
   async function assertAdapterConfigConstraints(
     companyId: string,
     adapterType: string | null | undefined,
     adapterConfig: Record<string, unknown>,
   ) {
+    if (adapterType === "claude_k8s") {
+      assertClaudeK8sSchedulability(adapterConfig);
+      return;
+    }
     if (adapterType !== "opencode_local") return;
     const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(companyId, adapterConfig);
     const runtimeEnv = asRecord(runtimeConfig.env) ?? {};
@@ -2446,6 +2477,14 @@ export function agentRoutes(
         requestedAdapterType,
         requestedRuntimeConfig,
         baseAdapterConfig,
+      );
+    }
+    if (touchesAdapterConfiguration) {
+      const effectiveAdapterConfig = asRecord(patchData.adapterConfig) ?? {};
+      await assertAdapterConfigConstraints(
+        existing.companyId,
+        requestedAdapterType,
+        effectiveAdapterConfig,
       );
     }
     if (touchesAdapterConfiguration || Object.prototype.hasOwnProperty.call(patchData, "defaultEnvironmentId")) {

--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -80,6 +80,7 @@ curl -sS "$PAPERCLIP_API_URL/llms/agent-icons.txt" \
 - `desiredSkills` from the company skill library when this role needs installed skills on day one
 - if any `desiredSkills` or adapter settings expand browser access, external-system reach, filesystem scope, or secret-handling capability, justify each one in the hire comment
 - adapter and runtime config aligned to this environment
+- for `claude_k8s`, copy the schedulability fields (`tolerations`, `nodeSelector`, `serviceAccountName`) from an existing peer `claude_k8s` agent in the same company — see "Adapter-specific notes" below. The control plane rejects `claude_k8s` configs missing any of these.
 - leave timer heartbeats off by default; only set `runtimeConfig.heartbeat.enabled=true` with an `intervalSec` when the role genuinely needs scheduled recurring work or the user explicitly asked for it
 - if the role may handle private advisories or sensitive disclosures, confirm a confidential workflow exists first (dedicated skill or documented manual process)
 - capabilities
@@ -153,6 +154,41 @@ curl -sS "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID/issues" \
 For each linked issue, either:
 - close it if the approval resolved the request, or
 - comment in markdown with links to the approval and next actions.
+
+## Adapter-specific notes
+
+### `claude_k8s` schedulability fields
+
+`claude_k8s` runs each agent assignment as a Kubernetes Job. The Job must schedule on a node that the cluster operator dedicated to Paperclip workloads, and bootstrap as the right service account, or the run dies with `claude exited 128 (StartError)` on every assignment — surfacing as a recovery cascade with no useful error.
+
+The control plane therefore **rejects** `POST /api/companies/:companyId/agents`, `POST /api/companies/:companyId/agent-hires`, and `PATCH /api/agents/:id` for `claude_k8s` when any of these is missing or empty:
+
+| Field | Shape | Why |
+|---|---|---|
+| `tolerations` | non-empty array | Tolerate the paperclip-workload taint so the Job can schedule |
+| `nodeSelector` | non-empty object | Pin the Job to the paperclip workload pool |
+| `serviceAccountName` | non-empty string | Bootstrap claude as the service account that has the right RBAC |
+
+The exact values are cluster-specific (different installs use different taint keys, labels, and service account names). Discover them by reading the most-recent peer `claude_k8s` config in the same company and copying its schedulability fields. Do NOT improvise — if you cannot find a peer, ask the operator before submitting.
+
+```sh
+# 1. List existing claude_k8s agents in the company
+curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-configurations" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  | jq '.[] | select(.adapterType == "claude_k8s") | {name, id, tolerations: .adapterConfig.tolerations, nodeSelector: .adapterConfig.nodeSelector, serviceAccountName: .adapterConfig.serviceAccountName}'
+
+# 2. Fetch the full adapterConfig for a healthy peer agent and copy the fields
+curl -sS "$PAPERCLIP_API_URL/api/agents/<peer-agent-id>/configuration" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  | jq '.adapterConfig | {tolerations, nodeSelector, serviceAccountName, graceSec, timeoutSec}'
+```
+
+Also recommended (not currently required by the server):
+
+- `paperclipSkillSync.desiredSkills` — list of skills to bake into the agent's pod on bootstrap; allowed empty for a degraded-mode hire but most roles need a non-empty list
+- `graceSec` (default `15`) and `timeoutSec` (default `0`, no timeout) — peer values are the right starting point
+
+`api-reference.md` has a full claude_k8s payload example.
 
 ## References
 

--- a/skills/paperclip-create-agent/references/api-reference.md
+++ b/skills/paperclip-create-agent/references/api-reference.md
@@ -86,6 +86,45 @@ If company setting disables required approval, `approval` is `null` and the agen
 `desiredSkills` accepts company skill ids, canonical keys, or a unique slug. The server resolves and stores canonical company skill keys.
 Leave timer heartbeats disabled by default. Only set `runtimeConfig.heartbeat.enabled=true` and include an `intervalSec` when the role truly needs scheduled recurring work or the user explicitly requested it.
 
+### `claude_k8s` adapterConfig requirements
+
+The control plane rejects `claude_k8s` agents (POST and PATCH) whose `adapterConfig` is missing any of `tolerations`, `nodeSelector`, or `serviceAccountName`. Copy the values from a healthy peer `claude_k8s` agent in the same company — they are cluster-specific. Example payload:
+
+```json
+{
+  "name": "ExampleK8sEngineer",
+  "role": "engineer",
+  "title": "Example Engineer",
+  "icon": "code",
+  "reportsTo": "uuid-or-null",
+  "capabilities": "Owns example workstream end-to-end",
+  "desiredSkills": ["paperclipai/paperclip/paperclip"],
+  "adapterType": "claude_k8s",
+  "adapterConfig": {
+    "model": "claude-sonnet-4-5-20250929",
+    "tolerations": [
+      { "key": "dedicated", "value": "paperclip", "effect": "NoSchedule", "operator": "Equal" }
+    ],
+    "nodeSelector": { "workload": "paperclip" },
+    "serviceAccountName": "paperclip",
+    "graceSec": 15,
+    "timeoutSec": 0,
+    "paperclipSkillSync": { "desiredSkills": ["paperclipai/paperclip/paperclip"] }
+  },
+  "instructionsBundle": { "files": { "AGENTS.md": "You are ExampleK8sEngineer..." } },
+  "runtimeConfig": { "heartbeat": { "enabled": false, "wakeOnDemand": true } },
+  "sourceIssueId": "uuid-or-null"
+}
+```
+
+Error response shape on a missing field (HTTP 422):
+
+```json
+{
+  "error": "Invalid claude_k8s adapterConfig: tolerations must be a non-empty array (Job pods need to tolerate the paperclip-workload taint)"
+}
+```
+
 ## Approval Lifecycle
 
 Statuses:

--- a/skills/paperclip-create-agent/references/draft-review-checklist.md
+++ b/skills/paperclip-create-agent/references/draft-review-checklist.md
@@ -57,6 +57,7 @@ Use it for every path: exact template, adjacent template, or generic fallback.
 - [ ] `sourceIssueId` (or `sourceIssueIds`) is set when the hire was triggered by an issue
 - [ ] `desiredSkills` lists only skills that already exist in the company library, or will be installed first via the company-skills workflow
 - [ ] Adapter config matches this Paperclip instance (cwd, model, credentials) per `/llms/agent-configuration/<adapter>.txt`
+- [ ] For `claude_k8s` adapters: `tolerations` (non-empty array), `nodeSelector` (non-empty object), and `serviceAccountName` (non-empty string) are all set, copied from a healthy peer `claude_k8s` agent in the same company. Without these the Job cannot schedule and every assignment fails with `claude exited 128 (StartError)`.
 - [ ] Local managed-bundle adapters send custom instructions through top-level `instructionsBundle.files["AGENTS.md"]` and do not set `adapterConfig.promptTemplate` or `bootstrapPromptTemplate`
 - [ ] Placeholders like `{{companyName}}`, `{{managerTitle}}`, `{{issuePrefix}}`, and any URL stubs are replaced with real values
 
@@ -93,3 +94,4 @@ Use it for every path: exact template, adjacent template, or generic fallback.
 - **No confidential path for sensitive work.** Roles that may receive private advisories or incident details need a private workflow, not normal issue comments.
 - **Missing governance fields.** A hire without `sourceIssueId`, `icon`, or a resolvable reporting line is hard to audit later.
 - **Unreplaced placeholders.** `{{companyName}}`, `{{managerTitle}}`, and URL stubs in a submitted draft are the most common rejected-hire defect — grep the draft for `{{` before submitting.
+- **`claude_k8s` schedulability omission.** Submitting a `claude_k8s` hire without `tolerations`, `nodeSelector`, and `serviceAccountName` is now rejected at the API. Copy these from a healthy peer `claude_k8s` agent in the same company before submitting — see SKILL.md "Adapter-specific notes".


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, dispatching their work as Kubernetes Jobs via the `claude_k8s` adapter
> - The hire flow (POST `/api/companies/:id/agent-hires`) and the create/update flows (POST/PATCH `/api/agents`) both let an operator submit a `claude_k8s` `adapterConfig` with no `tolerations`, no `nodeSelector`, and no `serviceAccountName`
> - In production those three fields are operationally required: pods can't schedule on the paperclip-tainted nodes without the toleration, can't pick the right pool without the nodeSelector, and can't bootstrap claude without the right service account
> - When this happened on Blockcast (Staff Engineer hire 2026-04-25, paperclip-create-agent skill landed an empty adapter config), every assignment died as `claude exited 128 (StartError)` and the recovery scheduler produced a 5-issue silent cascade in 15 minutes (BLO-2645 → BLO-2647 → BLO-2649 → BLO-2650 → BLO-2652) before any human noticed
> - This pull request adds shape-only validation to the control plane and operator-facing guidance to the paperclip-create-agent skill
> - The benefit is a foot-gun that's easy to trip — and silent when tripped — becomes a clear 422 at hire time, before any pod is ever created

## What Changed

- **`server/src/routes/agents.ts`** — extend `assertAdapterConfigConstraints` with a `claude_k8s` branch that requires non-empty `tolerations` (array), `nodeSelector` (object), and `serviceAccountName` (string). Exact values are cluster-specific and operator-supplied; only the shape is enforced.
- **`server/src/routes/agents.ts`** — PATCH `/agents/:id` now calls `assertAdapterConfigConstraints` whenever `adapterType` or `adapterConfig` is touched (was opencode_local-only). The function self-gates by adapter type, so opencode_local behavior is unchanged and the same claude_k8s guardrail now also covers PATCH.
- **`skills/paperclip-create-agent/SKILL.md`** — new "Adapter-specific notes → claude_k8s schedulability fields" section. Tells the operator to copy `tolerations` / `nodeSelector` / `serviceAccountName` from a healthy peer `claude_k8s` agent in the same company (cluster values don't transplant across installations) and provides discovery curl recipes.
- **`skills/paperclip-create-agent/references/draft-review-checklist.md`** — checklist bullet under section G + a "claude_k8s schedulability omission" failure mode entry.
- **`skills/paperclip-create-agent/references/api-reference.md`** — full claude_k8s example payload + a sample 422 error body so operators recognize the rejection.
- **`server/src/__tests__/agent-adapter-validation-routes.test.ts`** — eight new tests covering POST acceptance with full config, POST rejection on each missing/empty field (`tolerations`, `nodeSelector`, `serviceAccountName` with both "missing" and "empty/blank" variants), and a PATCH `replaceAdapterConfig` regression that drops the schedulability fields.

## Verification

```bash
# Targeted test file (10/10 pass)
pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-adapter-validation-routes.test.ts

# All agent route tests (103/103 pass)
pnpm --filter @paperclipai/server exec vitest run 'src/__tests__/agent'

# Adjacent route + opencode tests to confirm no regressions (passed locally)
pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/agent-instructions-routes.test.ts \
  src/__tests__/agent-skills-routes.test.ts \
  src/__tests__/agent-permissions-routes.test.ts \
  src/__tests__/opencode-local-adapter.test.ts \
  src/__tests__/opencode-local-skill-sync.test.ts \
  src/__tests__/opencode-local-adapter-environment.test.ts

# Typecheck
pnpm --filter @paperclipai/server typecheck
```

Manual: on a dev paperclip instance, `POST /api/companies/:id/agents` with `adapterType: "claude_k8s"` and an empty `adapterConfig: {}` → 422 with a field-named error. Re-submit with the three fields populated → 201.

## Risks

- **Low risk.** The validation is shape-only and only runs when `adapterType === "claude_k8s"`. Existing `claude_k8s` agents remain valid because their stored configs already have these fields (this is the only working configuration in the field — broken configs are exactly what this PR catches).
- **PATCH path now runs `assertAdapterConfigConstraints` unconditionally** instead of only for opencode_local. The function self-gates by adapter type, so behavior is unchanged for every adapter except `claude_k8s` (newly validated) and `opencode_local` (unchanged path). No new external calls fire for other adapter types.
- The defaults are **not** populated server-side, only validated, because the right values (taint key, node label, service account name) are cluster-specific and would be wrong for any other installation. The skill change directs operators to copy from a peer agent.

## Model Used

- Provider: Anthropic Claude
- Model ID: `claude-opus-4-7` (Opus 4.7, 1M context)
- Reasoning: standard tool-use loop, no extended thinking required for this scope

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server + skill docs only
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge