### PR TITLE
fix(cli): add explicit MCP SDK dependency for runtime compatibility

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.10.0",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@paperclipai/adapter-acpx-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.10.0
         version: 0.10.1
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@paperclipai/adapter-acpx-local':
         specifier: workspace:*
         version: link:../packages/adapters/acpx-local
@@ -8660,6 +8663,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.12.12)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.12
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
   '@noble/ciphers@2.1.1': {}
 
   '@noble/hashes@1.8.0': {}
@@ -10404,14 +10429,6 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
@@ -13555,7 +13572,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13711,6 +13728,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@3.25.76: {}
 

--- a/report/mji-12-mcp-sdk-compat-check.md
+++ b/report/mji-12-mcp-sdk-compat-check.md
@@ -1,0 +1,29 @@
+# MJI-12 MCP SDK Compatibility Check
+
+Date: 2026-05-03
+
+## Canonical source wiring
+- Added direct dependency in `cli/package.json`:
+  - `"@modelcontextprotocol/sdk": "1.29.0"`
+- Updated workspace lockfile via:
+  - `corepack pnpm install --lockfile-only --filter paperclipai`
+
+## Runtime resolution evidence
+Command:
+- `npm ls @modelcontextprotocol/sdk --all` (run in installed runtime package path)
+
+Output:
+- `paperclipai@2026.428.0 ...`
+- `└── @modelcontextprotocol/sdk@1.29.0`
+
+Resolved location observed in runtime install tree:
+- `/Users/marxcrackedupmac/.hermes/node/lib/node_modules/paperclipai/node_modules/@modelcontextprotocol/sdk`
+
+## Issue API flow smoke checks
+Commands executed successfully (`--help` load checks):
+- `node dist/index.js issue checkout --help`
+- `node dist/index.js issue comment --help`
+- `node dist/index.js issue update --help`
+
+Result:
+- Commands loaded and printed expected usage without runtime errors.


### PR DESCRIPTION
## Summary
- add direct `@modelcontextprotocol/sdk` dependency to `cli/package.json`
- update `pnpm-lock.yaml` for the new direct dependency
- add compatibility evidence doc at `report/mji-12-mcp-sdk-compat-check.md`

## Verification
- `npm ls @modelcontextprotocol/sdk --all` resolves `@modelcontextprotocol/sdk@1.29.0` in runtime install
- `node dist/index.js issue checkout --help`
- `node dist/index.js issue comment --help`
- `node dist/index.js issue update --help`

Refs MJI-12, MJI-26
