### PR TITLE
fix(gemini-local): skip YOLO informational stderr line in failure fallback

### DIFF
--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -52,7 +52,7 @@ import {
   isGeminiUnknownSessionError,
   parseGeminiJsonl,
 } from "./parse.js";
-import { firstNonEmptyLine } from "./utils.js";
+import { firstSignificantStderrLine } from "./utils.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -552,7 +552,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       } as Record<string, unknown>)
       : null;
     const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
-    const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const stderrLine = firstSignificantStderrLine(attempt.proc.stderr);
     const structuredFailure = attempt.parsed.resultEvent
       ? describeGeminiFailure(attempt.parsed.resultEvent)
       : null;

--- a/packages/adapters/gemini-local/src/server/test.ts
+++ b/packages/adapters/gemini-local/src/server/test.ts
@@ -21,7 +21,7 @@ import {
 } from "@paperclipai/adapter-utils/execution-target";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "../index.js";
 import { detectGeminiAuthRequired, detectGeminiQuotaExhausted, parseGeminiJsonl } from "./parse.js";
-import { firstNonEmptyLine } from "./utils.js";
+import { firstNonEmptyLine, firstSignificantStderrLine } from "./utils.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -39,7 +39,7 @@ function commandLooksLike(command: string, expected: string): boolean {
 }
 
 function summarizeProbeDetail(stdout: string, stderr: string, parsedError: string | null): string | null {
-  const raw = parsedError?.trim() || firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  const raw = parsedError?.trim() || firstSignificantStderrLine(stderr) || firstNonEmptyLine(stdout);
   if (!raw) return null;
   const clean = raw.replace(/\s+/g, " ").trim();
   const max = 240;

--- a/packages/adapters/gemini-local/src/server/utils.test.ts
+++ b/packages/adapters/gemini-local/src/server/utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { firstNonEmptyLine, firstSignificantStderrLine, isInformationalStderrLine } from "./utils.js";
+
+describe("firstNonEmptyLine", () => {
+  it("returns the first trimmed non-empty line", () => {
+    expect(firstNonEmptyLine("\n\n  hello\nworld\n")).toBe("hello");
+  });
+
+  it("returns empty string when input is blank", () => {
+    expect(firstNonEmptyLine("")).toBe("");
+    expect(firstNonEmptyLine("   \n\n")).toBe("");
+  });
+});
+
+describe("isInformationalStderrLine", () => {
+  it("flags the YOLO mode notice as informational", () => {
+    expect(
+      isInformationalStderrLine("YOLO mode is enabled. All tool calls will be automatically approved."),
+    ).toBe(true);
+  });
+
+  it("does not flag arbitrary error lines", () => {
+    expect(isInformationalStderrLine("Error: something exploded")).toBe(false);
+  });
+});
+
+describe("firstSignificantStderrLine", () => {
+  it("skips the YOLO informational line and returns the next significant line", () => {
+    const stderr = [
+      "YOLO mode is enabled. All tool calls will be automatically approved.",
+      "Error: rate limit exceeded",
+      "more details",
+    ].join("\n");
+    expect(firstSignificantStderrLine(stderr)).toBe("Error: rate limit exceeded");
+  });
+
+  it("returns empty string when stderr only contains informational notices", () => {
+    expect(
+      firstSignificantStderrLine(
+        "YOLO mode is enabled. All tool calls will be automatically approved.\n",
+      ),
+    ).toBe("");
+  });
+
+  it("falls back to the first significant line when leading lines are blank or noise", () => {
+    const stderr = "\n\n  YOLO mode is enabled.\n\n  real failure\n";
+    expect(firstSignificantStderrLine(stderr)).toBe("real failure");
+  });
+});

--- a/packages/adapters/gemini-local/src/server/utils.ts
+++ b/packages/adapters/gemini-local/src/server/utils.ts
@@ -1,8 +1,28 @@
 export function firstNonEmptyLine(text: string): string {
-    return (
-        text
-            .split(/\r?\n/)
-            .map((line) => line.trim())
-            .find(Boolean) ?? ""
-    );
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+// Informational lines that the Gemini CLI emits to stderr in approval-mode=yolo
+// even on a healthy run. They are not error signals and must not surface as the
+// adapter's failure message.
+const INFORMATIONAL_STDERR_PATTERNS: readonly RegExp[] = [/^YOLO mode is enabled\b/i];
+
+export function isInformationalStderrLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return true;
+  return INFORMATIONAL_STDERR_PATTERNS.some((re) => re.test(trimmed));
+}
+
+export function firstSignificantStderrLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0 && !isInformationalStderrLine(line)) ?? ""
+  );
 }

--- a/packages/adapters/gemini-local/vitest.config.ts
+++ b/packages/adapters/gemini-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

The `gemini_local` adapter unconditionally invokes the Gemini CLI with `--approval-mode yolo` for unattended heartbeat execution (`packages/adapters/gemini-local/src/server/execute.ts:402, :475`), and the CLI in turn always prints

```
YOLO mode is enabled. All tool calls will be automatically approved.
```

to **stderr**, even on a healthy run.

When the run later exits non-zero for any reason (signal, abrupt termination, etc.), the existing `firstNonEmptyLine(stderr)` fallback in `execute.ts` and `summarizeProbeDetail` in `test.ts` surfaces this YOLO notice as the adapter's `errorMessage`. The Paperclip heartbeat layer then classifies the run as `adapter_failed` with that misleading message and the operator-facing agent flips to `status=error`, even though YOLO mode is the configured, intended behavior.

This has caused a self-reinforcing recovery loop on agents whose adapter is `gemini_local` — they show "YOLO mode is enabled. All tool calls will be automatically approved." as a failure reason and trigger stranded-recovery cycles.

## Fix

- Add `firstSignificantStderrLine` and `isInformationalStderrLine` in `utils.ts`. The new helper filters known informational lines (currently the YOLO notice) and returns the first non-empty, non-informational stderr line.
- Use `firstSignificantStderrLine` for the stderr fallback in both the heartbeat execute path (`execute.ts`) and the hello probe summary (`test.ts`).
- The `stdout` fallback intentionally keeps `firstNonEmptyLine`, since stdout is the canonical output channel.

The flag itself is intentionally kept — `--approval-mode yolo` is required for headless execution and is documented in `commandNotes`.

## Tests

- Add `utils.test.ts` covering both the legacy `firstNonEmptyLine` behavior and the new helper for: skipping YOLO leading lines, returning empty when only informational lines are present, and falling through whitespace.
- Add a per-package `vitest.config.ts` so the workspace's vitest project resolves correctly (other adapter packages, e.g. `claude-local`, follow this same pattern).

## Test plan

- [x] `pnpm --filter @paperclipai/adapter-gemini-local typecheck`
- [x] `pnpm exec vitest run packages/adapters/gemini-local/src/server/utils.test.ts` — 7 tests pass
- [x] `pnpm --filter @paperclipai/adapter-gemini-local build`
- [ ] Maintainer verification: in a deployed environment with `gemini_local` agents that previously flipped to `status=error` with the YOLO message, confirm the heartbeat run ends with a real stderr line (or `Gemini exited with code N`) instead of the YOLO notice.