### PR TITLE
Fix local_trusted auth fallback handling

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -26,6 +26,8 @@
       "import": "./dist/*.js"
     }
   },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "publishConfig": {
     "access": "public",
     "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,9 +13,18 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./telemetry": "./src/telemetry/index.ts",
-    "./*": "./src/*.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./telemetry": {
+      "types": "./dist/telemetry/index.d.ts",
+      "import": "./dist/telemetry/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,21 +13,10 @@
   },
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    },
-    "./telemetry": {
-      "types": "./dist/telemetry/index.d.ts",
-      "import": "./dist/telemetry/index.js"
-    },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "import": "./dist/*.js"
-    }
+    ".": "./src/index.ts",
+    "./telemetry": "./src/telemetry/index.ts",
+    "./*": "./src/*.ts"
   },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "publishConfig": {
     "access": "public",
     "exports": {

--- a/server/src/__tests__/auth-middleware.test.ts
+++ b/server/src/__tests__/auth-middleware.test.ts
@@ -15,6 +15,18 @@ vi.mock("../services/board-auth.js", () => ({
 import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 import { actorMiddleware } from "../middleware/auth.js";
 
+type TestActor = {
+  type: string;
+  source: string;
+  userId?: string;
+  userName?: string;
+  userEmail?: string | null;
+  isInstanceAdmin?: boolean;
+  agentId?: string;
+  companyId?: string;
+  runId?: string;
+};
+
 function createSelectChain(rows: unknown[]) {
   return {
     from() {
@@ -63,11 +75,11 @@ async function createApp(selectRows: unknown[][] = [[], []]) {
   }
 
   function runActor(headers: Record<string, string | undefined> = {}) {
-    return new Promise<Record<string, unknown>>((resolve, reject) => {
+    return new Promise<TestActor>((resolve, reject) => {
       const req = createRequest(headers);
       middleware(req, {} as never, () => {
         try {
-          resolve(req.actor as Record<string, unknown>);
+          resolve(req.actor as TestActor);
         } catch (error) {
           reject(error);
         }
@@ -76,7 +88,10 @@ async function createApp(selectRows: unknown[][] = [[], []]) {
   }
 
   function runAgentOnly(headers: Record<string, string | undefined> = {}) {
-    return new Promise<{ status: number; body: Record<string, unknown> }>((resolve, reject) => {
+    return new Promise<{
+      status: number;
+      body: { error: string } | { agentId: string; companyId: string };
+    }>((resolve, reject) => {
       const req = createRequest(headers);
       const res = {
         statusCode: 200,
@@ -84,7 +99,7 @@ async function createApp(selectRows: unknown[][] = [[], []]) {
           this.statusCode = code;
           return this;
         },
-        json(body: Record<string, unknown>) {
+        json(body: { error: string } | { agentId: string; companyId: string }) {
           resolve({ status: this.statusCode, body });
           return this;
         },

--- a/server/src/__tests__/auth-middleware.test.ts
+++ b/server/src/__tests__/auth-middleware.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../agent-auth-jwt.js", () => ({
+  verifyLocalAgentJwt: vi.fn(),
+}));
+
+vi.mock("../services/board-auth.js", () => ({
+  boardAuthService: vi.fn(() => ({
+    findBoardApiKeyByToken: vi.fn().mockResolvedValue(null),
+    resolveBoardAccess: vi.fn(),
+    touchBoardApiKey: vi.fn(),
+  })),
+}));
+
+import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
+import { actorMiddleware } from "../middleware/auth.js";
+
+function createSelectChain(rows: unknown[]) {
+  return {
+    from() {
+      return {
+        where() {
+          return Promise.resolve(rows);
+        },
+      };
+    },
+  };
+}
+
+function createDb(selectRows: unknown[][] = [[], []]) {
+  const queue = [...selectRows];
+  return {
+    select: vi.fn(() => createSelectChain(queue.shift() ?? [])),
+    update: vi.fn(() => ({
+      set() {
+        return {
+          where() {
+            return Promise.resolve();
+          },
+        };
+      },
+    })),
+  } as any;
+}
+
+async function createApp(selectRows: unknown[][] = [[], []]) {
+  const middleware = actorMiddleware(createDb(selectRows), {
+    deploymentMode: "local_trusted",
+  });
+
+  function createRequest(headers: Record<string, string | undefined> = {}) {
+    const normalizedHeaders = Object.fromEntries(
+      Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+    );
+
+    return {
+      method: "GET",
+      originalUrl: "/",
+      header(name: string) {
+        return normalizedHeaders[name.toLowerCase()] ?? undefined;
+      },
+    } as any;
+  }
+
+  function runActor(headers: Record<string, string | undefined> = {}) {
+    return new Promise<Record<string, unknown>>((resolve, reject) => {
+      const req = createRequest(headers);
+      middleware(req, {} as never, () => {
+        try {
+          resolve(req.actor as Record<string, unknown>);
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  }
+
+  function runAgentOnly(headers: Record<string, string | undefined> = {}) {
+    return new Promise<{ status: number; body: Record<string, unknown> }>((resolve, reject) => {
+      const req = createRequest(headers);
+      const res = {
+        statusCode: 200,
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(body: Record<string, unknown>) {
+          resolve({ status: this.statusCode, body });
+          return this;
+        },
+      } as any;
+
+      middleware(req, res, () => {
+        try {
+          if (req.actor.type !== "agent") {
+            res.status(401).json({ error: "Agent authentication required" });
+            return;
+          }
+          res.json({ agentId: req.actor.agentId, companyId: req.actor.companyId });
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  }
+
+  return { runActor, runAgentOnly };
+}
+
+describe("actorMiddleware local_trusted bearer handling", () => {
+  it("keeps the implicit local board actor when no authorization header is present", async () => {
+    const app = await createApp();
+
+    const actor = await app.runActor();
+
+    expect(actor).toMatchObject({
+      type: "board",
+      userId: "local-board",
+      userName: "Local Board",
+      userEmail: null,
+      isInstanceAdmin: true,
+      source: "local_implicit",
+    });
+  });
+
+  it("drops back to an unauthenticated actor when a bearer token is invalid", async () => {
+    const app = await createApp();
+
+    const res = await app.runAgentOnly({ authorization: "Bearer not-a-valid-token" });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Agent authentication required" });
+
+    const actor = await app.runActor({ authorization: "Bearer not-a-valid-token" });
+    expect(actor).toMatchObject({
+      type: "none",
+      source: "none",
+    });
+  });
+
+  it("hydrates an agent actor from a valid local agent jwt", async () => {
+    vi.mocked(verifyLocalAgentJwt).mockReturnValue({
+      sub: "agent-1",
+      company_id: "company-1",
+      run_id: "run-1",
+    } as never);
+
+    const app = await createApp([
+      [],
+      [
+        {
+          id: "agent-1",
+          companyId: "company-1",
+          status: "idle",
+        },
+      ],
+    ]);
+
+    const res = await app.runActor({ authorization: "Bearer local-agent-jwt" });
+
+    expect(res).toMatchObject({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+      source: "agent_jwt",
+    });
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -21,8 +21,11 @@ interface ActorMiddlewareOptions {
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
   const boardAuth = boardAuthService(db);
   return async (req, _res, next) => {
+    const runIdHeader = req.header("x-paperclip-run-id");
+    const authHeader = req.header("authorization");
+
     req.actor =
-      opts.deploymentMode === "local_trusted"
+      authHeader === undefined && opts.deploymentMode === "local_trusted"
         ? {
             type: "board",
             userId: "local-board",
@@ -33,9 +36,6 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
           }
         : { type: "none", source: "none" };
 
-    const runIdHeader = req.header("x-paperclip-run-id");
-
-    const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {
       if (opts.deploymentMode === "authenticated" && opts.resolveSession) {
         let session: BetterAuthSessionResult | null = null;


### PR DESCRIPTION
## Thinking Path

> - DEA-52 exposed a real auth-path defect in `local_trusted` mode.
> - The valid durable fix is to prevent requests carrying an `Authorization` header from inheriting implicit local-board authority.
> - A broader shared-package export migration was explored earlier but proved destabilizing under cold monorepo typecheck and was removed from scope.
> - The right enterprise posture is to keep this PR narrowly scoped to the proven auth correction plus its regression coverage.
> - This reopened PR preserves that narrow truthful scope on a clean branch rebuilt from current upstream `master`.

## What Changed

- Restrict implicit local-board actor fallback to requests with **no** `Authorization` header in `server/src/middleware/auth.ts`
- Add focused regression coverage for local-trusted bearer handling in `server/src/__tests__/auth-middleware.test.ts`
- Tighten test typing so the regression suite passes the repository's strict verify path on the touched test surface

## Verification

- `PATH="/tmp/pnpm-shim:$PATH" corepack pnpm exec vitest run server/src/__tests__/auth-middleware.test.ts`
- Focused auth regression suite passes on the rebuilt branch
- Note: current upstream `master` in this clone fails broader `@paperclipai/server` local typecheck on existing `@paperclipai/adapter-acpx-local` resolution errors unrelated to this PR, so upstream CI is the correct full-branch gate on the current base

## Risks

- Low auth-path risk: the change only narrows implicit local-board fallback when an `Authorization` header is present.
- Low test risk: new regression coverage is isolated to the local-trusted bearer seam.

## Model Used

- OpenAI Codex
- Model ID: `openai-codex/gpt-5.4`
- Reasoning mode: medium
- Capabilities used: repository inspection, code editing, shell execution, CI inspection, and targeted validation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
