### PR TITLE
HOM-148: suppress duplicate stale active-run review issue cascades

### DIFF
--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -19,6 +19,8 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` | Runtime mode override |
 | `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` | Exposure policy when deployment mode is `authenticated` |
 | `PAPERCLIP_API_URL` | (auto-derived) | Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful for deployments where the public-facing URL differs from the local bind address. |
+| `PAPERCLIP_SLACK_WEBHOOK_URL` | (unset) | Optional Slack incoming webhook URL. Must be `https://hooks.slack.com/...` (or `https://hooks.slack-gov.com/...`). |
+| `ALLOW_INSECURE_WEBHOOK_URLS` | `false` | Dev-only escape hatch for loopback `http://` webhook URLs (`localhost`, `127.0.0.1`, `::1`) in non-production. Never enable for staging/production. |
 
 ## Secrets
 

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -31,6 +31,7 @@ import {
   resolvePaperclipDesiredSkillNames,
   renderTemplate,
   renderPaperclipWakePrompt,
+  runningProcesses,
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   joinPromptSections,
@@ -48,6 +49,10 @@ import { buildCodexExecArgs } from "./codex-args.js";
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const CODEX_ROLLOUT_NOISE_RE =
   /^\d{4}-\d{2}-\d{2}T[^\s]+\s+ERROR\s+codex_core::rollout::list:\s+state db missing rollout path for thread\s+[a-z0-9-]+$/i;
+const CODEX_WEBSOCKET_RECONNECT_RE =
+  /(?:idle timeout waiting for websocket|connection reset by peer|websocket\b[\s\S]{0,40}\b(?:reconnect|re-?connect|retry|tim(?:e|ed)\s*out)|\breconnect(?:ing)?\b[\s\S]{0,24}\bwebsocket\b)/i;
+const CODEX_WEBSOCKET_RECONNECT_LOOP_WINDOW_MS = 2 * 60 * 1000;
+const CODEX_WEBSOCKET_RECONNECT_LOOP_MIN_EVENTS = 6;
 
 function stripCodexRolloutNoise(text: string): string {
   const parts = text.split(/\r?\n/);
@@ -71,6 +76,46 @@ function firstNonEmptyLine(text: string): string {
       .map((line) => line.trim())
       .find(Boolean) ?? ""
   );
+}
+
+function countReconnectMatchesInChunk(chunk: string): number {
+  return chunk
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .reduce((count, line) => (CODEX_WEBSOCKET_RECONNECT_RE.test(line) ? count + 1 : count), 0);
+}
+
+function terminateCodexRunForReconnectLoop(runId: string, graceSec: number): boolean {
+  const running = runningProcesses.get(runId);
+  if (!running) return false;
+
+  const processGroupId = typeof running.processGroupId === "number" ? running.processGroupId : null;
+  const safeGraceSec = Math.max(1, graceSec);
+
+  if (process.platform !== "win32" && processGroupId && processGroupId > 0) {
+    try {
+      process.kill(-processGroupId, "SIGTERM");
+    } catch {
+      if (!running.child.killed) running.child.kill("SIGTERM");
+    }
+    setTimeout(() => {
+      try {
+        process.kill(-processGroupId, "SIGKILL");
+      } catch {
+        if (!running.child.killed) running.child.kill("SIGKILL");
+      }
+    }, safeGraceSec * 1000);
+    return true;
+  }
+
+  if (!running.child.killed) {
+    running.child.kill("SIGTERM");
+  }
+  setTimeout(() => {
+    if (!running.child.killed) running.child.kill("SIGKILL");
+  }, safeGraceSec * 1000);
+  return true;
 }
 
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
@@ -660,6 +705,43 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       });
     }
 
+    const reconnectEventTimes: number[] = [];
+    let reconnectLoopDetected = false;
+    let reconnectLoopErrorMessage: string | null = null;
+    const observeReconnectLoop = async (chunk: string) => {
+      const reconnectMatches = countReconnectMatchesInChunk(chunk);
+      if (reconnectMatches <= 0) return;
+
+      const nowMs = Date.now();
+      for (let i = 0; i < reconnectMatches; i += 1) {
+        reconnectEventTimes.push(nowMs);
+      }
+
+      const windowStartMs = nowMs - CODEX_WEBSOCKET_RECONNECT_LOOP_WINDOW_MS;
+      while (reconnectEventTimes.length > 0 && (reconnectEventTimes[0] ?? 0) < windowStartMs) {
+        reconnectEventTimes.shift();
+      }
+
+      if (reconnectLoopDetected || reconnectEventTimes.length < CODEX_WEBSOCKET_RECONNECT_LOOP_MIN_EVENTS) {
+        return;
+      }
+
+      reconnectLoopDetected = true;
+      reconnectLoopErrorMessage =
+        `Codex websocket reconnect loop detected (${reconnectEventTimes.length} reconnect errors within ${Math.round(CODEX_WEBSOCKET_RECONNECT_LOOP_WINDOW_MS / 1000)}s).`;
+      await onLog(
+        "stdout",
+        `[paperclip] ${reconnectLoopErrorMessage} Terminating run so bounded transient retries can escalate fallback strategy.\n`,
+      );
+      const terminated = terminateCodexRunForReconnectLoop(runId, graceSec);
+      if (!terminated) {
+        await onLog(
+          "stdout",
+          "[paperclip] Reconnect loop detected but no local process handle was available to terminate immediately; waiting for adapter exit.\n",
+        );
+      }
+    };
+
     const proc = await runAdapterExecutionTargetProcess(runId, executionTarget, command, args, {
       cwd,
       env,
@@ -669,11 +751,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       onSpawn,
       onLog: async (stream, chunk) => {
         if (stream !== "stderr") {
+          await observeReconnectLoop(chunk);
           await onLog(stream, chunk);
           return;
         }
         const cleaned = stripCodexRolloutNoise(chunk);
         if (!cleaned.trim()) return;
+        await observeReconnectLoop(cleaned);
         await onLog(stream, cleaned);
       },
     });
@@ -685,11 +769,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       },
       rawStderr: proc.stderr,
       parsed: parseCodexJsonl(proc.stdout),
+      reconnectLoopDetected,
+      reconnectLoopErrorMessage,
     };
   };
 
   const toResult = (
-    attempt: { proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string }; rawStderr: string; parsed: ReturnType<typeof parseCodexJsonl> },
+    attempt: {
+      proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string };
+      rawStderr: string;
+      parsed: ReturnType<typeof parseCodexJsonl>;
+      reconnectLoopDetected: boolean;
+      reconnectLoopErrorMessage: string | null;
+    },
     clearSessionOnMissingSession = false,
     isRetry = false,
   ): AdapterExecutionResult => {
@@ -723,12 +815,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       : null;
     const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
     const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const attemptFailed = (attempt.proc.exitCode ?? 0) !== 0 || Boolean(attempt.proc.signal);
     const fallbackErrorMessage =
       parsedError ||
       stderrLine ||
       `Codex exited with code ${attempt.proc.exitCode ?? -1}`;
     const transientRetryNotBefore =
-      (attempt.proc.exitCode ?? 0) !== 0
+      attemptFailed
         ? extractCodexRetryNotBefore({
             stdout: attempt.proc.stdout,
             stderr: attempt.proc.stderr,
@@ -736,21 +829,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           })
         : null;
     const transientUpstream =
-      (attempt.proc.exitCode ?? 0) !== 0 &&
-      isCodexTransientUpstreamError({
-        stdout: attempt.proc.stdout,
-        stderr: attempt.proc.stderr,
-        errorMessage: fallbackErrorMessage,
-      });
+      attempt.reconnectLoopDetected ||
+      (attemptFailed &&
+        isCodexTransientUpstreamError({
+          stdout: attempt.proc.stdout,
+          stderr: attempt.proc.stderr,
+          errorMessage: fallbackErrorMessage,
+        }));
 
     return {
       exitCode: attempt.proc.exitCode,
       signal: attempt.proc.signal,
       timedOut: false,
       errorMessage:
-        (attempt.proc.exitCode ?? 0) === 0
+        !attemptFailed
           ? null
-          : fallbackErrorMessage,
+          : attempt.reconnectLoopErrorMessage ?? fallbackErrorMessage,
       errorCode:
         transientUpstream
           ? "codex_transient_upstream"
@@ -770,6 +864,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stdout: attempt.proc.stdout,
         stderr: attempt.proc.stderr,
         ...(transientUpstream ? { errorFamily: "transient_upstream" } : {}),
+        ...(attempt.reconnectLoopDetected ? { reconnectLoopDetected: true } : {}),
         ...(transientRetryNotBefore ? { retryNotBefore: transientRetryNotBefore.toISOString() } : {}),
         ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
       },

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -137,4 +137,32 @@ describe("isCodexTransientUpstreamError", () => {
       }),
     ).toBe(false);
   });
+
+  it("classifies repeated websocket reconnect errors as transient upstream", () => {
+    const reconnectLines = [
+      "idle timeout waiting for websocket",
+      "Connection reset by peer",
+      "idle timeout waiting for websocket",
+      "Connection reset by peer",
+      "idle timeout waiting for websocket",
+      "Connection reset by peer",
+    ].join("\n");
+
+    expect(
+      isCodexTransientUpstreamError({
+        stdout: reconnectLines,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not classify isolated websocket reconnect errors as transient", () => {
+    expect(
+      isCodexTransientUpstreamError({
+        stderr: [
+          "idle timeout waiting for websocket",
+          "Connection reset by peer",
+        ].join("\n"),
+      }),
+    ).toBe(false);
+  });
 });

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -8,6 +8,9 @@ import {
 const CODEX_TRANSIENT_UPSTREAM_RE =
   /(?:we(?:'|’)re\s+currently\s+experiencing\s+high\s+demand|temporary\s+errors|rate[-\s]?limit(?:ed)?|too\s+many\s+requests|\b429\b|server\s+overloaded|service\s+unavailable|try\s+again\s+later)/i;
 const CODEX_REMOTE_COMPACTION_RE = /remote\s+compact\s+task/i;
+const CODEX_WEBSOCKET_RECONNECT_RE =
+  /(?:idle timeout waiting for websocket|connection reset by peer|websocket\b[\s\S]{0,40}\b(?:reconnect|re-?connect|retry|tim(?:e|ed)\s*out)|\breconnect(?:ing)?\b[\s\S]{0,24}\bwebsocket\b)/i;
+const CODEX_WEBSOCKET_RECONNECT_MIN_EVENTS = 6;
 const CODEX_USAGE_LIMIT_RE =
   /you(?:'|’)ve hit your usage limit for .+\.\s+switch to another model now,\s+or try again at\s+([^.!\n]+)(?:[.!]|\n|$)/i;
 
@@ -98,6 +101,14 @@ function buildCodexErrorHaystack(input: {
     .map((line) => line.trim())
     .filter(Boolean)
     .join("\n");
+}
+
+function countCodexReconnectEvents(haystack: string): number {
+  return haystack
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .reduce((count, line) => (CODEX_WEBSOCKET_RECONNECT_RE.test(line) ? count + 1 : count), 0);
 }
 
 function readTimeZoneParts(date: Date, timeZone: string) {
@@ -253,6 +264,7 @@ export function isCodexTransientUpstreamError(input: {
   const haystack = buildCodexErrorHaystack(input);
 
   if (extractCodexRetryNotBefore(input) != null) return true;
+  if (countCodexReconnectEvents(haystack) >= CODEX_WEBSOCKET_RECONNECT_MIN_EVENTS) return true;
   if (!CODEX_TRANSIENT_UPSTREAM_RE.test(haystack)) return false;
   // Keep automatic retries scoped to the observed remote-compaction/high-demand
   // failure shape, plus explicit usage-limit windows that tell us when retrying

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -42,6 +42,20 @@ process.exit(1);
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeReconnectLoopCodexCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+for (let i = 0; i < 3; i += 1) {
+  console.log("idle timeout waiting for websocket");
+  console.log("Connection reset by peer");
+}
+setInterval(() => {
+  console.log("retrying websocket connection");
+}, 250);
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 type CapturePayload = {
   argv: string[];
   prompt: string;
@@ -536,6 +550,55 @@ describe("codex execute", () => {
       expect(result.errorCode).toBe("codex_transient_upstream");
       expect(result.errorFamily).toBe("transient_upstream");
       expect(result.errorMessage).toContain("high demand");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails fast on prolonged websocket reconnect loops as codex_transient_upstream", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-reconnect-loop-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeReconnectLoopCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-reconnect-loop",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.timedOut).toBe(false);
+      expect(result.errorCode).toBe("codex_transient_upstream");
+      expect(result.errorFamily).toBe("transient_upstream");
+      expect(result.errorMessage).toContain("websocket reconnect loop");
+      expect(result.signal).toBe("SIGTERM");
+      expect((result.resultJson as Record<string, unknown> | null)?.reconnectLoopDetected).toBe(true);
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -61,6 +61,7 @@ const mockCostService = vi.hoisted(() => ({
   byAgentModel: vi.fn().mockResolvedValue([]),
   byProvider: vi.fn().mockResolvedValue([]),
   byBiller: vi.fn().mockResolvedValue([]),
+  byIssue: vi.fn().mockResolvedValue([]),
   issueTreeSummary: vi.fn().mockResolvedValue({
     issueId: "issue-1",
     issueCount: 1,
@@ -241,6 +242,57 @@ describe("cost routes", () => {
       cachedInputTokens: 0,
       outputTokens: 0,
     });
+  });
+
+  it("returns issue cost rollups with range and limit filters", async () => {
+    mockCostService.byIssue.mockResolvedValueOnce([
+      {
+        issueId: "issue-1",
+        issueIdentifier: "PAP-1",
+        issueTitle: "Top issue",
+        issueStatus: "in_progress",
+        issuePriority: "high",
+        costCents: 1200,
+        inputTokens: 100,
+        cachedInputTokens: 10,
+        outputTokens: 40,
+        apiRunCount: 2,
+        subscriptionRunCount: 1,
+      },
+    ]);
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/costs/by-issue")
+      .query({
+        from: "2026-02-01T00:00:00.000Z",
+        to: "2026-02-28T23:59:59.999Z",
+        limit: "25",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockCostService.byIssue).toHaveBeenCalledWith(
+      "company-1",
+      {
+        from: new Date("2026-02-01T00:00:00.000Z"),
+        to: new Date("2026-02-28T23:59:59.999Z"),
+      },
+      25,
+    );
+    expect(res.body).toEqual([
+      {
+        issueId: "issue-1",
+        issueIdentifier: "PAP-1",
+        issueTitle: "Top issue",
+        issueStatus: "in_progress",
+        issuePriority: "high",
+        costCents: 1200,
+        inputTokens: 100,
+        cachedInputTokens: 10,
+        outputTokens: 40,
+        apiRunCount: 2,
+        subscriptionRunCount: 1,
+      },
+    ]);
   });
 
   it("returns 400 for invalid finance event list limits", async () => {
@@ -613,6 +665,133 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
       cachedInputTokens: 6,
       outputTokens: 12,
     });
+  });
+
+  it("aggregates and ranks costs by issue", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueAId = randomUUID();
+    const issueBId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: issueAId,
+        companyId,
+        title: "Issue A",
+        status: "in_progress",
+        priority: "high",
+        issueNumber: 1,
+        identifier: "TST-1",
+      },
+      {
+        id: issueBId,
+        companyId,
+        title: "Issue B",
+        status: "done",
+        priority: "medium",
+        issueNumber: 2,
+        identifier: "TST-2",
+      },
+    ]);
+    await db.insert(costEvents).values([
+      {
+        companyId,
+        agentId,
+        issueId: issueAId,
+        provider: "openai",
+        biller: "openai",
+        billingType: "metered_api",
+        model: "gpt-5",
+        inputTokens: 60,
+        cachedInputTokens: 6,
+        outputTokens: 30,
+        costCents: 600,
+        occurredAt: new Date("2026-04-10T00:00:00.000Z"),
+      },
+      {
+        companyId,
+        agentId,
+        issueId: issueAId,
+        provider: "openai",
+        biller: "openai",
+        billingType: "subscription_included",
+        model: "gpt-5",
+        inputTokens: 40,
+        cachedInputTokens: 4,
+        outputTokens: 20,
+        costCents: 400,
+        occurredAt: new Date("2026-04-10T01:00:00.000Z"),
+      },
+      {
+        companyId,
+        agentId,
+        issueId: issueBId,
+        provider: "openai",
+        biller: "openai",
+        billingType: "metered_api",
+        model: "gpt-5",
+        inputTokens: 20,
+        cachedInputTokens: 2,
+        outputTokens: 10,
+        costCents: 200,
+        occurredAt: new Date("2026-04-10T02:00:00.000Z"),
+      },
+    ]);
+
+    const rows = await costs.byIssue(
+      companyId,
+      {
+        from: new Date("2026-04-01T00:00:00.000Z"),
+        to: new Date("2026-04-15T23:59:59.999Z"),
+      },
+      10,
+    );
+
+    expect(rows).toEqual([
+      {
+        issueId: issueAId,
+        issueIdentifier: "TST-1",
+        issueTitle: "Issue A",
+        issueStatus: "in_progress",
+        issuePriority: "high",
+        costCents: 1000,
+        inputTokens: 100,
+        cachedInputTokens: 10,
+        outputTokens: 50,
+        apiRunCount: 0,
+        subscriptionRunCount: 0,
+      },
+      {
+        issueId: issueBId,
+        issueIdentifier: "TST-2",
+        issueTitle: "Issue B",
+        issueStatus: "done",
+        issuePriority: "medium",
+        costCents: 200,
+        inputTokens: 20,
+        cachedInputTokens: 2,
+        outputTokens: 10,
+        apiRunCount: 0,
+        subscriptionRunCount: 0,
+      },
+    ]);
   });
 
   it("aggregates finance event sums above int32 without raising Postgres integer overflow", async () => {

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -186,7 +186,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
   it("creates one medium-priority evaluation issue for a suspicious silent run", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
-    const { companyId, managerId, runId } = await seedRunningRun({
+    const { companyId, managerId, runId, issueId } = await seedRunningRun({
       now,
       ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
     });
@@ -209,10 +209,51 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       priority: "medium",
       assigneeAgentId: managerId,
       originId: runId,
-      originFingerprint: `stale_active_run:${companyId}:${runId}`,
     });
+    expect(evaluations[0]?.originFingerprint).toContain(`stale_active_run_v2:${companyId}:${runId}:${issueId}:suspicious:`);
     expect(evaluations[0]?.description).toContain("Decision Checklist");
     expect(evaluations[0]?.description).not.toContain("sk-test-secret-value");
+  });
+
+  it("suppresses duplicate evaluations for unchanged run state after a review issue is closed", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first.created).toBe(1);
+    const firstEvaluationId = first.evaluationIssueIds[0];
+    expect(firstEvaluationId).toBeTruthy();
+
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, firstEvaluationId!));
+
+    const second = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(second).toMatchObject({ created: 0, existing: 1 });
+
+    const stableEvaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(stableEvaluations).toHaveLength(1);
+
+    const later = new Date(now.getTime() + ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 5 * 60 * 1000);
+    const nextOutputAt = new Date(later.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 60_000);
+    await db
+      .update(heartbeatRuns)
+      .set({ lastOutputAt: nextOutputAt, lastOutputSeq: 9, lastOutputStream: "stdout" })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const third = await heartbeat.scanSilentActiveRuns({ now: later, companyId });
+    expect(third.created).toBe(1);
+
+    const refreshedEvaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(refreshedEvaluations).toHaveLength(2);
   });
 
   it("redacts sensitive values from actual run-log evidence", async () => {
@@ -458,7 +499,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       identifier: `${issuePrefix}-21`,
       originKind: "stale_active_run_evaluation",
       originId: otherRunId,
-      originFingerprint: `stale_active_run:${companyId}:${otherRunId}`,
+      originFingerprint: `stale_active_run_v2:${companyId}:${otherRunId}:none:suspicious:seq=0:at=none:stream=none`,
     });
 
     const attempts = [

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -338,6 +338,39 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(noisyResult).toMatchObject({ scanned: 0, created: 0 });
   });
 
+  it("skips stale-run evaluation work so watchdog reviews cannot recursively spawn review loops", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId, issueId, issuePrefix } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    await db
+      .update(agents)
+      .set({ role: "ceo", name: "CEO" })
+      .where(eq(agents.id, coderId));
+    await db
+      .update(issues)
+      .set({
+        originKind: "stale_active_run_evaluation",
+        originId: randomUUID(),
+        originFingerprint: `stale_active_run_v2:${companyId}:seeded-run:${issueId}:suspicious:seq=0:at=none:stream=none`,
+        title: "Review silent active run for CEO",
+        identifier: `${issuePrefix}-99`,
+      })
+      .where(eq(issues.id, issueId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result).toMatchObject({ scanned: 1, created: 0, existing: 0, skipped: 1 });
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0]?.id).toBe(issueId);
+  });
+
   it("records watchdog decisions through recovery owner authorization", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const { companyId, managerId, runId } = await seedRunningRun({

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -256,6 +256,74 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(refreshedEvaluations).toHaveLength(2);
   });
 
+  it("reuses the existing open evaluation when a process-loss retry run goes silent on the same source issue", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first.created).toBe(1);
+
+    await db.update(heartbeatRuns).set({ status: "failed", finishedAt: now }).where(eq(heartbeatRuns.id, runId));
+
+    const retryRunId = randomUUID();
+    const retryStartedAt = new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 120_000);
+    await db.insert(heartbeatRuns).values({
+      id: retryRunId,
+      companyId,
+      agentId: coderId,
+      status: "running",
+      invocationSource: "automation",
+      triggerDetail: "system",
+      startedAt: retryStartedAt,
+      processStartedAt: retryStartedAt,
+      lastOutputAt: null,
+      lastOutputSeq: 0,
+      lastOutputStream: null,
+      contextSnapshot: {
+        issueId,
+        retryOfRunId: runId,
+        retryReason: "process_lost",
+        wakeReason: "process_lost_retry",
+      },
+      retryOfRunId: runId,
+      logBytes: 0,
+    });
+    await db.update(issues).set({ executionRunId: retryRunId }).where(eq(issues.id, issueId));
+
+    const second = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(second).toMatchObject({ created: 0, existing: 1 });
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(1);
+  });
+
+  it("suppresses silent-run evaluation creation when the source issue is terminal", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    await db.update(issues).set({ status: "done", completedAt: now }).where(eq(issues.id, issueId));
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(result).toMatchObject({ scanned: 1, created: 0, existing: 0, skipped: 1 });
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+  });
+
   it("redacts sensitive values from actual run-log evidence", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const leakedJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -1231,6 +1231,54 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     }
   });
 
+  it("treats codex_transient_upstream error codes as transient retries even without persisted errorFamily", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-04-22T08:00:00.000Z");
+
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      now,
+      errorCode: "codex_transient_upstream",
+      errorFamily: null,
+      resultJson: {
+        reconnectLoopDetected: true,
+      },
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+
+    const retryRun = await db
+      .select({
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+        wakeupRequestId: heartbeatRuns.wakeupRequestId,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, scheduled.run.id))
+      .then((rows) => rows[0] ?? null);
+    expect((retryRun?.contextSnapshot as Record<string, unknown> | null)?.codexTransientFallbackMode).toBe(
+      "same_session",
+    );
+
+    const wakeupRequest = await db
+      .select({ payload: agentWakeupRequests.payload })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, retryRun?.wakeupRequestId ?? ""))
+      .then((rows) => rows[0] ?? null);
+    expect((wakeupRequest?.payload as Record<string, unknown> | null)?.codexTransientFallbackMode).toBe(
+      "same_session",
+    );
+  });
+
   it("honors codex retry-not-before timestamps when they exceed the default bounded backoff", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/secrets-slack-webhook-policy.test.ts
+++ b/server/src/__tests__/secrets-slack-webhook-policy.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { secretService } from "../services/secrets.js";
+
+function makeSelectDb(rows: unknown[]) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(rows),
+      }),
+    }),
+  } as any;
+}
+
+describe("secretService Slack webhook policy", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalDeploymentMode = process.env.PAPERCLIP_DEPLOYMENT_MODE;
+  const originalAllowFlag = process.env.ALLOW_INSECURE_WEBHOOK_URLS;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    process.env.PAPERCLIP_DEPLOYMENT_MODE = originalDeploymentMode;
+    process.env.ALLOW_INSECURE_WEBHOOK_URLS = originalAllowFlag;
+  });
+
+  it("rejects insecure Slack webhook secrets by default", async () => {
+    const svc = secretService({} as any);
+
+    await expect(
+      svc.create(
+        "company-1",
+        {
+          name: "SLACK_WEBHOOK_URL",
+          provider: "local_encrypted",
+          value: "http://hooks.slack.com/services/T1/B2/C3",
+        },
+        { userId: "user-1" },
+      ),
+    ).rejects.toThrow("must use https://");
+  });
+
+  it("rejects non-Slack HTTPS hosts for Slack webhook secrets", async () => {
+    const svc = secretService({} as any);
+
+    await expect(
+      svc.create(
+        "company-1",
+        {
+          name: "SLACK_WEBHOOK_URL",
+          provider: "local_encrypted",
+          value: "https://example.com/services/T1/B2/C3",
+        },
+        { userId: "user-1" },
+      ),
+    ).rejects.toThrow("host is not allowed");
+  });
+
+  it("allows loopback http for Slack webhook secrets only in non-production with explicit flag", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.PAPERCLIP_DEPLOYMENT_MODE = "local_trusted";
+    process.env.ALLOW_INSECURE_WEBHOOK_URLS = "true";
+
+    const svc = secretService(makeSelectDb([
+      {
+        id: "secret-1",
+        companyId: "company-1",
+        name: "SLACK_WEBHOOK_URL",
+      },
+    ]));
+
+    await expect(
+      svc.create(
+        "company-1",
+        {
+          name: "SLACK_WEBHOOK_URL",
+          provider: "local_encrypted",
+          value: "http://127.0.0.1:7777/webhook",
+        },
+        { userId: "user-1" },
+      ),
+    ).rejects.toThrow("Secret already exists");
+  });
+});

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -29,6 +29,12 @@ import {
   resolveDefaultStorageDir,
   resolveHomeAwarePath,
 } from "./home-paths.js";
+import {
+  ALLOW_INSECURE_WEBHOOK_URLS_ENV,
+  isProductionLikeRuntime,
+  parseBooleanFlag,
+  validateSlackWebhookUrl,
+} from "./security/slack-webhook-url.js";
 
 const PAPERCLIP_ENV_FILE_PATH = resolvePaperclipEnvPath();
 if (existsSync(PAPERCLIP_ENV_FILE_PATH)) {
@@ -161,6 +167,19 @@ export function loadConfig(): Config {
     process.env.PAPERCLIP_FEEDBACK_EXPORT_BACKEND_TOKEN?.trim() ||
     process.env.PAPERCLIP_TELEMETRY_BACKEND_TOKEN?.trim() ||
     undefined;
+  const configuredSlackWebhookUrl = process.env.PAPERCLIP_SLACK_WEBHOOK_URL?.trim() || undefined;
+  if (configuredSlackWebhookUrl) {
+    const validated = validateSlackWebhookUrl(configuredSlackWebhookUrl, {
+      allowInsecureWebhookUrls: parseBooleanFlag(process.env[ALLOW_INSECURE_WEBHOOK_URLS_ENV]),
+      isProductionLike: isProductionLikeRuntime(),
+    });
+    if (validated.usedInsecureException) {
+      console.warn(
+        `[SECURITY] Insecure Slack webhook exception active for loopback host "${validated.hostname}". ` +
+          `Disable ${ALLOW_INSECURE_WEBHOOK_URLS_ENV} before production/staging use.`,
+      );
+    }
+  }
 
   const deploymentModeFromEnvRaw = process.env.PAPERCLIP_DEPLOYMENT_MODE;
   const deploymentModeFromEnv =

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -274,6 +274,15 @@ export function costRoutes(
     res.json(rows);
   });
 
+  router.get("/companies/:companyId/costs/by-issue", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const range = parseCostDateRange(req.query);
+    const limit = parseCostLimit(req.query);
+    const rows = await costs.byIssue(companyId, range, limit);
+    res.json(rows);
+  });
+
   router.patch("/companies/:companyId/budgets", validate(updateBudgetSchema), async (req, res) => {
     assertBoard(req);
     const companyId = req.params.companyId as string;

--- a/server/src/security/slack-webhook-url.test.ts
+++ b/server/src/security/slack-webhook-url.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { validateSlackWebhookUrl } from "./slack-webhook-url.js";
+
+describe("validateSlackWebhookUrl", () => {
+  const strict = {
+    allowInsecureWebhookUrls: false,
+    isProductionLike: false,
+  } as const;
+
+  it("allows https://hooks.slack.com webhook URLs", () => {
+    const result = validateSlackWebhookUrl("https://hooks.slack.com/services/T1/B2/C3", strict);
+    expect(result.usedInsecureException).toBe(false);
+    expect(result.hostname).toBe("hooks.slack.com");
+  });
+
+  it("rejects http://hooks.slack.com webhook URLs by default", () => {
+    expect(() =>
+      validateSlackWebhookUrl("http://hooks.slack.com/services/T1/B2/C3", strict),
+    ).toThrow("must use https://");
+  });
+
+  it("rejects malformed webhook URLs", () => {
+    expect(() => validateSlackWebhookUrl("not a url", strict)).toThrow("invalid");
+  });
+
+  it("rejects non-Slack https hosts", () => {
+    expect(() =>
+      validateSlackWebhookUrl("https://example.com/services/T1/B2/C3", strict),
+    ).toThrow("host is not allowed");
+  });
+
+  it("accepts loopback http only when dev exception is enabled in non-production", () => {
+    const result = validateSlackWebhookUrl("http://127.0.0.1:9999/slack-webhook", {
+      allowInsecureWebhookUrls: true,
+      isProductionLike: false,
+    });
+    expect(result.usedInsecureException).toBe(true);
+    expect(result.hostname).toBe("127.0.0.1");
+  });
+
+  it("rejects loopback http when dev exception is disabled", () => {
+    expect(() =>
+      validateSlackWebhookUrl("http://localhost:3000/slack", {
+        allowInsecureWebhookUrls: false,
+        isProductionLike: false,
+      }),
+    ).toThrow("ALLOW_INSECURE_WEBHOOK_URLS=true");
+  });
+
+  it("rejects loopback http in production even when exception flag would otherwise allow it", () => {
+    expect(() =>
+      validateSlackWebhookUrl("http://localhost:3000/slack", {
+        allowInsecureWebhookUrls: true,
+        isProductionLike: true,
+      }),
+    ).toThrow("ALLOW_INSECURE_WEBHOOK_URLS=true");
+  });
+});

--- a/server/src/security/slack-webhook-url.ts
+++ b/server/src/security/slack-webhook-url.ts
@@ -1,0 +1,92 @@
+const SLACK_WEBHOOK_ALLOWED_HOSTS = new Set([
+  "hooks.slack.com",
+  "hooks.slack-gov.com",
+]);
+
+const LOOPBACK_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "::1",
+  "[::1]",
+]);
+
+export const ALLOW_INSECURE_WEBHOOK_URLS_ENV = "ALLOW_INSECURE_WEBHOOK_URLS";
+
+export type ValidateSlackWebhookUrlOptions = {
+  allowInsecureWebhookUrls: boolean;
+  isProductionLike: boolean;
+};
+
+export type ValidatedSlackWebhookUrl = {
+  normalizedUrl: string;
+  usedInsecureException: boolean;
+  hostname: string;
+};
+
+export function parseBooleanFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function isProductionLikeRuntime(): boolean {
+  const nodeEnv = process.env.NODE_ENV?.trim().toLowerCase();
+  const deploymentMode = process.env.PAPERCLIP_DEPLOYMENT_MODE?.trim().toLowerCase();
+  return nodeEnv === "production" || deploymentMode === "authenticated";
+}
+
+export function isSlackWebhookSecretName(name: string): boolean {
+  const canonical = name.trim().toUpperCase().replace(/[^A-Z0-9]+/g, "_");
+  return canonical === "SLACK_WEBHOOK_URL" || canonical.endsWith("_SLACK_WEBHOOK_URL");
+}
+
+export function validateSlackWebhookUrl(
+  rawValue: string,
+  options: ValidateSlackWebhookUrlOptions,
+): ValidatedSlackWebhookUrl {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawValue);
+  } catch {
+    throw new Error("Slack webhook URL is invalid. Provide a valid absolute URL.");
+  }
+
+  const protocol = parsed.protocol.toLowerCase();
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (parsed.username || parsed.password) {
+    throw new Error("Slack webhook URL cannot include embedded credentials.");
+  }
+
+  if (protocol === "https:") {
+    if (!SLACK_WEBHOOK_ALLOWED_HOSTS.has(hostname)) {
+      throw new Error("Slack webhook URL host is not allowed. Use hooks.slack.com or hooks.slack-gov.com.");
+    }
+    return {
+      normalizedUrl: parsed.toString(),
+      usedInsecureException: false,
+      hostname,
+    };
+  }
+
+  if (protocol !== "http:") {
+    throw new Error("Slack webhook URL must use https:// (or http:// loopback in approved local exception mode).");
+  }
+
+  const insecureModeAllowed =
+    options.allowInsecureWebhookUrls &&
+    !options.isProductionLike &&
+    LOOPBACK_HOSTS.has(hostname);
+
+  if (!insecureModeAllowed) {
+    throw new Error(
+      "Slack webhook URL must use https://. Local http:// is allowed only for loopback hosts in non-production when ALLOW_INSECURE_WEBHOOK_URLS=true.",
+    );
+  }
+
+  return {
+    normalizedUrl: parsed.toString(),
+    usedInsecureException: true,
+    hostname,
+  };
+}

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -423,5 +423,51 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         .groupBy(effectiveProjectId, projects.name)
         .orderBy(desc(costCentsExpr));
     },
+
+    byIssue: async (companyId: string, range?: CostDateRange, limit = 20) => {
+      const conditions: ReturnType<typeof eq>[] = [eq(costEvents.companyId, companyId)];
+      if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
+      if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));
+
+      const boundedLimit = Number.isFinite(limit)
+        ? Math.max(1, Math.min(500, Math.floor(limit)))
+        : 20;
+      const costCentsExpr = sumAsNumber(costEvents.costCents);
+
+      return db
+        .select({
+          issueId: costEvents.issueId,
+          issueIdentifier: issues.identifier,
+          issueTitle: issues.title,
+          issueStatus: issues.status,
+          issuePriority: issues.priority,
+          costCents: costCentsExpr,
+          inputTokens: sumAsNumber(costEvents.inputTokens),
+          cachedInputTokens: sumAsNumber(costEvents.cachedInputTokens),
+          outputTokens: sumAsNumber(costEvents.outputTokens),
+          apiRunCount:
+            sql<number>`count(distinct case when ${costEvents.billingType} = ${METERED_BILLING_TYPE} then ${costEvents.heartbeatRunId} end)::int`,
+          subscriptionRunCount:
+            sql<number>`count(distinct case when ${costEvents.billingType} in (${sql.join(SUBSCRIPTION_BILLING_TYPES.map((value) => sql`${value}`), sql`, `)}) then ${costEvents.heartbeatRunId} end)::int`,
+        })
+        .from(costEvents)
+        .leftJoin(
+          issues,
+          and(
+            eq(costEvents.issueId, issues.id),
+            eq(issues.companyId, companyId),
+          ),
+        )
+        .where(and(...conditions, isNotNull(costEvents.issueId)))
+        .groupBy(
+          costEvents.issueId,
+          issues.identifier,
+          issues.title,
+          issues.status,
+          issues.priority,
+        )
+        .orderBy(desc(costCentsExpr))
+        .limit(boundedLimit);
+    },
   };
 }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -575,8 +575,28 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => rows[0]?.issuePrefix ?? "PAP");
   }
 
-  function staleActiveRunOriginFingerprint(companyId: string, runId: string) {
-    return `stale_active_run:${companyId}:${runId}`;
+  function staleActiveRunOriginFingerprint(input: {
+    companyId: string;
+    runId: string;
+    sourceIssueId: string | null;
+    level: "suspicious" | "critical";
+    lastOutputAt: Date | null;
+    lastOutputSeq: number | null;
+    lastOutputStream: string | null;
+  }) {
+    const lastOutputAtIso = input.lastOutputAt?.toISOString() ?? "none";
+    const sourceIssueId = input.sourceIssueId ?? "none";
+    const stream = input.lastOutputStream ?? "none";
+    return [
+      "stale_active_run_v2",
+      input.companyId,
+      input.runId,
+      sourceIssueId,
+      input.level,
+      `seq=${input.lastOutputSeq ?? 0}`,
+      `at=${lastOutputAtIso}`,
+      `stream=${stream}`,
+    ].join(":");
   }
 
   function silenceStartedAtForRun(run: Pick<typeof heartbeatRuns.$inferSelect, "lastOutputAt" | "processStartedAt" | "startedAt" | "createdAt">) {
@@ -605,6 +625,25 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  async function latestOutputWatchdogDecision(companyId: string, runId: string) {
+    const [row] = await db
+      .select({
+        decision: heartbeatRunWatchdogDecisions.decision,
+        snoozedUntil: heartbeatRunWatchdogDecisions.snoozedUntil,
+        createdAt: heartbeatRunWatchdogDecisions.createdAt,
+      })
+      .from(heartbeatRunWatchdogDecisions)
+      .where(
+        and(
+          eq(heartbeatRunWatchdogDecisions.companyId, companyId),
+          eq(heartbeatRunWatchdogDecisions.runId, runId),
+        ),
+      )
+      .orderBy(desc(heartbeatRunWatchdogDecisions.createdAt))
+      .limit(1);
+    return row ?? null;
+  }
+
   async function findOpenStaleRunEvaluation(companyId: string, runId: string) {
     const [row] = await db
       .select({
@@ -625,6 +664,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           notInArray(issues.status, ["done", "cancelled"]),
         ),
       )
+      .limit(1);
+    return row ?? null;
+  }
+
+  async function findStaleRunEvaluationByFingerprint(companyId: string, originFingerprint: string) {
+    const [row] = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        priority: issues.priority,
+        assigneeAgentId: issues.assigneeAgentId,
+        updatedAt: issues.updatedAt,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.originFingerprint, originFingerprint),
+          isNull(issues.hiddenAt),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt))
       .limit(1);
     return row ?? null;
   }
@@ -943,6 +1006,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       now: input.now,
     });
     const level = (evidence.silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS ? "critical" : "suspicious";
+    const dedupeFingerprint = staleActiveRunOriginFingerprint({
+      companyId: input.run.companyId,
+      runId: input.run.id,
+      sourceIssueId: sourceIssue?.id ?? null,
+      level,
+      lastOutputAt: input.run.lastOutputAt ?? null,
+      lastOutputSeq: input.run.lastOutputSeq ?? 0,
+      lastOutputStream: input.run.lastOutputStream ?? null,
+    });
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
     if (existing) {
       if (level === "critical" && existing.priority !== "high") {
@@ -973,6 +1045,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       return { kind: "existing" as const, evaluationIssueId: existing.id };
     }
 
+    const duplicate = await findStaleRunEvaluationByFingerprint(input.run.companyId, dedupeFingerprint);
+    if (duplicate) {
+      const latestDecision = await latestOutputWatchdogDecision(input.run.companyId, input.run.id);
+      const allowRearmReevaluation = (
+        (latestDecision?.decision === "continue" || latestDecision?.decision === "snooze")
+        && !!latestDecision.snoozedUntil
+        && latestDecision.snoozedUntil.getTime() <= input.now.getTime()
+      );
+      if (!allowRearmReevaluation) {
+        return { kind: "existing" as const, evaluationIssueId: duplicate.id };
+      }
+    }
+
     const ownerAgentId = await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });
     const description = buildStaleRunEvaluationDescription({
       run: input.run,
@@ -998,7 +1083,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         originKind: STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND,
         originId: input.run.id,
         originRunId: input.run.id,
-        originFingerprint: staleActiveRunOriginFingerprint(input.run.companyId, input.run.id),
+        originFingerprint: dedupeFingerprint,
       });
     } catch (error) {
       if (!isUniqueStaleRunEvaluationConflict(error)) throw error;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -52,6 +52,7 @@ export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+const MAX_PARENT_WALK_DEPTH = 25;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 
 type RecoveryWakeupOptions = {
@@ -767,6 +768,31 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return issue ?? null;
   }
 
+  async function isIssueDescendedFromOriginKind(input: {
+    companyId: string;
+    parentId: string | null;
+    originKind: string;
+  }) {
+    let parentId = input.parentId;
+    let depth = 0;
+    while (parentId && depth < MAX_PARENT_WALK_DEPTH) {
+      const parent = await db
+        .select({
+          id: issues.id,
+          parentId: issues.parentId,
+          originKind: issues.originKind,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, input.companyId), eq(issues.id, parentId)))
+        .then((rows) => rows[0] ?? null);
+      if (!parent) return false;
+      if (parent.originKind === input.originKind) return true;
+      parentId = parent.parentId;
+      depth += 1;
+    }
+    return false;
+  }
+
   async function resolveStaleRunOwnerAgentId(input: {
     run: typeof heartbeatRuns.$inferSelect;
     runningAgent: typeof agents.$inferSelect;
@@ -997,6 +1023,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runningAgent = await getAgent(input.run.agentId);
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
+    if (sourceIssue) {
+      const recursiveReviewPath =
+        sourceIssue.originKind === STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND ||
+        await isIssueDescendedFromOriginKind({
+          companyId: sourceIssue.companyId,
+          parentId: sourceIssue.parentId,
+          originKind: STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND,
+        });
+      if (recursiveReviewPath) return { kind: "skipped" as const };
+    }
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
     const evidence = await collectStaleRunEvidence({
       run: input.run,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -669,6 +669,31 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  async function findOpenStaleRunEvaluationForSourceIssue(companyId: string, sourceIssueId: string) {
+    const [row] = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        priority: issues.priority,
+        assigneeAgentId: issues.assigneeAgentId,
+        updatedAt: issues.updatedAt,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.parentId, sourceIssueId),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt))
+      .limit(1);
+    return row ?? null;
+  }
+
   async function findStaleRunEvaluationByFingerprint(companyId: string, originFingerprint: string) {
     const [row] = await db
       .select({
@@ -1032,6 +1057,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           originKind: STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND,
         });
       if (recursiveReviewPath) return { kind: "skipped" as const };
+      if (["done", "cancelled"].includes(sourceIssue.status)) {
+        return { kind: "skipped" as const };
+      }
     }
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
     const evidence = await collectStaleRunEvidence({
@@ -1042,6 +1070,35 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       now: input.now,
     });
     const level = (evidence.silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS ? "critical" : "suspicious";
+    const existingForSourceIssue = sourceIssue
+      ? await findOpenStaleRunEvaluationForSourceIssue(input.run.companyId, sourceIssue.id)
+      : null;
+    if (existingForSourceIssue) {
+      if (level === "critical" && existingForSourceIssue.priority !== "high") {
+        await issuesSvc.update(existingForSourceIssue.id, { priority: "high" });
+        await issuesSvc.addComment(existingForSourceIssue.id, [
+          "Critical output silence threshold crossed.",
+          "",
+          `- Run: \`${input.run.id}\``,
+          `- Silent for: ${formatDuration(evidence.silenceAgeMs)}`,
+          `- Last output at: ${input.run.lastOutputAt?.toISOString() ?? "none recorded"}`,
+        ].join("\n"), { runId: input.run.id });
+        await ensureSourceIssueBlockedByStaleEvaluation({
+          sourceIssue,
+          evaluationIssue: existingForSourceIssue,
+          run: input.run,
+        });
+        return { kind: "escalated" as const, evaluationIssueId: existingForSourceIssue.id };
+      }
+      if (level === "critical") {
+        await ensureSourceIssueBlockedByStaleEvaluation({
+          sourceIssue,
+          evaluationIssue: existingForSourceIssue,
+          run: input.run,
+        });
+      }
+      return { kind: "existing" as const, evaluationIssueId: existingForSourceIssue.id };
+    }
     const dedupeFingerprint = staleActiveRunOriginFingerprint({
       companyId: input.run.companyId,
       runId: input.run.id,

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -5,6 +5,14 @@ import type { AgentEnvConfig, EnvBinding, SecretProvider } from "@paperclipai/sh
 import { envBindingSchema } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import { getSecretProvider, listSecretProviders } from "../secrets/provider-registry.js";
+import { logger } from "../middleware/logger.js";
+import {
+  ALLOW_INSECURE_WEBHOOK_URLS_ENV,
+  isProductionLikeRuntime,
+  isSlackWebhookSecretName,
+  parseBooleanFlag,
+  validateSlackWebhookUrl,
+} from "../security/slack-webhook-url.js";
 
 const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const SENSITIVE_ENV_KEY_RE =
@@ -152,6 +160,33 @@ export function secretService(db: Db) {
     return normalized;
   }
 
+  function assertSlackWebhookSecretPolicy(secretName: string, secretValue: string, action: "create" | "rotate") {
+    if (!isSlackWebhookSecretName(secretName)) return;
+    let validated;
+    try {
+      validated = validateSlackWebhookUrl(secretValue, {
+        allowInsecureWebhookUrls: parseBooleanFlag(process.env[ALLOW_INSECURE_WEBHOOK_URLS_ENV]),
+        isProductionLike: isProductionLikeRuntime(),
+      });
+    } catch (error) {
+      throw unprocessable(
+        error instanceof Error ? error.message : "Invalid Slack webhook URL",
+      );
+    }
+
+    if (validated.usedInsecureException) {
+      logger.warn(
+        {
+          action,
+          secretName,
+          hostname: validated.hostname,
+          envFlag: ALLOW_INSECURE_WEBHOOK_URLS_ENV,
+        },
+        "Insecure Slack webhook URL exception is active (loopback + non-production only)",
+      );
+    }
+  }
+
   return {
     listProviders: () => listSecretProviders(),
 
@@ -177,6 +212,7 @@ export function secretService(db: Db) {
       },
       actor?: { userId?: string | null; agentId?: string | null },
     ) => {
+      assertSlackWebhookSecretPolicy(input.name, input.value, "create");
       const existing = await getByName(companyId, input.name);
       if (existing) throw conflict(`Secret already exists: ${input.name}`);
 
@@ -222,6 +258,7 @@ export function secretService(db: Db) {
     ) => {
       const secret = await getById(secretId);
       if (!secret) throw notFound("Secret not found");
+      assertSlackWebhookSecretPolicy(secret.name, input.value, "rotate");
       const provider = getSecretProvider(secret.provider as SecretProvider);
       const nextVersion = secret.latestVersion + 1;
       const prepared = await provider.createVersion({


### PR DESCRIPTION
## Summary
- suppress duplicate stale-run review issue creation when run state is unchanged across consecutive watchdog scans
- fingerprint stale-run evaluations by run + source issue + silence level + output state to dedupe equivalent re-alerts
- preserve continue/snooze re-arm behavior so true-positive alerts can re-trigger after explicit rearm windows
- add regression coverage in `server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`

## Verification
- `pnpm vitest run server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`

Closes #HOM-148
