### PR TITLE
Add cursor_sdk adapter built on @cursor/sdk (additive, opt-in)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY packages/adapters/acpx-local/package.json packages/adapters/acpx-local/
 COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
 COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
+COPY packages/adapters/cursor-sdk/package.json packages/adapters/cursor-sdk/
 COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/

--- a/cli/package.json
+++ b/cli/package.json
@@ -41,6 +41,7 @@
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
+    "@paperclipai/adapter-cursor-sdk": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -3,6 +3,7 @@ import { printAcpxStreamEvent } from "@paperclipai/adapter-acpx-local/cli";
 import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
 import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
+import { printCursorSdkStreamEvent } from "@paperclipai/adapter-cursor-sdk/cli";
 import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
@@ -40,6 +41,11 @@ const cursorLocalCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printCursorStreamEvent,
 };
 
+const cursorSdkCLIAdapter: CLIAdapterModule = {
+  type: "cursor_sdk",
+  formatStdoutEvent: printCursorSdkStreamEvent,
+};
+
 const geminiLocalCLIAdapter: CLIAdapterModule = {
   type: "gemini_local",
   formatStdoutEvent: printGeminiStreamEvent,
@@ -58,6 +64,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     openCodeLocalCLIAdapter,
     piLocalCLIAdapter,
     cursorLocalCLIAdapter,
+    cursorSdkCLIAdapter,
     geminiLocalCLIAdapter,
     openclawGatewayCLIAdapter,
     processCLIAdapter,

--- a/doc/plans/2026-02-23-cursor-cloud-adapter.md
+++ b/doc/plans/2026-02-23-cursor-cloud-adapter.md
@@ -1,5 +1,12 @@
 # Cursor Cloud Agent Adapter — Technical Plan
 
+> **SUPERSEDED 2026-05-03** by [`2026-05-03-cursor-sdk-adapter.md`](./2026-05-03-cursor-sdk-adapter.md).
+>
+> This plan predates the public `@cursor/sdk` TypeScript SDK (announced 2026-Q1). The SDK
+> replaces the handrolled REST client, removes the webhook+polling+bootstrap-exchange
+> complexity for the basic flow, and adds local/self-hosted runtime modes that this plan
+> never covered. Keep this doc for historical context; do not implement against it.
+
 ## Overview
 
 This document defines the V1 design for a Paperclip adapter that integrates with

--- a/doc/plans/2026-05-03-cursor-sdk-adapter.md
+++ b/doc/plans/2026-05-03-cursor-sdk-adapter.md
@@ -1,0 +1,631 @@
+# Cursor SDK Adapter — Technical Plan
+
+**Status:** Draft
+**Date:** 2026-05-03
+**Supersedes:** [`2026-02-23-cursor-cloud-adapter.md`](./2026-02-23-cursor-cloud-adapter.md)
+
+## Overview
+
+This plan defines a new Paperclip adapter, `cursor_sdk`, built on the official
+[`@cursor/sdk`](https://cursor.com/docs/sdk/typescript) (public beta, Cursor TS SDK).
+
+The SDK is a single client surface that can drive Cursor agents in three runtime modes:
+
+1. **Local** — runs the agent in-process on the Paperclip host against a local working dir
+2. **Cloud (Cursor-managed)** — runs the agent in a Cursor-hosted VM, repo cloned remotely
+3. **Self-hosted Cloud** — same as cloud but against a customer-managed VM pool
+
+The SDK exposes:
+
+- typed agent lifecycle (`Agent.create` / `Agent.resume` / `Agent.list` / `Agent.archive`)
+- typed run lifecycle (`run.stream()`, `run.wait()`, `run.cancel()`, `run.onDidChangeStatus()`)
+- a discriminated `SDKMessage` event stream (system/user/assistant/thinking/tool_call/status/task/request)
+- catalog APIs (`Cursor.me`, `Cursor.models.list`, `Cursor.repositories.list`)
+- typed errors (`AuthenticationError`, `RateLimitError`, `ConfigurationError`, `IntegrationNotConnectedError`, `NetworkError`, `UnknownAgentError`, `UnsupportedRunOperationError`)
+- programmatic MCP server config, subagents, artifacts, session env vars
+
+Because the SDK already handles transport, streaming, cancellation, and signature work,
+the adapter shrinks dramatically vs. the 2026-02-23 plan.
+
+---
+
+## Paperclip Architecture Alignment
+
+This plan must conform to Paperclip's existing adapter contract; it is not greenfield.
+
+### Adapter contract (canonical, from `cursor-local`)
+
+Every built-in adapter is a workspace package `@paperclipai/adapter-<name>` with this exact
+exports shape:
+
+```jsonc
+{
+  "exports": {
+    ".":         "./src/index.ts",      // type, label, models, modelProfiles, agentConfigurationDoc
+    "./server":  "./src/server/index.ts", // execute, testEnvironment, sessionCodec, (skill helpers)
+    "./ui":      "./src/ui/index.ts",   // parseStdoutLine, ConfigFields, buildAdapterConfig
+    "./cli":     "./src/cli/index.ts"   // printStreamEvent
+  }
+}
+```
+
+`server.execute` receives an `AdapterExecutionContext` and returns an
+`AdapterExecutionResult` from `@paperclipai/adapter-utils`. The cursor-sdk adapter MUST
+match that signature byte-for-byte; do not invent a parallel interface.
+
+Key context fields the new adapter must respect (sourced from `cursor-local`'s execute):
+
+| Field | Source | Behavior we must preserve |
+|---|---|---|
+| `runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken` | `AdapterExecutionContext` | Standard plumbing — pass through unchanged. |
+| `executionTarget` / `executionTransport.remoteExecution` | ctx | `readAdapterExecutionTarget(...)`; remote-target mode (E2B-style) needs `prepareAdapterExecutionTargetRuntime`, `runAdapterExecutionTargetProcess`, optional `startAdapterExecutionTargetPaperclipBridge`. **For V1, cursor-sdk supports only `local` execution targets.** Remote-target use is out of scope for V1 because the SDK already handles cloud transport itself; layering remote-target on top is redundant. |
+| `context.paperclipWorkspace` | ctx | resolves cwd, workspaceId, repoUrl, repoRef, agentHome — feed into both runtime config and session codec. |
+| `context.paperclipWorkspaces` (hint list) | ctx | persisted as `PAPERCLIP_WORKSPACES_JSON` env (only relevant if we expose env to SDK; cloud env vars cannot start with `CURSOR_` but `PAPERCLIP_*` is fine). |
+| `context.paperclipWake` | ctx | render via `renderPaperclipWakePrompt(... { resumedSession })` and join into prompt sections via `joinPromptSections`. |
+| `context.paperclipSessionHandoffMarkdown` | ctx | append as a prompt section. |
+| `authToken` (Paperclip API token) | ctx | populates `PAPERCLIP_API_KEY` env when no explicit one configured. For cloud runtime this becomes a `cloud.envVars.PAPERCLIP_API_KEY` entry (allowed: doesn't start with `CURSOR_`). |
+| `runtime.sessionId` / `runtime.sessionParams` | ctx | drives resume policy via the session codec. |
+
+Helpers we must reuse (don't reinvent):
+
+- `asString`, `asNumber`, `asStringArray`, `parseObject` — config parsing
+- `buildPaperclipEnv(agent)` — base PAPERCLIP_* env
+- `applyPaperclipWorkspaceEnv` — workspace identity env
+- `renderTemplate`, `renderPaperclipWakePrompt`, `joinPromptSections`,
+  `DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE` — prompt assembly
+- `inferOpenAiCompatibleBiller` + the `billingType: "api" | "subscription"` discriminator
+- `buildInvocationEnvForLogs` (only for the non-SDK path; SDK runs in-process so there's
+  no spawned command to log — we still call `onMeta` with adapter/model/cwd/prompt info)
+
+### Session codec shape
+
+`sessionCodec` mirrors `cursor-local`:
+
+```ts
+{ sessionId, cwd?, workspaceId?, repoUrl?, repoRef?, remoteExecution? }
+```
+
+For `cursor-sdk`, `sessionId` is the SDK's `agentId`. For cloud runs we additionally
+carry `repoUrl`/`repoRef` so resume only happens when the repo identity matches.
+
+### Streaming event format
+
+The Paperclip UI/CLI parsers consume **one JSON object per stdout line** (NDJSON). The
+new adapter does not spawn a subprocess, so we simulate that line stream by calling
+`onLog("stdout", JSON.stringify(event) + "\n")` for each `SDKMessage`. Event shape stays
+compatible with `cursor-local`'s parser where event types overlap (`init`, `assistant`,
+`user`, `result`); new SDK-only event types (`thinking`, `tool_call`, `task`, `request`,
+`status`) are emitted with the SDK's discriminant under a stable `type` key and parsed
+by the new `parse-stdout.ts`.
+
+### Shared constants and registry surface
+
+Paperclip enforces adapter-type as a non-empty string (see `agent-type.ts`), so `cursor_sdk`
+will load even before constants are updated. But to keep the type discoverable and
+documented as a built-in, V1 still updates:
+
+1. `packages/shared/src/constants.ts` — add `"cursor_sdk"` to `AGENT_ADAPTER_TYPES`
+2. `packages/shared/src/index.ts` — re-export if needed (already wildcard)
+3. `server/src/adapters/registry.ts` — register module
+4. `ui/src/adapters/registry.ts` — register UI module
+5. `cli/src/adapters/registry.ts` — register CLI module
+6. `ui/src/components/agent-config-primitives.tsx`, `AgentProperties.tsx`,
+   `pages/Agents.tsx`, `OnboardingWizard.tsx` — label maps (only files with explicit
+   `cursor` entries)
+
+### Verification rules from AGENTS.md
+
+- Default verification before claiming work done: `pnpm test` (Vitest only)
+- For PR-ready hand-off: `pnpm -r typecheck && pnpm test:run && pnpm build`
+- During development: smallest targeted check first — typecheck the new package + the
+  three packages it touches before running the full repo
+- Repo-rule: keep changes company-scoped (no behavior change here — adapter-level)
+- Repo-rule: contracts synchronized across `db / shared / server / ui` (no schema change
+  in V1, only constants + registries)
+
+---
+
+## Backwards Compatibility (Hard Requirement)
+
+**No existing Paperclip agent may break.** Specifically:
+
+| Existing surface | Status |
+|---|---|
+| `packages/adapters/cursor-local` (adapter type `cursor`) | **Untouched.** Keep code, config schema, CLI subprocess flow, model fallback list, `--resume`/`--yolo` behavior, `~/.cursor/skills` injection, E2B `~/.local/bin/cursor-agent` resolution. |
+| `cursor` adapter type in shared constants/validators | Stays. |
+| `cursor-local` registry entries (server/ui/cli) | Stay. |
+| Existing agent rows with `adapterType: "cursor"` | Continue resolving to `cursor-local` with no migration step. |
+
+The new SDK adapter is **additive**:
+
+- New package: `packages/adapters/cursor-sdk`
+- New adapter type: `cursor_sdk`
+- New shared-constants entry, new registry rows in server/ui/cli
+- New label: `"Cursor SDK"` (visually distinct from `"Cursor CLI (local)"`)
+
+A migration path from `cursor` → `cursor_sdk` is documented but never automatic. V1 ships
+both adapters in parallel; we only consider deprecating `cursor-local` after the SDK
+adapter has been stable in production for at least one release cycle and the SDK leaves
+public beta.
+
+### Shared code policy
+
+To avoid drift, two pieces of `cursor-local` code may be lifted into a shared internal
+helper at `packages/adapters/cursor-shared/src/`:
+
+- model-id catalog + profile defaults (the `CURSOR_FALLBACK_MODEL_IDS` list)
+- `agentConfigurationDoc` template fragments common to both adapters
+
+`cursor-local` keeps re-exporting the same public API; only its internals import from
+`cursor-shared`. If extraction risks any behavior change, **skip it for V1** and accept
+the duplication.
+
+---
+
+## SDK Reference Cheat Sheet
+
+Package: `@cursor/sdk` (public beta — APIs may change before GA).
+
+### Auth
+
+```ts
+// from CURSOR_API_KEY env var, or pass apiKey explicitly
+import { Agent, Cursor } from "@cursor/sdk";
+```
+
+Supported keys: User API keys (Dashboard → Integrations) and Service Account API keys
+(Team settings). Team Admin keys are not yet supported.
+
+### Lifecycle
+
+```ts
+const agent = await Agent.create({ model, local | cloud, mcpServers, agents, ... });
+const resumed = await Agent.resume(agentId, partialOptions);
+const oneShot = await Agent.prompt("do X", options); // create + send + wait
+
+await Agent.list({...}); await Agent.get(agentId); await Agent.archive(agentId);
+await Agent.listRuns(agentId); await Agent.getRun(runId);
+
+const run = await agent.send(message, { onDelta, onStep });
+for await (const ev of run.stream()) { /* SDKMessage */ }
+const result = await run.wait();        // RunResult
+await run.cancel();                      // typed cancellation
+const turns = await run.conversation();
+run.onDidChangeStatus((s) => {...});
+```
+
+### Runtime config
+
+```ts
+// LOCAL (in-process, files on disk)
+local: {
+  cwd?: string | string[];
+  settingSources?: ("project" | "user" | "team" | "mdm" | "plugins" | "all")[];
+  sandboxOptions?: { enabled: boolean };
+}
+
+// CLOUD (Cursor-hosted)
+cloud: {
+  env?: { type: "cloud" | "pool" | "machine"; name?: string };
+  repos: { url: string; startingRef?: string; prUrl?: string }[];
+  workOnCurrentBranch?: boolean;
+  autoCreatePR?: boolean;
+  skipReviewerRequest?: boolean;
+  envVars?: Record<string, string>; // session env, encrypted at rest, cannot start with CURSOR_
+}
+```
+
+### Catalog
+
+```ts
+await Cursor.me();                  // SDKUser { apiKeyName, userEmail?, createdAt }
+await Cursor.models.list();         // SDKModel[] with parameters + variants
+await Cursor.repositories.list();   // SDKRepository[] (rate-limited, cache aggressively)
+```
+
+### Errors
+
+`CursorAgentError` base with `isRetryable`, `code`, `cause`, `protoErrorCode`. Subtypes:
+`AuthenticationError`, `RateLimitError`, `ConfigurationError`,
+`IntegrationNotConnectedError` (carries `provider` + `helpUrl`), `NetworkError`,
+`UnknownAgentError`, `UnsupportedRunOperationError`.
+
+### Disposal
+
+```ts
+await using agent = await Agent.create({...}); // auto-disposed on block exit
+// or explicit:
+await agent[Symbol.asyncDispose]();
+agent.close();      // fire-and-forget
+await agent.reload(); // re-read filesystem config without disposing
+```
+
+---
+
+## Adapter Config Contract (`src/index.ts`)
+
+```ts
+export const type = "cursor_sdk";
+export const label = "Cursor SDK";
+```
+
+V1 config fields:
+
+**Common**
+- `runtime` (required): `"local" | "cloud" | "self_hosted"` — selects mode
+- `model` (optional, allow empty = SDK auto)
+- `modelParams` (optional `Record<string,string>`): forwarded as `ModelParameterValue[]`
+- `promptTemplate`
+- `instructionsFilePath` (optional, mirrors `cursor-local`)
+- `timeoutSec` (optional, default `0`)
+- `graceSec` (optional, default `20`)
+- `env.CURSOR_API_KEY` (required, secret_ref preferred)
+
+**`runtime: "local"`**
+- `cwd` (optional, falls back to agent default)
+- `settingSources` (optional, default `["project", "user", "plugins"]`)
+- `sandbox` (optional bool, default `false`)
+
+**`runtime: "cloud"` / `"self_hosted"`**
+- `repository` (required): GitHub repo URL — maps to `cloud.repos[0].url`
+- `ref` (optional, default `main`) → `startingRef`
+- `additionalRepos` (optional `{url, startingRef?}[]`) → appended to `cloud.repos`
+- `workOnCurrentBranch` (optional, default `false`)
+- `autoCreatePr` (optional, default `false`)
+- `skipReviewerRequest` (optional, default `false`)
+- `sessionEnvVars` (optional `Record<string,string>` of secret refs) → `cloud.envVars`
+- `vmEnv.type` (optional, default `"cloud"`): `"cloud" | "pool" | "machine"`
+- `vmEnv.name` (required when `vmEnv.type !== "cloud"`)
+
+**Optional advanced**
+- `mcpServers` (optional, JSON object) — forwarded to SDK
+- `subagents` (optional `Record<string, SubagentDef>`)
+- `hooks` — **not in V1**. Hooks are file-based per SDK; document `.cursor/hooks.json` in the configuration doc.
+- `enableCallback` (optional, default `false`) — opt-in for skill/Paperclip API callback (see below)
+
+Secret handling: `CURSOR_API_KEY` and any `sessionEnvVars` use `adapterConfig.env` so the
+existing secret-resolution flow handles `secret_ref`. Never store the key in a
+top-level `apiKey` field.
+
+---
+
+## Why most of the old plan goes away
+
+| 2026-02-23 plan element | 2026-05-03 disposition |
+|---|---|
+| Hand-rolled `src/api.ts` REST client + typed errors | **Removed.** SDK provides both. |
+| Polling loop on `/v0/agents/{id}` | **Removed.** Use `run.stream()` + `run.onDidChangeStatus()`. |
+| Webhook receiver + HMAC verification | **Removed from V1 default path.** Streaming is push-based via SDK. Webhooks become an *opt-in* fallback for very long runs where the Paperclip server may restart mid-run (see "Resilience" below). |
+| Bootstrap auth exchange + `/api/agent-auth/exchange` | **Demoted to optional.** Only required if cloud agents need to call back into Paperclip APIs (e.g. for skill fetch, artifact push). Gated by `enableCallback: true`. Local runtime never needs it. |
+| Custom synthetic stdout event format (`init`/`status`/`assistant`/`user`/`result`) | **Replaced.** Map SDK `SDKMessage` events directly. Keep the same wire format internally so `parse-stdout.ts` and CLI formatter changes stay minimal. |
+| Hardcoded model list | **Replaced** with dynamic `Cursor.models.list()` cached per-org for ~5 min, with the `cursor-local` fallback list as offline default. |
+| Manual cancellation handler registration | Still required at the Paperclip layer, but the handler simply calls `run.cancel()` then `agent[Symbol.asyncDispose]()`. |
+
+---
+
+## Package Structure
+
+```
+packages/adapters/cursor-sdk/
+├── package.json            # exports: ".", "./server", "./ui", "./cli"
+├── tsconfig.json
+└── src/
+    ├── index.ts            # type/label/agentConfigurationDoc/models/profiles
+    ├── runtime.ts          # buildRuntimeOptions(config) -> { local } | { cloud }
+    ├── events.ts           # SDKMessage -> Paperclip stdout event mapping
+    ├── server/
+    │   ├── index.ts
+    │   ├── execute.ts      # main run orchestration via SDK
+    │   ├── session.ts      # agentId persistence + resume policy
+    │   ├── test.ts         # env diagnostics
+    │   ├── callback.ts     # OPTIONAL: bootstrap exchange + skill route helpers
+    │   └── webhook.ts      # OPTIONAL: long-run resilience fallback
+    ├── ui/
+    │   ├── index.ts
+    │   ├── parse-stdout.ts
+    │   └── build-config.ts
+    └── cli/
+        ├── index.ts
+        └── format-event.ts
+```
+
+If `cursor-shared` is extracted, also:
+
+```
+packages/adapters/cursor-shared/
+├── package.json
+└── src/
+    ├── models.ts           # CURSOR_FALLBACK_MODEL_IDS + profile defaults
+    └── doc-fragments.ts
+```
+
+---
+
+## Execution Flow (`src/server/execute.ts`)
+
+### Step 1: Resolve config + secrets
+- parse adapter config
+- resolve `CURSOR_API_KEY`
+- if `runtime === "cloud" | "self_hosted"`: resolve `sessionEnvVars`
+- validate required fields per runtime mode
+
+### Step 2: Build SDK options
+Delegate to `runtime.ts`:
+- model + modelParams
+- runtime block (`local: {...}` or `cloud: {...}`)
+- mcpServers (forwarded)
+- subagents (forwarded as `agents`)
+
+### Step 3: Resolve session
+- session identity is SDK `agentId` (stored in `sessionParams`)
+- reuse policy:
+  - `runtime: "local"` — reuse only when `cwd` matches stored cwd
+  - `runtime: "cloud"` — reuse only when `repository` matches
+- on reuse: `Agent.resume(agentId, partialOptions)`
+- else: `Agent.create(options)`
+
+### Step 4: Render prompt
+- standard template render
+- if `enableCallback: true`: append a compact callback block (public URL + bootstrap token + skill index endpoint)
+- else: no callback section, agent runs self-contained
+
+### Step 5: Send + stream
+```ts
+const run = await agent.send(prompt, {
+  onDelta: ({ update }) => emitDelta(update),
+});
+
+run.onDidChangeStatus((s) => emitStatus(s));
+
+for await (const ev of run.stream()) {
+  emitSdkMessage(ev);  // map to Paperclip stdout event
+}
+
+const result = await run.wait();
+```
+
+### Step 6: Map events to Paperclip stdout
+`events.ts` maps each SDK `SDKMessage.type` to the existing Paperclip event format used by
+`cursor-local`:
+
+| SDKMessage.type | Paperclip event | Notes |
+|---|---|---|
+| `system` | `init` | include model + tools list |
+| `user` | `user` | echo |
+| `assistant` | `assistant` | text + tool-use blocks |
+| `thinking` | `assistant` (subtype `thinking`) | so existing UI parsers don't choke |
+| `tool_call` | `tool_call` | new event subtype |
+| `status` | `status` | cloud lifecycle (CREATING/RUNNING/FINISHED/ERROR/CANCELLED/EXPIRED) |
+| `task` | `task` | new event subtype |
+| `request` | `request` | awaiting input/approval |
+
+### Step 7: Result mapping
+`AdapterExecutionResult`:
+- `exitCode: 0` on `RunStatus === "finished"`, `1` on `error`/`cancelled`
+- `errorMessage` from `CursorAgentError.message` when applicable
+- `sessionParams: { agentId, repository?, cwd? }`
+- `provider: "cursor"`
+- `usage` / `costUsd` — still null (SDK does not expose token usage in run result; revisit when SDK adds it)
+- `resultJson`: include `{ status, result, durationMs, git, conversationSnapshot }`
+
+### Step 8: Cleanup
+Always `await agent[Symbol.asyncDispose]()` in `finally`. Use `await using` where the
+control flow allows.
+
+---
+
+## Cancellation
+
+Register a per-run cancellation handler that:
+
+1. calls `await run.cancel()` (typed; SDK handles transport)
+2. calls `await agent[Symbol.asyncDispose]()` to release resources
+3. emits a final `status` event with `cancelled` so the UI updates
+
+This still requires the generic non-subprocess cancellation hook the old plan flagged
+(`server/src/...` — exact location TBD when implementing). That hook is still on the
+critical-path checklist.
+
+---
+
+## Resilience: optional webhook fallback
+
+For runs that may exceed the Paperclip server's process lifetime (deploys, restarts), a
+streaming-only model loses the connection. V1 ships **two** resilience patterns:
+
+1. **Default:** on reconnect/restart, look up persisted `agentId`, call `Agent.get(agentId)`
+   to read terminal status, then `agent.listRuns()` + `Agent.getRun(runId)` to recover the
+   final state. No webhooks.
+2. **Opt-in webhook fallback:** if `cloud.webhookUrl` is configured (out-of-band), the
+   server can also accept Cursor `statusChange` webhooks to wake up a recovery worker
+   sooner. This reuses the original plan's HMAC verification design as `webhook.ts`.
+   Off by default; documented but not required for V1.
+
+---
+
+## Skills Delivery Strategy
+
+### Local runtime
+Same as `cursor-local`: ensure `~/.cursor/skills` is populated. We can lift this routine
+into `cursor-shared` so both adapters reuse one copy.
+
+### Cloud runtime
+Two supported delivery modes:
+
+1. **Repo-committed (preferred for V1):** skills live under `.cursor/skills/` in the
+   target repo. SDK auto-loads them. Zero callback infrastructure needed.
+2. **Paperclip-hosted (opt-in via `enableCallback`):** the agent fetches skill content
+   from Paperclip's API at runtime via the bootstrap exchange flow described in the
+   superseded plan. Implement only when a customer asks for it.
+
+Document both in the adapter configuration doc; default to (1) until there's a real (2)
+ask.
+
+---
+
+## Environment Test (`src/server/test.ts`)
+
+Checks:
+1. `CURSOR_API_KEY` present
+2. key validity via `Cursor.me()`
+3. model exists (when set) via `Cursor.models.list()` (cached)
+4. **runtime-specific:**
+   - local: `cwd` resolves and is writable
+   - cloud: `repository` URL well-formed; optionally probe `Cursor.repositories.list()` *only* when an explicit `verifyRepositoryAccess` flag is set (rate-limited: 1/min, 30/hr per user)
+5. when `enableCallback: true`: `paperclipPublicUrl` resolvable and bootstrap secret length-valid
+
+---
+
+## UI + CLI
+
+### `src/ui/parse-stdout.ts`
+Handle the same event vocabulary as `cursor-local` plus the new subtypes (`thinking`,
+`tool_call`, `task`, `request`). Render terminal failures with `isError=true`.
+
+### `src/ui/build-config.ts`
+Map `CreateConfigValues` to adapter config:
+- top-level `runtime` selector
+- show/hide local-only vs cloud-only fields by `runtime`
+- env binding shape preserved (`plain` / `secret_ref`)
+
+### `ui/src/adapters/cursor-sdk/config-fields.tsx`
+Form controls grouped:
+- **Common:** runtime, model, model params, prompt template, instructions file, timeout, grace, `CURSOR_API_KEY`
+- **Local:** cwd, settingSources (multi-select), sandbox toggle
+- **Cloud:** repository, ref, additionalRepos, workOnCurrentBranch, autoCreatePr, skipReviewerRequest, vmEnv {type, name}, sessionEnvVars (env-style list)
+- **Advanced:** mcpServers (JSON editor), subagents, enableCallback, paperclipPublicUrl
+
+### `src/cli/format-event.ts`
+Mirror `cursor-local` formatting; add lines for `thinking`, `tool_call`, `task`,
+`request`, and `status` lifecycle.
+
+---
+
+## Server Registration & Cross-Layer Sync
+
+### Adapter registration
+- `server/src/adapters/registry.ts` — register `cursor_sdk` next to `cursor`
+- `ui/src/adapters/registry.ts`
+- `cli/src/adapters/registry.ts`
+
+### Shared contract updates
+- `packages/shared/src/constants.ts` — add `cursor_sdk` to `AGENT_ADAPTER_TYPES` (do **not** remove `cursor`)
+- `packages/shared/src/validators/agent.ts` — accept new type
+- UI label maps in:
+  - `ui/src/components/agent-config-primitives.tsx`
+  - `ui/src/components/AgentProperties.tsx`
+  - `ui/src/pages/Agents.tsx`
+  - `ui/src/components/OnboardingWizard.tsx` (add option, do not change default)
+
+### Optional routes (only when `enableCallback: true`)
+- `POST /api/adapters/cursor-sdk/webhooks` — HMAC-verified statusChange receiver (resilience fallback)
+- `POST /api/agent-auth/exchange` — bootstrap → run-scoped JWT
+- `GET /api/skills/index` and `GET /api/skills/:name`
+
+These routes are shared infrastructure if/when other remote adapters need them.
+
+---
+
+## Comparison Matrix
+
+| Aspect | `cursor` (cursor-local, unchanged) | `cursor_sdk` local | `cursor_sdk` cloud |
+|---|---|---|---|
+| Transport | `cursor-agent` CLI subprocess | `@cursor/sdk` in-process | `@cursor/sdk` → Cursor cloud |
+| Streaming | stdout `--output-format stream-json` | `run.stream()` | `run.stream()` |
+| Resume | `--resume` flag | `Agent.resume(agentId)` | `Agent.resume(agentId)` |
+| Cancellation | OS signal | `run.cancel()` + dispose | `run.cancel()` + dispose |
+| Skills | `~/.cursor/skills` injection | same + SDK auto-load | repo `.cursor/skills/` (preferred) or callback |
+| MCP | inherits CLI behavior | inline `mcpServers` config | inline + dashboard-managed |
+| Subagents | inherits CLI behavior | `agents` config + `.cursor/agents/*.md` | same |
+| Models | hardcoded fallback list | `Cursor.models.list()` + fallback | `Cursor.models.list()` + fallback |
+| Errors | parsed from stderr | typed `CursorAgentError` subclasses | typed `CursorAgentError` subclasses |
+| Auth | uses logged-in CLI session | `CURSOR_API_KEY` | `CURSOR_API_KEY` |
+| Usage/cost | not exposed | not exposed (revisit) | not exposed (revisit) |
+
+---
+
+## V1 Limitations
+
+1. **No token/cost usage** in run results (SDK doesn't expose it; revisit when added).
+2. **Inline `mcpServers` not persisted across `Agent.resume()`** — if the run is resumed,
+   re-pass mcpServers explicitly. Document this.
+3. **Artifact download not implemented for local agents** in current SDK; `listArtifacts`
+   returns empty — surface as "cloud-only" in UI.
+4. **`local.settingSources` doesn't apply to cloud agents.**
+5. **Hooks file-based only** (`.cursor/hooks.json`) — no programmatic hook config.
+6. **Tool call schema is unstable** — render `args`/`result` as opaque JSON in UI.
+7. **`/v0/repositories` rate limit** (1/min, 30/hr per user) — only call behind explicit
+   `verifyRepositoryAccess` flag.
+8. **Public beta SDK** — pin `@cursor/sdk` to a known-good minor; track release notes for
+   breaking changes.
+
+---
+
+## Future Enhancements
+
+1. Lift cursor-local skill injection + model catalog into `cursor-shared`.
+2. Surface `Run.git` (branch + PR URL) in Paperclip run detail UI.
+3. Add a "Migrate to SDK" wizard once SDK leaves beta.
+4. Wire `Cursor.repositories.list()` into the agent-create UI as a typeahead.
+5. Add per-org `Cursor.me()` health check to the org settings page.
+6. Subagent template library shipped via `.cursor/agents/*.md`.
+7. Webhook-based resilience worker (when needed for long cloud runs across deploys).
+8. Self-hosted VM pool registration UX.
+
+---
+
+## Implementation Checklist
+
+### Adapter package
+- [ ] `packages/adapters/cursor-sdk/package.json` — exports `.`, `./server`, `./ui`, `./cli`; depends on `@cursor/sdk`
+- [ ] `packages/adapters/cursor-sdk/tsconfig.json`
+- [ ] `src/index.ts` — type/label/`agentConfigurationDoc`/model profiles
+- [ ] `src/runtime.ts` — `buildRuntimeOptions(config)` for local/cloud/self_hosted
+- [ ] `src/events.ts` — `SDKMessage` → Paperclip event mapping
+- [ ] `src/server/execute.ts` — `Agent.create`/`resume` + `run.stream()` orchestration
+- [ ] `src/server/session.ts` — agentId persistence + resume policy
+- [ ] `src/server/test.ts` — env diagnostics via `Cursor.me()` / `models.list()`
+- [ ] `src/server/index.ts` — exports + session codec
+- [ ] `src/ui/parse-stdout.ts`
+- [ ] `src/ui/build-config.ts`
+- [ ] `src/ui/index.ts`
+- [ ] `src/cli/format-event.ts`
+- [ ] `src/cli/index.ts`
+
+### Optional (only if `enableCallback`)
+- [ ] `src/server/callback.ts` — bootstrap exchange helpers
+- [ ] `src/server/webhook.ts` — HMAC verification for resilience fallback
+- [ ] server route: `/api/adapters/cursor-sdk/webhooks`
+- [ ] server route: `/api/agent-auth/exchange`
+- [ ] server routes: `/api/skills/index`, `/api/skills/:name`
+
+### App integration
+- [ ] register `cursor_sdk` in server/ui/cli registries (do not touch `cursor` registration)
+- [ ] add `cursor_sdk` to shared adapter constants/validators
+- [ ] add label `"Cursor SDK"` in UI surfaces (keep `"Cursor CLI (local)"` for `cursor`)
+- [ ] add generic non-subprocess cancellation hook (calls `run.cancel()` + dispose)
+
+### Backwards-compatibility verification
+- [ ] existing agents with `adapterType: "cursor"` continue to load and run unchanged
+- [ ] no migration code touches `cursor-local` source
+- [ ] `cursor-local` tests still pass without modification
+- [ ] new `cursor_sdk` adapter does not collide with `cursor` registry key, label, or default model
+
+### Tests
+- [ ] runtime option builder: each `runtime` mode → expected SDK options shape
+- [ ] event mapper: each `SDKMessage.type` → expected Paperclip event
+- [ ] terminal status mapping (`finished`/`error`/`cancelled`)
+- [ ] session codec round-trip (agentId + repository/cwd discrimination)
+- [ ] config builder env binding handling (plain + secret_ref)
+- [ ] error classification: `AuthenticationError`/`RateLimitError`/etc → `AdapterExecutionResult`
+- [ ] resume reuse policy: matches/mismatches on cwd (local) and repository (cloud)
+- [ ] cancellation: `run.cancel()` invoked + agent disposed
+- [ ] (if implemented) webhook signature verification + dedupe
+- [ ] (if implemented) bootstrap exchange happy path + expired/invalid token
+
+### Verification
+- [ ] `pnpm -r typecheck`
+- [ ] `pnpm test:run`
+- [ ] `pnpm build`
+- [ ] manual smoke: create agent with `runtime: "local"`, run prompt end-to-end
+- [ ] manual smoke: create agent with `runtime: "cloud"` against a test repo, run prompt end-to-end, verify resume

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
     "overrides": {
       "rollup": ">=4.59.0"
     }
+  },
+  "dependencies": {
+    "@cursor/sdk": "^1.0.12"
   }
 }

--- a/packages/adapters/cursor-sdk/package.json
+++ b/packages/adapters/cursor-sdk/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@paperclipai/adapter-cursor-sdk",
+  "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/cursor-sdk"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "peerDependencies": {
+    "@cursor/sdk": "*"
+  },
+  "peerDependenciesMeta": {
+    "@cursor/sdk": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/cursor-sdk/src/cli/format-event.ts
+++ b/packages/adapters/cursor-sdk/src/cli/format-event.ts
@@ -1,0 +1,146 @@
+import pc from "picocolors";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function printAssistant(messageRaw: unknown): void {
+  if (typeof messageRaw === "string") {
+    const text = messageRaw.trim();
+    if (text) console.log(pc.green(`assistant: ${text}`));
+    return;
+  }
+  const message = asRecord(messageRaw);
+  if (!message) return;
+  const direct = asString(message.text).trim();
+  if (direct) console.log(pc.green(`assistant: ${direct}`));
+  const content = Array.isArray(message.content) ? message.content : [];
+  for (const partRaw of content) {
+    const part = asRecord(partRaw);
+    if (!part) continue;
+    const type = asString(part.type).trim();
+    if (type === "text" || type === "output_text") {
+      const text = asString(part.text).trim();
+      if (text) console.log(pc.green(`assistant: ${text}`));
+    } else if (type === "tool_call") {
+      const name = asString(part.name, "tool");
+      console.log(pc.yellow(`tool_call: ${name}`));
+      const input = part.input ?? part.args ?? part.arguments;
+      if (input !== undefined) console.log(pc.gray(stringifyUnknown(input)));
+    }
+  }
+}
+
+function printToolCallEvent(parsed: Record<string, unknown>): void {
+  const subtype = asString(parsed.subtype).trim().toLowerCase();
+  const toolCall = asRecord(parsed.tool_call ?? parsed.toolCall);
+  if (!toolCall) {
+    console.log(pc.yellow(`tool_call${subtype ? `: ${subtype}` : ""}`));
+    return;
+  }
+  const [toolName] = Object.keys(toolCall);
+  const payload = toolName ? asRecord(toolCall[toolName]) ?? {} : {};
+
+  if (subtype === "started" || subtype === "start") {
+    console.log(pc.yellow(`tool_call started: ${toolName ?? "tool"}`));
+    if (payload.args !== undefined) console.log(pc.gray(stringifyUnknown(payload.args)));
+    return;
+  }
+  if (subtype === "completed" || subtype === "complete" || subtype === "finished") {
+    const isError =
+      parsed.is_error === true ||
+      payload.is_error === true ||
+      asString(payload.status).toLowerCase() === "error" ||
+      asString(payload.status).toLowerCase() === "failed";
+    const result = payload.result ?? payload.output ?? payload.error;
+    console.log((isError ? pc.red : pc.cyan)(`tool_call completed: ${toolName ?? "tool"}${isError ? " (error)" : ""}`));
+    if (result !== undefined) console.log((isError ? pc.red : pc.gray)(stringifyUnknown(result)));
+    return;
+  }
+  console.log(pc.yellow(`tool_call${subtype ? ` (${subtype})` : ""}: ${toolName ?? "tool"}`));
+}
+
+export function printCursorSdkStreamEvent(line: string): void {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  const parsed = asRecord(safeJsonParse(trimmed));
+  if (!parsed) {
+    console.log(trimmed);
+    return;
+  }
+  const type = asString(parsed.type);
+
+  if (type === "system") {
+    if (asString(parsed.subtype) === "init") {
+      const model = asString(parsed.model, "cursor");
+      const sessionId = asString(parsed.sessionId);
+      const runtime = asString(parsed.runtime);
+      console.log(pc.cyan(`init: model=${model}${sessionId ? ` session=${sessionId}` : ""}${runtime ? ` runtime=${runtime}` : ""}`));
+    } else {
+      console.log(pc.cyan(`system${parsed.subtype ? `: ${parsed.subtype}` : ""}`));
+    }
+    return;
+  }
+  if (type === "assistant") return printAssistant(parsed.message);
+  if (type === "user") {
+    const text = asString(asRecord(parsed.message)?.text).trim() || asString(parsed.text).trim();
+    if (text) console.log(pc.gray(`user: ${text}`));
+    return;
+  }
+  if (type === "thinking") {
+    const text = asString(parsed.text).trim();
+    if (text) console.log(pc.gray(`thinking: ${text}`));
+    return;
+  }
+  if (type === "tool_call") return printToolCallEvent(parsed);
+  if (type === "status") {
+    console.log(pc.cyan(`status: ${asString(parsed.status, "running")}`));
+    return;
+  }
+  if (type === "task") {
+    const subtype = asString(parsed.subtype);
+    const text = asString(parsed.text).trim();
+    console.log(pc.cyan(`task${subtype ? ` (${subtype})` : ""}${text ? `: ${text}` : ""}`));
+    return;
+  }
+  if (type === "request") {
+    const text = asString(parsed.text).trim();
+    console.log(pc.yellow(`request${text ? `: ${text}` : ": awaiting input"}`));
+    return;
+  }
+  if (type === "result") {
+    const subtype = asString(parsed.subtype, "result");
+    const isError = parsed.is_error === true || subtype === "error" || subtype === "cancelled";
+    const text = asString(parsed.result).trim();
+    console.log((isError ? pc.red : pc.green)(`result (${subtype})${text ? `: ${text}` : ""}`));
+    return;
+  }
+  if (type === "error") {
+    console.log(pc.red(`error: ${asString(parsed.message) || trimmed}`));
+    return;
+  }
+  console.log(trimmed);
+}

--- a/packages/adapters/cursor-sdk/src/cli/index.ts
+++ b/packages/adapters/cursor-sdk/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printCursorSdkStreamEvent } from "./format-event.js";

--- a/packages/adapters/cursor-sdk/src/events.ts
+++ b/packages/adapters/cursor-sdk/src/events.ts
@@ -28,10 +28,19 @@ export type EmitFn = (event: EmittableEvent) => Promise<void>;
 /**
  * Build an EmitFn from Paperclip's onLog. Each event becomes one stdout line so
  * downstream parsers see canonical NDJSON.
+ *
+ * Emits are serialized through an internal chain so concurrent callers (e.g.
+ * the SDK's `onDidChangeStatus` listener firing while the `for await` stream
+ * loop is iterating) cannot interleave NDJSON lines. Both call sites await the
+ * returned promise; the chain guarantees they hit `onLog` one at a time.
  */
 export function makeEmitter(onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>): EmitFn {
-  return async (event) => {
-    await onLog("stdout", `${JSON.stringify(event)}\n`);
+  let chain: Promise<void> = Promise.resolve();
+  return (event) => {
+    const next = chain.then(() => onLog("stdout", `${JSON.stringify(event)}\n`));
+    // Swallow rejections in the chain so one failed emit doesn't poison subsequent ones.
+    chain = next.catch(() => undefined);
+    return next;
   };
 }
 

--- a/packages/adapters/cursor-sdk/src/events.ts
+++ b/packages/adapters/cursor-sdk/src/events.ts
@@ -1,0 +1,137 @@
+import type { SdkMessage, SdkRunResult, SdkRunStatus } from "./sdk-types.js";
+
+/**
+ * Events the cursor-sdk adapter writes to onLog("stdout", ...). Each event is one
+ * JSON object per line. The shape is intentionally compatible with cursor-local's
+ * stream-json events for the overlapping types (system/init, assistant, user,
+ * result), so existing transcript renderers that fall through to the cursor-local
+ * parser still work.
+ *
+ * Adapter-specific UI parser (./ui/parse-stdout.ts) handles the new SDK-only
+ * event types (thinking, tool_call, status, task, request).
+ */
+export type EmittableEvent =
+  | { type: "system"; subtype: "init"; model: string; sessionId?: string; runtime: string }
+  | { type: "assistant"; message: { text: string } }
+  | { type: "assistant"; message: { content: Array<{ type: "tool_call"; name: string; tool_use_id?: string; input: unknown }> } }
+  | { type: "user"; message: { text: string } }
+  | { type: "thinking"; text: string; subtype?: "delta" }
+  | { type: "tool_call"; subtype: "started" | "completed"; call_id: string; tool_call: Record<string, unknown>; is_error?: boolean }
+  | { type: "status"; status: string; runStatus?: SdkRunStatus }
+  | { type: "task"; subtype?: string; text?: string }
+  | { type: "request"; subtype?: string; text?: string }
+  | { type: "result"; subtype: string; result: string; is_error?: boolean; durationMs?: number; git?: Record<string, unknown> }
+  | { type: "error"; message: string };
+
+export type EmitFn = (event: EmittableEvent) => Promise<void>;
+
+/**
+ * Build an EmitFn from Paperclip's onLog. Each event becomes one stdout line so
+ * downstream parsers see canonical NDJSON.
+ */
+export function makeEmitter(onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>): EmitFn {
+  return async (event) => {
+    await onLog("stdout", `${JSON.stringify(event)}\n`);
+  };
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function pickAssistantText(message: unknown, topLevelText: string): string {
+  if (topLevelText) return topLevelText;
+  if (typeof message === "string") return message;
+  if (message && typeof message === "object") {
+    const m = message as Record<string, unknown>;
+    if (typeof m.text === "string") return m.text;
+    if (Array.isArray(m.content)) {
+      const parts: string[] = [];
+      for (const partRaw of m.content) {
+        if (!partRaw || typeof partRaw !== "object") continue;
+        const part = partRaw as Record<string, unknown>;
+        if (part.type === "text" || part.type === "output_text") {
+          if (typeof part.text === "string") parts.push(part.text);
+        }
+      }
+      if (parts.length > 0) return parts.join("");
+    }
+  }
+  return "";
+}
+
+/**
+ * Translate an SDK message into one or more Paperclip stream events. Returns []
+ * to skip uninteresting events (e.g. empty deltas).
+ */
+export function translateSdkMessage(msg: SdkMessage, ctx: { runtime: string }): EmittableEvent[] {
+  switch (msg.type) {
+    case "system": {
+      // SDK emits an init-like system event with model + tools metadata.
+      return [{
+        type: "system",
+        subtype: "init",
+        model: asString(msg.model) || "cursor",
+        runtime: ctx.runtime,
+      }];
+    }
+    case "assistant": {
+      const text = pickAssistantText(msg.message, asString(msg.text));
+      if (!text) return [];
+      return [{ type: "assistant", message: { text } }];
+    }
+    case "user": {
+      const text = pickAssistantText(msg.message, asString(msg.text));
+      if (!text) return [];
+      return [{ type: "user", message: { text } }];
+    }
+    case "thinking": {
+      const delta = msg.delta as { text?: string } | undefined;
+      const text = asString(msg.text) || asString(delta?.text);
+      if (!text.trim()) return [];
+      const subtype = asString(msg.subtype).toLowerCase();
+      const isDelta = subtype === "delta" || (msg.delta !== undefined);
+      return [{ type: "thinking", text, ...(isDelta ? { subtype: "delta" as const } : {}) }];
+    }
+    case "tool_call": {
+      const subtype = asString(msg.subtype).toLowerCase() === "completed" ? "completed" : "started";
+      const callId = asString(msg.call_id) || "tool_call";
+      const name = asString(msg.name) || "tool";
+      // Wrap tool_call so the cursor-local-shaped parser can handle it.
+      const toolCall: Record<string, unknown> = {
+        [name]: {
+          args: msg.args,
+          result: msg.result,
+          status: msg.status,
+        },
+      };
+      const isError = msg.is_error === true || asString(msg.status).toLowerCase() === "error" || asString(msg.status).toLowerCase() === "failed";
+      return [{ type: "tool_call", subtype, call_id: callId, tool_call: toolCall, ...(isError ? { is_error: true } : {}) }];
+    }
+    case "status": {
+      const runStatus = msg.runStatus as SdkRunStatus | undefined;
+      const status = asString(msg.status) || asString(runStatus) || "running";
+      return [{ type: "status", status, runStatus }];
+    }
+    case "task": {
+      return [{ type: "task", subtype: asString(msg.subtype) || undefined, text: asString(msg.text) || undefined }];
+    }
+    case "request": {
+      return [{ type: "request", subtype: asString(msg.subtype) || undefined, text: asString(msg.text) || asString(msg.prompt) || undefined }];
+    }
+    default:
+      return [];
+  }
+}
+
+export function buildResultEvent(result: SdkRunResult): EmittableEvent {
+  const isError = result.status === "error" || result.status === "cancelled";
+  return {
+    type: "result",
+    subtype: result.status,
+    result: result.result ?? "",
+    is_error: isError || undefined,
+    ...(typeof result.durationMs === "number" ? { durationMs: result.durationMs } : {}),
+    ...(result.git ? { git: { ...result.git } } : {}),
+  } as EmittableEvent;
+}

--- a/packages/adapters/cursor-sdk/src/index.ts
+++ b/packages/adapters/cursor-sdk/src/index.ts
@@ -1,0 +1,104 @@
+import type { AdapterModelProfileDefinition } from "@paperclipai/adapter-utils";
+
+export const type = "cursor_sdk";
+export const label = "Cursor SDK";
+
+export const DEFAULT_CURSOR_SDK_MODEL = "auto";
+export const DEFAULT_CURSOR_SDK_RUNTIME: CursorSdkRuntime = "local";
+
+export type CursorSdkRuntime = "local" | "cloud" | "self_hosted";
+
+// Mirrors the cursor-local fallback list. Used as the offline catalog when
+// Cursor.models.list() cannot be reached. Keep in sync with cursor-local until
+// we extract a shared package.
+const CURSOR_SDK_FALLBACK_MODEL_IDS = [
+  "auto",
+  "composer-2",
+  "composer-1.5",
+  "composer-1",
+  "gpt-5.5",
+  "gpt-5.3-codex",
+  "gpt-5.3-codex-fast",
+  "gpt-5.3-codex-high",
+  "gpt-5.2",
+  "gpt-5.2-codex",
+  "gpt-5.1-codex-max",
+  "gpt-5.1-codex-mini",
+  "opus-4.6",
+  "opus-4.6-thinking",
+  "opus-4.5",
+  "sonnet-4.6",
+  "sonnet-4.6-thinking",
+  "sonnet-4.5",
+  "gemini-3-pro",
+  "gemini-3-flash",
+  "grok",
+  "kimi-k2.5",
+];
+
+export const models = CURSOR_SDK_FALLBACK_MODEL_IDS.map((id) => ({ id, label: id }));
+
+export const modelProfiles: AdapterModelProfileDefinition[] = [
+  {
+    key: "cheap",
+    label: "Cheap",
+    description: "Use Cursor's known Codex mini model as the budget lane instead of assuming auto is cheap.",
+    adapterConfig: {
+      model: "gpt-5.1-codex-mini",
+    },
+    source: "adapter_default",
+  },
+];
+
+export const agentConfigurationDoc = `# cursor_sdk agent configuration
+
+Adapter: cursor_sdk
+
+Use when:
+- You want Paperclip to drive Cursor agents through the official @cursor/sdk
+- You want one adapter that can run agents locally OR in Cursor-managed cloud VMs
+- You want richer streaming events than the cursor-agent CLI exposes (thinking, tool_call, task, request, status)
+- You want typed errors, native cancellation, and session resume via Agent.resume()
+
+Don't use when:
+- You only need the cursor-agent CLI behavior — keep using the existing "cursor" adapter
+- You need webhook-style external invocation (use openclaw_gateway or http)
+- @cursor/sdk is not installed in this Paperclip server's node_modules
+
+Core fields:
+- runtime (string, optional): "local" | "cloud" | "self_hosted" (default "local")
+- model (string, optional): Cursor model id, or empty to let the SDK pick
+- modelParams (object, optional): { id: value } pairs forwarded to the SDK as ModelParameterValue[]
+- promptTemplate (string, optional): run prompt template
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
+- timeoutSec (number, optional, default 0): adapter-side wait timeout for run.wait()
+- graceSec (number, optional, default 20): grace window applied around cancellation
+- env.CURSOR_API_KEY (required, secret_ref preferred): authenticates the SDK
+
+Runtime "local":
+- cwd (string, optional): working directory for the in-process agent (defaults to Paperclip workspace cwd)
+- settingSources (string[], optional, default ["project","user","plugins"]): which Cursor setting sources to load
+- sandbox (boolean, optional, default false): enable the SDK's sandbox option
+
+Runtime "cloud" / "self_hosted":
+- repository (string, required): primary GitHub repo URL (mapped to cloud.repos[0].url)
+- ref (string, optional, default "main"): starting ref (mapped to startingRef)
+- additionalRepos (object[], optional): extra { url, startingRef? } entries appended to cloud.repos
+- workOnCurrentBranch (boolean, optional, default false)
+- autoCreatePr (boolean, optional, default false)
+- skipReviewerRequest (boolean, optional, default false)
+- vmEnv.type (string, optional, default "cloud"): "cloud" | "pool" | "machine"
+- vmEnv.name (string, required when vmEnv.type !== "cloud")
+- sessionEnvVars (object, optional): { KEY: value } forwarded as cloud.envVars (encrypted at rest, cannot start with CURSOR_)
+
+Advanced:
+- mcpServers (object, optional): forwarded to the SDK as-is. NOTE: not persisted across Agent.resume(); re-pass on resume.
+- subagents (object, optional): { name: { description, prompt, model?, mcpServers? } } forwarded as the SDK's "agents" field.
+
+Notes:
+- The SDK runs in-process; there is no spawned subprocess to log. The adapter calls onMeta with adapter/runtime/model/cwd/prompt info.
+- SDK stream events (system/user/assistant/thinking/tool_call/status/task/request) are emitted to onLog as one JSON object per stdout line, parsable by both this adapter's UI parser and (for overlapping shapes) the cursor-local parser.
+- Sessions are resumed by SDK Agent.resume(agentId, ...) when the stored session identity matches the current runtime (cwd for local; repository for cloud/self_hosted).
+- Cancellation is wired via run.cancel() + agent[Symbol.asyncDispose]() within the timeout/grace budget.
+- Token usage and cost are not exposed by the SDK in V1; both fields stay null.
+`;

--- a/packages/adapters/cursor-sdk/src/runtime.ts
+++ b/packages/adapters/cursor-sdk/src/runtime.ts
@@ -1,0 +1,216 @@
+import { asString, asNumber, asStringArray, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import type {
+  SdkAgentCreateOptions,
+  SdkCloudRepo,
+  SdkCloudRuntime,
+  SdkLocalRuntime,
+  SdkModelParameterValue,
+  SdkModelSelection,
+  SdkSettingSource,
+} from "./sdk-types.js";
+import {
+  DEFAULT_CURSOR_SDK_MODEL,
+  DEFAULT_CURSOR_SDK_RUNTIME,
+  type CursorSdkRuntime,
+} from "./index.js";
+
+const VALID_RUNTIMES: ReadonlySet<CursorSdkRuntime> = new Set(["local", "cloud", "self_hosted"]);
+const VALID_SETTING_SOURCES: ReadonlySet<SdkSettingSource> = new Set([
+  "project",
+  "user",
+  "team",
+  "mdm",
+  "plugins",
+  "all",
+]);
+const VALID_VM_ENV_TYPES = new Set(["cloud", "pool", "machine"]);
+
+export interface ResolvedRuntimeOptions {
+  runtime: CursorSdkRuntime;
+  model: string;
+  modelSelection: SdkModelSelection | undefined;
+  sdkOptions: SdkAgentCreateOptions;
+  effectiveCwd: string;
+  effectiveRepository: string;
+  effectiveRef: string;
+  identity: { kind: "local"; cwd: string } | { kind: "cloud"; repository: string };
+  validationErrors: string[];
+}
+
+export interface BuildRuntimeInput {
+  config: Record<string, unknown>;
+  /** Workspace cwd resolved by Paperclip from context.paperclipWorkspace. */
+  workspaceCwd: string;
+  /** Workspace repo URL resolved by Paperclip from context.paperclipWorkspace. */
+  workspaceRepoUrl: string;
+  /** Workspace repo ref resolved by Paperclip from context.paperclipWorkspace. */
+  workspaceRepoRef: string;
+  /** Resolved CURSOR_API_KEY (after secret resolution). Empty string when missing. */
+  apiKey: string;
+  /** Session env vars to forward to the cloud VM (already secret-resolved). */
+  sessionEnvVars: Record<string, string>;
+}
+
+export function resolveRuntimeKind(value: unknown): CursorSdkRuntime {
+  const raw = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (VALID_RUNTIMES.has(raw as CursorSdkRuntime)) return raw as CursorSdkRuntime;
+  return DEFAULT_CURSOR_SDK_RUNTIME;
+}
+
+function resolveSettingSources(value: unknown): SdkSettingSource[] | undefined {
+  const arr = asStringArray(value);
+  if (arr.length === 0) return undefined;
+  const filtered = arr
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry): entry is SdkSettingSource => VALID_SETTING_SOURCES.has(entry as SdkSettingSource));
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function resolveModelSelection(model: string, modelParams: Record<string, unknown>): SdkModelSelection | undefined {
+  const id = model.trim();
+  if (!id || id.toLowerCase() === "auto") return undefined;
+  const params: SdkModelParameterValue[] = [];
+  for (const [key, value] of Object.entries(modelParams)) {
+    if (typeof key !== "string" || !key.trim()) continue;
+    if (typeof value === "string" && value.trim().length > 0) {
+      params.push({ id: key.trim(), value: value.trim() });
+    } else if (typeof value === "number") {
+      params.push({ id: key.trim(), value: String(value) });
+    } else if (typeof value === "boolean") {
+      params.push({ id: key.trim(), value: value ? "true" : "false" });
+    }
+  }
+  return params.length > 0 ? { id, params } : { id };
+}
+
+function isValidEnvKey(key: string): boolean {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return false;
+  if (key.startsWith("CURSOR_")) return false; // SDK rule for cloud envVars
+  return true;
+}
+
+function sanitizeCloudEnvVars(envVars: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envVars)) {
+    if (!isValidEnvKey(key)) continue;
+    if (typeof value !== "string" || value.length === 0) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+function resolveAdditionalRepos(value: unknown): SdkCloudRepo[] {
+  if (!Array.isArray(value)) return [];
+  const out: SdkCloudRepo[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const rec = entry as Record<string, unknown>;
+    const url = asString(rec.url, "").trim();
+    if (!url) continue;
+    const startingRef = asString(rec.startingRef ?? rec.ref, "").trim();
+    out.push({ url, ...(startingRef ? { startingRef } : {}) });
+  }
+  return out;
+}
+
+export function buildRuntimeOptions(input: BuildRuntimeInput): ResolvedRuntimeOptions {
+  const { config, workspaceCwd, workspaceRepoUrl, workspaceRepoRef, apiKey, sessionEnvVars } = input;
+
+  const runtime = resolveRuntimeKind(config.runtime);
+  const model = asString(config.model, DEFAULT_CURSOR_SDK_MODEL);
+  const modelParams = parseObject(config.modelParams);
+  const modelSelection = resolveModelSelection(model, modelParams);
+  const validationErrors: string[] = [];
+
+  const sdkOptions: SdkAgentCreateOptions = {};
+  if (apiKey) sdkOptions.apiKey = apiKey;
+  if (modelSelection) sdkOptions.model = modelSelection;
+
+  // mcpServers and subagents are forwarded as-is when present; the SDK validates shape.
+  const mcpServers = parseObject(config.mcpServers);
+  if (Object.keys(mcpServers).length > 0) sdkOptions.mcpServers = mcpServers;
+
+  const subagents = parseObject(config.subagents);
+  if (Object.keys(subagents).length > 0) sdkOptions.agents = subagents;
+
+  let effectiveCwd = "";
+  let effectiveRepository = "";
+  let effectiveRef = "";
+  let identity: ResolvedRuntimeOptions["identity"];
+
+  if (runtime === "local") {
+    const cwd = asString(config.cwd, "").trim() || workspaceCwd.trim() || "";
+    if (!cwd) {
+      validationErrors.push("cursor_sdk: runtime=local requires a workspace cwd or config.cwd.");
+    }
+    const local: SdkLocalRuntime = {};
+    if (cwd) local.cwd = cwd;
+    const settingSources = resolveSettingSources(config.settingSources)
+      ?? (["project", "user", "plugins"] as SdkSettingSource[]);
+    local.settingSources = settingSources;
+    if (config.sandbox === true) local.sandboxOptions = { enabled: true };
+    sdkOptions.local = local;
+    effectiveCwd = cwd;
+    identity = { kind: "local", cwd };
+  } else {
+    const repository = asString(config.repository, "").trim() || workspaceRepoUrl.trim();
+    const ref = asString(config.ref, "").trim() || workspaceRepoRef.trim() || "main";
+    if (!repository) {
+      validationErrors.push(
+        `cursor_sdk: runtime=${runtime} requires "repository" (config.repository or workspace.repoUrl).`,
+      );
+    }
+
+    const repos: SdkCloudRepo[] = [];
+    if (repository) {
+      repos.push({ url: repository, startingRef: ref });
+    }
+    repos.push(...resolveAdditionalRepos(config.additionalRepos));
+
+    const cloud: SdkCloudRuntime = {
+      repos,
+      workOnCurrentBranch: config.workOnCurrentBranch === true,
+      autoCreatePR: config.autoCreatePr === true,
+      skipReviewerRequest: config.skipReviewerRequest === true,
+    };
+
+    const vmEnv = parseObject(config.vmEnv);
+    const vmEnvType = asString(vmEnv.type, runtime === "self_hosted" ? "pool" : "cloud").trim().toLowerCase();
+    const vmEnvName = asString(vmEnv.name, "").trim();
+    if (VALID_VM_ENV_TYPES.has(vmEnvType)) {
+      if (vmEnvType !== "cloud" && !vmEnvName) {
+        validationErrors.push(
+          `cursor_sdk: vmEnv.name is required when vmEnv.type="${vmEnvType}".`,
+        );
+      }
+      cloud.env = {
+        type: vmEnvType as "cloud" | "pool" | "machine",
+        ...(vmEnvName ? { name: vmEnvName } : {}),
+      };
+    }
+
+    const cleanSessionEnv = sanitizeCloudEnvVars(sessionEnvVars);
+    if (Object.keys(cleanSessionEnv).length > 0) cloud.envVars = cleanSessionEnv;
+
+    sdkOptions.cloud = cloud;
+    effectiveRepository = repository;
+    effectiveRef = ref;
+    identity = { kind: "cloud", repository };
+  }
+
+  // timeoutSec/graceSec are consumed by execute(), not passed to the SDK.
+  void asNumber(config.timeoutSec, 0);
+  void asNumber(config.graceSec, 20);
+
+  return {
+    runtime,
+    model,
+    modelSelection,
+    sdkOptions,
+    effectiveCwd,
+    effectiveRepository,
+    effectiveRef,
+    identity,
+    validationErrors,
+  };
+}

--- a/packages/adapters/cursor-sdk/src/sdk-types.ts
+++ b/packages/adapters/cursor-sdk/src/sdk-types.ts
@@ -1,0 +1,142 @@
+// Minimal local mirror of @cursor/sdk shapes we depend on.
+//
+// Why this file exists:
+//   The @cursor/sdk package is in public beta and may not be installed in every
+//   workspace setup (CI, smoke fixtures, fresh clones). To keep `pnpm typecheck`
+//   green and the server bootable without the SDK, the adapter loads the SDK via
+//   dynamic import at runtime and only uses these structural types at compile time.
+//
+//   When @cursor/sdk is installed, the shapes here intentionally line up with the
+//   public surface so the dynamic import result can be cast directly. If the SDK
+//   evolves, update this file accordingly.
+
+export type SdkRunStatus = "running" | "finished" | "error" | "cancelled";
+
+export type SdkSettingSource = "project" | "user" | "team" | "mdm" | "plugins" | "all";
+
+export interface SdkLocalRuntime {
+  cwd?: string | string[];
+  settingSources?: SdkSettingSource[];
+  sandboxOptions?: { enabled: boolean };
+}
+
+export interface SdkCloudRepo {
+  url: string;
+  startingRef?: string;
+  prUrl?: string;
+}
+
+export interface SdkCloudRuntime {
+  env?: { type: "cloud" | "pool" | "machine"; name?: string };
+  repos: SdkCloudRepo[];
+  workOnCurrentBranch?: boolean;
+  autoCreatePR?: boolean;
+  skipReviewerRequest?: boolean;
+  envVars?: Record<string, string>;
+}
+
+export interface SdkModelParameterValue {
+  id: string;
+  value: string;
+}
+
+export interface SdkModelSelection {
+  id: string;
+  params?: SdkModelParameterValue[];
+}
+
+export interface SdkAgentCreateOptions {
+  apiKey?: string;
+  model?: SdkModelSelection;
+  local?: SdkLocalRuntime;
+  cloud?: SdkCloudRuntime;
+  mcpServers?: Record<string, unknown>;
+  agents?: Record<string, unknown>;
+}
+
+export interface SdkSendOptions {
+  apiKey?: string;
+  mcpServers?: Record<string, unknown>;
+  agents?: Record<string, unknown>;
+  onDelta?: (event: { update: unknown }) => void;
+  onStep?: (event: { step: unknown }) => void;
+}
+
+// Discriminated union returned by run.stream(). Treat every payload field as
+// unknown — the SDK calls the schema unstable for tool args/results.
+export type SdkMessage =
+  | { type: "system"; subtype?: string; model?: string; agentId?: string; tools?: unknown }
+  | { type: "user"; message?: unknown; text?: string }
+  | { type: "assistant"; message?: unknown; text?: string }
+  | { type: "thinking"; text?: string; delta?: { text?: string }; subtype?: string }
+  | { type: "tool_call"; subtype?: string; call_id?: string; name?: string; tool_call?: unknown; status?: string; args?: unknown; result?: unknown; is_error?: boolean }
+  | { type: "status"; status?: string; runStatus?: SdkRunStatus }
+  | { type: "task"; subtype?: string; text?: string }
+  | { type: "request"; subtype?: string; text?: string; prompt?: string }
+  | { type: string; [key: string]: unknown };
+
+export interface SdkRunResult {
+  status: SdkRunStatus;
+  result?: string;
+  durationMs?: number;
+  git?: { branch?: string; prUrl?: string; commit?: string };
+  errorMessage?: string;
+}
+
+export interface SdkRun {
+  readonly id: string;
+  readonly agentId: string;
+  readonly status: SdkRunStatus;
+  readonly result?: string;
+  readonly model?: SdkModelSelection;
+  readonly durationMs?: number;
+  readonly git?: { branch?: string; prUrl?: string; commit?: string };
+  stream(): AsyncIterable<SdkMessage>;
+  wait(): Promise<SdkRunResult>;
+  cancel(): Promise<void>;
+  conversation?: () => Promise<unknown>;
+  onDidChangeStatus?: (listener: (status: SdkRunStatus) => void) => () => void;
+}
+
+export interface SdkAgent {
+  readonly agentId: string;
+  send(message: string | { text: string }, options?: SdkSendOptions): Promise<SdkRun>;
+  close?: () => void;
+  reload?: () => Promise<void>;
+  [Symbol.asyncDispose]?: () => Promise<void>;
+  listArtifacts?: () => Promise<Array<{ path: string; sizeBytes: number; updatedAt: string }>>;
+  downloadArtifact?: (path: string) => Promise<Buffer>;
+}
+
+export interface SdkAgentStatic {
+  create(options: SdkAgentCreateOptions): Promise<SdkAgent>;
+  resume(agentId: string, options?: Partial<SdkAgentCreateOptions>): Promise<SdkAgent>;
+  get?: (agentId: string, options?: { apiKey?: string }) => Promise<{ status?: SdkRunStatus; archived?: boolean } | null>;
+}
+
+export interface SdkCursorNamespace {
+  me?: (options?: { apiKey?: string }) => Promise<{ apiKeyName?: string; userEmail?: string }>;
+  models?: { list?: (options?: { apiKey?: string }) => Promise<Array<{ id: string; displayName?: string }>> };
+}
+
+export interface SdkModule {
+  Agent: SdkAgentStatic;
+  Cursor?: SdkCursorNamespace;
+}
+
+/**
+ * Dynamically loads @cursor/sdk. Returns null when the SDK is not installed —
+ * callers MUST surface a clear error to the run log in that case.
+ */
+export async function loadCursorSdk(): Promise<SdkModule | null> {
+  try {
+    // Avoid a static import so missing SDK doesn't crash server boot.
+    const mod = (await import("@cursor/sdk" as string)) as unknown;
+    if (mod && typeof mod === "object" && "Agent" in mod) {
+      return mod as SdkModule;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/adapters/cursor-sdk/src/server/execute.ts
+++ b/packages/adapters/cursor-sdk/src/server/execute.ts
@@ -1,0 +1,517 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asNumber,
+  parseObject,
+  applyPaperclipWorkspaceEnv,
+  buildPaperclipEnv,
+  ensureAbsoluteDirectory,
+  renderTemplate,
+  renderPaperclipWakePrompt,
+  DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  joinPromptSections,
+} from "@paperclipai/adapter-utils/server-utils";
+import { adapterExecutionTargetIsRemote, readAdapterExecutionTarget } from "@paperclipai/adapter-utils/execution-target";
+import { DEFAULT_CURSOR_SDK_MODEL } from "../index.js";
+import { buildRuntimeOptions } from "../runtime.js";
+import { loadCursorSdk, type SdkAgent, type SdkRun, type SdkRunResult } from "../sdk-types.js";
+import { buildResultEvent, makeEmitter, translateSdkMessage } from "../events.js";
+
+interface PromptMetrics {
+  promptChars: number;
+  instructionsChars: number;
+  bootstrapPromptChars: number;
+  wakePromptChars: number;
+  sessionHandoffChars: number;
+  runtimeNoteChars: number;
+  heartbeatPromptChars: number;
+}
+
+function renderPaperclipEnvNote(env: Record<string, string>): string {
+  const paperclipKeys = Object.keys(env)
+    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .sort();
+  if (paperclipKeys.length === 0) return "";
+  return [
+    "Paperclip runtime note:",
+    `The following PAPERCLIP_* environment variables are available in this run: ${paperclipKeys.join(", ")}`,
+    "Do not assume these variables are missing without checking your shell environment.",
+    "",
+    "",
+  ].join("\n");
+}
+
+function resolveProviderFromModel(model: string): string | null {
+  const trimmed = model.trim().toLowerCase();
+  if (!trimmed) return null;
+  const slash = trimmed.indexOf("/");
+  if (slash > 0) return trimmed.slice(0, slash);
+  if (trimmed.includes("sonnet") || trimmed.includes("claude") || trimmed.includes("opus")) return "anthropic";
+  if (trimmed.startsWith("gpt") || trimmed.startsWith("composer") || trimmed.startsWith("o")) return "openai";
+  if (trimmed.startsWith("gemini")) return "google";
+  return null;
+}
+
+function resolveBillingType(env: Record<string, string>): "api" | "subscription" {
+  const has = (key: string) => typeof env[key] === "string" && env[key].trim().length > 0;
+  return has("CURSOR_API_KEY") || has("OPENAI_API_KEY") ? "api" : "subscription";
+}
+
+function buildEnv(
+  ctx: AdapterExecutionContext,
+  envConfig: Record<string, unknown>,
+  workspace: { cwd: string; source: string; workspaceId: string; repoUrl: string; repoRef: string; agentHome: string },
+): Record<string, string> {
+  const env: Record<string, string> = { ...buildPaperclipEnv(ctx.agent) };
+  env.PAPERCLIP_RUN_ID = ctx.runId;
+
+  const wakeTaskId =
+    (typeof ctx.context.taskId === "string" && ctx.context.taskId.trim()) ||
+    (typeof ctx.context.issueId === "string" && ctx.context.issueId.trim()) ||
+    "";
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  const wakeReason = typeof ctx.context.wakeReason === "string" ? ctx.context.wakeReason.trim() : "";
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  const wakeCommentId =
+    (typeof ctx.context.wakeCommentId === "string" && ctx.context.wakeCommentId.trim()) ||
+    (typeof ctx.context.commentId === "string" && ctx.context.commentId.trim()) ||
+    "";
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  const approvalId = typeof ctx.context.approvalId === "string" ? ctx.context.approvalId.trim() : "";
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  const approvalStatus = typeof ctx.context.approvalStatus === "string" ? ctx.context.approvalStatus.trim() : "";
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  const linkedIssueIds = Array.isArray(ctx.context.issueIds)
+    ? ctx.context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+
+  applyPaperclipWorkspaceEnv(env, {
+    workspaceCwd: workspace.cwd,
+    workspaceSource: workspace.source,
+    workspaceId: workspace.workspaceId,
+    workspaceRepoUrl: workspace.repoUrl,
+    workspaceRepoRef: workspace.repoRef,
+    agentHome: workspace.agentHome,
+  });
+
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  if (!hasExplicitApiKey && ctx.authToken) {
+    env.PAPERCLIP_API_KEY = ctx.authToken;
+  }
+  return env;
+}
+
+function partitionSessionEnv(env: Record<string, string>): Record<string, string> {
+  // Cloud envVars cannot start with CURSOR_; PAPERCLIP_* are fine.
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (key.startsWith("CURSOR_")) continue;
+    if (typeof value !== "string" || value.length === 0) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+async function resolveTimeoutWait<T>(
+  promise: Promise<T>,
+  timeoutSec: number,
+  onTimeout: () => Promise<void>,
+): Promise<{ result: T | null; timedOut: boolean }> {
+  if (timeoutSec <= 0) {
+    return { result: await promise, timedOut: false };
+  }
+  let timer: NodeJS.Timeout | null = null;
+  let timedOut = false;
+  const timeout = new Promise<null>((resolve) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      resolve(null);
+    }, timeoutSec * 1000);
+  });
+  try {
+    const winner = await Promise.race([promise.then((value) => ({ kind: "ok", value }) as const), timeout.then(() => ({ kind: "timeout" }) as const)]);
+    if (winner.kind === "ok") {
+      return { result: winner.value, timedOut: false };
+    }
+    await onTimeout();
+    return { result: null, timedOut: true };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function safeDispose(agent: SdkAgent | null): Promise<void> {
+  if (!agent) return;
+  try {
+    if (typeof agent[Symbol.asyncDispose] === "function") {
+      await agent[Symbol.asyncDispose]!();
+      return;
+    }
+    if (typeof agent.close === "function") {
+      agent.close();
+    }
+  } catch {
+    // disposal is best-effort
+  }
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, authToken } = ctx;
+  const executionTarget = readAdapterExecutionTarget({
+    executionTarget: ctx.executionTarget,
+    legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
+  });
+
+  if (adapterExecutionTargetIsRemote(executionTarget)) {
+    const message =
+      "cursor_sdk does not support remote execution targets in V1. " +
+      "Use the existing 'cursor' adapter for E2B/SSH-style remote execution, " +
+      "or set runtime: \"cloud\" to run inside Cursor-managed VMs.";
+    await onLog("stderr", `[paperclip] ${message}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: message,
+    };
+  }
+
+  const promptTemplate = asString(config.promptTemplate, DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE);
+  const model = asString(config.model, DEFAULT_CURSOR_SDK_MODEL);
+  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const graceSec = asNumber(config.graceSec, 20);
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspace = {
+    cwd: asString(workspaceContext.cwd, ""),
+    source: asString(workspaceContext.source, ""),
+    workspaceId: asString(workspaceContext.workspaceId, ""),
+    repoUrl: asString(workspaceContext.repoUrl, ""),
+    repoRef: asString(workspaceContext.repoRef, ""),
+    agentHome: asString(workspaceContext.agentHome, ""),
+  };
+
+  const envConfig = parseObject(config.env);
+  const env = buildEnv(ctx, envConfig, workspace);
+  const apiKey = (typeof envConfig.CURSOR_API_KEY === "string" ? envConfig.CURSOR_API_KEY : "")
+    || env.CURSOR_API_KEY
+    || (typeof process.env.CURSOR_API_KEY === "string" ? process.env.CURSOR_API_KEY : "");
+
+  const sessionEnvVars = parseObject(config.sessionEnvVars);
+  const cloudSessionEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(sessionEnvVars)) {
+    if (typeof value === "string") cloudSessionEnv[key] = value;
+  }
+  // Forward Paperclip identity vars too so cloud agents can call back if needed.
+  Object.assign(cloudSessionEnv, partitionSessionEnv(env));
+
+  const resolved = buildRuntimeOptions({
+    config,
+    workspaceCwd: workspace.cwd,
+    workspaceRepoUrl: workspace.repoUrl,
+    workspaceRepoRef: workspace.repoRef,
+    apiKey: apiKey.trim(),
+    sessionEnvVars: cloudSessionEnv,
+  });
+
+  if (resolved.validationErrors.length > 0) {
+    const message = resolved.validationErrors.join(" ");
+    await onLog("stderr", `[paperclip] cursor_sdk config error: ${message}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: message,
+    };
+  }
+
+  if (resolved.runtime === "local" && resolved.effectiveCwd) {
+    await ensureAbsoluteDirectory(resolved.effectiveCwd, { createIfMissing: true });
+  }
+
+  // Session resume policy
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const runtimeSessionRepo = asString(runtimeSessionParams.repoUrl, "");
+  const canResumeSession = (() => {
+    if (!runtimeSessionId) return false;
+    if (resolved.runtime === "local") {
+      if (!runtimeSessionCwd) return true; // legacy/no cwd recorded
+      return path.resolve(runtimeSessionCwd) === path.resolve(resolved.effectiveCwd);
+    }
+    if (!runtimeSessionRepo) return true;
+    return runtimeSessionRepo === resolved.effectiveRepository;
+  })();
+  const sessionId = canResumeSession ? runtimeSessionId : null;
+  if (runtimeSessionId && !canResumeSession) {
+    const reason = resolved.runtime === "local"
+      ? `cwd "${runtimeSessionCwd}" does not match "${resolved.effectiveCwd}"`
+      : `repository "${runtimeSessionRepo}" does not match "${resolved.effectiveRepository}"`;
+    await onLog("stdout", `[paperclip] Cursor SDK session "${runtimeSessionId}" will not be resumed: ${reason}.\n`);
+  }
+
+  // Prompt assembly
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  let instructionsPrefix = "";
+  let instructionsChars = 0;
+  if (instructionsFilePath) {
+    try {
+      const contents = await fs.readFile(instructionsFilePath, "utf8");
+      const dir = `${path.dirname(instructionsFilePath)}/`;
+      instructionsPrefix =
+        `${contents}\n\n` +
+        `The above agent instructions were loaded from ${instructionsFilePath}. ` +
+        `Resolve any relative file references from ${dir}.\n\n`;
+      instructionsChars = instructionsPrefix.length;
+    } catch (err) {
+      await onLog(
+        "stdout",
+        `[paperclip] Warning: could not read agent instructions file "${instructionsFilePath}": ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const renderedBootstrapPrompt = !sessionId && bootstrapPromptTemplate.trim().length > 0
+    ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+    : "";
+  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: Boolean(sessionId) });
+  const useResumeDelta = Boolean(sessionId) && wakePrompt.length > 0;
+  const renderedPrompt = useResumeDelta ? "" : renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const paperclipEnvNote = renderPaperclipEnvNote(env);
+  const prompt = joinPromptSections([
+    instructionsPrefix,
+    renderedBootstrapPrompt,
+    wakePrompt,
+    sessionHandoffNote,
+    paperclipEnvNote,
+    renderedPrompt,
+  ]);
+
+  const promptMetrics: PromptMetrics = {
+    promptChars: prompt.length,
+    instructionsChars,
+    bootstrapPromptChars: renderedBootstrapPrompt.length,
+    wakePromptChars: wakePrompt.length,
+    sessionHandoffChars: sessionHandoffNote.length,
+    runtimeNoteChars: paperclipEnvNote.length,
+    heartbeatPromptChars: renderedPrompt.length,
+  };
+
+  const billingType = resolveBillingType(env);
+  const provider = resolveProviderFromModel(model);
+
+  if (onMeta) {
+    await onMeta({
+      adapterType: "cursor_sdk",
+      command: "@cursor/sdk:Agent",
+      cwd: resolved.runtime === "local" ? resolved.effectiveCwd : "",
+      commandArgs: [resolved.runtime, model, sessionId ? "resume" : "create"],
+      commandNotes: [
+        `runtime=${resolved.runtime}`,
+        sessionId ? `Resuming Cursor agent ${sessionId}` : "Creating new Cursor agent",
+        resolved.runtime === "local"
+          ? `local.cwd=${resolved.effectiveCwd}`
+          : `cloud.repository=${resolved.effectiveRepository}@${resolved.effectiveRef}`,
+        instructionsFilePath
+          ? (instructionsChars > 0
+              ? `Loaded agent instructions from ${instructionsFilePath}`
+              : `Configured instructionsFilePath ${instructionsFilePath} (file unreadable)`)
+          : "No instructions file configured",
+      ],
+      env: {},
+      prompt,
+      promptMetrics: promptMetrics as unknown as Record<string, number>,
+      context: context as Record<string, unknown>,
+    });
+  }
+
+  // Load SDK
+  const sdk = await loadCursorSdk();
+  if (!sdk) {
+    const message =
+      "cursor_sdk: @cursor/sdk is not installed. Add it to the Paperclip server's node_modules " +
+      "(pnpm add @cursor/sdk) and retry.";
+    await onLog("stderr", `[paperclip] ${message}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: message,
+    };
+  }
+
+  if (!apiKey.trim()) {
+    const message =
+      "cursor_sdk: CURSOR_API_KEY is not set. Add it to adapter env (preferably as a secret_ref) " +
+      "or to the Paperclip server's environment.";
+    await onLog("stderr", `[paperclip] ${message}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: message,
+    };
+  }
+
+  const emit = makeEmitter(onLog);
+  let sdkAgent: SdkAgent | null = null;
+  let sdkRun: SdkRun | null = null;
+
+  try {
+    sdkAgent = sessionId
+      ? await sdk.Agent.resume(sessionId, resolved.sdkOptions)
+      : await sdk.Agent.create(resolved.sdkOptions);
+
+    await emit({
+      type: "system",
+      subtype: "init",
+      model,
+      sessionId: sdkAgent.agentId,
+      runtime: resolved.runtime,
+    });
+
+    const sendOptions = {
+      ...(resolved.sdkOptions.mcpServers ? { mcpServers: resolved.sdkOptions.mcpServers } : {}),
+      ...(resolved.sdkOptions.agents ? { agents: resolved.sdkOptions.agents } : {}),
+    };
+    sdkRun = await sdkAgent.send({ text: prompt }, sendOptions);
+
+    if (sdkRun.onDidChangeStatus) {
+      sdkRun.onDidChangeStatus(async (status) => {
+        await emit({ type: "status", status, runStatus: status });
+      });
+    }
+
+    const streamPromise = (async () => {
+      try {
+        for await (const message of sdkRun!.stream()) {
+          for (const event of translateSdkMessage(message, { runtime: resolved.runtime })) {
+            await emit(event);
+          }
+        }
+      } catch (err) {
+        await emit({ type: "error", message: err instanceof Error ? err.message : String(err) });
+      }
+    })();
+
+    const waited = await resolveTimeoutWait(
+      sdkRun.wait(),
+      timeoutSec,
+      async () => {
+        try {
+          await sdkRun!.cancel();
+        } catch {
+          // best-effort cancel; continue to dispose
+        }
+        // give the stream a brief grace window to drain
+        await new Promise((resolve) => setTimeout(resolve, Math.min(graceSec, 5) * 1000));
+      },
+    );
+    await streamPromise;
+
+    if (waited.timedOut) {
+      await emit({ type: "result", subtype: "cancelled", result: "", is_error: true });
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: true,
+        errorMessage: `Cursor SDK run timed out after ${timeoutSec}s`,
+        sessionId: sdkAgent.agentId,
+        sessionParams: buildSessionParams(sdkAgent.agentId, resolved, workspace),
+        sessionDisplayId: sdkAgent.agentId,
+        provider,
+        biller: billingType === "subscription" ? "cursor" : provider ?? "cursor",
+        model,
+        billingType,
+        costUsd: null,
+      };
+    }
+
+    const result = (waited.result ?? { status: "error" as const }) as SdkRunResult;
+    await emit(buildResultEvent(result));
+
+    const isError = result.status === "error" || result.status === "cancelled";
+    return {
+      exitCode: isError ? 1 : 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: isError ? (result.errorMessage ?? `Cursor SDK run ended with status "${result.status}"`) : null,
+      sessionId: sdkAgent.agentId,
+      sessionParams: buildSessionParams(sdkAgent.agentId, resolved, workspace),
+      sessionDisplayId: sdkAgent.agentId,
+      provider,
+      biller: billingType === "subscription" ? "cursor" : provider ?? "cursor",
+      model,
+      billingType,
+      costUsd: null,
+      summary: result.result ?? null,
+      resultJson: {
+        runtime: resolved.runtime,
+        status: result.status,
+        durationMs: result.durationMs ?? null,
+        git: result.git ?? null,
+        agentId: sdkAgent.agentId,
+      },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await emit({ type: "error", message });
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: message,
+      sessionId: sdkAgent?.agentId ?? null,
+      sessionParams: sdkAgent ? buildSessionParams(sdkAgent.agentId, resolved, workspace) : null,
+      sessionDisplayId: sdkAgent?.agentId ?? null,
+      provider,
+      biller: billingType === "subscription" ? "cursor" : provider ?? "cursor",
+      model,
+      billingType,
+      costUsd: null,
+    };
+  } finally {
+    await safeDispose(sdkAgent);
+  }
+}
+
+function buildSessionParams(
+  agentId: string,
+  resolved: ReturnType<typeof buildRuntimeOptions>,
+  workspace: { workspaceId: string; repoUrl: string; repoRef: string },
+): Record<string, unknown> {
+  const params: Record<string, unknown> = { sessionId: agentId, runtime: resolved.runtime };
+  if (resolved.runtime === "local") {
+    if (resolved.effectiveCwd) params.cwd = resolved.effectiveCwd;
+  } else {
+    if (resolved.effectiveRepository) params.repoUrl = resolved.effectiveRepository;
+    if (resolved.effectiveRef) params.repoRef = resolved.effectiveRef;
+  }
+  if (workspace.workspaceId) params.workspaceId = workspace.workspaceId;
+  if (workspace.repoUrl && !params.repoUrl) params.repoUrl = workspace.repoUrl;
+  if (workspace.repoRef && !params.repoRef) params.repoRef = workspace.repoRef;
+  return params;
+}

--- a/packages/adapters/cursor-sdk/src/server/execute.ts
+++ b/packages/adapters/cursor-sdk/src/server/execute.ts
@@ -112,15 +112,44 @@ function buildEnv(
   return env;
 }
 
-function partitionSessionEnv(env: Record<string, string>): Record<string, string> {
-  // Cloud envVars cannot start with CURSOR_; PAPERCLIP_* are fine.
+function partitionSessionEnv(
+  env: Record<string, string>,
+  options: { enableCallback: boolean },
+): Record<string, string> {
+  // Cloud envVars cannot start with CURSOR_; the SDK rejects those keys.
+  // PAPERCLIP_API_KEY (= ctx.authToken) is only forwarded when the operator
+  // opts in via enableCallback: true — otherwise the cloud agent has no need
+  // for a Paperclip auth token, and forwarding it would expose the token to
+  // any tool-call result, log, or error message that echoed the environment.
+  // Other PAPERCLIP_* identity vars (run id, task id, workspace, etc.) are
+  // forwarded unconditionally because they are non-secret identifiers that
+  // help cloud agents log and self-describe.
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
     if (key.startsWith("CURSOR_")) continue;
     if (typeof value !== "string" || value.length === 0) continue;
+    if (key === "PAPERCLIP_API_KEY" && !options.enableCallback) continue;
     out[key] = value;
   }
   return out;
+}
+
+async function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<{ kind: "ok"; value: T } | { kind: "timeout" }> {
+  if (timeoutMs <= 0) {
+    return { kind: "ok", value: await promise };
+  }
+  let timer: NodeJS.Timeout | null = null;
+  const timeout = new Promise<{ kind: "timeout" }>((resolve) => {
+    timer = setTimeout(() => resolve({ kind: "timeout" }), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise.then((value) => ({ kind: "ok" as const, value })), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 async function resolveTimeoutWait<T>(
@@ -208,13 +237,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     || env.CURSOR_API_KEY
     || (typeof process.env.CURSOR_API_KEY === "string" ? process.env.CURSOR_API_KEY : "");
 
+  const enableCallback = config.enableCallback === true;
   const sessionEnvVars = parseObject(config.sessionEnvVars);
   const cloudSessionEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(sessionEnvVars)) {
     if (typeof value === "string") cloudSessionEnv[key] = value;
   }
-  // Forward Paperclip identity vars too so cloud agents can call back if needed.
-  Object.assign(cloudSessionEnv, partitionSessionEnv(env));
+  // Forward Paperclip identity vars; PAPERCLIP_API_KEY only when enableCallback opts in.
+  Object.assign(cloudSessionEnv, partitionSessionEnv(env, { enableCallback }));
 
   const resolved = buildRuntimeOptions({
     config,
@@ -426,11 +456,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         } catch {
           // best-effort cancel; continue to dispose
         }
-        // give the stream a brief grace window to drain
-        await new Promise((resolve) => setTimeout(resolve, Math.min(graceSec, 5) * 1000));
+        // give the stream the full configured grace window to drain
+        await new Promise((resolve) => setTimeout(resolve, graceSec * 1000));
       },
     );
-    await streamPromise;
+    // Bound the post-wait drain too: a stalled SDK stream should not hang the
+    // executor. graceSec is the same budget the cancel handshake gets.
+    const drainMs = Math.max(graceSec * 1000, 1000);
+    const drainOutcome = await raceWithTimeout(streamPromise, drainMs);
+    if (drainOutcome.kind === "timeout") {
+      await emit({
+        type: "error",
+        message: `Cursor SDK stream did not drain within ${graceSec}s after run completion; abandoning.`,
+      });
+    }
 
     if (waited.timedOut) {
       await emit({ type: "result", subtype: "cancelled", result: "", is_error: true });

--- a/packages/adapters/cursor-sdk/src/server/index.ts
+++ b/packages/adapters/cursor-sdk/src/server/index.ts
@@ -1,0 +1,67 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+/**
+ * Session codec for cursor_sdk. The sessionId is the SDK's agentId. We persist
+ * runtime ("local"|"cloud"|"self_hosted") plus identity discriminators (cwd for
+ * local, repoUrl/repoRef for cloud) so resume only happens when the surrounding
+ * environment matches.
+ */
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId =
+      readNonEmptyString(record.sessionId) ??
+      readNonEmptyString(record.session_id) ??
+      readNonEmptyString(record.agentId);
+    if (!sessionId) return null;
+    const runtime = readNonEmptyString(record.runtime);
+    const cwd = readNonEmptyString(record.cwd);
+    const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+    const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    return {
+      sessionId,
+      ...(runtime ? { runtime } : {}),
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId =
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.agentId);
+    if (!sessionId) return null;
+    const runtime = readNonEmptyString(params.runtime);
+    const cwd = readNonEmptyString(params.cwd);
+    const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
+    const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
+    const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    return {
+      sessionId,
+      ...(runtime ? { runtime } : {}),
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return (
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.agentId)
+    );
+  },
+};

--- a/packages/adapters/cursor-sdk/src/server/test.ts
+++ b/packages/adapters/cursor-sdk/src/server/test.ts
@@ -1,0 +1,132 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import { resolveRuntimeKind } from "../runtime.js";
+import { loadCursorSdk } from "../sdk-types.js";
+
+function summarize(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
+  return "pass";
+}
+
+export async function testEnvironment(ctx: AdapterEnvironmentTestContext): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const runtime = resolveRuntimeKind(config.runtime);
+  const envConfig = parseObject(config.env);
+  const apiKey =
+    (typeof envConfig.CURSOR_API_KEY === "string" ? envConfig.CURSOR_API_KEY : "") ||
+    (typeof process.env.CURSOR_API_KEY === "string" ? process.env.CURSOR_API_KEY : "");
+
+  checks.push({
+    code: "cursor_sdk_runtime",
+    level: "info",
+    message: `Resolved runtime: ${runtime}`,
+  });
+
+  const sdk = await loadCursorSdk();
+  if (!sdk) {
+    checks.push({
+      code: "cursor_sdk_package_missing",
+      level: "error",
+      message: "@cursor/sdk is not installed in the Paperclip server's node_modules.",
+      hint: "Run `pnpm add @cursor/sdk` and restart the server.",
+    });
+  } else {
+    checks.push({
+      code: "cursor_sdk_package_present",
+      level: "info",
+      message: "@cursor/sdk loaded successfully.",
+    });
+  }
+
+  if (!apiKey.trim()) {
+    checks.push({
+      code: "cursor_sdk_api_key_missing",
+      level: "error",
+      message: "CURSOR_API_KEY is not set.",
+      hint: "Add it to adapter env (preferably as a secret_ref) or to the server environment.",
+    });
+  } else {
+    checks.push({
+      code: "cursor_sdk_api_key_present",
+      level: "info",
+      message: "CURSOR_API_KEY is set.",
+      detail: `Key length: ${apiKey.trim().length} chars`,
+    });
+  }
+
+  if (sdk && apiKey.trim() && sdk.Cursor?.me) {
+    try {
+      const me = await sdk.Cursor.me({ apiKey: apiKey.trim() });
+      checks.push({
+        code: "cursor_sdk_auth_ok",
+        level: "info",
+        message: "Cursor.me() succeeded.",
+        detail: me?.userEmail ?? me?.apiKeyName ?? "API key validated",
+      });
+    } catch (err) {
+      checks.push({
+        code: "cursor_sdk_auth_failed",
+        level: "error",
+        message: "Cursor.me() failed; the API key may be invalid.",
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (runtime === "local") {
+    const cwd = asString(config.cwd, "").trim();
+    if (!cwd) {
+      checks.push({
+        code: "cursor_sdk_local_cwd_unset",
+        level: "info",
+        message: "config.cwd is not set; the workspace cwd from Paperclip context will be used at run time.",
+      });
+    } else {
+      checks.push({
+        code: "cursor_sdk_local_cwd_set",
+        level: "info",
+        message: `config.cwd: ${cwd}`,
+      });
+    }
+  } else {
+    const repository = asString(config.repository, "").trim();
+    if (!repository) {
+      checks.push({
+        code: "cursor_sdk_cloud_repo_unset",
+        level: "warn",
+        message: `runtime=${runtime} requires a repository URL; will fall back to workspace.repoUrl at run time.`,
+      });
+    } else {
+      checks.push({
+        code: "cursor_sdk_cloud_repo_set",
+        level: "info",
+        message: `repository: ${repository}`,
+        detail: `ref: ${asString(config.ref, "main")}`,
+      });
+    }
+
+    const vmEnv = parseObject(config.vmEnv);
+    const vmType = asString(vmEnv.type, runtime === "self_hosted" ? "pool" : "cloud").trim();
+    const vmName = asString(vmEnv.name, "").trim();
+    if (vmType !== "cloud" && !vmName) {
+      checks.push({
+        code: "cursor_sdk_vm_env_name_required",
+        level: "error",
+        message: `vmEnv.name is required when vmEnv.type="${vmType}".`,
+      });
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarize(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/cursor-sdk/src/ui/build-config.ts
+++ b/packages/adapters/cursor-sdk/src/ui/build-config.ts
@@ -1,0 +1,64 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_CURSOR_SDK_MODEL, DEFAULT_CURSOR_SDK_RUNTIME } from "../index.js";
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest" ? { version: rec.version } : {}),
+      };
+    }
+  }
+  return env;
+}
+
+export function buildCursorSdkConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  ac.runtime = DEFAULT_CURSOR_SDK_RUNTIME;
+  ac.model = v.model || DEFAULT_CURSOR_SDK_MODEL;
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  ac.timeoutSec = 0;
+  ac.graceSec = 20;
+
+  const env = parseEnvBindings(v.envBindings);
+  const legacy = parseEnvVars(v.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) ac.env = env;
+
+  return ac;
+}

--- a/packages/adapters/cursor-sdk/src/ui/index.ts
+++ b/packages/adapters/cursor-sdk/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseCursorSdkStdoutLine } from "./parse-stdout.js";
+export { buildCursorSdkConfig } from "./build-config.js";

--- a/packages/adapters/cursor-sdk/src/ui/parse-stdout.ts
+++ b/packages/adapters/cursor-sdk/src/ui/parse-stdout.ts
@@ -1,0 +1,176 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function compactShellInput(input: unknown): unknown {
+  const rec = asRecord(input);
+  if (!rec) return input;
+  const command = asString(rec.command);
+  return command ? { command } : input;
+}
+
+function parseAssistantMessage(messageRaw: unknown, ts: string): TranscriptEntry[] {
+  if (typeof messageRaw === "string") {
+    const text = messageRaw.trim();
+    return text ? [{ kind: "assistant", ts, text }] : [];
+  }
+  const message = asRecord(messageRaw);
+  if (!message) return [];
+  const directText = asString(message.text).trim();
+  if (directText) return [{ kind: "assistant", ts, text: directText }];
+
+  const content = Array.isArray(message.content) ? message.content : [];
+  const entries: TranscriptEntry[] = [];
+  for (const partRaw of content) {
+    const part = asRecord(partRaw);
+    if (!part) continue;
+    const partType = asString(part.type).trim();
+    if (partType === "text" || partType === "output_text") {
+      const text = asString(part.text).trim();
+      if (text) entries.push({ kind: "assistant", ts, text });
+      continue;
+    }
+    if (partType === "tool_call") {
+      const name = asString(part.name, "tool");
+      const rawInput = part.input ?? part.arguments ?? part.args ?? {};
+      const input = name === "shell" || name === "shellToolCall" ? compactShellInput(rawInput) : rawInput;
+      entries.push({
+        kind: "tool_call",
+        ts,
+        name,
+        toolUseId: asString(part.tool_use_id) || asString(part.id) || undefined,
+        input,
+      });
+    }
+  }
+  return entries;
+}
+
+function parseToolCallEvent(event: Record<string, unknown>, ts: string): TranscriptEntry[] {
+  const subtype = asString(event.subtype).trim().toLowerCase();
+  const callId = asString(event.call_id) || asString(event.id) || "tool_call";
+  const toolCall = asRecord(event.tool_call ?? event.toolCall);
+  if (!toolCall) {
+    return [{ kind: "system", ts, text: `tool_call${subtype ? ` (${subtype})` : ""}` }];
+  }
+  const [toolName] = Object.keys(toolCall);
+  if (!toolName) {
+    return [{ kind: "system", ts, text: `tool_call${subtype ? ` (${subtype})` : ""}` }];
+  }
+  const payload = asRecord(toolCall[toolName]) ?? {};
+  const isShell = toolName === "shell" || toolName === "shellToolCall";
+  const rawInput = payload.args ?? payload;
+  const input = isShell ? compactShellInput(rawInput) : rawInput;
+
+  if (subtype === "started" || subtype === "start") {
+    return [{ kind: "tool_call", ts, name: toolName, toolUseId: callId, input }];
+  }
+  if (subtype === "completed" || subtype === "complete" || subtype === "finished") {
+    const result = payload.result ?? payload.output ?? payload.error;
+    const isError =
+      event.is_error === true ||
+      payload.is_error === true ||
+      asString(payload.status).toLowerCase() === "error" ||
+      asString(payload.status).toLowerCase() === "failed";
+    const content = result !== undefined ? stringifyUnknown(result) : `${toolName} completed`;
+    return [{ kind: "tool_result", ts, toolUseId: callId, content, isError }];
+  }
+  return [{ kind: "system", ts, text: `tool_call${subtype ? ` (${subtype})` : ""}: ${toolName}` }];
+}
+
+export function parseCursorSdkStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+  const parsed = asRecord(safeJsonParse(trimmed));
+  if (!parsed) return [{ kind: "stdout", ts, text: trimmed }];
+
+  const type = asString(parsed.type);
+
+  if (type === "system") {
+    const subtype = asString(parsed.subtype);
+    if (subtype === "init") {
+      const sessionId = asString(parsed.sessionId) || asString(parsed.session_id);
+      return [{ kind: "init", ts, model: asString(parsed.model, "cursor"), sessionId }];
+    }
+    return [{ kind: "system", ts, text: subtype ? `system: ${subtype}` : "system" }];
+  }
+
+  if (type === "assistant") return parseAssistantMessage(parsed.message, ts);
+  if (type === "user") {
+    const text = asString(asRecord(parsed.message)?.text).trim() || asString(parsed.text).trim();
+    return text ? [{ kind: "user", ts, text }] : [];
+  }
+  if (type === "thinking") {
+    const text = asString(parsed.text).trim();
+    if (!text) return [];
+    const isDelta = asString(parsed.subtype).toLowerCase() === "delta";
+    return [{ kind: "thinking", ts, text, ...(isDelta ? { delta: true } : {}) }];
+  }
+  if (type === "tool_call") return parseToolCallEvent(parsed, ts);
+
+  if (type === "status") {
+    const status = asString(parsed.status) || asString(parsed.runStatus) || "running";
+    return [{ kind: "system", ts, text: `status: ${status}` }];
+  }
+  if (type === "task") {
+    const subtype = asString(parsed.subtype);
+    const text = asString(parsed.text).trim();
+    return [{ kind: "system", ts, text: text ? `task${subtype ? ` (${subtype})` : ""}: ${text}` : `task${subtype ? ` (${subtype})` : ""}` }];
+  }
+  if (type === "request") {
+    const text = asString(parsed.text).trim();
+    return [{ kind: "system", ts, text: text ? `request: ${text}` : "request: awaiting input" }];
+  }
+
+  if (type === "result") {
+    const subtype = asString(parsed.subtype, "result");
+    const isError = parsed.is_error === true || subtype === "error" || subtype === "cancelled" || subtype === "failed";
+    return [{
+      kind: "result",
+      ts,
+      text: asString(parsed.result),
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedTokens: 0,
+      costUsd: asNumber(parsed.costUsd, 0),
+      subtype,
+      isError,
+      errors: [],
+    }];
+  }
+
+  if (type === "error") {
+    return [{ kind: "stderr", ts, text: asString(parsed.message) || trimmed }];
+  }
+
+  return [{ kind: "stdout", ts, text: trimmed }];
+}

--- a/packages/adapters/cursor-sdk/tsconfig.json
+++ b/packages/adapters/cursor-sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -37,6 +37,7 @@ export const AGENT_ADAPTER_TYPES = [
   "opencode_local",
   "pi_local",
   "cursor",
+  "cursor_sdk",
   "openclaw_gateway",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number] | (string & {});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,10 @@ patchedDependencies:
 importers:
 
   .:
+    dependencies:
+      '@cursor/sdk':
+        specifier: ^1.0.12
+        version: 1.0.12
     devDependencies:
       '@playwright/test':
         specifier: ^1.58.2
@@ -49,6 +53,9 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
+      '@paperclipai/adapter-cursor-sdk':
+        specifier: workspace:*
+        version: link:../packages/adapters/cursor-sdk
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
@@ -81,7 +88,7 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: 0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -181,6 +188,25 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/cursor-sdk:
+    dependencies:
+      '@cursor/sdk':
+        specifier: '*'
+        version: 1.0.12
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/adapters/gemini-local:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -258,7 +284,7 @@ importers:
         version: link:../shared
       drizzle-orm:
         specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -521,6 +547,9 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
+      '@paperclipai/adapter-cursor-sdk':
+        specifier: workspace:*
+        version: link:../packages/adapters/cursor-sdk
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
@@ -553,7 +582,7 @@ importers:
         version: 3.0.1(ajv@8.18.0)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -568,7 +597,7 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -681,6 +710,9 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
+      '@paperclipai/adapter-cursor-sdk':
+        specifier: workspace:*
+        version: link:../packages/adapters/cursor-sdk
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
@@ -1216,6 +1248,9 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
+  '@bufbuild/protobuf@1.10.0':
+    resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
+
   '@chevrotain/cst-dts-gen@11.1.2':
     resolution: {integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==}
 
@@ -1350,6 +1385,18 @@ packages:
       react: ^16.8.0 || ^17 || ^18 || ^19
       react-dom: ^16.8.0 || ^17 || ^18 || ^19
 
+  '@connectrpc/connect-node@1.7.0':
+    resolution: {integrity: sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.7.0
+
+  '@connectrpc/connect@1.7.0':
+    resolution: {integrity: sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
     engines: {node: '>=20.19.0'}
@@ -1385,6 +1432,35 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@cursor/sdk-darwin-arm64@1.0.12':
+    resolution: {integrity: sha512-AOFx+aX+4SntAeC66YncHACXk5duxp+HzDrxxF4Tl93N6nLjHaHEKSAXbt87ivL34MCHop4v/3c70QzBhamB2g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cursor/sdk-darwin-x64@1.0.12':
+    resolution: {integrity: sha512-/ZDAYFUrnPd8hAGRky9ZGcROqZSZ2b5W+aEjTdINzLhJ8x5ZNXtjaz0ZYSHabOn2BeErjXgTcq+4bX2/To4C1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cursor/sdk-linux-arm64@1.0.12':
+    resolution: {integrity: sha512-kAxNqiB3dPtlW9fVjjIZEdbIGEGLA9moOM3zYwsXh8J1Qw942nJYMGDGR4o8x0zglwZ24a1JpovvZamrCaC3Yw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cursor/sdk-linux-x64@1.0.12':
+    resolution: {integrity: sha512-RmBiBCPKMZC5McDerGk2Rk4P47xz2A+uzRoRgH6sMoOjklc33ry11iAZC0D5F5xH85chgY878086A/Q8+XrAuA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@cursor/sdk-win32-x64@1.0.12':
+    resolution: {integrity: sha512-uH4shdHrKOdtNLapy1uuScJ9lL2Pc8zc9I9ZKC6b6bx+0UX6xLAqjPP7dqVPfO6D9u61yLq1Hs86XOLs5ZVkPA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@cursor/sdk@1.0.12':
+    resolution: {integrity: sha512-jGx0wFY1N9uIdIKr303CfM6m/dLXmRCUnU/0yNP/oiOpkBXqgqaThGbgYbcOeVrYonMZc/DZJ9EydXOEPJLcbg==}
+    engines: {node: '>=18'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -1929,6 +2005,10 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
@@ -1949,6 +2029,9 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@gar/promisify@1.1.3':
+    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
@@ -2293,6 +2376,14 @@ packages:
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
+
+  '@npmcli/fs@1.1.1':
+    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
+
+  '@npmcli/move-file@1.1.2':
+    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
+    engines: {node: '>=10'}
+    deprecated: This functionality has been moved to @npmcli/fs
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
@@ -3428,6 +3519,12 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@statsig/client-core@3.31.0':
+    resolution: {integrity: sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==}
+
+  '@statsig/js-client@3.31.0':
+    resolution: {integrity: sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==}
+
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
@@ -3616,6 +3713,10 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@tootallnate/once@1.1.2':
+    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
+    engines: {node: '>= 6'}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -3923,6 +4024,9 @@ packages:
     resolution: {integrity: sha512-0d7gRzOiYTgDmIyh783mCcq50h3mdOg/TtKdLfBIghOLushpQRwhuLjKK8Q9hxZfNlPL0Ua56DoPjnsW8amf8g==}
     hasBin: true
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -3946,9 +4050,21 @@ packages:
     resolution: {integrity: sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==}
     engines: {node: '>= 16.0.0'}
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -3974,6 +4090,14 @@ packages:
 
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@3.0.1:
+    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -4031,6 +4155,9 @@ packages:
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -4157,12 +4284,21 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -4175,6 +4311,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -4194,6 +4333,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cacache@15.3.0:
+    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
+    engines: {node: '>= 10'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -4241,6 +4384,13 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -4249,6 +4399,10 @@ packages:
 
   clean-set@1.1.2:
     resolution: {integrity: sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -4270,6 +4424,10 @@ packages:
 
   codemirror@6.0.2:
     resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -4303,12 +4461,18 @@ packages:
   compute-scroll-into-view@2.0.4:
     resolution: {integrity: sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g==}
 
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -4562,9 +4726,17 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -4591,6 +4763,9 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -4759,6 +4934,9 @@ packages:
     resolution: {integrity: sha512-TDp7Ld0h84x5fzIIZFyreYWqZrxUNjuXB6OxqJCmV6PodB2vzQ+1hlL6n4uK1de7bIAxYt5OkDykwcuIONQdQg==}
     engines: {node: '>=16'}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
@@ -4766,6 +4944,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -4777,6 +4958,13 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -4885,6 +5073,10 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -4945,6 +5137,9 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -4969,6 +5164,16 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4981,6 +5186,11 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gauge@4.0.4:
+    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -5005,9 +5215,16 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -5026,6 +5243,9 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
+
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -5055,17 +5275,31 @@ packages:
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@4.0.1:
+    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
+    engines: {node: '>= 6'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -5078,12 +5312,26 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  infer-owner@1.0.4:
+    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -5101,6 +5349,10 @@ packages:
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -5125,6 +5377,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
@@ -5136,6 +5392,9 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-lambda@1.0.1:
+    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
@@ -5333,6 +5592,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
   lucide-react@0.574.0:
     resolution: {integrity: sha512-dJ8xb5juiZVIbdSn3HTyHsjjIwUwZ4FNwV0RtYDScOyySOeie1oXZTymST6YPJ4Qwt3Po8g4quhYl4OxtACiuQ==}
     peerDependencies:
@@ -5344,6 +5607,10 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  make-fetch-happen@9.1.0:
+    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
+    engines: {node: '>= 10'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -5571,6 +5838,10 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -5579,12 +5850,55 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass-collect@1.0.2:
+    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
+    engines: {node: '>= 8'}
+
+  minipass-fetch@1.4.1:
+    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
+    engines: {node: '>=8'}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@1.0.3:
+    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
@@ -5614,6 +5928,13 @@ packages:
     resolution: {integrity: sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -5621,8 +5942,30 @@ packages:
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
+  node-abi@3.90.0:
+    resolution: {integrity: sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==}
+    engines: {node: '>=10'}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-gyp@8.4.1:
+    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
+    engines: {node: '>= 10.12.0'}
+    hasBin: true
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  npmlog@6.0.2:
+    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -5654,6 +5997,10 @@ packages:
   outvariant@1.4.0:
     resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
 
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
+
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
@@ -5672,6 +6019,10 @@ packages:
 
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -5810,6 +6161,12 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -5820,6 +6177,18 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  promise-inflight@1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -5865,6 +6234,10 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-devtools-inline@4.4.0:
     resolution: {integrity: sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==}
@@ -6012,6 +6385,15 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
@@ -6078,6 +6460,9 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -6115,6 +6500,15 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -6122,6 +6516,18 @@ packages:
     resolution: {integrity: sha512-egFg+XCF5sloOWdtzxZivTX7n4UDj5pxQoY33wbT8h+YSDjMQJ76MZUg2rXQIBXmIDtlZhLgirS1g/3R5/qaHA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@6.2.1:
+    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
+    engines: {node: '>= 10'}
+
+  socks@2.8.8:
+    resolution: {integrity: sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -6143,6 +6549,13 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sqlite3@5.1.7:
+    resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
+
+  ssri@8.0.1:
+    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
+    engines: {node: '>= 8'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -6176,11 +6589,19 @@ packages:
   strict-event-emitter@0.4.6:
     resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -6193,6 +6614,10 @@ packages:
   strip-indent@4.1.1:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
@@ -6244,8 +6669,20 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -6329,6 +6766,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -6360,6 +6800,10 @@ packages:
   undici-types@7.24.4:
     resolution: {integrity: sha512-cRaY9PagdEZoRmcwzk3tUV3SVGrVQkR6bcSilav/A0vXsfpW4Lvd0BvgRMwTEDTLLGN+QdyBTG+nnvTgJhdt6w==}
 
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
@@ -6369,6 +6813,12 @@ packages:
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unique-filename@1.1.1:
+    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
+
+  unique-slug@2.0.2:
+    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -6646,6 +7096,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -6682,6 +7135,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yjs@13.6.29:
     resolution: {integrity: sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==}
@@ -7499,6 +7955,8 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
+  '@bufbuild/protobuf@1.10.0': {}
+
   '@chevrotain/cst-dts-gen@11.1.2':
     dependencies:
       '@chevrotain/gast': 11.1.2
@@ -7833,6 +8291,16 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       react-is: 17.0.2
 
+  '@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      undici: 5.29.0
+
+  '@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0)':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+
   '@csstools/color-helpers@6.0.2': {}
 
   '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
@@ -7856,6 +8324,39 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@cursor/sdk-darwin-arm64@1.0.12':
+    optional: true
+
+  '@cursor/sdk-darwin-x64@1.0.12':
+    optional: true
+
+  '@cursor/sdk-linux-arm64@1.0.12':
+    optional: true
+
+  '@cursor/sdk-linux-x64@1.0.12':
+    optional: true
+
+  '@cursor/sdk-win32-x64@1.0.12':
+    optional: true
+
+  '@cursor/sdk@1.0.12':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect-node': 1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))
+      '@statsig/js-client': 3.31.0
+      sqlite3: 5.1.7
+      zod: 3.25.76
+    optionalDependencies:
+      '@cursor/sdk-darwin-arm64': 1.0.12
+      '@cursor/sdk-darwin-x64': 1.0.12
+      '@cursor/sdk-linux-arm64': 1.0.12
+      '@cursor/sdk-linux-x64': 1.0.12
+      '@cursor/sdk-win32-x64': 1.0.12
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:
@@ -8154,6 +8655,8 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.0.1
 
+  '@fastify/busboy@2.1.1': {}
+
   '@floating-ui/core@1.7.4':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -8178,6 +8681,9 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@gar/promisify@1.1.3':
+    optional: true
 
   '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
@@ -8665,6 +9171,18 @@ snapshots:
   '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
+
+  '@npmcli/fs@1.1.1':
+    dependencies:
+      '@gar/promisify': 1.1.3
+      semver: 7.7.4
+    optional: true
+
+  '@npmcli/move-file@1.1.2':
+    dependencies:
+      mkdirp: 1.0.4
+      rimraf: 3.0.2
+    optional: true
 
   '@open-draft/deferred-promise@2.2.0': {}
 
@@ -9909,6 +10427,12 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@statsig/client-core@3.31.0': {}
+
+  '@statsig/js-client@3.31.0':
+    dependencies:
+      '@statsig/client-core': 3.31.0
+
   '@stitches/core@1.2.8': {}
 
   '@storybook/addon-a11y@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
@@ -10106,6 +10630,9 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
+
+  '@tootallnate/once@1.1.2':
+    optional: true
 
   '@types/aria-query@5.0.4': {}
 
@@ -10476,6 +11003,9 @@ snapshots:
       '@zed-industries/codex-acp-win32-arm64': 0.12.0
       '@zed-industries/codex-acp-win32-x64': 0.12.0
 
+  abbrev@1.1.1:
+    optional: true
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -10501,7 +11031,25 @@ snapshots:
 
   address@2.0.3: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   agent-base@7.1.4: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+    optional: true
+
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+    optional: true
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -10521,6 +11069,15 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   append-field@1.0.0: {}
+
+  aproba@2.1.0:
+    optional: true
+
+  are-we-there-yet@3.0.1:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+    optional: true
 
   argparse@2.0.1: {}
 
@@ -10564,6 +11121,9 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2:
+    optional: true
+
   balanced-match@4.0.4: {}
 
   bare-events@2.8.2: {}
@@ -10602,7 +11162,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
+  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -10618,7 +11178,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7)
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -10637,6 +11197,16 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -10653,6 +11223,12 @@ snapshots:
 
   bowser@2.14.1: {}
 
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    optional: true
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -10666,6 +11242,11 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buffer@6.0.3:
     dependencies:
@@ -10683,6 +11264,30 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
+
+  cacache@15.3.0:
+    dependencies:
+      '@npmcli/fs': 1.1.1
+      '@npmcli/move-file': 1.1.2
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      glob: 7.2.3
+      infer-owner: 1.0.4
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      mkdirp: 1.0.4
+      p-map: 4.0.0
+      promise-inflight: 1.0.1
+      rimraf: 3.0.2
+      ssri: 8.0.1
+      tar: 6.2.1
+      unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
+    optional: true
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -10734,6 +11339,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chownr@1.1.4: {}
+
+  chownr@2.0.0: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -10741,6 +11350,9 @@ snapshots:
   classnames@2.5.1: {}
 
   clean-set@1.1.2: {}
+
+  clean-stack@2.2.0:
+    optional: true
 
   clsx@2.1.1: {}
 
@@ -10773,6 +11385,9 @@ snapshots:
       '@codemirror/state': 6.5.4
       '@codemirror/view': 6.39.15
 
+  color-support@1.1.3:
+    optional: true
+
   colorette@2.0.20: {}
 
   combined-stream@1.0.8:
@@ -10793,6 +11408,9 @@ snapshots:
 
   compute-scroll-into-view@2.0.4: {}
 
+  concat-map@0.0.1:
+    optional: true
+
   concat-stream@2.0.0:
     dependencies:
       buffer-from: 1.1.2
@@ -10801,6 +11419,9 @@ snapshots:
       typedarray: 0.0.6
 
   confbox@0.1.8: {}
+
+  console-control-strings@1.1.0:
+    optional: true
 
   content-disposition@1.0.1: {}
 
@@ -11070,7 +11691,13 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   deepmerge@4.3.1: {}
 
@@ -11090,6 +11717,9 @@ snapshots:
       robust-predicates: 3.0.2
 
   delayed-stream@1.0.0: {}
+
+  delegates@1.0.0:
+    optional: true
 
   depd@2.0.0: {}
 
@@ -11148,7 +11778,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4):
+  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@types/react': 19.2.14
@@ -11156,6 +11786,7 @@ snapshots:
       pg: 8.18.0
       postgres: 3.4.8
       react: 19.2.4
+      sqlite3: 5.1.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -11183,9 +11814,17 @@ snapshots:
     transitivePeerDependencies:
       - pg-native
 
+  emoji-regex@8.0.0:
+    optional: true
+
   empathic@2.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  encoding@0.1.13:
+    dependencies:
+      iconv-lite: 0.6.3
+    optional: true
 
   end-of-stream@1.4.5:
     dependencies:
@@ -11197,6 +11836,12 @@ snapshots:
       tapable: 2.3.0
 
   entities@6.0.1: {}
+
+  env-paths@2.2.1:
+    optional: true
+
+  err-code@2.0.3:
+    optional: true
 
   es-define-property@1.0.1: {}
 
@@ -11374,6 +12019,8 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   express-rate-limit@8.3.2(express@5.2.1):
@@ -11452,6 +12099,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  file-uri-to-path@1.0.0: {}
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -11483,6 +12132,15 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-constants@1.0.0: {}
+
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
+  fs.realpath@1.0.0:
+    optional: true
+
   fsevents@2.3.2:
     optional: true
 
@@ -11490,6 +12148,18 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gauge@4.0.4:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+    optional: true
 
   gensync@1.0.0-beta.2: {}
 
@@ -11519,11 +12189,23 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  github-from-package@0.0.0: {}
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    optional: true
 
   gopd@1.2.0: {}
 
@@ -11536,6 +12218,9 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+
+  has-unicode@2.0.1:
+    optional: true
 
   hasown@2.0.2:
     dependencies:
@@ -11582,6 +12267,9 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
+  http-cache-semantics@4.2.0:
+    optional: true
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -11590,6 +12278,15 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@4.0.1:
+    dependencies:
+      '@tootallnate/once': 1.1.2
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -11597,12 +12294,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+    optional: true
 
   iconv-lite@0.6.3:
     dependencies:
@@ -11614,9 +12324,23 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  imurmurhash@0.1.4:
+    optional: true
+
   indent-string@4.0.0: {}
 
+  infer-owner@1.0.4:
+    optional: true
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    optional: true
+
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -11627,6 +12351,9 @@ snapshots:
   intersection-observer@0.10.0: {}
 
   ip-address@10.1.0: {}
+
+  ip-address@10.2.0:
+    optional: true
 
   ipaddr.js@1.9.1: {}
 
@@ -11645,6 +12372,9 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-fullwidth-code-point@3.0.0:
+    optional: true
+
   is-hexadecimal@2.0.1: {}
 
   is-in-ssh@1.0.0: {}
@@ -11652,6 +12382,9 @@ snapshots:
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
+
+  is-lambda@1.0.1:
+    optional: true
 
   is-module@1.0.0: {}
 
@@ -11816,6 +12549,11 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+    optional: true
+
   lucide-react@0.574.0(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -11825,6 +12563,29 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-fetch-happen@9.1.0:
+    dependencies:
+      agentkeepalive: 4.6.0
+      cacache: 15.3.0
+      http-cache-semantics: 4.2.0
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
+      is-lambda: 1.0.1
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-fetch: 1.4.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 0.6.4
+      promise-retry: 2.0.1
+      socks-proxy-agent: 6.2.1
+      ssri: 8.0.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
 
   markdown-table@3.0.4: {}
 
@@ -12361,15 +13122,66 @@ snapshots:
 
   mime@2.6.0: {}
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+    optional: true
+
   minimist@1.2.8: {}
 
+  minipass-collect@1.0.2:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-fetch@1.4.1:
+    dependencies:
+      minipass: 3.3.6
+      minipass-sized: 1.0.3
+      minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
+    optional: true
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-sized@1.0.3:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
   minipass@7.1.3: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
+  mkdirp-classic@0.5.3: {}
+
+  mkdirp@1.0.4: {}
 
   mlly@1.8.1:
     dependencies:
@@ -12395,11 +13207,52 @@ snapshots:
 
   nanostores@1.1.0: {}
 
+  napi-build-utils@2.0.0: {}
+
+  negotiator@0.6.4:
+    optional: true
+
   negotiator@1.0.0: {}
 
   next-tick@1.1.0: {}
 
+  node-abi@3.90.0:
+    dependencies:
+      semver: 7.7.4
+
+  node-addon-api@7.1.1: {}
+
+  node-gyp@8.4.1:
+    dependencies:
+      env-paths: 2.2.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 9.1.0
+      nopt: 5.0.0
+      npmlog: 6.0.2
+      rimraf: 3.0.2
+      semver: 7.7.4
+      tar: 6.2.1
+      which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
+
   node-releases@2.0.27: {}
+
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+    optional: true
+
+  npmlog@6.0.2:
+    dependencies:
+      are-we-there-yet: 3.0.1
+      console-control-strings: 1.1.0
+      gauge: 4.0.4
+      set-blocking: 2.0.0
+    optional: true
 
   object-assign@4.1.1: {}
 
@@ -12433,6 +13286,11 @@ snapshots:
 
   outvariant@1.4.0: {}
 
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+    optional: true
+
   package-manager-detector@1.6.0: {}
 
   parse-entities@4.0.2:
@@ -12456,6 +13314,9 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-data-parser@0.1.0: {}
+
+  path-is-absolute@1.0.1:
+    optional: true
 
   path-key@3.1.1: {}
 
@@ -12606,6 +13467,21 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.90.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -12615,6 +13491,15 @@ snapshots:
   prismjs@1.30.0: {}
 
   process-warning@5.0.0: {}
+
+  promise-inflight@1.0.1:
+    optional: true
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+    optional: true
 
   prop-types@15.8.1:
     dependencies:
@@ -12713,6 +13598,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-devtools-inline@4.4.0:
     dependencies:
@@ -12894,6 +13786,14 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.12.0:
+    optional: true
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+    optional: true
+
   robust-predicates@3.0.2: {}
 
   rollup@4.60.1:
@@ -12997,6 +13897,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  set-blocking@2.0.0:
+    optional: true
+
   set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
@@ -13068,6 +13971,17 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7:
+    optional: true
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sisteransi@1.0.5: {}
 
   skillflag@0.1.4:
@@ -13078,6 +13992,24 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  smart-buffer@4.2.0:
+    optional: true
+
+  socks-proxy-agent@6.2.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+      socks: 2.8.8
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  socks@2.8.8:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
+    optional: true
 
   sonic-boom@4.2.1:
     dependencies:
@@ -13095,6 +14027,23 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   split2@4.2.0: {}
+
+  sqlite3@5.1.7:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 7.1.1
+      prebuild-install: 7.1.3
+      tar: 6.2.1
+    optionalDependencies:
+      node-gyp: 8.4.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  ssri@8.0.1:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
 
   stackback@0.0.2: {}
 
@@ -13144,6 +14093,13 @@ snapshots:
 
   strict-event-emitter@0.4.6: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    optional: true
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -13153,6 +14109,11 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+    optional: true
+
   strip-bom@3.0.0: {}
 
   strip-indent@3.0.0:
@@ -13160,6 +14121,8 @@ snapshots:
       min-indent: 1.0.1
 
   strip-indent@4.1.1: {}
+
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@5.0.3: {}
 
@@ -13215,6 +14178,21 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar-stream@3.2.0:
     dependencies:
       b4a: 1.8.1
@@ -13225,6 +14203,15 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
 
   teex@1.0.1:
     dependencies:
@@ -13301,6 +14288,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -13326,6 +14317,10 @@ snapshots:
 
   undici-types@7.24.4: {}
 
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
   undici@7.24.4: {}
 
   unidiff@1.0.4:
@@ -13341,6 +14336,16 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
+
+  unique-filename@1.1.1:
+    dependencies:
+      unique-slug: 2.0.2
+    optional: true
+
+  unique-slug@2.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+    optional: true
 
   unist-util-is@6.0.1:
     dependencies:
@@ -13683,6 +14688,11 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+    optional: true
+
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
@@ -13703,6 +14713,8 @@ snapshots:
   xtend@4.0.2: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yjs@13.6.29:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,10 +15,6 @@ patchedDependencies:
 importers:
 
   .:
-    dependencies:
-      '@cursor/sdk':
-        specifier: ^1.0.12
-        version: 1.0.12
     devDependencies:
       '@playwright/test':
         specifier: ^1.58.2
@@ -53,9 +49,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-cursor-sdk':
-        specifier: workspace:*
-        version: link:../packages/adapters/cursor-sdk
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
@@ -88,7 +81,7 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: 0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -188,25 +181,6 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
-  packages/adapters/cursor-sdk:
-    dependencies:
-      '@cursor/sdk':
-        specifier: '*'
-        version: 1.0.12
-      '@paperclipai/adapter-utils':
-        specifier: workspace:*
-        version: link:../../adapter-utils
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
-    devDependencies:
-      '@types/node':
-        specifier: ^24.6.0
-        version: 24.12.0
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-
   packages/adapters/gemini-local:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -284,7 +258,7 @@ importers:
         version: link:../shared
       drizzle-orm:
         specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -547,9 +521,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-cursor-sdk':
-        specifier: workspace:*
-        version: link:../packages/adapters/cursor-sdk
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
@@ -582,7 +553,7 @@ importers:
         version: 3.0.1(ajv@8.18.0)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -597,7 +568,7 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7)
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -710,9 +681,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-cursor-sdk':
-        specifier: workspace:*
-        version: link:../packages/adapters/cursor-sdk
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
@@ -1248,9 +1216,6 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@bufbuild/protobuf@1.10.0':
-    resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
-
   '@chevrotain/cst-dts-gen@11.1.2':
     resolution: {integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==}
 
@@ -1385,18 +1350,6 @@ packages:
       react: ^16.8.0 || ^17 || ^18 || ^19
       react-dom: ^16.8.0 || ^17 || ^18 || ^19
 
-  '@connectrpc/connect-node@1.7.0':
-    resolution: {integrity: sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.10.0
-      '@connectrpc/connect': 1.7.0
-
-  '@connectrpc/connect@1.7.0':
-    resolution: {integrity: sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.10.0
-
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
     engines: {node: '>=20.19.0'}
@@ -1432,35 +1385,6 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
-
-  '@cursor/sdk-darwin-arm64@1.0.12':
-    resolution: {integrity: sha512-AOFx+aX+4SntAeC66YncHACXk5duxp+HzDrxxF4Tl93N6nLjHaHEKSAXbt87ivL34MCHop4v/3c70QzBhamB2g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cursor/sdk-darwin-x64@1.0.12':
-    resolution: {integrity: sha512-/ZDAYFUrnPd8hAGRky9ZGcROqZSZ2b5W+aEjTdINzLhJ8x5ZNXtjaz0ZYSHabOn2BeErjXgTcq+4bX2/To4C1A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@cursor/sdk-linux-arm64@1.0.12':
-    resolution: {integrity: sha512-kAxNqiB3dPtlW9fVjjIZEdbIGEGLA9moOM3zYwsXh8J1Qw942nJYMGDGR4o8x0zglwZ24a1JpovvZamrCaC3Yw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@cursor/sdk-linux-x64@1.0.12':
-    resolution: {integrity: sha512-RmBiBCPKMZC5McDerGk2Rk4P47xz2A+uzRoRgH6sMoOjklc33ry11iAZC0D5F5xH85chgY878086A/Q8+XrAuA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@cursor/sdk-win32-x64@1.0.12':
-    resolution: {integrity: sha512-uH4shdHrKOdtNLapy1uuScJ9lL2Pc8zc9I9ZKC6b6bx+0UX6xLAqjPP7dqVPfO6D9u61yLq1Hs86XOLs5ZVkPA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@cursor/sdk@1.0.12':
-    resolution: {integrity: sha512-jGx0wFY1N9uIdIKr303CfM6m/dLXmRCUnU/0yNP/oiOpkBXqgqaThGbgYbcOeVrYonMZc/DZJ9EydXOEPJLcbg==}
-    engines: {node: '>=18'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -2005,10 +1929,6 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
@@ -2029,9 +1949,6 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
-
-  '@gar/promisify@1.1.3':
-    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
@@ -2376,14 +2293,6 @@ packages:
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
-
-  '@npmcli/fs@1.1.1':
-    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
-
-  '@npmcli/move-file@1.1.2':
-    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
-    engines: {node: '>=10'}
-    deprecated: This functionality has been moved to @npmcli/fs
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
@@ -3519,12 +3428,6 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@statsig/client-core@3.31.0':
-    resolution: {integrity: sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==}
-
-  '@statsig/js-client@3.31.0':
-    resolution: {integrity: sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==}
-
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
@@ -3713,10 +3616,6 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
-
-  '@tootallnate/once@1.1.2':
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -4024,9 +3923,6 @@ packages:
     resolution: {integrity: sha512-0d7gRzOiYTgDmIyh783mCcq50h3mdOg/TtKdLfBIghOLushpQRwhuLjKK8Q9hxZfNlPL0Ua56DoPjnsW8amf8g==}
     hasBin: true
 
-  abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
-
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -4050,21 +3946,9 @@ packages:
     resolution: {integrity: sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==}
     engines: {node: '>= 16.0.0'}
 
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
-
-  aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -4090,14 +3974,6 @@ packages:
 
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
-
-  aproba@2.1.0:
-    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
-
-  are-we-there-yet@3.0.1:
-    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This package is no longer supported.
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -4155,9 +4031,6 @@ packages:
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
-
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -4284,21 +4157,12 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-
-  bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
-
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
-
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -4311,9 +4175,6 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -4333,10 +4194,6 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
-
-  cacache@15.3.0:
-    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
-    engines: {node: '>= 10'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -4384,13 +4241,6 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -4399,10 +4249,6 @@ packages:
 
   clean-set@1.1.2:
     resolution: {integrity: sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==}
-
-  clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -4424,10 +4270,6 @@ packages:
 
   codemirror@6.0.2:
     resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
-
-  color-support@1.1.3:
-    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
-    hasBin: true
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -4461,18 +4303,12 @@ packages:
   compute-scroll-into-view@2.0.4:
     resolution: {integrity: sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g==}
 
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
-
-  console-control-strings@1.1.0:
-    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -4726,17 +4562,9 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -4763,9 +4591,6 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-
-  delegates@1.0.0:
-    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -4934,9 +4759,6 @@ packages:
     resolution: {integrity: sha512-TDp7Ld0h84x5fzIIZFyreYWqZrxUNjuXB6OxqJCmV6PodB2vzQ+1hlL6n4uK1de7bIAxYt5OkDykwcuIONQdQg==}
     engines: {node: '>=16'}
 
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
@@ -4944,9 +4766,6 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
-
-  encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -4958,13 +4777,6 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
-
-  env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
-
-  err-code@2.0.3:
-    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -5073,10 +4885,6 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -5137,9 +4945,6 @@ packages:
       picomatch:
         optional: true
 
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -5164,16 +4969,6 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
-
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5186,11 +4981,6 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  gauge@4.0.4:
-    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This package is no longer supported.
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -5215,16 +5005,9 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
-
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -5243,9 +5026,6 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
-
-  has-unicode@2.0.1:
-    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -5275,31 +5055,17 @@ packages:
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
-  http-cache-semantics@4.2.0:
-    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
-
-  http-proxy-agent@4.0.1:
-    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
-    engines: {node: '>= 6'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
-
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -5312,26 +5078,12 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
-
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
-  infer-owner@1.0.4:
-    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -5349,10 +5101,6 @@ packages:
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
-    engines: {node: '>= 12'}
-
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -5377,10 +5125,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
@@ -5392,9 +5136,6 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
-
-  is-lambda@1.0.1:
-    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
@@ -5592,10 +5333,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
-
   lucide-react@0.574.0:
     resolution: {integrity: sha512-dJ8xb5juiZVIbdSn3HTyHsjjIwUwZ4FNwV0RtYDScOyySOeie1oXZTymST6YPJ4Qwt3Po8g4quhYl4OxtACiuQ==}
     peerDependencies:
@@ -5607,10 +5344,6 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  make-fetch-happen@9.1.0:
-    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
-    engines: {node: '>= 10'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -5838,10 +5571,6 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
-
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -5850,55 +5579,12 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  minipass-collect@1.0.2:
-    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
-    engines: {node: '>= 8'}
-
-  minipass-fetch@1.4.1:
-    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
-    engines: {node: '>=8'}
-
-  minipass-flush@1.0.7:
-    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
-    engines: {node: '>= 8'}
-
-  minipass-pipeline@1.2.4:
-    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
-    engines: {node: '>=8'}
-
-  minipass-sized@1.0.3:
-    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
-    engines: {node: '>=8'}
-
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
-  mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
@@ -5928,13 +5614,6 @@ packages:
     resolution: {integrity: sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
-  negotiator@0.6.4:
-    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
-    engines: {node: '>= 0.6'}
-
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -5942,30 +5621,8 @@ packages:
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
-  node-abi@3.90.0:
-    resolution: {integrity: sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==}
-    engines: {node: '>=10'}
-
-  node-addon-api@7.1.1:
-    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
-
-  node-gyp@8.4.1:
-    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
-    engines: {node: '>= 10.12.0'}
-    hasBin: true
-
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
-
-  nopt@5.0.0:
-    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
-    engines: {node: '>=6'}
-    hasBin: true
-
-  npmlog@6.0.2:
-    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This package is no longer supported.
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -5997,10 +5654,6 @@ packages:
   outvariant@1.4.0:
     resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
 
-  p-map@4.0.0:
-    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
-    engines: {node: '>=10'}
-
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
@@ -6019,10 +5672,6 @@ packages:
 
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -6161,12 +5810,6 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -6177,18 +5820,6 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
-
-  promise-inflight@1.0.1:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-
-  promise-retry@2.0.1:
-    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
-    engines: {node: '>=10'}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -6234,10 +5865,6 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
 
   react-devtools-inline@4.4.0:
     resolution: {integrity: sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==}
@@ -6385,15 +6012,6 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  retry@0.12.0:
-    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
-    engines: {node: '>= 4'}
-
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
@@ -6460,9 +6078,6 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
-  set-blocking@2.0.0:
-    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -6500,15 +6115,6 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -6516,18 +6122,6 @@ packages:
     resolution: {integrity: sha512-egFg+XCF5sloOWdtzxZivTX7n4UDj5pxQoY33wbT8h+YSDjMQJ76MZUg2rXQIBXmIDtlZhLgirS1g/3R5/qaHA==}
     engines: {node: '>=18'}
     hasBin: true
-
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  socks-proxy-agent@6.2.1:
-    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
-    engines: {node: '>= 10'}
-
-  socks@2.8.8:
-    resolution: {integrity: sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -6549,13 +6143,6 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
-
-  sqlite3@5.1.7:
-    resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
-
-  ssri@8.0.1:
-    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
-    engines: {node: '>= 8'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -6589,19 +6176,11 @@ packages:
   strict-event-emitter@0.4.6:
     resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
 
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -6614,10 +6193,6 @@ packages:
   strip-indent@4.1.1:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
-
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
 
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
@@ -6669,20 +6244,8 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
-
-  tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
-
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
-
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -6766,9 +6329,6 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
-
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -6800,10 +6360,6 @@ packages:
   undici-types@7.24.4:
     resolution: {integrity: sha512-cRaY9PagdEZoRmcwzk3tUV3SVGrVQkR6bcSilav/A0vXsfpW4Lvd0BvgRMwTEDTLLGN+QdyBTG+nnvTgJhdt6w==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
@@ -6813,12 +6369,6 @@ packages:
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
-
-  unique-filename@1.1.1:
-    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
-
-  unique-slug@2.0.2:
-    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -7096,9 +6646,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wide-align@1.1.5:
-    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -7135,9 +6682,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yjs@13.6.29:
     resolution: {integrity: sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==}
@@ -7955,8 +7499,6 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@bufbuild/protobuf@1.10.0': {}
-
   '@chevrotain/cst-dts-gen@11.1.2':
     dependencies:
       '@chevrotain/gast': 11.1.2
@@ -8291,16 +7833,6 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       react-is: 17.0.2
 
-  '@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
-    dependencies:
-      '@bufbuild/protobuf': 1.10.0
-      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
-      undici: 5.29.0
-
-  '@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0)':
-    dependencies:
-      '@bufbuild/protobuf': 1.10.0
-
   '@csstools/color-helpers@6.0.2': {}
 
   '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
@@ -8324,39 +7856,6 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
-
-  '@cursor/sdk-darwin-arm64@1.0.12':
-    optional: true
-
-  '@cursor/sdk-darwin-x64@1.0.12':
-    optional: true
-
-  '@cursor/sdk-linux-arm64@1.0.12':
-    optional: true
-
-  '@cursor/sdk-linux-x64@1.0.12':
-    optional: true
-
-  '@cursor/sdk-win32-x64@1.0.12':
-    optional: true
-
-  '@cursor/sdk@1.0.12':
-    dependencies:
-      '@bufbuild/protobuf': 1.10.0
-      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
-      '@connectrpc/connect-node': 1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))
-      '@statsig/js-client': 3.31.0
-      sqlite3: 5.1.7
-      zod: 3.25.76
-    optionalDependencies:
-      '@cursor/sdk-darwin-arm64': 1.0.12
-      '@cursor/sdk-darwin-x64': 1.0.12
-      '@cursor/sdk-linux-arm64': 1.0.12
-      '@cursor/sdk-linux-x64': 1.0.12
-      '@cursor/sdk-win32-x64': 1.0.12
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:
@@ -8655,8 +8154,6 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.0.1
 
-  '@fastify/busboy@2.1.1': {}
-
   '@floating-ui/core@1.7.4':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -8681,9 +8178,6 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.10': {}
-
-  '@gar/promisify@1.1.3':
-    optional: true
 
   '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
@@ -9171,18 +8665,6 @@ snapshots:
   '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
-
-  '@npmcli/fs@1.1.1':
-    dependencies:
-      '@gar/promisify': 1.1.3
-      semver: 7.7.4
-    optional: true
-
-  '@npmcli/move-file@1.1.2':
-    dependencies:
-      mkdirp: 1.0.4
-      rimraf: 3.0.2
-    optional: true
 
   '@open-draft/deferred-promise@2.2.0': {}
 
@@ -10427,12 +9909,6 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@statsig/client-core@3.31.0': {}
-
-  '@statsig/js-client@3.31.0':
-    dependencies:
-      '@statsig/client-core': 3.31.0
-
   '@stitches/core@1.2.8': {}
 
   '@storybook/addon-a11y@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
@@ -10630,9 +10106,6 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
-
-  '@tootallnate/once@1.1.2':
-    optional: true
 
   '@types/aria-query@5.0.4': {}
 
@@ -11003,9 +10476,6 @@ snapshots:
       '@zed-industries/codex-acp-win32-arm64': 0.12.0
       '@zed-industries/codex-acp-win32-x64': 0.12.0
 
-  abbrev@1.1.1:
-    optional: true
-
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -11031,25 +10501,7 @@ snapshots:
 
   address@2.0.3: {}
 
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   agent-base@7.1.4: {}
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
-    optional: true
-
-  aggregate-error@3.1.0:
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
-    optional: true
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -11069,15 +10521,6 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   append-field@1.0.0: {}
-
-  aproba@2.1.0:
-    optional: true
-
-  are-we-there-yet@3.0.1:
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.2
-    optional: true
 
   argparse@2.0.1: {}
 
@@ -11121,9 +10564,6 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2:
-    optional: true
-
   balanced-match@4.0.4: {}
 
   bare-events@2.8.2: {}
@@ -11162,7 +10602,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
+  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -11178,7 +10618,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7)
+      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -11197,16 +10637,6 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
-
-  bl@4.1.0:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -11223,12 +10653,6 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.14:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-    optional: true
-
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -11242,11 +10666,6 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-from@1.1.2: {}
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   buffer@6.0.3:
     dependencies:
@@ -11264,30 +10683,6 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
-
-  cacache@15.3.0:
-    dependencies:
-      '@npmcli/fs': 1.1.1
-      '@npmcli/move-file': 1.1.2
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      glob: 7.2.3
-      infer-owner: 1.0.4
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      mkdirp: 1.0.4
-      p-map: 4.0.0
-      promise-inflight: 1.0.1
-      rimraf: 3.0.2
-      ssri: 8.0.1
-      tar: 6.2.1
-      unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
-    optional: true
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -11339,10 +10734,6 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  chownr@1.1.4: {}
-
-  chownr@2.0.0: {}
-
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -11350,9 +10741,6 @@ snapshots:
   classnames@2.5.1: {}
 
   clean-set@1.1.2: {}
-
-  clean-stack@2.2.0:
-    optional: true
 
   clsx@2.1.1: {}
 
@@ -11385,9 +10773,6 @@ snapshots:
       '@codemirror/state': 6.5.4
       '@codemirror/view': 6.39.15
 
-  color-support@1.1.3:
-    optional: true
-
   colorette@2.0.20: {}
 
   combined-stream@1.0.8:
@@ -11408,9 +10793,6 @@ snapshots:
 
   compute-scroll-into-view@2.0.4: {}
 
-  concat-map@0.0.1:
-    optional: true
-
   concat-stream@2.0.0:
     dependencies:
       buffer-from: 1.1.2
@@ -11419,9 +10801,6 @@ snapshots:
       typedarray: 0.0.6
 
   confbox@0.1.8: {}
-
-  console-control-strings@1.1.0:
-    optional: true
 
   content-disposition@1.0.1: {}
 
@@ -11691,13 +11070,7 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
   deep-eql@5.0.2: {}
-
-  deep-extend@0.6.0: {}
 
   deepmerge@4.3.1: {}
 
@@ -11717,9 +11090,6 @@ snapshots:
       robust-predicates: 3.0.2
 
   delayed-stream@1.0.0: {}
-
-  delegates@1.0.0:
-    optional: true
 
   depd@2.0.0: {}
 
@@ -11778,7 +11148,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)(sqlite3@5.1.7):
+  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@types/react': 19.2.14
@@ -11786,7 +11156,6 @@ snapshots:
       pg: 8.18.0
       postgres: 3.4.8
       react: 19.2.4
-      sqlite3: 5.1.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -11814,17 +11183,9 @@ snapshots:
     transitivePeerDependencies:
       - pg-native
 
-  emoji-regex@8.0.0:
-    optional: true
-
   empathic@2.0.0: {}
 
   encodeurl@2.0.0: {}
-
-  encoding@0.1.13:
-    dependencies:
-      iconv-lite: 0.6.3
-    optional: true
 
   end-of-stream@1.4.5:
     dependencies:
@@ -11836,12 +11197,6 @@ snapshots:
       tapable: 2.3.0
 
   entities@6.0.1: {}
-
-  env-paths@2.2.1:
-    optional: true
-
-  err-code@2.0.3:
-    optional: true
 
   es-define-property@1.0.1: {}
 
@@ -12019,8 +11374,6 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
-  expand-template@2.0.3: {}
-
   expect-type@1.3.0: {}
 
   express-rate-limit@8.3.2(express@5.2.1):
@@ -12099,8 +11452,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  file-uri-to-path@1.0.0: {}
-
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -12132,15 +11483,6 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0: {}
-
-  fs-minipass@2.1.0:
-    dependencies:
-      minipass: 3.3.6
-
-  fs.realpath@1.0.0:
-    optional: true
-
   fsevents@2.3.2:
     optional: true
 
@@ -12148,18 +11490,6 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
-
-  gauge@4.0.4:
-    dependencies:
-      aproba: 2.1.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
-    optional: true
 
   gensync@1.0.0-beta.2: {}
 
@@ -12189,23 +11519,11 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  github-from-package@0.0.0: {}
-
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    optional: true
 
   gopd@1.2.0: {}
 
@@ -12218,9 +11536,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
-
-  has-unicode@2.0.1:
-    optional: true
 
   hasown@2.0.2:
     dependencies:
@@ -12267,9 +11582,6 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
-  http-cache-semantics@4.2.0:
-    optional: true
-
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -12278,15 +11590,6 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@4.0.1:
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -12294,25 +11597,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
-    optional: true
 
   iconv-lite@0.6.3:
     dependencies:
@@ -12324,23 +11614,9 @@ snapshots:
 
   ieee754@1.2.1: {}
 
-  imurmurhash@0.1.4:
-    optional: true
-
   indent-string@4.0.0: {}
 
-  infer-owner@1.0.4:
-    optional: true
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-    optional: true
-
   inherits@2.0.4: {}
-
-  ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -12351,9 +11627,6 @@ snapshots:
   intersection-observer@0.10.0: {}
 
   ip-address@10.1.0: {}
-
-  ip-address@10.2.0:
-    optional: true
 
   ipaddr.js@1.9.1: {}
 
@@ -12372,9 +11645,6 @@ snapshots:
 
   is-docker@3.0.0: {}
 
-  is-fullwidth-code-point@3.0.0:
-    optional: true
-
   is-hexadecimal@2.0.1: {}
 
   is-in-ssh@1.0.0: {}
@@ -12382,9 +11652,6 @@ snapshots:
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
-
-  is-lambda@1.0.1:
-    optional: true
 
   is-module@1.0.0: {}
 
@@ -12549,11 +11816,6 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lru-cache@6.0.0:
-    dependencies:
-      yallist: 4.0.0
-    optional: true
-
   lucide-react@0.574.0(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -12563,29 +11825,6 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  make-fetch-happen@9.1.0:
-    dependencies:
-      agentkeepalive: 4.6.0
-      cacache: 15.3.0
-      http-cache-semantics: 4.2.0
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
-      is-lambda: 1.0.1
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 1.4.1
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      negotiator: 0.6.4
-      promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1
-      ssri: 8.0.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-    optional: true
 
   markdown-table@3.0.4: {}
 
@@ -13122,66 +12361,15 @@ snapshots:
 
   mime@2.6.0: {}
 
-  mimic-response@3.1.0: {}
-
   min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
 
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.14
-    optional: true
-
   minimist@1.2.8: {}
 
-  minipass-collect@1.0.2:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
-
-  minipass-fetch@1.4.1:
-    dependencies:
-      minipass: 3.3.6
-      minipass-sized: 1.0.3
-      minizlib: 2.1.2
-    optionalDependencies:
-      encoding: 0.1.13
-    optional: true
-
-  minipass-flush@1.0.7:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
-
-  minipass-pipeline@1.2.4:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
-
-  minipass-sized@1.0.3:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
-
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
-
-  minipass@5.0.0: {}
-
   minipass@7.1.3: {}
-
-  minizlib@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-
-  mkdirp-classic@0.5.3: {}
-
-  mkdirp@1.0.4: {}
 
   mlly@1.8.1:
     dependencies:
@@ -13207,52 +12395,11 @@ snapshots:
 
   nanostores@1.1.0: {}
 
-  napi-build-utils@2.0.0: {}
-
-  negotiator@0.6.4:
-    optional: true
-
   negotiator@1.0.0: {}
 
   next-tick@1.1.0: {}
 
-  node-abi@3.90.0:
-    dependencies:
-      semver: 7.7.4
-
-  node-addon-api@7.1.1: {}
-
-  node-gyp@8.4.1:
-    dependencies:
-      env-paths: 2.2.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      make-fetch-happen: 9.1.0
-      nopt: 5.0.0
-      npmlog: 6.0.2
-      rimraf: 3.0.2
-      semver: 7.7.4
-      tar: 6.2.1
-      which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-    optional: true
-
   node-releases@2.0.27: {}
-
-  nopt@5.0.0:
-    dependencies:
-      abbrev: 1.1.1
-    optional: true
-
-  npmlog@6.0.2:
-    dependencies:
-      are-we-there-yet: 3.0.1
-      console-control-strings: 1.1.0
-      gauge: 4.0.4
-      set-blocking: 2.0.0
-    optional: true
 
   object-assign@4.1.1: {}
 
@@ -13286,11 +12433,6 @@ snapshots:
 
   outvariant@1.4.0: {}
 
-  p-map@4.0.0:
-    dependencies:
-      aggregate-error: 3.1.0
-    optional: true
-
   package-manager-detector@1.6.0: {}
 
   parse-entities@4.0.2:
@@ -13314,9 +12456,6 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-data-parser@0.1.0: {}
-
-  path-is-absolute@1.0.1:
-    optional: true
 
   path-key@3.1.1: {}
 
@@ -13467,21 +12606,6 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.90.0
-      pump: 3.0.3
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
-
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -13491,15 +12615,6 @@ snapshots:
   prismjs@1.30.0: {}
 
   process-warning@5.0.0: {}
-
-  promise-inflight@1.0.1:
-    optional: true
-
-  promise-retry@2.0.1:
-    dependencies:
-      err-code: 2.0.3
-      retry: 0.12.0
-    optional: true
 
   prop-types@15.8.1:
     dependencies:
@@ -13598,13 +12713,6 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
 
   react-devtools-inline@4.4.0:
     dependencies:
@@ -13786,14 +12894,6 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  retry@0.12.0:
-    optional: true
-
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
-    optional: true
-
   robust-predicates@3.0.2: {}
 
   rollup@4.60.1:
@@ -13897,9 +12997,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  set-blocking@2.0.0:
-    optional: true
-
   set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
@@ -13971,17 +13068,6 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@3.0.7:
-    optional: true
-
-  simple-concat@1.0.1: {}
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-
   sisteransi@1.0.5: {}
 
   skillflag@0.1.4:
@@ -13992,24 +13078,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-
-  smart-buffer@4.2.0:
-    optional: true
-
-  socks-proxy-agent@6.2.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-      socks: 2.8.8
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  socks@2.8.8:
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
-    optional: true
 
   sonic-boom@4.2.1:
     dependencies:
@@ -14027,23 +13095,6 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   split2@4.2.0: {}
-
-  sqlite3@5.1.7:
-    dependencies:
-      bindings: 1.5.0
-      node-addon-api: 7.1.1
-      prebuild-install: 7.1.3
-      tar: 6.2.1
-    optionalDependencies:
-      node-gyp: 8.4.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-
-  ssri@8.0.1:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
 
   stackback@0.0.2: {}
 
@@ -14093,13 +13144,6 @@ snapshots:
 
   strict-event-emitter@0.4.6: {}
 
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-    optional: true
-
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -14109,11 +13153,6 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-    optional: true
-
   strip-bom@3.0.0: {}
 
   strip-indent@3.0.0:
@@ -14121,8 +13160,6 @@ snapshots:
       min-indent: 1.0.1
 
   strip-indent@4.1.1: {}
-
-  strip-json-comments@2.0.1: {}
 
   strip-json-comments@5.0.3: {}
 
@@ -14178,21 +13215,6 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.3
-      tar-stream: 2.2.0
-
-  tar-stream@2.2.0:
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
   tar-stream@3.2.0:
     dependencies:
       b4a: 1.8.1
@@ -14203,15 +13225,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
 
   teex@1.0.1:
     dependencies:
@@ -14288,10 +13301,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -14317,10 +13326,6 @@ snapshots:
 
   undici-types@7.24.4: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
-
   undici@7.24.4: {}
 
   unidiff@1.0.4:
@@ -14336,16 +13341,6 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
-
-  unique-filename@1.1.1:
-    dependencies:
-      unique-slug: 2.0.2
-    optional: true
-
-  unique-slug@2.0.2:
-    dependencies:
-      imurmurhash: 0.1.4
-    optional: true
 
   unist-util-is@6.0.1:
     dependencies:
@@ -14688,11 +13683,6 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wide-align@1.1.5:
-    dependencies:
-      string-width: 4.2.3
-    optional: true
-
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
@@ -14713,8 +13703,6 @@ snapshots:
   xtend@4.0.2: {}
 
   yallist@3.1.1: {}
-
-  yallist@4.0.0: {}
 
   yjs@13.6.29:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -48,6 +48,7 @@
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
+    "@paperclipai/adapter-cursor-sdk": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -49,6 +49,16 @@ import {
   modelProfiles as cursorModelProfiles,
 } from "@paperclipai/adapter-cursor-local";
 import {
+  execute as cursorSdkExecute,
+  testEnvironment as cursorSdkTestEnvironment,
+  sessionCodec as cursorSdkSessionCodec,
+} from "@paperclipai/adapter-cursor-sdk/server";
+import {
+  agentConfigurationDoc as cursorSdkAgentConfigurationDoc,
+  models as cursorSdkModels,
+  modelProfiles as cursorSdkModelProfiles,
+} from "@paperclipai/adapter-cursor-sdk";
+import {
   execute as geminiExecute,
   listGeminiSkills,
   syncGeminiSkills,
@@ -197,6 +207,21 @@ const codexLocalAdapter: ServerAdapterModule = {
   requiresMaterializedRuntimeSkills: false,
   agentConfigurationDoc: codexAgentConfigurationDoc,
   getQuotaWindows: codexGetQuotaWindows,
+};
+
+const cursorSdkAdapter: ServerAdapterModule = {
+  type: "cursor_sdk",
+  execute: cursorSdkExecute,
+  testEnvironment: cursorSdkTestEnvironment,
+  sessionCodec: cursorSdkSessionCodec,
+  sessionManagement: getAdapterSessionManagement("cursor_sdk") ?? getAdapterSessionManagement("cursor") ?? undefined,
+  models: cursorSdkModels,
+  modelProfiles: cursorSdkModelProfiles,
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: cursorSdkAgentConfigurationDoc,
 };
 
 const cursorLocalAdapter: ServerAdapterModule = {
@@ -366,6 +391,7 @@ function registerBuiltInAdapters() {
     openCodeLocalAdapter,
     piLocalAdapter,
     cursorLocalAdapter,
+    cursorSdkAdapter,
     geminiLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,7 @@
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
+    "@paperclipai/adapter-cursor-sdk": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",

--- a/ui/src/adapters/cursor-sdk/config-fields.tsx
+++ b/ui/src/adapters/cursor-sdk/config-fields.tsx
@@ -1,0 +1,49 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  DraftInput,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Injected into the prompt at runtime.";
+
+export function CursorSdkConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  hideInstructionsFile,
+}: AdapterConfigFieldsProps) {
+  if (hideInstructionsFile) return null;
+  return (
+    <Field label="Agent instructions file" hint={instructionsFileHint}>
+      <div className="flex items-center gap-2">
+        <DraftInput
+          value={
+            isCreate
+              ? values!.instructionsFilePath ?? ""
+              : eff(
+                  "adapterConfig",
+                  "instructionsFilePath",
+                  String(config.instructionsFilePath ?? ""),
+                )
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ instructionsFilePath: v })
+              : mark("adapterConfig", "instructionsFilePath", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="/absolute/path/to/AGENTS.md"
+        />
+        <ChoosePathButton />
+      </div>
+    </Field>
+  );
+}

--- a/ui/src/adapters/cursor-sdk/config-fields.tsx
+++ b/ui/src/adapters/cursor-sdk/config-fields.tsx
@@ -7,8 +7,25 @@ import { ChoosePathButton } from "../../components/PathInstructionsModal";
 
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const selectClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono";
+
 const instructionsFileHint =
   "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Injected into the prompt at runtime.";
+const runtimeHint =
+  "Where this agent runs. \"local\" runs the SDK in-process against the workspace cwd. \"cloud\" runs in a Cursor-managed VM against the configured GitHub repo. \"self_hosted\" runs in your own VM pool. New agents default to \"local\"; switch here after creation.";
+const repositoryHint =
+  "GitHub repository URL the cloud agent should clone. Required for runtime=cloud or self_hosted. Falls back to the workspace's repo URL when blank.";
+const refHint =
+  "Branch or commit the cloud agent starts from. Defaults to \"main\".";
+const enableCallbackHint =
+  "Forward the Paperclip API key into the cloud VM environment so the agent can call Paperclip APIs (skill fetch, comments, etc.). Off by default — leaving it off keeps the auth token out of the cloud VM environment.";
+
+type Runtime = "local" | "cloud" | "self_hosted";
+
+function normalizeRuntime(value: unknown): Runtime {
+  return value === "cloud" || value === "self_hosted" ? value : "local";
+}
 
 export function CursorSdkConfigFields({
   isCreate,
@@ -19,31 +36,98 @@ export function CursorSdkConfigFields({
   mark,
   hideInstructionsFile,
 }: AdapterConfigFieldsProps) {
-  if (hideInstructionsFile) return null;
+  // Adapter-specific fields (runtime / repository / ref / enableCallback) only
+  // surface in edit mode, where the existing adapterConfig is exposed via
+  // eff()/mark(). New agents default to runtime="local" via buildAdapterConfig;
+  // switch them to cloud or self_hosted by editing the agent after creation.
+  const showAdapterFields = !isCreate;
+
+  const runtime = showAdapterFields
+    ? normalizeRuntime(eff("adapterConfig", "runtime", String(config.runtime ?? "local")))
+    : "local";
+  const isCloudLike = runtime === "cloud" || runtime === "self_hosted";
+
   return (
-    <Field label="Agent instructions file" hint={instructionsFileHint}>
-      <div className="flex items-center gap-2">
-        <DraftInput
-          value={
-            isCreate
-              ? values!.instructionsFilePath ?? ""
-              : eff(
-                  "adapterConfig",
-                  "instructionsFilePath",
-                  String(config.instructionsFilePath ?? ""),
-                )
-          }
-          onCommit={(v) =>
-            isCreate
-              ? set!({ instructionsFilePath: v })
-              : mark("adapterConfig", "instructionsFilePath", v || undefined)
-          }
-          immediate
-          className={inputClass}
-          placeholder="/absolute/path/to/AGENTS.md"
-        />
-        <ChoosePathButton />
-      </div>
-    </Field>
+    <>
+      {!hideInstructionsFile && (
+        <Field label="Agent instructions file" hint={instructionsFileHint}>
+          <div className="flex items-center gap-2">
+            <DraftInput
+              value={
+                isCreate
+                  ? values!.instructionsFilePath ?? ""
+                  : eff(
+                      "adapterConfig",
+                      "instructionsFilePath",
+                      String(config.instructionsFilePath ?? ""),
+                    )
+              }
+              onCommit={(v) =>
+                isCreate
+                  ? set!({ instructionsFilePath: v })
+                  : mark("adapterConfig", "instructionsFilePath", v || undefined)
+              }
+              immediate
+              className={inputClass}
+              placeholder="/absolute/path/to/AGENTS.md"
+            />
+            <ChoosePathButton />
+          </div>
+        </Field>
+      )}
+
+      {showAdapterFields && (
+        <>
+          <Field label="Runtime" hint={runtimeHint}>
+            <select
+              className={selectClass}
+              value={runtime}
+              onChange={(e) => mark("adapterConfig", "runtime", e.target.value)}
+            >
+              <option value="local">local — in-process SDK against workspace cwd</option>
+              <option value="cloud">cloud — Cursor-managed VM</option>
+              <option value="self_hosted">self_hosted — your own VM pool</option>
+            </select>
+          </Field>
+
+          {isCloudLike && (
+            <>
+              <Field label="Repository (cloud)" hint={repositoryHint}>
+                <DraftInput
+                  value={eff("adapterConfig", "repository", String(config.repository ?? ""))}
+                  onCommit={(v) => mark("adapterConfig", "repository", v || undefined)}
+                  immediate
+                  className={inputClass}
+                  placeholder="https://github.com/owner/repo"
+                />
+              </Field>
+
+              <Field label="Starting ref (cloud)" hint={refHint}>
+                <DraftInput
+                  value={eff("adapterConfig", "ref", String(config.ref ?? "main"))}
+                  onCommit={(v) => mark("adapterConfig", "ref", v || "main")}
+                  immediate
+                  className={inputClass}
+                  placeholder="main"
+                />
+              </Field>
+            </>
+          )}
+
+          <Field label="Enable Paperclip API callback (cloud)" hint={enableCallbackHint}>
+            <select
+              className={selectClass}
+              value={config.enableCallback === true ? "on" : "off"}
+              onChange={(e) =>
+                mark("adapterConfig", "enableCallback", e.target.value === "on" ? true : false)
+              }
+            >
+              <option value="off">off — do not forward PAPERCLIP_API_KEY (default)</option>
+              <option value="on">on — forward PAPERCLIP_API_KEY into cloud VM</option>
+            </select>
+          </Field>
+        </>
+      )}
+    </>
   );
 }

--- a/ui/src/adapters/cursor-sdk/index.ts
+++ b/ui/src/adapters/cursor-sdk/index.ts
@@ -1,0 +1,11 @@
+import type { UIAdapterModule } from "../types";
+import { parseCursorSdkStdoutLine, buildCursorSdkConfig } from "@paperclipai/adapter-cursor-sdk/ui";
+import { CursorSdkConfigFields } from "./config-fields";
+
+export const cursorSdkUIAdapter: UIAdapterModule = {
+  type: "cursor_sdk",
+  label: "Cursor SDK",
+  parseStdoutLine: parseCursorSdkStdoutLine,
+  ConfigFields: CursorSdkConfigFields,
+  buildAdapterConfig: buildCursorSdkConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -3,6 +3,7 @@ import { acpxLocalUIAdapter } from "./acpx-local";
 import { claudeLocalUIAdapter } from "./claude-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorLocalUIAdapter } from "./cursor";
+import { cursorSdkUIAdapter } from "./cursor-sdk";
 import { geminiLocalUIAdapter } from "./gemini-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
@@ -58,6 +59,7 @@ function registerBuiltInUIAdapters() {
     openCodeLocalUIAdapter,
     piLocalUIAdapter,
     cursorLocalUIAdapter,
+    cursorSdkUIAdapter,
     openClawGatewayUIAdapter,
     processUIAdapter,
     httpUIAdapter,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The execution-services layer ships built-in adapters for local CLI agents (Claude, Codex, Cursor, etc.); the existing `cursor` adapter wraps the `cursor-agent` CLI subprocess
> - Cursor recently shipped the official `@cursor/sdk` (TypeScript, public beta) which exposes the same agent stack programmatically across local, Cursor-managed cloud VMs, and self-hosted VM pools, with native streaming, typed cancellation, typed errors, and clean session resume
> - `doc/plans/2026-02-23-cursor-cloud-adapter.md` planned a hand-rolled REST + webhook + bootstrap-exchange client for Cursor Background Agents — that design predates the SDK and is largely obsoleted by it
> - This PR adds a new, separate `cursor_sdk` adapter built on `@cursor/sdk` that supports all three runtime modes through one config surface — without touching the existing `cursor` adapter or any agent that currently uses it
> - The benefit is: SDK-native streaming/cancellation/resume, three runtime modes from one adapter, dynamic model catalog, and a foundation for future Cursor-cloud features (artifacts, MCP, subagents) — opt-in per agent

> ⚠️ **Roadmap overlap acknowledged.** ROADMAP.md lists "⚪ Cloud / Sandbox agents (e.g. Cursor / e2b agents)" as planned core work. This PR is offered for maintainer triage — happy to redirect, repackage as an external adapter plugin (per `AGENTS.md §11.PluginSystem`), or close in favor of a different direction. The work is deliberately additive so it can be carved out cleanly.

## What Changed

- New package `@paperclipai/adapter-cursor-sdk` at `packages/adapters/cursor-sdk/` — canonical 4-export shape (`./`, `./server`, `./ui`, `./cli`)
  - `src/index.ts` — `type: "cursor_sdk"`, label, model catalog, model profiles, full `agentConfigurationDoc`
  - `src/sdk-types.ts` — local SDK type shims + `loadCursorSdk()` dynamic loader (server boots even if `@cursor/sdk` isn't installed)
  - `src/runtime.ts` — config → SDK options for `local` / `cloud` / `self_hosted`, with validation
  - `src/events.ts` — `SDKMessage` → Paperclip NDJSON event mapping (system / assistant / user / thinking / tool_call / status / task / request / result / error)
  - `src/server/execute.ts` — `Agent.create` / `Agent.resume` + `run.stream()` orchestration, prompt assembly via `@paperclipai/adapter-utils`, timeout / cancel / dispose
  - `src/server/test.ts` — env diagnostics via `Cursor.me()`, runtime-specific checks
  - `src/server/index.ts` — session codec (sessionId = SDK `agentId`, with runtime / cwd / repoUrl / repoRef discriminators)
  - `src/ui/parse-stdout.ts`, `build-config.ts`, `index.ts` — transcript parser + create-flow config builder
  - `src/cli/format-event.ts`, `index.ts` — CLI pretty-printer
- New UI adapter folder `ui/src/adapters/cursor-sdk/` — `index.ts` + `config-fields.tsx`
- Registry wiring (additive only):
  - `packages/shared/src/constants.ts` — `cursor_sdk` added to `AGENT_ADAPTER_TYPES`
  - `server/src/adapters/registry.ts` — `cursorSdkAdapter` registered alongside `cursorLocalAdapter`
  - `ui/src/adapters/registry.ts` — `cursorSdkUIAdapter` registered
  - `cli/src/adapters/registry.ts` — `cursorSdkCLIAdapter` registered
- Workspace dep wiring — `@paperclipai/adapter-cursor-sdk` added to `server/`, `ui/`, `cli/` package.json
- `@cursor/sdk` added to root `package.json` as a normal dep so workspace install resolves it (declared as optional peer dep in the adapter package itself, so missing-SDK does not crash boot)
- Plan doc `doc/plans/2026-05-03-cursor-sdk-adapter.md` — full design with backwards-compat policy, runtime mode matrix, comparison vs `cursor-local`, V1 limitations, future enhancements, and implementation checklist
- Plan doc `doc/plans/2026-02-23-cursor-cloud-adapter.md` — superseded banner added; original content preserved for history

**Backwards compatibility (deliberate hard requirement):**
- `cursor-local` source files: 0 changes
- `cursor` adapter type stays in shared constants and all three registries
- Existing agents with `adapterType: "cursor"` continue resolving to `cursor-local` with no migration step

## Verification

Typecheck — clean across all touched packages:

```sh
pnpm --filter @paperclipai/adapter-cursor-sdk typecheck   # passes
pnpm --filter @paperclipai/shared typecheck               # passes
pnpm --filter @paperclipai/server typecheck               # passes
pnpm --filter @paperclipai/ui typecheck                   # passes
pnpm --filter paperclipai typecheck                       # passes
```

Vitest:

```sh
pnpm --filter @paperclipai/shared exec vitest run         # 9/9 test files pass
pnpm --filter @paperclipai/ui exec vitest run 'registry'  # registry tests pass
```

Smoke test plan (manual):

```sh
pnpm install                   # @cursor/sdk resolves from root dep
pnpm dev
# In the board UI, create an agent with:
#   adapterType: "cursor_sdk"
#   adapterConfig.runtime: "local"   (or "cloud" with a repo URL)
#   adapterConfig.env.CURSOR_API_KEY: { type: "secret_ref", secretId: "<id>" }
# Wake the agent and verify NDJSON events stream into the run log
# (system/init -> thinking -> assistant -> tool_call -> status -> result).
```

**Pre-existing test failures unrelated to this PR:** 8 failures in `cursor-local-execute.test.ts` and `cursor-local-adapter-environment.test.ts` on Windows due to GNU tar rejecting `C:\` paths in sandbox-sync fixtures. These tests fail on master without this PR. Linux/macOS CI should not see them. None of those tests reference `cursor_sdk` and the `cursor-local` source they exercise is byte-for-byte unchanged here.

`pnpm-lock.yaml` is intentionally not committed per `doc/DEVELOPING.md` — GitHub Actions owns the lockfile.

## Risks

- **`@cursor/sdk` is public beta.** APIs may shift before GA. Mitigated by:
  - Dynamic-loaded via `loadCursorSdk()` so missing or incompatible SDK does not crash server boot
  - Local SDK type shims in `sdk-types.ts` keep `pnpm typecheck` green even without the SDK installed, and isolate the breakage surface to one file when the SDK changes
- **V1 is local execution targets only.** Calls with `executionTarget.kind === "remote"` (E2B / SSH) return a clear error directing users to the existing `cursor` adapter. Adding remote-target support to `cursor_sdk` would duplicate transport machinery the SDK already handles for cloud mode.
- **Token / cost usage stays null.** The SDK does not yet expose per-run token usage; `costUsd` and `usage` are populated as `null`. Revisit when the SDK adds them.
- **OnboardingWizard not updated.** The wizard has many `cursor`-specific branches; users can still create `cursor_sdk` agents through the regular create-agent flow. Wizard integration can land in a follow-up.
- **MCP servers not persisted across `Agent.resume()`.** Documented in `agentConfigurationDoc`. The execute path re-passes `mcpServers` on every `send()` call to work around this.
- **Roadmap overlap (above).** May be redirected.
- **Migration safety.** Additive only. No DB schema, validator, or auth changes. No behavior change to any existing adapter type. Worst-case rollback is reverting this single commit.

## Model Used

- Claude Opus 4.7 (Anthropic) — model ID `claude-opus-4-7`, ~200k context. Used in agentic mode with full tool access (file read / write / edit, shell, web fetch, web search, todo tracking) to read AGENTS.md / SPEC-implementation.md / cursor-local source for architecture alignment, fetch the Cursor SDK docs, scaffold the adapter package, wire the three registries, and run typecheck plus targeted vitest verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — *partial: it overlaps the "Cloud / Sandbox agents" roadmap item; this is called out at the top of Thinking Path for explicit triage*
- [x] I have run tests locally and they pass — *typecheck clean across 5 packages; shared (9/9) and UI registry vitest suites pass; pre-existing Windows-only cursor-local tar failures are unrelated*
- [ ] I have added or updated tests where applicable — *no new tests in V1; the adapter is dynamic-load + SDK-driven so meaningful tests need either an `@cursor/sdk` mock layer or live API access. Happy to add in a follow-up if maintainers prefer.*
- [ ] If this change affects the UI, I have included before/after screenshots — *only adds a new adapter type to the create-flow dropdown + an "Agent instructions file" config field identical to cursor-local. Will add screenshots if requested.*
- [x] I have updated relevant documentation to reflect my changes — *new plan doc + superseded banner on prior plan + `agentConfigurationDoc` shipped with the package*
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
