### PR TITLE
fix(claude-local): retry session on 'Could not process image' API error (exits 0)

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -45,6 +45,7 @@ import {
   describeClaudeFailure,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
+  isClaudeImageProcessingError,
   isClaudeMaxTurnsResult,
   isClaudeTransientUpstreamError,
   isClaudeUnknownSessionError,
@@ -829,17 +830,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   try {
     const initial = await runAttempt(sessionId ?? null);
-    if (
+    const isUnknownSession =
       sessionId &&
       !initial.proc.timedOut &&
       (initial.proc.exitCode ?? 0) !== 0 &&
       initial.parsed &&
-      isClaudeUnknownSessionError(initial.parsed)
-    ) {
-      await onLog(
-        "stdout",
-        `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
-      );
+      isClaudeUnknownSessionError(initial.parsed);
+    // Image-processing errors exit with code 0 (subtype:"success", is_error:true), so the
+    // exit-code gate used for unknown-session errors would never fire for them.
+    const isImageErrorOnResume =
+      sessionId && !initial.proc.timedOut && initial.parsed && isClaudeImageProcessingError(initial.parsed);
+    if (isUnknownSession || isImageErrorOnResume) {
+      const reason = isImageErrorOnResume ? `stored session contains an unprocessable image` : `is unavailable`;
+      await onLog("stdout", `[paperclip] Claude resume session "${sessionId}" ${reason}; retrying with a fresh session.\n`);
       const retry = await runAttempt(null);
       return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
     }

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -127,6 +127,15 @@ describe("isClaudeImageProcessingError", () => {
     ).toBe(true);
   });
 
+  it("returns false when is_error is false even if message text matches", () => {
+    expect(
+      isClaudeImageProcessingError({
+        is_error: false,
+        result: "Task complete: could not process image due to format, but handled gracefully.",
+      }),
+    ).toBe(false);
+  });
+
   it("returns false for unrelated errors", () => {
     expect(
       isClaudeImageProcessingError({

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   extractClaudeRetryNotBefore,
+  isClaudeImageProcessingError,
   isClaudeTransientUpstreamError,
 } from "./parse.js";
 
@@ -91,6 +92,52 @@ describe("isClaudeTransientUpstreamError", () => {
     expect(
       isClaudeTransientUpstreamError({
         errorMessage: "Invalid request_error: Unknown parameter 'foo'.",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isClaudeImageProcessingError", () => {
+  it("detects 'Could not process image' in result text (exit-code-0 path)", () => {
+    expect(
+      isClaudeImageProcessingError({
+        subtype: "success",
+        is_error: true,
+        result: "API Error: 400 {\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Could not process image\"}}",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects 'Could not process image' in the errors array", () => {
+    expect(
+      isClaudeImageProcessingError({
+        is_error: true,
+        result: "",
+        errors: [{ type: "invalid_request_error", message: "Could not process image" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(
+      isClaudeImageProcessingError({
+        is_error: true,
+        result: "could not process image: bad format",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(
+      isClaudeImageProcessingError({
+        is_error: true,
+        result: "No conversation found with session id abc-123",
+      }),
+    ).toBe(false);
+    expect(
+      isClaudeImageProcessingError({
+        is_error: false,
+        result: "Task complete.",
       }),
     ).toBe(false);
   });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -188,6 +188,15 @@ export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): bo
   );
 }
 
+export function isClaudeImageProcessingError(parsed: Record<string, unknown>): boolean {
+  const resultText = asString(parsed.result, "").trim();
+  const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
+    .map((msg) => msg.trim())
+    .filter(Boolean);
+
+  return allMessages.some((msg) => /could not process image/i.test(msg));
+}
+
 function buildClaudeTransientHaystack(input: {
   parsed?: Record<string, unknown> | null;
   stdout?: string | null;

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -189,6 +189,7 @@ export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): bo
 }
 
 export function isClaudeImageProcessingError(parsed: Record<string, unknown>): boolean {
+  if (!parsed.is_error) return false;
   const resultText = asString(parsed.result, "").trim();
   const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
     .map((msg) => msg.trim())


### PR DESCRIPTION
Closes #5090

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The `claude-local` adapter runs the Claude CLI as a subprocess and manages session state between turns
> - When a session is resumed, the Claude CLI replays stored history — including any image bytes from prior turns
> - If those image bytes are no longer processable by the Anthropic API (e.g. after a session gap), the API returns HTTP 400 with `"Could not process image"`
> - The Claude CLI exits with **code 0** in this case (`subtype: "success"`, `is_error: true`), because it treats the response as a completed run rather than a crash
> - The existing `isClaudeUnknownSessionError` retry gate in `execute.ts` checks `(exitCode ?? 0) !== 0` — so it never fires for this error class
> - This PR adds `isClaudeImageProcessingError` detection in `parse.ts` and a matching retry branch in `execute.ts` that bypasses the exit-code gate, clearing the stale session and retrying fresh
> - The benefit is that agents recover automatically from image-processing failures on session resume, instead of looping indefinitely

## What Changed

- **`parse.ts`** — adds `isClaudeImageProcessingError(parsed)`: detects `/could not process image/i` in `result` text and `errors[]`, following the same shape as `isClaudeUnknownSessionError`
- **`execute.ts`** — imports `isClaudeImageProcessingError`; splits the existing guard into `isUnknownSession` (keeps exit-code gate) and `isImageErrorOnResume` (no exit-code gate); combined `if (isUnknownSession || isImageErrorOnResume)` clears session and retries with a descriptive log line
- **`parse.test.ts`** — four new unit tests for `isClaudeImageProcessingError`: exit-code-0 result path, errors-array path, case insensitivity, false-positive rejection

## Verification

- Run `npm test` in `packages/adapters/claude-local` — all four new tests pass, existing tests unaffected
- Validated in production on a Paperclip instance running `@paperclipai/adapter-claude-local@2026.428.0` by patching `dist/` directly — the agent successfully recovered from the image error and completed a previously-stuck task that had been looping on every resume attempt

## Risks

Low risk. The change is purely additive:
- `isClaudeImageProcessingError` is a new function; no existing code paths are modified
- The retry logic itself is unchanged — only the condition for entering the retry block is extended to include this new error class
- The exit-code gate removal applies only to image errors; unknown-session retry behaviour is unaffected
- Worst case: a false-positive match causes one unnecessary session reset (recoverable)

## Model Used

- **Provider:** Anthropic
- **Model:** claude-sonnet-4-6 (Claude Sonnet 4.6)
- **Context window:** 200k tokens
- **Mode:** Standard (tool use enabled; no extended thinking)
- This PR was produced with AI assistance via the Paperclip agent harness running the `claude-local` adapter

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (this is a bug fix, not a feature)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (4 new unit tests in `parse.test.ts`)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [x] I have updated relevant documentation to reflect my changes (N/A — internal adapter logic)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge