### PR TITLE
Allow same-company agents to post issue comments (#2884)

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -61,6 +61,18 @@ const mockIssueThreadInteractionService = vi.hoisted(() => ({
   expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
 }));
 
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+async function waitForWakeup(assertion: () => void) {
+  await vi.waitFor(assertion);
+}
+
 function registerRouteMocks() {
   vi.doMock("@paperclipai/shared/telemetry", () => ({
     trackAgentTaskCompleted: vi.fn(),
@@ -106,13 +118,7 @@ function registerRouteMocks() {
       saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
     }),
     goalService: () => ({}),
-    heartbeatService: () => ({
-      wakeup: vi.fn(async () => undefined),
-      reportRunActivity: vi.fn(async () => undefined),
-      getRun: vi.fn(async () => null),
-      getActiveRunForAgent: vi.fn(async () => null),
-      cancelRun: vi.fn(async () => null),
-    }),
+    heartbeatService: () => mockHeartbeatService,
     instanceSettingsService: () => ({
       get: vi.fn(async () => ({
         id: "instance-settings-1",
@@ -270,6 +276,16 @@ describe("agent issue mutation checkout ownership", () => {
     mockStorageService.getObject.mockReset();
     mockStorageService.headObject.mockReset();
     mockStorageService.deleteObject.mockReset();
+    mockHeartbeatService.wakeup.mockReset();
+    mockHeartbeatService.reportRunActivity.mockReset();
+    mockHeartbeatService.getRun.mockReset();
+    mockHeartbeatService.getActiveRunForAgent.mockReset();
+    mockHeartbeatService.cancelRun.mockReset();
+    mockHeartbeatService.wakeup.mockResolvedValue(undefined);
+    mockHeartbeatService.reportRunActivity.mockResolvedValue(undefined);
+    mockHeartbeatService.getRun.mockResolvedValue(null);
+    mockHeartbeatService.getActiveRunForAgent.mockResolvedValue(null);
+    mockHeartbeatService.cancelRun.mockResolvedValue(null);
     mockAccessService.canUser.mockResolvedValue(true);
     mockAccessService.hasPermission.mockResolvedValue(false);
     mockAgentService.getById.mockImplementation(async (id: string) => {
@@ -358,7 +374,6 @@ describe("agent issue mutation checkout ownership", () => {
   it.each([
     ["patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked" })],
     ["delete", (app: express.Express) => request(app).delete(`/api/issues/${issueId}`)],
-    ["comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "blocked" })],
     [
       "document upsert",
       (app: express.Express) =>
@@ -439,7 +454,6 @@ describe("agent issue mutation checkout ownership", () => {
 
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
-    ["todo", "comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo noise" })],
     ["blocked", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked update" })],
   ])("rejects peer agent %s issue %s mutations outside active checkout ownership", async (status, _kind, sendRequest) => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: status as "todo" | "blocked", assigneeAgentId: ownerAgentId }));
@@ -451,6 +465,156 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  // ANKA-364: comments are append-only evidence and must be writable by any same-company agent,
+  // even when the issue is assigned to (and checked out by) someone else. The AGENTS.md
+  // mention-wake protocol depends on this channel for stranded triage notes. Mutating endpoints
+  // (PATCH, checkout) keep their assignee-only guards — they are covered by the rejection cases
+  // above and the dedicated checkout test below.
+  describe("non-assignee comment posting (ANKA-364)", () => {
+    it.each([
+      ["in_progress", "the issue is checked out by the owner"],
+      ["in_review", "a reviewer holds the issue"],
+      ["todo", "the issue is queued for the assignee"],
+      ["blocked", "the issue is waiting on a blocker"],
+      ["done", "the issue is closed"],
+    ])(
+      "allows a same-company peer to POST a comment when status is %s (%s)",
+      async (status) => {
+        mockIssueService.getById.mockResolvedValue(
+          makeIssue({ status, assigneeAgentId: ownerAgentId }),
+        );
+
+        const res = await request(await createApp(peerActor()))
+          .post(`/api/issues/${issueId}/comments`)
+          .send({ body: "evidence from mention-wake" });
+
+        expect(res.status, JSON.stringify(res.body)).toBe(201);
+        expect(mockIssueService.addComment).toHaveBeenCalledWith(
+          issueId,
+          "evidence from mention-wake",
+          expect.objectContaining({ agentId: peerAgentId }),
+        );
+        expect(mockIssueService.update).not.toHaveBeenCalled();
+        expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+      },
+    );
+
+    it("still rejects peer PATCH on the same in_review issue", async () => {
+      mockIssueService.getById.mockResolvedValue(
+        makeIssue({ status: "in_review", assigneeAgentId: ownerAgentId }),
+      );
+
+      const res = await request(await createApp(peerActor()))
+        .patch(`/api/issues/${issueId}`)
+        .send({ title: "should be blocked" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+      expect(mockIssueService.update).not.toHaveBeenCalled();
+    });
+
+    it("still rejects peer POST /checkout on the same in_review issue", async () => {
+      mockIssueService.getById.mockResolvedValue(
+        makeIssue({ status: "in_review", assigneeAgentId: ownerAgentId }),
+      );
+
+      const res = await request(await createApp(peerActor()))
+        .post(`/api/issues/${issueId}/checkout`)
+        .send({
+          agentId: ownerAgentId,
+          expectedStatuses: ["in_review"],
+        });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Agent can only checkout as itself");
+    });
+
+    it("rejects cross-company agent comments via assertCompanyAccess", async () => {
+      const res = await request(
+        await createApp(peerActor({ companyId: "99999999-9999-4999-8999-999999999999" })),
+      )
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: "wrong tenant" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    });
+
+    // Pin the wakeup side-effect of dropping the mutation guard from POST /comments.
+    // Greptile flagged on PR #4846 that peer-comment wakeup behaviour was not asserted; this
+    // block makes the contract explicit: peer comments wake the assignee on every active status
+    // (so #2884's mention-wake handoff lands), and stay silent on closed issues so they don't
+    // resurrect work that has already shipped.
+    describe("assignee wakeup behaviour on peer comments (ANKA-364 / #2884)", () => {
+      it.each(["todo", "in_progress", "in_review", "blocked"] as const)(
+        "wakes the assignee with reason=issue_commented when status is %s",
+        async (status) => {
+          mockIssueService.getById.mockResolvedValue(
+            makeIssue({ status, assigneeAgentId: ownerAgentId }),
+          );
+
+          const res = await request(await createApp(peerActor()))
+            .post(`/api/issues/${issueId}/comments`)
+            .send({ body: "peer evidence" });
+
+          expect(res.status, JSON.stringify(res.body)).toBe(201);
+          await waitForWakeup(() =>
+            expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+              ownerAgentId,
+              expect.objectContaining({
+                reason: "issue_commented",
+                requestedByActorType: "agent",
+                requestedByActorId: peerAgentId,
+                payload: expect.objectContaining({
+                  issueId,
+                  mutation: "comment",
+                }),
+              }),
+            ),
+          );
+        },
+      );
+
+      it.each(["done", "cancelled"] as const)(
+        "does not wake the assignee when peer comments on a closed (%s) issue",
+        async (status) => {
+          mockIssueService.getById.mockResolvedValue(
+            makeIssue({ status, assigneeAgentId: ownerAgentId }),
+          );
+
+          const res = await request(await createApp(peerActor()))
+            .post(`/api/issues/${issueId}/comments`)
+            .send({ body: "peer note on closed issue" });
+
+          expect(res.status, JSON.stringify(res.body)).toBe(201);
+          // Wakeups dispatch asynchronously; give the queued microtasks a chance to flush so a
+          // late wake call cannot escape this assertion.
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+        },
+      );
+
+      it("does not wake the assignee when the peer self-comments on its own assigned issue", async () => {
+        // Self-comment guard: actor === assignee should be a no-op wake even on active issues.
+        mockIssueService.getById.mockResolvedValue(
+          makeIssue({ status: "in_progress", assigneeAgentId: peerAgentId }),
+        );
+
+        const res = await request(await createApp(peerActor()))
+          .post(`/api/issues/${issueId}/comments`)
+          .send({ body: "self note" });
+
+        expect(res.status, JSON.stringify(res.body)).toBe(201);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        // The peer is the assignee here, so the wakeup-skip path (selfComment) should engage.
+        const calls = mockHeartbeatService.wakeup.mock.calls.filter(
+          ([targetAgentId]) => targetAgentId === peerAgentId,
+        );
+        expect(calls).toHaveLength(0);
+      });
+    });
   });
 
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -480,7 +480,10 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
-  it("rejects non-assignee agent POST comments on closed issues", async () => {
+  // ANKA-364: non-assignee agents may post comments (append-only evidence) but must NOT
+  // implicitly reopen a closed issue. Implicit reopen is restricted to human board comments
+  // by shouldImplicitlyMoveCommentedIssueToTodo; agent comments stay communicative.
+  it("accepts non-assignee agent POST comments on closed issues without reopening", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.addComment.mockResolvedValue({
       id: "comment-1",
@@ -503,10 +506,13 @@ describe.sequential("issue comment reopen routes", () => {
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "hello" });
 
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "hello",
+      expect.objectContaining({ agentId: "33333333-3333-4333-8333-333333333333" }),
+    );
     expect(mockIssueService.update).not.toHaveBeenCalled();
-    expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
@@ -875,7 +881,10 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "restart someone else's work", resume: true });
 
     expect(res.status).toBe(403);
-    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    // ANKA-364 dropped the generic mutation guard from POST /comments, so non-assignee resume
+    // intent is now caught one layer down by assertExplicitResumeIntentAllowed, whose message
+    // more accurately describes the action that was rejected.
+    expect(res.body.error).toBe("Agent cannot request follow-up for another agent's issue");
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3406,7 +3406,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    // Comments are append-only evidence and explicitly do not mutate status, ownership, or fields,
+    // so any same-company agent may post even if the issue is assigned to someone else. The
+    // AGENTS.md mention-wake protocol depends on this channel for stranded triage notes.
+    // Reopen / resume / interrupt intents are still gated by assertExplicitResumeIntentAllowed and
+    // the board-only interrupt branch below; implicit reopen is restricted to board users in
+    // shouldImplicitlyMoveCommentedIssueToTodo.
     const closedExecutionWorkspace = await getClosedIssueExecutionWorkspace(issue);
     if (closedExecutionWorkspace) {
       respondClosedIssueExecutionWorkspace(res, closedExecutionWorkspace);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, so cross-agent communication on a shared issue is part of the core control-plane contract.
> - The `agent-mentions` skill documents `agent://` mentions in issue comments as the canonical wake primitive between peers.
> - The runtime currently rejects exactly that flow: `POST /api/issues/:id/comments` calls `assertAgentIssueMutationAllowed`, which 403s with `Agent cannot mutate another agent's issue` whenever a peer agent (no `tasks:manage_active_checkouts` grant, not upstream in the `reportsTo` chain) tries to post evidence on the assignee's issue.
> - Closed PR #4846 (ANKA-364) proposed exactly this fix and was reviewed 4/5 by Greptile but closed unmerged for a tenant-internal governance reason — not on technical grounds. Issue #2884 tracks the same workflow gap from a second tenant; this is now at least the third tenant hitting it (Forma context: a `Reviewer` peer of `Engineer`, both reporting to `CTO`, gets 403 on every approve-and-notify path).
> - This pull request remirrors the #4846 diff and closes the wakeup test gap Greptile flagged on it.
> - The benefit is that the documented `AGENTS.md` mention-wake handoff actually lands instead of stranding evidence — without loosening any other mutation surface.

## What Changed

- `server/src/routes/issues.ts`: drop the single `assertAgentIssueMutationAllowed` call from the `POST /api/issues/:id/comments` handler. Replace it with a comment block explaining why comments are exempt. `assertCompanyAccess` stays in place. Reopen / resume / interrupt intents continue to be gated by `assertExplicitResumeIntentAllowed` and the existing board-only interrupt branch; implicit reopen is still restricted to board users via `shouldImplicitlyMoveCommentedIssueToTodo`.
- `server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`: keep the existing ANKA-364 acceptance block (peer agents may comment across active and closed statuses; PATCH and `/checkout` still 403; cross-company still 403). Promote the inline `heartbeatService` stub to a hoisted `mockHeartbeatService` so wakeup behaviour can be asserted, and add an `assignee wakeup behaviour on peer comments` describe block that pins the wake contract: peer comments fire `heartbeat.wakeup(assigneeId, { reason: "issue_commented" })` on `todo` / `in_progress` / `in_review` / `blocked`, do not wake on `done` / `cancelled`, and stay no-op when the actor is the assignee (self-comment skip).
- `server/src/__tests__/issue-comment-reopen-routes.test.ts`: flip the closed-issue non-assignee case from rejected→accepted (no implicit reopen, no wake) and reword the explicit-resume rejection to the more precise message produced one layer down by `assertExplicitResumeIntentAllowed`.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-agent-mutation-ownership-routes.test.ts src/__tests__/issue-comment-reopen-routes.test.ts` → 55 / 55 passing.
- Adjacent comment / heartbeat coverage also green: `issue-comment-cancel-routes.test.ts`, `issue-update-comment-wakeup-routes.test.ts`, `heartbeat-comment-wake-batching.test.ts` → 14 / 14 passing.
- Existing peer-agent rejection cases (`patch`, `delete`, `checkout`, `attachment upload`, `document upsert`, `work-products`) still return 403 — covered by the rejection tests in `issue-agent-mutation-ownership-routes.test.ts` that this PR leaves untouched.
- `npx tsc --noEmit` introduces no new errors. The pre-existing errors in `plugin-host-services.ts` / `plugin-tool-*.ts` reproduce on `master` without this PR (missing `@paperclipai/plugin-sdk` build artifacts in a clean install) and are unrelated.

## Risks

- **Behavioural shift, intentional**: peer-agent comments on non-closed issues now enqueue an `issue_commented` wake for the assignee. This was previously unreachable behind the 403. It is the behaviour issue #2884 explicitly asks for, and #4079 narrowed the wake scope so non-mentioned bystanders are not woken. The new test block pins this contract per status.
- **No change** to PATCH, `/checkout`, attachments, documents, work-products, interactions, dependency edits, feedback votes, or any other mutation route. Cross-company writes still 403 via `assertCompanyAccess`.
- **No schema change**, no migration, no API contract change. Same request/response shape on `POST /comments`; only the auth gate is loosened.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (1M context)
- Exact ID: `claude-opus-4-7[1m]`
- Capabilities used: extended reasoning, tool use (Read / Edit / Bash / gh CLI / direct repo + DB inspection), browsed prior closed PR #4846 and open issues #2884 / #4079 / #2063 / #4873 to confirm the fix has been independently proposed and is not duplicating planned roadmap work.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

Refs: closes #2884, mirrors closed PR #4846, related issues #4079 (mention scoping), #2063 (sub-agent comment 401 — separate code path, not addressed here).
