### PR TITLE
fix(heartbeat): detect stream-stalled runs in reapOrphanedRuns (#4266)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { spawn, type ChildProcess } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
 import { and, eq, or, inArray } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
@@ -68,6 +72,15 @@ vi.mock("../adapters/index.ts", async () => {
     })),
   };
 });
+
+// Redirect run-log writes to a per-run-process tmpdir so the local-file
+// store does not pollute the real ~/.paperclip/data/run-logs while these
+// tests are running. The store reads RUN_LOG_BASE_PATH at first use, so
+// this MUST be set before the heartbeat module is imported below.
+const RUN_LOG_TMPDIR =
+  process.env.RUN_LOG_BASE_PATH ??
+  mkdtempSync(path.join(os.tmpdir(), "paperclip-test-run-logs-"));
+process.env.RUN_LOG_BASE_PATH = RUN_LOG_TMPDIR;
 
 import { heartbeatService } from "../services/heartbeat.ts";
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -2337,6 +2350,149 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       retryOfRunId: runId,
       source: "issue.productive_terminal_continuation_recovery",
     });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Watchdog stream-stall coverage (issue #4266 + silent-stuck symmetry).
+  // The PID-only reaper used to leave runs in `running` whenever the
+  // child PID was alive. These two tests pin the new behavior:
+  //   - log shows a terminal `result` event → force-finalize
+  //   - PID alive but stream silent past threshold → kill + force-fail
+  // ─────────────────────────────────────────────────────────────────
+
+  function safeSegment(value: string) {
+    return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+  }
+
+  async function seedRunLogFile(input: {
+    companyId: string;
+    agentId: string;
+    runId: string;
+    events: Array<Record<string, unknown>>;
+  }): Promise<{ logRef: string }> {
+    const dir = path.join(
+      RUN_LOG_TMPDIR,
+      safeSegment(input.companyId),
+      safeSegment(input.agentId),
+    );
+    await fs.mkdir(dir, { recursive: true });
+    const relPath = path.join(
+      safeSegment(input.companyId),
+      safeSegment(input.agentId),
+      `${safeSegment(input.runId)}.ndjson`,
+    );
+    const absPath = path.join(RUN_LOG_TMPDIR, relPath);
+    const ts = new Date().toISOString();
+    const lines = input.events
+      .map((event) =>
+        JSON.stringify({
+          ts,
+          stream: "stdout",
+          chunk: JSON.stringify(event),
+        }),
+      )
+      .join("\n");
+    await fs.writeFile(absPath, `${lines}\n`, "utf8");
+    await db
+      .update(heartbeatRuns)
+      .set({ logStore: "local_file", logRef: relPath })
+      .where(eq(heartbeatRuns.id, input.runId));
+    return { logRef: relPath };
+  }
+
+  it("force-finalizes a run when the log already shows a terminal result event but the wrapper is hung (issue #4266)", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { runId, wakeupRequestId, companyId, agentId, issueId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+    });
+
+    // Synthesize the canonical claude-local terminal stream-json event:
+    // wrapper would have written this just before calling setRunStatus.
+    await seedRunLogFile({
+      companyId,
+      agentId,
+      runId,
+      events: [
+        { type: "system", subtype: "init", session_id: "s1" },
+        { type: "assistant", message: { content: [{ type: "text", text: "done" }] } },
+        {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          stop_reason: "end_turn",
+          num_turns: 7,
+          duration_ms: 1234,
+          session_id: "s1",
+        },
+      ],
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const reapedRun = await heartbeat.getRun(runId);
+    expect(reapedRun?.status).toBe("succeeded");
+    expect(reapedRun?.errorCode).toBeNull();
+    expect(reapedRun?.finishedAt).toBeTruthy();
+    // The wrapper PID must be terminated so the agent slot is freed.
+    expect(await waitForPidExit(child.pid as number, 2_000)).toBe(true);
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("completed");
+
+    // Issue should be released for the next pickup, not stuck waiting on the dead run.
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
+  });
+
+  it("force-fails a run when the PID is alive but the stream has been silent past the silent-stuck threshold", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { runId, companyId, agentId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+    });
+
+    // Backdate lastOutputAt so the reaper sees a 30-minute silent gap
+    // (well past the default 15-minute threshold). startedAt remains the
+    // fixture default — only stream-derived timestamps drive silent-stuck.
+    const silentSince = new Date(Date.now() - 30 * 60 * 1000);
+    await db
+      .update(heartbeatRuns)
+      .set({
+        lastOutputAt: silentSince,
+        processStartedAt: silentSince,
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns({
+      silentStuckThresholdMs: 15 * 60 * 1000,
+    });
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const reapedRun = await heartbeat.getRun(runId);
+    expect(reapedRun?.status).toBe("failed");
+    expect(reapedRun?.errorCode).toBe("silent_stuck");
+    expect(reapedRun?.error ?? "").toContain("silent_stuck");
+    expect(reapedRun?.finishedAt).toBeTruthy();
+    // The watchdog must terminate the silent child so the agent unblocks.
+    expect(await waitForPidExit(child.pid as number, 2_000)).toBe(true);
   });
 
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -155,6 +155,17 @@ const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
 const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+// Watchdog error codes for the two stream-stall failure modes the
+// PID-only reaper used to miss (see issue #4266 + paperclip ops notes).
+//   wrapper_hung_after_completion: log already shows a terminal `result`
+//     event but the wrapper never updated the DB (e.g. setRunStatus hung
+//     on a transient DB connection).
+//   silent_stuck: PID alive but no stdout/stderr events for more than
+//     SILENT_STUCK_DEFAULT_THRESHOLD_MS (typically a non-Anthropic backend
+//     dropping the SSE stream mid-tool-call without closing the socket).
+const WRAPPER_HUNG_AFTER_COMPLETION_ERROR_CODE = "wrapper_hung_after_completion";
+const SILENT_STUCK_ERROR_CODE = "silent_stuck";
+const SILENT_STUCK_DEFAULT_THRESHOLD_MS = 15 * 60 * 1000;
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
@@ -1989,6 +2000,76 @@ export function buildPaperclipTaskMarkdown(input: {
   }
   lines.push("", "Use this task context as the current assignment.");
   return lines.join("\n");
+}
+
+// Peek at the last segment of a run's log file and look for a terminal
+// stream-json `result` event. Used by reapOrphanedRuns to detect the
+// "Claude completed but wrapper never updated the DB" failure mode
+// (issue #4266) and to distinguish a working child from a silent-stuck
+// one. Returns null if the log is unreadable, missing, or contains no
+// `result` event yet.
+async function peekRunLogForTerminal(
+  store: { read(handle: { store: "local_file"; logRef: string }, opts?: { offset?: number; limitBytes?: number }): Promise<{ content: string; nextOffset?: number }> },
+  handle: { store: "local_file"; logRef: string },
+): Promise<
+  | {
+      terminal: true;
+      isError: boolean;
+      stopReason: string | null;
+      numTurns: number | null;
+    }
+  | null
+> {
+  let content: string;
+  try {
+    // 2 MiB is more than enough for any well-behaved heartbeat run; the
+    // result event is always emitted last so reading from offset 0 is fine.
+    const result = await store.read(handle, { offset: 0, limitBytes: 2_000_000 });
+    content = result.content;
+  } catch {
+    return null;
+  }
+  if (!content) return null;
+
+  let found = false;
+  let isError = false;
+  let stopReason: string | null = null;
+  let numTurns: number | null = null;
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    let outer: { stream?: unknown; chunk?: unknown } | null = null;
+    try {
+      outer = JSON.parse(trimmed) as { stream?: unknown; chunk?: unknown };
+    } catch {
+      continue;
+    }
+    const chunk = typeof outer?.chunk === "string" ? outer.chunk.trimEnd() : "";
+    if (!chunk) continue;
+    // Each chunk can carry one or more newline-separated stream-json events.
+    for (const sub of chunk.split("\n")) {
+      const subTrim = sub.trim();
+      if (!subTrim.startsWith("{")) continue;
+      let inner: { type?: unknown; is_error?: unknown; stop_reason?: unknown; num_turns?: unknown } | null = null;
+      try {
+        inner = JSON.parse(subTrim);
+      } catch {
+        continue;
+      }
+      if (inner?.type === "result") {
+        found = true;
+        isError = Boolean(inner.is_error);
+        stopReason = typeof inner.stop_reason === "string" ? inner.stop_reason : null;
+        numTurns = typeof inner.num_turns === "number" && Number.isFinite(inner.num_turns) ? inner.num_turns : null;
+        // Don't break; keep scanning so the LAST result event in the file wins
+        // (multi-attempt/resumed runs emit multiple).
+      }
+    }
+  }
+
+  if (!found) return null;
+  return { terminal: true, isError, stopReason, numTurns };
 }
 
 // A positive liveness check means some process currently owns the PID.
@@ -4571,8 +4652,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
-  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
+  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number; silentStuckThresholdMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
+    const silentStuckThresholdMs = opts?.silentStuckThresholdMs ?? SILENT_STUCK_DEFAULT_THRESHOLD_MS;
     const now = new Date();
 
     // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
@@ -4601,6 +4683,157 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
       if (processPidAlive) {
+        // Two stream-stall failure modes were previously invisible to the
+        // PID-only reaper (issue #4266):
+        //   (A) wrapper_hung_after_completion: Claude already wrote a
+        //       terminal `result` event to the log, but the wrapper
+        //       never persisted the final status to the DB.
+        //   (B) silent_stuck: child is alive but has not produced any
+        //       stdout/stderr events for >silentStuckThresholdMs (a
+        //       non-Anthropic backend dropping the SSE stream
+        //       mid-tool-call is the typical cause).
+        const logHandle: { store: "local_file"; logRef: string } | null =
+          run.logStore === "local_file" && run.logRef
+            ? { store: "local_file", logRef: run.logRef }
+            : null;
+        const terminal = logHandle ? await peekRunLogForTerminal(runLogStore, logHandle) : null;
+
+        if (terminal?.terminal) {
+          // (A) wrapper-hung-after-completion — force-finalize.
+          const finalStatus = terminal.isError ? "failed" : "succeeded";
+          const reason =
+            `Reaper: child pid ${run.processPid} alive but log shows terminal stream-json result event ` +
+            `(stop_reason=${terminal.stopReason ?? "?"}, is_error=${terminal.isError}); ` +
+            `force-finalizing as ${finalStatus} (${WRAPPER_HUNG_AFTER_COMPLETION_ERROR_CODE}, issue #4266).`;
+          await terminateHeartbeatRunProcess({
+            pid: run.processPid,
+            processGroupId: run.processGroupId,
+          }).catch(() => {});
+
+          let finalizedRun = await setRunStatus(run.id, finalStatus, {
+            error: terminal.isError ? reason : null,
+            errorCode: terminal.isError ? WRAPPER_HUNG_AFTER_COMPLETION_ERROR_CODE : null,
+            finishedAt: now,
+            resultJson: mergeRunStopMetadataForAgent(
+              { adapterType, adapterConfig },
+              finalStatus,
+              {
+                resultJson: parseObject(run.resultJson),
+                errorCode: terminal.isError ? WRAPPER_HUNG_AFTER_COMPLETION_ERROR_CODE : null,
+                errorMessage: terminal.isError ? reason : null,
+              },
+            ),
+          });
+          await setWakeupStatus(
+            run.wakeupRequestId,
+            finalStatus === "succeeded" ? "completed" : "failed",
+            {
+              finishedAt: now,
+              error: finalStatus === "failed" ? reason : null,
+            },
+          );
+          if (!finalizedRun) finalizedRun = await getRun(run.id);
+          if (!finalizedRun) continue;
+          finalizedRun =
+            (await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson))) ?? finalizedRun;
+          await releaseEnvironmentLeasesForRun({
+            runId: finalizedRun.id,
+            companyId: finalizedRun.companyId,
+            agentId: finalizedRun.agentId,
+            status: finalizedRun.status,
+            failureReason: finalizedRun.error ?? undefined,
+          });
+          await releaseIssueExecutionAndPromote(finalizedRun);
+          await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
+            eventType: "lifecycle",
+            stream: "system",
+            level: terminal.isError ? "error" : "warn",
+            message: reason,
+            payload: {
+              processPid: run.processPid,
+              watchdogReason: WRAPPER_HUNG_AFTER_COMPLETION_ERROR_CODE,
+              terminalStopReason: terminal.stopReason,
+              terminalIsError: terminal.isError,
+              terminalNumTurns: terminal.numTurns,
+            },
+          });
+          await finalizeAgentStatus(run.agentId, finalStatus);
+          await startNextQueuedRunForAgent(run.agentId);
+          runningProcesses.delete(run.id);
+          reaped.push(run.id);
+          continue;
+        }
+
+        // (B) silent-stuck check: PID alive but no stream output for too long.
+        // Only `lastOutputAt` and `processStartedAt` are valid signals here —
+        // `startedAt` is just the DB row's createdAt-equivalent and bears no
+        // relationship to whether the child has actually been running silently.
+        const lastOutputMs = run.lastOutputAt
+          ? new Date(run.lastOutputAt).getTime()
+          : run.processStartedAt
+            ? new Date(run.processStartedAt).getTime()
+            : 0;
+        const silentForMs = lastOutputMs > 0 ? now.getTime() - lastOutputMs : 0;
+        if (silentStuckThresholdMs > 0 && silentForMs >= silentStuckThresholdMs) {
+          const minutes = Math.round(silentForMs / 60_000);
+          const thresholdMinutes = Math.round(silentStuckThresholdMs / 60_000);
+          const reason =
+            `Reaper: child pid ${run.processPid} alive but no stream-json output for ${minutes}m ` +
+            `(>= ${thresholdMinutes}m threshold); terminating as ${SILENT_STUCK_ERROR_CODE}.`;
+          await terminateHeartbeatRunProcess({
+            pid: run.processPid,
+            processGroupId: run.processGroupId,
+          }).catch(() => {});
+
+          let finalizedRun = await setRunStatus(run.id, "failed", {
+            error: reason,
+            errorCode: SILENT_STUCK_ERROR_CODE,
+            finishedAt: now,
+            resultJson: mergeRunStopMetadataForAgent(
+              { adapterType, adapterConfig },
+              "failed",
+              {
+                resultJson: parseObject(run.resultJson),
+                errorCode: SILENT_STUCK_ERROR_CODE,
+                errorMessage: reason,
+              },
+            ),
+          });
+          await setWakeupStatus(run.wakeupRequestId, "failed", { finishedAt: now, error: reason });
+          if (!finalizedRun) finalizedRun = await getRun(run.id);
+          if (!finalizedRun) continue;
+          finalizedRun =
+            (await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson))) ?? finalizedRun;
+          await releaseEnvironmentLeasesForRun({
+            runId: finalizedRun.id,
+            companyId: finalizedRun.companyId,
+            agentId: finalizedRun.agentId,
+            status: finalizedRun.status,
+            failureReason: finalizedRun.error ?? undefined,
+          });
+          await releaseIssueExecutionAndPromote(finalizedRun);
+          await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
+            eventType: "lifecycle",
+            stream: "system",
+            level: "error",
+            message: reason,
+            payload: {
+              processPid: run.processPid,
+              watchdogReason: SILENT_STUCK_ERROR_CODE,
+              silentForMs,
+              silentStuckThresholdMs,
+            },
+          });
+          await finalizeAgentStatus(run.agentId, "failed");
+          await startNextQueuedRunForAgent(run.agentId);
+          runningProcesses.delete(run.id);
+          reaped.push(run.id);
+          continue;
+        }
+
+        // (C) Healthy: PID alive AND recent output AND no terminal event yet.
+        // Mark the run as detached so operators can see the in-memory handle
+        // was lost, but otherwise leave it alone (existing behavior).
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
           const detachedRun = await setRunStatus(run.id, "running", {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each heartbeat run spawns a long-lived child process via the adapter (e.g. `claude --print`) and is supervised by `reapOrphanedRuns()`
> - The reaper currently makes its keep-or-kill decision on a single signal: is the recorded `processPid` still alive?
> - That misses two real failure modes — a wrapper hung on a DB write *after* Claude already wrote a terminal `result` event to the log (issue #4266), and a child sitting alive at 0.2 % CPU because the upstream provider stalled mid-tool-call without closing the SSE socket
> - Both look identical in the DB (status `running`, `errorCode: null`, PID alive) and the only recovery today is a manual operator intervention with `kill -9` plus a SQL update
> - This PR teaches the reaper to inspect the run log file before deciding the child is healthy: if the log already shows a stream-json `result` event, force-finalize; if there has been no output for a configurable threshold, kill the wrapper and fail the run with `silent_stuck`
> - The benefit is that an idle but alive child no longer blocks the agent slot indefinitely — the queue advances on its own and operators stop being on call for what is in principle a recoverable state

## What Changed

- New helper \`peekRunLogForTerminal()\` in \`server/src/services/heartbeat.ts\` that reads up to 2 MiB of the run's NDJSON log, parses outer envelopes + inner stream-json events, and returns the last \`type:\"result\"\` event (\`isError\`, \`stopReason\`, \`numTurns\`).
- Two new branches inside the existing \`processPidAlive\` arm of \`reapOrphanedRuns()\`:
  - \`wrapper_hung_after_completion\` — log already shows a terminal \`result\` event ⇒ kill the wrapper, force-finalize the run as \`succeeded\`/\`failed\` per \`is_error\`, release env leases, promote next queued run.
  - \`silent_stuck\` — \`lastOutputAt\` (or \`processStartedAt\` when output never started) is older than \`silentStuckThresholdMs\` (default 15 min, configurable per call via \`opts.silentStuckThresholdMs\`) ⇒ kill, fail with \`errorCode: silent_stuck\`. \`startedAt\` is **not** a fallback signal — it is the DB-row creation timestamp and is unrelated to child activity.
- Healthy runs (PID alive, no terminal event, recent stream output) keep the existing behavior of being marked \`process_detached\`.
- New error codes added next to \`DETACHED_PROCESS_ERROR_CODE\`: \`WRAPPER_HUNG_AFTER_COMPLETION_ERROR_CODE\`, \`SILENT_STUCK_ERROR_CODE\`, plus the new \`SILENT_STUCK_DEFAULT_THRESHOLD_MS\` constant.
- Two regression tests in \`server/src/__tests__/heartbeat-process-recovery.test.ts\`:
  - \`force-finalizes a run when the log already shows a terminal result event but the wrapper is hung (issue #4266)\` — synthesizes a stream-json \`result\` event in the log, asserts \`succeeded\` + the wrapper PID was terminated + the issue's \`executionRunId\` was released.
  - \`force-fails a run when the PID is alive but the stream has been silent past the silent-stuck threshold\` — backdates \`lastOutputAt\` 30 min, asserts \`failed\` with \`errorCode: silent_stuck\` and PID terminated.
- The test file points \`RUN_LOG_BASE_PATH\` at a per-test-process tmpdir (set before the heartbeat module is imported) so the synthetic log files do not pollute the real \`~/.paperclip/data/run-logs\` tree.

## Verification

\`\`\`sh
# from repo root
pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts --no-coverage
# expected: Tests  39 passed (39)  — 37 pre-existing + 2 new

# also run the full heartbeat-* family for regression
pnpm exec vitest run server/src/__tests__/heartbeat-*.test.ts --no-coverage
# expected: Tests  150 passed (150)
\`\`\`

Manual reproduction in the issue thread (#4266): a Claude child wrote \`terminal_reason: completed\` to the run log but \`setRunStatus()\` hung for ~40 minutes; before this PR the reaper looped the staleness check forever; after this PR the next reaper tick force-finalizes the run as \`succeeded\` and unblocks the issue.

This branch was deployed live in our local Paperclip instance for ~3 hours of mixed agent traffic; no false-positive reaps were observed (healthy runs with active stream output were never mistakenly killed).

## Risks

- **Low** for the wrapper-hung path: it only fires when a terminal \`result\` event has already been emitted by the adapter, so the work is provably done — we are recovering accounting, not killing in-flight work.
- **Medium** for the silent-stuck path. The default 15-minute threshold should comfortably exceed any legitimate cargo build / large LLM response, but very long single tool calls (e.g. a 20-minute terminal-bench evaluation) could be falsely classified as stuck. Mitigation: threshold is per-call configurable (\`opts.silentStuckThresholdMs\`), and the log-peek runs first — if the log has emitted *anything* recent, \`lastOutputAt\` is fresh and the path is skipped.
- The 2 MiB log read is bounded and runs only on the cron tick, never per request.
- No DB schema change, no public API change, no UI change.

## Model Used

- Claude Opus 4.7 (\`claude-opus-4-7\`), 1M-context build, extended thinking + tool use enabled. Used to read the upstream \`heartbeat.ts\` reaper, design the two new branches against the existing \`activeExecutionRun\` lookup, write the helper + tests, and produce this PR description.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (39 in the touched file, 150 across the heartbeat-* family)
- [x] I have added or updated tests where applicable (2 new regression tests cover both new branches)
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-side reaper)
- [x] I have updated relevant documentation to reflect my changes — code comments document both new branches in-line
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge