### PR TITLE
fix(claude_local): treat clean terminal result + grace-SIGTERM exit as success, not failure

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -770,7 +770,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       : null;
     const clearSessionForMaxTurns = isClaudeMaxTurnsResult(parsed);
     const parsedIsError = asBoolean(parsed.is_error, false);
-    const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
+    // A clean terminal `result` event (parsedStream.resultJson set,
+    // is_error=false) means Claude finished the turn successfully even
+    // if the wrapper process was force-terminated afterwards by the
+    // adapter's terminalResultCleanup grace timer (exit code 143 from
+    // SIGTERM). Without this guard the grace SIGTERM is misread as a
+    // failure, which then trips the transient-upstream regex on words
+    // like "limit" or "reached" in the agent's own result text and
+    // marks the run `claude_transient_upstream`, triggering needless
+    // retry wakes.
+    const hasSuccessfulTerminalResult =
+      parsedStream.resultJson !== null && !parsedIsError;
+    const failed = !hasSuccessfulTerminalResult && ((proc.exitCode ?? 0) !== 0 || parsedIsError);
     const errorMessage = failed
       ? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
       : null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The \`claude_local\` adapter spawns a long-lived \`claude --print\` child for every heartbeat run
> - The adapter has a \`terminalResultCleanup\` grace timer (default 5 s) that SIGTERMs the child after Claude has already written a terminal stream-json \`result\` event to stdout, so a child that is slow to release file handles does not block the agent slot
> - SIGTERM exits the child with code 143 (128 + 15)
> - But \`toAdapterResult()\` reads \`failed = (exitCode !== 0) || parsedIsError\` and marks every such grace-cleanup path as failed
> - Worse, paperclip then runs \`isClaudeTransientUpstreamError\` against stdout + the assistant's own text — and real-world agent verdicts routinely contain the words \"limit\", \"reached\", \"extra\", \"usage\", \"overloaded\", which match the transient-upstream regex
> - Net effect: a successful run gets stamped \`errorCode: claude_transient_upstream\` and triggers a retry wake — a wake-spam loop on what was actually a clean exit
> - This pull request makes the success criteria look at the parsed terminal result instead of the exit code: if Claude wrote a clean \`result\` event (\`is_error: false\`), the run is succeeded regardless of how the wrapper finally exited

## What Changed

- One-line guard in \`packages/adapters/claude-local/src/server/execute.ts\` inside \`toAdapterResult()\`:

  ```ts
  const hasSuccessfulTerminalResult =
    parsedStream.resultJson !== null && !parsedIsError;
  const failed = !hasSuccessfulTerminalResult && ((proc.exitCode ?? 0) !== 0 || parsedIsError);
  ```

  with a multi-line comment block above it explaining the grace-SIGTERM origin and why the regex match on assistant text is the actual harm.
- No change to \`is_error: true\` handling (real upstream errors still fail).
- No change to \"non-zero exit and no terminal result\" handling (genuine crashes before the agent finished still fail).
- No change to the transient-upstream classifier itself or its regex.

## Verification

\`\`\`sh
# adapter-claude-local typecheck
pnpm --filter @paperclipai/adapter-claude-local typecheck
# clean

# existing parse tests still pass
pnpm exec vitest run packages/adapters/claude-local/src/server/parse.test.ts --no-coverage
# Tests  9 passed (9)
\`\`\`

Wild incident captured before the fix:

- Run id (in our local instance): \`cac43d0f-e5ba-4314-928f-c7f93b0dd127\`
- Reviewer agent (Opus 4.7), 32 turns, finished with \`type: \"result\"\` and \`is_error: false\`, posted a Round-2 review and reassigned the issue back to Coder.
- Wrapper proc exit code: \`143\` (SIGTERM from \`terminalResultCleanup\` grace timer).
- DB row: \`status: failed\`, \`errorCode: claude_transient_upstream\`, \`error: \"Claude run failed: subtype=success: Round-2 review complete and bounced back to Coder. ...\"\`.
- The regex matched on the words \`reached\` / \`limit\` inside the agent's own review verdict text. After the patch the same scenario keeps the run marked \`succeeded\` and no retry wake is queued.

I deliberately did not add a unit test in this patch — the failed path runs through \`runAdapterExecutionTargetProcess\` (real spawn) and \`parseClaudeStreamJson\`, so a representative regression test needs a small fixture for both. Happy to add one in a follow-up commit on this branch if reviewers prefer it pinned. Suggested fixture: a fake \`runAdapterExecutionTargetProcess\` that returns \`exitCode: 143\` plus stdout containing one valid stream-json \`result\` event with \`is_error: false\`, asserted via \`toAdapterResult\` returning \`errorCode: null\` and \`failed: false\` semantics.

## Risks

- **Low.** The new guard only flips success when *both* of these are true:
  - The parser already reconstructed a terminal \`result\` event (\`parsedStream.resultJson !== null\`), i.e. Claude actually finished its turn.
  - That \`result\` does not have \`is_error: true\`.
- A real Anthropic-side error (\`is_error: true\`) is unaffected — \`failed\` still evaluates true.
- A genuine crash before any \`result\` event (no \`parsedStream.resultJson\`, exit non-zero) is unaffected — \`failed\` still evaluates true.
- The companion early-return path at \`execute.ts:718\` (loginMeta / no parsed terminal) already returns \`errorCode: claude_transient_upstream\` only on the no-parsed-terminal branch, so the asymmetry is removed: now both paths agree that \"clean terminal result wins.\"
- No DB schema change, no public API change, no UI change.

## Model Used

- Claude Opus 4.7 (\`claude-opus-4-7\`), 1M-context build, extended thinking + tool use enabled. Used to trace the wild incident from \`heartbeat_runs.error\` back through \`toAdapterResult\` to the \`terminalResultCleanup\` grace mechanism, identify the regex-on-assistant-text feedback loop, and produce the minimal fix above.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (9 existing claude-local parse tests; typecheck clean)
- [ ] I have added or updated tests where applicable — see Verification section; happy to add a focused regression test on this branch if requested
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-side adapter)
- [x] I have updated relevant documentation to reflect my changes — in-line code comment explains the grace-cleanup origin
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge