### PR TITLE
ci: publish docker image on stable release (fixes #3195)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,17 @@ on:
       - "master"
     tags:
       - "v*"
+  # Reusable entrypoint for release.yml. The push trigger above does not fire
+  # for stable v* tags because release.yml pushes them with the default
+  # GITHUB_TOKEN, which GitHub deliberately suppresses to prevent recursion.
+  # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+  workflow_call:
+    inputs:
+      tag:
+        description: "Stable git tag to build (e.g. v2026.428.0). When set, the image is tagged latest, MAJOR.MINOR, and the full semver."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -16,11 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
-      group: docker-${{ github.ref }}
+      group: docker-${{ inputs.tag != '' && format('tag-{0}', inputs.tag) || github.ref }}
       cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag != '' && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -38,10 +51,10 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' || inputs.tag != '' }}
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
+            type=sha,enable=${{ inputs.tag == '' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    outputs:
+      tag: ${{ steps.push_tag.outputs.tag }}
 
     steps:
       - name: Checkout repository
@@ -240,12 +242,14 @@ jobs:
           ./scripts/release.sh "${args[@]}"
 
       - name: Push stable tag
+        id: push_tag
         run: |
           tag="$(git tag --points-at HEAD | grep '^v' | head -1)"
           if [ -z "$tag" ]; then
             echo "Error: no stable tag points at HEAD after release." >&2
             exit 1
           fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
           git push origin "refs/tags/${tag}"
 
       - name: Create GitHub Release
@@ -259,3 +263,15 @@ jobs:
             exit 1
           fi
           ./scripts/create-github-release.sh "$version"
+
+  publish_stable_docker:
+    # Build & push the GHCR image for the stable release. Cannot rely on
+    # docker.yml's `on: push: tags: ['v*']` trigger because publish_stable
+    # pushes the tag with the default GITHUB_TOKEN, which GitHub suppresses
+    # workflow triggers for (anti-recursion). Calls docker.yml as a reusable
+    # workflow instead, with the freshly created tag passed as an input.
+    if: github.event_name == 'workflow_dispatch' && !inputs.dry_run
+    needs: publish_stable
+    uses: ./.github/workflows/docker.yml
+    with:
+      tag: ${{ needs.publish_stable.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,5 +273,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && !inputs.dry_run
     needs: publish_stable
     uses: ./.github/workflows/docker.yml
+    permissions:
+      contents: read
+      packages: write
     with:
       tag: ${{ needs.publish_stable.outputs.tag }}


### PR DESCRIPTION
## Why

Issue #3195 asks for tagged Docker images on GHCR. The `docker.yml` workflow already *looks* configured for this — `on: push: tags: ['v*']` is declared and `docker/metadata-action` is set up with `type=semver`. The auto-bot review on the issue concluded "already implemented" on this basis.

But empirically it doesn't work. Across the last 100 runs of `docker.yml`, **zero were triggered by tag pushes** — every run is a `master` branch push:

```
$ gh run list --repo paperclipai/paperclip --workflow=docker.yml --event=push --limit 100 \
    --json headBranch | jq '[.[] | select(.headBranch | startswith("v"))] | length'
0
```

Yet stable tags exist on the repo: `v2026.428.0`, `v2026.427.0`, `v2026.416.0`, `v2026.403.0`, …

## Root cause

`release.yml`'s `publish_stable` job (line 242–249) pushes the v\* tag using the default `GITHUB_TOKEN`:

```yaml
- name: Push stable tag
  run: |
    tag="$(git tag --points-at HEAD | grep '^v' | head -1)"
    ...
    git push origin "refs/tags/${tag}"
```

GitHub deliberately suppresses workflow triggers for refs pushed by the default `GITHUB_TOKEN`, to prevent recursion. So the tag lands in the repo, but `docker.yml`'s `on: push: tags: ['v*']` never sees the event. ([docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow))

## Fix

Make `docker.yml` callable as a reusable workflow with an optional `tag` input, and dispatch it from `release.yml` as a dependent job after the tag is pushed.

- `docker.yml` gains a `workflow_call` trigger with a `tag` input. When set:
  - `Checkout` uses `refs/tags/<tag>`
  - Image is tagged `latest`, `MAJOR.MINOR`, and the full semver
  - `sha-*` tag is suppressed (would otherwise reflect the caller's `github.sha`, which is the master commit that started `release.yml`, not the tag's commit)
- `release.yml`'s `publish_stable` job now exposes the pushed tag as a job output, and a new `publish_stable_docker` job invokes `docker.yml` via `uses:` with that tag.

The push-trigger paths (`master` branch push, manually-pushed `v*` tag) are unchanged.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker.yml'))"`)
- [x] Verified `docker/metadata-action@v5` semver behavior with empty `value=`: falls back to `github.ref` extraction, otherwise overrides ([source](https://github.com/docker/metadata-action/blob/v5/src/meta.ts#L155-L165)) — so the push-event behavior is preserved.
- [ ] **Maintainer**: push a throwaway `v0.0.0-test` tag manually (this hits the existing `on: push: tags: v*` trigger which still works for non-`GITHUB_TOKEN` pushes) and confirm it builds `latest` + `0.0.0` + `0.0` + `sha-*`. Delete tag and image after.
- [ ] **Maintainer**: dry-run the workflow_call path with `release.yml` `dry_run=true` (the docker job is gated on `!inputs.dry_run`, so it'll be skipped — but the rest of the dispatch path can be sanity-checked).
- [ ] **Live validation**: next stable release (`workflow_dispatch` on `release.yml` with `dry_run=false`) builds and pushes the versioned image automatically.

## Notes

- Closes #3195.
- This complements PR #542 (which set up `docker.yml`); does not replace any of it.
- Canary tags (`canary/v*`) are out of scope — they don't match the existing `v*` glob and weren't part of the request.