### PR TITLE
fix(gemini-local): stream prompt via stdin instead of --prompt argv

### DIFF
--- a/packages/adapters/gemini-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/gemini-local/src/server/execute.remote.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -268,5 +268,82 @@ describe("gemini remote execution", () => {
     expect(prepareWorkspaceForSshExecution).toHaveBeenCalledTimes(1);
     expect(restoreWorkspaceFromSshExecution).toHaveBeenCalledTimes(1);
     expect(runChildProcess).not.toHaveBeenCalled();
+  });
+});
+
+describe("gemini local prompt transport", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("streams a large prompt via stdin instead of argv to avoid Windows cmd.exe argv limits", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-stdin-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+    const instructionsPath = path.join(rootDir, "AGENTS.md");
+    const longInstructions = "X".repeat(12_000);
+    await writeFile(instructionsPath, longInstructions, "utf8");
+
+    await execute({
+      runId: "run-stdin-1",
+      agent: {
+        id: "agent-stdin",
+        companyId: "company-1",
+        name: "Gemini Stdin Test",
+        adapterType: "gemini_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "gemini",
+        cwd: workspaceDir,
+        instructionsFilePath: instructionsPath,
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    const call = runChildProcess.mock.calls[0] as unknown as
+      | [string, string, string[], { stdin?: string }]
+      | undefined;
+    const args = call?.[2] ?? [];
+    const opts = call?.[3] ?? {};
+
+    // No argv element should contain the long instructions payload.
+    for (const arg of args) {
+      expect(arg).not.toContain(longInstructions);
+      // Sanity-check that no individual arg is dangerously large either.
+      expect(arg.length).toBeLessThan(2_000);
+    }
+
+    // --prompt must NOT be in argv: Gemini CLI 0.38.2 enters headless mode
+    // automatically when stdin is piped, and rejects --prompt + stdin together
+    // ("Cannot use both a positional prompt and the --prompt (-p) flag together").
+    expect(args).not.toContain("--prompt");
+    expect(args).not.toContain("-p");
+
+    // The full prompt — including the long instructions prefix — must be on stdin.
+    expect(typeof opts.stdin).toBe("string");
+    expect(opts.stdin).toContain(longInstructions);
+    expect((opts.stdin ?? "").length).toBeGreaterThan(longInstructions.length);
   });
 });

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -375,7 +375,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
   }
   const commandNotes = (() => {
-    const notes: string[] = ["Prompt is passed to Gemini via --prompt for non-interactive execution."];
+    const notes: string[] = [
+      "Prompt is streamed to Gemini via stdin to avoid Windows cmd.exe argv limits. No --prompt flag is passed: Gemini CLI 0.38.2 enters non-interactive (headless) mode automatically when stdin is piped, and rejects --prompt when stdin also has bytes ('Cannot use both a positional prompt and the --prompt (-p) flag together').",
+    ];
     notes.push("Added --approval-mode yolo for unattended execution.");
     if (!instructionsFilePath) return notes;
     if (instructionsPrefix.length > 0) {
@@ -430,6 +432,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     heartbeatPromptChars: renderedPrompt.length,
   };
 
+  // Gemini CLI: in 0.38.2 non-interactive (headless) mode is triggered
+  // automatically when stdin is piped — no --prompt flag is needed, and in
+  // fact passing --prompt while stdin has bytes is rejected by yargs with
+  // "Cannot use both a positional prompt and the --prompt (-p) flag together".
+  // We stream the entire prompt via stdin to keep argv small (Windows cmd.exe
+  // wrappers cap the full command line at 8,191 chars). Mirrors claude-local's
+  // `--print -` + stdin pattern, just without an explicit headless trigger.
   const buildArgs = (resumeSessionId: string | null) => {
     const args = ["--output-format", "stream-json"];
     if (resumeSessionId) args.push("--resume", resumeSessionId);
@@ -441,7 +450,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--sandbox=none");
     }
     if (extraArgs.length > 0) args.push(...extraArgs);
-    args.push("--prompt", prompt);
     return args;
   };
 
@@ -453,9 +461,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         command: resolvedCommand,
         cwd: effectiveExecutionCwd,
         commandNotes,
-        commandArgs: args.map((value, index) => (
-          index === args.length - 1 ? `<prompt ${prompt.length} chars>` : value
-        )),
+        commandArgs: args,
         env: loggedEnv,
         prompt,
         promptMetrics,
@@ -466,6 +472,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const proc = await runAdapterExecutionTargetProcess(runId, executionTarget, command, args, {
       cwd,
       env,
+      stdin: prompt,
       timeoutSec,
       graceSec,
       onSpawn,


### PR DESCRIPTION
## Summary

- Gemini CLI 0.38.2 enters non-interactive (headless) mode automatically when stdin is piped, and rejects `--prompt` when stdin also has bytes (`"Cannot use both a positional prompt and the --prompt (-p) flag together"`). Drop `--prompt` from argv and pipe the rendered prompt over stdin instead.
- Also fixes a real-world Windows failure: `cmd.exe` caps the full command line at 8,191 chars, and large `AGENTS.md` instructions prefixes were blowing past that limit, surfacing as `"command line is too long"` errors in `heartbeat_runs` for agents with non-trivial instructions files.
- Mirrors the existing `claude-local` `--print -` + stdin pattern.

## Test plan

- [x] New vitest in ``packages/adapters/gemini-local/src/server/execute.remote.test.ts`` (`describe("gemini local prompt transport")`) covering a 12k-char instructions prefix and asserting:
  - no argv element contains the long instructions payload
  - `--prompt` / `-p` are absent from argv
  - the full rendered prompt (including instructions prefix) lands on `opts.stdin`
- [x] Manual run on Windows: `Daily CTR Check` agent (~14k-char instructions prefix) — previously failing with `command line is too long`, now executes cleanly via stdin transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)