### PR TITLE
Add OpenClaw completion hook for heartbeat runs

### DIFF
--- a/server/src/__tests__/heartbeat-openclaw-completion-hook.test.ts
+++ b/server/src/__tests__/heartbeat-openclaw-completion-hook.test.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const adapterExecute = vi.hoisted(() => vi.fn(async () => ({
+  exitCode: 0,
+  signal: null,
+  timedOut: false,
+  sessionParams: { sessionId: "session-1" },
+  sessionDisplayId: "session-1",
+  provider: "test",
+  model: "test-model",
+  summary: "test completion summary",
+  resultJson: { summary: "test completion summary" },
+})));
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+vi.mock("../adapters/index.js", () => ({
+  getServerAdapter: () => ({
+    type: "codex_local",
+    execute: adapterExecute,
+    supportsLocalAgentJwt: false,
+  }),
+  runningProcesses: new Map(),
+}));
+
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres OpenClaw completion hook tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat OpenClaw completion hook", () => {
+  let stopDb: (() => Promise<void>) | null = null;
+  let db!: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    const started = await startEmbeddedPostgresTestDatabase("heartbeat-openclaw-completion-hook");
+    stopDb = started.stop;
+    db = createDb(started.connectionString);
+  }, 20_000);
+
+  afterEach(() => {
+    adapterExecute.mockClear();
+    spawnMock.mockReset();
+  });
+
+  afterAll(async () => {
+    await stopDb?.();
+  });
+
+  function mockSpawnSuccess() {
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        once: (event: string, listener: (...args: any[]) => void) => any;
+      };
+      process.nextTick(() => child.emit("exit", 0));
+      return child;
+    });
+  }
+
+  function mockSpawnFailure() {
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        once: (event: string, listener: (...args: any[]) => void) => any;
+      };
+      process.nextTick(() => child.emit("error", new Error("spawn failed")));
+      return child;
+    });
+  }
+
+  let fixtureCounter = 0;
+
+  async function createAgentFixture() {
+    fixtureCounter += 1;
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: `Acme ${fixtureCounter}`,
+      issuePrefix: `T${fixtureCounter}`,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return { companyId, agentId };
+  }
+
+  it("dispatches an OpenClaw completion event and marks the run result when the hook succeeds", async () => {
+    mockSpawnSuccess();
+    const { agentId } = await createAgentFixture();
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+    });
+
+    expect(run).not.toBeNull();
+    await vi.waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      expect(latest?.status).toBe("succeeded");
+      expect((latest?.resultJson as Record<string, unknown> | null)?.openclawCompletionHookSent).toBe(true);
+    }, { timeout: 5_000 });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [bin, args] = spawnMock.mock.calls[0] ?? [];
+    expect(bin).toBe("/usr/local/bin/openclaw");
+    expect(args).toEqual([
+      "system",
+      "event",
+      "--text",
+      "Paperclip done: test completion summary",
+      "--mode",
+      "now",
+    ]);
+  });
+
+  it("does not fail the heartbeat run when OpenClaw completion dispatch fails", async () => {
+    mockSpawnFailure();
+    const { agentId } = await createAgentFixture();
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+    });
+
+    expect(run).not.toBeNull();
+    await vi.waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      expect(latest?.status).toBe("succeeded");
+      expect(spawnMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+    }, { timeout: 5_000 });
+
+    const persisted = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, run!.id)).then((rows) => rows[0] ?? null);
+    expect(persisted?.status).toBe("succeeded");
+    expect((persisted?.resultJson as Record<string, unknown> | null)?.openclawCompletionHookSent).not.toBe(true);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/__tests__/heartbeat-openclaw-completion-hook.test.ts
+++ b/server/src/__tests__/heartbeat-openclaw-completion-hook.test.ts
@@ -151,9 +151,10 @@ describeEmbeddedPostgres("heartbeat OpenClaw completion hook", () => {
     }, { timeout: 5_000 });
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
-    const [bin, args] = spawnMock.mock.calls[0] ?? [];
-    expect(bin).toBe("/usr/local/bin/openclaw");
+    const [bin, args, options] = spawnMock.mock.calls[0] ?? [];
+    expect(bin).toBe(process.execPath);
     expect(args).toEqual([
+      "/usr/local/lib/node_modules/openclaw/openclaw.mjs",
       "system",
       "event",
       "--text",
@@ -161,6 +162,13 @@ describeEmbeddedPostgres("heartbeat OpenClaw completion hook", () => {
       "--mode",
       "now",
     ]);
+    expect(options).toMatchObject({
+      stdio: "ignore",
+      detached: false,
+      env: expect.objectContaining({
+        NODE: process.execPath,
+      }),
+    });
   });
 
   it("does not fail the heartbeat run when OpenClaw completion dispatch fails", async () => {

--- a/server/src/__tests__/heartbeat-openclaw-completion-hook.test.ts
+++ b/server/src/__tests__/heartbeat-openclaw-completion-hook.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { ChildProcess } from "node:child_process";
 import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
 import { eq } from "drizzle-orm";
 import {
@@ -89,6 +90,19 @@ describeEmbeddedPostgres("heartbeat OpenClaw completion hook", () => {
     });
   }
 
+  function mockSpawnHang() {
+    const kill = vi.fn();
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter() as EventEmitter & ChildProcess & {
+        once: (event: string, listener: (...args: any[]) => void) => any;
+        kill: typeof kill;
+      };
+      child.kill = kill;
+      return child;
+    });
+    return { kill };
+  }
+
   let fixtureCounter = 0;
 
   async function createAgentFixture() {
@@ -171,4 +185,27 @@ describeEmbeddedPostgres("heartbeat OpenClaw completion hook", () => {
     expect((persisted?.resultJson as Record<string, unknown> | null)?.openclawCompletionHookSent).not.toBe(true);
     expect(spawnMock).toHaveBeenCalledTimes(1);
   });
+
+  it("times out a hung OpenClaw completion dispatch without blocking heartbeat finalization", async () => {
+    const { kill } = mockSpawnHang();
+    const { agentId } = await createAgentFixture();
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+    });
+
+    expect(run).not.toBeNull();
+    await vi.waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      expect(latest?.status).toBe("succeeded");
+      expect(spawnMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect(kill).toHaveBeenCalledTimes(1);
+    }, { timeout: 10_000 });
+
+    const persisted = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, run!.id)).then((rows) => rows[0] ?? null);
+    expect(persisted?.status).toBe("succeeded");
+    expect((persisted?.resultJson as Record<string, unknown> | null)?.openclawCompletionHookSent).not.toBe(true);
+  }, 15_000);
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -262,8 +262,35 @@ const INLINE_BASE64_IMAGE_DATA_RE = /("type":"image","source":\{"type":"base64",
 const OPENCLAW_EVENT_TEXT_MAX_CHARS = 500;
 const OPENCLAW_COMPLETION_HOOK_SENT_KEY = "openclawCompletionHookSent";
 const OPENCLAW_COMPLETION_HOOK_TIMEOUT_MS = 5_000;
+const OPENCLAW_COMPLETION_HOOK_DEFAULT_PATH = [
+  "/usr/local/bin",
+  "/usr/bin",
+  "/bin",
+  "/usr/sbin",
+  "/sbin",
+].join(":");
+const OPENCLAW_NODE_BIN = process.env.OPENCLAW_NODE_BIN || process.execPath || "/usr/local/bin/node";
+const OPENCLAW_ENTRYPOINT = process.env.OPENCLAW_ENTRYPOINT || "/usr/local/lib/node_modules/openclaw/openclaw.mjs";
 function readOpenClawBin(): string {
   return process.env.OPENCLAW_BIN || "/usr/local/bin/openclaw";
+}
+function buildOpenClawCompletionHookEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  env.PATH = env.PATH && env.PATH.trim().length > 0 ? env.PATH : OPENCLAW_COMPLETION_HOOK_DEFAULT_PATH;
+  env.NODE = env.NODE || OPENCLAW_NODE_BIN;
+  return env;
+}
+function buildOpenClawCompletionCommand(): { command: string; args: string[] } {
+  if (OPENCLAW_ENTRYPOINT) {
+    return {
+      command: OPENCLAW_NODE_BIN,
+      args: [OPENCLAW_ENTRYPOINT],
+    };
+  }
+  return {
+    command: readOpenClawBin(),
+    args: [],
+  };
 }
 function truncateOpenClawEventText(value: string | null | undefined): string {
   if (typeof value !== "string") return "";
@@ -312,12 +339,12 @@ async function dispatchOpenClawCompletionEvent(input: {
 }): Promise<void> {
   const eventText = buildOpenClawCompletionEventText(input);
   if (!eventText) return;
-  const openclawBin = readOpenClawBin();
+  const openclaw = buildOpenClawCompletionCommand();
   await new Promise<void>((resolve, reject) => {
     const child = spawn(
-      openclawBin,
-      ["system", "event", "--text", eventText, "--mode", "now"],
-      { stdio: "ignore", detached: false },
+      openclaw.command,
+      [...openclaw.args, "system", "event", "--text", eventText, "--mode", "now"],
+      { stdio: "ignore", detached: false, env: buildOpenClawCompletionHookEnv() },
     );
     let settled = false;
     const finish = (fn: () => void) => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { execFile as execFileCallback } from "node:child_process";
+import { execFile as execFileCallback, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
 import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lte, notInArray, or, sql } from "drizzle-orm";
@@ -259,6 +259,69 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "pi_local",
 ]);
 const INLINE_BASE64_IMAGE_DATA_RE = /("type":"image","source":\{"type":"base64","data":")([A-Za-z0-9+/=]{1024,})(")/g;
+const OPENCLAW_EVENT_TEXT_MAX_CHARS = 500;
+const OPENCLAW_COMPLETION_HOOK_SENT_KEY = "openclawCompletionHookSent";
+const OPENCLAW_BIN = process.env.OPENCLAW_BIN || "/usr/local/bin/openclaw";
+function truncateOpenClawEventText(value: string | null | undefined): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.replace(/\s+/g, " ").trim();
+  return trimmed.length > OPENCLAW_EVENT_TEXT_MAX_CHARS
+    ? trimmed.slice(0, OPENCLAW_EVENT_TEXT_MAX_CHARS)
+    : trimmed;
+}
+function readOpenClawCompletionHookState(resultJson: Record<string, unknown> | null | undefined): boolean {
+  if (!resultJson || typeof resultJson !== "object" || Array.isArray(resultJson)) return false;
+  return resultJson[OPENCLAW_COMPLETION_HOOK_SENT_KEY] === true;
+}
+function mergeOpenClawCompletionHookState(
+  resultJson: Record<string, unknown> | null | undefined,
+  sent: boolean,
+): Record<string, unknown> {
+  const base = resultJson && typeof resultJson === "object" && !Array.isArray(resultJson)
+    ? resultJson
+    : {};
+  return {
+    ...base,
+    [OPENCLAW_COMPLETION_HOOK_SENT_KEY]: sent,
+  };
+}
+function buildOpenClawCompletionEventText(input: {
+  status: string;
+  agentName: string;
+  issueTitle: string | null;
+  summary: string | null;
+  error: string | null;
+}): string {
+  const issuePart = input.issueTitle ? ` on ${input.issueTitle}` : "";
+  if (input.status === "succeeded") {
+    const summary = truncateOpenClawEventText(input.summary || `${input.agentName} finished${issuePart}`);
+    return truncateOpenClawEventText(`Paperclip done: ${summary}`);
+  }
+  const failure = truncateOpenClawEventText(input.error || `Run ${input.status}`);
+  return truncateOpenClawEventText(`Paperclip failed: ${input.agentName}${issuePart} — ${failure}`);
+}
+async function dispatchOpenClawCompletionEvent(input: {
+  status: string;
+  agentName: string;
+  issueTitle: string | null;
+  summary: string | null;
+  error: string | null;
+}): Promise<void> {
+  const eventText = buildOpenClawCompletionEventText(input);
+  if (!eventText) return;
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      OPENCLAW_BIN,
+      ["system", "event", "--text", eventText, "--mode", "now"],
+      { stdio: "ignore", detached: false },
+    );
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`openclaw system event exited with code ${code ?? -1}`));
+    });
+  });
+}
 
 type RuntimeConfigSecretResolver = Pick<
   ReturnType<typeof secretService>,
@@ -5922,7 +5985,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             } as Record<string, unknown>)
           : null;
 
-      const persistedResultJson = mergeHeartbeatRunResultJson(
+      let persistedResultJson = mergeHeartbeatRunResultJson(
         mergeRunStopMetadataForAgent(agent, outcome, {
           resultJson: mergeModelProfileRunMetadata(
             mergeAdapterRecoveryMetadata({
@@ -5937,6 +6000,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }),
         adapterResult.summary ?? null,
       );
+      const completionHookAlreadySent = readOpenClawCompletionHookState(persistedResultJson);
 
       let persistedRun = await setRunStatus(run.id, status, {
         finishedAt: new Date(),
@@ -5998,6 +6062,35 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         await finalizeIssueCommentPolicy(livenessRun, agent);
         await releaseIssueExecutionAndPromote(livenessRun);
         await handleRunLivenessContinuation(livenessRun);
+      }
+      if (finalizedRun && !completionHookAlreadySent) {
+        try {
+          const issueTitle = issueRef?.title ?? null;
+          await dispatchOpenClawCompletionEvent({
+            status,
+            agentName: agent.name,
+            issueTitle,
+            summary: readNonEmptyString(adapterResult.summary) ?? readNonEmptyString(persistedResultJson?.summary) ?? null,
+            error: outcome === "succeeded" ? null : (readNonEmptyString(adapterResult.errorMessage) ?? readNonEmptyString(finalizedRun.error) ?? null),
+          });
+          persistedResultJson = mergeOpenClawCompletionHookState(persistedResultJson, true);
+          await db
+            .update(heartbeatRuns)
+            .set({
+              resultJson: persistedResultJson,
+              updatedAt: new Date(),
+            })
+            .where(eq(heartbeatRuns.id, finalizedRun.id));
+        } catch (hookErr) {
+          logger.warn(
+            {
+              err: hookErr instanceof Error ? { message: hookErr.message, stack: hookErr.stack } : String(hookErr),
+              runId: finalizedRun.id,
+              openclawBin: OPENCLAW_BIN,
+            },
+            "failed to dispatch OpenClaw completion hook",
+          );
+        }
       }
 
       if (finalizedRun) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -269,22 +269,27 @@ const OPENCLAW_COMPLETION_HOOK_DEFAULT_PATH = [
   "/usr/sbin",
   "/sbin",
 ].join(":");
-const OPENCLAW_NODE_BIN = process.env.OPENCLAW_NODE_BIN || process.execPath || "/usr/local/bin/node";
-const OPENCLAW_ENTRYPOINT = process.env.OPENCLAW_ENTRYPOINT || "/usr/local/lib/node_modules/openclaw/openclaw.mjs";
+function readOpenClawNodeBin(): string {
+  return process.env.OPENCLAW_NODE_BIN || process.execPath || "/usr/local/bin/node";
+}
+function readOpenClawEntrypoint(): string {
+  return process.env.OPENCLAW_ENTRYPOINT || "/usr/local/lib/node_modules/openclaw/openclaw.mjs";
+}
 function readOpenClawBin(): string {
   return process.env.OPENCLAW_BIN || "/usr/local/bin/openclaw";
 }
 function buildOpenClawCompletionHookEnv(): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
   env.PATH = env.PATH && env.PATH.trim().length > 0 ? env.PATH : OPENCLAW_COMPLETION_HOOK_DEFAULT_PATH;
-  env.NODE = env.NODE || OPENCLAW_NODE_BIN;
+  env.NODE = env.NODE || readOpenClawNodeBin();
   return env;
 }
 function buildOpenClawCompletionCommand(): { command: string; args: string[] } {
-  if (OPENCLAW_ENTRYPOINT) {
+  const entrypoint = readOpenClawEntrypoint();
+  if (entrypoint) {
     return {
-      command: OPENCLAW_NODE_BIN,
-      args: [OPENCLAW_ENTRYPOINT],
+      command: readOpenClawNodeBin(),
+      args: [entrypoint],
     };
   }
   return {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -261,7 +261,9 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
 const INLINE_BASE64_IMAGE_DATA_RE = /("type":"image","source":\{"type":"base64","data":")([A-Za-z0-9+/=]{1024,})(")/g;
 const OPENCLAW_EVENT_TEXT_MAX_CHARS = 500;
 const OPENCLAW_COMPLETION_HOOK_SENT_KEY = "openclawCompletionHookSent";
-const OPENCLAW_BIN = process.env.OPENCLAW_BIN || "/usr/local/bin/openclaw";
+function readOpenClawBin(): string {
+  return process.env.OPENCLAW_BIN || "/usr/local/bin/openclaw";
+}
 function truncateOpenClawEventText(value: string | null | undefined): string {
   if (typeof value !== "string") return "";
   const trimmed = value.replace(/\s+/g, " ").trim();
@@ -294,10 +296,10 @@ function buildOpenClawCompletionEventText(input: {
 }): string {
   const issuePart = input.issueTitle ? ` on ${input.issueTitle}` : "";
   if (input.status === "succeeded") {
-    const summary = truncateOpenClawEventText(input.summary || `${input.agentName} finished${issuePart}`);
+    const summary = input.summary?.replace(/\s+/g, " ").trim() || `${input.agentName} finished${issuePart}`;
     return truncateOpenClawEventText(`Paperclip done: ${summary}`);
   }
-  const failure = truncateOpenClawEventText(input.error || `Run ${input.status}`);
+  const failure = input.error?.replace(/\s+/g, " ").trim() || `Run ${input.status}`;
   return truncateOpenClawEventText(`Paperclip failed: ${input.agentName}${issuePart} — ${failure}`);
 }
 async function dispatchOpenClawCompletionEvent(input: {
@@ -309,9 +311,10 @@ async function dispatchOpenClawCompletionEvent(input: {
 }): Promise<void> {
   const eventText = buildOpenClawCompletionEventText(input);
   if (!eventText) return;
+  const openclawBin = readOpenClawBin();
   await new Promise<void>((resolve, reject) => {
     const child = spawn(
-      OPENCLAW_BIN,
+      openclawBin,
       ["system", "event", "--text", eventText, "--mode", "now"],
       { stdio: "ignore", detached: false },
     );
@@ -6086,7 +6089,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             {
               err: hookErr instanceof Error ? { message: hookErr.message, stack: hookErr.stack } : String(hookErr),
               runId: finalizedRun.id,
-              openclawBin: OPENCLAW_BIN,
+              openclawBin: readOpenClawBin(),
             },
             "failed to dispatch OpenClaw completion hook",
           );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -261,6 +261,7 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
 const INLINE_BASE64_IMAGE_DATA_RE = /("type":"image","source":\{"type":"base64","data":")([A-Za-z0-9+/=]{1024,})(")/g;
 const OPENCLAW_EVENT_TEXT_MAX_CHARS = 500;
 const OPENCLAW_COMPLETION_HOOK_SENT_KEY = "openclawCompletionHookSent";
+const OPENCLAW_COMPLETION_HOOK_TIMEOUT_MS = 5_000;
 function readOpenClawBin(): string {
   return process.env.OPENCLAW_BIN || "/usr/local/bin/openclaw";
 }
@@ -318,10 +319,25 @@ async function dispatchOpenClawCompletionEvent(input: {
       ["system", "event", "--text", eventText, "--mode", "now"],
       { stdio: "ignore", detached: false },
     );
-    child.once("error", reject);
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      fn();
+    };
+    const timeout = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // ignore kill errors; timeout rejection is the important path
+      }
+      finish(() => reject(new Error(`openclaw system event timed out after ${OPENCLAW_COMPLETION_HOOK_TIMEOUT_MS}ms`)));
+    }, OPENCLAW_COMPLETION_HOOK_TIMEOUT_MS);
+    child.once("error", (err) => finish(() => reject(err)));
     child.once("exit", (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`openclaw system event exited with code ${code ?? -1}`));
+      if (code === 0) finish(resolve);
+      else finish(() => reject(new Error(`openclaw system event exited with code ${code ?? -1}`)));
     });
   });
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates agent work and heartbeat runs are part of the core execution/finalization path.
> - This PR touches the heartbeat finalization flow in the server runtime, specifically the OpenClaw completion notification hook.
> - The goal of the hook is to emit a best-effort OpenClaw system event after terminal heartbeat runs complete, without changing run success semantics.
> - Reviewer feedback previously surfaced that an unbounded spawn path could block heartbeat finalization indefinitely.
> - This reopened PR preserves the bounded, best-effort dispatch behavior on a clean branch rebuilt from current upstream `master`.
> - The benefit is that heartbeat finalization remains non-blocking even when the external OpenClaw binary hangs or exits badly, which is the safer behavior for a central runtime path.

## What Changed

- Add an OpenClaw completion hook to terminal heartbeat run finalization in `server/src/services/heartbeat.ts`
- Bound completion-hook dispatch with a timeout so a hung `openclaw` invocation cannot freeze heartbeat finalization
- Keep the hook non-fatal: failures warn and continue instead of changing run success semantics
- Add focused regression coverage in `server/src/__tests__/heartbeat-openclaw-completion-hook.test.ts`
- Late-bind OpenClaw command/env resolution and harden invocation through Node + `openclaw.mjs`

## Verification

- `PATH="/tmp/pnpm-shim:$PATH" corepack pnpm exec vitest run server/src/__tests__/heartbeat-openclaw-completion-hook.test.ts`
- Focused completion-hook suite passes on the rebuilt branch
- Note: current upstream `master` in this clone fails broader `@paperclipai/server` local typecheck on existing `@paperclipai/adapter-acpx-local` resolution errors unrelated to this PR, so upstream CI is the correct full-branch gate on the current base

## Risks

- Low to moderate runtime risk: this changes a central heartbeat finalization path, but only inside the best-effort OpenClaw completion hook.
- A too-short timeout could suppress legitimate but slow event dispatches; 5 seconds intentionally favors run finalization safety over delayed out-of-process notification delivery.
- The hook remains non-fatal by design, so failure to dispatch still logs a warning and preserves run success semantics.

## Model Used

- OpenAI Codex
- Model ID: `openai-codex/gpt-5.4`
- Reasoning mode: medium
- Capabilities used: repository inspection, code editing, shell execution, CI inspection, and targeted validation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
