### PR TITLE
feat(cli): PID file + paperclipai stop + instance guard

### DIFF
--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -42,6 +42,22 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   const paths = describeLocalInstancePaths(instanceId);
   fs.mkdirSync(paths.instanceRoot, { recursive: true });
 
+  // Instance guard: abort if another server process is already running for this instance.
+  const pidFile = path.join(paths.instanceRoot, "server.pid");
+  if (fs.existsSync(pidFile)) {
+    const rawPid = fs.readFileSync(pidFile, "utf-8").trim();
+    const existingPid = parseInt(rawPid, 10);
+    if (!isNaN(existingPid) && existingPid > 0 && isProcessAlive(existingPid)) {
+      console.error(
+        `Error: a Paperclip server is already running for instance "${instanceId}" (PID ${existingPid}).\n` +
+          `Stop it first with: paperclipai stop`,
+      );
+      process.exit(1);
+    }
+    // Stale PID file — remove it and continue.
+    fs.rmSync(pidFile);
+  }
+
   const configPath = resolveConfigPath(opts.config);
   process.env.PAPERCLIP_CONFIG = configPath;
   loadPaperclipEnvFile(configPath);
@@ -83,6 +99,21 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   p.log.step("Starting Paperclip server...");
   const startedServer = await importServerEntry();
 
+  // Write PID file so `paperclipai stop` and the instance guard can find this process.
+  fs.writeFileSync(pidFile, String(process.pid), "utf-8");
+
+  // Remove the PID file when the process exits for any reason.
+  const removePidFile = (): void => {
+    try {
+      if (fs.existsSync(pidFile)) fs.rmSync(pidFile);
+    } catch {
+      // best-effort
+    }
+  };
+  process.once("exit", removePidFile);
+  process.once("SIGINT", () => { removePidFile(); process.exit(130); });
+  process.once("SIGTERM", () => { removePidFile(); process.exit(143); });
+
   if (shouldGenerateBootstrapInviteAfterStart(config)) {
     p.log.step("Generating bootstrap CEO invite");
     await bootstrapCeoInvite({
@@ -90,6 +121,15 @@ export async function runCommand(opts: RunOptions): Promise<void> {
       dbUrl: startedServer.databaseUrl,
       baseUrl: resolveBootstrapInviteBaseUrl(config, startedServer),
     });
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as { code?: string }).code !== "ESRCH";
   }
 }
 

--- a/cli/src/commands/stop.ts
+++ b/cli/src/commands/stop.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { describeLocalInstancePaths, resolvePaperclipInstanceId } from "../config/home.js";
+
+interface StopOptions {
+  instance?: string;
+  force?: boolean;
+}
+
+const GRACEFUL_WAIT_MS = 10_000;
+const POLL_INTERVAL_MS = 200;
+
+export async function stopCommand(opts: StopOptions): Promise<void> {
+  const instanceId = resolvePaperclipInstanceId(opts.instance);
+  const paths = describeLocalInstancePaths(instanceId);
+  const pidFile = path.join(paths.instanceRoot, "server.pid");
+
+  p.intro(pc.bgCyan(pc.black(" paperclipai stop ")));
+  p.log.message(pc.dim(`Instance: ${instanceId}`));
+
+  if (!fs.existsSync(pidFile)) {
+    p.log.warn(`No PID file found at ${pidFile}. Is the server running?`);
+    process.exit(1);
+  }
+
+  const rawPid = fs.readFileSync(pidFile, "utf-8").trim();
+  const pid = parseInt(rawPid, 10);
+
+  if (isNaN(pid) || pid <= 0) {
+    p.log.error(`PID file contains invalid value: ${JSON.stringify(rawPid)}`);
+    fs.rmSync(pidFile);
+    process.exit(1);
+  }
+
+  if (!isProcessAlive(pid)) {
+    p.log.warn(`Process ${pid} is not running. Removing stale PID file.`);
+    fs.rmSync(pidFile);
+    process.exit(0);
+  }
+
+  p.log.step(`Sending SIGTERM to process ${pid}...`);
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ESRCH") {
+      p.log.warn(`Process ${pid} already exited. Removing stale PID file.`);
+      fs.rmSync(pidFile);
+      process.exit(0);
+    }
+    throw err;
+  }
+
+  const spinner = p.spinner();
+  spinner.start(`Waiting for process ${pid} to exit (up to ${GRACEFUL_WAIT_MS / 1000}s)...`);
+
+  const deadline = Date.now() + GRACEFUL_WAIT_MS;
+  let exited = false;
+
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+    if (!isProcessAlive(pid)) {
+      exited = true;
+      break;
+    }
+  }
+
+  if (exited) {
+    spinner.stop(`Process ${pid} exited cleanly.`);
+    if (fs.existsSync(pidFile)) {
+      fs.rmSync(pidFile);
+    }
+    p.outro(pc.green("Paperclip server stopped."));
+  } else {
+    spinner.stop(pc.yellow(`Process ${pid} did not exit within ${GRACEFUL_WAIT_MS / 1000}s.`));
+    p.log.warn(
+      `The server is still running. You can force-kill it with: kill -9 ${pid}`,
+    );
+    process.exit(1);
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    return code !== "ESRCH";
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,7 @@ import { configure } from "./commands/configure.js";
 import { addAllowedHostname } from "./commands/allowed-hostname.js";
 import { heartbeatRun } from "./commands/heartbeat-run.js";
 import { runCommand } from "./commands/run.js";
+import { stopCommand } from "./commands/stop.js";
 import { bootstrapCeoInvite } from "./commands/auth-bootstrap-ceo.js";
 import { dbBackupCommand } from "./commands/db-backup.js";
 import { registerEnvLabCommands } from "./commands/env-lab.js";
@@ -114,6 +115,13 @@ program
   .option("--repair", "Attempt automatic repairs during doctor", true)
   .option("--no-repair", "Disable automatic repairs during doctor")
   .action(runCommand);
+
+program
+  .command("stop")
+  .description("Gracefully stop a running Paperclip server")
+  .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
+  .option("-i, --instance <id>", "Local instance id (default: default)")
+  .action(stopCommand);
 
 const heartbeat = program.command("heartbeat").description("Heartbeat utilities");
 


### PR DESCRIPTION
## Problem

When a Paperclip server crashes or is killed without cleanup, there is no record of whether a server is already running for a given instance. Running `paperclipai run` a second time silently starts a second server, causing port conflicts and data corruption (reported in CES-3512).

Additionally, there is no clean way to stop a running server from the CLI — operators must find the PID manually via `ps`.

## Solution

Three complementary changes in `cli/src/`:

### 1. PID file (`run.ts`)

After `startServer()` returns, `runCommand` writes `process.pid` to:

```
~/.paperclip/instances/{instanceId}/server.pid
```

The file is removed on process `exit`, `SIGINT`, and `SIGTERM` via `process.once` listeners (best-effort — won't block shutdown).

### 2. Instance guard (`run.ts`)

At the top of `runCommand`, before any UI output, the command checks whether a PID file already exists for the target instance. If the recorded PID is still alive (`kill(pid, 0)`), it prints a clear error and exits 1 without starting a second server:

```
Error: a Paperclip server is already running for instance "default" (PID 12345).
Stop it first with: paperclipai stop
```

Stale PID files (process no longer exists, e.g. after a crash) are removed silently so they don't block restarts.

### 3. `paperclipai stop` command (`stop.ts`, `index.ts`)

```
paperclipai stop [-i <instance>] [-d <data-dir>]
```

- Reads the PID file for the given instance.
- Sends `SIGTERM` to the recorded process.
- Polls every 200 ms for up to 10 s waiting for the process to exit.
- On clean exit: removes the PID file, prints success.
- On timeout: prints the PID for manual `kill -9` and exits 1.

## Acceptance criteria

- [x] `paperclipai run` with an active instance prints error and exits without starting a second server.
- [x] `paperclipai stop` terminates the server gracefully.
- [x] PID file is removed after a clean stop.
- [x] Stale PID files from crashes do not block subsequent `run` invocations.

## Files changed

| File | Change |
|---|---|
| `cli/src/commands/run.ts` | Instance guard + PID file write + exit cleanup |
| `cli/src/commands/stop.ts` | New — `stopCommand` implementation |
| `cli/src/index.ts` | Import and register `paperclipai stop` |