### PR TITLE
feat: return HTTP 423 on checkout when ancestor has pending plan confirmation

### DIFF
--- a/server/src/__tests__/issues-checkout-plan-lock.test.ts
+++ b/server/src/__tests__/issues-checkout-plan-lock.test.ts
@@ -1,0 +1,226 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const issueId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const parentIssueId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const companyId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const agentId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const interactionId = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+
+const mockIssueService = vi.hoisted(() => ({
+  checkout: vi.fn(),
+  getAncestors: vi.fn(),
+  getById: vi.fn(),
+}));
+
+const mockInteractionService = vi.hoisted(() => ({
+  expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+  expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+  hasPendingPlanConfirmationOnAnyIssue: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentTaskCompleted: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+}));
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => ({
+      canUser: vi.fn(async () => true),
+      hasPermission: vi.fn(async () => false),
+    }),
+    agentService: () => ({
+      getById: vi.fn(async () => null),
+      list: vi.fn(async () => []),
+      resolveByReference: vi.fn(async () => ({ ambiguous: false, agent: null })),
+    }),
+    clampIssueListLimit: (v: number) => v,
+    ISSUE_LIST_DEFAULT_LIMIT: 500,
+    ISSUE_LIST_MAX_LIMIT: 1000,
+    companyService: () => ({
+      getById: vi.fn(async () => ({ id: companyId, issuePrefix: "TST" })),
+    }),
+    documentService: () => ({}),
+    environmentService: () => ({}),
+    executionWorkspaceService: () => ({ getById: vi.fn(async () => null) }),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+    }),
+    goalService: () => ({}),
+    heartbeatService: () => ({
+      wakeup: vi.fn(async () => undefined),
+    }),
+    instanceSettingsService: () => ({
+      get: vi.fn(async () => ({
+        id: "instance-settings-1",
+        general: {
+          censorUsernameInLogs: false,
+          feedbackDataSharingPreference: "prompt",
+        },
+      })),
+      listCompanyIds: vi.fn(async () => [companyId]),
+    }),
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: async () => undefined,
+      diffIssueReferenceSummary: () => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      }),
+      emptySummary: () => ({ outbound: [], inbound: [] }),
+      listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+      syncComment: async () => undefined,
+      syncDocument: async () => undefined,
+      syncIssue: async () => undefined,
+    }),
+    issueService: () => mockIssueService,
+    issueThreadInteractionService: () => mockInteractionService,
+    logActivity: mockLogActivity,
+    projectService: () => ({
+      getById: vi.fn(async () => null),
+    }),
+    routineService: () => ({
+      syncRunStatusForIssue: vi.fn(async () => undefined),
+    }),
+    workProductService: () => ({ getById: vi.fn(async () => null) }),
+  }));
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: issueId,
+    companyId,
+    status: "in_progress",
+    priority: "medium",
+    projectId: null,
+    goalId: null,
+    parentId: null,
+    assigneeAgentId: agentId,
+    assigneeUserId: null,
+    createdByUserId: "local-board",
+    identifier: "TST-42",
+    title: "A task",
+    executionPolicy: null,
+    executionState: null,
+    executionWorkspaceId: null,
+    hiddenAt: null,
+    checkoutRunId: null,
+    ...overrides,
+  };
+}
+
+async function createApp() {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/issues.js"),
+    import("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: [companyId],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("checkout plan lock (§3.5 Option A)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.doUnmock("../services/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+
+    // Default: issue found, no ancestors, checkout succeeds
+    mockIssueService.getById.mockResolvedValue(makeIssue());
+    mockIssueService.getAncestors.mockResolvedValue([]);
+    mockIssueService.checkout.mockResolvedValue(makeIssue({ checkoutRunId: "run-1" }));
+    mockInteractionService.hasPendingPlanConfirmationOnAnyIssue.mockResolvedValue(null);
+  });
+
+  it("allows checkout when issue has no ancestors", async () => {
+    mockIssueService.getAncestors.mockResolvedValue([]);
+
+    const app = await createApp();
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["todo", "in_progress"] });
+
+    expect(res.status).toBe(200);
+    expect(mockInteractionService.hasPendingPlanConfirmationOnAnyIssue).not.toHaveBeenCalled();
+  });
+
+  it("allows checkout when ancestors have no pending plan confirmation", async () => {
+    mockIssueService.getAncestors.mockResolvedValue([
+      { id: parentIssueId, identifier: "TST-10", title: "Parent" },
+    ]);
+    mockInteractionService.hasPendingPlanConfirmationOnAnyIssue.mockResolvedValue(null);
+
+    const app = await createApp();
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["todo", "in_progress"] });
+
+    expect(res.status).toBe(200);
+    expect(mockInteractionService.hasPendingPlanConfirmationOnAnyIssue).toHaveBeenCalledWith(
+      [parentIssueId],
+      companyId,
+    );
+  });
+
+  it("returns 423 when an ancestor has a pending plan confirmation", async () => {
+    mockIssueService.getAncestors.mockResolvedValue([
+      { id: parentIssueId, identifier: "TST-10", title: "Parent" },
+    ]);
+    mockInteractionService.hasPendingPlanConfirmationOnAnyIssue.mockResolvedValue({
+      id: interactionId,
+      issueId: parentIssueId,
+    });
+
+    const app = await createApp();
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["todo", "in_progress"] });
+
+    expect(res.status).toBe(423);
+    expect(res.body).toMatchObject({
+      error: expect.stringContaining("pending plan confirmation"),
+      lockedByIssueId: parentIssueId,
+      interactionId,
+    });
+    expect(mockIssueService.checkout).not.toHaveBeenCalled();
+  });
+
+  it("does not check ancestors when the issue itself is the root (no ancestors)", async () => {
+    // Issue without parent — getAncestors returns []
+    mockIssueService.getById.mockResolvedValue(makeIssue({ parentId: null }));
+    mockIssueService.getAncestors.mockResolvedValue([]);
+
+    const app = await createApp();
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["todo", "in_progress"] });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.checkout).toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2751,6 +2751,25 @@ export function issueRoutes(
       }
     }
 
+    // Hard checkout lock (§3.5 Option A): walk ancestor chain and return 423 if any
+    // ancestor has a pending plan request_confirmation awaiting board approval.
+    const ancestors = await svc.getAncestors(issue.id);
+    if (ancestors.length > 0) {
+      const ancestorIds = ancestors.map((a) => a.id);
+      const planLock = await issueThreadInteractionService(db).hasPendingPlanConfirmationOnAnyIssue(
+        ancestorIds,
+        issue.companyId,
+      );
+      if (planLock) {
+        res.status(423).json({
+          error: "Checkout locked: an ancestor issue has a pending plan confirmation awaiting approval",
+          lockedByIssueId: planLock.issueId,
+          interactionId: planLock.id,
+        });
+        return;
+      }
+    }
+
     if (req.actor.type === "agent" && req.actor.agentId !== req.body.agentId) {
       res.status(403).json({ error: "Agent can only checkout as itself" });
       return;

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1205,5 +1205,49 @@ export function issueThreadInteractionService(db: Db) {
       await touchIssue(db, issue.id);
       return hydrateInteraction(updated);
     },
+
+    /**
+     * Returns the first pending plan `request_confirmation` found on any of the given issues,
+     * or null if none exists. Used by the checkout lock to block execution while a plan
+     * awaits approval on an ancestor issue.
+     */
+    hasPendingPlanConfirmationOnAnyIssue: async (
+      issueIds: string[],
+      companyId: string,
+    ): Promise<{ id: string; issueId: string } | null> => {
+      if (issueIds.length === 0) return null;
+
+      // Chunk to stay within DB IN-clause limits
+      const chunkSize = 100;
+      for (let i = 0; i < issueIds.length; i += chunkSize) {
+        const chunk = issueIds.slice(i, i + chunkSize);
+        const rows = await db
+          .select({
+            id: issueThreadInteractions.id,
+            issueId: issueThreadInteractions.issueId,
+            payload: issueThreadInteractions.payload,
+          })
+          .from(issueThreadInteractions)
+          .where(
+            and(
+              eq(issueThreadInteractions.companyId, companyId),
+              inArray(issueThreadInteractions.issueId, chunk),
+              eq(issueThreadInteractions.kind, "request_confirmation"),
+              eq(issueThreadInteractions.status, "pending"),
+            ),
+          );
+
+        const hit = rows.find((row) => {
+          const payload = requestConfirmationPayloadSchema.parse(row.payload) as {
+            target?: { type?: string; key?: string } | null;
+          };
+          return payload.target?.type === "issue_document" && payload.target?.key === "plan";
+        });
+
+        if (hit) return { id: hit.id, issueId: hit.issueId };
+      }
+
+      return null;
+    },
   };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; agents are assigned issues and check them out to begin execution
> - The Plan Room feature (FUS-26) introduces a hierarchical project-planning surface where a board member must approve a plan document before agents can execute against it
> - Without a hard lock, agents could check out child issues and start execution even while the plan awaits board approval, defeating the review gate
> - §3.5 Option A of the Plan Room spec calls for a hard checkout lock: `POST /api/issues/:id/checkout` should walk the ancestor chain and return HTTP 423 if any ancestor holds a pending `request_confirmation` targeting the `plan` document
> - This PR implements that lock: a new service helper checks ancestors in a single batched DB query, and the checkout route calls it before advancing to the checkout step
> - The benefit is that no child-issue execution can begin while a plan is pending board sign-off, enforcing the review gate without requiring manual coordination

## What Changed

- **`server/src/services/issue-thread-interactions.ts`**: adds `hasPendingPlanConfirmationOnAnyIssue(issueIds, companyId)` — a batched query against `issue_thread_interactions` that returns the first `request_confirmation` with `status=pending` and `payload.target.key="plan"` found across any of the supplied issue IDs
- **`server/src/routes/issues.ts`**: after the project-pause check in the checkout route, walks `svc.getAncestors(issue.id)` and calls the new helper; if a lock is found, returns `{ status: 423, error: "...", lockedByIssueId, interactionId }`; short-circuits before `svc.checkout` is called
- **`server/src/__tests__/issues-checkout-plan-lock.test.ts`**: four unit tests covering no-ancestor pass-through, ancestor-with-no-lock pass-through, 423 lock response (verifies body fields and that `checkout` is never called), and root-issue-bypass (root has no ancestors so it can still be checked out to respond to plan rejections)

## Verification

```bash
# Run the new tests
pnpm vitest run "src/__tests__/issues-checkout-plan-lock.test.ts"
# Expected: 4 passed

# Run typecheck
cd server && pnpm typecheck
# Expected: exit 0

# Manual: create a child issue under a parent that has a pending plan
# request_confirmation, then attempt POST /api/issues/:childId/checkout
# → expect HTTP 423 with lockedByIssueId matching the parent
# Accept the plan confirmation, retry checkout → expect HTTP 200
```

## Risks

- **Perf**: `getAncestors` issues one DB query per ancestor level (typically 1–3 levels); the new helper adds one more batched query. Acceptable for a checkout path that is not on a hot loop.
- **Root-issue bypass**: issues with no ancestors skip the check, letting the plan-holder itself be checked out (intentional — needed to respond to plan rejections).
- **No schema migration**: pure query-layer addition, no schema changes.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context window: 200 K tokens
- Capabilities: tool use, code execution, extended reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge