### PR TITLE
fix(codex-local): read models from codex's models_cache.json

### DIFF
--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -199,6 +199,35 @@ describe("loadCodexModels — cache path", () => {
     expect(models.some((m) => m.id === "codex-from-env-dir")).toBe(true);
   });
 
+  it("re-reads codex cache on refresh instead of using stale file data", async () => {
+    process.env.CODEX_HOME = tmpDir;
+    const cacheFile = path.join(tmpDir, "models_cache.json");
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        models: [
+          { slug: "codex-cache-before-refresh", display_name: "Before Refresh", visibility: "list" },
+        ],
+      }),
+    );
+
+    const initial = await listAdapterModels("codex_local");
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        models: [
+          { slug: "codex-cache-after-refresh", display_name: "After Refresh", visibility: "list" },
+        ],
+      }),
+    );
+
+    const refreshed = await refreshAdapterModels("codex_local");
+
+    expect(initial.some((m) => m.id === "codex-cache-before-refresh")).toBe(true);
+    expect(refreshed.some((m) => m.id === "codex-cache-after-refresh")).toBe(true);
+    expect(refreshed.some((m) => m.id === "codex-cache-before-refresh")).toBe(false);
+  });
+
   it("returns static fallback models when cache file is missing, without throwing", async () => {
     // tmpDir has no models_cache.json — simulates missing cache
     process.env.CODEX_HOME = tmpDir;

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import os from "os";
+import path from "path";
+import fs from "fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { models as cursorFallbackModels } from "@paperclipai/adapter-cursor-local";
 import { models as opencodeFallbackModels } from "@paperclipai/adapter-opencode-local";
@@ -8,7 +11,11 @@ import { resetCodexModelsCacheForTests } from "../adapters/codex-models.js";
 import { resetCursorModelsCacheForTests, setCursorModelsRunnerForTests } from "../adapters/cursor-models.js";
 
 describe("adapter model listing", () => {
+  let emptyCodexHome: string;
+
   beforeEach(() => {
+    emptyCodexHome = fs.mkdtempSync(path.join(os.tmpdir(), "codex-no-cache-"));
+    process.env.CODEX_HOME = emptyCodexHome;
     delete process.env.OPENAI_API_KEY;
     delete process.env.PAPERCLIP_OPENCODE_COMMAND;
     resetCodexModelsCacheForTests();
@@ -16,6 +23,11 @@ describe("adapter model listing", () => {
     setCursorModelsRunnerForTests(null);
     resetOpenCodeModelsCacheForTests();
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.CODEX_HOME;
+    fs.rmSync(emptyCodexHome, { recursive: true, force: true });
   });
 
   it("returns an empty list for unknown adapters", async () => {
@@ -128,4 +140,84 @@ describe("adapter model listing", () => {
     expect(first.some((model) => model.id === "composer-1")).toBe(true);
   });
 
+});
+
+
+describe("loadCodexModels — cache path", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-test-"));
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.CODEX_HOME;
+    resetCodexModelsCacheForTests();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.CODEX_HOME;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reads cache and filters out non-list visibility entries", async () => {
+    process.env.CODEX_HOME = tmpDir;
+    fs.writeFileSync(
+      path.join(tmpDir, "models_cache.json"),
+      JSON.stringify({
+        models: [
+          { slug: "codex-cache-visible", display_name: "Visible Model", visibility: "list" },
+          { slug: "codex-cache-hidden", display_name: "Hidden Model", visibility: "hidden" },
+          { slug: "codex-cache-internal", display_name: "Internal Model", visibility: "internal" },
+        ],
+      }),
+    );
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const models = await listAdapterModels("codex_local");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(models.some((m) => m.id === "codex-cache-visible")).toBe(true);
+    expect(models.some((m) => m.id === "codex-cache-hidden")).toBe(false);
+    expect(models.some((m) => m.id === "codex-cache-internal")).toBe(false);
+    // mergedWithFallback ensures static fallback ids are still present
+    expect(models.some((m) => m.id === "codex-mini-latest")).toBe(true);
+  });
+
+  it("honors CODEX_HOME env var for cache lookup, not ~/.codex", async () => {
+    process.env.CODEX_HOME = tmpDir;
+    fs.writeFileSync(
+      path.join(tmpDir, "models_cache.json"),
+      JSON.stringify({
+        models: [
+          { slug: "codex-from-env-dir", display_name: "From Env Dir", visibility: "list" },
+        ],
+      }),
+    );
+
+    const models = await listAdapterModels("codex_local");
+
+    expect(models.some((m) => m.id === "codex-from-env-dir")).toBe(true);
+  });
+
+  it("returns static fallback models when cache file is missing, without throwing", async () => {
+    // tmpDir has no models_cache.json — simulates missing cache
+    process.env.CODEX_HOME = tmpDir;
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const models = await listAdapterModels("codex_local");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(models).toEqual(codexFallbackModels);
+  });
+
+  it("returns static fallback models when cache file contains malformed JSON, without throwing", async () => {
+    process.env.CODEX_HOME = tmpDir;
+    fs.writeFileSync(path.join(tmpDir, "models_cache.json"), "{ not valid json ~~~");
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const models = await listAdapterModels("codex_local");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(models).toEqual(codexFallbackModels);
+  });
 });

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -1,6 +1,6 @@
-import os from "os";
-import path from "path";
-import fs from "fs";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { models as cursorFallbackModels } from "@paperclipai/adapter-cursor-local";

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -104,6 +104,9 @@ async function loadCodexModels(options?: { forceRefresh?: boolean }): Promise<Ad
   const forceRefresh = options?.forceRefresh === true;
   const fallback = dedupeModels(codexFallbackModels);
 
+  // Codex's file cache is the source of truth for ChatGPT-authenticated installs.
+  // forceRefresh only bypasses the in-memory OpenAI API cache below; this path
+  // intentionally re-reads models_cache.json on every call instead.
   const fromCache = readCodexModelsCache();
   if (fromCache.length > 0) {
     return mergedWithFallback(fromCache);

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -108,13 +108,11 @@ async function loadCodexModels(options?: { forceRefresh?: boolean }): Promise<Ad
   const forceRefresh = options?.forceRefresh === true;
   const fallback = dedupeModels(codexFallbackModels);
 
-  // Source 1: codex's own ChatGPT-auth-populated cache (no key needed)
   const fromCache = readCodexModelsCache();
   if (fromCache.length > 0) {
     return mergedWithFallback(fromCache);
   }
 
-  // Source 2 (existing): API-key path
   const apiKey = resolveOpenAiApiKey();
   if (!apiKey) return fallback;
 

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -104,9 +104,8 @@ async function loadCodexModels(options?: { forceRefresh?: boolean }): Promise<Ad
   const forceRefresh = options?.forceRefresh === true;
   const fallback = dedupeModels(codexFallbackModels);
 
-  // Codex's file cache is the source of truth for ChatGPT-authenticated installs.
-  // forceRefresh only bypasses the in-memory OpenAI API cache below; this path
-  // intentionally re-reads models_cache.json on every call instead.
+  // forceRefresh is a no-op here — reading the file is cheap, and the only
+  // memoization (cached) fingerprints the API-key path below.
   const fromCache = readCodexModelsCache();
   if (fromCache.length > 0) {
     return mergedWithFallback(fromCache);

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -1,8 +1,8 @@
-import os from "os";
-import path from "path";
-import fs from "fs";
+import path from "node:path";
+import fs from "node:fs";
 import type { AdapterModel } from "./types.js";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
+import { codexHomeDir } from "@paperclipai/adapter-codex-local/server";
 import { readConfigFile } from "../config-file.js";
 
 const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
@@ -50,13 +50,9 @@ interface CodexCacheEntry {
   visibility?: unknown;
 }
 
-function resolveCodexHome(): string {
-  return process.env.CODEX_HOME?.trim() || path.join(os.homedir(), ".codex");
-}
-
 function readCodexModelsCache(): AdapterModel[] {
   try {
-    const file = path.join(resolveCodexHome(), "models_cache.json");
+    const file = path.join(codexHomeDir(), "models_cache.json");
     const raw = JSON.parse(fs.readFileSync(file, "utf-8"));
     const list: CodexCacheEntry[] = Array.isArray(raw?.models) ? raw.models : [];
     return dedupeModels(

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -1,3 +1,6 @@
+import os from "os";
+import path from "path";
+import fs from "fs";
 import type { AdapterModel } from "./types.js";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { readConfigFile } from "../config-file.js";
@@ -41,6 +44,37 @@ function resolveOpenAiApiKey(): string | null {
   return configKey && configKey.length > 0 ? configKey : null;
 }
 
+interface CodexCacheEntry {
+  slug?: unknown;
+  display_name?: unknown;
+  visibility?: unknown;
+}
+
+function resolveCodexHome(): string {
+  return process.env.CODEX_HOME?.trim() || path.join(os.homedir(), ".codex");
+}
+
+function readCodexModelsCache(): AdapterModel[] {
+  try {
+    const file = path.join(resolveCodexHome(), "models_cache.json");
+    const raw = JSON.parse(fs.readFileSync(file, "utf-8"));
+    const list: CodexCacheEntry[] = Array.isArray(raw?.models) ? raw.models : [];
+    return dedupeModels(
+      list
+        .filter((m) => m.visibility === "list" && typeof m.slug === "string")
+        .map((m) => ({
+          id: (m.slug as string).trim(),
+          label:
+            typeof m.display_name === "string" && m.display_name.trim().length > 0
+              ? m.display_name.trim()
+              : (m.slug as string).trim(),
+        })),
+    );
+  } catch {
+    return [];
+  }
+}
+
 async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), OPENAI_MODELS_TIMEOUT_MS);
@@ -72,8 +106,16 @@ async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
 
 async function loadCodexModels(options?: { forceRefresh?: boolean }): Promise<AdapterModel[]> {
   const forceRefresh = options?.forceRefresh === true;
-  const apiKey = resolveOpenAiApiKey();
   const fallback = dedupeModels(codexFallbackModels);
+
+  // Source 1: codex's own ChatGPT-auth-populated cache (no key needed)
+  const fromCache = readCodexModelsCache();
+  if (fromCache.length > 0) {
+    return mergedWithFallback(fromCache);
+  }
+
+  // Source 2 (existing): API-key path
+  const apiKey = resolveOpenAiApiKey();
   if (!apiKey) return fallback;
 
   const now = Date.now();


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The Codex local adapter exposes which models the user's Codex install can run.
> - Discovery previously went OpenAI API key -> static fallback list.
> - Most Codex users authenticate via ChatGPT account and have no `OPENAI_API_KEY`, so the API path was a silent no-op and Refresh did nothing.
> - Codex itself populates `~/.codex/models_cache.json` from chatgpt.com/backend-api during normal use.
> - This PR reads that cache as the highest-priority source, then falls through to the existing API and static paths.
> - Benefit: ChatGPT-auth users now see their real available models without new credentials, network calls, or auth.

## What Changed

- `server/src/adapters/codex-models.ts`: read `~/.codex/models_cache.json` (honoring `CODEX_HOME`) as the first model source.
- Filter cached entries to visible `"list"` models, then merge with the static fallback list via existing `dedupeModels` / `mergedWithFallback`.
- Reuses `codexHomeDir` and `codexFallbackModels` from `@paperclipai/adapter-codex-local/server` — no new helpers.
- Existing OpenAI API-key path and static fallback preserved when the cache is missing, empty, or malformed.
- `server/src/__tests__/adapter-models.test.ts`: tests for cache-present + visibility filter, `CODEX_HOME` override, missing cache, malformed JSON. Existing tests isolated from any real `~/.codex/models_cache.json` on host.

## Verification

- `pnpm exec vitest run server/src/__tests__/adapter-models.test.ts` — green.
- Local CI mirror green: typecheck, build, tests.
- Live-tested on openclaw at `192.168.5.28:32752`: new slugs (`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.2`) appear in the Codex model dropdown after clicking Refresh.

## Risks

- Low. No new network calls, no new auth.
- Cache only refreshes during interactive Codex sessions, so users without recent Codex activity may see stale data. Static fallback list mitigates regression vs. prior behavior.
- `forceRefresh` re-reads the file every call (Codex owns refreshing it); it does not bypass the file cache to hit the OpenAI API. Intentional — the file is authoritative when present.

## Model Used

- Anthropic Claude Opus 4.7 (`claude-opus-4-7`) via Claude Code, with shell, git, and `gh` tool access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — adapter-only; verified via live dropdown on openclaw)
- [x] I have updated relevant documentation to reflect my changes (N/A — no user-facing docs)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #1317. Sibling: opencode adapter fix in #3137. Related: #3848, #3128.