### PR TITLE
fix(server): spawn productivity reviews at priority low

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -355,7 +355,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(result.created).toBe(1);
     const [review] = await listProductivityReviews(seeded.companyId);
     expect(review?.description).toContain("Primary trigger: `long_active_duration`");
-    expect(review?.priority).toBe("medium");
+    expect(review?.priority).toBe("low");
     expect(hold.held).toBe(false);
   });
 

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -681,7 +681,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         title: `Review productivity for ${evidence.sourceIssue.identifier ?? evidence.sourceIssue.title}`,
         description: buildReviewMarkdown(evidence, opts.prefix),
         status: "todo",
-        priority: evidence.trigger === "long_active_duration" ? "medium" : "high",
+        priority: "low",
         parentId: evidence.sourceIssue.id,
         projectId: evidence.sourceIssue.projectId,
         goalId: evidence.sourceIssue.goalId,


### PR DESCRIPTION
CTO-Mentor recommends all auto-generated review productivity tasks spawn at `priority: low` so agents pick them up only when idle.

- Hardcodes `priority: "low"` in productivity review creation
- Updates test assertion to expect `"low"`

Fixes NOC-126