### PR TITLE
Fix external heartbeat orphan timeout race

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -284,6 +284,7 @@ Recovery rule:
 
 - Paperclip queues one automatic continuation wake
 - if that continuation wake also finishes and the issue is still stranded, Paperclip moves the issue to `blocked` and posts a visible comment
+- for external adapters such as `openclaw_gateway`, orphan reaping waits for the adapter's effective timeout window, including `waitTimeoutMs`, plus grace before treating the live path as disappeared
 
 This is an active-work continuity recovery.
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -385,6 +385,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   async function seedRunFixture(input?: {
     adapterType?: string;
+    adapterConfig?: Record<string, unknown>;
     agentStatus?: "paused" | "idle" | "running";
     runStatus?: "running" | "queued" | "failed";
     processPid?: number | null;
@@ -393,6 +394,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     includeIssue?: boolean;
     runErrorCode?: string | null;
     runError?: string | null;
+    updatedAt?: Date;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -416,7 +418,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       role: "engineer",
       status: input?.agentStatus ?? "paused",
       adapterType: input?.adapterType ?? "codex_local",
-      adapterConfig: {},
+      adapterConfig: input?.adapterConfig ?? {},
       runtimeConfig: {},
       permissions: {},
     });
@@ -449,7 +451,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       errorCode: input?.runErrorCode ?? null,
       error: input?.runError ?? null,
       startedAt: now,
-      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      updatedAt: input?.updatedAt ?? new Date("2026-03-19T00:00:00.000Z"),
     });
 
     if (input?.includeIssue !== false) {
@@ -947,6 +949,41 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(lease?.status).toBe("failed");
     expect(lease?.releasedAt).toBeTruthy();
+  });
+
+  it("does not reap an openclaw gateway run inside its wait timeout window", async () => {
+    const { agentId, runId, wakeupRequestId, issueId } = await seedRunFixture({
+      adapterType: "openclaw_gateway",
+      adapterConfig: {
+        timeoutSec: 120,
+        waitTimeoutMs: 600_000,
+      },
+      updatedAt: new Date(),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 });
+    expect(result.reaped).toBe(0);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("claimed");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBe(runId);
   });
 
   it.skipIf(process.platform === "win32")("reaps orphaned descendant process groups when the parent pid is already gone", async () => {

--- a/server/src/services/heartbeat-stop-metadata.test.ts
+++ b/server/src/services/heartbeat-stop-metadata.test.ts
@@ -42,6 +42,20 @@ describe("heartbeat stop metadata", () => {
     });
   });
 
+  it("uses openclaw gateway wait timeout as the effective run timeout", () => {
+    expect(
+      resolveHeartbeatRunTimeoutPolicy("openclaw_gateway", {
+        timeoutSec: 120,
+        waitTimeoutMs: 600_000,
+      }),
+    ).toEqual({
+      effectiveTimeoutSec: 600,
+      effectiveTimeoutMs: 600_000,
+      timeoutConfigured: true,
+      timeoutSource: "config",
+    });
+  });
+
   it("distinguishes budget cancellation from manual cancellation", () => {
     expect(
       buildHeartbeatRunStopMetadata({

--- a/server/src/services/heartbeat-stop-metadata.ts
+++ b/server/src/services/heartbeat-stop-metadata.ts
@@ -47,6 +47,13 @@ export function normalizeMaxTurnStopReason(value: unknown): Extract<HeartbeatRun
     : null;
 }
 
+function readPositiveIntegerMs(value: unknown): number | null {
+  const parsed = readFiniteNumber(value);
+  if (parsed == null) return null;
+  const floored = Math.floor(parsed);
+  return floored > 0 ? floored : null;
+}
+
 export function resolveHeartbeatRunTimeoutPolicy(
   adapterType: string,
   adapterConfig: Record<string, unknown> | null | undefined,
@@ -69,6 +76,18 @@ export function resolveHeartbeatRunTimeoutPolicy(
   const defaultTimeoutSec = defaultTimeoutSecForAdapter(adapterType);
   const rawTimeoutSec = hasTimeoutSec ? readFiniteNumber(config.timeoutSec) : defaultTimeoutSec;
   const timeoutSec = Math.max(0, Math.floor(rawTimeoutSec ?? defaultTimeoutSec));
+  const timeoutMs = timeoutSec > 0 ? timeoutSec * 1000 : 0;
+
+  if (adapterType === "openclaw_gateway") {
+    const waitTimeoutMs = readPositiveIntegerMs(config.waitTimeoutMs);
+    const effectiveTimeoutMs = Math.max(timeoutMs, waitTimeoutMs ?? 0);
+    return {
+      effectiveTimeoutSec: effectiveTimeoutMs > 0 ? effectiveTimeoutMs / 1000 : 0,
+      effectiveTimeoutMs,
+      timeoutConfigured: effectiveTimeoutMs > 0,
+      timeoutSource: hasTimeoutSec || waitTimeoutMs != null ? "config" : "default",
+    };
+  }
 
   return {
     effectiveTimeoutSec: timeoutSec,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -71,6 +71,7 @@ import {
   buildHeartbeatRunStopMetadata,
   mergeHeartbeatRunStopMetadata,
   normalizeMaxTurnStopReason,
+  resolveHeartbeatRunTimeoutPolicy,
 } from "./heartbeat-stop-metadata.js";
 import {
   classifyRunLiveness,
@@ -1967,6 +1968,20 @@ function isSameTaskScope(left: string | null, right: string | null) {
 
 function isTrackedLocalChildProcessAdapter(adapterType: string) {
   return SESSIONED_LOCAL_ADAPTERS.has(adapterType);
+}
+
+const EXTERNAL_ORPHAN_REAP_GRACE_MS = 60_000;
+
+function resolveExternalOrphanReapThresholdMs(input: {
+  adapterType: string;
+  adapterConfig: Record<string, unknown> | null | undefined;
+  staleThresholdMs: number;
+}) {
+  const timeoutPolicy = resolveHeartbeatRunTimeoutPolicy(input.adapterType, input.adapterConfig);
+  const timeoutMs =
+    timeoutPolicy.effectiveTimeoutMs ??
+    (timeoutPolicy.effectiveTimeoutSec != null ? timeoutPolicy.effectiveTimeoutSec * 1000 : 0);
+  return Math.max(input.staleThresholdMs, timeoutMs + EXTERNAL_ORPHAN_REAP_GRACE_MS);
 }
 
 function isHeartbeatRunTerminalStatus(
@@ -5805,14 +5820,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     for (const { run, adapterType, adapterConfig } of activeRuns) {
       if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
+      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
 
       // Apply staleness threshold to avoid false positives
-      if (staleThresholdMs > 0) {
+      const effectiveStaleThresholdMs = tracksLocalChild
+        ? staleThresholdMs
+        : resolveExternalOrphanReapThresholdMs({
+          adapterType,
+          adapterConfig: parseObject(adapterConfig),
+          staleThresholdMs,
+        });
+      if (effectiveStaleThresholdMs > 0) {
         const refTime = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
-        if (now.getTime() - refTime < staleThresholdMs) continue;
+        if (now.getTime() - refTime < effectiveStaleThresholdMs) continue;
       }
 
-      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
       if (processPidAlive) {


### PR DESCRIPTION
## Summary
- Uses OpenClaw gateway `waitTimeoutMs` as part of heartbeat timeout metadata.
- Prevents external/non-local heartbeat runs from being reaped until the effective timeout window plus a 60s grace has elapsed.
- Adds regression coverage for the CHO-1348/CHO-1334 race where Paperclip's 5-minute orphan reaper could retry a still-live OpenClaw gateway run.

## Verification
- `pnpm run preflight:workspace-links && pnpm exec vitest run --project @paperclipai/server server/src/services/heartbeat-stop-metadata.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts --pool=forks --poolOptions.forks.isolate=true` — 45 tests passed
- `pnpm --filter @paperclipai/server typecheck` — passed
- `git diff --check HEAD~1..HEAD` — passed

## Paperclip
- Follow-up for [CHO-1348](/CHO/issues/CHO-1348)
- Shipping ticket: [CHO-1355](/CHO/issues/CHO-1355)
