### PR TITLE
recovery: skip stranded-recovery for routine_execution issues

### DIFF
--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1334,6 +1334,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) return null;
 
+    // PATCH 2026-05-03 (alex@antoniou.net): skip recovery for issues with
+    // originKind "routine_execution". These are the per-tick issues created
+    // by cron-fired routines (e.g. CoS hourly briefing, McKinsey 4hr brief);
+    // their `runId=null` between scheduled ticks is the NORMAL steady state,
+    // not a stranded condition. Treating them as stranded spawned ~1 recovery
+    // wrapper per cron tick (~50+ wrappers in 24h on PortfolioHQ alone),
+    // polluting the inbox.
+    // The latestRun.status==succeeded check below would catch SOME of these
+    // but the issue's own status flips to in_progress/todo on each tick,
+    // and with runId=null, the detector still fires on at least the first
+    // pass after each tick.
+    // Filed at briefings/escalations/ for upstream Paperclip team.
+    if (input.issue.originKind === "routine_execution") return null;
+
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
     if (existing) return existing;
 


### PR DESCRIPTION
## Summary

`ensureStrandedIssueRecoveryIssue` treats issues with `executionRunId: null` and stale lastRun as stranded after 30 minutes. But cron-fired routines (created via the routine schedule trigger) reuse the same `originKind: "routine_execution"` issue across ticks, and their `runId=null` between ticks is the **normal steady state** — not a stranded condition.

**Result before this patch:** every cron tick produced one recovery wrapper. On a Portfolio HQ instance running 4 routines (hourly Chief of Staff + 4hr McKinsey + 12hr Paperclip Feedback + heartbeat-driven CEO check-ins), this produced **~50 recovery wrappers in 24h**, polluting the inbox and burning ~5-10 phantom heartbeats/hour.

## Fix

Add a single guard alongside the existing `isStrandedIssueRecoveryIssue` check (which already prevents recursive recovery):

```ts
if (input.issue.originKind === "routine_execution") return null;
```

New rule: routines manage their own liveness via the schedule; the recovery system should not interfere.

## Verification

After applying the patch locally:

- Two consecutive CoS hourly cron ticks (12:00 ET → 13:00 ET 2026-05-03) produced **zero new recovery wrappers**
- The routine itself fired and completed normally (heartbeat run `succeeded`)
- Existing recovery wrappers (50+ pre-patch) remain `done` / `cancelled` and don't reappear

Before the patch, the same routine produced wrappers at every tick:
- 12:00 ET → POR-86 (Recover stalled issue POR-85)
- 11:10 ET → POR-40 (Recover stalled issue POR-38)
- 10:20 ET → POR-34 (Recover stalled issue POR-32)
- ... (every hour)

## Repro before this patch

1. Create a routine with a `schedule` trigger (e.g., `0 * * * *`)
2. Wait for one cron tick. The routine's `routine_execution` issue gets `runId=null` after the run completes.
3. Wait 30+ minutes. The detector treats the issue as stranded and spawns "Recover stalled issue X".
4. Repeat every hour indefinitely.

## Related

This is the second `claude_local` / paperclip-engine patch in our local instance; the first (`#5042`) covers `--chrome` / `--effort` / `--max-turns` / `--append-system-prompt-file` flag compatibility with public Claude Code 2.0.30. Same root cause class (forward-looking code that doesn't match production reality).

## Tests

Not adding tests in this PR — the existing `heartbeat-process-recovery.test.ts` covers the recursion guard and would be the right place to add a `routine_execution` exemption test. Happy to add if requested.

## Reproduction environment

- Paperclip @ commit 76f09c8e (master, 2026-05-03)
- Node 22.22.2
- Local Postgres via embedded mode
- Public Claude Code 2.0.30