### PR TITLE
feat(cli): full-API CLI extension (re #5058)

### DIFF
--- a/cli/src/client/http.ts
+++ b/cli/src/client/http.ts
@@ -81,6 +81,13 @@ export class PaperclipApiClient {
     }, opts);
   }
 
+  put<T>(path: string, body?: unknown, opts?: RequestOptions): Promise<T | null> {
+    return this.request<T>(path, {
+      method: "PUT",
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }, opts);
+  }
+
   delete<T>(path: string, opts?: RequestOptions): Promise<T | null> {
     return this.request<T>(path, { method: "DELETE" }, opts);
   }

--- a/cli/src/client/http.ts
+++ b/cli/src/client/http.ts
@@ -110,6 +110,26 @@ export class PaperclipApiClient {
   }
 
   /**
+   * Issue a GET that streams the binary response body. Caller is responsible
+   * for piping the returned ReadableStream into a writable destination.
+   */
+  async getStream(path: string): Promise<{ body: ReadableStream<Uint8Array>; contentType: string | null }> {
+    const url = buildUrl(this.apiBase, path);
+    const headers: Record<string, string> = { accept: "*/*" };
+    if (this.apiKey) headers.authorization = `Bearer ${this.apiKey}`;
+    if (this.runId) headers["x-paperclip-run-id"] = this.runId;
+    let response: Response;
+    try {
+      response = await fetch(url, { headers });
+    } catch (error) {
+      throw new ApiConnectionError({ apiBase: this.apiBase, path, method: "GET", cause: error });
+    }
+    if (!response.ok) throw await toApiError(response);
+    if (!response.body) throw new Error("Empty response body");
+    return { body: response.body, contentType: response.headers.get("content-type") };
+  }
+
+  /**
    * Issue a POST whose body is multipart form data. Used for asset/image
    * upload endpoints.
    */

--- a/cli/src/client/http.ts
+++ b/cli/src/client/http.ts
@@ -88,6 +88,51 @@ export class PaperclipApiClient {
     }, opts);
   }
 
+  /**
+   * Issue a GET that returns raw text instead of JSON. Useful for
+   * /api/llms/* and other text/plain endpoints.
+   */
+  async getText(path: string): Promise<string> {
+    const url = buildUrl(this.apiBase, path);
+    const headers: Record<string, string> = { accept: "text/plain, */*" };
+    if (this.apiKey) headers.authorization = `Bearer ${this.apiKey}`;
+    if (this.runId) headers["x-paperclip-run-id"] = this.runId;
+    let response: Response;
+    try {
+      response = await fetch(url, { headers });
+    } catch (error) {
+      throw new ApiConnectionError({ apiBase: this.apiBase, path, method: "GET", cause: error });
+    }
+    if (!response.ok) {
+      throw await toApiError(response);
+    }
+    return await response.text();
+  }
+
+  /**
+   * Issue a POST whose body is multipart form data. Used for asset/image
+   * upload endpoints.
+   */
+  async postMultipart<T>(path: string, form: FormData): Promise<T | null> {
+    const url = buildUrl(this.apiBase, path);
+    const headers: Record<string, string> = { accept: "application/json" };
+    if (this.apiKey) headers.authorization = `Bearer ${this.apiKey}`;
+    if (this.runId) headers["x-paperclip-run-id"] = this.runId;
+    let response: Response;
+    try {
+      response = await fetch(url, { method: "POST", headers, body: form });
+    } catch (error) {
+      throw new ApiConnectionError({ apiBase: this.apiBase, path, method: "POST", cause: error });
+    }
+    if (!response.ok) {
+      throw await toApiError(response);
+    }
+    if (response.status === 204) return null;
+    const text = await response.text();
+    if (!text.trim()) return null;
+    return safeParseJson(text) as T;
+  }
+
   delete<T>(path: string, opts?: RequestOptions): Promise<T | null> {
     return this.request<T>(path, { method: "DELETE" }, opts);
   }

--- a/cli/src/commands/client/access.ts
+++ b/cli/src/commands/client/access.ts
@@ -1,0 +1,640 @@
+import { readFileSync } from "node:fs";
+import { Command } from "commander";
+import {
+  acceptInviteSchema,
+  archiveCompanyMemberSchema,
+  claimJoinRequestApiKeySchema,
+  createCompanyInviteSchema,
+  createOpenClawInvitePromptSchema,
+  updateCompanyMemberSchema,
+  updateCompanyMemberWithPermissionsSchema,
+  updateMemberPermissionsSchema,
+  updateUserCompanyAccessSchema,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface PayloadOptions extends BaseClientOptions {
+  payload?: string;
+  payloadFile?: string;
+}
+
+interface CompanyOnly extends BaseClientOptions {
+  companyId?: string;
+}
+
+function readJson(opts: PayloadOptions, name: string): unknown {
+  if (opts.payload !== undefined && opts.payloadFile !== undefined) {
+    throw new Error(`Pass either --${name} or --${name}-file, not both.`);
+  }
+  if (opts.payload !== undefined) {
+    try {
+      return JSON.parse(opts.payload);
+    } catch (err) {
+      throw new Error(`--${name} must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  if (opts.payloadFile !== undefined) {
+    const raw = readFileSync(opts.payloadFile, "utf8");
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`--${name}-file must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  return undefined;
+}
+
+export function registerAccessCommands(program: Command): void {
+  // ── invites ─────────────────────────────────────────────────────────────
+  const invite = program.command("invite").description("Company invite operations");
+
+  addCommonClientOptions(
+    invite
+      .command("list")
+      .description("List invites for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: CompanyOnly) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/invites`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    invite
+      .command("create")
+      .description("Create a new invite")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--payload <json>", "Invite payload as JSON object")
+      .option("--payload-file <path>", "Read invite payload from JSON file")
+      .action(async (opts: PayloadOptions & CompanyOnly) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = createCompanyInviteSchema.parse(payload);
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/invites`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    invite
+      .command("openclaw-prompt")
+      .description("Generate an OpenClaw invite prompt for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--payload <json>", "Prompt payload as JSON object")
+      .option("--payload-file <path>", "Read prompt payload from JSON file")
+      .action(async (opts: PayloadOptions & CompanyOnly) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = createOpenClawInvitePromptSchema.parse(payload);
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/openclaw/invite-prompt`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    invite
+      .command("get")
+      .description("Look up an invite by token")
+      .argument("<token>", "Invite token")
+      .action(async (token: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/invites/${encodeURIComponent(token)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  for (const [verb, path] of [
+    ["onboarding", "onboarding"],
+    ["onboarding-text", "onboarding.txt"],
+    ["skills-index", "skills/index"],
+    ["test-resolution", "test-resolution"],
+  ] as const) {
+    addCommonClientOptions(
+      invite
+        .command(verb)
+        .description(`Get an invite's ${verb}`)
+        .argument("<token>", "Invite token")
+        .action(async (token: string, opts: BaseClientOptions) => {
+          try {
+            const ctx = resolveCommandContext(opts);
+            const row = await ctx.api.get<unknown>(
+              `/api/invites/${encodeURIComponent(token)}/${path}`,
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+
+  addCommonClientOptions(
+    invite
+      .command("skill")
+      .description("Get a single invite skill by name")
+      .argument("<token>", "Invite token")
+      .argument("<skillName>", "Skill name")
+      .action(async (token: string, skillName: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/invites/${encodeURIComponent(token)}/skills/${encodeURIComponent(skillName)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    invite
+      .command("accept")
+      .description("Accept an invite (joining a company)")
+      .argument("<token>", "Invite token")
+      .option("--payload <json>", "Accept payload as JSON object")
+      .option("--payload-file <path>", "Read accept payload from JSON file")
+      .action(async (token: string, opts: PayloadOptions) => {
+        try {
+          const payload = (readJson(opts, "payload") as Record<string, unknown> | undefined) ?? {};
+          const parsed = acceptInviteSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/invites/${encodeURIComponent(token)}/accept`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    invite
+      .command("revoke")
+      .description("Revoke an invite by ID")
+      .argument("<inviteId>", "Invite ID")
+      .action(async (inviteId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/invites/${encodeURIComponent(inviteId)}/revoke`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── join requests ───────────────────────────────────────────────────────
+  const joinRequest = program
+    .command("join-request")
+    .description("Company join request operations");
+
+  addCommonClientOptions(
+    joinRequest
+      .command("list")
+      .description("List join requests for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: CompanyOnly) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/join-requests`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  for (const verb of ["approve", "reject"] as const) {
+    addCommonClientOptions(
+      joinRequest
+        .command(verb)
+        .description(`${verb[0].toUpperCase()}${verb.slice(1)} a join request`)
+        .requiredOption("-C, --company-id <id>", "Company ID")
+        .argument("<requestId>", "Join request ID")
+        .action(async (requestId: string, opts: CompanyOnly) => {
+          try {
+            const ctx = resolveCommandContext(opts, { requireCompany: true });
+            const row = await ctx.api.post<unknown>(
+              `/api/companies/${ctx.companyId}/join-requests/${encodeURIComponent(requestId)}/${verb}`,
+              {},
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+
+  addCommonClientOptions(
+    joinRequest
+      .command("claim-api-key")
+      .description("Claim the API key for an approved join request via secret")
+      .argument("<requestId>", "Join request ID")
+      .option("--payload <json>", "Claim payload { claimSecret } as JSON")
+      .option("--payload-file <path>", "Read claim payload from JSON file")
+      .action(async (requestId: string, opts: PayloadOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = claimJoinRequestApiKeySchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/join-requests/${encodeURIComponent(requestId)}/claim-api-key`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── members ─────────────────────────────────────────────────────────────
+  const member = program.command("member").description("Company member operations");
+
+  addCommonClientOptions(
+    member
+      .command("list")
+      .description("List members in a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: CompanyOnly) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/members`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    member
+      .command("user-directory")
+      .description("List the user directory for a company (users + agents)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: CompanyOnly) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/user-directory`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    member
+      .command("update")
+      .description("Update a member's role")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<memberId>", "Member ID")
+      .option("--payload <json>", "Patch as JSON object")
+      .option("--payload-file <path>", "Read patch from JSON file")
+      .action(async (memberId: string, opts: PayloadOptions & CompanyOnly) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = updateCompanyMemberSchema.parse(payload);
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.patch<unknown>(
+            `/api/companies/${ctx.companyId}/members/${encodeURIComponent(memberId)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    member
+      .command("role-and-grants")
+      .description("Update a member's role and permission grants together")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<memberId>", "Member ID")
+      .option("--payload <json>", "Patch as JSON object")
+      .option("--payload-file <path>", "Read patch from JSON file")
+      .action(async (memberId: string, opts: PayloadOptions & CompanyOnly) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = updateCompanyMemberWithPermissionsSchema.parse(payload);
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.patch<unknown>(
+            `/api/companies/${ctx.companyId}/members/${encodeURIComponent(memberId)}/role-and-grants`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    member
+      .command("archive")
+      .description("Archive a member from a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<memberId>", "Member ID")
+      .option("--payload <json>", "Archive payload as JSON")
+      .option("--payload-file <path>", "Read archive payload from JSON file")
+      .action(async (memberId: string, opts: PayloadOptions & CompanyOnly) => {
+        try {
+          const payload = (readJson(opts, "payload") as Record<string, unknown> | undefined) ?? {};
+          const parsed = archiveCompanyMemberSchema.parse(payload);
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/members/${encodeURIComponent(memberId)}/archive`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    member
+      .command("permissions")
+      .description("Update a member's permission grants")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<memberId>", "Member ID")
+      .option("--payload <json>", "Permissions patch as JSON")
+      .option("--payload-file <path>", "Read permissions patch from JSON file")
+      .action(async (memberId: string, opts: PayloadOptions & CompanyOnly) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = updateMemberPermissionsSchema.parse(payload);
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.patch<unknown>(
+            `/api/companies/${ctx.companyId}/members/${encodeURIComponent(memberId)}/permissions`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── admin users ─────────────────────────────────────────────────────────
+  const adminUser = program
+    .command("admin-user")
+    .description("Instance admin user operations");
+
+  addCommonClientOptions(
+    adminUser
+      .command("list")
+      .description("List instance users")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>("/api/admin/users")) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  for (const verb of ["promote-instance-admin", "demote-instance-admin"] as const) {
+    addCommonClientOptions(
+      adminUser
+        .command(verb)
+        .description(`${verb.replace("-", " ")} for a user`)
+        .argument("<userId>", "User ID")
+        .action(async (userId: string, opts: BaseClientOptions) => {
+          try {
+            const ctx = resolveCommandContext(opts);
+            const row = await ctx.api.post<unknown>(
+              `/api/admin/users/${encodeURIComponent(userId)}/${verb}`,
+              {},
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+
+  addCommonClientOptions(
+    adminUser
+      .command("company-access-get")
+      .description("List the companies a user has access to")
+      .argument("<userId>", "User ID")
+      .action(async (userId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/admin/users/${encodeURIComponent(userId)}/company-access`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    adminUser
+      .command("company-access-set")
+      .description("Replace the companies a user has access to")
+      .argument("<userId>", "User ID")
+      .option("--payload <json>", "Update payload as JSON object")
+      .option("--payload-file <path>", "Read payload from JSON file")
+      .action(async (userId: string, opts: PayloadOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = updateUserCompanyAccessSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.put<unknown>(
+            `/api/admin/users/${encodeURIComponent(userId)}/company-access`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── skills catalog (instance-wide) ──────────────────────────────────────
+  const catalog = program
+    .command("skill-catalog")
+    .description("Instance-wide skill catalog (built-in / available)");
+
+  addCommonClientOptions(
+    catalog
+      .command("available")
+      .description("List skills available on this instance")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>("/api/skills/available");
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    catalog
+      .command("index")
+      .description("Get the skills index")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>("/api/skills/index");
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    catalog
+      .command("get")
+      .description("Get one skill from the catalog")
+      .argument("<skillName>", "Skill name")
+      .action(async (skillName: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/skills/${encodeURIComponent(skillName)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── board claim ─────────────────────────────────────────────────────────
+  const boardClaim = program
+    .command("board-claim")
+    .description("Board admin claim flow");
+
+  addCommonClientOptions(
+    boardClaim
+      .command("get")
+      .description("Inspect a board claim token")
+      .argument("<token>", "Claim token")
+      .action(async (token: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/board-claim/${encodeURIComponent(token)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    boardClaim
+      .command("claim")
+      .description("Claim a board claim token (becomes board admin)")
+      .argument("<token>", "Claim token")
+      .option("--payload <json>", "Optional claim body as JSON")
+      .option("--payload-file <path>", "Read claim body from JSON file")
+      .action(async (token: string, opts: PayloadOptions) => {
+        try {
+          const payload = readJson(opts, "payload") ?? {};
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/board-claim/${encodeURIComponent(token)}/claim`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/adapter.ts
+++ b/cli/src/commands/client/adapter.ts
@@ -1,0 +1,362 @@
+import { Command } from "commander";
+import { testAdapterEnvironmentSchema } from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface AdapterInstallOptions extends BaseClientOptions {
+  package: string;
+  localPath?: boolean;
+  version?: string;
+}
+
+interface AdapterDeleteOptions extends BaseClientOptions {
+  yes?: boolean;
+}
+
+interface AdapterModelsOptions extends BaseClientOptions {
+  companyId?: string;
+  refresh?: boolean;
+}
+
+interface AdapterTestEnvOptions extends BaseClientOptions {
+  companyId?: string;
+  adapterConfig?: string;
+  environmentId?: string;
+}
+
+function parseJsonObject(
+  raw: string | undefined,
+  name: string,
+): Record<string, unknown> | undefined {
+  if (raw === undefined) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`--${name} must be valid JSON: ${(err as Error).message}`);
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`--${name} must be a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+async function confirmAction(message: string): Promise<boolean> {
+  const { confirm } = await import("@clack/prompts");
+  const answer = await confirm({ message, initialValue: false });
+  return answer === true;
+}
+
+export function registerAdapterCommands(program: Command): void {
+  const adapter = program
+    .command("adapter")
+    .description("Adapter (instance) and per-company adapter introspection");
+
+  addCommonClientOptions(
+    adapter
+      .command("list")
+      .description("List installed adapters and their state")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>("/api/adapters")) ?? [];
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const r of rows as Array<Record<string, unknown>>) {
+            console.log(
+              formatInlineRecord({
+                type: r.type as string | undefined,
+                source: (r.source as string | undefined) ?? null,
+                version: (r.version as string | undefined) ?? null,
+                disabled: r.disabled as boolean | undefined,
+                overridesBuiltin: r.overridesBuiltin as boolean | undefined,
+                overridePaused: r.overridePaused as boolean | undefined,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    adapter
+      .command("install")
+      .description("Install an external adapter from npm or a local path (instance admin)")
+      .requiredOption("--package <name>", "npm package name or local path")
+      .option("--local-path", "Treat --package as a local filesystem path")
+      .option("--version <version>", "npm version to install (npm packages only)")
+      .action(async (opts: AdapterInstallOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload: Record<string, unknown> = { packageName: opts.package };
+          if (opts.localPath) payload.isLocalPath = true;
+          if (opts.version !== undefined) payload.version = opts.version;
+          const row = await ctx.api.post<unknown>("/api/adapters/install", payload);
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    adapter
+      .command("enable")
+      .description("Enable an adapter (instance admin)")
+      .argument("<type>", "Adapter type")
+      .action(async (type: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.patch<unknown>(
+            `/api/adapters/${encodeURIComponent(type)}`,
+            { disabled: false },
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    adapter
+      .command("disable")
+      .description("Disable an adapter (instance admin)")
+      .argument("<type>", "Adapter type")
+      .action(async (type: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.patch<unknown>(
+            `/api/adapters/${encodeURIComponent(type)}`,
+            { disabled: true },
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const override = adapter
+    .command("override")
+    .description("Pause/resume an external adapter's override of a builtin (instance admin)");
+
+  for (const [verb, paused] of [["pause", true], ["resume", false]] as const) {
+    addCommonClientOptions(
+      override
+        .command(verb)
+        .description(`${verb[0].toUpperCase()}${verb.slice(1)} the override (paused=${paused})`)
+        .argument("<type>", "Builtin adapter type")
+        .action(async (type: string, opts: BaseClientOptions) => {
+          try {
+            const ctx = resolveCommandContext(opts);
+            const row = await ctx.api.patch<unknown>(
+              `/api/adapters/${encodeURIComponent(type)}/override`,
+              { paused },
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+
+  addCommonClientOptions(
+    adapter
+      .command("delete")
+      .description("Unregister an external adapter (instance admin, builtins blocked)")
+      .argument("<type>", "Adapter type")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (type: string, opts: AdapterDeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const ok = await confirmAction(
+              `Delete adapter ${type}? Existing agents using it will lose runtime support.`,
+            );
+            if (!ok) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<unknown>(`/api/adapters/${encodeURIComponent(type)}`);
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    adapter
+      .command("reload")
+      .description("Reload an external adapter module without restarting the server")
+      .argument("<type>", "Adapter type")
+      .action(async (type: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/adapters/${encodeURIComponent(type)}/reload`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    adapter
+      .command("reinstall")
+      .description("Reinstall an npm-sourced adapter (pulls latest)")
+      .argument("<type>", "Adapter type")
+      .action(async (type: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/adapters/${encodeURIComponent(type)}/reinstall`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    adapter
+      .command("config-schema")
+      .description("Fetch an adapter's declarative config schema")
+      .argument("<type>", "Adapter type")
+      .action(async (type: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/adapters/${encodeURIComponent(type)}/config-schema`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    adapter
+      .command("models")
+      .description("List available models for an adapter in a company")
+      .argument("<type>", "Adapter type")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--refresh", "Force refresh from upstream (slower)")
+      .action(async (type: string, opts: AdapterModelsOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const params = new URLSearchParams();
+          if (opts.refresh) params.set("refresh", "1");
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/adapters/${encodeURIComponent(type)}/models${query}`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    adapter
+      .command("model-profiles")
+      .description("List adapter model profiles for a company")
+      .argument("<type>", "Adapter type")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (type: string, opts: AdapterModelsOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/adapters/${encodeURIComponent(type)}/model-profiles`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    adapter
+      .command("detect-model")
+      .description("Detect the most recently used model for an adapter")
+      .argument("<type>", "Adapter type")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (type: string, opts: AdapterModelsOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.get<unknown>(
+            `/api/companies/${ctx.companyId}/adapters/${encodeURIComponent(type)}/detect-model`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    adapter
+      .command("test-environment")
+      .description("Test an adapter config against a target environment")
+      .argument("<type>", "Adapter type")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--adapter-config <json>", "Adapter config to test as JSON object")
+      .option("--environment-id <id>", "Environment UUID (omit to test on local host)")
+      .action(async (type: string, opts: AdapterTestEnvOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const payload: Record<string, unknown> = {};
+          const adapterConfig = parseJsonObject(opts.adapterConfig, "adapter-config");
+          if (adapterConfig !== undefined) payload.adapterConfig = adapterConfig;
+          if (opts.environmentId !== undefined) payload.environmentId = opts.environmentId;
+
+          const parsed = testAdapterEnvironmentSchema.parse(payload);
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/adapters/${encodeURIComponent(type)}/test-environment`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/agent-extras.ts
+++ b/cli/src/commands/client/agent-extras.ts
@@ -1,0 +1,661 @@
+import { readFileSync } from "node:fs";
+import { Command } from "commander";
+import {
+  agentMineInboxQuerySchema,
+  agentSkillSyncSchema,
+  createAgentHireSchema,
+  resetAgentSessionSchema,
+  updateAgentInstructionsBundleSchema,
+  updateAgentInstructionsPathSchema,
+  upsertAgentInstructionsFileSchema,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface CompanyOnly extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface MineInboxOptions extends CompanyOnly {
+  userId: string;
+  status?: string;
+}
+
+interface PayloadOptions extends BaseClientOptions {
+  payload?: string;
+  payloadFile?: string;
+}
+
+interface SkillsSetOptions extends BaseClientOptions {
+  desiredSkills: string;
+}
+
+interface InstructionsPathOptions extends BaseClientOptions {
+  path?: string;
+  unset?: boolean;
+  adapterConfigKey?: string;
+}
+
+interface InstructionsBundleUpdateOptions extends BaseClientOptions {
+  mode?: string;
+  rootPath?: string;
+  unsetRootPath?: boolean;
+  entryFile?: string;
+  clearLegacyPromptTemplate?: boolean;
+}
+
+interface InstructionsFileGetOptions extends BaseClientOptions {
+  path: string;
+}
+
+interface InstructionsFileUpsertOptions extends BaseClientOptions {
+  path: string;
+  content?: string;
+  contentFile?: string;
+  clearLegacyPromptTemplate?: boolean;
+}
+
+interface InstructionsFileDeleteOptions extends BaseClientOptions {
+  path: string;
+  yes?: boolean;
+}
+
+interface RunResetSessionOptions extends BaseClientOptions {
+  taskKey?: string;
+}
+
+function readJson(opts: PayloadOptions, name: string): unknown {
+  if (opts.payload !== undefined && opts.payloadFile !== undefined) {
+    throw new Error(`Pass either --${name} or --${name}-file, not both.`);
+  }
+  if (opts.payload !== undefined) {
+    try {
+      return JSON.parse(opts.payload);
+    } catch (err) {
+      throw new Error(`--${name} must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  if (opts.payloadFile !== undefined) {
+    const raw = readFileSync(opts.payloadFile, "utf8");
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`--${name}-file must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  return undefined;
+}
+
+async function confirmAction(message: string): Promise<boolean> {
+  const { confirm } = await import("@clack/prompts");
+  const answer = await confirm({ message, initialValue: false });
+  return answer === true;
+}
+
+function getAgentCommand(program: Command): Command {
+  const agent = program.commands.find((c) => c.name() === "agent");
+  if (!agent) throw new Error("agent command not registered yet; load order error");
+  return agent;
+}
+
+export function registerAgentExtensionCommands(program: Command): void {
+  const agent = getAgentCommand(program);
+
+  // ── self ────────────────────────────────────────────────────────────────
+  addCommonClientOptions(
+    agent
+      .command("me")
+      .description("Get the agent associated with the current API key")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>("/api/agents/me");
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("inbox-lite")
+      .description("Get a lightweight inbox snapshot for the current agent")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>("/api/agents/me/inbox-lite");
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("inbox-mine")
+      .description("Get the issues inbox for a given user (board)")
+      .requiredOption("--user-id <id>", "User ID")
+      .option("--status <filter>", "Status filter")
+      .action(async (opts: MineInboxOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const parsed = agentMineInboxQuerySchema.parse({
+            userId: opts.userId,
+            ...(opts.status !== undefined ? { status: opts.status } : {}),
+          });
+          const params = new URLSearchParams();
+          for (const [k, v] of Object.entries(parsed)) {
+            if (v !== undefined) params.set(k, String(v));
+          }
+          const row = await ctx.api.get<unknown>(
+            `/api/agents/me/inbox/mine?${params.toString()}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── per-company agent metadata ──────────────────────────────────────────
+  addCommonClientOptions(
+    agent
+      .command("configurations")
+      .description("List agent configurations for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: CompanyOnly) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.get<unknown>(
+            `/api/companies/${ctx.companyId}/agent-configurations`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("org")
+      .description("Get the org chart for a company (JSON)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: CompanyOnly) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.get<unknown>(
+            `/api/companies/${ctx.companyId}/org`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── configuration / config-revisions ────────────────────────────────────
+  addCommonClientOptions(
+    agent
+      .command("configuration")
+      .description("Get an agent's resolved configuration")
+      .argument("<agentId>", "Agent ID")
+      .action(async (agentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/configuration`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const revision = agent.command("config-revision").description("Agent config revision history");
+
+  addCommonClientOptions(
+    revision
+      .command("list")
+      .description("List config revisions for an agent")
+      .argument("<agentId>", "Agent ID")
+      .action(async (agentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/agents/${encodeURIComponent(agentId)}/config-revisions`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    revision
+      .command("get")
+      .description("Get a single config revision")
+      .argument("<agentId>", "Agent ID")
+      .argument("<revisionId>", "Revision ID")
+      .action(async (agentId: string, revisionId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/config-revisions/${encodeURIComponent(revisionId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    revision
+      .command("rollback")
+      .description("Roll an agent's config back to a prior revision")
+      .argument("<agentId>", "Agent ID")
+      .argument("<revisionId>", "Revision ID")
+      .action(async (agentId: string, revisionId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/config-revisions/${encodeURIComponent(revisionId)}/rollback`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── runtime state / sessions ────────────────────────────────────────────
+  addCommonClientOptions(
+    agent
+      .command("runtime-state")
+      .description("Get an agent's runtime state")
+      .argument("<agentId>", "Agent ID")
+      .action(async (agentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/runtime-state`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("task-sessions")
+      .description("List task sessions for an agent")
+      .argument("<agentId>", "Agent ID")
+      .action(async (agentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/agents/${encodeURIComponent(agentId)}/task-sessions`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("reset-session")
+      .description("Reset an agent's session (optionally for a specific task key)")
+      .argument("<agentId>", "Agent ID")
+      .option("--task-key <key>", "Reset only this task key")
+      .action(async (agentId: string, opts: RunResetSessionOptions) => {
+        try {
+          const payload: Record<string, unknown> = {};
+          if (opts.taskKey !== undefined) payload.taskKey = opts.taskKey;
+          const parsed = resetAgentSessionSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/runtime-state/reset-session`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── hires ───────────────────────────────────────────────────────────────
+  addCommonClientOptions(
+    agent
+      .command("hire")
+      .description("Hire an agent (extended createAgent with optional source issues)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--payload <json>", "Hire payload as JSON object")
+      .option("--payload-file <path>", "Read hire payload from JSON file")
+      .action(async (opts: PayloadOptions & CompanyOnly) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = createAgentHireSchema.parse(payload);
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/agent-hires`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── skills ──────────────────────────────────────────────────────────────
+  const skill = agent.command("skill").description("Agent skill operations");
+
+  addCommonClientOptions(
+    skill
+      .command("list")
+      .description("List skills resolved for an agent")
+      .argument("<agentId>", "Agent ID")
+      .action(async (agentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/skills`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    skill
+      .command("sync")
+      .description("Replace an agent's desired-skills list")
+      .argument("<agentId>", "Agent ID")
+      .requiredOption("--desired-skills <list>", "Comma-separated skill names")
+      .action(async (agentId: string, opts: SkillsSetOptions) => {
+        try {
+          const desired = opts.desiredSkills
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+          const parsed = agentSkillSyncSchema.parse({ desiredSkills: desired });
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/skills/sync`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── instructions bundle ─────────────────────────────────────────────────
+  const instr = agent.command("instructions").description("Agent instructions bundle operations");
+
+  addCommonClientOptions(
+    instr
+      .command("path")
+      .description("Update the agent's instructions path inside its adapter config")
+      .argument("<agentId>", "Agent ID")
+      .option("--path <path>", "New instructions path")
+      .option("--unset", "Clear the instructions path (sets to null)")
+      .option("--adapter-config-key <key>", "Adapter config key to write to")
+      .action(async (agentId: string, opts: InstructionsPathOptions) => {
+        try {
+          if (opts.path !== undefined && opts.unset) {
+            throw new Error("Pass either --path or --unset, not both.");
+          }
+          const payload: Record<string, unknown> = {
+            path: opts.unset ? null : opts.path,
+          };
+          if (opts.adapterConfigKey !== undefined) payload.adapterConfigKey = opts.adapterConfigKey;
+          const parsed = updateAgentInstructionsPathSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.patch<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/instructions-path`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    instr
+      .command("bundle-get")
+      .description("Get an agent's instructions bundle metadata")
+      .argument("<agentId>", "Agent ID")
+      .action(async (agentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/instructions-bundle`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    instr
+      .command("bundle-update")
+      .description("Update agent's instructions bundle settings")
+      .argument("<agentId>", "Agent ID")
+      .option("--mode <mode>", "Bundle mode (managed | external)")
+      .option("--root-path <path>", "External root path")
+      .option("--unset-root-path", "Clear external root path")
+      .option("--entry-file <name>", "Entry file name")
+      .option("--clear-legacy-prompt-template", "Clear legacy prompt template")
+      .action(async (agentId: string, opts: InstructionsBundleUpdateOptions) => {
+        try {
+          if (opts.rootPath !== undefined && opts.unsetRootPath) {
+            throw new Error("Pass either --root-path or --unset-root-path, not both.");
+          }
+          const payload: Record<string, unknown> = {};
+          if (opts.mode !== undefined) payload.mode = opts.mode;
+          if (opts.rootPath !== undefined) payload.rootPath = opts.rootPath;
+          else if (opts.unsetRootPath) payload.rootPath = null;
+          if (opts.entryFile !== undefined) payload.entryFile = opts.entryFile;
+          if (opts.clearLegacyPromptTemplate) payload.clearLegacyPromptTemplate = true;
+          const parsed = updateAgentInstructionsBundleSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.patch<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/instructions-bundle`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    instr
+      .command("file-get")
+      .description("Read one file from the bundle")
+      .argument("<agentId>", "Agent ID")
+      .requiredOption("--path <relative>", "File path within the bundle")
+      .action(async (agentId: string, opts: InstructionsFileGetOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const params = new URLSearchParams({ path: opts.path });
+          const row = await ctx.api.get<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/instructions-bundle/file?${params.toString()}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    instr
+      .command("file-upsert")
+      .description("Create/replace a file in the bundle")
+      .argument("<agentId>", "Agent ID")
+      .requiredOption("--path <relative>", "File path within the bundle")
+      .option("--content <text>", "New content")
+      .option("--content-file <path>", "Read content from file")
+      .option("--clear-legacy-prompt-template", "Clear legacy prompt template")
+      .action(async (agentId: string, opts: InstructionsFileUpsertOptions) => {
+        try {
+          if (opts.content !== undefined && opts.contentFile !== undefined) {
+            throw new Error("Pass either --content or --content-file, not both.");
+          }
+          let content: string;
+          if (opts.contentFile !== undefined) {
+            content = readFileSync(opts.contentFile, "utf8");
+          } else if (opts.content !== undefined) {
+            content = opts.content;
+          } else {
+            throw new Error("Pass --content or --content-file.");
+          }
+          const payload: Record<string, unknown> = { path: opts.path, content };
+          if (opts.clearLegacyPromptTemplate) payload.clearLegacyPromptTemplate = true;
+          const parsed = upsertAgentInstructionsFileSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.put<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/instructions-bundle/file`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    instr
+      .command("file-delete")
+      .description("Delete a file from the bundle")
+      .argument("<agentId>", "Agent ID")
+      .requiredOption("--path <relative>", "File path within the bundle")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (agentId: string, opts: InstructionsFileDeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const ok = await confirmAction(`Delete ${opts.path} from agent ${agentId}'s bundle?`);
+            if (!ok) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const params = new URLSearchParams({ path: opts.path });
+          const row = await ctx.api.delete<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/instructions-bundle/file?${params.toString()}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── heartbeat invoke + claude login ─────────────────────────────────────
+  addCommonClientOptions(
+    agent
+      .command("heartbeat-invoke")
+      .description("Invoke a one-off heartbeat for an agent")
+      .argument("<agentId>", "Agent ID")
+      .action(async (agentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/heartbeat/invoke`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("claude-login")
+      .description("Trigger a Claude login flow for the agent")
+      .argument("<agentId>", "Agent ID")
+      .action(async (agentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/claude-login`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── instance scheduler heartbeats ───────────────────────────────────────
+  addCommonClientOptions(
+    agent
+      .command("scheduler-heartbeats")
+      .description("Get instance-level scheduler heartbeats")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>("/api/instance/scheduler-heartbeats");
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -1,5 +1,12 @@
 import { Command } from "commander";
-import type { Agent } from "@paperclipai/shared";
+import {
+  createAgentKeySchema,
+  createAgentSchema,
+  updateAgentPermissionsSchema,
+  updateAgentSchema,
+  wakeAgentSchema,
+  type Agent,
+} from "@paperclipai/shared";
 import {
   removeMaintainerOnlySkillSymlinks,
   resolvePaperclipSkillsDir,
@@ -25,6 +32,111 @@ interface AgentLocalCliOptions extends BaseClientOptions {
   companyId?: string;
   keyName?: string;
   installSkills?: boolean;
+}
+
+interface AgentCreateOptions extends BaseClientOptions {
+  companyId?: string;
+  name: string;
+  adapterType: string;
+  role?: string;
+  title?: string;
+  icon?: string;
+  reportsTo?: string;
+  capabilities?: string;
+  desiredSkills?: string;
+  adapterConfig?: string;
+  runtimeConfig?: string;
+  defaultEnvironmentId?: string;
+  budgetMonthlyCents?: string;
+  metadata?: string;
+}
+
+interface AgentUpdateOptions extends BaseClientOptions {
+  name?: string;
+  role?: string;
+  title?: string;
+  icon?: string;
+  reportsTo?: string;
+  capabilities?: string;
+  desiredSkills?: string;
+  adapterType?: string;
+  adapterConfig?: string;
+  replaceAdapterConfig?: boolean;
+  runtimeConfig?: string;
+  defaultEnvironmentId?: string;
+  budgetMonthlyCents?: string;
+  status?: string;
+  metadata?: string;
+}
+
+interface AgentDeleteOptions extends BaseClientOptions {
+  yes?: boolean;
+}
+
+interface AgentPermissionsOptions extends BaseClientOptions {
+  canCreateAgents: string;
+  canAssignTasks: string;
+}
+
+interface AgentKeyCreateOptions extends BaseClientOptions {
+  name?: string;
+}
+
+interface AgentKeyDeleteOptions extends BaseClientOptions {
+  yes?: boolean;
+}
+
+interface AgentWakeupOptions extends BaseClientOptions {
+  source?: string;
+  triggerDetail?: string;
+  reason?: string;
+  payload?: string;
+  idempotencyKey?: string;
+  forceFreshSession?: boolean;
+}
+
+function parseJsonObject(
+  raw: string | undefined,
+  flag: string,
+): Record<string, unknown> | undefined {
+  if (raw === undefined) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`--${flag} must be valid JSON: ${(err as Error).message}`);
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`--${flag} must be a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parseBoolFlag(value: string, name: string): boolean {
+  const v = value.toLowerCase();
+  if (v === "true" || v === "1" || v === "yes") return true;
+  if (v === "false" || v === "0" || v === "no") return false;
+  throw new Error(`--${name} must be true or false`);
+}
+
+function parseIntOpt(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    throw new Error(`--${name} must be a non-negative integer`);
+  }
+  return n;
+}
+
+function splitCsv(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  return value.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+async function confirmAction(message: string): Promise<boolean> {
+  const { confirm } = await import("@clack/prompts");
+  const answer = await confirm({ message, initialValue: false });
+  return answer === true;
 }
 
 interface CreatedAgentKey {
@@ -306,6 +418,306 @@ export function registerAgentCommands(program: Command): void {
           console.log("");
           console.log("# Run this in your shell before launching codex/claude:");
           console.log(exportsText);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("create")
+      .description("Create a new agent in a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--name <name>", "Agent display name")
+      .requiredOption("--adapter-type <type>", "Adapter type (e.g. claude, codex, copilot)")
+      .option("--role <role>", "Agent role")
+      .option("--title <title>", "Agent title")
+      .option("--icon <icon>", "Agent icon name")
+      .option("--reports-to <id>", "Manager agent UUID")
+      .option("--capabilities <text>", "Capabilities description")
+      .option("--desired-skills <list>", "Comma-separated desired skill names")
+      .option("--adapter-config <json>", "Adapter config as JSON object", "{}")
+      .option("--runtime-config <json>", "Runtime config as JSON object", "{}")
+      .option("--default-environment-id <id>", "Default environment UUID")
+      .option("--budget-monthly-cents <n>", "Monthly budget in cents")
+      .option("--metadata <json>", "Metadata as JSON object")
+      .action(async (opts: AgentCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+
+          const payload: Record<string, unknown> = {
+            name: opts.name,
+            adapterType: opts.adapterType,
+          };
+          if (opts.role !== undefined) payload.role = opts.role;
+          if (opts.title !== undefined) payload.title = opts.title;
+          if (opts.icon !== undefined) payload.icon = opts.icon;
+          if (opts.reportsTo !== undefined) payload.reportsTo = opts.reportsTo;
+          if (opts.capabilities !== undefined) payload.capabilities = opts.capabilities;
+          const skills = splitCsv(opts.desiredSkills);
+          if (skills !== undefined) payload.desiredSkills = skills;
+          const adapterConfig = parseJsonObject(opts.adapterConfig, "adapter-config");
+          if (adapterConfig !== undefined) payload.adapterConfig = adapterConfig;
+          const runtimeConfig = parseJsonObject(opts.runtimeConfig, "runtime-config");
+          if (runtimeConfig !== undefined) payload.runtimeConfig = runtimeConfig;
+          if (opts.defaultEnvironmentId !== undefined)
+            payload.defaultEnvironmentId = opts.defaultEnvironmentId;
+          const budget = parseIntOpt(opts.budgetMonthlyCents, "budget-monthly-cents");
+          if (budget !== undefined) payload.budgetMonthlyCents = budget;
+          const metadata = parseJsonObject(opts.metadata, "metadata");
+          if (metadata !== undefined) payload.metadata = metadata;
+
+          const parsed = createAgentSchema.parse(payload);
+          const row = await ctx.api.post<Agent>(
+            `/api/companies/${ctx.companyId}/agents`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("update")
+      .description("Update an agent's mutable fields")
+      .argument("<agentId>", "Agent ID")
+      .option("--name <name>", "New name")
+      .option("--role <role>", "New role")
+      .option("--title <title>", "New title")
+      .option("--icon <icon>", "New icon")
+      .option("--reports-to <id>", "New manager agent UUID (or empty string to unset)")
+      .option("--capabilities <text>", "New capabilities description")
+      .option("--desired-skills <list>", "Comma-separated desired skills (replaces list)")
+      .option("--adapter-type <type>", "New adapter type")
+      .option("--adapter-config <json>", "Adapter config as JSON object (merged unless --replace-adapter-config)")
+      .option("--replace-adapter-config", "Replace adapter config wholesale instead of merging")
+      .option("--runtime-config <json>", "Runtime config as JSON object")
+      .option("--default-environment-id <id>", "New default environment UUID")
+      .option("--budget-monthly-cents <n>", "New monthly budget in cents")
+      .option("--status <status>", "New status")
+      .option("--metadata <json>", "Metadata as JSON object")
+      .action(async (agentId: string, opts: AgentUpdateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload: Record<string, unknown> = {};
+          if (opts.name !== undefined) payload.name = opts.name;
+          if (opts.role !== undefined) payload.role = opts.role;
+          if (opts.title !== undefined) payload.title = opts.title;
+          if (opts.icon !== undefined) payload.icon = opts.icon;
+          if (opts.reportsTo !== undefined) payload.reportsTo = opts.reportsTo === "" ? null : opts.reportsTo;
+          if (opts.capabilities !== undefined) payload.capabilities = opts.capabilities;
+          const skills = splitCsv(opts.desiredSkills);
+          if (skills !== undefined) payload.desiredSkills = skills;
+          if (opts.adapterType !== undefined) payload.adapterType = opts.adapterType;
+          const adapterConfig = parseJsonObject(opts.adapterConfig, "adapter-config");
+          if (adapterConfig !== undefined) payload.adapterConfig = adapterConfig;
+          if (opts.replaceAdapterConfig) payload.replaceAdapterConfig = true;
+          const runtimeConfig = parseJsonObject(opts.runtimeConfig, "runtime-config");
+          if (runtimeConfig !== undefined) payload.runtimeConfig = runtimeConfig;
+          if (opts.defaultEnvironmentId !== undefined)
+            payload.defaultEnvironmentId = opts.defaultEnvironmentId === ""
+              ? null
+              : opts.defaultEnvironmentId;
+          const budget = parseIntOpt(opts.budgetMonthlyCents, "budget-monthly-cents");
+          if (budget !== undefined) payload.budgetMonthlyCents = budget;
+          if (opts.status !== undefined) payload.status = opts.status;
+          const metadata = parseJsonObject(opts.metadata, "metadata");
+          if (metadata !== undefined) payload.metadata = metadata;
+
+          const parsed = updateAgentSchema.parse(payload);
+          const row = await ctx.api.patch<Agent>(
+            `/api/agents/${encodeURIComponent(agentId)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("delete")
+      .description("Delete an agent")
+      .argument("<agentId>", "Agent ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (agentId: string, opts: AgentDeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const ok = await confirmAction(`Delete agent ${agentId}? This cannot be undone.`);
+            if (!ok) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<Agent>(`/api/agents/${encodeURIComponent(agentId)}`);
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  for (const action of ["pause", "resume", "approve", "terminate"] as const) {
+    addCommonClientOptions(
+      agent
+        .command(action)
+        .description(`${action[0].toUpperCase()}${action.slice(1)} an agent`)
+        .argument("<agentId>", "Agent ID")
+        .action(async (agentId: string, opts: BaseClientOptions) => {
+          try {
+            const ctx = resolveCommandContext(opts);
+            const row = await ctx.api.post<Agent>(
+              `/api/agents/${encodeURIComponent(agentId)}/${action}`,
+              {},
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+
+  addCommonClientOptions(
+    agent
+      .command("permissions")
+      .description("Update agent permissions (canCreateAgents, canAssignTasks)")
+      .argument("<agentId>", "Agent ID")
+      .requiredOption("--can-create-agents <bool>", "true or false")
+      .requiredOption("--can-assign-tasks <bool>", "true or false")
+      .action(async (agentId: string, opts: AgentPermissionsOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const parsed = updateAgentPermissionsSchema.parse({
+            canCreateAgents: parseBoolFlag(opts.canCreateAgents, "can-create-agents"),
+            canAssignTasks: parseBoolFlag(opts.canAssignTasks, "can-assign-tasks"),
+          });
+          const row = await ctx.api.patch<Agent>(
+            `/api/agents/${encodeURIComponent(agentId)}/permissions`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("wakeup")
+      .description("Wake up an agent (enqueue a heartbeat run)")
+      .argument("<agentId>", "Agent ID")
+      .option("--source <source>", "Source (timer, assignment, on_demand, automation)")
+      .option("--trigger-detail <detail>", "Trigger detail (manual, ping, callback, system)")
+      .option("--reason <text>", "Reason")
+      .option("--payload <json>", "Wake-up payload as JSON object")
+      .option("--idempotency-key <key>", "Idempotency key")
+      .option("--force-fresh-session", "Force a fresh session")
+      .action(async (agentId: string, opts: AgentWakeupOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload: Record<string, unknown> = {};
+          if (opts.source !== undefined) payload.source = opts.source;
+          if (opts.triggerDetail !== undefined) payload.triggerDetail = opts.triggerDetail;
+          if (opts.reason !== undefined) payload.reason = opts.reason;
+          const wakePayload = parseJsonObject(opts.payload, "payload");
+          if (wakePayload !== undefined) payload.payload = wakePayload;
+          if (opts.idempotencyKey !== undefined) payload.idempotencyKey = opts.idempotencyKey;
+          if (opts.forceFreshSession) payload.forceFreshSession = true;
+
+          const parsed = wakeAgentSchema.parse(payload);
+          const row = await ctx.api.post<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/wakeup`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const key = agent.command("key").description("Agent API key operations");
+
+  addCommonClientOptions(
+    key
+      .command("list")
+      .description("List API keys for an agent")
+      .argument("<agentId>", "Agent ID")
+      .action(async (agentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/agents/${encodeURIComponent(agentId)}/keys`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    key
+      .command("create")
+      .description("Create a new API key for an agent (token returned once)")
+      .argument("<agentId>", "Agent ID")
+      .option("--name <name>", "Key label", "default")
+      .action(async (agentId: string, opts: AgentKeyCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload = createAgentKeySchema.parse({ name: opts.name ?? "default" });
+          const row = await ctx.api.post<CreatedAgentKey>(
+            `/api/agents/${encodeURIComponent(agentId)}/keys`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    key
+      .command("delete")
+      .description("Delete an API key")
+      .argument("<agentId>", "Agent ID")
+      .argument("<keyId>", "Key ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (agentId: string, keyId: string, opts: AgentKeyDeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const ok = await confirmAction(
+              `Delete API key ${keyId} for agent ${agentId}? Anything using it will lose access.`,
+            );
+            if (!ok) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/keys/${encodeURIComponent(keyId)}`,
+          );
+          printOutput(row, { json: ctx.json });
         } catch (err) {
           handleCommandError(err);
         }

--- a/cli/src/commands/client/approval-extras.ts
+++ b/cli/src/commands/client/approval-extras.ts
@@ -1,0 +1,56 @@
+import { Command } from "commander";
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+function getApprovalCommand(program: Command): Command {
+  const cmd = program.commands.find((c) => c.name() === "approval");
+  if (!cmd) throw new Error("approval command not registered yet; load order error");
+  return cmd;
+}
+
+export function registerApprovalExtensionCommands(program: Command): void {
+  const approval = getApprovalCommand(program);
+
+  addCommonClientOptions(
+    approval
+      .command("issues")
+      .description("List issues linked to an approval")
+      .argument("<approvalId>", "Approval ID")
+      .action(async (approvalId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/approvals/${encodeURIComponent(approvalId)}/issues`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    approval
+      .command("comments")
+      .description("List comments on an approval")
+      .argument("<approvalId>", "Approval ID")
+      .action(async (approvalId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/approvals/${encodeURIComponent(approvalId)}/comments`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/asset.ts
+++ b/cli/src/commands/client/asset.ts
@@ -1,0 +1,143 @@
+import { createWriteStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import { basename } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { Command } from "commander";
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface ImageUploadOptions extends BaseClientOptions {
+  companyId?: string;
+  file: string;
+  namespace?: string;
+}
+
+interface LogoUploadOptions extends BaseClientOptions {
+  companyId?: string;
+  file: string;
+}
+
+interface ContentDownloadOptions extends BaseClientOptions {
+  output?: string;
+}
+
+const SUPPORTED_IMAGE_TYPES = new Map<string, string>([
+  ["png", "image/png"],
+  ["jpg", "image/jpeg"],
+  ["jpeg", "image/jpeg"],
+  ["gif", "image/gif"],
+  ["webp", "image/webp"],
+  ["svg", "image/svg+xml"],
+]);
+
+function inferMimeType(path: string): string {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  return SUPPORTED_IMAGE_TYPES.get(ext) ?? "application/octet-stream";
+}
+
+async function loadFileAsBlob(path: string): Promise<{ blob: Blob; filename: string }> {
+  await stat(path);
+  const buf = await readFile(path);
+  const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  const blob = new Blob([arrayBuffer], { type: inferMimeType(path) });
+  return { blob, filename: basename(path) };
+}
+
+export function registerAssetCommands(program: Command): void {
+  const asset = program
+    .command("asset")
+    .description("Asset upload and content download");
+
+  addCommonClientOptions(
+    asset
+      .command("upload-image")
+      .description("Upload an image asset to a company namespace")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--file <path>", "Path to local image file")
+      .option("--namespace <name>", "Namespace suffix (default: general)")
+      .action(async (opts: ImageUploadOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const { blob, filename } = await loadFileAsBlob(opts.file);
+          const form = new FormData();
+          form.append("file", blob, filename);
+          if (opts.namespace !== undefined) form.append("namespace", opts.namespace);
+          const row = await ctx.api.postMultipart<unknown>(
+            `/api/companies/${ctx.companyId}/assets/images`,
+            form,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    asset
+      .command("upload-logo")
+      .description("Upload a company logo")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--file <path>", "Path to local logo file")
+      .action(async (opts: LogoUploadOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const { blob, filename } = await loadFileAsBlob(opts.file);
+          const form = new FormData();
+          form.append("file", blob, filename);
+          const row = await ctx.api.postMultipart<unknown>(
+            `/api/companies/${ctx.companyId}/logo`,
+            form,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    asset
+      .command("download")
+      .description("Download asset content (writes to --output or stdout)")
+      .argument("<assetId>", "Asset ID")
+      .option("--output <path>", "Output file path (omit to write to stdout)")
+      .action(async (assetId: string, opts: ContentDownloadOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const url = `${ctx.api.apiBase}/api/assets/${encodeURIComponent(assetId)}/content`;
+          const headers: Record<string, string> = { accept: "*/*" };
+          // Reach into the bare api key by re-using fetch directly; the generic
+          // client only handles JSON. We replicate auth header + run id here.
+          const apiKey = (ctx.api as unknown as { apiKey?: string }).apiKey;
+          if (apiKey) headers.authorization = `Bearer ${apiKey}`;
+          const response = await fetch(url, { headers });
+          if (!response.ok) {
+            const body = await response.text().catch(() => "");
+            throw new Error(`HTTP ${response.status}: ${body || response.statusText}`);
+          }
+          if (!response.body) {
+            throw new Error("Empty response body");
+          }
+          const nodeStream = Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]);
+          if (opts.output) {
+            await pipeline(nodeStream, createWriteStream(opts.output));
+            console.error(`wrote ${opts.output}`);
+          } else {
+            await pipeline(nodeStream, process.stdout);
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/asset.ts
+++ b/cli/src/commands/client/asset.ts
@@ -113,21 +113,10 @@ export function registerAssetCommands(program: Command): void {
       .action(async (assetId: string, opts: ContentDownloadOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const url = `${ctx.api.apiBase}/api/assets/${encodeURIComponent(assetId)}/content`;
-          const headers: Record<string, string> = { accept: "*/*" };
-          // Reach into the bare api key by re-using fetch directly; the generic
-          // client only handles JSON. We replicate auth header + run id here.
-          const apiKey = (ctx.api as unknown as { apiKey?: string }).apiKey;
-          if (apiKey) headers.authorization = `Bearer ${apiKey}`;
-          const response = await fetch(url, { headers });
-          if (!response.ok) {
-            const body = await response.text().catch(() => "");
-            throw new Error(`HTTP ${response.status}: ${body || response.statusText}`);
-          }
-          if (!response.body) {
-            throw new Error("Empty response body");
-          }
-          const nodeStream = Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]);
+          const { body } = await ctx.api.getStream(
+            `/api/assets/${encodeURIComponent(assetId)}/content`,
+          );
+          const nodeStream = Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]);
           if (opts.output) {
             await pipeline(nodeStream, createWriteStream(opts.output));
             console.error(`wrote ${opts.output}`);

--- a/cli/src/commands/client/attachment-extras.ts
+++ b/cli/src/commands/client/attachment-extras.ts
@@ -1,0 +1,152 @@
+import { createWriteStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import { basename } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { Command } from "commander";
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface CompanyOnly extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface AttachmentUploadOptions extends CompanyOnly {
+  file: string;
+  contentType?: string;
+}
+
+interface AttachmentDownloadOptions extends BaseClientOptions {
+  output?: string;
+}
+
+const MIME_BY_EXT = new Map<string, string>([
+  ["png", "image/png"],
+  ["jpg", "image/jpeg"],
+  ["jpeg", "image/jpeg"],
+  ["gif", "image/gif"],
+  ["webp", "image/webp"],
+  ["svg", "image/svg+xml"],
+  ["pdf", "application/pdf"],
+  ["txt", "text/plain"],
+  ["json", "application/json"],
+  ["md", "text/markdown"],
+]);
+
+function inferMimeType(path: string): string {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  return MIME_BY_EXT.get(ext) ?? "application/octet-stream";
+}
+
+async function loadFileAsBlob(path: string, contentType?: string): Promise<{ blob: Blob; filename: string }> {
+  await stat(path);
+  const buf = await readFile(path);
+  const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  const blob = new Blob([arrayBuffer], { type: contentType ?? inferMimeType(path) });
+  return { blob, filename: basename(path) };
+}
+
+function getIssueCommand(program: Command): Command {
+  const issue = program.commands.find((c) => c.name() === "issue");
+  if (!issue) throw new Error("issue command not registered yet; load order error");
+  return issue;
+}
+
+export function registerAttachmentExtensionCommands(program: Command): void {
+  const issue = getIssueCommand(program);
+
+  addCommonClientOptions(
+    issue
+      .command("attachment-list")
+      .description("List attachments on an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = await ctx.api.get<unknown[]>(
+            `/api/issues/${encodeURIComponent(issueId)}/attachments`,
+          );
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    issue
+      .command("attachment-upload")
+      .description("Upload a file as an issue attachment")
+      .argument("<issueId>", "Issue ID")
+      .requiredOption("-C, --company-id <id>", "Company ID owning the issue")
+      .requiredOption("--file <path>", "Path to local file")
+      .option("--content-type <mime>", "Override inferred MIME type")
+      .action(async (issueId: string, opts: AttachmentUploadOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const { blob, filename } = await loadFileAsBlob(opts.file, opts.contentType);
+          const form = new FormData();
+          form.append("file", blob, filename);
+          const row = await ctx.api.postMultipart<unknown>(
+            `/api/companies/${ctx.companyId}/issues/${encodeURIComponent(issueId)}/attachments`,
+            form,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    issue
+      .command("attachment-download")
+      .description("Download an attachment's content (writes to --output or stdout)")
+      .argument("<attachmentId>", "Attachment ID")
+      .option("--output <path>", "Output file path (omit to write to stdout)")
+      .action(async (attachmentId: string, opts: AttachmentDownloadOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const { body } = await ctx.api.getStream(
+            `/api/attachments/${encodeURIComponent(attachmentId)}/content`,
+          );
+          const nodeStream = Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]);
+          if (opts.output) {
+            await pipeline(nodeStream, createWriteStream(opts.output));
+            console.error(`wrote ${opts.output}`);
+          } else {
+            await pipeline(nodeStream, process.stdout);
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    issue
+      .command("attachment-delete")
+      .description("Delete an issue attachment")
+      .argument("<attachmentId>", "Attachment ID")
+      .action(async (attachmentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          await ctx.api.delete(
+            `/api/attachments/${encodeURIComponent(attachmentId)}`,
+          );
+          printOutput({ ok: true, attachmentId }, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/budget.ts
+++ b/cli/src/commands/client/budget.ts
@@ -1,0 +1,273 @@
+import { Command } from "commander";
+import {
+  resolveBudgetIncidentSchema,
+  updateBudgetSchema,
+  upsertBudgetPolicySchema,
+  type BudgetIncident,
+  type BudgetOverview,
+  type BudgetPolicySummary,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface BudgetOverviewOptions extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface BudgetSetCompanyOptions extends BaseClientOptions {
+  companyId?: string;
+  monthlyCents: string;
+}
+
+interface BudgetSetAgentOptions extends BaseClientOptions {
+  monthlyCents: string;
+}
+
+interface BudgetPolicyUpsertOptions extends BaseClientOptions {
+  companyId?: string;
+  scopeType: string;
+  scopeId: string;
+  amount: string;
+  metric?: string;
+  windowKind?: string;
+  warnPercent?: string;
+  hardStop?: string;
+  notify?: string;
+  active?: string;
+}
+
+interface BudgetIncidentResolveOptions extends BaseClientOptions {
+  companyId?: string;
+  action: string;
+  amount?: string;
+  decisionNote?: string;
+}
+
+function parseIntOpt(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    throw new Error(`--${name} must be a non-negative integer`);
+  }
+  return n;
+}
+
+function parseBoolOpt(value: string | undefined, name: string): boolean | undefined {
+  if (value === undefined) return undefined;
+  const v = value.toLowerCase();
+  if (v === "true" || v === "1" || v === "yes") return true;
+  if (v === "false" || v === "0" || v === "no") return false;
+  throw new Error(`--${name} must be true or false`);
+}
+
+export function registerBudgetCommands(program: Command): void {
+  const budget = program.command("budget").description("Budget policies and spend overview");
+
+  addCommonClientOptions(
+    budget
+      .command("overview")
+      .description("Budget policies, observed spend, active incidents")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: BudgetOverviewOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.get<BudgetOverview>(
+            `/api/companies/${ctx.companyId}/budgets/overview`,
+          );
+
+          if (ctx.json) {
+            printOutput(row, { json: true });
+            return;
+          }
+          if (!row) {
+            printOutput(null, { json: false });
+            return;
+          }
+
+          console.log(
+            formatInlineRecord({
+              companyId: row.companyId,
+              policyCount: row.policies.length,
+              activeIncidentCount: row.activeIncidents.length,
+              pausedAgentCount: row.pausedAgentCount,
+              pausedProjectCount: row.pausedProjectCount,
+              pendingApprovalCount: row.pendingApprovalCount,
+            }),
+          );
+          if (row.policies.length > 0) {
+            console.log("policies:");
+            for (const p of row.policies as BudgetPolicySummary[]) {
+              console.log(
+                "  " +
+                  formatInlineRecord({
+                    policyId: p.policyId,
+                    scopeType: p.scopeType,
+                    scopeId: p.scopeId,
+                    scopeName: p.scopeName,
+                    amount: p.amount,
+                    observed: p.observedAmount,
+                    utilization: p.utilizationPercent,
+                    status: p.status,
+                    paused: p.paused,
+                  }),
+              );
+            }
+          }
+          if (row.activeIncidents.length > 0) {
+            console.log("incidents:");
+            for (const i of row.activeIncidents as BudgetIncident[]) {
+              console.log(
+                "  " +
+                  formatInlineRecord({
+                    id: i.id,
+                    scopeType: i.scopeType,
+                    scopeName: i.scopeName,
+                    threshold: i.thresholdType,
+                    limit: i.amountLimit,
+                    observed: i.amountObserved,
+                    status: i.status,
+                  }),
+              );
+            }
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    budget
+      .command("set-company")
+      .description("Set company monthly budget (also writes a company-scoped policy)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--monthly-cents <n>", "Monthly budget in cents")
+      .action(async (opts: BudgetSetCompanyOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const payload = updateBudgetSchema.parse({
+            budgetMonthlyCents: parseIntOpt(opts.monthlyCents, "monthly-cents")!,
+          });
+          const row = await ctx.api.patch<unknown>(
+            `/api/companies/${ctx.companyId}/budgets`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    budget
+      .command("set-agent")
+      .description("Set agent monthly budget (also writes an agent-scoped policy)")
+      .argument("<agentId>", "Agent ID")
+      .requiredOption("--monthly-cents <n>", "Monthly budget in cents")
+      .action(async (agentId: string, opts: BudgetSetAgentOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload = updateBudgetSchema.parse({
+            budgetMonthlyCents: parseIntOpt(opts.monthlyCents, "monthly-cents")!,
+          });
+          const row = await ctx.api.patch<unknown>(
+            `/api/agents/${encodeURIComponent(agentId)}/budgets`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const policy = budget.command("policy").description("Budget policy operations");
+
+  addCommonClientOptions(
+    policy
+      .command("upsert")
+      .description("Create or update a budget policy for a scope")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--scope-type <type>", "Scope type (e.g. company, agent, project)")
+      .requiredOption("--scope-id <id>", "Scope ID (UUID)")
+      .requiredOption("--amount <n>", "Limit amount (cents, integer)")
+      .option("--metric <metric>", "Metric (default billed_cents)")
+      .option("--window-kind <kind>", "Window kind (default calendar_month_utc)")
+      .option("--warn-percent <n>", "Warning threshold percent (1-99, default 80)")
+      .option("--hard-stop <bool>", "Enable hard stop (true/false, default true)")
+      .option("--notify <bool>", "Enable notifications (true/false, default true)")
+      .option("--active <bool>", "Mark policy active (true/false, default true)")
+      .action(async (opts: BudgetPolicyUpsertOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const payload: Record<string, unknown> = {
+            scopeType: opts.scopeType,
+            scopeId: opts.scopeId,
+            amount: parseIntOpt(opts.amount, "amount")!,
+          };
+          if (opts.metric !== undefined) payload.metric = opts.metric;
+          if (opts.windowKind !== undefined) payload.windowKind = opts.windowKind;
+          const warn = parseIntOpt(opts.warnPercent, "warn-percent");
+          if (warn !== undefined) payload.warnPercent = warn;
+          const hardStop = parseBoolOpt(opts.hardStop, "hard-stop");
+          if (hardStop !== undefined) payload.hardStopEnabled = hardStop;
+          const notify = parseBoolOpt(opts.notify, "notify");
+          if (notify !== undefined) payload.notifyEnabled = notify;
+          const active = parseBoolOpt(opts.active, "active");
+          if (active !== undefined) payload.isActive = active;
+
+          const parsed = upsertBudgetPolicySchema.parse(payload);
+          const row = await ctx.api.post<BudgetPolicySummary>(
+            `/api/companies/${ctx.companyId}/budgets/policies`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const incident = budget.command("incident").description("Budget incident operations");
+
+  addCommonClientOptions(
+    incident
+      .command("resolve")
+      .description("Resolve a budget incident with a chosen action")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<incidentId>", "Incident ID")
+      .requiredOption("--action <action>", "Resolution action (e.g. raise_budget_and_resume, dismiss)")
+      .option("--amount <n>", "New budget amount (required for raise_budget_and_resume)")
+      .option("--decision-note <text>", "Decision note")
+      .action(async (incidentId: string, opts: BudgetIncidentResolveOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const payload: Record<string, unknown> = { action: opts.action };
+          const amount = parseIntOpt(opts.amount, "amount");
+          if (amount !== undefined) payload.amount = amount;
+          if (opts.decisionNote !== undefined) payload.decisionNote = opts.decisionNote;
+
+          const parsed = resolveBudgetIncidentSchema.parse(payload);
+          const row = await ctx.api.post<BudgetIncident>(
+            `/api/companies/${ctx.companyId}/budget-incidents/${encodeURIComponent(incidentId)}/resolve`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/company-extras.ts
+++ b/cli/src/commands/client/company-extras.ts
@@ -74,22 +74,6 @@ export function registerCompanyExtensionCommands(program: Command): void {
 
   addCommonClientOptions(
     company
-      .command("instance-issues")
-      .description("List instance-wide issues exposed via /api/companies/issues")
-      .action(async (opts: BaseClientOptions) => {
-        try {
-          const ctx = resolveCommandContext(opts);
-          const row = await ctx.api.get<unknown>("/api/companies/issues");
-          printOutput(row, { json: ctx.json });
-        } catch (err) {
-          handleCommandError(err);
-        }
-      }),
-    { includeCompany: false },
-  );
-
-  addCommonClientOptions(
-    company
       .command("create")
       .description("Create a new company")
       .option("--payload <json>", "Create payload as JSON object")

--- a/cli/src/commands/client/company-extras.ts
+++ b/cli/src/commands/client/company-extras.ts
@@ -1,4 +1,7 @@
+import { createWriteStream } from "node:fs";
 import { readFileSync } from "node:fs";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { Command } from "commander";
 import {
   companyPortabilityExportSchema,
@@ -24,6 +27,14 @@ interface PayloadOptions extends BaseClientOptions {
 interface CompanyOnly extends BaseClientOptions {
   companyId?: string;
 }
+
+interface OrgChartOptions extends CompanyOnly {
+  format: string;
+  style?: string;
+  output?: string;
+}
+
+const ORG_CHART_STYLES = ["monochrome", "nebula", "circuit", "warmth", "schematic"];
 
 function readJson(opts: PayloadOptions, name: string): unknown {
   if (opts.payload !== undefined && opts.payloadFile !== undefined) {
@@ -158,6 +169,42 @@ export function registerCompanyExtensionCommands(program: Command): void {
             {},
           );
           printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    company
+      .command("org-chart")
+      .description("Download a rendered company org chart (svg or png)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--format <fmt>", "Output format: svg or png", "svg")
+      .option("--style <style>", `Visual style: ${ORG_CHART_STYLES.join("|")}`)
+      .option("--output <path>", "Output file path (omit to write to stdout)")
+      .action(async (opts: OrgChartOptions) => {
+        try {
+          const fmt = opts.format.toLowerCase();
+          if (fmt !== "svg" && fmt !== "png") {
+            throw new Error("--format must be svg or png");
+          }
+          if (opts.style !== undefined && !ORG_CHART_STYLES.includes(opts.style)) {
+            throw new Error(`--style must be one of: ${ORG_CHART_STYLES.join(", ")}`);
+          }
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const query = opts.style ? `?style=${encodeURIComponent(opts.style)}` : "";
+          const { body } = await ctx.api.getStream(
+            `/api/companies/${ctx.companyId}/org.${fmt}${query}`,
+          );
+          const nodeStream = Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]);
+          if (opts.output) {
+            await pipeline(nodeStream, createWriteStream(opts.output));
+            console.error(`wrote ${opts.output}`);
+          } else {
+            await pipeline(nodeStream, process.stdout);
+          }
         } catch (err) {
           handleCommandError(err);
         }

--- a/cli/src/commands/client/company-extras.ts
+++ b/cli/src/commands/client/company-extras.ts
@@ -1,0 +1,218 @@
+import { readFileSync } from "node:fs";
+import { Command } from "commander";
+import {
+  companyPortabilityExportSchema,
+  companyPortabilityImportSchema,
+  companyPortabilityPreviewSchema,
+  createCompanySchema,
+  updateCompanyBrandingSchema,
+  updateCompanySchema,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface PayloadOptions extends BaseClientOptions {
+  payload?: string;
+  payloadFile?: string;
+}
+
+interface CompanyOnly extends BaseClientOptions {
+  companyId?: string;
+}
+
+function readJson(opts: PayloadOptions, name: string): unknown {
+  if (opts.payload !== undefined && opts.payloadFile !== undefined) {
+    throw new Error(`Pass either --${name} or --${name}-file, not both.`);
+  }
+  if (opts.payload !== undefined) {
+    try {
+      return JSON.parse(opts.payload);
+    } catch (err) {
+      throw new Error(`--${name} must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  if (opts.payloadFile !== undefined) {
+    const raw = readFileSync(opts.payloadFile, "utf8");
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`--${name}-file must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  return undefined;
+}
+
+function getCompanyCommand(program: Command): Command {
+  const cmd = program.commands.find((c) => c.name() === "company");
+  if (!cmd) throw new Error("company command not registered yet; load order error");
+  return cmd;
+}
+
+export function registerCompanyExtensionCommands(program: Command): void {
+  const company = getCompanyCommand(program);
+
+  addCommonClientOptions(
+    company
+      .command("stats")
+      .description("Get instance-wide company stats")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>("/api/companies/stats");
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    company
+      .command("instance-issues")
+      .description("List instance-wide issues exposed via /api/companies/issues")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>("/api/companies/issues");
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    company
+      .command("create")
+      .description("Create a new company")
+      .option("--payload <json>", "Create payload as JSON object")
+      .option("--payload-file <path>", "Read payload from JSON file")
+      .action(async (opts: PayloadOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = createCompanySchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>("/api/companies/", parsed);
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    company
+      .command("update")
+      .description("Update a company (board: full schema; CEO agents: branding only)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--payload <json>", "Update payload as JSON object")
+      .option("--payload-file <path>", "Read payload from JSON file")
+      .action(async (opts: PayloadOptions & CompanyOnly) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          // Don't enforce updateCompanySchema vs updateCompanyBrandingSchema client-side
+          // because the server picks based on actor type — let it validate.
+          updateCompanySchema.parse(payload); // best-effort; will still pass branding-only via server
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.patch<unknown>(
+            `/api/companies/${ctx.companyId}`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    company
+      .command("branding-update")
+      .description("Update only company branding (CEO agents allowed)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--payload <json>", "Branding payload as JSON object")
+      .option("--payload-file <path>", "Read payload from JSON file")
+      .action(async (opts: PayloadOptions & CompanyOnly) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = updateCompanyBrandingSchema.parse(payload);
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.patch<unknown>(
+            `/api/companies/${ctx.companyId}/branding`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    company
+      .command("archive")
+      .description("Archive a company (board)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: CompanyOnly) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/archive`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── server-side portability variants ────────────────────────────────────
+  const portability = company.command("portability").description("Server-side portability flows");
+
+  for (const [verb, path, schema] of [
+    ["export-preview", "exports/preview", companyPortabilityExportSchema],
+    ["export", "exports", companyPortabilityExportSchema],
+    ["import-preview", "imports/preview", companyPortabilityPreviewSchema],
+    ["import-apply", "imports/apply", companyPortabilityImportSchema],
+  ] as const) {
+    addCommonClientOptions(
+      portability
+        .command(verb)
+        .description(`Per-company ${verb.replace("-", " ")}`)
+        .requiredOption("-C, --company-id <id>", "Company ID")
+        .option("--payload <json>", "Payload as JSON object")
+        .option("--payload-file <path>", "Read payload from JSON file")
+        .action(async (opts: PayloadOptions & CompanyOnly) => {
+          try {
+            const payload = readJson(opts, "payload");
+            if (payload === undefined) throw new Error("--payload or --payload-file required");
+            const parsed = schema.parse(payload);
+            const ctx = resolveCommandContext(opts, { requireCompany: true });
+            const row = await ctx.api.post<unknown>(
+              `/api/companies/${ctx.companyId}/${path}`,
+              parsed,
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+}

--- a/cli/src/commands/client/company-skill.ts
+++ b/cli/src/commands/client/company-skill.ts
@@ -1,0 +1,355 @@
+import { readFileSync } from "node:fs";
+import { Command } from "commander";
+import {
+  companySkillCreateSchema,
+  companySkillFileUpdateSchema,
+  companySkillImportSchema,
+  companySkillProjectScanRequestSchema,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface SkillListOptions extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface SkillCreateOptions extends BaseClientOptions {
+  companyId?: string;
+  name: string;
+  slug?: string;
+  description?: string;
+  markdown?: string;
+  markdownFile?: string;
+}
+
+interface SkillImportOptions extends BaseClientOptions {
+  companyId?: string;
+  source: string;
+}
+
+interface SkillScanOptions extends BaseClientOptions {
+  companyId?: string;
+  projectIds?: string;
+  workspaceIds?: string;
+}
+
+interface SkillFileGetOptions extends BaseClientOptions {
+  companyId?: string;
+  path?: string;
+}
+
+interface SkillFileUpdateOptions extends BaseClientOptions {
+  companyId?: string;
+  path: string;
+  content?: string;
+  contentFile?: string;
+}
+
+interface SkillDeleteOptions extends BaseClientOptions {
+  companyId?: string;
+  yes?: boolean;
+}
+
+function splitCsv(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  return value.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+async function confirmAction(message: string): Promise<boolean> {
+  const { confirm } = await import("@clack/prompts");
+  const answer = await confirm({ message, initialValue: false });
+  return answer === true;
+}
+
+export function registerCompanySkillCommands(program: Command): void {
+  const skill = program
+    .command("company-skill")
+    .description("Company skill (markdown + scripts) library");
+
+  addCommonClientOptions(
+    skill
+      .command("list")
+      .description("List company skills")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: SkillListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/skills`,
+          )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const r of rows as Array<Record<string, unknown>>) {
+            console.log(
+              formatInlineRecord({
+                id: r.id as string,
+                slug: r.slug as string,
+                name: r.name as string,
+                sourceType: r.sourceType as string | null,
+                trustLevel: r.trustLevel as string | null,
+                attachedAgentCount: (r.attachedAgentCount as number | null) ?? null,
+                editable: r.editable as boolean | null,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    skill
+      .command("get")
+      .description("Get one company skill with usage details")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<skillId>", "Skill ID")
+      .action(async (skillId: string, opts: SkillListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.get<unknown>(
+            `/api/companies/${ctx.companyId}/skills/${encodeURIComponent(skillId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    skill
+      .command("update-status")
+      .description("Check whether an upstream update is available for a tracked skill")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<skillId>", "Skill ID")
+      .action(async (skillId: string, opts: SkillListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.get<unknown>(
+            `/api/companies/${ctx.companyId}/skills/${encodeURIComponent(skillId)}/update-status`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    skill
+      .command("file-get")
+      .description("Read one file inside a skill (defaults to SKILL.md)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<skillId>", "Skill ID")
+      .option("--path <relative>", "File path within the skill", "SKILL.md")
+      .action(async (skillId: string, opts: SkillFileGetOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const params = new URLSearchParams();
+          if (opts.path) params.set("path", opts.path);
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const row = await ctx.api.get<unknown>(
+            `/api/companies/${ctx.companyId}/skills/${encodeURIComponent(skillId)}/files${query}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    skill
+      .command("create")
+      .description("Create a new local skill in the company library")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--name <name>", "Skill display name")
+      .option("--slug <slug>", "URL slug (auto-derived if omitted)")
+      .option("--description <text>", "Description")
+      .option("--markdown <text>", "Initial SKILL.md content")
+      .option("--markdown-file <path>", "Read SKILL.md content from file")
+      .action(async (opts: SkillCreateOptions) => {
+        try {
+          if (opts.markdown !== undefined && opts.markdownFile !== undefined) {
+            throw new Error("Pass either --markdown or --markdown-file, not both.");
+          }
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+
+          const payload: Record<string, unknown> = { name: opts.name };
+          if (opts.slug !== undefined) payload.slug = opts.slug;
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.markdown !== undefined) payload.markdown = opts.markdown;
+          if (opts.markdownFile !== undefined) {
+            payload.markdown = readFileSync(opts.markdownFile, "utf8");
+          }
+
+          const parsed = companySkillCreateSchema.parse(payload);
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/skills`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    skill
+      .command("import")
+      .description("Import skills from a source (github URL, skills.sh, local path, catalog ref)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--source <source>", "Source string")
+      .action(async (opts: SkillImportOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const parsed = companySkillImportSchema.parse({ source: opts.source });
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/skills/import`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    skill
+      .command("scan-projects")
+      .description("Scan project workspaces for skills directories and import them")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--project-ids <list>", "Comma-separated project UUIDs")
+      .option("--workspace-ids <list>", "Comma-separated workspace UUIDs")
+      .action(async (opts: SkillScanOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const payload: Record<string, unknown> = {};
+          const projectIds = splitCsv(opts.projectIds);
+          if (projectIds !== undefined) payload.projectIds = projectIds;
+          const workspaceIds = splitCsv(opts.workspaceIds);
+          if (workspaceIds !== undefined) payload.workspaceIds = workspaceIds;
+
+          const parsed = companySkillProjectScanRequestSchema.parse(payload);
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/skills/scan-projects`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    skill
+      .command("file-update")
+      .description("Replace a file's content inside a skill")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<skillId>", "Skill ID")
+      .requiredOption("--path <relative>", "File path within the skill")
+      .option("--content <text>", "New content")
+      .option("--content-file <path>", "Read new content from a file")
+      .action(async (skillId: string, opts: SkillFileUpdateOptions) => {
+        try {
+          if (opts.content !== undefined && opts.contentFile !== undefined) {
+            throw new Error("Pass either --content or --content-file, not both.");
+          }
+          let content: string;
+          if (opts.contentFile !== undefined) {
+            content = readFileSync(opts.contentFile, "utf8");
+          } else if (opts.content !== undefined) {
+            content = opts.content;
+          } else {
+            throw new Error("Pass --content or --content-file.");
+          }
+
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const parsed = companySkillFileUpdateSchema.parse({ path: opts.path, content });
+          const row = await ctx.api.patch<unknown>(
+            `/api/companies/${ctx.companyId}/skills/${encodeURIComponent(skillId)}/files`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    skill
+      .command("delete")
+      .description("Delete a company skill")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<skillId>", "Skill ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (skillId: string, opts: SkillDeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const ok = await confirmAction(
+              `Delete skill ${skillId}? Agents that reference it will lose the skill.`,
+            );
+            if (!ok) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.delete<unknown>(
+            `/api/companies/${ctx.companyId}/skills/${encodeURIComponent(skillId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    skill
+      .command("install-update")
+      .description("Pull the latest version for a tracked skill")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<skillId>", "Skill ID")
+      .action(async (skillId: string, opts: SkillListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/skills/${encodeURIComponent(skillId)}/install-update`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/cost.ts
+++ b/cli/src/commands/client/cost.ts
@@ -1,0 +1,318 @@
+import { Command } from "commander";
+import {
+  createCostEventSchema,
+  type CostByAgent,
+  type CostByAgentModel,
+  type CostByBiller,
+  type CostByProject,
+  type CostByProviderModel,
+  type CostEvent,
+  type CostSummary,
+  type IssueCostSummary,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface CostRangeOptions extends BaseClientOptions {
+  companyId?: string;
+  from?: string;
+  to?: string;
+}
+
+interface CostReportOptions extends BaseClientOptions {
+  companyId?: string;
+  agentId: string;
+  issueId?: string;
+  projectId?: string;
+  goalId?: string;
+  heartbeatRunId?: string;
+  billingCode?: string;
+  provider: string;
+  biller?: string;
+  billingType?: string;
+  model: string;
+  inputTokens?: string;
+  cachedInputTokens?: string;
+  outputTokens?: string;
+  costCents: string;
+  occurredAt?: string;
+}
+
+function buildRangeQuery(opts: { from?: string; to?: string }): string {
+  const params = new URLSearchParams();
+  if (opts.from) params.set("from", opts.from);
+  if (opts.to) params.set("to", opts.to);
+  const s = params.toString();
+  return s ? `?${s}` : "";
+}
+
+function addRangeOptions(cmd: Command): Command {
+  return cmd
+    .option("--from <iso>", "Start of date range (ISO 8601)")
+    .option("--to <iso>", "End of date range (ISO 8601)");
+}
+
+function parseIntOpt(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    throw new Error(`--${name} must be a non-negative integer`);
+  }
+  return n;
+}
+
+export function registerCostCommands(program: Command): void {
+  const cost = program.command("cost").description("LLM cost tracking and breakdowns");
+
+  addCommonClientOptions(
+    addRangeOptions(
+      cost
+        .command("summary")
+        .description("Total spend, budget, and utilization for a company")
+        .requiredOption("-C, --company-id <id>", "Company ID"),
+    ).action(async (opts: CostRangeOptions) => {
+      try {
+        const ctx = resolveCommandContext(opts, { requireCompany: true });
+        const row = await ctx.api.get<CostSummary>(
+          `/api/companies/${ctx.companyId}/costs/summary${buildRangeQuery(opts)}`,
+        );
+        printOutput(row, { json: ctx.json });
+      } catch (err) {
+        handleCommandError(err);
+      }
+    }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    cost
+      .command("issue-summary")
+      .description("Aggregated cost for an issue tree")
+      .argument("<issueId>", "Issue ID or identifier (e.g. ENG-12)")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<IssueCostSummary>(
+            `/api/issues/${encodeURIComponent(issueId)}/cost-summary`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const by = cost.command("by").description("Cost breakdowns by dimension");
+
+  const byDimensions: Array<{
+    name: string;
+    path: string;
+    description: string;
+    keys: (row: any) => Record<string, unknown>;
+  }> = [
+    {
+      name: "agent",
+      path: "by-agent",
+      description: "Cost grouped by agent",
+      keys: (r: CostByAgent) => ({
+        agentId: r.agentId,
+        agentName: r.agentName ?? null,
+        costCents: r.costCents,
+        inputTokens: r.inputTokens,
+        outputTokens: r.outputTokens,
+        apiRunCount: r.apiRunCount,
+        subscriptionRunCount: r.subscriptionRunCount,
+      }),
+    },
+    {
+      name: "agent-model",
+      path: "by-agent-model",
+      description: "Cost grouped by agent + provider + model",
+      keys: (r: CostByAgentModel) => ({
+        agentId: r.agentId,
+        agentName: r.agentName ?? null,
+        provider: r.provider,
+        model: r.model,
+        costCents: r.costCents,
+        inputTokens: r.inputTokens,
+        outputTokens: r.outputTokens,
+      }),
+    },
+    {
+      name: "provider",
+      path: "by-provider",
+      description: "Cost grouped by provider + model",
+      keys: (r: CostByProviderModel) => ({
+        provider: r.provider,
+        biller: r.biller,
+        model: r.model,
+        costCents: r.costCents,
+        inputTokens: r.inputTokens,
+        outputTokens: r.outputTokens,
+        apiRunCount: r.apiRunCount,
+      }),
+    },
+    {
+      name: "biller",
+      path: "by-biller",
+      description: "Cost grouped by biller",
+      keys: (r: CostByBiller) => ({
+        biller: r.biller,
+        costCents: r.costCents,
+        inputTokens: r.inputTokens,
+        outputTokens: r.outputTokens,
+        providerCount: r.providerCount,
+        modelCount: r.modelCount,
+      }),
+    },
+    {
+      name: "project",
+      path: "by-project",
+      description: "Cost attributed to projects",
+      keys: (r: CostByProject) => ({
+        projectId: r.projectId ?? null,
+        projectName: r.projectName ?? null,
+        costCents: r.costCents,
+        inputTokens: r.inputTokens,
+        outputTokens: r.outputTokens,
+      }),
+    },
+  ];
+
+  for (const dim of byDimensions) {
+    addCommonClientOptions(
+      addRangeOptions(
+        by
+          .command(dim.name)
+          .description(dim.description)
+          .requiredOption("-C, --company-id <id>", "Company ID"),
+      ).action(async (opts: CostRangeOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows =
+            (await ctx.api.get<unknown[]>(
+              `/api/companies/${ctx.companyId}/costs/${dim.path}${buildRangeQuery(opts)}`,
+            )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const row of rows) {
+            console.log(formatInlineRecord(dim.keys(row)));
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+      { includeCompany: false },
+    );
+  }
+
+  addCommonClientOptions(
+    cost
+      .command("windows")
+      .description("Rolling-window spend per provider")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: CostRangeOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/costs/window-spend`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    cost
+      .command("quota-windows")
+      .description("Provider-side quota window snapshots (board only)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: CostRangeOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/costs/quota-windows`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    cost
+      .command("report")
+      .description("Report a cost event (agents may only report their own)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--agent-id <id>", "Agent ID that incurred the cost")
+      .requiredOption("--provider <provider>", "Provider (e.g. anthropic, openai)")
+      .requiredOption("--model <model>", "Model identifier")
+      .requiredOption("--cost-cents <n>", "Cost in cents (integer)")
+      .option("--issue-id <id>", "Issue UUID")
+      .option("--project-id <id>", "Project UUID")
+      .option("--goal-id <id>", "Goal UUID")
+      .option("--heartbeat-run-id <id>", "Heartbeat run UUID")
+      .option("--billing-code <code>", "Billing code")
+      .option("--biller <biller>", "Biller (defaults to provider)")
+      .option("--billing-type <type>", "Billing type (e.g. api, subscription, unknown)")
+      .option("--input-tokens <n>", "Input tokens")
+      .option("--cached-input-tokens <n>", "Cached input tokens")
+      .option("--output-tokens <n>", "Output tokens")
+      .option("--occurred-at <iso>", "Event timestamp (ISO 8601, defaults to now)")
+      .action(async (opts: CostReportOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+
+          const payload: Record<string, unknown> = {
+            agentId: opts.agentId,
+            provider: opts.provider,
+            model: opts.model,
+            costCents: parseIntOpt(opts.costCents, "cost-cents")!,
+            occurredAt: opts.occurredAt ?? new Date().toISOString(),
+          };
+          if (opts.issueId !== undefined) payload.issueId = opts.issueId;
+          if (opts.projectId !== undefined) payload.projectId = opts.projectId;
+          if (opts.goalId !== undefined) payload.goalId = opts.goalId;
+          if (opts.heartbeatRunId !== undefined) payload.heartbeatRunId = opts.heartbeatRunId;
+          if (opts.billingCode !== undefined) payload.billingCode = opts.billingCode;
+          if (opts.biller !== undefined) payload.biller = opts.biller;
+          if (opts.billingType !== undefined) payload.billingType = opts.billingType;
+          const inputTokens = parseIntOpt(opts.inputTokens, "input-tokens");
+          if (inputTokens !== undefined) payload.inputTokens = inputTokens;
+          const cached = parseIntOpt(opts.cachedInputTokens, "cached-input-tokens");
+          if (cached !== undefined) payload.cachedInputTokens = cached;
+          const outputTokens = parseIntOpt(opts.outputTokens, "output-tokens");
+          if (outputTokens !== undefined) payload.outputTokens = outputTokens;
+
+          const parsed = createCostEventSchema.parse(payload);
+          const row = await ctx.api.post<CostEvent>(
+            `/api/companies/${ctx.companyId}/cost-events`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/environment.ts
+++ b/cli/src/commands/client/environment.ts
@@ -33,8 +33,8 @@ interface EnvironmentCreateOptions extends BaseClientOptions {
   driver: string;
   description?: string;
   status?: string;
-  config?: string;
-  configFile?: string;
+  driverConfig?: string;
+  driverConfigFile?: string;
   metadata?: string;
   metadataFile?: string;
 }
@@ -44,8 +44,8 @@ interface EnvironmentUpdateOptions extends BaseClientOptions {
   description?: string;
   driver?: string;
   status?: string;
-  config?: string;
-  configFile?: string;
+  driverConfig?: string;
+  driverConfigFile?: string;
   metadata?: string;
   metadataFile?: string;
 }
@@ -59,8 +59,8 @@ interface EnvironmentProbeConfigOptions extends BaseClientOptions {
   name?: string;
   description?: string;
   driver: string;
-  config?: string;
-  configFile?: string;
+  driverConfig?: string;
+  driverConfigFile?: string;
   metadata?: string;
   metadataFile?: string;
 }
@@ -269,14 +269,14 @@ export function registerEnvironmentCommands(program: Command): void {
       .requiredOption("--driver <driver>", "Environment driver (e.g. local, ssh, sandbox)")
       .option("--description <text>", "Description")
       .option("--status <status>", "Environment status (e.g. active, disabled)")
-      .option("--config <json>", "Driver config as JSON object")
-      .option("--config-file <path>", "Path to JSON file with driver config")
+      .option("--driver-config <json>", "Driver config as JSON object")
+      .option("--driver-config-file <path>", "Path to JSON file with driver config")
       .option("--metadata <json>", "Metadata as JSON object")
       .option("--metadata-file <path>", "Path to JSON file with metadata")
       .action(async (opts: EnvironmentCreateOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
-          const config = readJsonOption(opts.config, opts.configFile, "config");
+          const config = readJsonOption(opts.driverConfig, opts.driverConfigFile, "driver-config");
           const metadata = readJsonOption(opts.metadata, opts.metadataFile, "metadata");
 
           const payload: Record<string, unknown> = {
@@ -310,14 +310,14 @@ export function registerEnvironmentCommands(program: Command): void {
       .option("--description <text>", "New description")
       .option("--driver <driver>", "New driver (resets config unless --config provided)")
       .option("--status <status>", "New status")
-      .option("--config <json>", "Replacement/merge driver config as JSON object")
-      .option("--config-file <path>", "Path to JSON file with driver config")
+      .option("--driver-config <json>", "Replacement/merge driver config as JSON object")
+      .option("--driver-config-file <path>", "Path to JSON file with driver config")
       .option("--metadata <json>", "Metadata as JSON object")
       .option("--metadata-file <path>", "Path to JSON file with metadata")
       .action(async (environmentId: string, opts: EnvironmentUpdateOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const config = readJsonOption(opts.config, opts.configFile, "config");
+          const config = readJsonOption(opts.driverConfig, opts.driverConfigFile, "driver-config");
           const metadata = readJsonOption(opts.metadata, opts.metadataFile, "metadata");
 
           const payload: Record<string, unknown> = {};
@@ -400,14 +400,14 @@ export function registerEnvironmentCommands(program: Command): void {
       .requiredOption("--driver <driver>", "Environment driver")
       .option("--name <name>", "Display name (defaults to 'Unsaved environment')")
       .option("--description <text>", "Description")
-      .option("--config <json>", "Driver config as JSON object")
-      .option("--config-file <path>", "Path to JSON file with driver config")
+      .option("--driver-config <json>", "Driver config as JSON object")
+      .option("--driver-config-file <path>", "Path to JSON file with driver config")
       .option("--metadata <json>", "Metadata as JSON object")
       .option("--metadata-file <path>", "Path to JSON file with metadata")
       .action(async (opts: EnvironmentProbeConfigOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
-          const config = readJsonOption(opts.config, opts.configFile, "config");
+          const config = readJsonOption(opts.driverConfig, opts.driverConfigFile, "driver-config");
           const metadata = readJsonOption(opts.metadata, opts.metadataFile, "metadata");
 
           const payload: Record<string, unknown> = { driver: opts.driver };

--- a/cli/src/commands/client/environment.ts
+++ b/cli/src/commands/client/environment.ts
@@ -1,0 +1,433 @@
+import { readFileSync } from "node:fs";
+import { Command } from "commander";
+import {
+  createEnvironmentSchema,
+  probeEnvironmentConfigSchema,
+  updateEnvironmentSchema,
+  type Environment,
+  type EnvironmentLease,
+  type EnvironmentProbeResult,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface EnvironmentListOptions extends BaseClientOptions {
+  companyId?: string;
+  status?: string;
+  driver?: string;
+}
+
+interface EnvironmentCapabilitiesOptions extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface EnvironmentCreateOptions extends BaseClientOptions {
+  companyId?: string;
+  name: string;
+  driver: string;
+  description?: string;
+  status?: string;
+  config?: string;
+  configFile?: string;
+  metadata?: string;
+  metadataFile?: string;
+}
+
+interface EnvironmentUpdateOptions extends BaseClientOptions {
+  name?: string;
+  description?: string;
+  driver?: string;
+  status?: string;
+  config?: string;
+  configFile?: string;
+  metadata?: string;
+  metadataFile?: string;
+}
+
+interface EnvironmentDeleteOptions extends BaseClientOptions {
+  yes?: boolean;
+}
+
+interface EnvironmentProbeConfigOptions extends BaseClientOptions {
+  companyId?: string;
+  name?: string;
+  description?: string;
+  driver: string;
+  config?: string;
+  configFile?: string;
+  metadata?: string;
+  metadataFile?: string;
+}
+
+interface EnvironmentLeaseListOptions extends BaseClientOptions {
+  status?: string;
+}
+
+function readJsonOption(
+  inline: string | undefined,
+  filePath: string | undefined,
+  flagName: string,
+): Record<string, unknown> | undefined {
+  if (inline !== undefined && filePath !== undefined) {
+    throw new Error(`Pass either --${flagName} or --${flagName}-file, not both.`);
+  }
+  const raw =
+    inline !== undefined
+      ? inline
+      : filePath !== undefined
+        ? readFileSync(filePath, "utf8")
+        : undefined;
+  if (raw === undefined) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`--${flagName} must be valid JSON: ${(err as Error).message}`);
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`--${flagName} must be a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function printEnvironmentRow(row: Environment): void {
+  console.log(
+    formatInlineRecord({
+      id: row.id,
+      name: row.name,
+      driver: row.driver,
+      status: row.status,
+      configKeys: Object.keys(row.config ?? {}).length,
+    }),
+  );
+}
+
+function registerLeaseSubcommands(parent: Command): void {
+  const lease = parent.command("lease").description("Environment lease operations");
+
+  addCommonClientOptions(
+    lease
+      .command("list")
+      .description("List leases for an environment")
+      .argument("<environmentId>", "Environment ID")
+      .option("--status <status>", "Filter by lease status")
+      .action(async (environmentId: string, opts: EnvironmentLeaseListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const query = opts.status
+            ? `?status=${encodeURIComponent(opts.status)}`
+            : "";
+          const rows =
+            (await ctx.api.get<EnvironmentLease[]>(
+              `/api/environments/${encodeURIComponent(environmentId)}/leases${query}`,
+            )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+
+          for (const row of rows) {
+            console.log(
+              formatInlineRecord({
+                id: row.id,
+                status: row.status,
+                provider: row.provider ?? null,
+                executionWorkspaceId: row.executionWorkspaceId ?? null,
+                issueId: row.issueId ?? null,
+                acquiredAt: row.acquiredAt instanceof Date
+                  ? row.acquiredAt.toISOString()
+                  : (row.acquiredAt as unknown as string),
+                expiresAt: row.expiresAt instanceof Date
+                  ? row.expiresAt.toISOString()
+                  : (row.expiresAt as unknown as string | null),
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    lease
+      .command("get")
+      .description("Get one environment lease")
+      .argument("<leaseId>", "Lease ID")
+      .action(async (leaseId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<EnvironmentLease>(
+            `/api/environment-leases/${encodeURIComponent(leaseId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}
+
+export function registerEnvironmentCommands(program: Command): void {
+  const env = program.command("environment").description("Execution environment operations");
+
+  addCommonClientOptions(
+    env
+      .command("list")
+      .description("List environments for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--status <status>", "Filter by environment status")
+      .option("--driver <driver>", "Filter by environment driver")
+      .action(async (opts: EnvironmentListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const params = new URLSearchParams();
+          if (opts.status) params.set("status", opts.status);
+          if (opts.driver) params.set("driver", opts.driver);
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const rows =
+            (await ctx.api.get<Environment[]>(
+              `/api/companies/${ctx.companyId}/environments${query}`,
+            )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+
+          for (const row of rows) printEnvironmentRow(row);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    env
+      .command("capabilities")
+      .description("Show environment capabilities (drivers, sandbox providers) for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: EnvironmentCapabilitiesOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.get<unknown>(
+            `/api/companies/${ctx.companyId}/environments/capabilities`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    env
+      .command("get")
+      .description("Get one environment")
+      .argument("<environmentId>", "Environment ID")
+      .action(async (environmentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<Environment>(
+            `/api/environments/${encodeURIComponent(environmentId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    env
+      .command("create")
+      .description("Create a new environment")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--name <name>", "Environment name")
+      .requiredOption("--driver <driver>", "Environment driver (e.g. local, ssh, sandbox)")
+      .option("--description <text>", "Description")
+      .option("--status <status>", "Environment status (e.g. active, disabled)")
+      .option("--config <json>", "Driver config as JSON object")
+      .option("--config-file <path>", "Path to JSON file with driver config")
+      .option("--metadata <json>", "Metadata as JSON object")
+      .option("--metadata-file <path>", "Path to JSON file with metadata")
+      .action(async (opts: EnvironmentCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const config = readJsonOption(opts.config, opts.configFile, "config");
+          const metadata = readJsonOption(opts.metadata, opts.metadataFile, "metadata");
+
+          const payload: Record<string, unknown> = {
+            name: opts.name,
+            driver: opts.driver,
+          };
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.status !== undefined) payload.status = opts.status;
+          if (config !== undefined) payload.config = config;
+          if (metadata !== undefined) payload.metadata = metadata;
+
+          const parsed = createEnvironmentSchema.parse(payload);
+          const row = await ctx.api.post<Environment>(
+            `/api/companies/${ctx.companyId}/environments`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    env
+      .command("update")
+      .description("Update an environment")
+      .argument("<environmentId>", "Environment ID")
+      .option("--name <name>", "New name")
+      .option("--description <text>", "New description")
+      .option("--driver <driver>", "New driver (resets config unless --config provided)")
+      .option("--status <status>", "New status")
+      .option("--config <json>", "Replacement/merge driver config as JSON object")
+      .option("--config-file <path>", "Path to JSON file with driver config")
+      .option("--metadata <json>", "Metadata as JSON object")
+      .option("--metadata-file <path>", "Path to JSON file with metadata")
+      .action(async (environmentId: string, opts: EnvironmentUpdateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const config = readJsonOption(opts.config, opts.configFile, "config");
+          const metadata = readJsonOption(opts.metadata, opts.metadataFile, "metadata");
+
+          const payload: Record<string, unknown> = {};
+          if (opts.name !== undefined) payload.name = opts.name;
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.driver !== undefined) payload.driver = opts.driver;
+          if (opts.status !== undefined) payload.status = opts.status;
+          if (config !== undefined) payload.config = config;
+          if (metadata !== undefined) payload.metadata = metadata;
+
+          const parsed = updateEnvironmentSchema.parse(payload);
+          const row = await ctx.api.patch<Environment>(
+            `/api/environments/${encodeURIComponent(environmentId)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    env
+      .command("delete")
+      .description("Delete an environment (releases SSH key secret if present)")
+      .argument("<environmentId>", "Environment ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (environmentId: string, opts: EnvironmentDeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const { confirm } = await import("@clack/prompts");
+            const answer = await confirm({
+              message: `Delete environment ${environmentId}? Active leases will be invalidated.`,
+              initialValue: false,
+            });
+            if (answer !== true) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<Environment>(
+            `/api/environments/${encodeURIComponent(environmentId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    env
+      .command("probe")
+      .description("Probe a saved environment to verify it is reachable")
+      .argument("<environmentId>", "Environment ID")
+      .action(async (environmentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<EnvironmentProbeResult>(
+            `/api/environments/${encodeURIComponent(environmentId)}/probe`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    env
+      .command("probe-config")
+      .description("Probe an unsaved environment config without persisting it")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--driver <driver>", "Environment driver")
+      .option("--name <name>", "Display name (defaults to 'Unsaved environment')")
+      .option("--description <text>", "Description")
+      .option("--config <json>", "Driver config as JSON object")
+      .option("--config-file <path>", "Path to JSON file with driver config")
+      .option("--metadata <json>", "Metadata as JSON object")
+      .option("--metadata-file <path>", "Path to JSON file with metadata")
+      .action(async (opts: EnvironmentProbeConfigOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const config = readJsonOption(opts.config, opts.configFile, "config");
+          const metadata = readJsonOption(opts.metadata, opts.metadataFile, "metadata");
+
+          const payload: Record<string, unknown> = { driver: opts.driver };
+          if (opts.name !== undefined) payload.name = opts.name;
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (config !== undefined) payload.config = config;
+          if (metadata !== undefined) payload.metadata = metadata;
+
+          const parsed = probeEnvironmentConfigSchema.parse(payload);
+          const row = await ctx.api.post<EnvironmentProbeResult>(
+            `/api/companies/${ctx.companyId}/environments/probe-config`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  registerLeaseSubcommands(env);
+}

--- a/cli/src/commands/client/execution-workspace.ts
+++ b/cli/src/commands/client/execution-workspace.ts
@@ -1,0 +1,317 @@
+import { Command } from "commander";
+import {
+  updateExecutionWorkspaceSchema,
+  workspaceRuntimeControlTargetSchema,
+  type ExecutionWorkspace,
+  type ExecutionWorkspaceCloseReadiness,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface WorkspaceListOptions extends BaseClientOptions {
+  companyId?: string;
+  projectId?: string;
+  projectWorkspaceId?: string;
+  issueId?: string;
+  status?: string;
+  reuseEligible?: boolean;
+  summary?: boolean;
+}
+
+interface WorkspaceUpdateOptions extends BaseClientOptions {
+  name?: string;
+  cwd?: string;
+  repoUrl?: string;
+  baseRef?: string;
+  branchName?: string;
+  providerRef?: string;
+  status?: string;
+  cleanupEligibleAt?: string;
+  cleanupReason?: string;
+  config?: string;
+  metadata?: string;
+}
+
+interface RuntimeControlOptions extends BaseClientOptions {
+  action: string;
+  workspaceCommandId?: string;
+  runtimeServiceId?: string;
+  serviceIndex?: string;
+}
+
+const RUNTIME_ACTIONS = ["start", "stop", "restart", "run"] as const;
+
+function parseJsonObject(
+  raw: string | undefined,
+  name: string,
+): Record<string, unknown> | undefined {
+  if (raw === undefined) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`--${name} must be valid JSON: ${(err as Error).message}`);
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`--${name} must be a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parseIntOpt(raw: string | undefined, name: string): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    throw new Error(`--${name} must be a non-negative integer`);
+  }
+  return n;
+}
+
+function buildRuntimeTargetPayload(opts: RuntimeControlOptions): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  if (opts.workspaceCommandId !== undefined) payload.workspaceCommandId = opts.workspaceCommandId;
+  if (opts.runtimeServiceId !== undefined) payload.runtimeServiceId = opts.runtimeServiceId;
+  const idx = parseIntOpt(opts.serviceIndex, "service-index");
+  if (idx !== undefined) payload.serviceIndex = idx;
+  return payload;
+}
+
+function assertRuntimeAction(action: string): void {
+  if (!RUNTIME_ACTIONS.includes(action as (typeof RUNTIME_ACTIONS)[number])) {
+    throw new Error(`--action must be one of: ${RUNTIME_ACTIONS.join(", ")}`);
+  }
+}
+
+export function registerExecutionWorkspaceCommands(program: Command): void {
+  const ws = program
+    .command("execution-workspace")
+    .description("Per-issue execution workspace operations");
+
+  addCommonClientOptions(
+    ws
+      .command("list")
+      .description("List execution workspaces for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--project-id <id>", "Filter by project")
+      .option("--project-workspace-id <id>", "Filter by project workspace")
+      .option("--issue-id <id>", "Filter by source issue")
+      .option("--status <status>", "Filter by status")
+      .option("--reuse-eligible", "Only reuse-eligible workspaces")
+      .option("--summary", "Return summary rows instead of full records")
+      .action(async (opts: WorkspaceListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const params = new URLSearchParams();
+          if (opts.projectId) params.set("projectId", opts.projectId);
+          if (opts.projectWorkspaceId) params.set("projectWorkspaceId", opts.projectWorkspaceId);
+          if (opts.issueId) params.set("issueId", opts.issueId);
+          if (opts.status) params.set("status", opts.status);
+          if (opts.reuseEligible) params.set("reuseEligible", "true");
+          if (opts.summary) params.set("summary", "true");
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/execution-workspaces${query}`,
+          )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const r of rows as Array<Partial<ExecutionWorkspace>>) {
+            console.log(
+              formatInlineRecord({
+                id: r.id ?? "",
+                name: r.name ?? null,
+                status: r.status ?? null,
+                cwd: r.cwd ?? null,
+                branchName: r.branchName ?? null,
+                projectId: r.projectId ?? null,
+                sourceIssueId: r.sourceIssueId ?? null,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    ws
+      .command("get")
+      .description("Get one execution workspace")
+      .argument("<id>", "Execution workspace ID")
+      .action(async (id: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<ExecutionWorkspace>(
+            `/api/execution-workspaces/${encodeURIComponent(id)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    ws
+      .command("close-readiness")
+      .description("Inspect close readiness (blockers, planned actions, runtime services)")
+      .argument("<id>", "Execution workspace ID")
+      .action(async (id: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<ExecutionWorkspaceCloseReadiness>(
+            `/api/execution-workspaces/${encodeURIComponent(id)}/close-readiness`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    ws
+      .command("operations")
+      .description("List workspace operations attached to this execution workspace")
+      .argument("<id>", "Execution workspace ID")
+      .action(async (id: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/execution-workspaces/${encodeURIComponent(id)}/workspace-operations`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    ws
+      .command("update")
+      .description("Update an execution workspace")
+      .argument("<id>", "Execution workspace ID")
+      .option("--name <name>", "New name")
+      .option("--cwd <path>", "Local checkout path (use empty string to clear)")
+      .option("--repo-url <url>", "Repo URL")
+      .option("--base-ref <ref>", "Base ref")
+      .option("--branch-name <name>", "Branch name")
+      .option("--provider-ref <ref>", "Provider reference")
+      .option("--status <status>", "Status (active, idle, in_review, archived, cleanup_failed)")
+      .option("--cleanup-eligible-at <iso>", "Cleanup eligibility timestamp (or empty to clear)")
+      .option("--cleanup-reason <text>", "Cleanup reason")
+      .option("--config <json>", "Config patch as JSON object")
+      .option("--metadata <json>", "Metadata as JSON object")
+      .action(async (id: string, opts: WorkspaceUpdateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload: Record<string, unknown> = {};
+          if (opts.name !== undefined) payload.name = opts.name;
+          if (opts.cwd !== undefined) payload.cwd = opts.cwd === "" ? null : opts.cwd;
+          if (opts.repoUrl !== undefined) payload.repoUrl = opts.repoUrl === "" ? null : opts.repoUrl;
+          if (opts.baseRef !== undefined) payload.baseRef = opts.baseRef === "" ? null : opts.baseRef;
+          if (opts.branchName !== undefined)
+            payload.branchName = opts.branchName === "" ? null : opts.branchName;
+          if (opts.providerRef !== undefined)
+            payload.providerRef = opts.providerRef === "" ? null : opts.providerRef;
+          if (opts.status !== undefined) payload.status = opts.status;
+          if (opts.cleanupEligibleAt !== undefined)
+            payload.cleanupEligibleAt = opts.cleanupEligibleAt === "" ? null : opts.cleanupEligibleAt;
+          if (opts.cleanupReason !== undefined)
+            payload.cleanupReason = opts.cleanupReason === "" ? null : opts.cleanupReason;
+          const config = parseJsonObject(opts.config, "config");
+          if (config !== undefined) payload.config = config;
+          const metadata = parseJsonObject(opts.metadata, "metadata");
+          if (metadata !== undefined) payload.metadata = metadata;
+
+          const parsed = updateExecutionWorkspaceSchema.parse(payload);
+          const row = await ctx.api.patch<ExecutionWorkspace>(
+            `/api/execution-workspaces/${encodeURIComponent(id)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    ws
+      .command("runtime-service")
+      .description(
+        `Control a runtime service on an execution workspace (action: ${RUNTIME_ACTIONS.join(", ")})`,
+      )
+      .argument("<id>", "Execution workspace ID")
+      .requiredOption("--action <action>", `One of: ${RUNTIME_ACTIONS.join(", ")}`)
+      .option("--workspace-command-id <id>", "Workspace command ID")
+      .option("--runtime-service-id <id>", "Existing runtime service ID")
+      .option("--service-index <n>", "Configured service index")
+      .action(async (id: string, opts: RuntimeControlOptions) => {
+        try {
+          assertRuntimeAction(opts.action);
+          const ctx = resolveCommandContext(opts);
+          const parsed = workspaceRuntimeControlTargetSchema.parse(
+            buildRuntimeTargetPayload(opts),
+          );
+          const row = await ctx.api.post<unknown>(
+            `/api/execution-workspaces/${encodeURIComponent(id)}/runtime-services/${encodeURIComponent(opts.action)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    ws
+      .command("runtime-command")
+      .description(
+        `Run a workspace command (action: ${RUNTIME_ACTIONS.join(", ")})`,
+      )
+      .argument("<id>", "Execution workspace ID")
+      .requiredOption("--action <action>", `One of: ${RUNTIME_ACTIONS.join(", ")}`)
+      .option("--workspace-command-id <id>", "Workspace command ID")
+      .option("--runtime-service-id <id>", "Existing runtime service ID")
+      .option("--service-index <n>", "Configured service index")
+      .action(async (id: string, opts: RuntimeControlOptions) => {
+        try {
+          assertRuntimeAction(opts.action);
+          const ctx = resolveCommandContext(opts);
+          const parsed = workspaceRuntimeControlTargetSchema.parse(
+            buildRuntimeTargetPayload(opts),
+          );
+          const row = await ctx.api.post<unknown>(
+            `/api/execution-workspaces/${encodeURIComponent(id)}/runtime-commands/${encodeURIComponent(opts.action)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/execution-workspace.ts
+++ b/cli/src/commands/client/execution-workspace.ts
@@ -34,7 +34,7 @@ interface WorkspaceUpdateOptions extends BaseClientOptions {
   status?: string;
   cleanupEligibleAt?: string;
   cleanupReason?: string;
-  config?: string;
+  workspaceConfig?: string;
   metadata?: string;
 }
 
@@ -218,7 +218,7 @@ export function registerExecutionWorkspaceCommands(program: Command): void {
       .option("--status <status>", "Status (active, idle, in_review, archived, cleanup_failed)")
       .option("--cleanup-eligible-at <iso>", "Cleanup eligibility timestamp (or empty to clear)")
       .option("--cleanup-reason <text>", "Cleanup reason")
-      .option("--config <json>", "Config patch as JSON object")
+      .option("--workspace-config <json>", "Config patch as JSON object")
       .option("--metadata <json>", "Metadata as JSON object")
       .action(async (id: string, opts: WorkspaceUpdateOptions) => {
         try {
@@ -237,7 +237,7 @@ export function registerExecutionWorkspaceCommands(program: Command): void {
             payload.cleanupEligibleAt = opts.cleanupEligibleAt === "" ? null : opts.cleanupEligibleAt;
           if (opts.cleanupReason !== undefined)
             payload.cleanupReason = opts.cleanupReason === "" ? null : opts.cleanupReason;
-          const config = parseJsonObject(opts.config, "config");
+          const config = parseJsonObject(opts.workspaceConfig, "workspace-config");
           if (config !== undefined) payload.config = config;
           const metadata = parseJsonObject(opts.metadata, "metadata");
           if (metadata !== undefined) payload.metadata = metadata;

--- a/cli/src/commands/client/finance.ts
+++ b/cli/src/commands/client/finance.ts
@@ -1,0 +1,252 @@
+import { Command } from "commander";
+import {
+  createFinanceEventSchema,
+  type FinanceEvent,
+  type FinanceSummary,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface FinanceRangeOptions extends BaseClientOptions {
+  companyId?: string;
+  from?: string;
+  to?: string;
+  limit?: string;
+}
+
+interface FinanceReportOptions extends BaseClientOptions {
+  companyId?: string;
+  eventKind: string;
+  biller: string;
+  amountCents: string;
+  occurredAt?: string;
+  agentId?: string;
+  issueId?: string;
+  projectId?: string;
+  goalId?: string;
+  heartbeatRunId?: string;
+  costEventId?: string;
+  billingCode?: string;
+  description?: string;
+  direction?: string;
+  provider?: string;
+  executionAdapterType?: string;
+  pricingTier?: string;
+  region?: string;
+  model?: string;
+  quantity?: string;
+  unit?: string;
+  currency?: string;
+  estimated?: boolean;
+  externalInvoiceId?: string;
+  metadata?: string;
+}
+
+function buildRangeQuery(opts: { from?: string; to?: string; limit?: string }): string {
+  const params = new URLSearchParams();
+  if (opts.from) params.set("from", opts.from);
+  if (opts.to) params.set("to", opts.to);
+  if (opts.limit) params.set("limit", opts.limit);
+  const s = params.toString();
+  return s ? `?${s}` : "";
+}
+
+function parseIntOpt(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    throw new Error(`--${name} must be a non-negative integer`);
+  }
+  return n;
+}
+
+export function registerFinanceCommands(program: Command): void {
+  const finance = program.command("finance").description("Finance event tracking and breakdowns");
+
+  addCommonClientOptions(
+    finance
+      .command("list")
+      .description("List finance events for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--from <iso>", "Start of date range (ISO 8601)")
+      .option("--to <iso>", "End of date range (ISO 8601)")
+      .option("--limit <n>", "Max results (1-500, default 100)")
+      .action(async (opts: FinanceRangeOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<FinanceEvent[]>(
+            `/api/companies/${ctx.companyId}/costs/finance-events${buildRangeQuery(opts)}`,
+          )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const row of rows) {
+            console.log(
+              formatInlineRecord({
+                id: row.id,
+                eventKind: row.eventKind,
+                biller: row.biller,
+                amountCents: row.amountCents,
+                currency: row.currency,
+                direction: row.direction,
+                estimated: row.estimated,
+                occurredAt: row.occurredAt instanceof Date
+                  ? row.occurredAt.toISOString()
+                  : (row.occurredAt as unknown as string),
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    finance
+      .command("summary")
+      .description("Aggregated finance event spend")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--from <iso>", "Start of date range (ISO 8601)")
+      .option("--to <iso>", "End of date range (ISO 8601)")
+      .action(async (opts: FinanceRangeOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.get<FinanceSummary>(
+            `/api/companies/${ctx.companyId}/costs/finance-summary${buildRangeQuery(opts)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  for (const dim of [
+    { name: "by-biller", path: "finance-by-biller", description: "Finance spend grouped by biller" },
+    { name: "by-kind", path: "finance-by-kind", description: "Finance spend grouped by event kind" },
+  ]) {
+    addCommonClientOptions(
+      finance
+        .command(dim.name)
+        .description(dim.description)
+        .requiredOption("-C, --company-id <id>", "Company ID")
+        .option("--from <iso>", "Start of date range (ISO 8601)")
+        .option("--to <iso>", "End of date range (ISO 8601)")
+        .action(async (opts: FinanceRangeOptions) => {
+          try {
+            const ctx = resolveCommandContext(opts, { requireCompany: true });
+            const rows = (await ctx.api.get<unknown[]>(
+              `/api/companies/${ctx.companyId}/costs/${dim.path}${buildRangeQuery(opts)}`,
+            )) ?? [];
+            printOutput(rows, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+
+  addCommonClientOptions(
+    finance
+      .command("report")
+      .description("Report a finance event (board only)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--event-kind <kind>", "Finance event kind")
+      .requiredOption("--biller <biller>", "Biller")
+      .requiredOption("--amount-cents <n>", "Amount in cents (integer)")
+      .option("--occurred-at <iso>", "Event timestamp (ISO 8601, defaults to now)")
+      .option("--agent-id <id>", "Agent UUID")
+      .option("--issue-id <id>", "Issue UUID")
+      .option("--project-id <id>", "Project UUID")
+      .option("--goal-id <id>", "Goal UUID")
+      .option("--heartbeat-run-id <id>", "Heartbeat run UUID")
+      .option("--cost-event-id <id>", "Linked cost event UUID")
+      .option("--billing-code <code>", "Billing code")
+      .option("--description <text>", "Description (max 500 chars)")
+      .option("--direction <direction>", "Direction (debit, credit)")
+      .option("--provider <provider>", "Provider")
+      .option("--execution-adapter-type <type>", "Execution adapter type")
+      .option("--pricing-tier <tier>", "Pricing tier")
+      .option("--region <region>", "Region")
+      .option("--model <model>", "Model identifier")
+      .option("--quantity <n>", "Quantity (non-negative integer)")
+      .option("--unit <unit>", "Unit")
+      .option("--currency <code>", "ISO currency code (default USD)")
+      .option("--estimated", "Mark event as estimated")
+      .option("--external-invoice-id <id>", "External invoice ID")
+      .option("--metadata <json>", "Metadata as JSON object")
+      .action(async (opts: FinanceReportOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+
+          let metadata: Record<string, unknown> | undefined;
+          if (opts.metadata !== undefined) {
+            try {
+              const parsed = JSON.parse(opts.metadata);
+              if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+                throw new Error("must be a JSON object");
+              }
+              metadata = parsed as Record<string, unknown>;
+            } catch (err) {
+              throw new Error(`--metadata must be valid JSON object: ${(err as Error).message}`);
+            }
+          }
+
+          const payload: Record<string, unknown> = {
+            eventKind: opts.eventKind,
+            biller: opts.biller,
+            amountCents: parseIntOpt(opts.amountCents, "amount-cents")!,
+            occurredAt: opts.occurredAt ?? new Date().toISOString(),
+          };
+          if (opts.agentId !== undefined) payload.agentId = opts.agentId;
+          if (opts.issueId !== undefined) payload.issueId = opts.issueId;
+          if (opts.projectId !== undefined) payload.projectId = opts.projectId;
+          if (opts.goalId !== undefined) payload.goalId = opts.goalId;
+          if (opts.heartbeatRunId !== undefined) payload.heartbeatRunId = opts.heartbeatRunId;
+          if (opts.costEventId !== undefined) payload.costEventId = opts.costEventId;
+          if (opts.billingCode !== undefined) payload.billingCode = opts.billingCode;
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.direction !== undefined) payload.direction = opts.direction;
+          if (opts.provider !== undefined) payload.provider = opts.provider;
+          if (opts.executionAdapterType !== undefined)
+            payload.executionAdapterType = opts.executionAdapterType;
+          if (opts.pricingTier !== undefined) payload.pricingTier = opts.pricingTier;
+          if (opts.region !== undefined) payload.region = opts.region;
+          if (opts.model !== undefined) payload.model = opts.model;
+          const quantity = parseIntOpt(opts.quantity, "quantity");
+          if (quantity !== undefined) payload.quantity = quantity;
+          if (opts.unit !== undefined) payload.unit = opts.unit;
+          if (opts.currency !== undefined) payload.currency = opts.currency;
+          if (opts.estimated) payload.estimated = true;
+          if (opts.externalInvoiceId !== undefined) payload.externalInvoiceId = opts.externalInvoiceId;
+          if (metadata !== undefined) payload.metadataJson = metadata;
+
+          const parsed = createFinanceEventSchema.parse(payload);
+          const row = await ctx.api.post<FinanceEvent>(
+            `/api/companies/${ctx.companyId}/finance-events`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/goal.ts
+++ b/cli/src/commands/client/goal.ts
@@ -1,0 +1,200 @@
+import { Command } from "commander";
+import {
+  createGoalSchema,
+  updateGoalSchema,
+  type Goal,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface GoalListOptions extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface GoalCreateOptions extends BaseClientOptions {
+  companyId?: string;
+  title: string;
+  description?: string;
+  level?: string;
+  status?: string;
+  parentId?: string;
+  ownerAgentId?: string;
+}
+
+interface GoalUpdateOptions extends BaseClientOptions {
+  title?: string;
+  description?: string;
+  level?: string;
+  status?: string;
+  parentId?: string;
+  ownerAgentId?: string;
+}
+
+interface GoalDeleteOptions extends BaseClientOptions {
+  yes?: boolean;
+}
+
+export function registerGoalCommands(program: Command): void {
+  const goal = program.command("goal").description("Goal operations");
+
+  addCommonClientOptions(
+    goal
+      .command("list")
+      .description("List goals for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: GoalListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows =
+            (await ctx.api.get<Goal[]>(`/api/companies/${ctx.companyId}/goals`)) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+
+          for (const row of rows) {
+            console.log(
+              formatInlineRecord({
+                id: row.id,
+                title: row.title,
+                level: row.level,
+                status: row.status,
+                parentId: row.parentId,
+                ownerAgentId: row.ownerAgentId,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    goal
+      .command("get")
+      .description("Get one goal")
+      .argument("<goalId>", "Goal ID")
+      .action(async (goalId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<Goal>(`/api/goals/${encodeURIComponent(goalId)}`);
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    goal
+      .command("create")
+      .description("Create a new goal in a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--title <title>", "Goal title")
+      .option("--description <text>", "Goal description")
+      .option("--level <level>", "Goal level (e.g. mission, strategy, task)")
+      .option("--status <status>", "Goal status (e.g. planned, active, done)")
+      .option("--parent-id <id>", "Parent goal ID")
+      .option("--owner-agent-id <id>", "Owner agent ID")
+      .action(async (opts: GoalCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const payload: Record<string, unknown> = { title: opts.title };
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.level !== undefined) payload.level = opts.level;
+          if (opts.status !== undefined) payload.status = opts.status;
+          if (opts.parentId !== undefined) payload.parentId = opts.parentId;
+          if (opts.ownerAgentId !== undefined) payload.ownerAgentId = opts.ownerAgentId;
+
+          const parsed = createGoalSchema.parse(payload);
+          const row = await ctx.api.post<Goal>(
+            `/api/companies/${ctx.companyId}/goals`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    goal
+      .command("update")
+      .description("Update a goal")
+      .argument("<goalId>", "Goal ID")
+      .option("--title <title>", "New title")
+      .option("--description <text>", "New description")
+      .option("--level <level>", "New level")
+      .option("--status <status>", "New status")
+      .option("--parent-id <id>", "New parent goal ID")
+      .option("--owner-agent-id <id>", "New owner agent ID")
+      .action(async (goalId: string, opts: GoalUpdateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload: Record<string, unknown> = {};
+          if (opts.title !== undefined) payload.title = opts.title;
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.level !== undefined) payload.level = opts.level;
+          if (opts.status !== undefined) payload.status = opts.status;
+          if (opts.parentId !== undefined) payload.parentId = opts.parentId;
+          if (opts.ownerAgentId !== undefined) payload.ownerAgentId = opts.ownerAgentId;
+
+          const parsed = updateGoalSchema.parse(payload);
+          const row = await ctx.api.patch<Goal>(
+            `/api/goals/${encodeURIComponent(goalId)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    goal
+      .command("delete")
+      .description("Delete a goal")
+      .argument("<goalId>", "Goal ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (goalId: string, opts: GoalDeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const { confirm } = await import("@clack/prompts");
+            const answer = await confirm({
+              message: `Delete goal ${goalId}? This cannot be undone.`,
+              initialValue: false,
+            });
+            if (answer !== true) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<Goal>(`/api/goals/${encodeURIComponent(goalId)}`);
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/instance.ts
+++ b/cli/src/commands/client/instance.ts
@@ -184,4 +184,20 @@ export function registerInstanceCommands(program: Command): void {
       }),
     { includeCompany: false },
   );
+
+  addCommonClientOptions(
+    instance
+      .command("health")
+      .description("Server health check (db reachability, dev server, bootstrap)")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>("/api/health/");
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
 }

--- a/cli/src/commands/client/instance.ts
+++ b/cli/src/commands/client/instance.ts
@@ -1,0 +1,187 @@
+import { readFileSync } from "node:fs";
+import { Command } from "commander";
+import {
+  issueGraphLivenessAutoRecoveryRequestSchema,
+  patchInstanceExperimentalSettingsSchema,
+  patchInstanceGeneralSettingsSchema,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface SettingsPatchOptions extends BaseClientOptions {
+  patch?: string;
+  patchFile?: string;
+}
+
+interface AutoRecoveryOptions extends BaseClientOptions {
+  lookbackHours?: string;
+}
+
+function parseJsonObject(
+  raw: string | undefined,
+  name: string,
+): Record<string, unknown> | undefined {
+  if (raw === undefined) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`--${name} must be valid JSON: ${(err as Error).message}`);
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`--${name} must be a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parseIntOpt(raw: string | undefined, name: string): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    throw new Error(`--${name} must be an integer`);
+  }
+  return n;
+}
+
+function readPatch(opts: SettingsPatchOptions): Record<string, unknown> {
+  if (opts.patch !== undefined && opts.patchFile !== undefined) {
+    throw new Error("Pass either --patch or --patch-file, not both.");
+  }
+  if (opts.patch !== undefined) {
+    return parseJsonObject(opts.patch, "patch") ?? {};
+  }
+  if (opts.patchFile !== undefined) {
+    const raw = readFileSync(opts.patchFile, "utf8");
+    return parseJsonObject(raw, "patch-file") ?? {};
+  }
+  throw new Error("Pass --patch or --patch-file with the JSON patch object.");
+}
+
+export function registerInstanceCommands(program: Command): void {
+  const instance = program
+    .command("instance")
+    .description("Instance-level settings and admin operations");
+
+  const settings = instance.command("settings").description("Instance settings");
+
+  for (const [verb, scope] of [
+    ["general", "general"],
+    ["experimental", "experimental"],
+  ] as const) {
+    addCommonClientOptions(
+      settings
+        .command(`${verb}-get`)
+        .description(`Get ${scope} instance settings`)
+        .action(async (opts: BaseClientOptions) => {
+          try {
+            const ctx = resolveCommandContext(opts);
+            const row = await ctx.api.get<unknown>(
+              `/api/instance/settings/${scope}`,
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+
+  addCommonClientOptions(
+    settings
+      .command("general-update")
+      .description("Update general instance settings (instance admin)")
+      .option("--patch <json>", "Patch object as JSON")
+      .option("--patch-file <path>", "Read patch object from file")
+      .action(async (opts: SettingsPatchOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const parsed = patchInstanceGeneralSettingsSchema.parse(readPatch(opts));
+          const row = await ctx.api.patch<unknown>(
+            "/api/instance/settings/general",
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    settings
+      .command("experimental-update")
+      .description("Update experimental instance settings (instance admin)")
+      .option("--patch <json>", "Patch object as JSON")
+      .option("--patch-file <path>", "Read patch object from file")
+      .action(async (opts: SettingsPatchOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const parsed = patchInstanceExperimentalSettingsSchema.parse(readPatch(opts));
+          const row = await ctx.api.patch<unknown>(
+            "/api/instance/settings/experimental",
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const autoRecovery = settings
+    .command("auto-recovery")
+    .description("Issue graph liveness auto-recovery (preview / run)");
+
+  for (const verb of ["preview", "run"] as const) {
+    addCommonClientOptions(
+      autoRecovery
+        .command(verb)
+        .description(`${verb[0].toUpperCase()}${verb.slice(1)} the auto-recovery sweep`)
+        .option("--lookback-hours <n>", "Override lookback window in hours")
+        .action(async (opts: AutoRecoveryOptions) => {
+          try {
+            const ctx = resolveCommandContext(opts);
+            const payload: Record<string, unknown> = {};
+            const lookback = parseIntOpt(opts.lookbackHours, "lookback-hours");
+            if (lookback !== undefined) payload.lookbackHours = lookback;
+            const parsed = issueGraphLivenessAutoRecoveryRequestSchema.parse(payload);
+            const row = await ctx.api.post<unknown>(
+              `/api/instance/settings/experimental/issue-graph-liveness-auto-recovery/${verb}`,
+              parsed,
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+
+  addCommonClientOptions(
+    instance
+      .command("backup-now")
+      .description("Trigger a manual database backup (instance admin)")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            "/api/instance/database-backups",
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/issue-extras.ts
+++ b/cli/src/commands/client/issue-extras.ts
@@ -1,0 +1,985 @@
+import { readFileSync } from "node:fs";
+import { Command } from "commander";
+import {
+  acceptIssueThreadInteractionSchema,
+  cancelIssueThreadInteractionSchema,
+  createChildIssueSchema,
+  createIssueLabelSchema,
+  createIssueThreadInteractionSchema,
+  createIssueWorkProductSchema,
+  linkIssueApprovalSchema,
+  rejectIssueThreadInteractionSchema,
+  respondIssueThreadInteractionSchema,
+  restoreIssueDocumentRevisionSchema,
+  updateIssueWorkProductSchema,
+  upsertIssueDocumentSchema,
+  upsertIssueFeedbackVoteSchema,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface CompanyOnly extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface LabelCreateOptions extends CompanyOnly {
+  name: string;
+  color: string;
+}
+
+interface DocUpsertOptions extends BaseClientOptions {
+  title?: string;
+  format: string;
+  body?: string;
+  bodyFile?: string;
+  changeSummary?: string;
+  baseRevisionId?: string;
+}
+
+interface DocRevisionsOptions extends BaseClientOptions {
+  limit?: string;
+}
+
+interface WorkProductCreateOptions extends BaseClientOptions {
+  payload?: string;
+  payloadFile?: string;
+}
+
+interface WorkProductUpdateOptions extends BaseClientOptions {
+  payload?: string;
+  payloadFile?: string;
+}
+
+interface ChildCreateOptions extends BaseClientOptions {
+  payload?: string;
+  payloadFile?: string;
+}
+
+interface InteractionCreateOptions extends BaseClientOptions {
+  payload?: string;
+  payloadFile?: string;
+}
+
+interface InteractionResolveOptions extends BaseClientOptions {
+  payload?: string;
+  payloadFile?: string;
+}
+
+interface FeedbackVoteOptions extends BaseClientOptions {
+  payload?: string;
+  payloadFile?: string;
+}
+
+interface DeleteOptions extends BaseClientOptions {
+  yes?: boolean;
+}
+
+function readJson(opts: { payload?: string; payloadFile?: string }, name: string): unknown {
+  if (opts.payload !== undefined && opts.payloadFile !== undefined) {
+    throw new Error(`Pass either --${name} or --${name}-file, not both.`);
+  }
+  if (opts.payload !== undefined) {
+    try {
+      return JSON.parse(opts.payload);
+    } catch (err) {
+      throw new Error(`--${name} must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  if (opts.payloadFile !== undefined) {
+    const raw = readFileSync(opts.payloadFile, "utf8");
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`--${name}-file must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  return undefined;
+}
+
+function readBody(opts: { body?: string; bodyFile?: string }): string {
+  if (opts.body !== undefined && opts.bodyFile !== undefined) {
+    throw new Error("Pass either --body or --body-file, not both.");
+  }
+  if (opts.body !== undefined) return opts.body;
+  if (opts.bodyFile !== undefined) {
+    return readFileSync(opts.bodyFile, "utf8");
+  }
+  throw new Error("Pass --body or --body-file with the document content.");
+}
+
+async function confirmAction(message: string): Promise<boolean> {
+  const { confirm } = await import("@clack/prompts");
+  const answer = await confirm({ message, initialValue: false });
+  return answer === true;
+}
+
+function getIssueCommand(program: Command): Command {
+  const issue = program.commands.find((c) => c.name() === "issue");
+  if (!issue) {
+    throw new Error("issue command not registered yet; load order error");
+  }
+  return issue;
+}
+
+export function registerIssueExtensionCommands(program: Command): void {
+  const issue = getIssueCommand(program);
+
+  // instance-wide listing
+  addCommonClientOptions(
+    issue
+      .command("instance-list")
+      .description("List issues across the entire instance (admin)")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>("/api/issues")) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    issue
+      .command("delete")
+      .description("Delete an issue")
+      .argument("<issueId>", "Issue ID or identifier (e.g. ENG-12)")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (issueId: string, opts: DeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const ok = await confirmAction(`Delete issue ${issueId}?`);
+            if (!ok) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<unknown>(`/api/issues/${encodeURIComponent(issueId)}`);
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    issue
+      .command("force-release")
+      .description("Force-release an issue checkout (admin override)")
+      .argument("<issueId>", "Issue ID or identifier")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/admin/force-release`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    issue
+      .command("heartbeat-context")
+      .description("Inspect heartbeat context for an issue (debug)")
+      .argument("<issueId>", "Issue ID or identifier")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/heartbeat-context`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    issue
+      .command("create-child")
+      .description("Create a child issue under a parent")
+      .argument("<parentIssueId>", "Parent issue ID")
+      .option("--payload <json>", "Child issue payload as JSON object")
+      .option("--payload-file <path>", "Read payload from JSON file")
+      .action(async (parentIssueId: string, opts: ChildCreateOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = createChildIssueSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(parentIssueId)}/children`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── read / archive markers ───────────────────────────────────────────────
+  for (const verb of ["read", "inbox-archive"] as const) {
+    addCommonClientOptions(
+      issue
+        .command(verb)
+        .description(`Mark an issue as ${verb}`)
+        .argument("<issueId>", "Issue ID or identifier")
+        .action(async (issueId: string, opts: BaseClientOptions) => {
+          try {
+            const ctx = resolveCommandContext(opts);
+            const row = await ctx.api.post<unknown>(
+              `/api/issues/${encodeURIComponent(issueId)}/${verb}`,
+              {},
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+
+    addCommonClientOptions(
+      issue
+        .command(`un-${verb}`)
+        .description(`Reverse the ${verb} marker on an issue`)
+        .argument("<issueId>", "Issue ID or identifier")
+        .action(async (issueId: string, opts: BaseClientOptions) => {
+          try {
+            const ctx = resolveCommandContext(opts);
+            const row = await ctx.api.delete<unknown>(
+              `/api/issues/${encodeURIComponent(issueId)}/${verb}`,
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+
+  // ── labels ──────────────────────────────────────────────────────────────
+  const label = issue.command("label").description("Issue label operations");
+
+  addCommonClientOptions(
+    label
+      .command("list")
+      .description("List labels for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: CompanyOnly) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/labels`,
+          )) ?? [];
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const r of rows as Array<Record<string, unknown>>) {
+            console.log(
+              formatInlineRecord({
+                id: r.id as string,
+                name: r.name as string,
+                color: r.color as string,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    label
+      .command("create")
+      .description("Create a new label")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--name <name>", "Label name (max 48 chars)")
+      .requiredOption("--color <hex>", "Hex color (#RRGGBB)")
+      .action(async (opts: LabelCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const parsed = createIssueLabelSchema.parse({ name: opts.name, color: opts.color });
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/labels`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    label
+      .command("delete")
+      .description("Delete a label")
+      .argument("<labelId>", "Label ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (labelId: string, opts: DeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const ok = await confirmAction(`Delete label ${labelId}?`);
+            if (!ok) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<unknown>(`/api/labels/${encodeURIComponent(labelId)}`);
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── work products ───────────────────────────────────────────────────────
+  const wp = issue.command("work-product").description("Issue work-product operations");
+
+  addCommonClientOptions(
+    wp
+      .command("list")
+      .description("List work products for an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/issues/${encodeURIComponent(issueId)}/work-products`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    wp
+      .command("create")
+      .description("Create a work product on an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .option("--payload <json>", "Work-product payload as JSON object")
+      .option("--payload-file <path>", "Read payload from JSON file")
+      .action(async (issueId: string, opts: WorkProductCreateOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = createIssueWorkProductSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/work-products`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    wp
+      .command("update")
+      .description("Update a work product")
+      .argument("<workProductId>", "Work product ID")
+      .option("--payload <json>", "Patch as JSON object")
+      .option("--payload-file <path>", "Read patch from JSON file")
+      .action(async (workProductId: string, opts: WorkProductUpdateOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = updateIssueWorkProductSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.patch<unknown>(
+            `/api/work-products/${encodeURIComponent(workProductId)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    wp
+      .command("delete")
+      .description("Delete a work product")
+      .argument("<workProductId>", "Work product ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (workProductId: string, opts: DeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const ok = await confirmAction(`Delete work product ${workProductId}?`);
+            if (!ok) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<unknown>(
+            `/api/work-products/${encodeURIComponent(workProductId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── documents ───────────────────────────────────────────────────────────
+  const doc = issue.command("document").description("Issue document operations");
+
+  addCommonClientOptions(
+    doc
+      .command("list")
+      .description("List documents on an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/issues/${encodeURIComponent(issueId)}/documents`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    doc
+      .command("get")
+      .description("Get one document on an issue by key")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<key>", "Document key")
+      .action(async (issueId: string, key: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    doc
+      .command("upsert")
+      .description("Create or update an issue document by key")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<key>", "Document key")
+      .option("--title <text>", "Title (max 200 chars)")
+      .requiredOption("--format <format>", "Format (markdown)")
+      .option("--body <text>", "Document body")
+      .option("--body-file <path>", "Read document body from file")
+      .option("--change-summary <text>", "Change summary (max 500 chars)")
+      .option("--base-revision-id <id>", "Base revision UUID for optimistic concurrency")
+      .action(async (issueId: string, key: string, opts: DocUpsertOptions) => {
+        try {
+          const body = readBody(opts);
+          const payload: Record<string, unknown> = {
+            format: opts.format,
+            body,
+          };
+          if (opts.title !== undefined) payload.title = opts.title;
+          if (opts.changeSummary !== undefined) payload.changeSummary = opts.changeSummary;
+          if (opts.baseRevisionId !== undefined) payload.baseRevisionId = opts.baseRevisionId;
+
+          const parsed = upsertIssueDocumentSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.put<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    doc
+      .command("revisions")
+      .description("List revisions for a document")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<key>", "Document key")
+      .option("--limit <n>", "Max results")
+      .action(async (issueId: string, key: string, opts: DocRevisionsOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const params = new URLSearchParams();
+          if (opts.limit) params.set("limit", opts.limit);
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}/revisions${query}`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    doc
+      .command("restore-revision")
+      .description("Restore a previous revision of a document")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<key>", "Document key")
+      .argument("<revisionId>", "Revision ID")
+      .action(async (issueId: string, key: string, revisionId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const parsed = restoreIssueDocumentRevisionSchema.parse({});
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}/revisions/${encodeURIComponent(revisionId)}/restore`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    doc
+      .command("delete")
+      .description("Delete a document on an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<key>", "Document key")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (issueId: string, key: string, opts: DeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const ok = await confirmAction(`Delete document ${key} on ${issueId}?`);
+            if (!ok) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── linked approvals ────────────────────────────────────────────────────
+  const linkedApproval = issue
+    .command("linked-approval")
+    .description("Manage approvals linked to an issue");
+
+  addCommonClientOptions(
+    linkedApproval
+      .command("list")
+      .description("List approvals linked to an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/issues/${encodeURIComponent(issueId)}/approvals`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    linkedApproval
+      .command("link")
+      .description("Link an existing approval to an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<approvalId>", "Approval ID")
+      .action(async (issueId: string, approvalId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const parsed = linkIssueApprovalSchema.parse({ approvalId });
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/approvals`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    linkedApproval
+      .command("unlink")
+      .description("Unlink an approval from an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<approvalId>", "Approval ID")
+      .action(async (issueId: string, approvalId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/approvals/${encodeURIComponent(approvalId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── comments depth ──────────────────────────────────────────────────────
+  addCommonClientOptions(
+    issue
+      .command("comments-list")
+      .description("List comments on an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/issues/${encodeURIComponent(issueId)}/comments`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    issue
+      .command("comment-get")
+      .description("Get a single comment by ID")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<commentId>", "Comment ID")
+      .action(async (issueId: string, commentId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/comments/${encodeURIComponent(commentId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    issue
+      .command("comment-delete")
+      .description("Delete a comment")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<commentId>", "Comment ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (issueId: string, commentId: string, opts: DeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const ok = await confirmAction(`Delete comment ${commentId}?`);
+            if (!ok) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/comments/${encodeURIComponent(commentId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── interactions ────────────────────────────────────────────────────────
+  const inter = issue.command("interaction").description("Issue thread interaction operations");
+
+  addCommonClientOptions(
+    inter
+      .command("list")
+      .description("List interactions on an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/issues/${encodeURIComponent(issueId)}/interactions`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    inter
+      .command("create")
+      .description(
+        "Create an interaction (kind: suggest_tasks | ask_user_questions | request_confirmation)",
+      )
+      .argument("<issueId>", "Issue ID or identifier")
+      .option("--payload <json>", "Discriminated-union interaction payload as JSON")
+      .option("--payload-file <path>", "Read payload from JSON file")
+      .action(async (issueId: string, opts: InteractionCreateOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = createIssueThreadInteractionSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/interactions`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    inter
+      .command("accept")
+      .description("Accept an interaction (optionally with --payload {selectedClientKeys: []})")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<interactionId>", "Interaction ID")
+      .option("--payload <json>", "Optional accept payload as JSON object")
+      .option("--payload-file <path>", "Read accept payload from JSON file")
+      .action(async (issueId: string, interactionId: string, opts: InteractionResolveOptions) => {
+        try {
+          const payload = (readJson(opts, "payload") as Record<string, unknown> | undefined) ?? {};
+          const parsed = acceptIssueThreadInteractionSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/interactions/${encodeURIComponent(interactionId)}/accept`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  for (const verb of ["reject", "cancel"] as const) {
+    addCommonClientOptions(
+      inter
+        .command(verb)
+        .description(`${verb[0].toUpperCase()}${verb.slice(1)} an interaction`)
+        .argument("<issueId>", "Issue ID or identifier")
+        .argument("<interactionId>", "Interaction ID")
+        .option("--reason <text>", "Reason (max 4000 chars)")
+        .action(async (issueId: string, interactionId: string, opts: BaseClientOptions & { reason?: string }) => {
+          try {
+            const payload: Record<string, unknown> = {};
+            if (opts.reason !== undefined) payload.reason = opts.reason;
+            const schema = verb === "reject" ? rejectIssueThreadInteractionSchema : cancelIssueThreadInteractionSchema;
+            const parsed = schema.parse(payload);
+            const ctx = resolveCommandContext(opts);
+            const row = await ctx.api.post<unknown>(
+              `/api/issues/${encodeURIComponent(issueId)}/interactions/${encodeURIComponent(interactionId)}/${verb}`,
+              parsed,
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+
+  addCommonClientOptions(
+    inter
+      .command("respond")
+      .description("Respond to an ask_user_questions interaction")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<interactionId>", "Interaction ID")
+      .option("--payload <json>", "Response payload as JSON object")
+      .option("--payload-file <path>", "Read response payload from JSON file")
+      .action(async (issueId: string, interactionId: string, opts: InteractionResolveOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = respondIssueThreadInteractionSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/interactions/${encodeURIComponent(interactionId)}/respond`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── feedback votes / traces ─────────────────────────────────────────────
+  const feedback = issue.command("feedback").description("Issue feedback votes and traces");
+
+  addCommonClientOptions(
+    feedback
+      .command("votes")
+      .description("List feedback votes on an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/issues/${encodeURIComponent(issueId)}/feedback-votes`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    feedback
+      .command("vote")
+      .description("Upsert a feedback vote on an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .option("--payload <json>", "Vote payload as JSON")
+      .option("--payload-file <path>", "Read vote payload from JSON file")
+      .action(async (issueId: string, opts: FeedbackVoteOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = upsertIssueFeedbackVoteSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/feedback-votes`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    feedback
+      .command("traces")
+      .description("List feedback traces on an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/issues/${encodeURIComponent(issueId)}/feedback-traces`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    feedback
+      .command("trace-get")
+      .description("Get a single feedback trace by ID")
+      .argument("<traceId>", "Trace ID")
+      .action(async (traceId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/feedback-traces/${encodeURIComponent(traceId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    feedback
+      .command("trace-bundle")
+      .description("Get a feedback trace bundle (full event tree)")
+      .argument("<traceId>", "Trace ID")
+      .action(async (traceId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/feedback-traces/${encodeURIComponent(traceId)}/bundle`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/issue-extras.ts
+++ b/cli/src/commands/client/issue-extras.ts
@@ -130,23 +130,6 @@ function getIssueCommand(program: Command): Command {
 export function registerIssueExtensionCommands(program: Command): void {
   const issue = getIssueCommand(program);
 
-  // instance-wide listing
-  addCommonClientOptions(
-    issue
-      .command("instance-list")
-      .description("List issues across the entire instance (admin)")
-      .action(async (opts: BaseClientOptions) => {
-        try {
-          const ctx = resolveCommandContext(opts);
-          const rows = (await ctx.api.get<unknown[]>("/api/issues")) ?? [];
-          printOutput(rows, { json: ctx.json });
-        } catch (err) {
-          handleCommandError(err);
-        }
-      }),
-    { includeCompany: false },
-  );
-
   addCommonClientOptions(
     issue
       .command("delete")

--- a/cli/src/commands/client/issue-tree-control.ts
+++ b/cli/src/commands/client/issue-tree-control.ts
@@ -1,0 +1,196 @@
+import { readFileSync } from "node:fs";
+import { Command } from "commander";
+import {
+  createIssueTreeHoldSchema,
+  previewIssueTreeControlSchema,
+  releaseIssueTreeHoldSchema,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface PayloadOptions extends BaseClientOptions {
+  payload?: string;
+  payloadFile?: string;
+}
+
+interface HoldsListOptions extends BaseClientOptions {
+  status?: string;
+  mode?: string;
+  includeMembers?: boolean;
+}
+
+function readJson(opts: PayloadOptions, name: string): unknown {
+  if (opts.payload !== undefined && opts.payloadFile !== undefined) {
+    throw new Error(`Pass either --${name} or --${name}-file, not both.`);
+  }
+  if (opts.payload !== undefined) {
+    try {
+      return JSON.parse(opts.payload);
+    } catch (err) {
+      throw new Error(`--${name} must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  if (opts.payloadFile !== undefined) {
+    const raw = readFileSync(opts.payloadFile, "utf8");
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`--${name}-file must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  return undefined;
+}
+
+export function registerIssueTreeControlCommands(program: Command): void {
+  const tree = program
+    .command("issue-tree")
+    .description("Issue tree control: pause/resume/cancel/restore subtrees");
+
+  addCommonClientOptions(
+    tree
+      .command("preview")
+      .description("Preview a tree-control operation against a root issue")
+      .argument("<rootIssueId>", "Root issue ID or identifier")
+      .option("--payload <json>", "Preview request payload as JSON object")
+      .option("--payload-file <path>", "Read payload from JSON file")
+      .action(async (rootIssueId: string, opts: PayloadOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = previewIssueTreeControlSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(rootIssueId)}/tree-control/preview`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    tree
+      .command("state")
+      .description("Get the active pause-hold gate for an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/tree-control/state`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const hold = tree.command("hold").description("Tree hold operations");
+
+  addCommonClientOptions(
+    hold
+      .command("create")
+      .description("Create a new tree hold (pause/resume/cancel/restore)")
+      .argument("<rootIssueId>", "Root issue ID or identifier")
+      .option("--payload <json>", "Hold payload as JSON object")
+      .option("--payload-file <path>", "Read payload from JSON file")
+      .action(async (rootIssueId: string, opts: PayloadOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const parsed = createIssueTreeHoldSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(rootIssueId)}/tree-holds`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    hold
+      .command("list")
+      .description("List tree holds for a root issue")
+      .argument("<rootIssueId>", "Root issue ID or identifier")
+      .option("--status <status>", "Filter by status (active, released)")
+      .option("--mode <mode>", "Filter by mode (pause, resume, cancel, restore)")
+      .option("--include-members", "Include hold members")
+      .action(async (rootIssueId: string, opts: HoldsListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const params = new URLSearchParams();
+          if (opts.status) params.set("status", opts.status);
+          if (opts.mode) params.set("mode", opts.mode);
+          if (opts.includeMembers) params.set("includeMembers", "true");
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/issues/${encodeURIComponent(rootIssueId)}/tree-holds${query}`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    hold
+      .command("get")
+      .description("Get a single tree hold")
+      .argument("<rootIssueId>", "Root issue ID or identifier")
+      .argument("<holdId>", "Hold ID")
+      .action(async (rootIssueId: string, holdId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/issues/${encodeURIComponent(rootIssueId)}/tree-holds/${encodeURIComponent(holdId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    hold
+      .command("release")
+      .description("Release an active tree hold")
+      .argument("<rootIssueId>", "Root issue ID or identifier")
+      .argument("<holdId>", "Hold ID")
+      .option("--payload <json>", "Release payload as JSON object")
+      .option("--payload-file <path>", "Read payload from JSON file")
+      .action(async (rootIssueId: string, holdId: string, opts: PayloadOptions) => {
+        try {
+          const payload = (readJson(opts, "payload") as Record<string, unknown> | undefined) ?? {};
+          const parsed = releaseIssueTreeHoldSchema.parse(payload);
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/issues/${encodeURIComponent(rootIssueId)}/tree-holds/${encodeURIComponent(holdId)}/release`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/llms.ts
+++ b/cli/src/commands/client/llms.ts
@@ -9,7 +9,7 @@ import {
 export function registerLlmsCommands(program: Command): void {
   const llms = program
     .command("llms")
-    .description("LLM-facing reflection text endpoints (/api/llms/*)");
+    .description("LLM-facing reflection text endpoints (/llms/*)");
 
   addCommonClientOptions(
     llms
@@ -18,7 +18,7 @@ export function registerLlmsCommands(program: Command): void {
       .action(async (opts: BaseClientOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const text = await ctx.api.getText("/api/llms/agent-configuration.txt");
+          const text = await ctx.api.getText("/llms/agent-configuration.txt");
           process.stdout.write(text);
         } catch (err) {
           handleCommandError(err);
@@ -34,7 +34,7 @@ export function registerLlmsCommands(program: Command): void {
       .action(async (opts: BaseClientOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const text = await ctx.api.getText("/api/llms/agent-icons.txt");
+          const text = await ctx.api.getText("/llms/agent-icons.txt");
           process.stdout.write(text);
         } catch (err) {
           handleCommandError(err);
@@ -52,7 +52,7 @@ export function registerLlmsCommands(program: Command): void {
         try {
           const ctx = resolveCommandContext(opts);
           const text = await ctx.api.getText(
-            `/api/llms/agent-configuration/${encodeURIComponent(adapterType)}.txt`,
+            `/llms/agent-configuration/${encodeURIComponent(adapterType)}.txt`,
           );
           process.stdout.write(text);
         } catch (err) {

--- a/cli/src/commands/client/llms.ts
+++ b/cli/src/commands/client/llms.ts
@@ -1,0 +1,64 @@
+import { Command } from "commander";
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+export function registerLlmsCommands(program: Command): void {
+  const llms = program
+    .command("llms")
+    .description("LLM-facing reflection text endpoints (/api/llms/*)");
+
+  addCommonClientOptions(
+    llms
+      .command("agent-configuration")
+      .description("Index page describing agent configuration endpoints")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const text = await ctx.api.getText("/api/llms/agent-configuration.txt");
+          process.stdout.write(text);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    llms
+      .command("agent-icons")
+      .description("List of valid agent icon names with examples")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const text = await ctx.api.getText("/api/llms/agent-icons.txt");
+          process.stdout.write(text);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    llms
+      .command("agent-config-doc")
+      .description("Adapter-specific agent configuration documentation")
+      .argument("<adapterType>", "Adapter type")
+      .action(async (adapterType: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const text = await ctx.api.getText(
+            `/api/llms/agent-configuration/${encodeURIComponent(adapterType)}.txt`,
+          );
+          process.stdout.write(text);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/plugin-extras.ts
+++ b/cli/src/commands/client/plugin-extras.ts
@@ -1,0 +1,366 @@
+import { readFileSync } from "node:fs";
+import { Command } from "commander";
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface PayloadOptions extends BaseClientOptions {
+  payload?: string;
+  payloadFile?: string;
+}
+
+interface ParamsOptions extends BaseClientOptions {
+  params?: string;
+  paramsFile?: string;
+  companyId?: string;
+}
+
+function readJson(opts: { payload?: string; payloadFile?: string }, name: string): unknown {
+  if (opts.payload !== undefined && opts.payloadFile !== undefined) {
+    throw new Error(`Pass either --${name} or --${name}-file, not both.`);
+  }
+  if (opts.payload !== undefined) {
+    try {
+      return JSON.parse(opts.payload);
+    } catch (err) {
+      throw new Error(`--${name} must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  if (opts.payloadFile !== undefined) {
+    const raw = readFileSync(opts.payloadFile, "utf8");
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`--${name}-file must be valid JSON: ${(err as Error).message}`);
+    }
+  }
+  return undefined;
+}
+
+function readJsonParams(opts: ParamsOptions): Record<string, unknown> | undefined {
+  const value = readJson(
+    { payload: opts.params, payloadFile: opts.paramsFile },
+    "params",
+  );
+  if (value === undefined) return undefined;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("--params must be a JSON object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function getPluginCommand(program: Command): Command {
+  const cmd = program.commands.find((c) => c.name() === "plugin");
+  if (!cmd) throw new Error("plugin command not registered yet; load order error");
+  return cmd;
+}
+
+export function registerPluginExtensionCommands(program: Command): void {
+  const plugin = getPluginCommand(program);
+
+  // ── instance-level plugin info ──────────────────────────────────────────
+  addCommonClientOptions(
+    plugin
+      .command("ui-contributions")
+      .description("List UI contributions exposed by ready plugins")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>("/api/plugins/ui-contributions");
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    plugin
+      .command("tools")
+      .description("List plugin-registered tools available to agents")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>("/api/plugins/tools");
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    plugin
+      .command("tools-execute")
+      .description("Execute a plugin tool with a runContext")
+      .option("--payload <json>", "Tool execute body { tool, parameters?, runContext } as JSON")
+      .option("--payload-file <path>", "Read body from JSON file")
+      .action(async (opts: PayloadOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            "/api/plugins/tools/execute",
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── per-plugin runtime info ─────────────────────────────────────────────
+  for (const [verb, path] of [
+    ["health", "health"],
+    ["logs", "logs"],
+    ["dashboard", "dashboard"],
+    ["jobs", "jobs"],
+  ] as const) {
+    addCommonClientOptions(
+      plugin
+        .command(verb)
+        .description(`Get plugin ${verb}`)
+        .argument("<pluginId>", "Plugin ID")
+        .action(async (pluginId: string, opts: BaseClientOptions) => {
+          try {
+            const ctx = resolveCommandContext(opts);
+            const row = await ctx.api.get<unknown>(
+              `/api/plugins/${encodeURIComponent(pluginId)}/${path}`,
+            );
+            printOutput(row, { json: ctx.json });
+          } catch (err) {
+            handleCommandError(err);
+          }
+        }),
+      { includeCompany: false },
+    );
+  }
+
+  addCommonClientOptions(
+    plugin
+      .command("upgrade")
+      .description("Upgrade a plugin to the latest registered version")
+      .argument("<pluginId>", "Plugin ID")
+      .action(async (pluginId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/plugins/${encodeURIComponent(pluginId)}/upgrade`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── plugin config ───────────────────────────────────────────────────────
+  const config = plugin.command("config").description("Plugin config get/set/test");
+
+  addCommonClientOptions(
+    config
+      .command("get")
+      .description("Get the saved plugin config")
+      .argument("<pluginId>", "Plugin ID")
+      .action(async (pluginId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/plugins/${encodeURIComponent(pluginId)}/config`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    config
+      .command("set")
+      .description("Set the plugin config (replaces saved config)")
+      .argument("<pluginId>", "Plugin ID")
+      .option("--payload <json>", "Config object as JSON")
+      .option("--payload-file <path>", "Read config from JSON file")
+      .action(async (pluginId: string, opts: PayloadOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/plugins/${encodeURIComponent(pluginId)}/config`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    config
+      .command("test")
+      .description("Test a plugin config without persisting it")
+      .argument("<pluginId>", "Plugin ID")
+      .option("--payload <json>", "Config object as JSON")
+      .option("--payload-file <path>", "Read config from JSON file")
+      .action(async (pluginId: string, opts: PayloadOptions) => {
+        try {
+          const payload = readJson(opts, "payload");
+          if (payload === undefined) throw new Error("--payload or --payload-file required");
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/plugins/${encodeURIComponent(pluginId)}/config/test`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── plugin jobs ─────────────────────────────────────────────────────────
+  const job = plugin.command("job").description("Plugin job operations");
+
+  addCommonClientOptions(
+    job
+      .command("runs")
+      .description("List runs of a plugin job")
+      .argument("<pluginId>", "Plugin ID")
+      .argument("<jobId>", "Job ID")
+      .action(async (pluginId: string, jobId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/plugins/${encodeURIComponent(pluginId)}/jobs/${encodeURIComponent(jobId)}/runs`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    job
+      .command("trigger")
+      .description("Manually trigger a plugin job")
+      .argument("<pluginId>", "Plugin ID")
+      .argument("<jobId>", "Job ID")
+      .option("--payload <json>", "Optional trigger body as JSON")
+      .option("--payload-file <path>", "Read trigger body from JSON file")
+      .action(async (pluginId: string, jobId: string, opts: PayloadOptions) => {
+        try {
+          const payload = readJson(opts, "payload") ?? {};
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/plugins/${encodeURIComponent(pluginId)}/jobs/${encodeURIComponent(jobId)}/trigger`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── webhook ─────────────────────────────────────────────────────────────
+  addCommonClientOptions(
+    plugin
+      .command("webhook")
+      .description("Trigger a plugin webhook endpoint")
+      .argument("<pluginId>", "Plugin ID")
+      .argument("<endpointKey>", "Webhook endpoint key")
+      .option("--payload <json>", "Webhook body as JSON object")
+      .option("--payload-file <path>", "Read webhook body from JSON file")
+      .action(async (pluginId: string, endpointKey: string, opts: PayloadOptions) => {
+        try {
+          const payload = readJson(opts, "payload") ?? {};
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/plugins/${encodeURIComponent(pluginId)}/webhooks/${encodeURIComponent(endpointKey)}`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // ── data / action bridge passthroughs ───────────────────────────────────
+  addCommonClientOptions(
+    plugin
+      .command("data")
+      .description("Call a plugin's getData(key) over the bridge")
+      .argument("<pluginId>", "Plugin ID")
+      .argument("<key>", "Data key")
+      .option("-C, --company-id <id>", "Company ID for bridge scope (optional)")
+      .option("--params <json>", "Params object as JSON")
+      .option("--params-file <path>", "Read params from JSON file")
+      .action(async (pluginId: string, key: string, opts: ParamsOptions) => {
+        try {
+          const params = readJsonParams(opts);
+          const payload: Record<string, unknown> = {};
+          if (opts.companyId !== undefined) payload.companyId = opts.companyId;
+          if (params !== undefined) payload.params = params;
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/plugins/${encodeURIComponent(pluginId)}/data/${encodeURIComponent(key)}`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    plugin
+      .command("action")
+      .description("Call a plugin's performAction(key) over the bridge")
+      .argument("<pluginId>", "Plugin ID")
+      .argument("<key>", "Action key")
+      .option("-C, --company-id <id>", "Company ID for bridge scope (optional)")
+      .option("--params <json>", "Params object as JSON")
+      .option("--params-file <path>", "Read params from JSON file")
+      .action(async (pluginId: string, key: string, opts: ParamsOptions) => {
+        try {
+          const params = readJsonParams(opts);
+          const payload: Record<string, unknown> = {};
+          if (opts.companyId !== undefined) payload.companyId = opts.companyId;
+          if (params !== undefined) payload.params = params;
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/plugins/${encodeURIComponent(pluginId)}/actions/${encodeURIComponent(key)}`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/project.ts
+++ b/cli/src/commands/client/project.ts
@@ -1,0 +1,301 @@
+import { Command } from "commander";
+import {
+  createProjectSchema,
+  updateProjectSchema,
+  type Project,
+  type ProjectWorkspace,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface ProjectListOptions extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface ProjectCreateOptions extends BaseClientOptions {
+  companyId?: string;
+  name: string;
+  description?: string;
+  status?: string;
+  color?: string;
+  targetDate?: string;
+  leadAgentId?: string;
+  goalId?: string;
+  goalIds?: string;
+}
+
+interface ProjectUpdateOptions extends BaseClientOptions {
+  name?: string;
+  description?: string;
+  status?: string;
+  color?: string;
+  targetDate?: string;
+  leadAgentId?: string;
+  goalIds?: string;
+  archive?: boolean;
+  unarchive?: boolean;
+}
+
+interface ProjectDeleteOptions extends BaseClientOptions {
+  yes?: boolean;
+}
+
+export function registerProjectCommands(program: Command): void {
+  const project = program.command("project").description("Project operations");
+
+  addCommonClientOptions(
+    project
+      .command("list")
+      .description("List projects for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: ProjectListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows =
+            (await ctx.api.get<Project[]>(`/api/companies/${ctx.companyId}/projects`)) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+
+          for (const row of rows) {
+            console.log(
+              formatInlineRecord({
+                id: row.id,
+                name: row.name,
+                status: row.status,
+                urlKey: row.urlKey,
+                leadAgentId: row.leadAgentId ?? null,
+                archivedAt: row.archivedAt ?? null,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    project
+      .command("get")
+      .description("Get one project")
+      .argument("<projectId>", "Project ID or shortname (with --company-id)")
+      .action(async (projectId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const query = ctx.companyId ? `?companyId=${encodeURIComponent(ctx.companyId)}` : "";
+          const row = await ctx.api.get<Project>(`/api/projects/${encodeURIComponent(projectId)}${query}`);
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+
+  addCommonClientOptions(
+    project
+      .command("create")
+      .description("Create a new project in a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--name <name>", "Project name")
+      .option("--description <text>", "Project description")
+      .option("--status <status>", "Project status (e.g. backlog, active, done)")
+      .option("--color <color>", "Project color")
+      .option("--target-date <date>", "Target completion date (ISO string)")
+      .option("--lead-agent-id <id>", "Lead agent ID")
+      .option("--goal-id <id>", "Linked goal ID (deprecated, prefer --goal-ids)")
+      .option("--goal-ids <ids>", "Comma-separated goal IDs")
+      .action(async (opts: ProjectCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const payload: Record<string, unknown> = { name: opts.name };
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.status !== undefined) payload.status = opts.status;
+          if (opts.color !== undefined) payload.color = opts.color;
+          if (opts.targetDate !== undefined) payload.targetDate = opts.targetDate;
+          if (opts.leadAgentId !== undefined) payload.leadAgentId = opts.leadAgentId;
+          if (opts.goalId !== undefined) payload.goalId = opts.goalId;
+          if (opts.goalIds !== undefined) {
+            payload.goalIds = opts.goalIds.split(",").map((id) => id.trim()).filter(Boolean);
+          }
+
+          const parsed = createProjectSchema.parse(payload);
+          const row = await ctx.api.post<Project>(
+            `/api/companies/${ctx.companyId}/projects`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    project
+      .command("update")
+      .description("Update a project")
+      .argument("<projectId>", "Project ID")
+      .option("--name <name>", "New name")
+      .option("--description <text>", "New description")
+      .option("--status <status>", "New status")
+      .option("--color <color>", "New color")
+      .option("--target-date <date>", "New target date (ISO string)")
+      .option("--lead-agent-id <id>", "New lead agent ID")
+      .option("--goal-ids <ids>", "Comma-separated goal IDs")
+      .option("--archive", "Archive the project (sets archivedAt to now)")
+      .option("--unarchive", "Unarchive the project (clears archivedAt)")
+      .action(async (projectId: string, opts: ProjectUpdateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload: Record<string, unknown> = {};
+          if (opts.name !== undefined) payload.name = opts.name;
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.status !== undefined) payload.status = opts.status;
+          if (opts.color !== undefined) payload.color = opts.color;
+          if (opts.targetDate !== undefined) payload.targetDate = opts.targetDate;
+          if (opts.leadAgentId !== undefined) payload.leadAgentId = opts.leadAgentId;
+          if (opts.goalIds !== undefined) {
+            payload.goalIds = opts.goalIds.split(",").map((id) => id.trim()).filter(Boolean);
+          }
+          if (opts.archive && opts.unarchive) {
+            throw new Error("Pass either --archive or --unarchive, not both.");
+          }
+          if (opts.archive) payload.archivedAt = new Date().toISOString();
+          if (opts.unarchive) payload.archivedAt = null;
+
+          const parsed = updateProjectSchema.parse(payload);
+          const row = await ctx.api.patch<Project>(
+            `/api/projects/${encodeURIComponent(projectId)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    project
+      .command("delete")
+      .description("Delete a project")
+      .argument("<projectId>", "Project ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (projectId: string, opts: ProjectDeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const confirmed = await confirmDelete(projectId);
+            if (!confirmed) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<Project>(`/api/projects/${encodeURIComponent(projectId)}`);
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const workspace = project.command("workspace").description("Project workspace operations");
+
+  addCommonClientOptions(
+    workspace
+      .command("list")
+      .description("List workspaces for a project")
+      .argument("<projectId>", "Project ID")
+      .action(async (projectId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows =
+            (await ctx.api.get<ProjectWorkspace[]>(
+              `/api/projects/${encodeURIComponent(projectId)}/workspaces`,
+            )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+
+          for (const row of rows) {
+            console.log(
+              formatInlineRecord({
+                id: row.id,
+                name: row.name,
+                sourceType: row.sourceType,
+                cwd: row.cwd ?? null,
+                repoUrl: row.repoUrl ?? null,
+                isPrimary: row.isPrimary,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    workspace
+      .command("delete")
+      .description("Delete a project workspace")
+      .argument("<projectId>", "Project ID")
+      .argument("<workspaceId>", "Workspace ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (projectId: string, workspaceId: string, opts: ProjectDeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const confirmed = await confirmDelete(`workspace ${workspaceId}`);
+            if (!confirmed) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<ProjectWorkspace>(
+            `/api/projects/${encodeURIComponent(projectId)}/workspaces/${encodeURIComponent(workspaceId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}
+
+async function confirmDelete(label: string): Promise<boolean> {
+  const { confirm } = await import("@clack/prompts");
+  const answer = await confirm({
+    message: `Delete ${label}? This cannot be undone.`,
+    initialValue: false,
+  });
+  return answer === true;
+}

--- a/cli/src/commands/client/routine.ts
+++ b/cli/src/commands/client/routine.ts
@@ -1,0 +1,551 @@
+import { Command } from "commander";
+import {
+  createRoutineSchema,
+  createRoutineTriggerSchema,
+  rotateRoutineTriggerSecretSchema,
+  runRoutineSchema,
+  updateRoutineSchema,
+  updateRoutineTriggerSchema,
+  type Routine,
+  type RoutineDetail,
+  type RoutineRun,
+  type RoutineTrigger,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface RoutineListOptions extends BaseClientOptions {
+  companyId?: string;
+  projectId?: string;
+}
+
+interface RoutineCreateOptions extends BaseClientOptions {
+  companyId?: string;
+  title: string;
+  description?: string;
+  projectId?: string;
+  goalId?: string;
+  parentIssueId?: string;
+  assigneeAgentId?: string;
+  priority?: string;
+  status?: string;
+  concurrencyPolicy?: string;
+  catchUpPolicy?: string;
+  variables?: string;
+}
+
+interface RoutineUpdateOptions extends BaseClientOptions {
+  title?: string;
+  description?: string;
+  projectId?: string;
+  goalId?: string;
+  parentIssueId?: string;
+  assigneeAgentId?: string;
+  priority?: string;
+  status?: string;
+  concurrencyPolicy?: string;
+  catchUpPolicy?: string;
+  variables?: string;
+}
+
+interface RoutineRunsOptions extends BaseClientOptions {
+  limit?: string;
+}
+
+interface RoutineRunOptions extends BaseClientOptions {
+  triggerId?: string;
+  payload?: string;
+  variables?: string;
+  projectId?: string;
+  assigneeAgentId?: string;
+  idempotencyKey?: string;
+  source?: string;
+  executionWorkspaceId?: string;
+  executionWorkspacePreference?: string;
+  executionWorkspaceSettings?: string;
+}
+
+interface TriggerCreateOptions extends BaseClientOptions {
+  kind: string;
+  label?: string;
+  enabled?: string;
+  cronExpression?: string;
+  timezone?: string;
+  signingMode?: string;
+  replayWindowSec?: string;
+}
+
+interface TriggerUpdateOptions extends BaseClientOptions {
+  label?: string;
+  enabled?: string;
+  cronExpression?: string;
+  timezone?: string;
+  signingMode?: string;
+  replayWindowSec?: string;
+}
+
+interface TriggerDeleteOptions extends BaseClientOptions {
+  yes?: boolean;
+}
+
+function parseJson(raw: string | undefined, name: string): unknown {
+  if (raw === undefined) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`--${name} must be valid JSON: ${(err as Error).message}`);
+  }
+}
+
+function parseJsonObject(
+  raw: string | undefined,
+  name: string,
+): Record<string, unknown> | undefined {
+  const value = parseJson(raw, name);
+  if (value === undefined) return undefined;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`--${name} must be a JSON object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseJsonArray(raw: string | undefined, name: string): unknown[] | undefined {
+  const value = parseJson(raw, name);
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error(`--${name} must be a JSON array`);
+  }
+  return value;
+}
+
+function parseBool(raw: string | undefined, name: string): boolean | undefined {
+  if (raw === undefined) return undefined;
+  const v = raw.toLowerCase();
+  if (v === "true" || v === "1" || v === "yes") return true;
+  if (v === "false" || v === "0" || v === "no") return false;
+  throw new Error(`--${name} must be true or false`);
+}
+
+function parseIntOpt(raw: string | undefined, name: string): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    throw new Error(`--${name} must be an integer`);
+  }
+  return n;
+}
+
+async function confirmAction(message: string): Promise<boolean> {
+  const { confirm } = await import("@clack/prompts");
+  const answer = await confirm({ message, initialValue: false });
+  return answer === true;
+}
+
+export function registerRoutineClientCommands(program: Command): void {
+  const routine = program
+    .command("routine")
+    .description("Routine (recurring task) operations");
+
+  addCommonClientOptions(
+    routine
+      .command("list")
+      .description("List routines for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--project-id <id>", "Filter by project ID")
+      .action(async (opts: RoutineListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const params = new URLSearchParams();
+          if (opts.projectId) params.set("projectId", opts.projectId);
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const rows = (await ctx.api.get<Routine[]>(
+            `/api/companies/${ctx.companyId}/routines${query}`,
+          )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const row of rows) {
+            console.log(
+              formatInlineRecord({
+                id: row.id,
+                title: row.title,
+                status: row.status,
+                priority: row.priority,
+                assigneeAgentId: row.assigneeAgentId ?? null,
+                projectId: row.projectId ?? null,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    routine
+      .command("get")
+      .description("Get one routine with triggers and recent runs")
+      .argument("<routineId>", "Routine ID")
+      .action(async (routineId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<RoutineDetail>(
+            `/api/routines/${encodeURIComponent(routineId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    routine
+      .command("create")
+      .description("Create a new routine")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--title <text>", "Routine title")
+      .option("--description <text>", "Routine description")
+      .option("--project-id <id>", "Project UUID")
+      .option("--goal-id <id>", "Goal UUID")
+      .option("--parent-issue-id <id>", "Parent issue UUID")
+      .option("--assignee-agent-id <id>", "Assignee agent UUID")
+      .option("--priority <priority>", "Issue priority (e.g. low, medium, high)")
+      .option("--status <status>", "Routine status (e.g. active, paused)")
+      .option(
+        "--concurrency-policy <policy>",
+        "e.g. coalesce_if_active, queue, drop_if_active",
+      )
+      .option("--catch-up-policy <policy>", "e.g. skip_missed, run_one_per_window")
+      .option("--variables <json>", "Variables as JSON array")
+      .action(async (opts: RoutineCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+
+          const payload: Record<string, unknown> = { title: opts.title };
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.projectId !== undefined) payload.projectId = opts.projectId;
+          if (opts.goalId !== undefined) payload.goalId = opts.goalId;
+          if (opts.parentIssueId !== undefined) payload.parentIssueId = opts.parentIssueId;
+          if (opts.assigneeAgentId !== undefined) payload.assigneeAgentId = opts.assigneeAgentId;
+          if (opts.priority !== undefined) payload.priority = opts.priority;
+          if (opts.status !== undefined) payload.status = opts.status;
+          if (opts.concurrencyPolicy !== undefined) payload.concurrencyPolicy = opts.concurrencyPolicy;
+          if (opts.catchUpPolicy !== undefined) payload.catchUpPolicy = opts.catchUpPolicy;
+          const variables = parseJsonArray(opts.variables, "variables");
+          if (variables !== undefined) payload.variables = variables;
+
+          const parsed = createRoutineSchema.parse(payload);
+          const row = await ctx.api.post<Routine>(
+            `/api/companies/${ctx.companyId}/routines`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    routine
+      .command("update")
+      .description("Update a routine")
+      .argument("<routineId>", "Routine ID")
+      .option("--title <text>", "New title")
+      .option("--description <text>", "New description")
+      .option("--project-id <id>", "New project UUID")
+      .option("--goal-id <id>", "New goal UUID")
+      .option("--parent-issue-id <id>", "New parent issue UUID")
+      .option("--assignee-agent-id <id>", "New assignee agent UUID")
+      .option("--priority <priority>", "New priority")
+      .option("--status <status>", "New status")
+      .option("--concurrency-policy <policy>", "New concurrency policy")
+      .option("--catch-up-policy <policy>", "New catch-up policy")
+      .option("--variables <json>", "Replacement variables as JSON array")
+      .action(async (routineId: string, opts: RoutineUpdateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload: Record<string, unknown> = {};
+          if (opts.title !== undefined) payload.title = opts.title;
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.projectId !== undefined) payload.projectId = opts.projectId;
+          if (opts.goalId !== undefined) payload.goalId = opts.goalId;
+          if (opts.parentIssueId !== undefined) payload.parentIssueId = opts.parentIssueId;
+          if (opts.assigneeAgentId !== undefined) payload.assigneeAgentId = opts.assigneeAgentId;
+          if (opts.priority !== undefined) payload.priority = opts.priority;
+          if (opts.status !== undefined) payload.status = opts.status;
+          if (opts.concurrencyPolicy !== undefined) payload.concurrencyPolicy = opts.concurrencyPolicy;
+          if (opts.catchUpPolicy !== undefined) payload.catchUpPolicy = opts.catchUpPolicy;
+          const variables = parseJsonArray(opts.variables, "variables");
+          if (variables !== undefined) payload.variables = variables;
+
+          const parsed = updateRoutineSchema.parse(payload);
+          const row = await ctx.api.patch<Routine>(
+            `/api/routines/${encodeURIComponent(routineId)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    routine
+      .command("runs")
+      .description("List historical runs for a routine")
+      .argument("<routineId>", "Routine ID")
+      .option("--limit <n>", "Max runs (default 50)")
+      .action(async (routineId: string, opts: RoutineRunsOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const params = new URLSearchParams();
+          if (opts.limit) params.set("limit", opts.limit);
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const rows = (await ctx.api.get<RoutineRun[]>(
+            `/api/routines/${encodeURIComponent(routineId)}/runs${query}`,
+          )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const row of rows) {
+            console.log(
+              formatInlineRecord({
+                id: row.id,
+                status: row.status,
+                source: row.source,
+                triggeredAt: row.triggeredAt instanceof Date
+                  ? row.triggeredAt.toISOString()
+                  : (row.triggeredAt as unknown as string),
+                completedAt: row.completedAt instanceof Date
+                  ? row.completedAt.toISOString()
+                  : (row.completedAt as unknown as string | null),
+                linkedIssueId: row.linkedIssueId ?? null,
+                failureReason: row.failureReason ?? null,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    routine
+      .command("run")
+      .description("Manually trigger a routine run")
+      .argument("<routineId>", "Routine ID")
+      .option("--trigger-id <id>", "Optional trigger UUID")
+      .option("--payload <json>", "Trigger payload as JSON object")
+      .option("--variables <json>", "Variable values as JSON object")
+      .option("--project-id <id>", "Project UUID override")
+      .option("--assignee-agent-id <id>", "Assignee agent UUID override")
+      .option("--idempotency-key <key>", "Idempotency key (max 255 chars)")
+      .option("--source <source>", "Source (manual or api, default manual)")
+      .option("--execution-workspace-id <id>", "Execution workspace UUID")
+      .option("--execution-workspace-preference <pref>", "Execution workspace preference")
+      .option("--execution-workspace-settings <json>", "Execution workspace settings as JSON object")
+      .action(async (routineId: string, opts: RoutineRunOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload: Record<string, unknown> = {};
+          if (opts.triggerId !== undefined) payload.triggerId = opts.triggerId;
+          const wakePayload = parseJsonObject(opts.payload, "payload");
+          if (wakePayload !== undefined) payload.payload = wakePayload;
+          const variables = parseJsonObject(opts.variables, "variables");
+          if (variables !== undefined) payload.variables = variables;
+          if (opts.projectId !== undefined) payload.projectId = opts.projectId;
+          if (opts.assigneeAgentId !== undefined) payload.assigneeAgentId = opts.assigneeAgentId;
+          if (opts.idempotencyKey !== undefined) payload.idempotencyKey = opts.idempotencyKey;
+          if (opts.source !== undefined) payload.source = opts.source;
+          if (opts.executionWorkspaceId !== undefined)
+            payload.executionWorkspaceId = opts.executionWorkspaceId;
+          if (opts.executionWorkspacePreference !== undefined)
+            payload.executionWorkspacePreference = opts.executionWorkspacePreference;
+          const settings = parseJsonObject(
+            opts.executionWorkspaceSettings,
+            "execution-workspace-settings",
+          );
+          if (settings !== undefined) payload.executionWorkspaceSettings = settings;
+
+          const parsed = runRoutineSchema.parse(payload);
+          const row = await ctx.api.post<RoutineRun>(
+            `/api/routines/${encodeURIComponent(routineId)}/run`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const trigger = routine.command("trigger").description("Routine trigger operations");
+
+  addCommonClientOptions(
+    trigger
+      .command("create")
+      .description("Create a new trigger for a routine")
+      .argument("<routineId>", "Routine ID")
+      .requiredOption("--kind <kind>", "Trigger kind: schedule, webhook, or api")
+      .option("--label <text>", "Trigger label (max 120 chars)")
+      .option("--enabled <bool>", "Enable trigger (true/false, default true)")
+      .option("--cron-expression <expr>", "Cron expression (required for kind=schedule)")
+      .option("--timezone <tz>", "Timezone for schedule (default UTC)")
+      .option("--signing-mode <mode>", "Webhook signing mode (default bearer)")
+      .option(
+        "--replay-window-sec <n>",
+        "Webhook replay window in seconds (30-86400, default 300)",
+      )
+      .action(async (routineId: string, opts: TriggerCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload: Record<string, unknown> = { kind: opts.kind };
+          if (opts.label !== undefined) payload.label = opts.label;
+          const enabled = parseBool(opts.enabled, "enabled");
+          if (enabled !== undefined) payload.enabled = enabled;
+
+          if (opts.kind === "schedule") {
+            if (opts.cronExpression === undefined) {
+              throw new Error("--cron-expression is required when --kind is schedule");
+            }
+            payload.cronExpression = opts.cronExpression;
+            if (opts.timezone !== undefined) payload.timezone = opts.timezone;
+          } else if (opts.kind === "webhook") {
+            if (opts.signingMode !== undefined) payload.signingMode = opts.signingMode;
+            const replay = parseIntOpt(opts.replayWindowSec, "replay-window-sec");
+            if (replay !== undefined) payload.replayWindowSec = replay;
+          }
+
+          const parsed = createRoutineTriggerSchema.parse(payload);
+          const row = await ctx.api.post<unknown>(
+            `/api/routines/${encodeURIComponent(routineId)}/triggers`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    trigger
+      .command("update")
+      .description("Update a routine trigger")
+      .argument("<triggerId>", "Trigger ID")
+      .option("--label <text>", "New label")
+      .option("--enabled <bool>", "Enable/disable (true/false)")
+      .option("--cron-expression <expr>", "New cron expression")
+      .option("--timezone <tz>", "New timezone")
+      .option("--signing-mode <mode>", "New signing mode")
+      .option("--replay-window-sec <n>", "New replay window seconds (30-86400)")
+      .action(async (triggerId: string, opts: TriggerUpdateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload: Record<string, unknown> = {};
+          if (opts.label !== undefined) payload.label = opts.label;
+          const enabled = parseBool(opts.enabled, "enabled");
+          if (enabled !== undefined) payload.enabled = enabled;
+          if (opts.cronExpression !== undefined) payload.cronExpression = opts.cronExpression;
+          if (opts.timezone !== undefined) payload.timezone = opts.timezone;
+          if (opts.signingMode !== undefined) payload.signingMode = opts.signingMode;
+          const replay = parseIntOpt(opts.replayWindowSec, "replay-window-sec");
+          if (replay !== undefined) payload.replayWindowSec = replay;
+
+          const parsed = updateRoutineTriggerSchema.parse(payload);
+          const row = await ctx.api.patch<RoutineTrigger>(
+            `/api/routine-triggers/${encodeURIComponent(triggerId)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    trigger
+      .command("delete")
+      .description("Delete a routine trigger")
+      .argument("<triggerId>", "Trigger ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (triggerId: string, opts: TriggerDeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const ok = await confirmAction(`Delete trigger ${triggerId}?`);
+            if (!ok) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          await ctx.api.delete<void>(
+            `/api/routine-triggers/${encodeURIComponent(triggerId)}`,
+          );
+          if (ctx.json) {
+            printOutput({ ok: true }, { json: true });
+          } else {
+            console.log("deleted");
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    trigger
+      .command("rotate-secret")
+      .description(
+        "Rotate a webhook trigger's signing secret (returned once, store immediately)",
+      )
+      .argument("<triggerId>", "Trigger ID")
+      .action(async (triggerId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const parsed = rotateRoutineTriggerSecretSchema.parse({});
+          const row = await ctx.api.post<unknown>(
+            `/api/routine-triggers/${encodeURIComponent(triggerId)}/rotate-secret`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/run.ts
+++ b/cli/src/commands/client/run.ts
@@ -86,7 +86,9 @@ function printRunRow(row: HeartbeatRun & { agentName?: string | null }): void {
 }
 
 export function registerRunCommands(program: Command): void {
-  const run = program.command("run").description("Heartbeat run observability");
+  const run = program
+    .command("heartbeat-run")
+    .description("Heartbeat run observability");
 
   addCommonClientOptions(
     run

--- a/cli/src/commands/client/run.ts
+++ b/cli/src/commands/client/run.ts
@@ -49,15 +49,6 @@ interface WorkspaceOperationLogOptions extends BaseClientOptions {
 
 const WATCHDOG_DECISIONS = ["snooze", "continue", "dismissed_false_positive"] as const;
 
-function parseIntOpt(value: string | undefined, name: string): number | undefined {
-  if (value === undefined) return undefined;
-  const n = Number(value);
-  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
-    throw new Error(`--${name} must be a non-negative integer`);
-  }
-  return n;
-}
-
 function isoOrThrow(value: string, name: string): string {
   const d = new Date(value);
   if (Number.isNaN(d.getTime())) {
@@ -378,9 +369,9 @@ export function registerRunCommands(program: Command): void {
       }),
     { includeCompany: false },
   );
+}
 
-  // Workspace operation log lives at /api/workspace-operations/:id/log,
-  // logically grouped here since it's the per-operation log for run actions.
+export function registerWorkspaceOperationCommands(program: Command): void {
   const workspaceOp = program
     .command("workspace-operation")
     .description("Workspace operation observability");
@@ -409,7 +400,4 @@ export function registerRunCommands(program: Command): void {
       }),
     { includeCompany: false },
   );
-
-  // Suppress unused warning if parseIntOpt isn't called in this file revision.
-  void parseIntOpt;
 }

--- a/cli/src/commands/client/run.ts
+++ b/cli/src/commands/client/run.ts
@@ -1,0 +1,413 @@
+import { Command } from "commander";
+import type {
+  HeartbeatRun,
+  HeartbeatRunEvent,
+  WorkspaceOperation,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface RunListOptions extends BaseClientOptions {
+  companyId?: string;
+  agentId?: string;
+  limit?: string;
+}
+
+interface RunLiveOptions extends BaseClientOptions {
+  companyId?: string;
+  limit?: string;
+  minCount?: string;
+}
+
+interface RunEventsOptions extends BaseClientOptions {
+  afterSeq?: string;
+  limit?: string;
+}
+
+interface RunLogOptions extends BaseClientOptions {
+  offset?: string;
+  limitBytes?: string;
+}
+
+interface RunWatchdogOptions extends BaseClientOptions {
+  decision: string;
+  reason?: string;
+  evaluationIssueId?: string;
+  snoozedUntil?: string;
+}
+
+interface WorkspaceOperationLogOptions extends BaseClientOptions {
+  offset?: string;
+  limitBytes?: string;
+}
+
+const WATCHDOG_DECISIONS = ["snooze", "continue", "dismissed_false_positive"] as const;
+
+function parseIntOpt(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    throw new Error(`--${name} must be a non-negative integer`);
+  }
+  return n;
+}
+
+function isoOrThrow(value: string, name: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`--${name} must be a valid ISO 8601 datetime`);
+  }
+  return d.toISOString();
+}
+
+function printRunRow(row: HeartbeatRun & { agentName?: string | null }): void {
+  console.log(
+    formatInlineRecord({
+      id: row.id,
+      status: row.status,
+      agentId: row.agentId,
+      agentName: (row as { agentName?: string | null }).agentName ?? null,
+      invocationSource: row.invocationSource,
+      triggerDetail: row.triggerDetail ?? null,
+      startedAt: row.startedAt instanceof Date
+        ? row.startedAt.toISOString()
+        : (row.startedAt as unknown as string | null),
+      finishedAt: row.finishedAt instanceof Date
+        ? row.finishedAt.toISOString()
+        : (row.finishedAt as unknown as string | null),
+    }),
+  );
+}
+
+export function registerRunCommands(program: Command): void {
+  const run = program.command("run").description("Heartbeat run observability");
+
+  addCommonClientOptions(
+    run
+      .command("list")
+      .description("List heartbeat runs for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--agent-id <id>", "Filter by agent ID")
+      .option("--limit <n>", "Max results (1-1000, default 200)")
+      .action(async (opts: RunListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const params = new URLSearchParams();
+          if (opts.agentId) params.set("agentId", opts.agentId);
+          if (opts.limit) params.set("limit", opts.limit);
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const rows = (await ctx.api.get<HeartbeatRun[]>(
+            `/api/companies/${ctx.companyId}/heartbeat-runs${query}`,
+          )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const row of rows) printRunRow(row);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    run
+      .command("live")
+      .description("List active (queued/running) runs, optionally padded with recent runs")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--limit <n>", "Max results (default 50)")
+      .option("--min-count <n>", "Minimum row count (pads with recent runs, default 0)")
+      .action(async (opts: RunLiveOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const params = new URLSearchParams();
+          if (opts.limit) params.set("limit", opts.limit);
+          if (opts.minCount) params.set("minCount", opts.minCount);
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const rows = (await ctx.api.get<Array<HeartbeatRun & { agentName: string | null }>>(
+            `/api/companies/${ctx.companyId}/live-runs${query}`,
+          )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const row of rows) printRunRow(row);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    run
+      .command("get")
+      .description("Get one heartbeat run")
+      .argument("<runId>", "Run ID")
+      .action(async (runId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<HeartbeatRun>(
+            `/api/heartbeat-runs/${encodeURIComponent(runId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    run
+      .command("cancel")
+      .description("Cancel a heartbeat run")
+      .argument("<runId>", "Run ID")
+      .action(async (runId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<HeartbeatRun | null>(
+            `/api/heartbeat-runs/${encodeURIComponent(runId)}/cancel`,
+            {},
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    run
+      .command("events")
+      .description("List events for a run (paginate via --after-seq)")
+      .argument("<runId>", "Run ID")
+      .option("--after-seq <n>", "Return events after this sequence number")
+      .option("--limit <n>", "Max events (default 200)")
+      .action(async (runId: string, opts: RunEventsOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const params = new URLSearchParams();
+          if (opts.afterSeq) params.set("afterSeq", opts.afterSeq);
+          if (opts.limit) params.set("limit", opts.limit);
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const rows = (await ctx.api.get<HeartbeatRunEvent[]>(
+            `/api/heartbeat-runs/${encodeURIComponent(runId)}/events${query}`,
+          )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const row of rows) {
+            console.log(
+              formatInlineRecord({
+                seq: (row as { seq?: number }).seq ?? null,
+                kind: (row as { kind?: string }).kind ?? null,
+                createdAt: (row as { createdAt?: Date | string }).createdAt
+                  ? String((row as { createdAt?: Date | string }).createdAt)
+                  : null,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    run
+      .command("log")
+      .description("Read run log bytes (paginate via --offset)")
+      .argument("<runId>", "Run ID")
+      .option("--offset <n>", "Byte offset to start reading from")
+      .option("--limit-bytes <n>", "Max bytes to return")
+      .action(async (runId: string, opts: RunLogOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const params = new URLSearchParams();
+          if (opts.offset) params.set("offset", opts.offset);
+          if (opts.limitBytes) params.set("limitBytes", opts.limitBytes);
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const row = await ctx.api.get<unknown>(
+            `/api/heartbeat-runs/${encodeURIComponent(runId)}/log${query}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    run
+      .command("workspace-operations")
+      .description("List workspace operations triggered by a run")
+      .argument("<runId>", "Run ID")
+      .action(async (runId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<WorkspaceOperation[]>(
+            `/api/heartbeat-runs/${encodeURIComponent(runId)}/workspace-operations`,
+          )) ?? [];
+          printOutput(rows, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    run
+      .command("watchdog")
+      .description("Record a watchdog decision for a run")
+      .argument("<runId>", "Run ID")
+      .requiredOption(
+        "--decision <decision>",
+        `One of: ${WATCHDOG_DECISIONS.join(", ")}`,
+      )
+      .option("--reason <text>", "Reason (max 4000 chars)")
+      .option("--evaluation-issue-id <id>", "Evaluation issue UUID")
+      .option(
+        "--snoozed-until <iso>",
+        "Future ISO 8601 datetime (required for --decision snooze)",
+      )
+      .action(async (runId: string, opts: RunWatchdogOptions) => {
+        try {
+          if (!WATCHDOG_DECISIONS.includes(opts.decision as (typeof WATCHDOG_DECISIONS)[number])) {
+            throw new Error(`--decision must be one of: ${WATCHDOG_DECISIONS.join(", ")}`);
+          }
+          const payload: Record<string, unknown> = { decision: opts.decision };
+          if (opts.reason !== undefined) payload.reason = opts.reason;
+          if (opts.evaluationIssueId !== undefined) payload.evaluationIssueId = opts.evaluationIssueId;
+          if (opts.decision === "snooze") {
+            if (!opts.snoozedUntil) {
+              throw new Error("--snoozed-until is required when --decision is snooze");
+            }
+            const iso = isoOrThrow(opts.snoozedUntil, "snoozed-until");
+            if (new Date(iso) <= new Date()) {
+              throw new Error("--snoozed-until must be in the future");
+            }
+            payload.snoozedUntil = iso;
+          }
+
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.post<unknown>(
+            `/api/heartbeat-runs/${encodeURIComponent(runId)}/watchdog-decisions`,
+            payload,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    run
+      .command("by-issue")
+      .description("List active runs for an issue")
+      .argument("<issueId>", "Issue ID or identifier (e.g. ENG-12)")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<Array<HeartbeatRun & { agentName: string | null }>>(
+            `/api/issues/${encodeURIComponent(issueId)}/live-runs`,
+          )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const row of rows) printRunRow(row);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    run
+      .command("active-for-issue")
+      .description("Get the currently active run for an issue (if any)")
+      .argument("<issueId>", "Issue ID or identifier (e.g. ENG-12)")
+      .action(async (issueId: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>(
+            `/api/issues/${encodeURIComponent(issueId)}/active-run`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // Workspace operation log lives at /api/workspace-operations/:id/log,
+  // logically grouped here since it's the per-operation log for run actions.
+  const workspaceOp = program
+    .command("workspace-operation")
+    .description("Workspace operation observability");
+
+  addCommonClientOptions(
+    workspaceOp
+      .command("log")
+      .description("Read workspace operation log bytes")
+      .argument("<operationId>", "Operation ID")
+      .option("--offset <n>", "Byte offset")
+      .option("--limit-bytes <n>", "Max bytes")
+      .action(async (operationId: string, opts: WorkspaceOperationLogOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const params = new URLSearchParams();
+          if (opts.offset) params.set("offset", opts.offset);
+          if (opts.limitBytes) params.set("limitBytes", opts.limitBytes);
+          const query = params.toString() ? `?${params.toString()}` : "";
+          const row = await ctx.api.get<unknown>(
+            `/api/workspace-operations/${encodeURIComponent(operationId)}/log${query}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  // Suppress unused warning if parseIntOpt isn't called in this file revision.
+  void parseIntOpt;
+}

--- a/cli/src/commands/client/secret.ts
+++ b/cli/src/commands/client/secret.ts
@@ -1,0 +1,286 @@
+import { Command } from "commander";
+import {
+  createSecretSchema,
+  rotateSecretSchema,
+  updateSecretSchema,
+  type CompanySecret,
+  type SecretProviderDescriptor,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface SecretListOptions extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface SecretProvidersOptions extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface SecretCreateOptions extends BaseClientOptions {
+  companyId?: string;
+  name: string;
+  value?: string;
+  valueStdin?: boolean;
+  provider?: string;
+  description?: string;
+  externalRef?: string;
+}
+
+interface SecretRotateOptions extends BaseClientOptions {
+  value?: string;
+  valueStdin?: boolean;
+  externalRef?: string;
+}
+
+interface SecretUpdateOptions extends BaseClientOptions {
+  name?: string;
+  description?: string;
+  externalRef?: string;
+}
+
+interface SecretDeleteOptions extends BaseClientOptions {
+  yes?: boolean;
+}
+
+async function readStdinValue(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8").replace(/\r?\n$/, "");
+}
+
+export function registerSecretCommands(program: Command): void {
+  const secret = program.command("secret").description("Company secret operations");
+
+  addCommonClientOptions(
+    secret
+      .command("list")
+      .description("List secrets for a company (metadata only, never values)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: SecretListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows =
+            (await ctx.api.get<CompanySecret[]>(
+              `/api/companies/${ctx.companyId}/secrets`,
+            )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+
+          for (const row of rows) {
+            console.log(
+              formatInlineRecord({
+                id: row.id,
+                name: row.name,
+                provider: row.provider,
+                latestVersion: row.latestVersion,
+                externalRef: row.externalRef ?? null,
+                description: row.description ?? null,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    secret
+      .command("providers")
+      .description("List configured secret providers for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: SecretProvidersOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows =
+            (await ctx.api.get<SecretProviderDescriptor[]>(
+              `/api/companies/${ctx.companyId}/secret-providers`,
+            )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+
+          for (const row of rows) {
+            console.log(
+              formatInlineRecord({
+                id: row.id,
+                label: row.label,
+                requiresExternalRef: row.requiresExternalRef,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    secret
+      .command("create")
+      .description("Create a new secret. Pass value via --value-stdin to avoid shell history.")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--name <name>", "Secret name (env var key)")
+      .option("--value <value>", "Secret value (prefer --value-stdin)")
+      .option("--value-stdin", "Read secret value from stdin")
+      .option("--provider <provider>", "Secret provider (local_encrypted, aws_secrets_manager, gcp_secret_manager, vault)")
+      .option("--description <text>", "Description")
+      .option("--external-ref <ref>", "External reference (for non-local providers)")
+      .action(async (opts: SecretCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+
+          if (opts.value !== undefined && opts.valueStdin) {
+            throw new Error("Pass either --value or --value-stdin, not both.");
+          }
+          let value = opts.value;
+          if (opts.valueStdin) {
+            value = await readStdinValue();
+          }
+          if (value === undefined || value.length === 0) {
+            throw new Error("A non-empty secret value is required (use --value or --value-stdin).");
+          }
+
+          const payload: Record<string, unknown> = { name: opts.name, value };
+          if (opts.provider !== undefined) payload.provider = opts.provider;
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.externalRef !== undefined) payload.externalRef = opts.externalRef;
+
+          const parsed = createSecretSchema.parse(payload);
+          const row = await ctx.api.post<CompanySecret>(
+            `/api/companies/${ctx.companyId}/secrets`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    secret
+      .command("rotate")
+      .description("Rotate a secret to a new value. Prefer --value-stdin.")
+      .argument("<secretId>", "Secret ID")
+      .option("--value <value>", "New value (prefer --value-stdin)")
+      .option("--value-stdin", "Read new value from stdin")
+      .option("--external-ref <ref>", "Updated external reference")
+      .action(async (secretId: string, opts: SecretRotateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+
+          if (opts.value !== undefined && opts.valueStdin) {
+            throw new Error("Pass either --value or --value-stdin, not both.");
+          }
+          let value = opts.value;
+          if (opts.valueStdin) {
+            value = await readStdinValue();
+          }
+          if (value === undefined || value.length === 0) {
+            throw new Error("A non-empty rotation value is required (use --value or --value-stdin).");
+          }
+
+          const payload: Record<string, unknown> = { value };
+          if (opts.externalRef !== undefined) payload.externalRef = opts.externalRef;
+
+          const parsed = rotateSecretSchema.parse(payload);
+          const row = await ctx.api.post<CompanySecret>(
+            `/api/secrets/${encodeURIComponent(secretId)}/rotate`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    secret
+      .command("update")
+      .description("Update secret metadata (does not rotate the value)")
+      .argument("<secretId>", "Secret ID")
+      .option("--name <name>", "New name")
+      .option("--description <text>", "New description")
+      .option("--external-ref <ref>", "New external reference")
+      .action(async (secretId: string, opts: SecretUpdateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload: Record<string, unknown> = {};
+          if (opts.name !== undefined) payload.name = opts.name;
+          if (opts.description !== undefined) payload.description = opts.description;
+          if (opts.externalRef !== undefined) payload.externalRef = opts.externalRef;
+
+          const parsed = updateSecretSchema.parse(payload);
+          const row = await ctx.api.patch<CompanySecret>(
+            `/api/secrets/${encodeURIComponent(secretId)}`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    secret
+      .command("delete")
+      .description("Delete a secret")
+      .argument("<secretId>", "Secret ID")
+      .option("-y, --yes", "Skip confirmation prompt")
+      .action(async (secretId: string, opts: SecretDeleteOptions) => {
+        try {
+          if (!opts.yes && process.stdin.isTTY) {
+            const { confirm } = await import("@clack/prompts");
+            const answer = await confirm({
+              message: `Delete secret ${secretId}? This cannot be undone and any references will break.`,
+              initialValue: false,
+            });
+            if (answer !== true) {
+              console.error("Aborted.");
+              process.exit(1);
+            }
+          }
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.delete<{ ok: boolean }>(
+            `/api/secrets/${encodeURIComponent(secretId)}`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/commands/client/secret.ts
+++ b/cli/src/commands/client/secret.ts
@@ -26,7 +26,6 @@ interface SecretProvidersOptions extends BaseClientOptions {
 interface SecretCreateOptions extends BaseClientOptions {
   companyId?: string;
   name: string;
-  value?: string;
   valueStdin?: boolean;
   provider?: string;
   description?: string;
@@ -34,7 +33,6 @@ interface SecretCreateOptions extends BaseClientOptions {
 }
 
 interface SecretRotateOptions extends BaseClientOptions {
-  value?: string;
   valueStdin?: boolean;
   externalRef?: string;
 }
@@ -144,11 +142,10 @@ export function registerSecretCommands(program: Command): void {
   addCommonClientOptions(
     secret
       .command("create")
-      .description("Create a new secret. Pass value via --value-stdin to avoid shell history.")
+      .description("Create a new secret. The value is read from stdin via --value-stdin to keep it out of process argv and shell history.")
       .requiredOption("-C, --company-id <id>", "Company ID")
       .requiredOption("--name <name>", "Secret name (env var key)")
-      .option("--value <value>", "Secret value (prefer --value-stdin)")
-      .option("--value-stdin", "Read secret value from stdin")
+      .requiredOption("--value-stdin", "Read secret value from stdin (the only supported channel)")
       .option("--provider <provider>", "Secret provider (local_encrypted, aws_secrets_manager, gcp_secret_manager, vault)")
       .option("--description <text>", "Description")
       .option("--external-ref <ref>", "External reference (for non-local providers)")
@@ -156,15 +153,12 @@ export function registerSecretCommands(program: Command): void {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
 
-          if (opts.value !== undefined && opts.valueStdin) {
-            throw new Error("Pass either --value or --value-stdin, not both.");
+          if (!opts.valueStdin) {
+            throw new Error("--value-stdin is required. Pipe the secret value on stdin.");
           }
-          let value = opts.value;
-          if (opts.valueStdin) {
-            value = await readStdinValue();
-          }
-          if (value === undefined || value.length === 0) {
-            throw new Error("A non-empty secret value is required (use --value or --value-stdin).");
+          const value = await readStdinValue();
+          if (value.length === 0) {
+            throw new Error("Secret value read from stdin was empty.");
           }
 
           const payload: Record<string, unknown> = { name: opts.name, value };
@@ -188,24 +182,20 @@ export function registerSecretCommands(program: Command): void {
   addCommonClientOptions(
     secret
       .command("rotate")
-      .description("Rotate a secret to a new value. Prefer --value-stdin.")
+      .description("Rotate a secret to a new value. The new value is read from stdin via --value-stdin to keep it out of process argv and shell history.")
       .argument("<secretId>", "Secret ID")
-      .option("--value <value>", "New value (prefer --value-stdin)")
-      .option("--value-stdin", "Read new value from stdin")
+      .requiredOption("--value-stdin", "Read new value from stdin (the only supported channel)")
       .option("--external-ref <ref>", "Updated external reference")
       .action(async (secretId: string, opts: SecretRotateOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
 
-          if (opts.value !== undefined && opts.valueStdin) {
-            throw new Error("Pass either --value or --value-stdin, not both.");
+          if (!opts.valueStdin) {
+            throw new Error("--value-stdin is required. Pipe the new secret value on stdin.");
           }
-          let value = opts.value;
-          if (opts.valueStdin) {
-            value = await readStdinValue();
-          }
-          if (value === undefined || value.length === 0) {
-            throw new Error("A non-empty rotation value is required (use --value or --value-stdin).");
+          const value = await readStdinValue();
+          if (value.length === 0) {
+            throw new Error("Rotation value read from stdin was empty.");
           }
 
           const payload: Record<string, unknown> = { value };

--- a/cli/src/commands/client/user.ts
+++ b/cli/src/commands/client/user.ts
@@ -1,0 +1,226 @@
+import { Command } from "commander";
+import { upsertSidebarOrderPreferenceSchema } from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface IdsOptions extends BaseClientOptions {
+  ids: string;
+}
+
+interface CompanyIdsOptions extends BaseClientOptions {
+  companyId?: string;
+  ids: string;
+}
+
+interface InboxListOptions extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface InboxDismissOptions extends BaseClientOptions {
+  companyId?: string;
+  itemKey: string;
+}
+
+function splitCsv(value: string): string[] {
+  return value.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+export function registerUserCommands(program: Command): void {
+  const user = program
+    .command("user")
+    .description("Per-user state (sidebar prefs, inbox dismissals)");
+
+  const sidebar = user.command("sidebar").description("Sidebar order preferences");
+
+  const companyOrder = sidebar
+    .command("company-order")
+    .description("Cross-company sidebar ordering");
+
+  addCommonClientOptions(
+    companyOrder
+      .command("get")
+      .description("Get the user's cross-company sidebar order")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<unknown>("/api/sidebar-preferences/me");
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    companyOrder
+      .command("set")
+      .description("Replace the user's cross-company sidebar order")
+      .requiredOption("--ids <list>", "Comma-separated company UUIDs in display order")
+      .action(async (opts: IdsOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const parsed = upsertSidebarOrderPreferenceSchema.parse({
+            orderedIds: splitCsv(opts.ids),
+          });
+          const row = await ctx.api.put<unknown>("/api/sidebar-preferences/me", parsed);
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const projectOrder = sidebar
+    .command("project-order")
+    .description("Per-company project ordering");
+
+  addCommonClientOptions(
+    projectOrder
+      .command("get")
+      .description("Get the user's project order for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.get<unknown>(
+            `/api/companies/${ctx.companyId}/sidebar-preferences/me`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    projectOrder
+      .command("set")
+      .description("Replace the user's project order in a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--ids <list>", "Comma-separated project UUIDs in display order")
+      .action(async (opts: CompanyIdsOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const parsed = upsertSidebarOrderPreferenceSchema.parse({
+            orderedIds: splitCsv(opts.ids),
+          });
+          const row = await ctx.api.put<unknown>(
+            `/api/companies/${ctx.companyId}/sidebar-preferences/me`,
+            parsed,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  const inbox = user.command("inbox").description("Inbox dismissals");
+
+  addCommonClientOptions(
+    inbox
+      .command("dismissals")
+      .description("List dismissed inbox items for the current user in a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: InboxListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<unknown[]>(
+            `/api/companies/${ctx.companyId}/inbox-dismissals`,
+          )) ?? [];
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const r of rows as Array<Record<string, unknown>>) {
+            console.log(
+              formatInlineRecord({
+                itemKey: r.itemKey as string | null,
+                dismissedAt:
+                  r.dismissedAt instanceof Date
+                    ? r.dismissedAt.toISOString()
+                    : (r.dismissedAt as string | null),
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    inbox
+      .command("dismiss")
+      .description("Dismiss an inbox item (key format: approval|join|run:<id>)")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--item-key <key>", "Item key to dismiss")
+      .action(async (opts: InboxDismissOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.post<unknown>(
+            `/api/companies/${ctx.companyId}/inbox-dismissals`,
+            { itemKey: opts.itemKey },
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    user
+      .command("sidebar-badges")
+      .description("Get sidebar badges (unread counts, indicators) for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .action(async (opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.get<unknown>(
+            `/api/companies/${ctx.companyId}/sidebar-badges`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    user
+      .command("profile")
+      .description("Get a user's company profile by slug")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .argument("<userSlug>", "User slug")
+      .action(async (userSlug: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const row = await ctx.api.get<unknown>(
+            `/api/companies/${ctx.companyId}/users/${encodeURIComponent(userSlug)}/profile`,
+          );
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -38,6 +38,8 @@ import { registerCompanySkillCommands } from "./commands/client/company-skill.js
 import { registerInstanceCommands } from "./commands/client/instance.js";
 import { registerUserCommands } from "./commands/client/user.js";
 import { registerIssueExtensionCommands } from "./commands/client/issue-extras.js";
+import { registerIssueTreeControlCommands } from "./commands/client/issue-tree-control.js";
+import { registerAgentExtensionCommands } from "./commands/client/agent-extras.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -180,6 +182,8 @@ registerCompanySkillCommands(program);
 registerInstanceCommands(program);
 registerUserCommands(program);
 registerIssueExtensionCommands(program);
+registerIssueTreeControlCommands(program);
+registerAgentExtensionCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -23,6 +23,7 @@ import { loadPaperclipEnvFile } from "./config/env.js";
 import { initTelemetryFromConfigFile, flushTelemetry } from "./telemetry.js";
 import { registerWorktreeCommands } from "./commands/worktree.js";
 import { registerPluginCommands } from "./commands/client/plugin.js";
+import { registerProjectCommands } from "./commands/client/project.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -150,6 +151,7 @@ registerFeedbackCommands(program);
 registerWorktreeCommands(program);
 registerEnvLabCommands(program);
 registerPluginCommands(program);
+registerProjectCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -25,6 +25,7 @@ import { registerWorktreeCommands } from "./commands/worktree.js";
 import { registerPluginCommands } from "./commands/client/plugin.js";
 import { registerProjectCommands } from "./commands/client/project.js";
 import { registerGoalCommands } from "./commands/client/goal.js";
+import { registerSecretCommands } from "./commands/client/secret.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -154,6 +155,7 @@ registerEnvLabCommands(program);
 registerPluginCommands(program);
 registerProjectCommands(program);
 registerGoalCommands(program);
+registerSecretCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -27,6 +27,9 @@ import { registerProjectCommands } from "./commands/client/project.js";
 import { registerGoalCommands } from "./commands/client/goal.js";
 import { registerSecretCommands } from "./commands/client/secret.js";
 import { registerEnvironmentCommands } from "./commands/client/environment.js";
+import { registerCostCommands } from "./commands/client/cost.js";
+import { registerFinanceCommands } from "./commands/client/finance.js";
+import { registerBudgetCommands } from "./commands/client/budget.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -158,6 +161,9 @@ registerProjectCommands(program);
 registerGoalCommands(program);
 registerSecretCommands(program);
 registerEnvironmentCommands(program);
+registerCostCommands(program);
+registerFinanceCommands(program);
+registerBudgetCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -36,6 +36,7 @@ import { registerExecutionWorkspaceCommands } from "./commands/client/execution-
 import { registerAdapterCommands } from "./commands/client/adapter.js";
 import { registerCompanySkillCommands } from "./commands/client/company-skill.js";
 import { registerInstanceCommands } from "./commands/client/instance.js";
+import { registerUserCommands } from "./commands/client/user.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -176,6 +177,7 @@ registerExecutionWorkspaceCommands(program);
 registerAdapterCommands(program);
 registerCompanySkillCommands(program);
 registerInstanceCommands(program);
+registerUserCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -40,6 +40,8 @@ import { registerUserCommands } from "./commands/client/user.js";
 import { registerIssueExtensionCommands } from "./commands/client/issue-extras.js";
 import { registerIssueTreeControlCommands } from "./commands/client/issue-tree-control.js";
 import { registerAgentExtensionCommands } from "./commands/client/agent-extras.js";
+import { registerCompanyExtensionCommands } from "./commands/client/company-extras.js";
+import { registerPluginExtensionCommands } from "./commands/client/plugin-extras.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -184,6 +186,8 @@ registerUserCommands(program);
 registerIssueExtensionCommands(program);
 registerIssueTreeControlCommands(program);
 registerAgentExtensionCommands(program);
+registerCompanyExtensionCommands(program);
+registerPluginExtensionCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -35,6 +35,7 @@ import { registerRoutineClientCommands } from "./commands/client/routine.js";
 import { registerExecutionWorkspaceCommands } from "./commands/client/execution-workspace.js";
 import { registerAdapterCommands } from "./commands/client/adapter.js";
 import { registerCompanySkillCommands } from "./commands/client/company-skill.js";
+import { registerInstanceCommands } from "./commands/client/instance.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -174,6 +175,7 @@ registerRoutineClientCommands(program);
 registerExecutionWorkspaceCommands(program);
 registerAdapterCommands(program);
 registerCompanySkillCommands(program);
+registerInstanceCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -30,6 +30,7 @@ import { registerEnvironmentCommands } from "./commands/client/environment.js";
 import { registerCostCommands } from "./commands/client/cost.js";
 import { registerFinanceCommands } from "./commands/client/finance.js";
 import { registerBudgetCommands } from "./commands/client/budget.js";
+import { registerRunCommands } from "./commands/client/run.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -164,6 +165,7 @@ registerEnvironmentCommands(program);
 registerCostCommands(program);
 registerFinanceCommands(program);
 registerBudgetCommands(program);
+registerRunCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -34,6 +34,7 @@ import { registerRunCommands } from "./commands/client/run.js";
 import { registerRoutineClientCommands } from "./commands/client/routine.js";
 import { registerExecutionWorkspaceCommands } from "./commands/client/execution-workspace.js";
 import { registerAdapterCommands } from "./commands/client/adapter.js";
+import { registerCompanySkillCommands } from "./commands/client/company-skill.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -172,6 +173,7 @@ registerRunCommands(program);
 registerRoutineClientCommands(program);
 registerExecutionWorkspaceCommands(program);
 registerAdapterCommands(program);
+registerCompanySkillCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -30,7 +30,10 @@ import { registerEnvironmentCommands } from "./commands/client/environment.js";
 import { registerCostCommands } from "./commands/client/cost.js";
 import { registerFinanceCommands } from "./commands/client/finance.js";
 import { registerBudgetCommands } from "./commands/client/budget.js";
-import { registerRunCommands } from "./commands/client/run.js";
+import {
+  registerRunCommands,
+  registerWorkspaceOperationCommands,
+} from "./commands/client/run.js";
 import { registerRoutineClientCommands } from "./commands/client/routine.js";
 import { registerExecutionWorkspaceCommands } from "./commands/client/execution-workspace.js";
 import { registerAdapterCommands } from "./commands/client/adapter.js";
@@ -182,6 +185,7 @@ registerCostCommands(program);
 registerFinanceCommands(program);
 registerBudgetCommands(program);
 registerRunCommands(program);
+registerWorkspaceOperationCommands(program);
 registerRoutineClientCommands(program);
 registerExecutionWorkspaceCommands(program);
 registerAdapterCommands(program);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -45,6 +45,7 @@ import { registerPluginExtensionCommands } from "./commands/client/plugin-extras
 import { registerAccessCommands } from "./commands/client/access.js";
 import { registerLlmsCommands } from "./commands/client/llms.js";
 import { registerAssetCommands } from "./commands/client/asset.js";
+import { registerAttachmentExtensionCommands } from "./commands/client/attachment-extras.js";
 import { registerApprovalExtensionCommands } from "./commands/client/approval-extras.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
@@ -188,6 +189,7 @@ registerCompanySkillCommands(program);
 registerInstanceCommands(program);
 registerUserCommands(program);
 registerIssueExtensionCommands(program);
+registerAttachmentExtensionCommands(program);
 registerIssueTreeControlCommands(program);
 registerAgentExtensionCommands(program);
 registerCompanyExtensionCommands(program);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ import { initTelemetryFromConfigFile, flushTelemetry } from "./telemetry.js";
 import { registerWorktreeCommands } from "./commands/worktree.js";
 import { registerPluginCommands } from "./commands/client/plugin.js";
 import { registerProjectCommands } from "./commands/client/project.js";
+import { registerGoalCommands } from "./commands/client/goal.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -152,6 +153,7 @@ registerWorktreeCommands(program);
 registerEnvLabCommands(program);
 registerPluginCommands(program);
 registerProjectCommands(program);
+registerGoalCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -31,6 +31,7 @@ import { registerCostCommands } from "./commands/client/cost.js";
 import { registerFinanceCommands } from "./commands/client/finance.js";
 import { registerBudgetCommands } from "./commands/client/budget.js";
 import { registerRunCommands } from "./commands/client/run.js";
+import { registerRoutineClientCommands } from "./commands/client/routine.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -166,6 +167,7 @@ registerCostCommands(program);
 registerFinanceCommands(program);
 registerBudgetCommands(program);
 registerRunCommands(program);
+registerRoutineClientCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -32,6 +32,7 @@ import { registerFinanceCommands } from "./commands/client/finance.js";
 import { registerBudgetCommands } from "./commands/client/budget.js";
 import { registerRunCommands } from "./commands/client/run.js";
 import { registerRoutineClientCommands } from "./commands/client/routine.js";
+import { registerExecutionWorkspaceCommands } from "./commands/client/execution-workspace.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -168,6 +169,7 @@ registerFinanceCommands(program);
 registerBudgetCommands(program);
 registerRunCommands(program);
 registerRoutineClientCommands(program);
+registerExecutionWorkspaceCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -42,6 +42,10 @@ import { registerIssueTreeControlCommands } from "./commands/client/issue-tree-c
 import { registerAgentExtensionCommands } from "./commands/client/agent-extras.js";
 import { registerCompanyExtensionCommands } from "./commands/client/company-extras.js";
 import { registerPluginExtensionCommands } from "./commands/client/plugin-extras.js";
+import { registerAccessCommands } from "./commands/client/access.js";
+import { registerLlmsCommands } from "./commands/client/llms.js";
+import { registerAssetCommands } from "./commands/client/asset.js";
+import { registerApprovalExtensionCommands } from "./commands/client/approval-extras.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -188,6 +192,10 @@ registerIssueTreeControlCommands(program);
 registerAgentExtensionCommands(program);
 registerCompanyExtensionCommands(program);
 registerPluginExtensionCommands(program);
+registerApprovalExtensionCommands(program);
+registerAccessCommands(program);
+registerLlmsCommands(program);
+registerAssetCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -37,6 +37,7 @@ import { registerAdapterCommands } from "./commands/client/adapter.js";
 import { registerCompanySkillCommands } from "./commands/client/company-skill.js";
 import { registerInstanceCommands } from "./commands/client/instance.js";
 import { registerUserCommands } from "./commands/client/user.js";
+import { registerIssueExtensionCommands } from "./commands/client/issue-extras.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -178,6 +179,7 @@ registerAdapterCommands(program);
 registerCompanySkillCommands(program);
 registerInstanceCommands(program);
 registerUserCommands(program);
+registerIssueExtensionCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -26,6 +26,7 @@ import { registerPluginCommands } from "./commands/client/plugin.js";
 import { registerProjectCommands } from "./commands/client/project.js";
 import { registerGoalCommands } from "./commands/client/goal.js";
 import { registerSecretCommands } from "./commands/client/secret.js";
+import { registerEnvironmentCommands } from "./commands/client/environment.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -156,6 +157,7 @@ registerPluginCommands(program);
 registerProjectCommands(program);
 registerGoalCommands(program);
 registerSecretCommands(program);
+registerEnvironmentCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -33,6 +33,7 @@ import { registerBudgetCommands } from "./commands/client/budget.js";
 import { registerRunCommands } from "./commands/client/run.js";
 import { registerRoutineClientCommands } from "./commands/client/routine.js";
 import { registerExecutionWorkspaceCommands } from "./commands/client/execution-workspace.js";
+import { registerAdapterCommands } from "./commands/client/adapter.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
 import { cliVersion } from "./version.js";
 
@@ -170,6 +171,7 @@ registerBudgetCommands(program);
 registerRunCommands(program);
 registerRoutineClientCommands(program);
 registerExecutionWorkspaceCommands(program);
+registerAdapterCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 


### PR DESCRIPTION
Tracks discussion: paperclipai/paperclip#5058

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, with a control plane that exposes ~200 HTTP endpoints
> - The CLI under `cli/src/commands/client/` is the operator-side companion to that API and the bridge agents reach for when scripting against an instance
> - Coverage was incomplete: many nouns existed only as partial commands or were missing entirely (project, goal, secret, environment, cost/finance/budget, routine, execution-workspace, adapter, company-skill, instance, user, issue-tree, access, llms, asset), so operators had to drop into curl + JSON to do common work
> - That makes scripted ops brittle, hides the API surface from agents, and forces every workflow to rebuild auth/output/error handling
> - This pull request adds full-API coverage following the existing `addCommonClientOptions` / `resolveCommandContext` / `printOutput` / `cli-auth` device-flow pattern, plus three HTTP primitives (`put`, `getText`, `postMultipart`) on `PaperclipApiClient`
> - The benefit is operators and agents get a single composable surface for the platform: every noun is reachable as `paperclipai <noun> <verb>`, with consistent `--json`, consistent error handling, and no bespoke auth

## What Changed

- 22 new top-level command nouns in `cli/src/commands/client/`: `project`, `goal`, `secret`, `environment`, `cost`, `finance`, `budget`, `heartbeat-run`, `workspace-operation`, `routine`, `execution-workspace`, `adapter`, `company-skill`, `instance`, `user`, `issue-tree`, `access`, `llms`, `asset` (plus extras files for `agent`, `issue`, `company`, `plugin`, `approval`, `attachment`)
- Depth-fills on existing nouns: `agent` (+30 subcommands), `issue` (+28), `company` (stats/branding/portability), `plugin` (ui-contributions, tools, health, dashboard, jobs, upgrade, config, webhook, data, action), `approval` (missing GETs)
- New HTTP primitives in `cli/src/client/http.ts`: `put`, `getText`, `getStream`, `postMultipart`
- Each command file is wired through `cli/src/index.ts` via a single `register*Commands` export
- Secrets enter only via `--value-stdin` (no `--value` flag exists, after Greptile P1 fix below)
- `workspace-operation` is its own `registerWorkspaceOperationCommands` export, not a side effect of `registerRunCommands`

## Verification

- `pnpm -r typecheck` clean (verified locally before each push; CI re-runs)
- `pnpm test:run` clean on CI (verify, e2e, policy, snyk all SUCCESS)
- E2E smoke against a running dev server (port 3100, embedded Postgres, `local_trusted` auth):

| Category | Tests | Pass |
|---|---|---|
| Read-only across all 22 nouns | 50 | 50 |
| Goal / project / label / secret / company-skill CRUD | 18 | 18 |
| Agent introspection + lifecycle | 11 | 11 |
| Routine + trigger CRUD | 5 | 5 |
| Environment update + probe + probe-config | 4 | 4 |
| Asset upload (multipart) + download (binary stream) | 2 | 2 |
| Adapter introspection + LLMs text endpoints | 5 | 5 |

- Asset upload-image → download produced a byte-identical 68-byte PNG round-trip, exercising both new HTTP primitives
- Bugs caught and fixed during E2E: flag collision `--config`/`-c` (renamed to `--driver-config` and `--workspace-config`), command collision on `run` (renamed to `heartbeat-run`), `llms` mount path (`/llms/*` not `/api/llms/*`), two dead endpoints removed (instance-list issues, instance-issues)
- After Greptile review: rebuilt CLI, re-typechecked, manually exercised `secret create --help`, `secret rotate --help`, `workspace-operation --help` to confirm shape

## Risks

- **Low risk for the core CLI surface.** Every command is additive; no existing behavior is changed. The framework patterns are unchanged.
- **Behavioral change after Greptile fix:** `secret create` and `secret rotate` no longer accept `--value <value>`. Any existing script that piped values via `--value` must switch to `printf '%s' "$VAL" | paperclipai secret create --name X --value-stdin` (which was already documented as the recommended path). This is intentional — `--value` was a credential-leakage vector via process argv and shell history.
- **No schema or service migrations** — pure CLI additions against existing endpoints.
- **No breaking change** to existing CLI commands. Only `secret`'s `--value` is removed, and it was always documented as the unsafe alternative.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

Discussed in #5058 before opening.

## Model Used

- Provider: Anthropic
- Model ID: `claude-opus-4-7` (Claude Opus 4.7, 1M context window)
- Reasoning mode: extended thinking, default reasoning effort
- Capability details: tool use (file edit, bash, gh CLI), agent-driven multi-step planning. Used as a pair-programmer through Claude Code; each commit was authored interactively against a running dev server with E2E verification, not generated in one shot.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (CLI commands tested via live E2E; no unit tests existed for the parallel partial commands either)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — CLI-only)
- [x] I have updated relevant documentation to reflect my changes (each command has `--help` text; descriptions updated for `secret create`/`rotate` to reflect stdin-only)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

## Greptile follow-ups (this push)

The first Greptile pass left 4 comments. All addressed in commit `d031bd24`:

1. **PR template** — fixed in this description.
2. **`secret create`/`secret rotate` `--value` leak** (P1, security) — `--value <value>` removed from both commands. `--value-stdin` is now the only channel (and is `requiredOption`). Plaintext can no longer reach `/proc/<pid>/cmdline`, `ps aux`, or shell history.
3. **Dead `parseIntOpt` + `void parseIntOpt;` suppressor in `run.ts`** (P1) — both removed. `--limit` / `--offset` / `--limit-bytes` continue to pass through as raw strings, matching the rest of the file's option handling.
4. **Hidden `workspace-operation` command registered as side effect** (P2) — extracted into a new `registerWorkspaceOperationCommands` export. `cli/src/index.ts` now wires it explicitly, matching the pattern every other noun in this PR follows.