### PR TITLE
fix: add missing company-scoped agent detail route

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1427,6 +1427,26 @@ export function agentRoutes(
     res.json(result.map((agent) => redactForRestrictedAgentView(agent)));
   });
 
+  router.get("/companies/:companyId/agents/:id", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const id = req.params.id as string;
+    assertCompanyAccess(req, companyId);
+    const agent = await svc.getById(id);
+    if (!agent || agent.companyId !== companyId) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    const isSelf = req.actor.type === "agent" && req.actor.agentId === id;
+    const canReadSensitiveDetail = isSelf
+      ? true
+      : await actorCanReadConfigurationsForCompany(req, companyId);
+    if (!canReadSensitiveDetail) {
+      res.json(await buildAgentDetail(agent, { restricted: true }));
+      return;
+    }
+    res.json(await buildAgentDetail(agent));
+  });
+
   router.get("/instance/scheduler-heartbeats", async (req, res) => {
     assertInstanceAdmin(req);
 


### PR DESCRIPTION
## Summary

- Add `GET /companies/:companyId/agents/:id` endpoint that was missing from the API
- Previously only the global `/agents/:id` route existed, causing 404 "API route not found" errors when clients used the company-scoped path to fetch a single agent
- The new route validates the agent belongs to the specified company and applies the same access control as the existing global route

## Problem

The API has `GET /companies/:companyId/agents` (list) and `GET /agents/:id` (detail), but no `GET /companies/:companyId/agents/:id`. This inconsistency causes 404 errors for clients that naturally follow the REST pattern of scoping resources under their parent.

## Changes

Added route handler in `server/src/routes/agents.ts` that:
1. Validates company access via `assertCompanyAccess`
2. Fetches agent by ID and verifies it belongs to the specified company
3. Applies the same restricted/unrestricted detail logic as the existing global route

## Test plan

- [ ] Verify `GET /api/companies/:companyId/agents/:agentId` returns agent details (200)
- [ ] Verify mismatched companyId returns 404
- [ ] Verify non-existent agentId returns 404
- [ ] Verify access control applies (restricted view for non-privileged actors)